### PR TITLE
[graphql] refactor rexecution code

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1536,7 +1536,8 @@ class DagsterInstance(DynamicPartitionsStore):
         parent_run: DagsterRun,
         code_location: "CodeLocation",
         external_job: "ExternalJob",
-        strategy: "ReexecutionStrategy",
+        strategy: Optional["ReexecutionStrategy"],
+        step_keys_to_execute: Optional[Sequence[str]] = None,
         extra_tags: Optional[Mapping[str, Any]] = None,
         run_config: Optional[Mapping[str, Any]] = None,
         use_parent_run_tags: bool = False,
@@ -1591,6 +1592,12 @@ class DagsterInstance(DynamicPartitionsStore):
         elif strategy == ReexecutionStrategy.ALL_STEPS:
             step_keys_to_execute = None
             known_state = None
+        elif strategy is None:
+            if not step_keys_to_execute:
+                raise DagsterInvariantViolationError(
+                    "Expected step_keys_to_execute with no reexecution strategy"
+                )
+            known_state = KnownExecutionState.build_for_reexecution(self, parent_run)
         else:
             raise DagsterInvariantViolationError(f"Unknown reexecution strategy: {strategy}")
 


### PR DESCRIPTION
trying to reduce callsites that build execution state

There are two code paths for triggering retry-from-failure:
* the newer: when `reexecutionParams` are set with the `strategy` 
* the original: when we see the "resume retry" tag and assert the additional `executionMetadata` for lineage is set correctly 

This attempts to consolidate to just the newer entry point 

## How I Tested These Changes

existing suite