### PR TITLE
Change migration guide to use ConfigurableResource as factory

### DIFF
--- a/docs/content/guides/dagster/migrating-to-pythonic-resources-and-config.mdx
+++ b/docs/content/guides/dagster/migrating-to-pythonic-resources-and-config.mdx
@@ -221,21 +221,20 @@ def existing_asset(context) -> None:
     context.resources.fancy_db.execute_query("SELECT * FROM foo")
 ```
 
-With Pythonic-style resources you would write a class that can return that client from a method. In code that consumes that resource you would call that method to access the underlying client.
+With Pythonic-style resources you would write `ConfigurableResource` subclass that overrides `create_resource` to return the original object type
 
 ```python file=/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py  startafter=begin_new_third_party_resource endbefore=end_new_third_party_resource dedent=4
-from dagster import ConfigurableResource, asset
+from dagster import ConfigurableResource, ResourceParam, asset
 
 class FancyDbResource(ConfigurableResource):
     conn_string: str
 
-    def get_client(self) -> FancyDbClient:
+    def create_resource(self, context) -> FancyDbClient:
         return FancyDbClient(self.conn_string)
 
 @asset
-def new_asset(fancy_db: FancyDbResource) -> None:
-    client = fancy_db.get_client()
-    client.execute_query("SELECT * FROM foo")
+def new_asset(fancy_db: ResourceParam[FancyDbClient]) -> None:
+    fancy_db.execute_query("SELECT * FROM foo")
 ```
 
 ### Resources with context managers
@@ -283,47 +282,6 @@ class FancyDbResource(ConfigurableResource):
 def asset_one(fancy_db: FancyDbResource) -> None:
     with fancy_db.get_client() as client:
         client.execute_query("SELECT * FROM foo")
-```
-
-### Migrating code with resources with separate business objects
-
-While there are benefits to managing object access in a resource rather than having the `@resource` factory function return the object, this does present a problem with performing an at-scale migration. The old code will expect the business object on the `context` object while the new code will expect the enclosing resource object when it's accessed as a parameter.
-
-```python file=/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py  startafter=begin_broken_unmigrated_code endbefore=end_broken_unmigrated_code dedent=4
-@asset(required_resource_keys={"fancy_db"})
-def existing_asset(context) -> None:
-    # This code is now broken because the resource is no longer a FancyDbClient
-    # but it is a FancyDbResource.
-    context.resources.fancy_db.execute_query("SELECT * FROM foo")
-```
-
-Ultimately, we want the underlying client to reside in the context of the old code, but in the new code, have the new resource passed to the asset.
-
-You can accomplish this by using Dagster's framework support, `IAttachDifferentObjectToOpContext`. Implementing this interface allows you to instruct the framework to place a different object on the context object.
-
-This framework can be implemented while you migrate your code, so that both new and old code can co-exist:
-
-```python file=/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py  startafter=begin_new_third_party_resource_with_interface endbefore=end_new_third_party_resource_with_interface dedent=4    return FancyDbClient(self.conn_string)
-from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, asset
-
-class FancyDbResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
-    conn_string: str
-
-    def get_object_to_set_on_execution_context(self) -> FancyDbClient:
-        return self.get_client()
-
-    def get_client(self) -> FancyDbClient:
-        return FancyDbClient(self.conn_string)
-
-@asset
-def new_asset(fancy_db: FancyDbResource) -> None:
-    client = fancy_db.get_client()
-    client.execute_query("SELECT * FROM foo")
-
-@asset(required_resource_keys={"fancy_db"})
-def existing_asset(context) -> None:
-    # This code now works because context.resources.fancy_db is now a FancyDbClient
-    context.resources.fancy_db.execute_query("SELECT * FROM foo")
 ```
 
 ---

--- a/docs/content/guides/dagster/migrating-to-pythonic-resources-and-config.mdx
+++ b/docs/content/guides/dagster/migrating-to-pythonic-resources-and-config.mdx
@@ -260,18 +260,18 @@ def asset_one(context) -> None:
     context.resources.fancy_db.execute_query("SELECT * FROM foo")
 ```
 
-This could cause confusion and difficult-to-understand stack traces. With Pythonic resources, you can manage this directly in the body of the asset or op:
+This is also supported when using `ConfigurableResource` as a factory. You can override `yield_for_execution` which allows you to use a context manager to yield an object of a different type at runtime.
 
 ```python file=/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py  startafter=begin_new_resource_code_contextmanager endbefore=end_new_resource_code_contextmanager dedent=4
 from contextlib import contextmanager
 
