### PR TITLE
remove executions resolver on GrapheneAssetCheck

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -865,7 +865,6 @@ type AssetCheck {
   name: String!
   assetKey: AssetKey!
   description: String
-  executions(limit: Int!, cursor: String): [AssetCheckExecution!]!
   executionForLatestMaterialization: AssetCheckExecution
   canExecuteIndividually: AssetCheckCanExecuteIndividually!
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -130,13 +130,7 @@ export type AssetCheck = {
   canExecuteIndividually: AssetCheckCanExecuteIndividually;
   description: Maybe<Scalars['String']>;
   executionForLatestMaterialization: Maybe<AssetCheckExecution>;
-  executions: Array<AssetCheckExecution>;
   name: Scalars['String'];
-};
-
-export type AssetCheckExecutionsArgs = {
-  cursor?: InputMaybe<Scalars['String']>;
-  limit: Scalars['Int'];
 };
 
 export enum AssetCheckCanExecuteIndividually {
@@ -4637,7 +4631,6 @@ export const buildAssetCheck = (
         : relationshipsToOmit.has('AssetCheckExecution')
         ? ({} as AssetCheckExecution)
         : buildAssetCheckExecution({}, relationshipsToOmit),
-    executions: overrides && overrides.hasOwnProperty('executions') ? overrides.executions! : [],
     name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : 'dignissimos',
   };
 };

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Optional, Union, cast
 
 import dagster._check as check
 import graphene
@@ -132,12 +132,6 @@ class GrapheneAssetCheck(graphene.ObjectType):
     name = graphene.NonNull(graphene.String)
     assetKey = graphene.NonNull(GrapheneAssetKey)
     description = graphene.String()
-    # deprecated. Use the top level assetCheckExecutions resolver instead
-    executions = graphene.Field(
-        non_null_list(GrapheneAssetCheckExecution),
-        limit=graphene.NonNull(graphene.Int),
-        cursor=graphene.String(),
-    )
     executionForLatestMaterialization = graphene.Field(GrapheneAssetCheckExecution)
     canExecuteIndividually = graphene.NonNull(GrapheneAssetCheckCanExecuteIndividually)
 
@@ -162,20 +156,6 @@ class GrapheneAssetCheck(graphene.ObjectType):
 
     def resolve_description(self, _) -> Optional[str]:
         return self._asset_check.description
-
-    def resolve_executions(
-        self, graphene_info: ResolveInfo, **kwargs
-    ) -> List[GrapheneAssetCheckExecution]:
-        from dagster_graphql.implementation.fetch_asset_checks import (
-            fetch_asset_check_executions,
-        )
-
-        return fetch_asset_check_executions(
-            graphene_info.context.instance,
-            self._asset_check.key,
-            kwargs["limit"],
-            kwargs.get("cursor"),
-        )
 
     def resolve_executionForLatestMaterialization(
         self, _graphene_info: ResolveInfo


### PR DESCRIPTION
Replaced by top level assetCheckExecutions resolver