### PR TITLE
Revert "Better fix for to_timezone in pendulum (#17563)"

### DIFF
--- a/python_modules/dagster/dagster/_seven/compat/pendulum.py
+++ b/python_modules/dagster/dagster/_seven/compat/pendulum.py
@@ -54,5 +54,4 @@ PendulumDateTime: TypeAlias = (
 # Workaround for issue with .in_tz() in pendulum:
 # https://github.com/sdispater/pendulum/issues/535
 def to_timezone(dt: PendulumDateTime, tz: str):
-    timezone = pendulum.timezone(tz)
-    return timezone.convert(dt)
+    return pendulum.from_timestamp(dt.timestamp(), tz=tz)


### PR DESCRIPTION
This reverts commit 656fd36923913fef355a174620c1be4aa12bde48. This ended up failing tests once they were covering more DST edge cases - it seems calling tz.convert without explicitly passing in a dst_rule runs into the same problem as the linked github issue.

Test Plan: BK (fixes test failure in https://github.com/dagster-io/dagster/pull/17547)

## Summary & Motivation

## How I Tested These Changes
