### PR TITLE
Only have one kind of context for direct invocation

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -538,6 +538,6 @@ def _type_check_output(
             dagster_type=dagster_type,
         )
 
-    context.execution_properties.observe_output(
+    context.observe_output(
         output_def.name, output.mapping_key if isinstance(output, DynamicOutput) else None
     )

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -221,7 +221,7 @@ def direct_invocation_result(
 
     res = _type_check_output_wrapper(op_def, result, bound_context)
 
-    bound_context.unbind()
+    # bound_context.unbind()
 
     return res
 

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -224,9 +224,9 @@ def direct_invocation_result(
             resource_args=resource_arg_mapping,
         )
         return _type_check_output_wrapper(op_def, result, bound_context)
-    except Exception as e:
+    except Exception:
         bound_context.unbind()
-        raise e
+        raise
 
 
 def _resolve_inputs(
@@ -413,9 +413,9 @@ def _type_check_output_wrapper(
                 # async generators, the errors will only be surfaced here
                 async for event in async_gen:
                     yield _handle_gen_event(event, op_def, context, output_defs, outputs_seen)
-            except Exception as e:
+            except Exception:
                 context.unbind()
-                raise e
+                raise
 
             for output_def in op_def.output_defs:
                 if (
@@ -443,9 +443,9 @@ def _type_check_output_wrapper(
                 # if the compute function fails, we want to ensure we unbind the context. For
                 # async, the errors will only be surfaced here
                 out = await coro
-            except Exception as e:
+            except Exception:
                 context.unbind()
-                raise e
+                raise
             return _type_check_function_output(op_def, out, context)
 
         return type_check_coroutine(result)
@@ -460,9 +460,9 @@ def _type_check_output_wrapper(
                 # generators, the errors will only be surfaced here
                 for event in gen:
                     yield _handle_gen_event(event, op_def, context, output_defs, outputs_seen)
-            except Exception as e:
+            except Exception:
                 context.unbind()
-                raise e
+                raise
 
             for output_def in op_def.output_defs:
                 if (

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -219,7 +219,11 @@ def direct_invocation_result(
         resource_args=resource_arg_mapping,
     )
 
-    return _type_check_output_wrapper(op_def, result, bound_context)
+    res = _type_check_output_wrapper(op_def, result, bound_context)
+
+    bound_context.unbind()
+
+    return res
 
 
 def _resolve_inputs(

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -32,7 +32,7 @@ from .output import DynamicOutputDefinition, OutputDefinition
 from .result import MaterializeResult
 
 if TYPE_CHECKING:
-    from ..execution.context.invocation import DirectInvocationOpExecutionContext
+    from ..execution.context.invocation import RunlessOpExecutionContext
     from .assets import AssetsDefinition
     from .composition import PendingNodeInvocation
     from .decorators.op_decorator import DecoratedOpFunction
@@ -109,7 +109,7 @@ def direct_invocation_result(
 ) -> Any:
     from dagster._config.pythonic_config import Config
     from dagster._core.execution.context.invocation import (
-        DirectInvocationOpExecutionContext,
+        RunlessOpExecutionContext,
         build_op_context,
     )
 
@@ -149,12 +149,12 @@ def direct_invocation_result(
                 " no context was provided when invoking."
             )
         if len(args) > 0:
-            if args[0] is not None and not isinstance(args[0], DirectInvocationOpExecutionContext):
+            if args[0] is not None and not isinstance(args[0], RunlessOpExecutionContext):
                 raise DagsterInvalidInvocationError(
                     f"Decorated function '{compute_fn.name}' has context argument, "
                     "but no context was provided when invoking."
                 )
-            context = cast(DirectInvocationOpExecutionContext, args[0])
+            context = cast(RunlessOpExecutionContext, args[0])
             # update args to omit context
             args = args[1:]
         else:  # context argument is provided under kwargs
@@ -165,14 +165,14 @@ def direct_invocation_result(
                     f"'{context_param_name}', but no value for '{context_param_name}' was "
                     f"found when invoking. Provided kwargs: {kwargs}"
                 )
-            context = cast(DirectInvocationOpExecutionContext, kwargs[context_param_name])
+            context = cast(RunlessOpExecutionContext, kwargs[context_param_name])
             # update kwargs to remove context
             kwargs = {
                 kwarg: val for kwarg, val in kwargs.items() if not kwarg == context_param_name
             }
     # allow passing context, even if the function doesn't have an arg for it
-    elif len(args) > 0 and isinstance(args[0], DirectInvocationOpExecutionContext):
-        context = cast(DirectInvocationOpExecutionContext, args[0])
+    elif len(args) > 0 and isinstance(args[0], RunlessOpExecutionContext):
+        context = cast(RunlessOpExecutionContext, args[0])
         args = args[1:]
 
     resource_arg_mapping = {arg.name: arg.name for arg in compute_fn.get_resource_args()}
@@ -230,7 +230,7 @@ def direct_invocation_result(
 
 
 def _resolve_inputs(
-    op_def: "OpDefinition", args, kwargs, context: "DirectInvocationOpExecutionContext"
+    op_def: "OpDefinition", args, kwargs, context: "RunlessOpExecutionContext"
 ) -> Mapping[str, Any]:
     from dagster._core.execution.plan.execute_step import do_type_check
 
@@ -333,9 +333,7 @@ def _resolve_inputs(
     return input_dict
 
 
-def _key_for_result(
-    result: MaterializeResult, context: "DirectInvocationOpExecutionContext"
-) -> AssetKey:
+def _key_for_result(result: MaterializeResult, context: "RunlessOpExecutionContext") -> AssetKey:
     if result.asset_key:
         return result.asset_key
 
@@ -350,7 +348,7 @@ def _key_for_result(
 
 def _output_name_for_result_obj(
     event: MaterializeResult,
-    context: "DirectInvocationOpExecutionContext",
+    context: "RunlessOpExecutionContext",
 ):
     asset_key = _key_for_result(event, context)
     return context.assets_def.get_output_name_for_asset_key(asset_key)
@@ -359,7 +357,7 @@ def _output_name_for_result_obj(
 def _handle_gen_event(
     event: T,
     op_def: "OpDefinition",
-    context: "DirectInvocationOpExecutionContext",
+    context: "RunlessOpExecutionContext",
     output_defs: Mapping[str, OutputDefinition],
     outputs_seen: Set[str],
 ) -> T:
@@ -393,7 +391,7 @@ def _handle_gen_event(
 
 
 def _type_check_output_wrapper(
-    op_def: "OpDefinition", result: Any, context: "DirectInvocationOpExecutionContext"
+    op_def: "OpDefinition", result: Any, context: "RunlessOpExecutionContext"
 ) -> Any:
     """Type checks and returns the result of a op.
 
@@ -487,7 +485,7 @@ def _type_check_output_wrapper(
 
 
 def _type_check_function_output(
-    op_def: "OpDefinition", result: T, context: "DirectInvocationOpExecutionContext"
+    op_def: "OpDefinition", result: T, context: "RunlessOpExecutionContext"
 ) -> T:
     from ..execution.plan.compute_generator import validate_and_coerce_op_result_to_iterator
 
@@ -506,14 +504,14 @@ def _type_check_function_output(
 def _type_check_output(
     output_def: "OutputDefinition",
     output: Union[Output, DynamicOutput],
-    context: "DirectInvocationOpExecutionContext",
+    context: "RunlessOpExecutionContext",
 ) -> None:
     """Validates and performs core type check on a provided output.
 
     Args:
         output_def (OutputDefinition): The output definition to validate against.
         output (Any): The output to validate.
-        context (DirectInvocationOpExecutionContext): Context containing resources to be used for type
+        context (RunlessOpExecutionContext): Context containing resources to be used for type
             check.
     """
     from ..execution.plan.execute_step import do_type_check

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -219,11 +219,7 @@ def direct_invocation_result(
         resource_args=resource_arg_mapping,
     )
 
-    res = _type_check_output_wrapper(op_def, result, bound_context)
-
-    # bound_context.unbind()
-
-    return res
+    return _type_check_output_wrapper(op_def, result, bound_context)
 
 
 def _resolve_inputs(

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -418,6 +418,7 @@ def _type_check_output_wrapper(
                             f"Invocation of {op_def.node_type_str} '{context.alias}' did not"
                             f" return an output for non-optional output '{output_def.name}'"
                         )
+            context.unbind()
 
         return to_gen(result)
 
@@ -452,6 +453,7 @@ def _type_check_output_wrapper(
                             f'Invocation of {op_def.node_type_str} "{context.alias}" did not'
                             f' return an output for non-optional output "{output_def.name}"'
                         )
+            context.unbind()
 
         return type_check_gen(result)
 
@@ -472,6 +474,7 @@ def _type_check_function_output(
             # ensure result objects are contextually valid
             _output_name_for_result_obj(event, context)
 
+    context.unbind()
     return result
 
 

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -76,7 +76,7 @@ class BoundProperties:
         alias: str,
         assets_def: Optional[AssetsDefinition],
         resources: Resources,
-        op_config: Dict[str, Any],
+        op_config: Optional[Dict[str, Any]],
     ):
         """Maintains the properties of the context that are provided at bind time.
         This class is not implemented as a NamedTuple because requires_typed_event_stream
@@ -86,9 +86,9 @@ class BoundProperties:
         self.tags = check.dict_param(tags, "tags", Any, Any)
         self.hook_defs = check.opt_set_param(hook_defs, "hook_defs", HookDefinition)
         self.alias = check.str_param(alias, "alias")
-        self.assets_def = check.inst_param(assets_def, "assets_def", AssetsDefinition)
+        self.assets_def = check.opt_inst_param(assets_def, "assets_def", AssetsDefinition)
         self.resources = check.inst_param(resources, "resources", Resources)
-        self.op_config = check.dict_param(op_config, "op_config", str, Any)
+        self.op_config = check.opt_dict_param(op_config, "op_config", str, Any)
         self.requires_typed_event_stream = False
         self.typed_event_stream_error_message = None
 
@@ -197,6 +197,7 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
         from dagster._core.definitions.resource_invocation import resolve_bound_config
 
         if self._bound_properties is not None:
+            # if self._completed:
             warnings.warn(
                 f"This context was already used to execute {self.alias}. The information about"
                 f" {self.alias} will be cleared, including user events and output metadata."
@@ -205,6 +206,8 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
                 f" information about {self.alias} using the unbind() method."
             )
             self.unbind()
+            # else:
+            #     raise DagsterInvalidInvocationError(f"This context is currently being used to execute {self.alias}. The context cannot be used to execute another op until {self.alias} has finished executing.")
 
         # update the bound context with properties relevant to the execution of the op
 

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -228,6 +228,9 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
                 build_resources(resource_defs, self.instance, self._resources_config)
             )
         else:
+            # this runs the check in resources() to ensure we are in a context manager if necessary
+            self._resources = self.resources
+
             resource_defs = self._resource_defs
 
         _validate_resource_requirements(resource_defs, op_def)

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -201,7 +201,7 @@ class InvocationProperties:
         self.typed_event_stream_error_message = error_message
 
 
-class DirectInvocationOpExecutionContext(OpExecutionContext):
+class RunlessOpExecutionContext(OpExecutionContext):
     """The ``context`` object available as the first argument to an op's compute function when
     being invoked directly. Can also be used as a context manager.
     """
@@ -296,7 +296,7 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
         assets_def: Optional[AssetsDefinition],
         config_from_args: Optional[Mapping[str, Any]],
         resources_from_args: Optional[Mapping[str, Any]],
-    ) -> "DirectInvocationOpExecutionContext":
+    ) -> "RunlessOpExecutionContext":
         from dagster._core.definitions.resource_invocation import resolve_bound_config
 
         if self._bound_properties is not None:
@@ -703,7 +703,7 @@ def build_op_context(
     partition_key_range: Optional[PartitionKeyRange] = None,
     mapping_key: Optional[str] = None,
     _assets_def: Optional[AssetsDefinition] = None,
-) -> DirectInvocationOpExecutionContext:
+) -> RunlessOpExecutionContext:
     """Builds op execution context from provided parameters.
 
     ``build_op_context`` can be used as either a function or context manager. If there is a
@@ -751,7 +751,7 @@ def build_op_context(
         )
 
     op_config = op_config if op_config else config
-    return DirectInvocationOpExecutionContext(
+    return RunlessOpExecutionContext(
         resources_dict=check.opt_mapping_param(resources, "resources", key_type=str),
         resources_config=check.opt_mapping_param(
             resources_config, "resources_config", key_type=str

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -274,9 +274,9 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
 
         _validate_resource_requirements(resource_defs, op_def)
 
-        if self.op_config and config_from_args:
+        if self._op_config and config_from_args:
             raise DagsterInvalidInvocationError("Cannot provide config in both context and kwargs")
-        op_config = resolve_bound_config(config_from_args or self.op_config, op_def)
+        op_config = resolve_bound_config(config_from_args or self._op_config, op_def)
 
         self._bound_properties = BoundProperties(
             op_def=op_def,
@@ -297,7 +297,9 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
 
     @property
     def op_config(self) -> Any:
-        return self._op_config
+        if self._bound_properties is None:
+            return self._op_config
+        return self._bound_properties.op_config
 
     @property
     def resource_keys(self) -> AbstractSet[str]:

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -81,6 +81,11 @@ class BoundProperties(
         ],
     )
 ):
+    """Maintains properties that are only available once the context has been bound to a particular
+    asset or op execution. By splitting these out into a separate object, it is easier to ensure that
+    all properties bound to an execution are cleared once the execution is complete.
+    """
+
     def __new__(
         cls,
         op_def: OpDefinition,
@@ -92,7 +97,6 @@ class BoundProperties(
         op_config: Any,
         step_description: str,
     ):
-        """Maintains the properties of the context that are provided at bind time."""
         return super(BoundProperties, cls).__new__(
             cls,
             op_def=check.inst_param(op_def, "op_def", OpDefinition),
@@ -107,9 +111,9 @@ class BoundProperties(
 
 
 class DirectExecutionProperties:
-    """Maintains information about the invocation that is updated during execution time. This information
-    needs to be available to the user once invocation is complete, so that they can assert on events and
-    outputs. It needs to be cleared before the context is used for another invocation.
+    """Maintains information about the execution that can only be updated during execution (when
+    the context is bound), but can be read after execution is complete. It needs to be cleared before
+    the context is used for another execution.
 
     This is not implemented as a NamedTuple because the various attributes will be mutated during
     execution.

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -648,17 +648,17 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
     @property
     def requires_typed_event_stream(self) -> bool:
         self._check_bound(fn_name="requires_typed_event_stream", fn_type="property")
-        return self._requires_typed_event_stream
+        return self._bound_properties.requires_typed_event_stream
 
     @property
     def typed_event_stream_error_message(self) -> Optional[str]:
         self._check_bound(fn_name="typed_event_stream_error_message", fn_type="property")
-        return self._typed_event_stream_error_message
+        return self._bound_properties.typed_event_stream_error_message
 
     def set_requires_typed_event_stream(self, *, error_message: Optional[str]) -> None:
         self._check_bound(fn_name="set_requires_typed_event_stream", fn_type="method")
-        self._requires_typed_event_stream = True
-        self._typed_event_stream_error_message = error_message
+        self._bound_properties.requires_typed_event_stream = True
+        self._bound_properties.typed_event_stream_error_message = error_message
 
 
 def _validate_resource_requirements(

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -409,6 +409,10 @@ class RunlessOpExecutionContext(OpExecutionContext):
         self._bound_properties = None
 
     @property
+    def is_bound(self) -> bool:
+        return self._bound_properties is not None
+
+    @property
     def execution_properties(self) -> RunlessExecutionProperties:
         return self._execution_properties
 

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -118,6 +118,12 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
 
         self._assets_def = check.opt_inst_param(assets_def, "assets_def", AssetsDefinition)
 
+        # These attributes will be set when the context is bound to an op invocation
+        self._op_def = None
+        self._alias = None
+        self._hook_defs = None
+        self._tags = {}
+
         # Indicates whether the context has been bound to a particular invocation of an op
         # @op
         # def my_op(context):
@@ -199,7 +205,7 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
         self._check_bound(fn_name="run_config", fn_type="property")
 
         run_config: Dict[str, object] = {}
-        if self._op_config:
+        if self._op_config and self._op_def:
             run_config["ops"] = {self._op_def.name: {"config": self._op_config}}
         run_config["resources"] = self._resources_config
         return run_config

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -139,14 +139,17 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
         self._bound = False
 
     def __enter__(self):
-        self._cm_scope_entered = True
+        if not self._bound:
+            self._cm_scope_entered = True
         return self
 
     def __exit__(self, *exc):
-        self._exit_stack.close()
+        if not self._bound:
+            self._exit_stack.close()
 
     def __del__(self):
-        self._exit_stack.close()
+        if not self._bound:
+            self._exit_stack.close()
 
     def _check_bound(self, fn_name: str, fn_type: str):
         if not self._bound:
@@ -160,7 +163,7 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
         config_from_args: Optional[Mapping[str, Any]],
         resources_from_args: Optional[Mapping[str, Any]],
     ) -> "DirectInvocationOpExecutionContext":
-        return self.bind_self(
+        return self.bind_copy(
             op_def=op_def,
             pending_invocation=pending_invocation,
             assets_def=assets_def,

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -3,6 +3,7 @@ from typing import (
     AbstractSet,
     Any,
     Dict,
+    List,
     Mapping,
     NamedTuple,
     Optional,
@@ -114,11 +115,31 @@ class RunlessExecutionProperties:
     """
 
     def __init__(self):
-        self.user_events = []
-        self.seen_outputs = {}
-        self.output_metadata = {}
-        self.requires_typed_event_stream = False
-        self.typed_event_stream_error_message: Optional[str] = None
+        self._events: List[UserEvent] = []
+        self._seen_outputs = {}
+        self._output_metadata = {}
+        self._requires_typed_event_stream = False
+        self._typed_event_stream_error_message = None
+
+    @property
+    def user_events(self):
+        return self._events
+
+    @property
+    def seen_outputs(self):
+        return self._seen_outputs
+
+    @property
+    def output_metadata(self):
+        return self._output_metadata
+
+    @property
+    def requires_typed_event_stream(self) -> bool:
+        return self._requires_typed_event_stream
+
+    @property
+    def typed_event_stream_error_message(self) -> Optional[str]:
+        return self._typed_event_stream_error_message
 
     def log_event(self, event: UserEvent) -> None:
         check.inst_param(
@@ -126,15 +147,15 @@ class RunlessExecutionProperties:
             "event",
             (AssetMaterialization, AssetObservation, ExpectationResult),
         )
-        self.user_events.append(event)
+        self._events.append(event)
 
     def observe_output(self, output_name: str, mapping_key: Optional[str] = None) -> None:
         if mapping_key:
             if output_name not in self.seen_outputs:
-                self.seen_outputs[output_name] = set()
-            cast(Set[str], self.seen_outputs[output_name]).add(mapping_key)
+                self._seen_outputs[output_name] = set()
+            cast(Set[str], self._seen_outputs[output_name]).add(mapping_key)
         else:
-            self.seen_outputs[output_name] = "seen"
+            self._seen_outputs[output_name] = "seen"
 
     def has_seen_output(self, output_name: str, mapping_key: Optional[str] = None) -> bool:
         if mapping_key:
@@ -193,15 +214,15 @@ class RunlessExecutionProperties:
                 )
         if mapping_key:
             if output_name not in self.output_metadata:
-                self.output_metadata[output_name] = {}
-            self.output_metadata[output_name][mapping_key] = metadata
+                self._output_metadata[output_name] = {}
+            self._output_metadata[output_name][mapping_key] = metadata
 
         else:
-            self.output_metadata[output_name] = metadata
+            self._output_metadata[output_name] = metadata
 
     def set_requires_typed_event_stream(self, *, error_message: Optional[str]) -> None:
-        self.requires_typed_event_stream = True
-        self.typed_event_stream_error_message = error_message
+        self._requires_typed_event_stream = True
+        self._typed_event_stream_error_message = error_message
 
 
 class RunlessOpExecutionContext(OpExecutionContext):

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -93,19 +93,17 @@ class BoundProperties(
         step_description: str,
     ):
         """Maintains the properties of the context that are provided at bind time."""
-
-        def __new__(cls):
-            return super(BoundProperties, cls).__new__(
-                cls,
-                op_def=check.inst_param(op_def, "op_def", OpDefinition),
-                tags=check.dict_param(tags, "tags"),
-                hook_defs=check.opt_set_param(hook_defs, "hook_defs", HookDefinition),
-                alias=check.str_param(alias, "alias"),
-                assets_def=check.opt_inst_param(assets_def, "assets_def", AssetsDefinition),
-                resources=check.inst_param(resources, "resources", Resources),
-                op_config=op_config,
-                step_description=step_description,
-            )
+        return super(BoundProperties, cls).__new__(
+            cls,
+            op_def=check.inst_param(op_def, "op_def", OpDefinition),
+            tags=check.dict_param(tags, "tags"),
+            hook_defs=check.opt_set_param(hook_defs, "hook_defs", HookDefinition),
+            alias=check.str_param(alias, "alias"),
+            assets_def=check.opt_inst_param(assets_def, "assets_def", AssetsDefinition),
+            resources=check.inst_param(resources, "resources", Resources),
+            op_config=op_config,
+            step_description=step_description,
+        )
 
 
 class RunlessExecutionProperties:

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -234,7 +234,6 @@ class DirectOpExecutionContext(OpExecutionContext):
         self._execution_properties = DirectExecutionProperties()
 
         # update the bound context with properties relevant to the execution of the op
-
         invocation_tags = (
             pending_invocation.tags
             if isinstance(pending_invocation, PendingNodeInvocation)
@@ -291,10 +290,7 @@ class DirectOpExecutionContext(OpExecutionContext):
             raise DagsterInvalidInvocationError("Cannot provide config in both context and kwargs")
         op_config = resolve_bound_config(config_from_args or self._op_config, op_def)
 
-        if isinstance(op_def, OpDefinition):
-            step_description = f'op "{op_def.name}"'
-        else:
-            step_description = f'solid "{op_def.name}"'
+        step_description = f'op "{op_def.name}"'
 
         self._bound_properties = BoundProperties(
             op_def=op_def,

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -103,9 +103,6 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
                 resource_config=resources_config,
             )
         )
-        self._init_resources = (
-            self._resources
-        )  # so we can unbind the context back to it's original state
         self._resources_contain_cm = isinstance(self._resources, IContainsGenerator)
 
         self._log = initialize_console_manager(None)
@@ -140,6 +137,7 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
         #     ...
         # ctx = build_op_context() # ctx._bound is False
         # my_op(ctx)
+        # ctx._bound is True, must call ctx.unbind() to unbind
         self._bound = False
 
     def __enter__(self):
@@ -230,7 +228,6 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
                 build_resources(resource_defs, self.instance, self._resources_config)
             )
         else:
-            self._resources = self.resources
             resource_defs = self._resource_defs
 
         _validate_resource_requirements(resource_defs, op_def)
@@ -337,7 +334,7 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
 
     @property
     def node_handle(self) -> NodeHandle:
-        raise DagsterInvalidPropertyError(_property_msg("solid_handle", "property"))
+        raise DagsterInvalidPropertyError(_property_msg("node_handle", "property"))
 
     @property
     def op(self) -> Node:
@@ -350,7 +347,7 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
     @property
     def op_def(self) -> OpDefinition:
         self._check_bound(fn_name="op_def", fn_type="property")
-        return self._op_def
+        return cast(OpDefinition, self._op_def)
 
     @property
     def has_assets_def(self) -> bool:
@@ -405,7 +402,7 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
     @property
     def alias(self) -> str:
         self._check_bound(fn_name="alias", fn_type="property")
-        return self._alias
+        return cast(str, self._alias)
 
     def get_step_execution_context(self) -> StepExecutionContext:
         raise DagsterInvalidPropertyError(_property_msg("get_step_execution_context", "method"))

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -75,7 +75,7 @@ class BoundProperties:
         alias: str,
         assets_def: Optional[AssetsDefinition],
         resources: Resources,
-        op_config: Optional[Dict[str, Any]],
+        op_config: Any,
     ):
         """Maintains the properties of the context that are provided at bind time.
         This class is not implemented as a NamedTuple because requires_typed_event_stream
@@ -87,7 +87,7 @@ class BoundProperties:
         self.alias = check.str_param(alias, "alias")
         self.assets_def = check.opt_inst_param(assets_def, "assets_def", AssetsDefinition)
         self.resources = check.inst_param(resources, "resources", Resources)
-        self.op_config = check.opt_dict_param(op_config, "op_config")
+        self.op_config = op_config
         self.requires_typed_event_stream = False
         self.typed_event_stream_error_message = None
 
@@ -174,7 +174,7 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
         self._bound_properties = None
 
         # Maintains the properties on the context that are modified during invocation
-        self._invocation_properties = None
+        self._invocation_properties = InvocationProperties()
 
     def __enter__(self):
         self._cm_scope_entered = True
@@ -466,7 +466,6 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
                 expectation_results = [event for event in all_user_events if isinstance(event, ExpectationResult)]
                 ...
         """
-        self._check_bound(fn_name="get_events", fn_type="method")
         return self._invocation_properties.user_events
 
     def get_output_metadata(
@@ -483,7 +482,6 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
         Returns:
             Optional[Mapping[str, Any]]: The metadata values present for the output_name/mapping_key combination, if present.
         """
-        self._check_bound(fn_name="get_output_metadata", fn_type="method")
         metadata = self._invocation_properties.output_metadata.get(output_name)
         if mapping_key and metadata:
             return metadata.get(mapping_key)
@@ -528,7 +526,6 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
             self._invocation_properties.seen_outputs[output_name] = "seen"
 
     def has_seen_output(self, output_name: str, mapping_key: Optional[str] = None) -> bool:
-        self._check_bound(fn_name="has_seen_output", fn_type="method")
         if mapping_key:
             return (
                 output_name in self._invocation_properties.seen_outputs

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -82,12 +82,12 @@ class BoundProperties:
         and type_event_stream_error_message should be mutable.
         """
         self.op_def = check.inst_param(op_def, "op_def", OpDefinition)
-        self.tags = check.dict_param(tags, "tags", Any, Any)
+        self.tags = check.dict_param(tags, "tags")
         self.hook_defs = check.opt_set_param(hook_defs, "hook_defs", HookDefinition)
         self.alias = check.str_param(alias, "alias")
         self.assets_def = check.opt_inst_param(assets_def, "assets_def", AssetsDefinition)
         self.resources = check.inst_param(resources, "resources", Resources)
-        self.op_config = check.opt_dict_param(op_config, "op_config", str, Any)
+        self.op_config = check.opt_dict_param(op_config, "op_config")
         self.requires_typed_event_stream = False
         self.typed_event_stream_error_message = None
 

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -67,24 +67,9 @@ def _property_msg(prop_name: str, method_name: str) -> str:
     )
 
 
-class BoundProperties(
-    NamedTuple(
-        "_BoundProperties",
-        [
-            ("op_def", OpDefinition),
-            ("tags", Mapping[Any, Any]),
-            ("hook_defs", Optional[AbstractSet[HookDefinition]]),
-            ("alias", str),
-            ("assets_def", Optional[AssetsDefinition]),
-            ("resources", Resources),
-            ("op_config", Dict[str, Any]),
-            ("requires_typed_event_stream", bool),
-            ("typed_event_stream_error_message", Optional[str]),
-        ],
-    )
-):
-    def __new__(
-        cls,
+class BoundProperties:
+    def __init__(
+        self,
         op_def: OpDefinition,
         tags: Mapping[Any, Any],
         hook_defs: Optional[AbstractSet[HookDefinition]],
@@ -93,18 +78,19 @@ class BoundProperties(
         resources: Resources,
         op_config: Dict[str, Any],
     ):
-        return super(BoundProperties, cls).__new__(
-            cls,
-            op_def=op_def,
-            tags=tags,
-            hook_defs=hook_defs,
-            alias=alias,
-            assets_def=assets_def,
-            resources=resources,
-            op_config=op_config,
-            requires_typed_event_stream=False,
-            typed_event_stream_error_message=None,
-        )
+        """Maintains the properties of the context that are provided at bind time.
+        This class is not implemented as a NamedTuple because requires_typed_event_stream
+        and type_event_stream_error_message should be mutable.
+        """
+        self.op_def = check.inst_param(op_def, "op_def", OpDefinition)
+        self.tags = check.dict_param(tags, "tags", Any, Any)
+        self.hook_defs = check.opt_set_param(hook_defs, "hook_defs", HookDefinition)
+        self.alias = check.str_param(alias, "alias")
+        self.assets_def = check.inst_param(assets_def, "assets_def", AssetsDefinition)
+        self.resources = check.inst_param(resources, "resources", Resources)
+        self.op_config = check.dict_param(op_config, "op_config", str, Any)
+        self.requires_typed_event_stream = False
+        self.typed_event_stream_error_message = None
 
 
 class InvocationProperties(

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -170,10 +170,18 @@ class DirectInvocationOpExecutionContext(OpExecutionContext):
         #     ...
         # ctx = build_op_context() # ctx._bound_properties is None
         # my_op(ctx)
-        # ctx._bound_properties.alias is "my_op", must call ctx.unbind() to unbind
+        # ctx._bound_properties is None # ctx is unbound at the end of invocation
         self._bound_properties = None
 
         # Maintains the properties on the context that are modified during invocation
+        # @op
+        # def my_op(context):
+        #     # context._invocation_properties can be modified with output metadata etc.
+        #     ...
+        # ctx = build_op_context() # ctx._invocation_properties is empty
+        # my_op(ctx)
+        # ctx._invocation_properties.output_metadata # information is retained after invocation
+        # my_op(ctx) # ctx._invocation_properties is cleared at the beginning of the next invocation
         self._invocation_properties = InvocationProperties()
 
     def __enter__(self):

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -39,7 +39,7 @@ from dagster._core.definitions.time_window_partitions import (
 from dagster._core.errors import DagsterPipesExecutionError
 from dagster._core.events import EngineEventData
 from dagster._core.execution.context.compute import OpExecutionContext
-from dagster._core.execution.context.invocation import RunlessOpExecutionContext
+from dagster._core.execution.context.invocation import DirectOpExecutionContext
 from dagster._utils.error import (
     ExceptionInfo,
     SerializableErrorInfo,
@@ -406,8 +406,8 @@ def build_external_execution_context_data(
             _convert_time_window(partition_time_window) if partition_time_window else None
         ),
         run_id=context.run_id,
-        job_name=None if isinstance(context, RunlessOpExecutionContext) else context.job_name,
-        retry_number=0 if isinstance(context, RunlessOpExecutionContext) else context.retry_number,
+        job_name=None if isinstance(context, DirectOpExecutionContext) else context.job_name,
+        retry_number=0 if isinstance(context, DirectOpExecutionContext) else context.retry_number,
         extras=extras or {},
     )
 

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -39,7 +39,7 @@ from dagster._core.definitions.time_window_partitions import (
 from dagster._core.errors import DagsterPipesExecutionError
 from dagster._core.events import EngineEventData
 from dagster._core.execution.context.compute import OpExecutionContext
-from dagster._core.execution.context.invocation import BoundOpExecutionContext
+from dagster._core.execution.context.invocation import DirectInvocationOpExecutionContext
 from dagster._utils.error import (
     ExceptionInfo,
     SerializableErrorInfo,
@@ -406,8 +406,12 @@ def build_external_execution_context_data(
             _convert_time_window(partition_time_window) if partition_time_window else None
         ),
         run_id=context.run_id,
-        job_name=None if isinstance(context, BoundOpExecutionContext) else context.job_name,
-        retry_number=0 if isinstance(context, BoundOpExecutionContext) else context.retry_number,
+        job_name=None
+        if isinstance(context, DirectInvocationOpExecutionContext)
+        else context.job_name,
+        retry_number=0
+        if isinstance(context, DirectInvocationOpExecutionContext)
+        else context.retry_number,
         extras=extras or {},
     )
 

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -39,7 +39,7 @@ from dagster._core.definitions.time_window_partitions import (
 from dagster._core.errors import DagsterPipesExecutionError
 from dagster._core.events import EngineEventData
 from dagster._core.execution.context.compute import OpExecutionContext
-from dagster._core.execution.context.invocation import DirectInvocationOpExecutionContext
+from dagster._core.execution.context.invocation import RunlessOpExecutionContext
 from dagster._utils.error import (
     ExceptionInfo,
     SerializableErrorInfo,
@@ -406,12 +406,8 @@ def build_external_execution_context_data(
             _convert_time_window(partition_time_window) if partition_time_window else None
         ),
         run_id=context.run_id,
-        job_name=None
-        if isinstance(context, DirectInvocationOpExecutionContext)
-        else context.job_name,
-        retry_number=0
-        if isinstance(context, DirectInvocationOpExecutionContext)
-        else context.retry_number,
+        job_name=None if isinstance(context, RunlessOpExecutionContext) else context.job_name,
+        retry_number=0 if isinstance(context, RunlessOpExecutionContext) else context.retry_number,
         extras=extras or {},
     )
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -227,7 +227,7 @@ def test_access_partition_keys_from_context_direct_invocation():
     @asset
     def non_partitioned_asset(context):
         with pytest.raises(
-            CheckError, match="Tried to access partition_key for a non-partitioned asset"
+            CheckError, match="Tried to access partition_key for a non-partitioned run"
         ):
             context.asset_partition_key_for_output()
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
@@ -509,8 +509,8 @@ def test_bound_state():
     my_asset(ctx)
     assert ctx._bound_properties is not None  # noqa: SLF001
 
-    ctx.unbind()
-    assert ctx._bound_properties is None  # noqa: SLF001
+    # ctx.unbind()
+    # assert ctx._bound_properties is None
     my_asset(ctx)
     assert ctx._bound_properties is not None  # noqa: SLF001
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
@@ -506,4 +506,4 @@ def test_bound_state():
     ctx = build_op_context()
     assert not ctx._bound  # noqa: SLF001
     my_asset(ctx)
-    assert not ctx._bound  # noqa: SLF001gi
+    assert not ctx._bound  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
@@ -477,7 +477,8 @@ def test_async_assets_with_shared_context():
 
     with pytest.raises(
         DagsterInvalidInvocationError,
-        match=r"This context is currently being used to execute .* The context cannot be used to execute another op until .* has finished executing",
+        match=r"This context is currently being used to execute .* The context"
+        r" cannot be used to execute another op until .* has finished executing",
     ):
         asyncio.run(main())
 
@@ -508,7 +509,6 @@ def test_context_bound_state_non_generator():
 
     ctx = build_op_context()
     assert ctx._bound_properties is None  # noqa: SLF001
-    assert ctx._invocation_properties is None  # noqa: SLF001
 
     my_asset(ctx)
     assert ctx._bound_properties is None  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
@@ -483,7 +483,7 @@ def test_direct_invocation_resource_context_manager():
     from dagster import resource
 
     class YieldedResource:
-        def get_value():
+        def get_value(self):
             return 1
 
     @resource
@@ -494,6 +494,16 @@ def test_direct_invocation_resource_context_manager():
     def my_asset(context):
         assert context.resources.yielded_resource.get_value() == 1
 
-    ctx = build_op_context(resources={"yielded_resource": yielding_resource})
+    with build_op_context(resources={"yielded_resource": yielding_resource}) as ctx:
+        my_asset(ctx)
 
+
+def test_bound_state():
+    @asset
+    def my_asset(context):
+        assert context._bound  # noqa: SLF001
+
+    ctx = build_op_context()
+    assert not ctx._bound  # noqa: SLF001
     my_asset(ctx)
+    assert not ctx._bound  # noqa: SLF001gi

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
@@ -501,18 +501,18 @@ def test_direct_invocation_resource_context_manager():
 def test_bound_state():
     @asset
     def my_asset(context):
-        assert context._bound  # noqa: SLF001
+        assert context._bound_properties is not None  # noqa: SLF001
 
     ctx = build_op_context()
-    assert not ctx._bound  # noqa: SLF001
+    assert ctx._bound_properties is None  # noqa: SLF001
 
     my_asset(ctx)
-    assert ctx._bound  # noqa: SLF001
+    assert ctx._bound_properties is not None  # noqa: SLF001
 
     ctx.unbind()
-    assert not ctx._bound  # noqa: SLF001
+    assert ctx._bound_properties is None  # noqa: SLF001
     my_asset(ctx)
-    assert ctx._bound  # noqa: SLF001
+    assert ctx._bound_properties is not None  # noqa: SLF001
 
 
 def test_bound_state_warning():
@@ -521,13 +521,13 @@ def test_bound_state_warning():
 
     @asset
     def my_asset(context):
-        assert context._bound  # noqa: SLF001
+        assert context._bound_properties is not None  # noqa: SLF001
 
     ctx = build_op_context()
-    assert not ctx._bound  # noqa: SLF001
+    assert ctx._bound_properties is None  # noqa: SLF001
 
     my_asset(ctx)
-    assert ctx._bound  # noqa: SLF001
+    assert ctx._bound_properties is not None  # noqa: SLF001
 
     with pytest.raises(UserWarning, match="This context was already used to execute my_asset"):
         my_asset(ctx)

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
@@ -1,4 +1,5 @@
 import asyncio
+import warnings
 
 import pytest
 from dagster import (
@@ -505,5 +506,29 @@ def test_bound_state():
 
     ctx = build_op_context()
     assert not ctx._bound  # noqa: SLF001
+
     my_asset(ctx)
+    assert ctx._bound  # noqa: SLF001
+
+    ctx.unbind()
     assert not ctx._bound  # noqa: SLF001
+    my_asset(ctx)
+    assert ctx._bound  # noqa: SLF001
+
+
+def test_bound_state_warning():
+    warnings.resetwarnings()
+    warnings.filterwarnings("error")
+
+    @asset
+    def my_asset(context):
+        assert context._bound  # noqa: SLF001
+
+    ctx = build_op_context()
+    assert not ctx._bound  # noqa: SLF001
+
+    my_asset(ctx)
+    assert ctx._bound  # noqa: SLF001
+
+    with pytest.raises(UserWarning, match="This context was already used to execute my_asset"):
+        my_asset(ctx)

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
@@ -9,7 +9,7 @@ from dagster import (
     asset,
     op,
 )
-from dagster._core.errors import DagsterInvalidInvocationError, DagsterInvariantViolationError
+from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.execution.context.invocation import build_asset_context, build_op_context
 
 
@@ -446,11 +446,9 @@ def test_direct_invocation_output_metadata():
     my_asset(ctx)
     assert ctx.get_output_metadata("result") == {"foo": "bar"}
 
-    with pytest.raises(
-        DagsterInvariantViolationError,
-        match="attempted to log metadata for output 'result' more than once",
-    ):
-        my_other_asset(ctx)
+    # context in unbound when used in another invocation. This allows the metadata to be
+    # added in my_other_asset
+    my_other_asset(ctx)
 
 
 def test_async_assets_with_shared_context():
@@ -479,6 +477,7 @@ def test_async_assets_with_shared_context():
     result = asyncio.run(main())
     assert result[0] == "one"
     assert result[1] == "two"
+
 
 def test_direct_invocation_resource_context_manager():
     from dagster import resource

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
@@ -478,3 +478,22 @@ def test_async_assets_with_shared_context():
     result = asyncio.run(main())
     assert result[0] == "one"
     assert result[1] == "two"
+
+def test_direct_invocation_resource_context_manager():
+    from dagster import resource
+
+    class YieldedResource:
+        def get_value():
+            return 1
+
+    @resource
+    def yielding_resource(context):
+        yield YieldedResource()
+
+    @asset(required_resource_keys={"yielded_resource"})
+    def my_asset(context):
+        assert context.resources.yielded_resource.get_value() == 1
+
+    ctx = build_op_context(resources={"yielded_resource": yielding_resource})
+
+    my_asset(ctx)

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -1390,22 +1390,22 @@ def test_async_assets_with_shared_context():
 
 def assert_context_unbound(context: RunlessOpExecutionContext):
     # to assert that the context is correctly unbound after op invocation
-    assert context._bound_properties is None  # noqa: SLF001
+    assert context.bound_properties is None
 
 
 def assert_context_bound(context: RunlessOpExecutionContext):
     # to assert that the context is correctly bound during op invocation
-    assert context._bound_properties is not None  # noqa: SLF001
+    assert context.bound_properties is not None
 
 
 def assert_execution_properties_cleared(context: RunlessOpExecutionContext):
     # to assert that the invocation properties are reset at the beginning of op invocation
-    assert len(context._execution_properties.output_metadata.keys()) == 0  # noqa: SLF001
+    assert len(context.execution_properties.output_metadata.keys()) == 0
 
 
 def assert_execution_properties_exist(context: RunlessOpExecutionContext):
     # to assert that the invocation properties remain accessible after op invocation
-    assert len(context._execution_properties.output_metadata.keys()) > 0  # noqa: SLF001
+    assert len(context.execution_properties.output_metadata.keys()) > 0
 
 
 def test_context_bound_state_non_generator():

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -1508,7 +1508,7 @@ def test_context_bound_state_async_generator():
 def test_bound_state_with_error_assets():
     @asset
     def throws_error(context):
-        assert context.alias == "throws_error"
+        assert context.asset_key.to_user_string() == "throws_error"
         raise Failure("something bad happened!")
 
     ctx = build_asset_context()

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -45,7 +45,7 @@ from dagster._core.errors import (
 )
 from dagster._core.execution.context.compute import AssetExecutionContext, OpExecutionContext
 from dagster._core.execution.context.invocation import (
-    RunlessOpExecutionContext,
+    DirectOpExecutionContext,
     build_asset_context,
 )
 from dagster._utils.test import wrap_op_in_graph_and_execute
@@ -1388,22 +1388,22 @@ def test_async_assets_with_shared_context():
         asyncio.run(main())
 
 
-def assert_context_unbound(context: RunlessOpExecutionContext):
+def assert_context_unbound(context: DirectOpExecutionContext):
     # to assert that the context is correctly unbound after op invocation
     assert not context.is_bound
 
 
-def assert_context_bound(context: RunlessOpExecutionContext):
+def assert_context_bound(context: DirectOpExecutionContext):
     # to assert that the context is correctly bound during op invocation
     assert context.is_bound
 
 
-def assert_execution_properties_cleared(context: RunlessOpExecutionContext):
+def assert_execution_properties_cleared(context: DirectOpExecutionContext):
     # to assert that the invocation properties are reset at the beginning of op invocation
     assert len(context.execution_properties.output_metadata.keys()) == 0
 
 
-def assert_execution_properties_exist(context: RunlessOpExecutionContext):
+def assert_execution_properties_exist(context: DirectOpExecutionContext):
     # to assert that the invocation properties remain accessible after op invocation
     assert len(context.execution_properties.output_metadata.keys()) > 0
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -1333,3 +1333,148 @@ def test_partition_range_asset_invocation():
         partition_key_range=PartitionKeyRange("2023-01-01", "2023-01-02"),
     )
     assert foo(context) == {"2023-01-01": True, "2023-01-02": True}
+
+
+def test_direct_invocation_output_metadata():
+    @asset
+    def my_asset(context):
+        context.add_output_metadata({"foo": "bar"})
+
+    @asset
+    def my_other_asset(context):
+        context.add_output_metadata({"baz": "qux"})
+
+    ctx = build_asset_context()
+
+    my_asset(ctx)
+    assert ctx.get_output_metadata("result") == {"foo": "bar"}
+
+    # context in unbound when used in another invocation. This allows the metadata to be
+    # added in my_other_asset
+    my_other_asset(ctx)
+
+
+def test_async_assets_with_shared_context():
+    @asset
+    async def async_asset_one(context):
+        assert context.asset_key.to_user_string() == "async_asset_one"
+        await asyncio.sleep(0.01)
+        return "one"
+
+    @asset
+    async def async_asset_two(context):
+        assert context.asset_key.to_user_string() == "async_asset_two"
+        await asyncio.sleep(0.01)
+        return "two"
+
+    # test that we can run two ops/assets with the same context at the same time without
+    # overriding op/asset specific attributes
+    ctx = build_asset_context()
+
+    async def main():
+        return await asyncio.gather(
+            async_asset_one(ctx),
+            async_asset_two(ctx),
+        )
+
+    with pytest.raises(
+        DagsterInvalidInvocationError,
+        match=r"This context is currently being used to execute .* The context"
+        r" cannot be used to execute another op until .* has finished executing",
+    ):
+        asyncio.run(main())
+
+
+def test_context_bound_state_non_generator():
+    @asset
+    def my_asset(context):
+        assert context._bound_properties is not None  # noqa: SLF001
+
+    ctx = build_op_context()
+    assert ctx._bound_properties is None  # noqa: SLF001
+
+    my_asset(ctx)
+    assert ctx._bound_properties is None  # noqa: SLF001
+    assert ctx._invocation_properties is not None  # noqa: SLF001
+
+
+def test_context_bound_state_generator():
+    @op(out={"first": Out(), "second": Out()})
+    def generator(context):
+        assert context._bound_properties is not None  # noqa: SLF001
+        yield Output("one", output_name="first")
+        yield Output("two", output_name="second")
+
+    ctx = build_op_context()
+
+    result = list(generator(ctx))
+    assert result[0].value == "one"
+    assert result[1].value == "two"
+
+    assert ctx._bound_properties is None  # noqa: SLF001
+    assert ctx._invocation_properties is not None  # noqa: SLF001
+
+
+def test_context_bound_state_async():
+    @asset
+    async def async_asset(context):
+        assert context._bound_properties is not None  # noqa: SLF001
+        assert context.asset_key.to_user_string() == "async_asset"
+        await asyncio.sleep(0.01)
+        return "one"
+
+    ctx = build_asset_context()
+
+    result = asyncio.run(async_asset(ctx))
+    assert result == "one"
+
+    assert ctx._bound_properties is None  # noqa: SLF001
+    assert ctx._invocation_properties is not None  # noqa: SLF001
+
+
+def test_context_bound_state_async_generator():
+    @op(out={"first": Out(), "second": Out()})
+    async def async_generator(context):
+        assert context._bound_properties is not None  # noqa: SLF001
+        yield Output("one", output_name="first")
+        await asyncio.sleep(0.01)
+        yield Output("two", output_name="second")
+
+    ctx = build_op_context()
+
+    async def get_results():
+        res = []
+        async for output in async_generator(ctx):
+            res.append(output)
+        return res
+
+    result = asyncio.run(get_results())
+    assert result[0].value == "one"
+    assert result[1].value == "two"
+
+    assert ctx._bound_properties is None  # noqa: SLF001
+    assert ctx._invocation_properties is not None  # noqa: SLF001
+
+
+def test_bound_state_with_error():
+    @asset
+    def throws_error(context):
+        assert context.alias == "throws_error"
+        raise Failure("something bad happened!")
+
+    ctx = build_asset_context()
+
+    throws_error(ctx)
+
+    with pytest.raises(Failure):
+        throws_error(ctx)
+
+    # invocation pathway was interrupted, ctx is still in bound state
+    assert ctx._bound_properties is not None  # noqa: SLF001
+
+    @asset
+    def no_error(context):
+        assert context.alias == "no_error"
+
+    with pytest.raises(DagsterInvalidInvocationError):
+        no_error(ctx)

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -1390,12 +1390,12 @@ def test_async_assets_with_shared_context():
 
 def assert_context_unbound(context: RunlessOpExecutionContext):
     # to assert that the context is correctly unbound after op invocation
-    assert context.bound_properties is None
+    assert not context.is_bound
 
 
 def assert_context_bound(context: RunlessOpExecutionContext):
     # to assert that the context is correctly bound during op invocation
-    assert context.bound_properties is not None
+    assert context.is_bound
 
 
 def assert_execution_properties_cleared(context: RunlessOpExecutionContext):

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -1398,21 +1398,21 @@ def assert_context_bound(context: RunlessOpExecutionContext):
     assert context._bound_properties is not None  # noqa: SLF001
 
 
-def assert_invocation_properties_cleared(context: RunlessOpExecutionContext):
+def assert_execution_properties_cleared(context: RunlessOpExecutionContext):
     # to assert that the invocation properties are reset at the beginning of op invocation
-    assert len(context._invocation_properties.output_metadata.keys()) == 0  # noqa: SLF001
+    assert len(context._execution_properties.output_metadata.keys()) == 0  # noqa: SLF001
 
 
-def assert_invocation_properties_exist(context: RunlessOpExecutionContext):
+def assert_execution_properties_exist(context: RunlessOpExecutionContext):
     # to assert that the invocation properties remain accessible after op invocation
-    assert len(context._invocation_properties.output_metadata.keys()) > 0  # noqa: SLF001
+    assert len(context._execution_properties.output_metadata.keys()) > 0  # noqa: SLF001
 
 
 def test_context_bound_state_non_generator():
     @asset
     def my_asset(context):
         assert_context_bound(context)
-        assert_invocation_properties_cleared(context)
+        assert_execution_properties_cleared(context)
         context.add_output_metadata({"foo": "bar"})
 
     ctx = build_op_context()
@@ -1420,18 +1420,18 @@ def test_context_bound_state_non_generator():
 
     my_asset(ctx)
     assert_context_unbound(ctx)
-    assert_invocation_properties_exist(ctx)
+    assert_execution_properties_exist(ctx)
 
     my_asset(ctx)
     assert_context_unbound(ctx)
-    assert_invocation_properties_exist(ctx)
+    assert_execution_properties_exist(ctx)
 
 
 def test_context_bound_state_generator():
     @op(out={"first": Out(), "second": Out()})
     def generator(context):
         assert_context_bound(context)
-        assert_invocation_properties_cleared(context)
+        assert_execution_properties_cleared(context)
         context.add_output_metadata({"foo": "bar"}, output_name="one")
         yield Output("one", output_name="first")
         yield Output("two", output_name="second")
@@ -1442,20 +1442,20 @@ def test_context_bound_state_generator():
     assert result[0].value == "one"
     assert result[1].value == "two"
     assert_context_unbound(ctx)
-    assert_invocation_properties_exist(ctx)
+    assert_execution_properties_exist(ctx)
 
     result = list(generator(ctx))
     assert result[0].value == "one"
     assert result[1].value == "two"
     assert_context_unbound(ctx)
-    assert_invocation_properties_exist(ctx)
+    assert_execution_properties_exist(ctx)
 
 
 def test_context_bound_state_async():
     @asset
     async def async_asset(context):
         assert_context_bound(context)
-        assert_invocation_properties_cleared(context)
+        assert_execution_properties_cleared(context)
         assert context.asset_key.to_user_string() == "async_asset"
         context.add_output_metadata({"foo": "bar"})
         await asyncio.sleep(0.01)
@@ -1466,19 +1466,19 @@ def test_context_bound_state_async():
     result = asyncio.run(async_asset(ctx))
     assert result == "one"
     assert_context_unbound(ctx)
-    assert_invocation_properties_exist(ctx)
+    assert_execution_properties_exist(ctx)
 
     result = asyncio.run(async_asset(ctx))
     assert result == "one"
     assert_context_unbound(ctx)
-    assert_invocation_properties_exist(ctx)
+    assert_execution_properties_exist(ctx)
 
 
 def test_context_bound_state_async_generator():
     @op(out={"first": Out(), "second": Out()})
     async def async_generator(context):
         assert_context_bound(context)
-        assert_invocation_properties_cleared(context)
+        assert_execution_properties_cleared(context)
         context.add_output_metadata({"foo": "bar"}, output_name="one")
         yield Output("one", output_name="first")
         await asyncio.sleep(0.01)
@@ -1496,13 +1496,13 @@ def test_context_bound_state_async_generator():
     assert result[0].value == "one"
     assert result[1].value == "two"
     assert_context_unbound(ctx)
-    assert_invocation_properties_exist(ctx)
+    assert_execution_properties_exist(ctx)
 
     result = asyncio.run(get_results())
     assert result[0].value == "one"
     assert result[1].value == "two"
     assert_context_unbound(ctx)
-    assert_invocation_properties_exist(ctx)
+    assert_execution_properties_exist(ctx)
 
 
 def test_bound_state_with_error_assets():

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -1432,7 +1432,7 @@ def test_context_bound_state_generator():
     def generator(context):
         assert_context_bound(context)
         assert_execution_properties_cleared(context)
-        context.add_output_metadata({"foo": "bar"}, output_name="one")
+        context.add_output_metadata({"foo": "bar"}, output_name="first")
         yield Output("one", output_name="first")
         yield Output("two", output_name="second")
 
@@ -1479,7 +1479,7 @@ def test_context_bound_state_async_generator():
     async def async_generator(context):
         assert_context_bound(context)
         assert_execution_properties_cleared(context)
-        context.add_output_metadata({"foo": "bar"}, output_name="one")
+        context.add_output_metadata({"foo": "bar"}, output_name="first")
         yield Output("one", output_name="first")
         await asyncio.sleep(0.01)
         yield Output("two", output_name="second")

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -45,7 +45,7 @@ from dagster._core.errors import (
 )
 from dagster._core.execution.context.compute import AssetExecutionContext, OpExecutionContext
 from dagster._core.execution.context.invocation import (
-    DirectInvocationOpExecutionContext,
+    RunlessOpExecutionContext,
     build_asset_context,
 )
 from dagster._utils.test import wrap_op_in_graph_and_execute
@@ -1388,22 +1388,22 @@ def test_async_assets_with_shared_context():
         asyncio.run(main())
 
 
-def assert_context_unbound(context: DirectInvocationOpExecutionContext):
+def assert_context_unbound(context: RunlessOpExecutionContext):
     # to assert that the context is correctly unbound after op invocation
     assert context._bound_properties is None  # noqa: SLF001
 
 
-def assert_context_bound(context: DirectInvocationOpExecutionContext):
+def assert_context_bound(context: RunlessOpExecutionContext):
     # to assert that the context is correctly bound during op invocation
     assert context._bound_properties is not None  # noqa: SLF001
 
 
-def assert_invocation_properties_cleared(context: DirectInvocationOpExecutionContext):
+def assert_invocation_properties_cleared(context: RunlessOpExecutionContext):
     # to assert that the invocation properties are reset at the beginning of op invocation
     assert len(context._invocation_properties.output_metadata.keys()) == 0  # noqa: SLF001
 
 
-def assert_invocation_properties_exist(context: DirectInvocationOpExecutionContext):
+def assert_invocation_properties_exist(context: RunlessOpExecutionContext):
     # to assert that the invocation properties remain accessible after op invocation
     assert len(context._invocation_properties.output_metadata.keys()) > 0  # noqa: SLF001
 


### PR DESCRIPTION
## Summary & Motivation
This PR merges `UnboundOpExecutionContext` and `BoundOpExecutionContext` into a single object, `DirectOpExecutionContext`. 

There are three states the `DirectOpExecutionContext` can be in:
1. pre-execution. The context is not tied to a particular asset or op to be executed. Therefore information like `op_config` or `asset_key` is not accessible. We call this state "unbound" or "not bound"
2. during execution. The context is now tied to a particular asset or op that is being executed. The information above (like `op_config`) is now accessible. Additionally, the user may do things that mutate the context, like emit user events or add output metadata. We call this state "bound". This state of the context is the `BoundOpExecutionContext` in the old version of the code. 
3. post-execution. The context is no longer tied to a particular op/asset execution, however, information about emitted events or output metadata still needs to be available to the user so they can assert on the contents of these events. The context is also considered "unbound" in this state. 

In order to make the distinction between these states more clear and easier to maintain for engineers, the attributes associated with each state are split into separate objects:
`BoundProperties` - maintains properties that are only available when the context is bound to an asset or op execution. When the context is bound to an invocation of a particular op, the `BoundProperties` object will be instantiated with the relevant properties for the context as bound to that op. At the end of execution, this object is deleted. We track the bound/unbound state of the context by the existence of the `BoundProperties` object. 
`DirectExecutionProperties` - maintains attributes that can only be mutated while the context is bound, but can be read at any time (pre or post execution). If another execution begins using the same context, the `DirectExecutionProperties` object is replaced with a fresh instantiation. 

Previous PR that does a similar thing but wasn't merged https://github.com/dagster-io/dagster/pull/15083

This PR accomplishes two main goals:

* Makes is easier to add an `AssetExecutionContext` for direct invocation since the pattern for a direct invocation context is simplified. 
* Generally cleans up the direct invocation path by removing a confusing section of code. Sean put it well: 
  * >Motivation:
Currently there are two classes UnboundOpExecutionContext and BoundOpExecutionContext. Both classes inherit from OpExecutionContext. UnboundOpExecutionContext is returned by build_op_context, i.e. it is used for direct op invocation. This is converted to a BoundOpExecutionContext in the __call__ method of OpDefinition when an op is invoked.
~ The status quo is problematic for a few reasons:
~ The names (Un)BoundOpExecutionContext are confusing. It makes it sound like these classes are used for all op executions, when in fact they are never used as part of a run-- only for what is called "invocation".
There is a large amount of code duplication between the two classes. This is hard to maintain and probably a source of bugs.


## How I Tested These Changes
new unit tests