### PR TITLE
fix backfill policies with dynamic partitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -31,6 +31,7 @@ from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.time_window_partitions import (
     get_time_partitions_def,
 )
+from dagster._core.instance import DynamicPartitionsStore
 from dagster._utils.cached_method import cached_method
 
 from ... import PartitionKeyRange
@@ -636,6 +637,7 @@ def build_run_requests_with_backfill_policies(
     asset_partitions: Iterable[AssetKeyPartitionKey],
     asset_graph: AssetGraph,
     run_tags: Optional[Mapping[str, str]],
+    dynamic_partitions_store: DynamicPartitionsStore,
 ) -> Sequence[RunRequest]:
     """If all assets have backfill policies, we should respect them and materialize them according
     to their backfill policies.
@@ -687,6 +689,7 @@ def build_run_requests_with_backfill_policies(
                         check.not_none(partition_keys),
                         check.not_none(partitions_def),
                         tags,
+                        dynamic_partitions_store=dynamic_partitions_store,
                     )
                 )
             else:
@@ -700,6 +703,7 @@ def build_run_requests_with_backfill_policies(
                             check.not_none(partition_keys),
                             check.not_none(partitions_def),
                             tags,
+                            dynamic_partitions_store=dynamic_partitions_store,
                         )
                     )
     return run_requests
@@ -711,10 +715,13 @@ def _build_run_requests_with_backfill_policy(
     partition_keys: FrozenSet[str],
     partitions_def: PartitionsDefinition,
     tags: Dict[str, Any],
+    dynamic_partitions_store: DynamicPartitionsStore,
 ) -> Sequence[RunRequest]:
     run_requests = []
     partition_subset = partitions_def.subset_with_partition_keys(partition_keys)
-    partition_key_ranges = partition_subset.get_partition_key_ranges()
+    partition_key_ranges = partition_subset.get_partition_key_ranges(
+        dynamic_partitions_store=dynamic_partitions_store
+    )
     for partition_key_range in partition_key_ranges:
         # We might resolve more than one partition key range for the given partition keys.
         # We can only apply chunking on individual partition key ranges.

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1181,6 +1181,7 @@ def execute_asset_backfill_iteration_inner(
             asset_partitions=asset_partitions_to_request,
             asset_graph=asset_graph,
             run_tags={**run_tags, BACKFILL_ID_TAG: backfill_id},
+            dynamic_partitions_store=instance_queryer,
         )
     else:
         if not all(backfill_policy is None for backfill_policy in asset_backfill_policies):


### PR DESCRIPTION
## Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/17693

## How I Tested These Changes

Manually ran a backfill with this:

```python
from dagster import BackfillPolicy, DynamicPartitionsDefinition, asset


@asset(
    backfill_policy=BackfillPolicy.single_run(),
    partitions_def=DynamicPartitionsDefinition(name="apple"),
)
def asset1() -> None:
    ...
```