### PR TITLE
[2/n subset refactor] Make TimeWindowPartitionsDefinition serializable

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -84,6 +84,10 @@ class TimeWindow(NamedTuple):
     end: PublicAttr[datetime]
 
 
+# Unfortunately we can't use @whitelist_for_serdes on TimeWindowPartitionsDefinition
+# because args to __new__ are a different order than the fields in the NamedTuple, and we can't
+# reorder them because it's a public API. Until TimeWindowPartitionsDefinition can decorated,
+# this class is used to serialize it.
 @whitelist_for_serdes(
     field_serializers={"start": DatetimeFieldSerializer, "end": DatetimeFieldSerializer}
 )
@@ -222,6 +226,8 @@ class TimeWindowPartitionsDefinition(
                 " TimeWindowPartitionsDefinition."
             )
 
+        # When adding new fields to the NamedTuple, update the SerializableTimeWindowPartitionsDefinition
+        # class with the same fields.
         return super(TimeWindowPartitionsDefinition, cls).__new__(
             cls, start_dt, timezone, end_dt, fmt, end_offset, cron_schedule
         )

--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -208,7 +208,7 @@ def whitelist_for_serdes(
     old_fields: Optional[Mapping[str, JsonSerializableValue]] = ...,
     skip_when_empty_fields: Optional[AbstractSet[str]] = ...,
     field_serializers: Optional[Mapping[str, Type["FieldSerializer"]]] = None,
-    require_args_to_match_field_ordering: bool = True,
+    is_pickleable: bool = True,
 ) -> Callable[[T_Type], T_Type]:
     ...
 
