### PR TITLE
Fix the cursor comparison

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -108,7 +108,7 @@ def get_assets(
         asset_key: asset_node
         for asset_key, asset_node in get_asset_nodes_by_asset_key(graphene_info).items()
         if (not prefix or asset_key.path[: len(prefix)] == prefix)
-        and (not cursor or asset_key.to_string() > cursor)
+        and (not cursor or asset_key.to_string() > normalized_cursor_str)
     }
 
     asset_keys = sorted(set(materialized_keys).union(asset_nodes_by_asset_key.keys()), key=str)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -108,7 +108,7 @@ def get_assets(
         asset_key: asset_node
         for asset_key, asset_node in get_asset_nodes_by_asset_key(graphene_info).items()
         if (not prefix or asset_key.path[: len(prefix)] == prefix)
-        and (not cursor or asset_key.to_string() > normalized_cursor_str)
+        and (not normalized_cursor_str or asset_key.to_string() > normalized_cursor_str)
     }
 
     asset_keys = sorted(set(materialized_keys).union(asset_nodes_by_asset_key.keys()), key=str)


### PR DESCRIPTION
Compare with the normalized cursor instead of user supplied one

## Summary & Motivation

As other code locations nearby state correctly - cursor value can differ between semantically equivalent json serialization formats.
This one code expression does not use normalized value, so it will return invalid results.

## How I Tested These Changes

Locally, there needs to be a unittest added.