### PR TITLE
add partition-mapping auto-materialize perf scenario

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/perf/partition_mappings_galore_perf_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/perf/partition_mappings_galore_perf_scenario.py
@@ -1,0 +1,96 @@
+from typing import Optional, Sequence
+
+from dagster import (
+    AssetDep,
+    AssetsDefinition,
+    AutoMaterializePolicy,
+    DailyPartitionsDefinition,
+    Definitions,
+    HourlyPartitionsDefinition,
+    PartitionsDefinition,
+    RunRequest,
+    TimeWindowPartitionMapping,
+    asset,
+)
+from dagster._core.storage.tags import (
+    ASSET_PARTITION_RANGE_END_TAG,
+    ASSET_PARTITION_RANGE_START_TAG,
+)
+
+from .perf_scenario import ActivityHistory, PerfScenario
+
+
+def asset_def(
+    key: str,
+    deps: Sequence[str],
+    partitions_def: Optional[PartitionsDefinition] = None,
+) -> AssetsDefinition:
+    @asset(
+        name=key,
+        partitions_def=partitions_def,
+        deps=deps,
+        auto_materialize_policy=AutoMaterializePolicy.eager(),
+    )
+    def _asset() -> None:
+        ...
+
+    return _asset
+
+
+hourly_one_year = HourlyPartitionsDefinition(start_date="2022-10-18-00:00")
+hourly_two_years = HourlyPartitionsDefinition(start_date="2021-10-18-00:00")
+daily_one_year = DailyPartitionsDefinition(start_date="2022-10-18")
+daily_four_years = DailyPartitionsDefinition(start_date="2019-10-18")
+daily_ten_years = DailyPartitionsDefinition(start_date="2013-10-18")
+
+
+assets = [
+    asset_def("a_1", deps=[], partitions_def=hourly_two_years),
+    asset_def("a_2", deps=[], partitions_def=hourly_two_years),
+    asset_def("b", deps=["a_1"], partitions_def=daily_four_years),
+    asset_def(
+        "c",
+        deps=[
+            "a_1",
+            AssetDep("a_2", partition_mapping=TimeWindowPartitionMapping(start_offset=-3)),
+        ],
+        partitions_def=hourly_one_year,
+    ),
+    asset_def("d", deps=["a_1", "b"], partitions_def=daily_four_years),
+    asset_def("e", deps=["c"], partitions_def=daily_ten_years),
+    asset_def("f", deps=["c"], partitions_def=daily_one_year),
+    asset_def(
+        "leaf",
+        deps=[
+            "d",
+            AssetDep("e", partition_mapping=TimeWindowPartitionMapping(start_offset=-28)),
+            "f",
+        ],
+        partitions_def=daily_four_years,
+    ),
+]
+assets_by_key = {asset_def.key.to_user_string(): asset_def for asset_def in assets}
+
+
+defs = Definitions(assets)
+
+
+def build_run_request_for_all_partitions(asset_def: AssetsDefinition) -> RunRequest:
+    return RunRequest(
+        asset_selection=[asset_def.key],
+        tags={
+            ASSET_PARTITION_RANGE_START_TAG: asset_def.partitions_def.get_first_partition_key(),
+            ASSET_PARTITION_RANGE_END_TAG: asset_def.partitions_def.get_last_partition_key(),
+        },
+    )
+
+
+partition_mappings_galore_perf_scenario = PerfScenario(
+    name="partition_mappings_galore",
+    defs=defs,
+    max_execution_time_seconds=25,
+    activity_history=ActivityHistory(
+        [build_run_request_for_all_partitions(a) for a in assets]
+        + [build_run_request_for_all_partitions(assets_by_key["d"])]
+    ),
+)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/perf/perf_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/perf/perf_scenario.py
@@ -4,6 +4,7 @@ import tarfile
 import tempfile
 import warnings
 from contextlib import contextmanager
+from datetime import datetime
 from typing import List, NamedTuple, Optional, Sequence
 
 from dagster import (
@@ -57,6 +58,7 @@ class PerfScenario(NamedTuple):
     defs: Definitions
     activity_history: ActivityHistory
     max_execution_time_seconds: int
+    current_time: Optional[datetime] = None
 
     def save_instance_snapshot(self) -> None:
         """Executes the specified runs for the given asset graph, writing the resulting instance to

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/perf/test_asset_daemon_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/perf/test_asset_daemon_perf.py
@@ -98,6 +98,7 @@ def test_auto_materialize_perf(scenario: PerfScenario):
             observe_run_tags=None,
             respect_materialization_data_versions=True,
             logger=logging.getLogger("dagster.amp"),
+            evaluation_time=scenario.current_time,
         ).evaluate()
 
         end = time.time()

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/perf/test_asset_daemon_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/perf/test_asset_daemon_perf.py
@@ -15,6 +15,7 @@ from dagster import (
 from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 
+from .partition_mappings_galore_perf_scenario import partition_mappings_galore_perf_scenario
 from .perf_scenario import PerfScenario, RandomAssets
 
 warnings.simplefilter("ignore", category=ExperimentalWarning)
@@ -74,6 +75,7 @@ perf_scenarios = [
         ),
         max_execution_time_seconds=30,
     ),
+    partition_mappings_galore_perf_scenario,
 ]
 
 


### PR DESCRIPTION
## Summary & Motivation

I developed this a couple weeks ago to exercise some of the slow code paths that one of our large auto-materialize users was hitting. It involves a set of different time window partitions definitions. It currently takes about 19 seconds to execute.

## How I Tested These Changes