@@ -223,7 +223,7 @@ def whitelist_for_serdes(
     old_fields: Optional[Mapping[str, JsonSerializableValue]] = None,
     skip_when_empty_fields: Optional[AbstractSet[str]] = None,
     field_serializers: Optional[Mapping[str, Type["FieldSerializer"]]] = None,
-    require_args_to_match_field_ordering: bool = True,
+    is_pickleable: bool = True,
 ) -> Union[T_Type, Callable[[T_Type], T_Type]]:
     """Decorator to whitelist a NamedTuple or Enum subclass to be serializable. Various arguments can be passed
     to alter serialization behavior for backcompat purposes.
@@ -280,7 +280,7 @@ def whitelist_for_serdes(
         check.class_param(__cls, "__cls")
         return _whitelist_for_serdes(
             whitelist_map=_WHITELIST_MAP,
-            require_args_to_match_field_ordering=require_args_to_match_field_ordering,
+            is_pickleable=is_pickleable,
         )(__cls)
     else:  # decorator passed params
         check.opt_class_param(serializer, "serializer", superclass=Serializer)
@@ -293,7 +293,7 @@ def whitelist_for_serdes(
             old_fields=old_fields,
             skip_when_empty_fields=skip_when_empty_fields,
             field_serializers=field_serializers,
-            require_args_to_match_field_ordering=require_args_to_match_field_ordering,
+            is_pickleable=is_pickleable,
         )
 
 
@@ -306,7 +306,7 @@ def _whitelist_for_serdes(
     old_fields: Optional[Mapping[str, JsonSerializableValue]] = None,
     skip_when_empty_fields: Optional[AbstractSet[str]] = None,
     field_serializers: Optional[Mapping[str, Type["FieldSerializer"]]] = None,
-    require_args_to_match_field_ordering: bool = True,
+    is_pickleable: bool = True,
 ) -> Callable[[T_Type], T_Type]:
     def __whitelist_for_serdes(klass: T_Type) -> T_Type:
         if issubclass(klass, Enum) and (
@@ -323,9 +323,7 @@ def _whitelist_for_serdes(
         elif is_named_tuple_subclass(klass) and (
             serializer is None or issubclass(serializer, NamedTupleSerializer)
         ):
-            _check_serdes_tuple_class_invariants(
-                klass, require_args_to_match_field_ordering=require_args_to_match_field_ordering
-            )
+            _check_serdes_tuple_class_invariants(klass, is_pickleable=is_pickleable)
             whitelist_map.register_tuple(
                 klass.__name__,
                 klass,
@@ -942,7 +940,7 @@ def _unpack_value(
 
 
 def _check_serdes_tuple_class_invariants(
-    klass: Type[NamedTuple], require_args_to_match_field_ordering: bool = True
+    klass: Type[NamedTuple], is_pickleable: bool = True
 ) -> None:
     sig_params = signature(klass.__new__).parameters
     dunder_new_params = list(sig_params.values())
@@ -971,7 +969,7 @@ def _check_serdes_tuple_class_invariants(
 
             raise SerdesUsageError(_with_header(error_msg))
 
-        if require_args_to_match_field_ordering:
+        if is_pickleable:
             value_param = value_params[index]
             if value_param.name != field:
                 error_msg = (

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -25,6 +25,7 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
     TimeWindowPartitionsSubset,
 )
+from dagster._serdes import deserialize_value, serialize_value
 from dagster._seven.compat.pendulum import create_pendulum_time
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
 
@@ -1310,3 +1311,25 @@ def test_partition_with_end_date(
     assert partitions_def.has_partition_key(first_partition_window[0])
     assert partitions_def.has_partition_key(last_partition_window[0])
     assert not partitions_def.has_partition_key(last_partition_window[1])
+
+
+@pytest.mark.parametrize(
+    "partitions_def",
+    [
+        (DailyPartitionsDefinition("2023-01-01", timezone="America/New_York")),
+        (DailyPartitionsDefinition("2023-01-01", timezone="America/New_York")),
+    ],
+)
+def test_time_window_partitions_def_serialization(partitions_def):
+    time_window_partitions_def = TimeWindowPartitionsDefinition(
+        start=partitions_def.start,
+        end=partitions_def.end,
+        cron_schedule="0 0 * * *",
+        fmt="%Y-%m-%d",
+        timezone=partitions_def.timezone,
+        end_offset=partitions_def.end_offset,
+    )
+    deserialized = deserialize_value(
+        serialize_value(time_window_partitions_def), TimeWindowPartitionsDefinition
+    )
+    assert deserialized == time_window_partitions_def

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1330,8 +1330,5 @@ def test_time_window_partitions_def_serialization(partitions_def):
         end_offset=partitions_def.end_offset,
     )
     assert (
-        deserialize_value(
-            serialize_value(time_window_partitions_def.to_serializable_time_window_partitions_def())
-        ).to_time_window_partitions_def()
-        == time_window_partitions_def
+        deserialize_value(serialize_value(time_window_partitions_def)) == time_window_partitions_def
     )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1329,7 +1329,9 @@ def test_time_window_partitions_def_serialization(partitions_def):
         timezone=partitions_def.timezone,
         end_offset=partitions_def.end_offset,
     )
-    deserialized = deserialize_value(
-        serialize_value(time_window_partitions_def), TimeWindowPartitionsDefinition
+    assert (
+        deserialize_value(
+            serialize_value(time_window_partitions_def.to_serializable_time_window_partitions_def())
+        ).to_time_window_partitions_def()
+        == time_window_partitions_def
     )
-    assert deserialized == time_window_partitions_def

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1317,7 +1317,7 @@ def test_partition_with_end_date(
     "partitions_def",
     [
         (DailyPartitionsDefinition("2023-01-01", timezone="America/New_York")),
-        (DailyPartitionsDefinition("2023-01-01", timezone="America/New_York")),
+        (DailyPartitionsDefinition("2023-01-01")),
     ],
 )
 def test_time_window_partitions_def_serialization(partitions_def):


### PR DESCRIPTION
This PR supports serializing `TimeWindowPartitionsDefinition` objects.

`whitelist_for_serdes` enforces a constraint where the arguments to `__new__` must match the ordering of fields in the named tuple. This constraint is required to pack and unpack objects properly during pickling. 

Unfortunately this ordering doesn't match in `TimeWindowPartitionsDefinition`, and we can't reorder the fields without breaking users :( This PR loosens the ordering restriction via a new `is_pickleable` arg, and raises an error when attempting to pickle a `TimeWindowPartitionsDefinition`.