### PR TITLE
[auto-materialize] Port most freshness-policy scenarios to new framework

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -1,5 +1,6 @@
 import datetime
 import hashlib
+import json
 import logging
 import os
 import sys
@@ -20,6 +21,7 @@ import dagster._check as check
 import mock
 import pendulum
 from dagster import (
+    AssetExecutionContext,
     AssetKey,
     AssetsDefinition,
     AssetSpec,
@@ -53,7 +55,7 @@ from dagster._core.test_utils import (
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._daemon.asset_daemon import CURSOR_KEY, AssetDaemon
 
-from .base_scenario import run_request
+from .base_scenario import FAIL_TAG, run_request
 
 
 def get_code_location_origin(
@@ -177,8 +179,13 @@ class AssetDaemonScenarioState(NamedTuple):
 
     @property
     def assets(self) -> Sequence[AssetsDefinition]:
-        def fn() -> None:
-            ...
+        def compute_fn(context: AssetExecutionContext) -> None:
+            fail_keys = {
+                AssetKey.from_coercible(s)
+                for s in json.loads(context.run.tags.get(FAIL_TAG) or "[]")
+            }
+            if context.asset_key in fail_keys:
+                raise Exception("Asset failed")
 
         assets = []
         params = {
@@ -187,11 +194,15 @@ class AssetDaemonScenarioState(NamedTuple):
             "group_name",
             "code_version",
             "auto_materialize_policy",
+            "freshness_policy",
             "partitions_def",
         }
         for spec in self.asset_specs:
             assets.append(
-                asset(compute_fn=fn, **{k: v for k, v in spec._asdict().items() if k in params})
+                asset(
+                    compute_fn=compute_fn,
+                    **{k: v for k, v in spec._asdict().items() if k in params},
+                )
             )
         return assets
 
@@ -258,16 +269,18 @@ class AssetDaemonScenarioState(NamedTuple):
                     selection=rr.asset_selection,
                 )
         # increment current_time by however much time elapsed during the materialize call
-        return self._replace(current_time=datetime.datetime.fromtimestamp(test_time_fn()))
-
-    def with_requested_runs(self) -> "AssetDaemonScenarioState":
-        return self.with_runs(*self.run_requests)
+        return self._replace(current_time=pendulum.from_timestamp(test_time_fn()))
 
     def with_not_started_runs(self) -> "AssetDaemonScenarioState":
-        """Execute all runs in the NOT_STARTED state."""
+        """Execute all runs in the NOT_STARTED state and delete them from the instance. The scenario
+        adds in the run requests from previous ticks as runs in the NOT_STARTED state, so this method
+        executes requested runs from previous ticks.
+        """
         not_started_runs = self.instance.get_runs(
             filters=RunsFilter(statuses=[DagsterRunStatus.NOT_STARTED])
         )
+        for run in not_started_runs:
+            self.instance.delete_run(run_id=run.run_id)
         return self.with_runs(
             *[
                 run_request(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -17,6 +17,7 @@ from typing import (
 )
 
 import dagster._check as check
+import mock
 import pendulum
 from dagster import (
     AssetKey,
@@ -43,7 +44,7 @@ from dagster._core.definitions.auto_materialize_rule import (
 from dagster._core.definitions.events import CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import in_process_executor
 from dagster._core.host_representation.origin import InProcessCodeLocationOrigin
-from dagster._core.storage.dagster_run import RunsFilter
+from dagster._core.storage.dagster_run import DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._core.test_utils import (
     InProcessTestWorkspaceLoadTarget,
@@ -195,6 +196,10 @@ class AssetDaemonScenarioState(NamedTuple):
         return assets
 
     @property
+    def defs(self) -> Definitions:
+        return Definitions(assets=self.assets)
+
+    @property
     def asset_graph(self) -> AssetGraph:
         return AssetGraph.from_assets(self.assets)
 
@@ -235,7 +240,14 @@ class AssetDaemonScenarioState(NamedTuple):
         return self._replace(current_time=self.current_time + datetime.timedelta(**kwargs))
 
     def with_runs(self, *run_requests: RunRequest) -> "AssetDaemonScenarioState":
-        with pendulum.test(self.current_time):
+        start = datetime.datetime.now()
+
+        def test_time_fn() -> float:
+            # this function will increment the current timestamp in real time, relative to the
+            # fake current_time on the scenario state
+            return (self.current_time + (datetime.datetime.now() - start)).timestamp()
+
+        with pendulum.test(self.current_time), mock.patch("time.time", new=test_time_fn):
             for rr in run_requests:
                 materialize(
                     assets=self.assets,
@@ -245,10 +257,26 @@ class AssetDaemonScenarioState(NamedTuple):
                     raise_on_error=False,
                     selection=rr.asset_selection,
                 )
-        return self
+        # increment current_time by however much time elapsed during the materialize call
+        return self._replace(current_time=datetime.datetime.fromtimestamp(test_time_fn()))
 
     def with_requested_runs(self) -> "AssetDaemonScenarioState":
         return self.with_runs(*self.run_requests)
+
+    def with_not_started_runs(self) -> "AssetDaemonScenarioState":
+        """Execute all runs in the NOT_STARTED state."""
+        not_started_runs = self.instance.get_runs(
+            filters=RunsFilter(statuses=[DagsterRunStatus.NOT_STARTED])
+        )
+        return self.with_runs(
+            *[
+                run_request(
+                    asset_keys=list(run.asset_selection or set()),
+                    partition_key=run.tags.get(PARTITION_NAME_TAG),
+                )
+                for run in not_started_runs
+            ]
+        )
 
     def _evaluate_tick_fast(
         self,
@@ -316,6 +344,16 @@ class AssetDaemonScenarioState(NamedTuple):
                 new_run_requests, new_cursor, new_evaluations = self._evaluate_tick_daemon()
             else:
                 new_run_requests, new_cursor, new_evaluations = self._evaluate_tick_fast()
+
+        # make sure these run requests are available on the instance
+        for request in new_run_requests:
+            asset_selection = check.not_none(request.asset_selection)
+            job_def = self.defs.get_implicit_job_def_for_assets(asset_selection)
+            self.instance.create_run_for_job(
+                job_def=check.not_none(job_def),
+                asset_selection=set(asset_selection),
+                tags=request.tags,
+            )
 
         return self._replace(
             run_requests=new_run_requests,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -1,6 +1,7 @@
 import contextlib
 import datetime
 import itertools
+import json
 import logging
 import os
 import random
@@ -592,12 +593,18 @@ def run(
     )
 
 
+FAIL_TAG = "test/fail"
+
+
 def run_request(
-    asset_keys: Sequence[CoercibleToAssetKey], partition_key: Optional[str] = None
+    asset_keys: Sequence[CoercibleToAssetKey],
+    partition_key: Optional[str] = None,
+    fail_keys: Optional[Sequence[str]] = None,
 ) -> RunRequest:
     return RunRequest(
         asset_selection=[AssetKey.from_coercible(key) for key in asset_keys],
         partition_key=partition_key,
+        tags={FAIL_TAG: json.dumps(fail_keys)} if fail_keys else {},
     )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -34,7 +34,6 @@ from .exotic_partition_mapping_scenarios import (
 )
 from .freshness_policy_scenarios import (
     daily_to_unpartitioned,
-    overlapping_freshness_inf,
 )
 from .partition_scenarios import (
     hourly_partitions_def,
@@ -175,42 +174,6 @@ one_upstream_starts_later_than_downstream_skip_on_not_all_parents_updated = (
 
 # auto materialization policies
 auto_materialize_policy_scenarios = {
-    "auto_materialize_policy_lazy_missing": AssetReconciliationScenario(
-        assets=single_lazy_asset,
-        unevaluated_runs=[],
-        expected_run_requests=[],
-    ),
-    "auto_materialize_policy_lazy_freshness_missing": AssetReconciliationScenario(
-        assets=single_lazy_asset_with_freshness_policy,
-        unevaluated_runs=[],
-        expected_run_requests=[run_request(asset_keys=["asset1"])],
-    ),
-    "auto_materialize_policy_eager_with_freshness_policies": AssetReconciliationScenario(
-        assets=with_auto_materialize_policy(
-            overlapping_freshness_inf, AutoMaterializePolicy.eager()
-        ),
-        cursor_from=AssetReconciliationScenario(
-            assets=overlapping_freshness_inf,
-            unevaluated_runs=[run(["asset1", "asset2", "asset3", "asset4", "asset5", "asset6"])],
-        ),
-        # change at the top, should be immediately propagated as all assets have eager reconciliation
-        unevaluated_runs=[run(["asset1"])],
-        expected_run_requests=[
-            run_request(asset_keys=["asset2", "asset3", "asset4", "asset5", "asset6"])
-        ],
-    ),
-    "auto_materialize_policy_lazy_with_freshness_policies": AssetReconciliationScenario(
-        assets=with_auto_materialize_policy(
-            overlapping_freshness_inf, AutoMaterializePolicy.lazy()
-        ),
-        cursor_from=AssetReconciliationScenario(
-            assets=overlapping_freshness_inf,
-            unevaluated_runs=[run(["asset1", "asset2", "asset3", "asset4", "asset5", "asset6"])],
-        ),
-        # change at the top, should be immediately propagated as all assets have eager reconciliation
-        unevaluated_runs=[run(["asset1"])],
-        expected_run_requests=[],
-    ),
     "auto_materialize_policy_with_default_scope_hourly_to_daily_partitions_never_materialized": AssetReconciliationScenario(
         assets=with_auto_materialize_policy(
             hourly_to_daily_partitions,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -174,6 +174,12 @@ one_upstream_starts_later_than_downstream_skip_on_not_all_parents_updated = (
 
 # auto materialization policies
 auto_materialize_policy_scenarios = {
+    # need to keep this around temporarily as test_asset_daemon.py relies on it
+    "auto_materialize_policy_lazy_freshness_missing": AssetReconciliationScenario(
+        assets=single_lazy_asset_with_freshness_policy,
+        unevaluated_runs=[],
+        expected_run_requests=[run_request(asset_keys=["asset1"])],
+    ),
     "auto_materialize_policy_with_default_scope_hourly_to_daily_partitions_never_materialized": AssetReconciliationScenario(
         assets=with_auto_materialize_policy(
             hourly_to_daily_partitions,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/freshness_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/freshness_policy_scenarios.py
@@ -3,7 +3,6 @@ import datetime
 from dagster import (
     AssetSelection,
     DailyPartitionsDefinition,
-    SourceAsset,
 )
 from dagster._core.definitions.auto_materialize_rule import (
     AutoMaterializeRule,
@@ -12,7 +11,6 @@ from dagster._core.definitions.auto_materialize_rule import (
 )
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
-from dagster._seven.compat.pendulum import create_pendulum_time
 
 from ..base_scenario import (
     AssetEvaluationSpec,
@@ -22,51 +20,9 @@ from ..base_scenario import (
     run,
     run_request,
 )
-from .basic_scenarios import diamond
 
 freshness_30m = FreshnessPolicy(maximum_lag_minutes=30)
 freshness_60m = FreshnessPolicy(maximum_lag_minutes=60)
-freshness_1d = FreshnessPolicy(maximum_lag_minutes=24 * 60)
-freshness_inf = FreshnessPolicy(maximum_lag_minutes=99999)
-freshness_cron = FreshnessPolicy(cron_schedule="0 7 * * *", maximum_lag_minutes=7 * 60)
-
-
-nothing_dep_freshness = [
-    asset_def("asset1", ["some_undefined_source"], freshness_policy=freshness_30m)
-]
-many_to_one_freshness = [
-    asset_def("asset1"),
-    asset_def("asset2"),
-    asset_def("asset3"),
-    asset_def("asset4", ["asset1", "asset2", "asset3"]),
-    asset_def("asset5", ["asset4"], freshness_policy=freshness_30m),
-]
-diamond_freshness = diamond[:-1] + [
-    asset_def("asset4", ["asset2", "asset3"], freshness_policy=freshness_30m)
-]
-overlapping_freshness = diamond + [
-    asset_def("asset5", ["asset3"], freshness_policy=freshness_30m),
-    asset_def("asset6", ["asset4"], freshness_policy=freshness_60m),
-]
-overlapping_freshness_with_source = [
-    SourceAsset("source_asset"),
-    asset_def("asset1", ["source_asset"]),
-] + overlapping_freshness[1:]
-overlapping_freshness_inf = diamond + [
-    asset_def("asset5", ["asset3"], freshness_policy=freshness_30m),
-    asset_def("asset6", ["asset4"], freshness_policy=freshness_inf),
-]
-overlapping_freshness_none = diamond + [
-    asset_def("asset5", ["asset3"], freshness_policy=freshness_30m),
-    asset_def("asset6", ["asset4"], freshness_policy=None),
-]
-
-overlapping_freshness_cron = [
-    asset_def("asset1"),
-    asset_def("asset2", ["asset1"], freshness_policy=freshness_30m),
-    asset_def("asset3", ["asset1"], freshness_policy=freshness_cron),
-]
-
 
 non_subsettable_multi_asset_on_top = [
     multi_asset_def(["asset1", "asset2", "asset3"], can_subset=False),
@@ -111,193 +67,6 @@ daily_to_unpartitioned = [
 ]
 
 freshness_policy_scenarios = {
-    "freshness_many_to_one_some_updated": AssetReconciliationScenario(
-        assets=many_to_one_freshness,
-        unevaluated_runs=[
-            run(["asset1", "asset2", "asset3", "asset4", "asset5"]),
-            run(["asset2", "asset3", "asset4", "asset5"]),
-        ],
-        between_runs_delta=datetime.timedelta(minutes=60),
-        expected_run_requests=[run_request(["asset1", "asset4", "asset5"])],
-    ),
-    "freshness_many_to_one_roots_unselectable": AssetReconciliationScenario(
-        assets=many_to_one_freshness,
-        # the roots of this graph cannot be executed by this sensor
-        asset_selection=AssetSelection.keys("asset4", "asset5"),
-        unevaluated_runs=[
-            run(["asset1", "asset2", "asset3", "asset4", "asset5"]),
-            run(["asset2", "asset3"]),
-        ],
-        between_runs_delta=datetime.timedelta(minutes=35),
-        # should wait for asset1 to become available before launching unnecessary runs
-        expected_run_requests=[],
-    ),
-    "freshness_half_run_with_failure": AssetReconciliationScenario(
-        assets=diamond_freshness,
-        unevaluated_runs=[
-            run(["asset1", "asset2", "asset3", "asset4"]),
-            run(["asset3"], failed_asset_keys=["asset3"]),
-        ],
-        expected_run_requests=[],
-    ),
-    "freshness_half_run_after_delay": AssetReconciliationScenario(
-        assets=diamond_freshness,
-        unevaluated_runs=[
-            run(["asset1", "asset2", "asset3", "asset4"]),
-            run(["asset1", "asset3"]),
-        ],
-        between_runs_delta=datetime.timedelta(minutes=35),
-        evaluation_delta=datetime.timedelta(minutes=5),
-        expected_run_requests=[run_request(asset_keys=["asset2", "asset4"])],
-    ),
-    "freshness_half_run_with_failure_after_delay": AssetReconciliationScenario(
-        assets=diamond_freshness,
-        unevaluated_runs=[
-            run(["asset1", "asset2", "asset3", "asset4"]),
-            run(["asset1", "asset2", "asset3"], failed_asset_keys=["asset3"]),
-        ],
-        between_runs_delta=datetime.timedelta(minutes=35),
-        evaluation_delta=datetime.timedelta(minutes=5),
-        # even though 4 doesn't have the most up to date data yet, we just tried to materialize
-        # asset 3 and it failed, so it doesn't make sense to try to run it again to get 4 up to date
-        expected_run_requests=[],
-    ),
-    "freshness_half_run_with_failure_after_delay2": AssetReconciliationScenario(
-        assets=diamond_freshness,
-        unevaluated_runs=[
-            run(["asset1", "asset2", "asset3", "asset4"]),
-            run(["asset1", "asset2", "asset3"], failed_asset_keys=["asset3"]),
-        ],
-        between_runs_delta=datetime.timedelta(minutes=35),
-        evaluation_delta=datetime.timedelta(minutes=35),
-        # now that it's been awhile since that run failed, give it another attempt
-        expected_run_requests=[run_request(asset_keys=["asset1", "asset2", "asset3", "asset4"])],
-        expected_evaluations=[
-            AssetEvaluationSpec.from_single_rule(
-                "asset1",
-                AutoMaterializeRule.materialize_on_required_for_freshness(),
-                TextRuleEvaluationData("Required by downstream asset's policy"),
-            ),
-            AssetEvaluationSpec.from_single_rule(
-                "asset2",
-                AutoMaterializeRule.materialize_on_required_for_freshness(),
-                TextRuleEvaluationData("Required by downstream asset's policy"),
-            ),
-            AssetEvaluationSpec.from_single_rule(
-                "asset3",
-                AutoMaterializeRule.materialize_on_required_for_freshness(),
-                TextRuleEvaluationData("Required by downstream asset's policy"),
-            ),
-            AssetEvaluationSpec.from_single_rule(
-                "asset4",
-                AutoMaterializeRule.materialize_on_required_for_freshness(),
-                TextRuleEvaluationData("Required by this asset's policy"),
-            ),
-        ],
-    ),
-    "freshness_root_failure": AssetReconciliationScenario(
-        assets=diamond_freshness,
-        unevaluated_runs=[
-            run(["asset1", "asset2", "asset3", "asset4"]),
-            run(["asset1"], failed_asset_keys=["asset1"]),
-        ],
-        between_runs_delta=datetime.timedelta(minutes=35),
-        evaluation_delta=datetime.timedelta(minutes=5),
-        # need to rematerialize all, but asset1 just failed so we don't want to retry immediately
-        expected_run_requests=[],
-    ),
-    "freshness_root_failure_after_delay": AssetReconciliationScenario(
-        assets=diamond_freshness,
-        unevaluated_runs=[
-            run(["asset1", "asset2", "asset3", "asset4"]),
-            run(["asset1"], failed_asset_keys=["asset1"]),
-        ],
-        between_runs_delta=datetime.timedelta(minutes=35),
-        evaluation_delta=datetime.timedelta(minutes=35),
-        # asset1 failed last time, but it's been awhile so we'll give it another shot
-        expected_run_requests=[run_request(asset_keys=["asset1", "asset2", "asset3", "asset4"])],
-    ),
-    "freshness_half_run_stale": AssetReconciliationScenario(
-        assets=diamond_freshness,
-        unevaluated_runs=[run(["asset1", "asset2"])],
-        evaluation_delta=datetime.timedelta(minutes=35),
-        expected_run_requests=[run_request(asset_keys=["asset1", "asset2", "asset3", "asset4"])],
-    ),
-    "freshness_overlapping_runs": AssetReconciliationScenario(
-        assets=overlapping_freshness,
-        unevaluated_runs=[run(["asset1", "asset3", "asset5"]), run(["asset2", "asset4", "asset6"])],
-        expected_run_requests=[],
-    ),
-    "freshness_overlapping_with_source": AssetReconciliationScenario(
-        assets=overlapping_freshness_with_source,
-        unevaluated_runs=[run(["asset1", "asset3", "asset5"]), run(["asset2", "asset4", "asset6"])],
-        expected_run_requests=[],
-    ),
-    "freshness_overlapping_failure": AssetReconciliationScenario(
-        assets=overlapping_freshness,
-        unevaluated_runs=[
-            run(["asset1", "asset2", "asset3", "asset4", "asset5", "asset6"]),
-            run(["asset1"], failed_asset_keys=["asset1"]),
-        ],
-        between_runs_delta=datetime.timedelta(minutes=35),
-        # need new data, but don't want to re-run immediately
-        expected_run_requests=[],
-    ),
-    "freshness_overlapping_failure_after_delay": AssetReconciliationScenario(
-        assets=overlapping_freshness,
-        unevaluated_runs=[
-            run(["asset1", "asset2", "asset3", "asset4", "asset5", "asset6"]),
-            run(["asset1"], failed_asset_keys=["asset1"]),
-        ],
-        between_runs_delta=datetime.timedelta(minutes=35),
-        evaluation_delta=datetime.timedelta(minutes=35),
-        # after 30 minutes, we can try to kick off a run again
-        expected_run_requests=[
-            run_request(asset_keys=["asset1", "asset2", "asset3", "asset4", "asset5", "asset6"])
-        ],
-    ),
-    "freshness_overlapping_runs_half_stale": AssetReconciliationScenario(
-        assets=overlapping_freshness_inf,
-        unevaluated_runs=[run(["asset1", "asset3", "asset5"]), run(["asset2", "asset4", "asset6"])],
-        # evaluate 35 minutes later, only need to refresh the assets on the shorter freshness policy
-        evaluation_delta=datetime.timedelta(minutes=35),
-        expected_run_requests=[run_request(asset_keys=["asset1", "asset3", "asset5"])],
-    ),
-    "freshness_overlapping_defer_propagate": AssetReconciliationScenario(
-        assets=overlapping_freshness_inf,
-        cursor_from=AssetReconciliationScenario(
-            assets=overlapping_freshness_inf,
-            unevaluated_runs=[run(["asset1", "asset2", "asset3", "asset4", "asset5", "asset6"])],
-        ),
-        # change at the top, will not propagate immediately as freshness policies will handle it
-        # (even though it will take awhile)
-        unevaluated_runs=[run(["asset1"])],
-        expected_run_requests=[],
-    ),
-    "freshness_overlapping_defer_propagate2": AssetReconciliationScenario(
-        assets=overlapping_freshness_none,
-        cursor_from=AssetReconciliationScenario(
-            assets=overlapping_freshness_inf,
-            unevaluated_runs=[run(["asset1", "asset2", "asset3", "asset4", "asset5", "asset6"])],
-        ),
-        # change at the top, doesn't need to be propagated to 1, 3, 5 as freshness policy will
-        # handle it, but assets 2, 4, 6 will not recieve an update because they are not
-        # upstream of a freshness policy. 2 can be updated immediately, but 4 and 6 depend on
-        # 3, so will be defered
-        unevaluated_runs=[run(["asset1"])],
-        expected_run_requests=[run_request(asset_keys=["asset2"])],
-    ),
-    "freshness_overlapping_defer_propagate_with_cron": AssetReconciliationScenario(
-        assets=overlapping_freshness_cron,
-        current_time=create_pendulum_time(year=2023, month=1, day=1, hour=6, tz="UTC"),
-        evaluation_delta=datetime.timedelta(minutes=90),
-        unevaluated_runs=[
-            run(["asset1", "asset2", "asset3"]),
-            run(["asset1"]),
-        ],
-        # don't run asset 3 even though its parent updated as freshness policy will handle it
-        expected_run_requests=[run_request(asset_keys=["asset1", "asset2"])],
-    ),
     "freshness_non_subsettable_multi_asset_on_top": AssetReconciliationScenario(
         assets=non_subsettable_multi_asset_on_top,
         unevaluated_runs=[run([f"asset{i}" for i in range(1, 6)])],

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/freshness_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/freshness_policy_scenarios.py
@@ -111,58 +111,6 @@ daily_to_unpartitioned = [
 ]
 
 freshness_policy_scenarios = {
-    "freshness_blank_slate": AssetReconciliationScenario(
-        assets=diamond_freshness,
-        unevaluated_runs=[],
-        expected_run_requests=[run_request(asset_keys=["asset1", "asset2", "asset3", "asset4"])],
-    ),
-    "freshness_blank_slate_root_unselected": AssetReconciliationScenario(
-        assets=diamond_freshness,
-        asset_selection=AssetSelection.all() - AssetSelection.keys("asset1"),
-        unevaluated_runs=[],
-        expected_run_requests=[],
-    ),
-    "freshness_blank_slate_root_unselected_and_materialized": AssetReconciliationScenario(
-        assets=diamond_freshness,
-        asset_selection=AssetSelection.all() - AssetSelection.keys("asset1"),
-        unevaluated_runs=[run(["asset1"])],
-        expected_run_requests=[run_request(asset_keys=["asset2", "asset3", "asset4"])],
-    ),
-    "freshness_all_fresh": AssetReconciliationScenario(
-        assets=diamond_freshness,
-        unevaluated_runs=[run(["asset1", "asset2", "asset3", "asset4"])],
-        expected_run_requests=[],
-    ),
-    "freshness_all_fresh_with_new_run": AssetReconciliationScenario(
-        # expect no runs as the freshness policy will propagate the new change w/in the plan window
-        assets=diamond_freshness,
-        cursor_from=AssetReconciliationScenario(
-            assets=diamond_freshness,
-            unevaluated_runs=[run(["asset1", "asset2", "asset3", "asset4"])],
-        ),
-        unevaluated_runs=[run(["asset1"])],
-        expected_run_requests=[],
-    ),
-    "freshness_all_fresh_with_new_run_stale": AssetReconciliationScenario(
-        assets=diamond_freshness,
-        cursor_from=AssetReconciliationScenario(
-            assets=diamond_freshness,
-            unevaluated_runs=[run(["asset1", "asset2", "asset3", "asset4"])],
-        ),
-        unevaluated_runs=[run(["asset1"])],
-        evaluation_delta=datetime.timedelta(minutes=35),
-        expected_run_requests=[run_request(asset_keys=["asset1", "asset2", "asset3", "asset4"])],
-    ),
-    "freshness_half_run": AssetReconciliationScenario(
-        assets=diamond_freshness,
-        unevaluated_runs=[run(["asset1", "asset2"])],
-        expected_run_requests=[run_request(asset_keys=["asset3", "asset4"])],
-    ),
-    "freshness_nothing_dep": AssetReconciliationScenario(
-        assets=nothing_dep_freshness,
-        unevaluated_runs=[],
-        expected_run_requests=[run_request(asset_keys=["asset1"])],
-    ),
     "freshness_many_to_one_some_updated": AssetReconciliationScenario(
         assets=many_to_one_freshness,
         unevaluated_runs=[
@@ -443,19 +391,5 @@ freshness_policy_scenarios = {
             ),
         ],
         expected_run_requests=[],
-    ),
-    "freshness_partitioned_to_unpartitioned_empty": AssetReconciliationScenario(
-        assets=daily_to_unpartitioned,
-        asset_selection=AssetSelection.keys("unpartitioned"),
-        current_time=create_pendulum_time(year=2020, month=1, day=2, hour=6, tz="UTC"),
-        unevaluated_runs=[],
-        expected_run_requests=[],
-    ),
-    "freshness_partitioned_to_unpartitioned_nonempty": AssetReconciliationScenario(
-        assets=daily_to_unpartitioned,
-        asset_selection=AssetSelection.keys("unpartitioned"),
-        current_time=create_pendulum_time(year=2020, month=1, day=2, hour=6, tz="UTC"),
-        unevaluated_runs=[run(["daily"], partition_key="2020-01-01")],
-        expected_run_requests=[run_request(["unpartitioned"])],
     ),
 }

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/multi_code_location_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/multi_code_location_scenarios.py
@@ -1,17 +1,23 @@
 import copy
 from typing import Sequence
 
-from dagster import (
-    AssetsDefinition,
-)
+from dagster import AssetsDefinition, FreshnessPolicy
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 
-from ..base_scenario import (
-    AssetReconciliationScenario,
-    run,
-    run_request,
-)
-from .freshness_policy_scenarios import diamond_freshness, overlapping_freshness_inf
+from ..base_scenario import AssetReconciliationScenario, asset_def, run, run_request
+from .basic_scenarios import diamond
+
+freshness_30m = FreshnessPolicy(maximum_lag_minutes=30)
+freshness_inf = FreshnessPolicy(maximum_lag_minutes=99999)
+
+diamond_freshness = diamond[:-1] + [
+    asset_def("asset4", ["asset2", "asset3"], freshness_policy=freshness_30m)
+]
+
+overlapping_freshness_inf = diamond + [
+    asset_def("asset5", ["asset3"], freshness_policy=freshness_30m),
+    asset_def("asset6", ["asset4"], freshness_policy=freshness_inf),
+]
 
 
 def with_auto_materialize_policy(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
@@ -1,3 +1,5 @@
+from typing import Generator
+
 import pytest
 from dagster import DagsterInstance
 from dagster._core.instance_for_test import instance_for_test
@@ -6,13 +8,14 @@ from dagster._daemon.asset_daemon import set_auto_materialize_paused
 from .asset_daemon_scenario import AssetDaemonScenario
 from .updated_scenarios.basic_scenarios import basic_scenarios
 from .updated_scenarios.cron_scenarios import cron_scenarios
+from .updated_scenarios.freshness_policy_scenarios import freshness_policy_scenarios
 from .updated_scenarios.partition_scenarios import partition_scenarios
 
-all_scenarios = basic_scenarios + partition_scenarios + cron_scenarios
+all_scenarios = basic_scenarios + cron_scenarios + freshness_policy_scenarios + partition_scenarios
 
 
 @pytest.fixture
-def daemon_instance():
+def daemon_instance() -> Generator[DagsterInstance, None, None]:
     with instance_for_test(
         overrides={
             "run_launcher": {
@@ -20,9 +23,9 @@ def daemon_instance():
                 "class": "SyncInMemoryRunLauncher",
             }
         }
-    ) as the_instance:
-        set_auto_materialize_paused(the_instance, False)
-        yield the_instance
+    ) as instance:
+        set_auto_materialize_paused(instance, False)
+        yield instance
 
 
 @pytest.mark.parametrize("scenario", all_scenarios, ids=[scenario.id for scenario in all_scenarios])

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/basic_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/basic_scenarios.py
@@ -283,7 +283,7 @@ basic_scenarios = [
         .with_runs(run_request(["A"]), run_request(["A"]))
         .evaluate_tick()
         .assert_requested_runs(run_request(["B"]))
-        .with_requested_runs()
+        .with_not_started_runs()
         .evaluate_tick()
         .assert_requested_runs(),
     ),

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
@@ -356,7 +356,7 @@ cron_scenarios = [
         .assert_requested_runs(
             *[run_request(["A"], hour_partition_key(state.current_time, delta=i)) for i in range(3)]
         )
-        .with_requested_runs()
+        .with_not_started_runs()
         .with_current_time_advanced(hours=2)
         .evaluate_tick()
         .assert_requested_runs(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/freshness_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/freshness_policy_scenarios.py
@@ -1,0 +1,285 @@
+from dagster import AutoMaterializePolicy, FreshnessPolicy
+from dagster._core.definitions.asset_spec import AssetSpec
+
+from ..asset_daemon_scenario import (
+    AssetDaemonScenario,
+    AssetDaemonScenarioState,
+    day_partition_key,
+)
+from ..base_scenario import run_request
+from .asset_daemon_scenario_states import (
+    daily_partitions_def,
+    diamond,
+    one_asset,
+    one_asset_depends_on_two,
+    time_partitions_start,
+    two_assets_depend_on_one,
+    two_assets_in_sequence,
+)
+
+freshness_30m = FreshnessPolicy(maximum_lag_minutes=30)
+freshness_60m = FreshnessPolicy(maximum_lag_minutes=60)
+extended_diamond = AssetDaemonScenarioState(
+    asset_specs=[*diamond.asset_specs, AssetSpec("E", deps=["C"]), AssetSpec("F", deps=["D"])]
+)
+
+freshness_policy_scenarios = [
+    AssetDaemonScenario(
+        id="one_asset_lazy_never_materialized",
+        initial_state=one_asset.with_asset_properties(
+            auto_materialize_policy=AutoMaterializePolicy.lazy()
+        ),
+        execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(),
+    ),
+    AssetDaemonScenario(
+        id="one_asset_lazy_never_materialized_nothing_dep",
+        initial_state=AssetDaemonScenarioState(
+            asset_specs=[AssetSpec("B", deps=["A"])]
+        ).with_asset_properties(
+            auto_materialize_policy=AutoMaterializePolicy.lazy(), freshness_policy=freshness_30m
+        ),
+        execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(run_request("B")),
+    ),
+    AssetDaemonScenario(
+        id="one_asset_lazy_with_freshness_policy_never_materialized",
+        initial_state=one_asset.with_asset_properties(
+            auto_materialize_policy=AutoMaterializePolicy.lazy(),
+            freshness_policy=FreshnessPolicy(maximum_lag_minutes=10),
+        ),
+        execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(run_request("A")),
+    ),
+    AssetDaemonScenario(
+        id="two_assets_eager_with_freshness_policies",
+        initial_state=two_assets_in_sequence.with_asset_properties(
+            auto_materialize_policy=AutoMaterializePolicy.eager(),
+            freshness_policy=FreshnessPolicy(maximum_lag_minutes=1000),
+        ),
+        execution_fn=lambda state: state.evaluate_tick()
+        .assert_requested_runs(run_request(["A", "B"]))
+        .with_runs(run_request("A"))
+        .evaluate_tick()
+        .assert_requested_runs(run_request("B")),
+    ),
+    AssetDaemonScenario(
+        id="one_asset_depends_on_two_lazy",
+        initial_state=one_asset_depends_on_two.with_asset_properties(
+            auto_materialize_policy=AutoMaterializePolicy.lazy(),
+            freshness_policy=freshness_30m,
+        ),
+        execution_fn=lambda state: state.with_runs(run_request(["A", "B", "C"]))
+        .with_current_time_advanced(minutes=35)
+        .with_runs(run_request("A"))
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["B", "C"]))
+        .with_not_started_runs()
+        .evaluate_tick()
+        # now policies are taken off of the root assets
+        .assert_requested_runs()
+        .with_asset_properties(keys=["A", "B"], auto_materialize_policy=None)
+        .with_current_time_advanced(minutes=35)
+        .evaluate_tick()
+        # waiting for A and B to become available
+        .assert_requested_runs()
+        .with_runs(run_request("A"))
+        .evaluate_tick()
+        # waiting for B to become available
+        .assert_requested_runs()
+        .with_runs(run_request("B"))
+        .evaluate_tick()
+        .assert_requested_runs(run_request("C")),
+    ),
+    AssetDaemonScenario(
+        id="diamond_lazy_basic",
+        initial_state=diamond.with_asset_properties(
+            auto_materialize_policy=AutoMaterializePolicy.lazy(),
+            freshness_policy=freshness_30m,
+        ),
+        execution_fn=lambda state: state.evaluate_tick()
+        # at first, nothing materialized, so must materialize everything
+        .assert_requested_runs(run_request(["A", "B", "C", "D"]))
+        .with_not_started_runs()
+        # 35 minutes later, must materialize A, B, C, D again
+        .with_current_time_advanced(minutes=35)
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["A", "B", "C", "D"]))
+        # even though that run hasn't completed, it will complete within the plan window
+        .with_current_time_advanced(minutes=1)
+        .evaluate_tick()
+        .assert_requested_runs()
+        # now that run completes
+        .with_not_started_runs()
+        .evaluate_tick()
+        .assert_requested_runs()
+        # a new run comes in
+        .with_runs(run_request("A"))
+        # but we don't evaluate until 35 minutes later, when it's time to materialize A, B, C, D again
+        .with_current_time_advanced(minutes=35)
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["A", "B", "C", "D"])),
+    ),
+    AssetDaemonScenario(
+        id="diamond_lazy_half_run_stale",
+        initial_state=diamond.with_asset_properties(
+            auto_materialize_policy=AutoMaterializePolicy.lazy(),
+            freshness_policy=freshness_30m,
+        ),
+        execution_fn=lambda state: state.with_runs(run_request(["A", "B"]))
+        .with_current_time_advanced(minutes=35)
+        .evaluate_tick()
+        # the runs of A and B are too old to be used
+        .assert_requested_runs(run_request(["A", "B", "C", "D"])),
+    ),
+    AssetDaemonScenario(
+        id="diamond_lazy_half_run_and_failures",
+        initial_state=diamond.with_asset_properties(
+            auto_materialize_policy=AutoMaterializePolicy.lazy(),
+            freshness_policy=freshness_30m,
+        ),
+        execution_fn=lambda state: state.with_runs(run_request(["A", "B"]))
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["C", "D"]))
+        .with_not_started_runs()
+        # now a failed run of C comes in, nothing should happen
+        .with_runs(run_request("C", fail_keys=["C"]))
+        .evaluate_tick()
+        .assert_requested_runs()
+        # 35 minutes later assets should be materialized again
+        .with_current_time_advanced(minutes=35)
+        # A and C happen manually
+        .with_runs(run_request(["A", "C"]))
+        .with_current_time_advanced(minutes=5)
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["B", "D"]))
+        .with_not_started_runs()
+        # everything was up to date, but now it's 35 minutes later, so we need to materialize again
+        .with_current_time_advanced(minutes=35)
+        .with_runs(run_request(["A", "B", "C"], fail_keys=["C"]))
+        .evaluate_tick()
+        # even though D doesn't have the most up to date data yet, we just tried to materialize C
+        # and failed, so it doesn't make sense to try to run it again to get D up to date
+        .assert_requested_runs()
+        # now that it's been awhile since the run failed, we can try again
+        .with_current_time_advanced(minutes=30)
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["A", "B", "C", "D"]))
+        .with_not_started_runs()
+        .with_current_time_advanced(minutes=35)
+        .with_runs(
+            run_request("A", fail_keys=["A"]),
+        )
+        .evaluate_tick()
+        # need to rematerialize all, but A just failed so we don't want to retry immediately
+        .assert_requested_runs()
+        # now that it's been awhile since the run failed, we can try again
+        .with_current_time_advanced(minutes=35)
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["A", "B", "C", "D"]))
+        .with_not_started_runs(),
+    ),
+    AssetDaemonScenario(
+        id="diamond_lazy_root_unselected",
+        initial_state=diamond.with_asset_properties(
+            auto_materialize_policy=AutoMaterializePolicy.lazy(),
+            freshness_policy=freshness_30m,
+        ).with_asset_properties(keys=["A"], auto_materialize_policy=None),
+        execution_fn=lambda state: state.evaluate_tick()
+        .assert_requested_runs()
+        .with_runs(run_request("A"))
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["B", "C", "D"]))
+        .evaluate_tick()
+        .assert_requested_runs(),
+    ),
+    AssetDaemonScenario(
+        id="extended_diamond_lazy",
+        initial_state=extended_diamond.with_asset_properties(
+            auto_materialize_policy=AutoMaterializePolicy.lazy(),
+        )
+        .with_asset_properties(keys=["E"], freshness_policy=freshness_30m)
+        .with_asset_properties(keys=["F"], freshness_policy=freshness_60m),
+        execution_fn=lambda state: state.with_runs(
+            run_request(["A", "C", "E"]), run_request(["B", "D", "F"])
+        )
+        .evaluate_tick()
+        .assert_requested_runs()
+        .with_current_time_advanced(minutes=65)
+        .with_runs(run_request(["A"], fail_keys=["A"]))
+        .evaluate_tick()
+        # need new data, but run just failed, so must wait
+        .assert_requested_runs()
+        .with_current_time_advanced(minutes=65)
+        .evaluate_tick()
+        # now we can try again
+        .assert_requested_runs(run_request(["A", "B", "C", "D", "E", "F"]))
+        .with_not_started_runs()
+        .with_current_time_advanced(minutes=35)
+        .evaluate_tick()
+        # 35 minutes later, only need to refresh the assets on the shorter freshness policy
+        .assert_requested_runs(run_request(["A", "C", "E"])),
+    ),
+    AssetDaemonScenario(
+        id="two_assets_depend_on_one_lazy_with_cron_freshness",
+        initial_state=two_assets_depend_on_one.with_asset_properties(
+            auto_materialize_policy=AutoMaterializePolicy.lazy(),
+        )
+        .with_asset_properties(keys=["B"], freshness_policy=freshness_30m)
+        .with_asset_properties(
+            keys=["C"],
+            freshness_policy=FreshnessPolicy(cron_schedule="0 7 * * *", maximum_lag_minutes=7 * 60),
+        )
+        .with_current_time("2023-01-01T06:00"),
+        execution_fn=lambda state: state.with_runs(run_request(["A", "B", "C"]))
+        .with_current_time_advanced(minutes=90)
+        .evaluate_tick()
+        # A and B are stale, but C is not
+        .assert_requested_runs(run_request(["A", "B"]))
+        .with_not_started_runs()
+        # now all are stale
+        .with_current_time_advanced(hours=20)
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["A", "B", "C"])),
+    ),
+    AssetDaemonScenario(
+        id="extended_diamond_with_source_lazy",
+        initial_state=extended_diamond.with_asset_properties(
+            auto_materialize_policy=AutoMaterializePolicy.lazy(),
+        )
+        .with_asset_properties(keys=["A"], deps=["source"])
+        .with_asset_properties(keys=["E"], freshness_policy=freshness_30m)
+        .with_asset_properties(keys=["F"], freshness_policy=freshness_60m),
+        execution_fn=lambda state: state.with_runs(
+            run_request(["A", "C", "E"]), run_request(["B", "D", "F"])
+        )
+        .evaluate_tick()
+        .assert_requested_runs(),
+    ),
+    AssetDaemonScenario(
+        id="daily_to_unpartitioned_lazy",
+        initial_state=two_assets_in_sequence.with_asset_properties(
+            "A", partitions_def=daily_partitions_def
+        )
+        .with_asset_properties(
+            "B",
+            auto_materialize_policy=AutoMaterializePolicy.lazy(),
+            freshness_policy=freshness_30m,
+        )
+        .with_current_time(time_partitions_start)
+        .with_current_time_advanced(days=1),
+        execution_fn=lambda state: state.evaluate_tick()
+        .assert_requested_runs()
+        .with_runs(run_request("A", partition_key=day_partition_key(state.current_time)))
+        .evaluate_tick()
+        .assert_requested_runs(run_request("B")),
+    ),
+]
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    freshness_policy_scenarios,
+    ids=[scenario.id for scenario in freshness_policy_scenarios],
+)
+def test_scenario_fast(scenario: AssetDaemonScenario) -> None:
+    scenario.evaluate_fast()

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/freshness_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/freshness_policy_scenarios.py
@@ -272,14 +272,3 @@ freshness_policy_scenarios = [
         .assert_requested_runs(run_request("B")),
     ),
 ]
-
-import pytest
-
-
-@pytest.mark.parametrize(
-    "scenario",
-    freshness_policy_scenarios,
-    ids=[scenario.id for scenario in freshness_policy_scenarios],
-)
-def test_scenario_fast(scenario: AssetDaemonScenario) -> None:
-    scenario.evaluate_fast()


### PR DESCRIPTION
## Summary & Motivation

Further progress on porting over tests from the old framework. Leaves a few tests in the original `freshness_policy_scenarios.py`.

A few updates to the framework needed to be made in order for us to accurately test this stuff:

- Need to mock `time.time` so that runs will be executed with the proper timestamps (pendulum.test() doesn't cover all the places where we get the current time)
- Need to actually add requested runs to the instance after each tick evaluation, as freshness logic uses this
- Need a way to request a run that will fail partway through

In several places in the old framework, we'd have patterns where we'd have one scenario assert that no runs were kicked off if a run had just failed, then another scenario where it'd be the exact same, but with an extra delay (and then we'd assert that a run DID get kicked off). This is much more efficient in the new framework, and so many tests can be combined into one.

## How I Tested These Changes
