### PR TITLE
fix schedule with job partitions inferred from asset with multi-parti…

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
@@ -48,15 +48,16 @@ class UnresolvedPartitionedAssetScheduleDefinition(NamedTuple):
         partitions_def = _check_valid_schedule_partitions_def(partitions_def)
         time_partitions_def = check.not_none(get_time_partitions_def(partitions_def))
 
-        return ScheduleDefinition(
-            job=resolved_job,
+        return schedule(
             name=self.name,
-            execution_fn=_get_schedule_evaluation_fn(partitions_def, resolved_job, self.tags),
-            execution_timezone=time_partitions_def.timezone,
             cron_schedule=time_partitions_def.get_cron_schedule(
                 self.minute_of_hour, self.hour_of_day, self.day_of_week, self.day_of_month
             ),
-        )
+            job=resolved_job,
+            default_status=self.default_status,
+            execution_timezone=time_partitions_def.timezone,
+            description=self.description,
+        )(_get_schedule_evaluation_fn(partitions_def, resolved_job, self.tags))
 
 
 def build_schedule_from_partitioned_job(


### PR DESCRIPTION
…tions

## Summary & Motivation

When a partitions def is not explicitly supplied to `define_asset_job`, we infer one from the partitions on the underlying assets. When we use `build_schedule_from_partitioned_job` to build a schedule on top of that job, we use those inferred partitions.

When the inferred partitions definition is a multi-partitions definition, each schedule tick returns a list containing a run request per partition.

However, apparently, when you construct a schedule using the `ScheduleDefinition` constructor instead of the decorator, you're not allowed to return a list of run requests.

We were using the decorator in the case where the partitions definition was passed into `define_asset_job`, but using the constructor in the case where we inferred the partitions definition from the underlying assets. This fixes the issue by using the decorator in both cases.

Fixes https://github.com/dagster-io/dagster/issues/17592

## How I Tested These Changes
