### PR TITLE
[Asset graph] Make tight-tree the default layout algorithm

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -16,7 +16,6 @@ export const FeatureFlag = {
   flagDisableAutoLoadDefaults: 'flagDisableAutoLoadDefaults' as const,
   flagDAGSidebar: 'flagDAGSidebar' as const,
   flagDisableDAGCache: 'flagDisableDAGCache' as const,
-  flagTightTreeDag: 'flagTightTreeDag' as const,
   flagLongestPathDag: 'flagLongestPathDag' as const,
 };
 export type FeatureFlagType = keyof typeof FeatureFlag;

--- a/js_modules/dagster-ui/packages/ui-core/src/app/GraphQueryImpl.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/GraphQueryImpl.ts
@@ -84,7 +84,7 @@ function expansionDepthForClause(clause: string) {
 
 export function filterByQuery<T extends GraphQueryItem>(items: T[], query: string) {
   if (query === '*' || query === '') {
-    return {all: items, applyingEmptyDefault: false, focus: []};
+    return {all: items, focus: []};
   }
 
   const traverser = new GraphTraverser<T>(items);
@@ -124,6 +124,5 @@ export function filterByQuery<T extends GraphQueryItem>(items: T[], query: strin
   return {
     all: Array.from(results),
     focus: Array.from(focus),
-    applyingEmptyDefault: false,
   };
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/app/GraphQueryImpl.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/GraphQueryImpl.ts
@@ -1,9 +1,5 @@
 import {isPlannedDynamicStep, dynamicKeyWithoutIndex} from '../gantt/DynamicStepSupport';
 
-import {featureEnabled, FeatureFlag} from './Flags';
-
-const MAX_RENDERED_FOR_EMPTY_QUERY = 100;
-
 export interface GraphQueryItem {
   name: string;
   inputs: {
@@ -87,17 +83,8 @@ function expansionDepthForClause(clause: string) {
 }
 
 export function filterByQuery<T extends GraphQueryItem>(items: T[], query: string) {
-  if (query === '*') {
+  if (query === '*' || query === '') {
     return {all: items, applyingEmptyDefault: false, focus: []};
-  }
-  const fastDag =
-    featureEnabled(FeatureFlag.flagTightTreeDag) || featureEnabled(FeatureFlag.flagLongestPathDag);
-  if (query === '') {
-    return {
-      all: !fastDag && items.length >= MAX_RENDERED_FOR_EMPTY_QUERY ? [] : items,
-      applyingEmptyDefault: !fastDag && items.length >= MAX_RENDERED_FOR_EMPTY_QUERY,
-      focus: [],
-    };
   }
 
   const traverser = new GraphTraverser<T>(items);

--- a/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
@@ -58,24 +58,6 @@ export const getVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagDisableDAGCache,
   },
   {
-    key: 'Experimental tight tree DAG algorithm (Faster)',
-    flagType: FeatureFlag.flagTightTreeDag,
-    label: (
-      <Box flex={{direction: 'column'}}>
-        Experimental tight tree asset graph algorithm (Faster).
-        <div>
-          <a
-            href="https://github.com/dagster-io/dagster/discussions/17240"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Learn more
-          </a>
-        </div>
-      </Box>
-    ),
-  },
-  {
     key: 'Experimental longest path DAG algorithm (Faster)',
     flagType: FeatureFlag.flagLongestPathDag,
     label: (

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -30,15 +30,10 @@ import {
   RightInfoPanel,
   RightInfoPanelContent,
 } from '../pipelines/GraphExplorer';
-import {
-  EmptyDAGNotice,
-  EntirelyFilteredDAGNotice,
-  LargeDAGNotice,
-  LoadingNotice,
-} from '../pipelines/GraphNotices';
+import {EmptyDAGNotice, EntirelyFilteredDAGNotice, LoadingNotice} from '../pipelines/GraphNotices';
 import {ExplorerPath} from '../pipelines/PipelinePathUtils';
 import {GraphQueryInput} from '../ui/GraphQueryInput';
-import {Loading, LoadingSpinner} from '../ui/Loading';
+import {Loading} from '../ui/Loading';
 
 import {AssetEdges} from './AssetEdges';
 import {AssetGraphJobSidebar} from './AssetGraphJobSidebar';
@@ -71,19 +66,8 @@ export const MINIMAL_SCALE = 0.6;
 export const GROUPS_ONLY_SCALE = 0.15;
 
 export const AssetGraphExplorer = (props: Props) => {
-  const {
-    fetchResult,
-    assetGraphData,
-    fullAssetGraphData,
-    graphQueryItems,
-    allAssetKeys,
-    applyingEmptyDefault,
-    isCalculating,
-  } = useAssetGraphData(props.explorerPath.opsQuery, props.fetchOptions);
-
-  if (isCalculating) {
-    return <LoadingSpinner purpose="page" />;
-  }
+  const {fetchResult, assetGraphData, fullAssetGraphData, graphQueryItems, allAssetKeys} =
+    useAssetGraphData(props.explorerPath.opsQuery, props.fetchOptions);
 
   return (
     <Loading allowStaleData queryResult={fetchResult}>
@@ -110,7 +94,6 @@ export const AssetGraphExplorer = (props: Props) => {
             fullAssetGraphData={fullAssetGraphData}
             allAssetKeys={allAssetKeys}
             graphQueryItems={graphQueryItems}
-            applyingEmptyDefault={applyingEmptyDefault}
             {...props}
           />
         );
@@ -124,7 +107,6 @@ interface WithDataProps extends Props {
   assetGraphData: GraphData;
   fullAssetGraphData: GraphData;
   graphQueryItems: AssetGraphQueryItem[];
-  applyingEmptyDefault: boolean;
 }
 
 const AssetGraphExplorerWithData = ({
@@ -136,7 +118,6 @@ const AssetGraphExplorerWithData = ({
   assetGraphData,
   fullAssetGraphData,
   graphQueryItems,
-  applyingEmptyDefault,
   fetchOptions,
   fetchOptionFilters,
   allAssetKeys,
@@ -155,9 +136,7 @@ const AssetGraphExplorerWithData = ({
   const lastSelectedNode = selectedGraphNodes[selectedGraphNodes.length - 1]!;
 
   const selectedDefinitions = selectedGraphNodes.map((a) => a.definition);
-  const allDefinitionsForMaterialize = applyingEmptyDefault
-    ? graphQueryItems.map((a) => a.node)
-    : Object.values(assetGraphData.nodes).map((a) => a.definition);
+  const allDefinitionsForMaterialize = Object.values(assetGraphData.nodes).map((a) => a.definition);
 
   const onSelectNode = React.useCallback(
     async (
@@ -301,8 +280,6 @@ const AssetGraphExplorerWithData = ({
         <ErrorBoundary region="graph">
           {graphQueryItems.length === 0 ? (
             <EmptyDAGNotice nodeType="asset" isGraph />
-          ) : applyingEmptyDefault ? (
-            <LargeDAGNotice nodeType="asset" anchorLeft="40px" />
           ) : Object.keys(assetGraphData.nodes).length === 0 ? (
             <EntirelyFilteredDAGNotice nodeType="asset" />
           ) : undefined}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -41,7 +41,6 @@ const MARGIN = 100;
 
 export type LayoutAssetGraphOptions = {
   horizontalDAGs: boolean;
-  tightTree: boolean;
   longestPath: boolean;
 };
 
@@ -51,11 +50,7 @@ export const layoutAssetGraph = (
 ): AssetGraphLayout => {
   const g = new dagre.graphlib.Graph({compound: true});
 
-  const ranker = opts.tightTree
-    ? 'tight-tree'
-    : opts.longestPath
-    ? 'longest-path'
-    : 'network-simplex';
+  const ranker = opts.longestPath ? 'longest-path' : 'tight-tree';
 
   g.setGraph(
     opts.horizontalDAGs

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -58,7 +58,7 @@ const _assetLayoutCacheKey = (graphData: GraphData, opts: LayoutAssetGraphOption
     return newObj;
   }
 
-  return `${opts?.horizontalDAGs ? 'horizontal:' : ''}${opts?.tightTree ? 'tight-tree:' : ''}${
+  return `${opts?.horizontalDAGs ? 'horizontal:' : ''}${
     opts?.longestPath ? 'longest-path' : ''
   }${JSON.stringify({
     downstream: recreateObjectWithKeysSorted(graphData.downstream),
@@ -181,7 +181,6 @@ export function useAssetLayout(graphData: GraphData) {
   const opts = React.useMemo(
     () => ({
       horizontalDAGs: flags.flagHorizontalDAGs,
-      tightTree: flags.flagTightTreeDag,
       longestPath: flags.flagLongestPathDag,
     }),
     [flags],

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/layout.ts
@@ -134,7 +134,7 @@ export function layoutOpGraph(pipelineOps: ILayoutOp[], opts: LayoutOpGraphOptio
   }
 
   // Define a new top-down, left to right graph layout
-  g.setGraph({rankdir: 'TB', marginx, marginy});
+  g.setGraph({rankdir: 'TB', marginx, marginy, ranker: 'tight-tree'});
   g.setDefaultEdgeLabel(() => ({}));
 
   const edges: OpLayoutEdge[] = [];

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphExplorer.tsx
@@ -22,12 +22,7 @@ import {OpNameOrPath} from '../ops/OpNameOrPath';
 import {GraphQueryInput} from '../ui/GraphQueryInput';
 import {RepoAddress} from '../workspace/types';
 
-import {
-  EmptyDAGNotice,
-  EntirelyFilteredDAGNotice,
-  LargeDAGNotice,
-  LoadingNotice,
-} from './GraphNotices';
+import {EmptyDAGNotice, EntirelyFilteredDAGNotice, LoadingNotice} from './GraphNotices';
 import {ExplorerPath} from './PipelinePathUtils';
 import {SIDEBAR_ROOT_CONTAINER_FRAGMENT} from './SidebarContainerOverview';
 import {SidebarRoot} from './SidebarRoot';

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphExplorer.tsx
@@ -164,10 +164,7 @@ export const GraphExplorer = (props: GraphExplorerProps) => {
       solids.some((f) => f.definition.__typename === 'CompositeSolidDefinition'));
 
   const queryResultOps = React.useMemo(
-    () =>
-      solidsQueryEnabled
-        ? filterByQuery(solids, opsQuery)
-        : {all: solids, focus: [], applyingEmptyDefault: false},
+    () => (solidsQueryEnabled ? filterByQuery(solids, opsQuery) : {all: solids, focus: []}),
     [opsQuery, solids, solidsQueryEnabled],
   );
 
@@ -262,8 +259,6 @@ export const GraphExplorer = (props: GraphExplorerProps) => {
 
           {solids.length === 0 ? (
             <EmptyDAGNotice nodeType="op" isGraph={isGraph} />
-          ) : queryResultOps.applyingEmptyDefault ? (
-            <LargeDAGNotice nodeType="op" />
           ) : Object.keys(queryResultOps.all).length === 0 ? (
             <EntirelyFilteredDAGNotice nodeType="op" />
           ) : undefined}

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphNotices.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphNotices.tsx
@@ -1,36 +1,7 @@
-import {Box, Colors, Icon, NonIdealState, Spinner} from '@dagster-io/ui-components';
+import {Box, Colors, NonIdealState, Spinner} from '@dagster-io/ui-components';
 import capitalize from 'lodash/capitalize';
 import * as React from 'react';
 import styled from 'styled-components';
-
-export const LargeDAGNotice = ({
-  nodeType,
-  anchorLeft = '40px',
-}: {
-  nodeType: 'op' | 'asset';
-  anchorLeft?: string;
-}) => (
-  <LargeDAGContainer style={{left: anchorLeft}}>
-    <Icon name="arrow_upward" size={24} />
-    <LargeDAGInstructionBox>
-      <p>
-        This is a large DAG that may be difficult to visualize. Type <code>*</code> in the graph
-        filter bar to render the entire thing, or type {nodeType} names and use:
-      </p>
-      <ul style={{marginBottom: 0}}>
-        <li>
-          <code>+</code> to expand a single layer before or after the {nodeType}.
-        </li>
-        <li>
-          <code>*</code> to expand recursively before or after the {nodeType}.
-        </li>
-        <li>
-          <code>AND</code> to render another disconnected fragment.
-        </li>
-      </ul>
-    </LargeDAGInstructionBox>
-  </LargeDAGContainer>
-);
 
 export const EmptyDAGNotice = ({
   isGraph,

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphNotices.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphNotices.tsx
@@ -76,33 +76,3 @@ const CenteredContainer = styled.div`
   transform: translate(-50%, -50%);
   z-index: 2;
 `;
-
-const LargeDAGContainer = styled.div`
-  width: 45vw;
-  position: absolute;
-  top: 60px;
-  z-index: 2;
-  max-width: 500px;
-  display: flex;
-  flex-direction: column;
-  [role='img'] {
-    opacity: 0.5;
-    margin-left: 10vw;
-  }
-`;
-
-const LargeDAGInstructionBox = styled.div`
-  padding: 15px 20px;
-  border: 1px solid #fff5c3;
-  margin-top: 20px;
-  color: ${Colors.Gray800};
-  background: #fffbe5;
-  text-align: left;
-  line-height: 1.4rem;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-  code {
-    background: #f8ebad;
-    font-weight: 500;
-    padding: 0 4px;
-  }
-`;


### PR DESCRIPTION
## Summary & Motivation

In _most_ cases this algorithm behaves the same as network-simplex while being much much faster so we're making this the default.


## How I Tested These Changes
Local version of dagit, made sure the asset graph still loads