### PR TITLE
limit number of checks to fetch per asset

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -690,7 +690,7 @@ type AssetNode {
   hasMaterializePermission: Boolean!
   hasAssetChecks: Boolean!
   assetChecks: [AssetCheck!]!
-  assetChecksOrError: AssetChecksOrError!
+  assetChecksOrError(limit: Int): AssetChecksOrError!
 }
 
 type MaterializationUpstreamDataVersion {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -386,6 +386,10 @@ export type AssetNode = {
   type: Maybe<DagsterType>;
 };
 
+export type AssetNodeAssetChecksOrErrorArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+};
+
 export type AssetNodeAssetMaterializationUsedDataArgs = {
   timestampMillis: Scalars['String'];
 };

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -284,7 +284,10 @@ class GrapheneAssetNode(graphene.ObjectType):
     hasAssetChecks = graphene.NonNull(graphene.Boolean)
     # this field is deprecated- use assetChecksOrError instead
     assetChecks = non_null_list(GrapheneAssetCheck)
-    assetChecksOrError = graphene.NonNull(GrapheneAssetChecksOrError)
+    assetChecksOrError = graphene.Field(
+        graphene.NonNull(GrapheneAssetChecksOrError),
+        limit=graphene.Argument(graphene.Int),
+    )
 
     class Meta:
         name = "AssetNode"
@@ -1140,8 +1143,12 @@ class GrapheneAssetNode(graphene.ObjectType):
 
         return res.checks
 
-    def resolve_assetChecksOrError(self, graphene_info: ResolveInfo) -> AssetChecksOrErrorUnion:
-        return self._asset_checks_loader.get_checks_for_asset(self._external_asset_node.asset_key)
+    def resolve_assetChecksOrError(
+        self, graphene_info: ResolveInfo, limit=None
+    ) -> AssetChecksOrErrorUnion:
+        return self._asset_checks_loader.get_checks_for_asset(
+            self._external_asset_node.asset_key, limit
+        )
 
 
 class GrapheneAssetGroup(graphene.ObjectType):


### PR DESCRIPTION
Add a limit arg to `assetNode{assetChecksOrError(limit=...`. We'll use this when fetching checks for the asset graph and sidebar. The current plan is to set the limit to 51, and if 51 checks are returned switch to rendering "50+" instead of all the checks.