### PR TITLE
is_subset on AssetsDefinition and OpExecutionContext

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -91,7 +91,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
     _code_versions_by_key: Mapping[AssetKey, Optional[str]]
     _descriptions_by_key: Mapping[AssetKey, str]
     _selected_asset_check_keys: AbstractSet[AssetCheckKey]
-    _is_subsetted: bool
+    _is_subset: bool
 
     def __init__(
         self,
@@ -113,7 +113,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         descriptions_by_key: Optional[Mapping[AssetKey, str]] = None,
         check_specs_by_output_name: Optional[Mapping[str, AssetCheckSpec]] = None,
         selected_asset_check_keys: Optional[AbstractSet[AssetCheckKey]] = None,
-        is_subsetted: bool = False,
+        is_subset: bool = False,
         # if adding new fields, make sure to handle them in the with_attributes, from_graph, and
         # get_attributes_dict methods
     ):
@@ -305,7 +305,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             partitions_def=self._partitions_def,
         )
 
-        self._is_subsetted = check.bool_param(is_subsetted, "is_subsetted")
+        self._is_subset = check.bool_param(is_subset, "is_subset")
 
     @staticmethod
     def dagster_internal_init(
@@ -327,7 +327,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         descriptions_by_key: Optional[Mapping[AssetKey, str]],
         check_specs_by_output_name: Optional[Mapping[str, AssetCheckSpec]],
         selected_asset_check_keys: Optional[AbstractSet[AssetCheckKey]],
-        is_subsetted: bool,
+        is_subset: bool,
     ) -> "AssetsDefinition":
         return AssetsDefinition(
             keys_by_input_name=keys_by_input_name,
@@ -347,7 +347,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             descriptions_by_key=descriptions_by_key,
             check_specs_by_output_name=check_specs_by_output_name,
             selected_asset_check_keys=selected_asset_check_keys,
-            is_subsetted=is_subsetted,
+            is_subset=is_subset,
         )
 
     def __call__(self, *args: object, **kwargs: object) -> object:
@@ -702,7 +702,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             selected_asset_keys=None,  # node has no subselection info
             check_specs_by_output_name=check_specs_by_output_name,
             selected_asset_check_keys=None,
-            is_subsetted=False,
+            is_subset=False,
         )
 
     @public
@@ -967,7 +967,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             Union[AutoMaterializePolicy, Mapping[AssetKey, AutoMaterializePolicy]]
         ] = None,
         backfill_policy: Optional[BackfillPolicy] = None,
-        is_subsetted: bool = False,
+        is_subset: bool = False,
     ) -> "AssetsDefinition":
         output_asset_key_replacements = check.opt_mapping_param(
             output_asset_key_replacements,
@@ -1112,7 +1112,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             auto_materialize_policies_by_key=replaced_auto_materialize_policies_by_key,
             backfill_policy=backfill_policy if backfill_policy else self.backfill_policy,
             descriptions_by_key=replaced_descriptions_by_key,
-            is_subsetted=is_subsetted,
+            is_subset=is_subset,
         )
 
         return self.__class__(**merge_dicts(self.get_attributes_dict(), replaced_attributes))
@@ -1218,7 +1218,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
                 node_def=subsetted_node,
                 asset_deps=subsetted_asset_deps,
                 selected_asset_keys=selected_asset_keys & self.keys,
-                is_subsetted=True,
+                is_subset=True,
             )
 
             return self.__class__(**merge_dicts(self.get_attributes_dict(), replaced_attributes))
@@ -1227,13 +1227,13 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             replaced_attributes = {
                 "selected_asset_keys": asset_subselection,
                 "selected_asset_check_keys": asset_check_subselection,
-                "is_subsetted": True,
+                "is_subset": True,
             }
             return self.__class__(**merge_dicts(self.get_attributes_dict(), replaced_attributes))
 
     @property