-from dagster import ConfigurableResource, asset
+from dagster import ConfigurableResource, ResourceParam, asset
 
-class FancyDbResource(ConfigurableResource):
+class FancyDbResource(ConfigurableResource[FancyDbClient]):
     conn_string: str
 
     @contextmanager
-    def get_client(self) -> Iterator[FancyDbClient]:
+    def yield_for_execution(self, context) -> Iterator[FancyDbClient]:
         try:
             some_expensive_setup()
             yield FancyDbClient(self.conn_string)
@@ -279,9 +279,8 @@ class FancyDbResource(ConfigurableResource):
             some_expensive_teardown()
 
 @asset
-def asset_one(fancy_db: FancyDbResource) -> None:
-    with fancy_db.get_client() as client:
-        client.execute_query("SELECT * FROM foo")
+def asset_one(fancy_db: ResourceParam[FancyDbClient]) -> None:
+    fancy_db.execute_query("SELECT * FROM foo")
 ```
 
 ---

--- a/examples/docs_snippets/docs_snippets/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py
@@ -216,13 +216,13 @@ def new_resource_code_contextmanager() -> Definitions:
 
     from contextlib import contextmanager
 
-    from dagster import ConfigurableResource, asset
+    from dagster import ConfigurableResource, ResourceParam, asset
 
-    class FancyDbResource(ConfigurableResource):
+    class FancyDbResource(ConfigurableResource[FancyDbClient]):
         conn_string: str
 
         @contextmanager
-        def get_client(self) -> Iterator[FancyDbClient]:
+        def yield_for_execution(self, context) -> Iterator[FancyDbClient]:
             try:
                 some_expensive_setup()
                 yield FancyDbClient(self.conn_string)
@@ -230,9 +230,8 @@ def new_resource_code_contextmanager() -> Definitions:
                 some_expensive_teardown()
 
     @asset
-    def asset_one(fancy_db: FancyDbResource) -> None:
-        with fancy_db.get_client() as client:
-            client.execute_query("SELECT * FROM foo")
+    def asset_one(fancy_db: ResourceParam[FancyDbClient]) -> None:
+        fancy_db.execute_query("SELECT * FROM foo")
 
     # end_new_resource_code_contextmanager
 

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/migrating_to_python_resources_and_config_tests/test_migrating_resources.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/migrating_to_python_resources_and_config_tests/test_migrating_resources.py
@@ -4,8 +4,7 @@ from docs_snippets.guides.dagster.migrating_to_python_resources_and_config.migra
     new_resource_code_contextmanager,
     new_style_resource_on_context,
     new_style_resource_on_param,
-    new_third_party_resource_fixed,
-    new_third_party_resource_old_code_broken,
+    new_third_party_resource_factory_pattern,
     old_resource_code_contextmanager,
     old_third_party_resource,
 )
@@ -43,19 +42,6 @@ def test_new_resource_code_contextmanager() -> None:
     assert defs.get_implicit_global_asset_job_def().execute_in_process().success
 
 
-def test_new_third_party_resource_old_code_broken() -> None:
-    defs = new_third_party_resource_old_code_broken()
-
+def test_new_third_party_resource_factory_pattern() -> None:
+    defs = new_third_party_resource_factory_pattern()
     assert defs.get_job_def("new_asset_job").execute_in_process().success
-    assert (
-        not defs.get_job_def("existing_asset_job")
-        .execute_in_process(raise_on_error=False)
-        .success
-    )
-
-
-def test_new_third_party_resource_fixed() -> None:
-    defs = new_third_party_resource_fixed()
-
-    assert defs.get_job_def("new_asset_job").execute_in_process().success
-    assert defs.get_job_def("existing_asset_job").execute_in_process().success


### PR DESCRIPTION
## Summary & Motivation

If we are going to officially document and support using `ConfigurableResource` as a factory, we can use it in the migration guide. We can also drop the usage of `IAttachDifferentObjectToOpContext` which was always zany and weird.
 
## How I Tested These Changes

Read. Unit tests to test docs snippet.
