### PR TITLE
[auto-materialize] Change behavior of unpartitioned->dynamic partitioned

### DIFF
--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -28,7 +28,7 @@ from dagster._core.definitions.data_version import (
     extract_data_version_from_entry,
 )
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
-from dagster._core.definitions.partition import DynamicPartitionsDefinition, PartitionsSubset
+from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsDefinition,
     get_time_partition_key,

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -828,12 +828,10 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             ):
                 continue
 
-            # when mapping from time or dynamic downstream to unpartitioned upstream, only check
-            # for updates to the latest upstream partition
+            # when mapping from unpartitioned assets to time partitioned assets, we ignore
+            # historical time partitions
             if (
-                isinstance(
-                    partitions_def, (TimeWindowPartitionsDefinition, DynamicPartitionsDefinition)
-                )
+                isinstance(partitions_def, TimeWindowPartitionsDefinition)
                 and not self.asset_graph.is_partitioned(parent_key)
                 and asset_partition.partition_key
                 != partitions_def.get_last_partition_key(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -291,6 +291,14 @@ class AssetDaemonScenarioState(NamedTuple):
             ]
         )
 
+    def with_dynamic_partitions(
+        self, partitions_def_name: str, partition_keys: Sequence[str]
+    ) -> "AssetDaemonScenarioState":
+        self.instance.add_dynamic_partitions(
+            partitions_def_name=partitions_def_name, partition_keys=partition_keys
+        )
+        return self
+
     def _evaluate_tick_fast(
         self,
     ) -> Tuple[Sequence[RunRequest], AssetDaemonCursor, Sequence[AutoMaterializeAssetEvaluation]]:

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario_states.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario_states.py
@@ -1,5 +1,6 @@
 from dagster import AssetSpec, StaticPartitionsDefinition
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
+from dagster._core.definitions.partition import DynamicPartitionsDefinition
 from dagster._core.definitions.time_window_partitions import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
@@ -46,3 +47,4 @@ time_multipartitions_def = MultiPartitionsDefinition(
 static_multipartitions_def = MultiPartitionsDefinition(
     {"static1": two_partitions_def, "static2": two_partitions_def}
 )
+dynamic_partitions_def = DynamicPartitionsDefinition(name="dynamic")


### PR DESCRIPTION
## Summary & Motivation

Right now, if you have `A(unpartitioned) -> B(dynamic partitioned)`, and A updates, we treat this as if only the latest dynamic partition should update. This is a bit of an arbitrary choice (it more sense for time-partitioned assets), but arguably, we should treat these more like static partitioned assets.

Realistically, this just adds to the evidence that it'd be nice to have some sort of partition mapping concept that could represent these sorts of connections.

## How I Tested These Changes
