### PR TITLE
[Asset Graph] Improved keyboard navigation

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
@@ -173,7 +173,6 @@ export const Node = ({
                   onClick={(e) => {
                     // stop propagation outside of the popover to prevent parent onClick from being selected
                     e.stopPropagation();
-                    console.log('onClick');
                   }}
                 >
                   <Popover

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
@@ -112,6 +112,10 @@ export const Node = ({
 
   const ref = React.useRef<HTMLButtonElement | null>(null);
   React.useLayoutEffect(() => {
+    // When we click on a node in the graph it also changes "isSelected" in the sidebar.
+    // We want to check if the focus is currently in the graph and if it is lets keep it there
+    // Otherwise it means the click happened in the sidebar in which case we should move focus to the element
+    // in the sidebar
     if (ref.current && isSelected && !isElementInsideSVGViewport(document.activeElement)) {
       ref.current.focus();
     }
@@ -155,18 +159,13 @@ export const Node = ({
               <div style={{width: 18}} />
             )}
             <GrayOnHoverBox
-              onDoubleClick={() => {
-                if (!isOpen) {
-                  toggleOpen();
-                }
-              }}
+              onDoubleClick={toggleOpen}
               style={{
                 width: '100%',
                 borderRadius: '8px',
                 ...(isSelected ? {background: Colors.Blue50} : {}),
               }}
               $showFocusOutline={true}
-              autoFocus={isSelected}
               ref={ref}
             >
               <div
@@ -404,15 +403,5 @@ function StatusDot({node}: {node: Pick<GraphNode, 'assetKey' | 'definition'>}) {
 }
 
 function isElementInsideSVGViewport(element: Element | null) {
-  if (!element) {
-    // We've reached the root without finding an <svg> element
-    return false;
-  }
-
-  if (element.classList.contains('svgViewport')) {
-    return true;
-  }
-
-  // Start the recursive check
-  return isElementInsideSVGViewport(element.parentElement);
+  return !!element?.closest('[data-svg-viewport]');
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
@@ -110,6 +110,13 @@ export const Node = ({
   const showArrow =
     !isAssetNode || (viewType === 'tree' && downstream.filter((id) => graphData.nodes[id]).length);
 
+  const ref = React.useRef<HTMLElement | null>(null);
+  React.useLayoutEffect(() => {
+    if (isSelected) {
+      ref.current?.focus();
+    }
+  }, [isSelected]);
+
   return (
     <>
       {launchpadElement}
@@ -160,6 +167,7 @@ export const Node = ({
               }}
               $showFocusOutline={true}
               autoFocus={isSelected}
+              ref={ref}
             >
               <div
                 style={{

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
@@ -147,13 +147,13 @@ export const Node = ({
                   toggleOpen();
                 }
               }}
-              padding={{horizontal: 8, vertical: 5 as any}}
               style={{
                 width: '100%',
                 borderRadius: '8px',
                 ...(isSelected ? {background: Colors.Blue50} : {}),
               }}
               $showFocusOutline={true}
+              autoFocus={isSelected}
             >
               <div
                 style={{

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
@@ -8,6 +8,7 @@ import {
   MiddleTruncate,
   MenuDivider,
   Spinner,
+  UnstyledButton,
 } from '@dagster-io/ui-components';
 import React from 'react';
 import styled from 'styled-components';
@@ -124,7 +125,8 @@ export const Node = ({
         <BoxWrapper level={level}>
           <Box padding={{right: 12}} flex={{direction: 'row', alignItems: 'center'}}>
             {showArrow ? (
-              <div
+              <UnstyledButton
+                $showFocusOutline
                 onClick={(e) => {
                   e.stopPropagation();
                   toggleOpen();
@@ -135,7 +137,7 @@ export const Node = ({
                   name="arrow_drop_down"
                   style={{transform: isOpen ? 'rotate(0deg)' : 'rotate(-90deg)'}}
                 />
-              </div>
+              </UnstyledButton>
             ) : (
               <div style={{width: 18}} />
             )}
@@ -145,20 +147,13 @@ export const Node = ({
                   toggleOpen();
                 }
               }}
-              flex={{
-                direction: 'row',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                gap: 6,
-                grow: 1,
-                shrink: 1,
-              }}
               padding={{horizontal: 8, vertical: 5 as any}}
               style={{
                 width: '100%',
                 borderRadius: '8px',
                 ...(isSelected ? {background: Colors.Blue50} : {}),
               }}
+              $showFocusOutline={true}
             >
               <div
                 style={{
@@ -178,9 +173,11 @@ export const Node = ({
                   onClick={(e) => {
                     // stop propagation outside of the popover to prevent parent onClick from being selected
                     e.stopPropagation();
+                    console.log('onClick');
                   }}
                 >
                   <Popover
+                    usePortal
                     content={
                       <Menu>
                         <MenuItem
@@ -231,7 +228,7 @@ export const Node = ({
                     placement="right"
                     shouldReturnFocusOnClose
                   >
-                    <ExpandMore style={{cursor: 'pointer'}}>
+                    <ExpandMore tabIndex={0} role="button">
                       <Icon name="more_horiz" color={Colors.Gray500} />
                     </ExpandMore>
                   </Popover>
@@ -347,11 +344,21 @@ const BoxWrapper = ({level, children}: {level: number; children: React.ReactNode
 
 const ExpandMore = styled.div``;
 
-const GrayOnHoverBox = styled(Box)`
+const GrayOnHoverBox = styled(UnstyledButton)`
   border-radius: 8px;
   cursor: pointer;
   user-select: none;
-  &:hover {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 5px 8px;
+  justify-content: space-between;
+  gap: 6;
+  flex-grow: 1;
+  flex-shrink: 1;
+  &:hover,
+  &:focus-within {
     background: ${Colors.Gray100};
     transition: background 100ms linear;
     ${ExpandMore} {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
@@ -131,6 +131,12 @@ export const Node = ({
                   e.stopPropagation();
                   toggleOpen();
                 }}
+                onKeyDown={(e) => {
+                  if (e.code === 'Space') {
+                    // Prevent the default scrolling behavior
+                    e.preventDefault();
+                  }
+                }}
                 style={{cursor: 'pointer', width: 18}}
               >
                 <Icon
@@ -173,6 +179,12 @@ export const Node = ({
                   onClick={(e) => {
                     // stop propagation outside of the popover to prevent parent onClick from being selected
                     e.stopPropagation();
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.code === 'Space') {
+                      // Prevent the default scrolling behavior
+                      e.preventDefault();
+                    }
                   }}
                 >
                   <Popover

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
@@ -110,10 +110,10 @@ export const Node = ({
   const showArrow =
     !isAssetNode || (viewType === 'tree' && downstream.filter((id) => graphData.nodes[id]).length);
 
-  const ref = React.useRef<HTMLElement | null>(null);
+  const ref = React.useRef<HTMLButtonElement | null>(null);
   React.useLayoutEffect(() => {
-    if (isSelected) {
-      ref.current?.focus();
+    if (ref.current && isSelected && !isElementInsideSVGViewport(document.activeElement)) {
+      ref.current.focus();
     }
   }, [isSelected]);
 
@@ -401,4 +401,18 @@ function StatusDot({node}: {node: Pick<GraphNode, 'assetKey' | 'definition'>}) {
     expanded: true,
   });
   return <StatusCaseDot statusCase={status.case} />;
+}
+
+function isElementInsideSVGViewport(element: Element | null) {
+  if (!element) {
+    // We've reached the root without finding an <svg> element
+    return false;
+  }
+
+  if (element.classList.contains('svgViewport')) {
+    return true;
+  }
+
+  // Start the recursive check
+  return isElementInsideSVG(element.parentElement);
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Node.tsx
@@ -414,5 +414,5 @@ function isElementInsideSVGViewport(element: Element | null) {
   }
 
   // Start the recursive check
-  return isElementInsideSVG(element.parentElement);
+  return isElementInsideSVGViewport(element.parentElement);
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/SearchFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/SearchFilter.tsx
@@ -2,6 +2,8 @@ import {MenuItem, useViewport, Suggest} from '@dagster-io/ui-components';
 import React from 'react';
 import styled from 'styled-components';
 
+import {ShortcutHandler} from '../../app/ShortcutHandler';
+
 export const SearchFilter = <T,>({
   values,
   onSelectValue,
@@ -10,31 +12,52 @@ export const SearchFilter = <T,>({
   onSelectValue: (e: React.MouseEvent<any>, value: T) => void;
 }) => {
   const {viewport, containerProps} = useViewport();
+  const ref = React.useRef<HTMLDivElement | null>(null);
   return (
-    <SuggestWrapper {...containerProps}>
-      <Suggest<(typeof values)[0]>
-        key="asset-graph-explorer-search-bar"
-        inputProps={{placeholder: 'Jump to…', style: {width: `min(100%, ${viewport.width}px)`}}}
-        items={values}
-        inputValueRenderer={(item) => item.label}
-        itemPredicate={(query, item) =>
-          item.label.toLocaleLowerCase().includes(query.toLocaleLowerCase())
+    <ShortcutHandler
+      key="insights"
+      onShortcut={() => {
+        if (ref.current) {
+          ref.current.querySelector('input')?.focus();
         }
-        menuWidth={viewport.width}
-        popoverProps={{usePortal: false, fill: true}}
-        itemRenderer={(item, itemProps) => (
-          <MenuItem
-            active={itemProps.modifiers.active}
-            onClick={(e) => itemProps.handleClick(e)}
-            key={item.label}
-            text={item.label}
-          />
-        )}
-        noResults={<MenuItem disabled={true} text="No results" />}
-        onItemSelect={(item, e) => onSelectValue(e as any, item.value)}
-        selectedItem={null}
-      />
-    </SuggestWrapper>
+      }}
+      shortcutLabel="⌥J"
+      // Exclude metakey to not interfere with shortcut for opening/closing devtools
+      shortcutFilter={(e) => !e.metaKey && e.altKey && e.code === 'KeyJ'}
+    >
+      <SuggestWrapper
+        {...containerProps}
+        ref={(div) => {
+          if (div) {
+            ref.current = div;
+            containerProps.ref(div);
+          }
+        }}
+      >
+        <Suggest<(typeof values)[0]>
+          key="asset-graph-explorer-search-bar"
+          inputProps={{placeholder: 'Jump to…', style: {width: `min(100%, ${viewport.width}px)`}}}
+          items={values}
+          inputValueRenderer={(item) => item.label}
+          itemPredicate={(query, item) =>
+            item.label.toLocaleLowerCase().includes(query.toLocaleLowerCase())
+          }
+          menuWidth={viewport.width}
+          popoverProps={{usePortal: false, fill: true}}
+          itemRenderer={(item, itemProps) => (
+            <MenuItem
+              active={itemProps.modifiers.active}
+              onClick={(e) => itemProps.handleClick(e)}
+              key={item.label}
+              text={item.label}
+            />
+          )}
+          noResults={<MenuItem disabled={true} text="No results" />}
+          onItemSelect={(item, e) => onSelectValue(e as any, item.value)}
+          selectedItem={null}
+        />
+      </SuggestWrapper>
+    </ShortcutHandler>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -295,6 +295,8 @@ export const AssetGraphExplorerSidebar = React.memo(
       // eslint-disable-next-line react-hooks/exhaustive-deps
       [viewType, renderedNodes, selectedNode],
     );
+    const indexOfLastSelectedNodeRef = React.useRef(indexOfLastSelectedNode);
+    indexOfLastSelectedNodeRef.current = indexOfLastSelectedNode;
 
     React.useLayoutEffect(() => {
       if (indexOfLastSelectedNode !== -1) {
@@ -354,7 +356,8 @@ export const AssetGraphExplorerSidebar = React.memo(
             onKeyDown={(e) => {
               let nextIndex = 0;
               if (e.code === 'ArrowDown' || e.code === 'ArrowUp') {
-                nextIndex = indexOfLastSelectedNode + (e.code === 'ArrowDown' ? 1 : -1);
+                nextIndex = indexOfLastSelectedNodeRef.current + (e.code === 'ArrowDown' ? 1 : -1);
+                indexOfLastSelectedNodeRef.current = nextIndex;
                 e.preventDefault();
                 const nextNode = renderedNodes[nextIndex % renderedNodes.length]!;
                 setSelectedNode(nextNode);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -349,7 +349,34 @@ export const AssetGraphExplorerSidebar = React.memo(
           />
         </Box>
         <div>
-          <Container ref={containerRef}>
+          <Container
+            ref={containerRef}
+            onKeyDown={(e) => {
+              let nextIndex = 0;
+              if (e.code === 'ArrowDown' || e.code === 'ArrowUp') {
+                nextIndex = indexOfLastSelectedNode + (e.code === 'ArrowDown' ? 1 : -1);
+                e.preventDefault();
+                const nextNode = renderedNodes[nextIndex % renderedNodes.length]!;
+                setSelectedNode(nextNode);
+                selectNode(e, nextNode.id);
+              } else if (e.code === 'ArrowLeft' || e.code === 'ArrowRight') {
+                const open = e.code === 'ArrowRight';
+                setOpenNodes((nodes) => {
+                  const node = renderedNodes[indexOfLastSelectedNode];
+                  if (!node) {
+                    return nodes;
+                  }
+                  const openNodes = new Set(nodes);
+                  if (open) {
+                    openNodes.add(nodePathKey(node));
+                  } else {
+                    openNodes.delete(nodePathKey(node));
+                  }
+                  return openNodes;
+                });
+              }
+            }}
+          >
             <Inner $totalHeight={totalHeight}>
               {items.map(({index, key, size, start, measureElement}) => {
                 const node = renderedNodes[index]!;

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
@@ -606,7 +606,7 @@ export class SVGViewport extends React.Component<SVGViewportProps, SVGViewportSt
           backgroundSize: `${dotsize}px`,
           cursor: isClickHeld ? 'grabbing' : 'grab',
         })}
-        className="svgViewport"
+        data-svg-viewport="1"
         onMouseDown={(e) => interactor.onMouseDown(this, e)}
         onDoubleClick={this.onDoubleClick}
         onKeyDown={this.onKeyDown}

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
@@ -606,6 +606,7 @@ export class SVGViewport extends React.Component<SVGViewportProps, SVGViewportSt
           backgroundSize: `${dotsize}px`,
           cursor: isClickHeld ? 'grabbing' : 'grab',
         })}
+        className="svgViewport"
         onMouseDown={(e) => interactor.onMouseDown(this, e)}
         onDoubleClick={this.onDoubleClick}
         onKeyDown={this.onKeyDown}


### PR DESCRIPTION
## Summary & Motivation

- Use unstyled button for asset node divs in sidebar so that space/enter trigger the onClick and so that theyre tabbable
- Add tabIndex to button that opens popover because blueprints popover doesnt work well with buttons

## How I Tested These Changes

Locally
![Screenshot 2023-11-06 at 3 11 27 PM](https://github.com/dagster-io/dagster/assets/2286579/bf9b9e91-c42e-4a4d-8be0-6a2faacd0602)
![Screenshot 2023-11-06 at 3 11 23 PM](https://github.com/dagster-io/dagster/assets/2286579/fd64eae7-3674-4273-8b87-e89e9eca48f4)
![Screenshot 2023-11-06 at 3 11 20 PM](https://github.com/dagster-io/dagster/assets/2286579/ead43279-f696-4df8-94c0-26f3fcc5c9fb)
![Screenshot 2023-11-06 at 3 11 11 PM](https://github.com/dagster-io/dagster/assets/2286579/09f78e07-0a9d-4054-8e26-8f5033f75b6e)
![Screenshot 2023-11-06 at 3 11 09 PM](https://github.com/dagster-io/dagster/assets/2286579/93238ac9-4995-460c-8a9b-b81e51436267)
![Screenshot 2023-11-06 at 3 11 07 PM](https://github.com/dagster-io/dagster/assets/2286579/3d9657b9-155a-4f24-a12d-d0ec02be012c)

