### PR TITLE
improve error with load_asset_value and dynamic partitions

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -42,8 +42,12 @@ class AssetValueLoader:
         self._source_assets_by_key = source_assets_by_key
         self._resource_instance_cache: Dict[str, object] = {}
         self._exit_stack: ExitStack = ExitStack().__enter__()
-        if not instance and is_dagster_home_set():
-            self._instance = self._exit_stack.enter_context(DagsterInstance.get())
+        if not instance:
+            if is_dagster_home_set():
+                instance = DagsterInstance.get()
+            else:
+                instance = DagsterInstance.ephemeral()
+            self._instance = self._exit_stack.enter_context(instance)
         else:
             self._instance = instance
 


### PR DESCRIPTION
## Summary & Motivation

Motivated by https://github.com/dagster-io/dagster/issues/17664

Prior to this change, we would just raise an error saying the instance is not available and that this might be because they're on the wrong version.

## How I Tested These Changes
