### PR TITLE
[execute_job] tidy up rexecution from failure

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/state.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/state.py
@@ -15,14 +15,18 @@ from typing import (
 from typing_extensions import TypeAlias
 
 import dagster._check as check
-from dagster._core.errors import DagsterExecutionPlanSnapshotNotFoundError, DagsterRunNotFoundError
+from dagster._core.errors import (
+    DagsterExecutionPlanSnapshotNotFoundError,
+    DagsterInvariantViolationError,
+    DagsterRunNotFoundError,
+)
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.plan.handle import StepHandle, UnresolvedStepHandle
 from dagster._core.execution.plan.outputs import StepOutputHandle
 from dagster._core.execution.plan.step import ResolvedFromDynamicStepHandle
 from dagster._core.execution.retries import RetryState
 from dagster._core.instance import DagsterInstance
-from dagster._core.storage.dagster_run import DagsterRun
+from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._serdes import whitelist_for_serdes
 
 if TYPE_CHECKING:
@@ -155,6 +159,11 @@ class KnownExecutionState(
         instance: DagsterInstance,
         parent_run: DagsterRun,
     ) -> Tuple[Sequence[str], "KnownExecutionState"]:
+        if parent_run.status not in (DagsterRunStatus.FAILURE, DagsterRunStatus.CANCELED):
+            raise DagsterInvariantViolationError(
+                "Cannot reexecute from failure a run that is not failed or canceled",
+            )
+
         steps_to_retry, known_state = _derive_state_from_logs(instance, parent_run)
         return steps_to_retry, known_state.update_for_step_selection(steps_to_retry)
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1581,11 +1581,6 @@ class DagsterInstance(DynamicPartitionsStore):
         run_config = run_config if run_config is not None else parent_run.run_config
 
         if strategy == ReexecutionStrategy.FROM_FAILURE:
-            if parent_run.status != DagsterRunStatus.FAILURE:
-                raise DagsterInvariantViolationError(
-                    "Cannot reexecute from failure a run that is not failed",
-                )
-
             (
                 step_keys_to_execute,
                 known_state,

--- a/python_modules/dagster/dagster_tests/execution_tests/test_execute_job.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_execute_job.py
@@ -260,7 +260,11 @@ def test_reexecute_from_failure_successful_run(instance):
         assert result.success
 
     with pytest.raises(DagsterInvariantViolationError, match="run that is not failed"):
-        ReexecutionOptions.from_failure(result.run_id, instance)
+        execute_job(
+            reconstructable(emit_job),
+            instance,
+            reexecution_options=ReexecutionOptions.from_failure(result.run_id, instance),
+        )
 
 
 def highly_nested_job():


### PR DESCRIPTION
Bumped up against this, had an idea for how to resolve it and reduce the number of callsites where we build execution state.

## How I Tested These Changes

existing tests