-    def is_subsetted(self) -> bool:
-        return self._is_subsetted
+    def is_subset(self) -> bool:
+        return self._is_subset
 
     @public
     def to_source_assets(self) -> Sequence[SourceAsset]:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -483,6 +483,7 @@ class _Asset:
             descriptions_by_key=None,
             check_specs_by_output_name=check_specs_by_output_name,
             selected_asset_check_keys=None,  # no subselection in decorator
+            is_subsetted=False,
         )
 
 
@@ -866,6 +867,7 @@ def multi_asset(
             metadata_by_key=metadata_by_key,
             check_specs_by_output_name=check_specs_by_output_name,
             selected_asset_check_keys=None,  # no subselection in decorator
+            is_subsetted=False,
         )
 
     return inner

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -483,7 +483,7 @@ class _Asset:
             descriptions_by_key=None,
             check_specs_by_output_name=check_specs_by_output_name,
             selected_asset_check_keys=None,  # no subselection in decorator
-            is_subsetted=False,
+            is_subset=False,
         )
 
 
@@ -867,7 +867,7 @@ def multi_asset(
             metadata_by_key=metadata_by_key,
             check_specs_by_output_name=check_specs_by_output_name,
             selected_asset_check_keys=None,  # no subselection in decorator
-            is_subsetted=False,
+            is_subset=False,
         )
 
     return inner

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -625,13 +625,13 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
         return asset_checks_def
 
     @property
-    def is_subsetted(self):
+    def is_subset(self):
         """Whether the current AssetsDefinition is subsetted. Note that this can be True inside a
         a graph asset for an op that's not subsetted, if the graph asset is subsetted elsewhere.
         """
         if not self.has_assets_def:
             return False
-        return self.assets_def.is_subsetted
+        return self.assets_def.is_subset
 
     @public
     @property

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -624,6 +624,15 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
 
         return asset_checks_def
 
+    @property
+    def is_subsetted(self):
+        """Whether the current AssetsDefinition is subsetted. Note that this can be True inside a
+        a graph asset for an op that's not subsetted, if the graph asset is subsetted elsewhere.
+        """
+        if not self.has_assets_def:
+            return False
+        return self.assets_def.is_subsetted
+
     @public
     @property
     def selected_asset_check_keys(self) -> AbstractSet[AssetCheckKey]:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1202,7 +1202,7 @@ def test_graph_backed_asset_subset_context(
     @op(out={"out_1": Out(is_required=False), "out_2": Out(is_required=False)})
     def op_1(context):
         assert context.selected_output_names == selected_output_names_op_1
-        assert (num_materializations != 3) == context.is_subsetted
+        assert (num_materializations != 3) == context.is_subset
         if "out_1" in context.selected_output_names:
             yield Output(1, output_name="out_1")
         if "out_2" in context.selected_output_names:
@@ -1211,7 +1211,7 @@ def test_graph_backed_asset_subset_context(
     @op(out={"add_one_1": Out(is_required=False), "add_one_2": Out(is_required=False)})
     def add_one(context, x):
         assert context.selected_output_names == selected_output_names_op_2
-        assert (num_materializations != 3) == context.is_subsetted
+        assert (num_materializations != 3) == context.is_subset
         if "add_one_1" in context.selected_output_names:
             yield Output(x, output_name="add_one_1")
         if "add_one_2" in context.selected_output_names:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1202,6 +1202,7 @@ def test_graph_backed_asset_subset_context(
     @op(out={"out_1": Out(is_required=False), "out_2": Out(is_required=False)})
     def op_1(context):
         assert context.selected_output_names == selected_output_names_op_1
+        assert (num_materializations != 3) == context.is_subsetted
         if "out_1" in context.selected_output_names:
             yield Output(1, output_name="out_1")
         if "out_2" in context.selected_output_names:
@@ -1210,6 +1211,7 @@ def test_graph_backed_asset_subset_context(
     @op(out={"add_one_1": Out(is_required=False), "add_one_2": Out(is_required=False)})
     def add_one(context, x):
         assert context.selected_output_names == selected_output_names_op_2
+        assert (num_materializations != 3) == context.is_subsetted
         if "add_one_1" in context.selected_output_names:
             yield Output(x, output_name="add_one_1")
         if "add_one_2" in context.selected_output_names:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -1202,7 +1202,7 @@ def test_internal_asset_deps_assets():
     outs={"a": AssetOut(is_required=False), "b": AssetOut(is_required=False)}, can_subset=True
 )
 def ab(context, foo):
-    assert (context.selected_output_names != {"a", "b"}) == context.is_subsetted
+    assert (context.selected_output_names != {"a", "b"}) == context.is_subset
 
     if "a" in context.selected_output_names:
         yield Output(foo + 1, "a")
@@ -2233,7 +2233,7 @@ def _get_assets_defs(use_multi: bool = False, allow_subset: bool = False):
         can_subset=allow_subset,
     )
     def abc_(context, start):
-        assert (context.selected_output_names != {"a", "b", "c"}) == context.is_subsetted
+        assert (context.selected_output_names != {"a", "b", "c"}) == context.is_subset
 
         a = (start + 1) if start else None
         b = 1
@@ -2270,7 +2270,7 @@ def _get_assets_defs(use_multi: bool = False, allow_subset: bool = False):
         can_subset=allow_subset,
     )
     def def_(context, a, b, c):
-        assert (context.selected_output_names != {"d", "e", "f"}) == context.is_subsetted
+        assert (context.selected_output_names != {"d", "e", "f"}) == context.is_subset
 
         d = (a + b) if a and b else None
         e = (c + 1) if c else None
@@ -2609,7 +2609,7 @@ def test_subset_cycle_resolution_embed_assets_in_complex_graph():
     def foo(context, x, y):
         assert (
             context.selected_output_names != {"a", "b", "c", "d", "e", "f", "g", "h"}
-        ) == context.is_subsetted
+        ) == context.is_subset
 
         a = b = c = d = e = f = g = h = None
         if "a" in context.selected_output_names:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -1202,6 +1202,8 @@ def test_internal_asset_deps_assets():
     outs={"a": AssetOut(is_required=False), "b": AssetOut(is_required=False)}, can_subset=True
 )
 def ab(context, foo):
