### PR TITLE
[pythonic resources] only import pydantic core if using pydantic 2

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/pydantic_compat_layer.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/pydantic_compat_layer.py
@@ -14,18 +14,17 @@ from .attach_other_object_to_context import (
     IAttachDifferentObjectToOpContext as IAttachDifferentObjectToOpContext,
 )
 
+USING_PYDANTIC_2 = int(pydantic.__version__.split(".")[0]) >= 2
+
 PydanticUndefined = None
-try:
+if USING_PYDANTIC_2:
     from pydantic_core import PydanticUndefined as _PydanticUndefined  # type: ignore
 
     PydanticUndefined = _PydanticUndefined
-except:
-    pass
+
 
 if TYPE_CHECKING:
     from pydantic.fields import ModelField
-
-USING_PYDANTIC_2 = int(pydantic.__version__.split(".")[0]) >= 2
 
 
 class ModelFieldCompat:


### PR DESCRIPTION
## Summary

Pydantic 2 introduces a `pydantic_core` module which holds some core imports separate from the main module. Theoretically, a user should only have it installed if using `pydantic>=2.0.0`, but it may happen that version requirement pins lead a user to first install `pydantic>=2.0.0` (and `pydantic_core`) and then later downgrade to `pydantic<2.0.0`.

Dagster will misbehave in this case, since we would use the `pydantic>=2.0.0` notion of 'undefined' from `pydantic_core` in this case instead of `None`. This change makes us more strictly use this import if and only if pydantic 2 is being used.

## Test Plan

Manually constructed environment locally w/ `pydantic<2.0.0` and `pydantic-core`, ran tests which failed. Ran tests with change in this PR, tests succeed.