### PR TITLE
[1/n subset refactor] Split TimeWindowPartitionsSubset

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -36,6 +36,7 @@ from dagster._core.definitions.partition import (
     PartitionsSubset,
 )
 from dagster._core.definitions.time_window_partitions import (
+    BaseTimeWindowPartitionsSubset,
     PartitionRangeStatus,
     TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,
@@ -127,7 +128,7 @@ def get_assets(
 
 
 def repository_iter(
-    context: WorkspaceRequestContext
+    context: WorkspaceRequestContext,
 ) -> Iterator[Tuple[CodeLocation, ExternalRepository]]:
     for location in context.code_locations:
         for repository in location.get_repositories().values():
@@ -453,7 +454,7 @@ def build_partition_statuses(
         " in_progress_partitions_subset to be of the same type",
     )
 
-    if isinstance(materialized_partitions_subset, TimeWindowPartitionsSubset):
+    if isinstance(materialized_partitions_subset, BaseTimeWindowPartitionsSubset):
         ranges = fetch_flattened_time_window_ranges(
             {
                 PartitionRangeStatus.MATERIALIZED: materialized_partitions_subset,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -6,7 +6,7 @@ from dagster import AssetKey
 from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPolicyType
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
-    TimeWindowPartitionsSubset,
+    BaseTimeWindowPartitionsSubset,
 )
 from dagster._core.execution.asset_backfill import (
     AssetBackfillStatus,
@@ -130,7 +130,7 @@ class GrapheneAssetBackfillTargetPartitions(graphene.ObjectType):
     def __init__(self, partition_subset: PartitionsSubset):
         from dagster_graphql.schema.partition_sets import GraphenePartitionKeyRange
 
-        if isinstance(partition_subset, TimeWindowPartitionsSubset):
+        if isinstance(partition_subset, BaseTimeWindowPartitionsSubset):
             ranges = [
                 GraphenePartitionKeyRange(start, end)
                 for start, end in partition_subset.get_partition_key_ranges()

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -28,8 +28,8 @@ from dagster._core.definitions.data_version import (
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessMinutes
 from dagster._core.definitions.time_window_partitions import (
+    BaseTimeWindowPartitionsSubset,
     TimeWindowPartitionsDefinition,
-    TimeWindowPartitionsSubset,
 )
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import EventLogRecord
@@ -89,7 +89,7 @@ class CachingDataTimeResolver:
             )
         )
 
-        if not isinstance(partition_subset, TimeWindowPartitionsSubset):
+        if not isinstance(partition_subset, BaseTimeWindowPartitionsSubset):
             check.failed(f"Invalid partition subset {type(partition_subset)}")
 
         sorted_time_windows = sorted(partition_subset.included_time_windows)

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -6,6 +6,7 @@ from dagster._annotations import PublicAttr, experimental_param
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_mapping import PartitionMapping, UpstreamPartitionsResult
 from dagster._core.definitions.time_window_partitions import (
+    BaseTimeWindowPartitionsSubset,
     TimeWindow,
     TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,
@@ -111,8 +112,8 @@ class TimeWindowPartitionMapping(
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> UpstreamPartitionsResult:
-        if not isinstance(downstream_partitions_subset, TimeWindowPartitionsSubset):
-            check.failed("downstream_partitions_subset must be a TimeWindowPartitionsSubset")
+        if not isinstance(downstream_partitions_subset, BaseTimeWindowPartitionsSubset):
+            check.failed("downstream_partitions_subset must be a BaseTimeWindowPartitionsSubset")
 
         return self._map_partitions(
             downstream_partitions_subset.partitions_def,
@@ -161,8 +162,8 @@ class TimeWindowPartitionMapping(
         the filtered subset, also returning a bool indicating whether there were mapped time windows
         that did not exist in to_partitions_def.
         """
-        if not isinstance(from_partitions_subset, TimeWindowPartitionsSubset):
-            check.failed("from_partitions_subset must be a TimeWindowPartitionsSubset")
+        if not isinstance(from_partitions_subset, BaseTimeWindowPartitionsSubset):
+            check.failed("from_partitions_subset must be a BaseTimeWindowPartitionsSubset")
 
         if not isinstance(from_partitions_def, TimeWindowPartitionsDefinition):
             check.failed("from_partitions_def must be a TimeWindowPartitionsDefinition")
@@ -303,7 +304,7 @@ class TimeWindowPartitionMapping(
         self,
         from_partitions_def: TimeWindowPartitionsDefinition,
         to_partitions_def: TimeWindowPartitionsDefinition,
-        from_partitions_subset: TimeWindowPartitionsSubset,
+        from_partitions_subset: BaseTimeWindowPartitionsSubset,
         start_offset: int,
         end_offset: int,
         current_time: Optional[datetime],

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -734,7 +734,7 @@ class TimeWindowPartitionsDefinition(
 
     @property
     def partitions_subset_class(self) -> Type["PartitionsSubset"]:
-        return UnresolvedTimeWindowPartitionsSubset
+        return TimePartitionKeyPartitionsSubset
 
     def empty_subset(self) -> "PartitionsSubset":
         return self.partitions_subset_class.empty_subset(self)
@@ -1647,7 +1647,7 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
         )
 
 
-class UnresolvedTimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
+class TimePartitionKeyPartitionsSubset(BaseTimeWindowPartitionsSubset):
     def __init__(
         self,
         partitions_def: TimeWindowPartitionsDefinition,
@@ -1664,7 +1664,7 @@ class UnresolvedTimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
         self, partition_keys: Iterable[str]
     ) -> "BaseTimeWindowPartitionsSubset":
         new_partitions = {*(self._included_partition_keys or []), *partition_keys}
-        return UnresolvedTimeWindowPartitionsSubset(
+        return TimePartitionKeyPartitionsSubset(
             self._partitions_def,
             included_partition_keys=new_partitions,
         )
@@ -1744,10 +1744,10 @@ class UnresolvedTimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
 
     def __eq__(self, other):
         return (
-            isinstance(other, UnresolvedTimeWindowPartitionsSubset)
+            isinstance(other, TimePartitionKeyPartitionsSubset)
             and self.partitions_def == other.partitions_def
             and self._included_partition_keys == other._included_partition_keys
-        ) or super(UnresolvedTimeWindowPartitionsSubset, self).__eq__(other)
+        ) or super(TimePartitionKeyPartitionsSubset, self).__eq__(other)
 
     @classmethod
     def empty_subset(cls, partitions_def: PartitionsDefinition) -> "PartitionsSubset":
@@ -1764,7 +1764,7 @@ class UnresolvedTimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
             "num_partitions would become inaccurate if the partitions_defs had different cron"
             " schedules",
         )
-        return UnresolvedTimeWindowPartitionsSubset(
+        return TimePartitionKeyPartitionsSubset(
             partitions_def=partitions_def,
             included_partition_keys=self._included_partition_keys,
         )

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -20,7 +20,10 @@ from dagster._core.definitions.metadata import (
 )
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.time_window_partitions import TimeWindow, TimeWindowPartitionsSubset
+from dagster._core.definitions.time_window_partitions import (
+    BaseTimeWindowPartitionsSubset,
+    TimeWindow,
+)
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.instance import DagsterInstance, DynamicPartitionsStore
 
@@ -402,7 +405,7 @@ class InputContext:
                 "Tried to access asset_partitions_time_window, but the asset is not partitioned.",
             )
 
-        if not isinstance(subset, TimeWindowPartitionsSubset):
+        if not isinstance(subset, BaseTimeWindowPartitionsSubset):
             check.failed(
                 "Tried to access asset_partitions_time_window, but the asset is not partitioned"
                 " with time windows.",

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -11,7 +11,7 @@ from dagster import (
     WeeklyPartitionsDefinition,
 )
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsSubset
+from dagster._core.definitions.time_window_partitions import BaseTimeWindowPartitionsSubset
 
 
 def subset_with_keys(partitions_def: TimeWindowPartitionsDefinition, keys: Sequence[str]):
@@ -622,7 +622,7 @@ def test_daily_upstream_of_yearly():
     ],
 )
 def test_downstream_partition_has_valid_upstream_partitions(
-    downstream_partitions_subset: TimeWindowPartitionsSubset,
+    downstream_partitions_subset: BaseTimeWindowPartitionsSubset,
     upstream_partitions_def: TimeWindowPartitionsDefinition,
     allow_nonexistent_upstream_partitions: bool,
     current_time: datetime,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -3,6 +3,7 @@ from dagster import DailyPartitionsDefinition, MultiPartitionsDefinition, Static
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsSubset
 from dagster._core.definitions.partition import DefaultPartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
+    BaseTimeWindowPartitionsSubset,
     TimeWindowPartitionsSubset,
 )
 from dagster._core.errors import DagsterInvalidDeserializationVersionError
@@ -77,4 +78,4 @@ def test_get_subset_type():
 def test_empty_subsets():
     assert type(composite.empty_subset()) is MultiPartitionsSubset
     assert type(static_partitions.empty_subset()) is DefaultPartitionsSubset
-    assert type(time_window_partitions.empty_subset()) is TimeWindowPartitionsSubset
+    assert type(time_window_partitions.empty_subset()) is BaseTimeWindowPartitionsSubset

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -3,8 +3,8 @@ from dagster import DailyPartitionsDefinition, MultiPartitionsDefinition, Static
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsSubset
 from dagster._core.definitions.partition import DefaultPartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
-    BaseTimeWindowPartitionsSubset,
     TimeWindowPartitionsSubset,
+    UnresolvedTimeWindowPartitionsSubset,
 )
 from dagster._core.errors import DagsterInvalidDeserializationVersionError
 
@@ -78,4 +78,4 @@ def test_get_subset_type():
 def test_empty_subsets():
     assert type(composite.empty_subset()) is MultiPartitionsSubset
     assert type(static_partitions.empty_subset()) is DefaultPartitionsSubset
-    assert type(time_window_partitions.empty_subset()) is BaseTimeWindowPartitionsSubset
+    assert type(time_window_partitions.empty_subset()) is UnresolvedTimeWindowPartitionsSubset

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -3,8 +3,8 @@ from dagster import DailyPartitionsDefinition, MultiPartitionsDefinition, Static
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsSubset
 from dagster._core.definitions.partition import DefaultPartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
+    TimePartitionKeyPartitionsSubset,
     TimeWindowPartitionsSubset,
-    UnresolvedTimeWindowPartitionsSubset,
 )
 from dagster._core.errors import DagsterInvalidDeserializationVersionError
 
@@ -78,4 +78,4 @@ def test_get_subset_type():
 def test_empty_subsets():
     assert type(composite.empty_subset()) is MultiPartitionsSubset
     assert type(static_partitions.empty_subset()) is DefaultPartitionsSubset
-    assert type(time_window_partitions.empty_subset()) is UnresolvedTimeWindowPartitionsSubset
+    assert type(time_window_partitions.empty_subset()) is TimePartitionKeyPartitionsSubset

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -1,9 +1,13 @@
 import pytest
-from dagster import DailyPartitionsDefinition, MultiPartitionsDefinition, StaticPartitionsDefinition
+from dagster import (
+    DailyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
+)
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsSubset
 from dagster._core.definitions.partition import DefaultPartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
-    TimePartitionKeyPartitionsSubset,
+    PartitionKeysTimeWindowPartitionsSubset,
     TimeWindowPartitionsSubset,
 )
 from dagster._core.errors import DagsterInvalidDeserializationVersionError
@@ -78,4 +82,4 @@ def test_get_subset_type():
 def test_empty_subsets():
     assert type(composite.empty_subset()) is MultiPartitionsSubset
     assert type(static_partitions.empty_subset()) is DefaultPartitionsSubset
-    assert type(time_window_partitions.empty_subset()) is TimePartitionKeyPartitionsSubset
+    assert type(time_window_partitions.empty_subset()) is PartitionKeysTimeWindowPartitionsSubset

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
@@ -129,19 +129,19 @@ partition_scenarios = {
         active_backfill_targets=[
             {
                 AssetKey("daily"): TimeWindowPartitionsSubset(
-                    daily_partitions_def, num_partitions=1, included_partition_keys={"2013-01-06"}
-                )
+                    daily_partitions_def
+                ).with_partition_keys(["2013-01-06"])
             },
             {
                 AssetKey("hourly"): TimeWindowPartitionsSubset(
-                    hourly_partitions_def,
-                    num_partitions=3,
-                    included_partition_keys={
+                    hourly_partitions_def
+                ).with_partition_keys(
+                    [
                         "2013-01-06-01:00",
                         "2013-01-06-02:00",
                         "2013-01-06-03:00",
-                    },
-                )
+                    ]
+                ),
             },
         ],
         current_time=create_pendulum_time(year=2013, month=1, day=7, hour=4),
@@ -158,24 +158,22 @@ partition_scenarios = {
         active_backfill_targets=[
             {
                 AssetKey("hourly"): TimeWindowPartitionsSubset(
-                    hourly_partitions_def,
-                    num_partitions=3,
-                    included_partition_keys={
+                    hourly_partitions_def
+                ).with_partition_keys(
+                    [
                         "2013-01-05-00:00",
                         "2013-01-05-01:00",
                         "2013-01-05-02:00",
-                    },
+                    ],
                 ),
             },
             {
                 AssetKey(
                     "non_existant_asset"  # ignored since can't be loaded
-                ): TimeWindowPartitionsSubset(
-                    hourly_partitions_def,
-                    num_partitions=1,
-                    included_partition_keys={
+                ): TimeWindowPartitionsSubset(hourly_partitions_def).with_partition_keys(
+                    [
                         "2013-01-05-00:00",
-                    },
+                    ],
                 ),
             },
         ],
@@ -193,23 +191,13 @@ partition_scenarios = {
         active_backfill_targets=[
             {
                 AssetKey("hourly"): TimeWindowPartitionsSubset(
-                    hourly_partitions_def,
-                    num_partitions=len(
-                        {
-                            partition_key
-                            for partition_key in hourly_partitions_def.get_partition_keys_in_range(
-                                PartitionKeyRange(start="2013-01-05-00:00", end="2013-01-07-03:00")
-                            )
-                        },
-                    ),
-                    included_partition_keys={
-                        partition_key
-                        for partition_key in hourly_partitions_def.get_partition_keys_in_range(
-                            PartitionKeyRange(start="2013-01-05-00:00", end="2013-01-07-03:00")
-                        )
-                    },
+                    hourly_partitions_def
+                ).with_partition_keys(
+                    hourly_partitions_def.get_partition_keys_in_range(
+                        PartitionKeyRange(start="2013-01-05-00:00", end="2013-01-07-03:00")
+                    )
                 )
-            },
+            }
         ],
         current_time=create_pendulum_time(year=2013, month=1, day=7, hour=4),
         expected_run_requests=[],
@@ -239,10 +227,8 @@ partition_scenarios = {
         active_backfill_targets=[
             {
                 AssetKey("hourly"): TimeWindowPartitionsSubset(
-                    hourly_partitions_def,
-                    num_partitions=1,
-                    included_partition_keys={"2013-01-05-04:00"},
-                )
+                    hourly_partitions_def
+                ).with_partition_keys(["2013-01-05-04:00"])
             }
         ],
         unevaluated_runs=[],
@@ -300,9 +286,7 @@ partition_scenarios = {
             {
                 AssetKey("hourly"): TimeWindowPartitionsSubset(
                     hourly_partitions_def,
-                    num_partitions=1,
-                    included_partition_keys={"2013-01-05-04:00"},
-                )
+                ).with_partition_keys(["2013-01-05-04:00"])
             }
         ],
         unevaluated_runs=[],

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
@@ -129,12 +129,12 @@ partition_scenarios = {
         active_backfill_targets=[
             {
                 AssetKey("daily"): TimeWindowPartitionsSubset(
-                    daily_partitions_def
+                    daily_partitions_def, num_partitions=None, included_time_windows=[]
                 ).with_partition_keys(["2013-01-06"])
             },
             {
                 AssetKey("hourly"): TimeWindowPartitionsSubset(
-                    hourly_partitions_def
+                    hourly_partitions_def, num_partitions=None, included_time_windows=[]
                 ).with_partition_keys(
                     [
                         "2013-01-06-01:00",
@@ -158,7 +158,7 @@ partition_scenarios = {
         active_backfill_targets=[
             {
                 AssetKey("hourly"): TimeWindowPartitionsSubset(
-                    hourly_partitions_def
+                    hourly_partitions_def, num_partitions=None, included_time_windows=[]
                 ).with_partition_keys(
                     [
                         "2013-01-05-00:00",
@@ -170,7 +170,9 @@ partition_scenarios = {
             {
                 AssetKey(
                     "non_existant_asset"  # ignored since can't be loaded
-                ): TimeWindowPartitionsSubset(hourly_partitions_def).with_partition_keys(
+                ): TimeWindowPartitionsSubset(
+                    hourly_partitions_def, num_partitions=None, included_time_windows=[]
+                ).with_partition_keys(
                     [
                         "2013-01-05-00:00",
                     ],
@@ -191,7 +193,7 @@ partition_scenarios = {
         active_backfill_targets=[
             {
                 AssetKey("hourly"): TimeWindowPartitionsSubset(
-                    hourly_partitions_def
+                    hourly_partitions_def, num_partitions=None, included_time_windows=[]
                 ).with_partition_keys(
                     hourly_partitions_def.get_partition_keys_in_range(
                         PartitionKeyRange(start="2013-01-05-00:00", end="2013-01-07-03:00")
@@ -227,7 +229,7 @@ partition_scenarios = {
         active_backfill_targets=[
             {
                 AssetKey("hourly"): TimeWindowPartitionsSubset(
-                    hourly_partitions_def
+                    hourly_partitions_def, num_partitions=None, included_time_windows=[]
                 ).with_partition_keys(["2013-01-05-04:00"])
             }
         ],
@@ -285,7 +287,7 @@ partition_scenarios = {
         active_backfill_targets=[
             {
                 AssetKey("hourly"): TimeWindowPartitionsSubset(
-                    hourly_partitions_def,
+                    hourly_partitions_def, num_partitions=None, included_time_windows=[]
                 ).with_partition_keys(["2013-01-05-04:00"])
             }
         ],

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -20,8 +20,8 @@ from dagster import (
 from dagster._check import CheckError
 from dagster._core.definitions.time_window_partitions import (
     BaseTimeWindowPartitionsSubset,
+    PartitionKeysTimeWindowPartitionsSubset,
     ScheduleType,
-    TimePartitionKeyPartitionsSubset,
     TimeWindow,
     TimeWindowPartitionsSubset,
 )
@@ -33,7 +33,8 @@ DATE_FORMAT = "%Y-%m-%d"
 
 def time_window(start: str, end: str) -> TimeWindow:
     return TimeWindow(
-        cast(datetime, pendulum.parser.parse(start)), cast(datetime, pendulum.parser.parse(end))
+        cast(datetime, pendulum.parser.parse(start)),
+        cast(datetime, pendulum.parser.parse(end)),
     )
 
 
@@ -352,7 +353,14 @@ def assert_expected_partition_keys(
             datetime(year=2021, month=1, day=1),
             1,
             create_pendulum_time(2021, 1, 6, 1, 20),
-            ["2021-01-01", "2021-01-02", "2021-01-03", "2021-01-04", "2021-01-05", "2021-01-06"],
+            [
+                "2021-01-01",
+                "2021-01-02",
+                "2021-01-03",
+                "2021-01-04",
+                "2021-01-05",
+                "2021-01-06",
+            ],
             None,
         ),
         (
@@ -418,7 +426,8 @@ def test_time_partitions_daily_partitions(
     )
 
     assert_expected_partition_keys(
-        partitions_def.get_partition_keys(current_time=current_time), expected_partition_keys
+        partitions_def.get_partition_keys(current_time=current_time),
+        expected_partition_keys,
     )
 
 
@@ -480,7 +489,8 @@ def test_time_partitions_monthly_partitions(
     )
 
     assert_expected_partition_keys(
-        partitions_def.get_partition_keys(current_time=current_time), expected_partition_keys
+        partitions_def.get_partition_keys(current_time=current_time),
+        expected_partition_keys,
     )
 
 
@@ -515,7 +525,14 @@ def test_time_partitions_monthly_partitions(
             datetime(year=2021, month=1, day=1),
             2,
             create_pendulum_time(2021, 1, 31, 1, 20),
-            ["2021-01-03", "2021-01-10", "2021-01-17", "2021-01-24", "2021-01-31", "2021-02-07"],
+            [
+                "2021-01-03",
+                "2021-01-10",
+                "2021-01-17",
+                "2021-01-24",
+                "2021-01-31",
+                "2021-02-07",
+            ],
         ),
         (
             datetime(year=2021, month=1, day=1),
@@ -540,7 +557,8 @@ def test_time_partitions_weekly_partitions(
     partitions_def = WeeklyPartitionsDefinition(start_date=start, end_offset=partition_weeks_offset)
 
     assert_expected_partition_keys(
-        partitions_def.get_partition_keys(current_time=current_time), expected_partition_keys
+        partitions_def.get_partition_keys(current_time=current_time),
+        expected_partition_keys,
     )
 
 
@@ -674,7 +692,8 @@ def test_time_partitions_hourly_partitions(
     )
 
     assert_expected_partition_keys(
-        partitions_def.get_partition_keys(current_time=current_time), expected_partition_keys
+        partitions_def.get_partition_keys(current_time=current_time),
+        expected_partition_keys,
     )
 
 
@@ -745,7 +764,7 @@ def test_start_not_aligned():
 
 @pytest.mark.parametrize(
     "partitions_subset_class",
-    [TimePartitionKeyPartitionsSubset, TimeWindowPartitionsSubset],
+    [PartitionKeysTimeWindowPartitionsSubset, TimeWindowPartitionsSubset],
 )
 @pytest.mark.parametrize(
     "case_str",
@@ -792,7 +811,8 @@ def test_partition_subset_get_partition_keys_not_in_subset(
     )
     assert (
         cast(
-            TimeWindowPartitionsSubset, partitions_def.deserialize_subset(subset.serialize())
+            TimeWindowPartitionsSubset,
+            partitions_def.deserialize_subset(subset.serialize()),
         ).included_time_windows
         == subset.included_time_windows
     )
@@ -822,7 +842,7 @@ def test_time_partitions_subset_identical_serialization():
 
 @pytest.mark.parametrize(
     "partitions_subset_class",
-    [TimePartitionKeyPartitionsSubset, TimeWindowPartitionsSubset],
+    [PartitionKeysTimeWindowPartitionsSubset, TimeWindowPartitionsSubset],
 )
 @pytest.mark.parametrize(
     "initial, added",
@@ -1231,7 +1251,10 @@ def test_has_partition_key():
         ),
         (
             WeeklyPartitionsDefinition(start_date="2022-01-01", end_date="2022-02-01"),
-            ["2022-01-02", "2022-01-09"],  # 2022-01-02 is Sunday, weekly cron starts from Sunday
+            [
+                "2022-01-02",
+                "2022-01-09",
+            ],  # 2022-01-02 is Sunday, weekly cron starts from Sunday
             ["2022-01-23", "2022-01-30"],
             4,
             "%Y-%m-%d",

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -21,9 +21,9 @@ from dagster._check import CheckError
 from dagster._core.definitions.time_window_partitions import (
     BaseTimeWindowPartitionsSubset,
     ScheduleType,
+    TimePartitionKeyPartitionsSubset,
     TimeWindow,
     TimeWindowPartitionsSubset,
-    UnresolvedTimeWindowPartitionsSubset,
 )
 from dagster._seven.compat.pendulum import create_pendulum_time
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
@@ -745,7 +745,7 @@ def test_start_not_aligned():
 
 @pytest.mark.parametrize(
     "partitions_subset_class",
-    [UnresolvedTimeWindowPartitionsSubset, TimeWindowPartitionsSubset],
+    [TimePartitionKeyPartitionsSubset, TimeWindowPartitionsSubset],
 )
 @pytest.mark.parametrize(
     "case_str",
@@ -822,7 +822,7 @@ def test_time_partitions_subset_identical_serialization():
 
 @pytest.mark.parametrize(
     "partitions_subset_class",
-    [UnresolvedTimeWindowPartitionsSubset, TimeWindowPartitionsSubset],
+    [TimePartitionKeyPartitionsSubset, TimeWindowPartitionsSubset],
 )
 @pytest.mark.parametrize(
     "initial, added",

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -19,6 +19,7 @@ from dagster import (
 )
 from dagster._check import CheckError
 from dagster._core.definitions.time_window_partitions import (
+    BaseTimeWindowPartitionsSubset,
     ScheduleType,
     TimeWindow,
     TimeWindowPartitionsSubset,
@@ -771,7 +772,8 @@ def test_partition_subset_get_partition_keys_not_in_subset(case_str: str):
             expected_keys_not_in_subset.append(full_set_keys[i])
 
     subset = cast(
-        TimeWindowPartitionsSubset, partitions_def.empty_subset().with_partition_keys(subset_keys)
+        BaseTimeWindowPartitionsSubset,
+        partitions_def.empty_subset().with_partition_keys(subset_keys),
     )
     for partition_key in subset_keys:
         assert partition_key in subset
@@ -901,7 +903,9 @@ def test_partition_subset_with_partition_keys(initial: str, added: str):
 
     subset = partitions_def.empty_subset().with_partition_keys(initial_subset_keys)
     assert all(partition_key in subset for partition_key in initial_subset_keys)
-    updated_subset = cast(TimeWindowPartitionsSubset, subset.with_partition_keys(added_subset_keys))
+    updated_subset = cast(
+        BaseTimeWindowPartitionsSubset, subset.with_partition_keys(added_subset_keys)
+    )
     assert all(partition_key in updated_subset for partition_key in added_subset_keys)
     assert (
         updated_subset.get_partition_keys_not_in_subset(


### PR DESCRIPTION
`TimeWindowPartitionsSubset` has lots of performance improvement code that relies on representing partitions as keys, but relies on converting partition keys to time windows in order to serialize. In preparation for serializing the time window version, this PR splits the implementation:
- `BaseTimePartitionsSubset`: a time partitions subset superclass that defines abstract methods, and contains helper functions
- `TimePartitionKeyPartitionsSubset`: the "partition key" representation
- `TimeWindowPartitionsSubset`: the "time window" representation

By default, when creating partitions subsets via `partitions_def.empty_subset().with_partition_keys(...)`, a `TimePartitionKeyPartitionsSubset` will be created. This class contains a method to convert to a `TimeWindowPartitionsSubset` when it needs to be serialized. 

In future PRs, time partitions subsets can be directly deserialized as `TimeWindowPartitionsSubsets`.

