### PR TITLE
[asset backfill] RFC: Handle run success w/ no materialization

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1909,6 +1909,7 @@ class DagsterInstance(DynamicPartitionsStore):
         event_records_filter: "EventRecordsFilter",
         limit: Optional[int] = None,
         ascending: bool = False,
+        force_use_index_connection: bool = False,
     ) -> Sequence["EventLogRecord"]:
         """Return a list of event records stored in the event log storage.
 
@@ -1922,7 +1923,9 @@ class DagsterInstance(DynamicPartitionsStore):
         Returns:
             List[EventLogRecord]: List of event log records stored in the event log storage.
         """
-        return self._event_storage.get_event_records(event_records_filter, limit, ascending)
+        return self._event_storage.get_event_records(
+            event_records_filter, limit, ascending, force_use_index_connection
+        )
 
     @public
     @traced

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -233,6 +233,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         event_records_filter: EventRecordsFilter,
         limit: Optional[int] = None,
         ascending: bool = False,
+        force_use_index_connection: bool = False,
     ) -> Sequence[EventLogRecord]:
         pass
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -914,6 +914,7 @@ class SqlEventLogStorage(EventLogStorage):
         event_records_filter: EventRecordsFilter,
         limit: Optional[int] = None,
         ascending: bool = False,
+        force_use_index_connection: bool = False,
     ) -> Sequence[EventLogRecord]:
         return self._get_event_records(
             event_records_filter=event_records_filter, limit=limit, ascending=ascending

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -278,6 +278,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         event_records_filter: EventRecordsFilter,
         limit: Optional[int] = None,
         ascending: bool = False,
+        force_use_index_connection: bool = False,
     ) -> Sequence[EventLogRecord]:
         """Overridden method to enable cross-run event queries in sqlite.
 
@@ -289,7 +290,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         check.bool_param(ascending, "ascending")
 
         is_asset_query = event_records_filter and event_records_filter.event_type in ASSET_EVENTS
-        if is_asset_query:
+        if is_asset_query or force_use_index_connection:
             # asset materializations, observations and materialization planned events
             # get mirrored into the index shard, so no custom run shard-aware cursor logic needed
             return super(SqliteEventLogStorage, self).get_event_records(

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -449,6 +449,7 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         event_records_filter: Optional[EventRecordsFilter] = None,
         limit: Optional[int] = None,
         ascending: bool = False,
+        force_use_index_connection: bool = False,
     ) -> Iterable[EventLogRecord]:
         # type ignored because `get_event_records` does not accept None. Unclear which type
         # annotation is wrong.
@@ -456,6 +457,7 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
             event_records_filter,  # type: ignore
             limit,
             ascending,
+            force_use_index_connection,
         )
 
     def fetch_materializations(


### PR DESCRIPTION
Explores implementation for resolving https://github.com/dagster-io/dagster/issues/17745

**Problem statement**
When an asset backfill launches a run that completes successfully but does not materialize the asset (i.e. via optional output), the partition is stuck in an 'in progress' state forever, causing the backfill to hang indefinitely.

Impact: for certain cloud customers that use this pattern, hanging backfills cause network resource consumption (unsure of the details here) to grown unusually high.

**Background**
Because we don't store asset materialization failure events, in order to identify "unmaterialized but successful" partitions we have to query the backfill runs and use their statuses + asset materialization planned events to discover which partitions are done executing.

However, fetching runs can be expensive -- fetching all successful runs on each iteration would likely cause timeouts, so we need a bounded way to fetch runs launched by the backfill.

**Solution in this PR: In each iteration, fetch runs that completed since the prior iteration**
- We already store a `latest_storage_id` cursor that represents the latest event evaluated by the backfill
- In each iteration, fetch run success events after this cursor. Fetch the associated runs and filter by backfill ID to fetch just the backfill runs that have completed since the last iteration
- Use these runs to calculate which partitions are "unmaterialized but successfully executed".

Implementation details:
- `get_event_records` requires a run-sharded event cursor to fetch non-asset events (i.e. run success events) past a cursor in SQLite
    - Run success events are copied into the index shard, but unfortunately we can't change the behavior of `get_event_records` to search the index shard in this case since this would break existing run status sensors
    - This PR passes a `force_use_index_conn` param to force fetching run status events from the index shard. Realistically though I would prefer to store a `latest_evaluated_event_timestamp` value in `AssetBackfillData`  to build a run-sharded cursor

**Open questions**
- Should we mark these "unmaterialized but successful" partitions as successes or failures?
    - IMO these partitions are "successful" because they executed successfully
    - However, their downstreams need to be marked as failures since the upstream did not have a materialization (not implemented in this PR)
- Should we even allow this behavior? How high priority is fixing this issue?
    - Perhaps we should just find a way to stop backfills from hanging forever. I.e. in asset backfill iteration, if no runs have been launched in the last 24h but certain partitions are still hanging, we just mark the backfill as failed