+    assert (context.selected_output_names != {"a", "b"}) == context.is_subsetted
+
     if "a" in context.selected_output_names:
         yield Output(foo + 1, "a")
     if "b" in context.selected_output_names:
@@ -2231,6 +2233,8 @@ def _get_assets_defs(use_multi: bool = False, allow_subset: bool = False):
         can_subset=allow_subset,
     )
     def abc_(context, start):
+        assert (context.selected_output_names != {"a", "b", "c"}) == context.is_subsetted
+
         a = (start + 1) if start else None
         b = 1
         c = b + 1
@@ -2266,6 +2270,8 @@ def _get_assets_defs(use_multi: bool = False, allow_subset: bool = False):
         can_subset=allow_subset,
     )
     def def_(context, a, b, c):
+        assert (context.selected_output_names != {"d", "e", "f"}) == context.is_subsetted
+
         d = (a + b) if a and b else None
         e = (c + 1) if c else None
         f = (d + e) if d and e else None
@@ -2601,6 +2607,10 @@ def test_subset_cycle_resolution_embed_assets_in_complex_graph():
         can_subset=True,
     )
     def foo(context, x, y):
+        assert (
+            context.selected_output_names != {"a", "b", "c", "d", "e", "f", "g", "h"}
+        ) == context.is_subsetted
+
         a = b = c = d = e = f = g = h = None
         if "a" in context.selected_output_names:
             a = 1


### PR DESCRIPTION
Surface a new `is_subset` on the context. In the next diff I'll use this with dagster-dbt in place of https://github.com/dagster-io/dagster/blob/johann/11-01-is_subsetted_on_AssetsDefinition/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py#L973-L977.

We could try to derive is_subsetted by comparing to something like node_keys_by_output_name instead of setting it explicitly. I think either approach has risk of getting out of sync.

Added tests on multi_asset and graph_asset