### PR TITLE
[auto-materialize] Update `test_asset_daemon.py`

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -426,8 +426,6 @@ class AssetDaemonScenarioState(NamedTuple):
             else TickStatus.SKIPPED
         )
 
-        print(latest_tick)
-        print(expected_requested_asset_partitions)
         assert latest_tick.requested_asset_materialization_count == len(
             expected_requested_asset_partitions
         )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -61,7 +61,6 @@ from dagster._daemon.asset_daemon import (
     FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
     FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
     AssetDaemon,
-    get_auto_materialize_paused,
     get_current_evaluation_id,
 )
 
@@ -439,9 +438,6 @@ class AssetDaemonScenarioState(NamedTuple):
         """Asserts that the set of runs requested by the previously-evaluated tick is identical to
         the set of runs specified in the expected_run_requests argument.
         """
-        if self.is_daemon and get_auto_materialize_paused(self.instance):
-            assert len(self.run_requests) == 0
-            return self
 
         def sort_run_request_key_fn(run_request) -> Tuple[AssetKey, Optional[str]]:
             return (min(run_request.asset_selection), run_request.partition_key)
@@ -495,10 +491,6 @@ class AssetDaemonScenarioState(NamedTuple):
         """
         asset_key = AssetKey.from_coercible(key)
         actual_evaluation = next((e for e in self.evaluations if e.asset_key == asset_key), None)
-
-        if self.is_daemon and get_auto_materialize_paused(self.instance):
-            assert actual_evaluation is None
-            return self
 
         if actual_evaluation is None:
             try:

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -46,16 +46,24 @@ from dagster._core.definitions.auto_materialize_rule import (
     AutoMaterializeRuleEvaluation,
     AutoMaterializeRuleEvaluationData,
 )
-from dagster._core.definitions.events import CoercibleToAssetKey
+from dagster._core.definitions.events import AssetKeyPartitionKey, CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import in_process_executor
 from dagster._core.host_representation.origin import InProcessCodeLocationOrigin
+from dagster._core.scheduler.instigation import TickStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._core.test_utils import (
     InProcessTestWorkspaceLoadTarget,
     create_test_daemon_workspace_context,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._daemon.asset_daemon import CURSOR_KEY, AssetDaemon
+from dagster._daemon.asset_daemon import (
+    CURSOR_KEY,
+    FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+    FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+    AssetDaemon,
+    get_auto_materialize_paused,
+    get_current_evaluation_id,
+)
 
 from .base_scenario import FAIL_TAG, run_request
 
@@ -307,9 +315,9 @@ class AssetDaemonScenarioState(NamedTuple):
         return self
 
     def _evaluate_tick_fast(
-        self,
+        self
     ) -> Tuple[Sequence[RunRequest], AssetDaemonCursor, Sequence[AutoMaterializeAssetEvaluation]]:
-        return AssetDaemonContext(
+        new_run_requests, new_cursor, new_evaluations = AssetDaemonContext(
             asset_graph=self.asset_graph,
             target_asset_keys=None,
             instance=self.instance,
@@ -320,6 +328,17 @@ class AssetDaemonScenarioState(NamedTuple):
             respect_materialization_data_versions=False,
             logger=self.logger,
         ).evaluate()
+
+        # make sure these run requests are available on the instance
+        for request in new_run_requests:
+            asset_selection = check.not_none(request.asset_selection)
+            job_def = self.defs.get_implicit_job_def_for_assets(asset_selection)
+            self.instance.create_run_for_job(
+                job_def=check.not_none(job_def),
+                asset_selection=set(asset_selection),
+                tags=request.tags,
+            )
+        return new_run_requests, new_cursor, new_evaluations
 
     def _evaluate_tick_daemon(
         self,
@@ -341,17 +360,16 @@ class AssetDaemonScenarioState(NamedTuple):
                 )
             )
             new_cursor = AssetDaemonCursor.from_serialized(
-                check.not_none(
-                    self.instance.daemon_cursor_storage.get_cursor_values({CURSOR_KEY}).get(
-                        CURSOR_KEY
-                    )
+                self.instance.daemon_cursor_storage.get_cursor_values({CURSOR_KEY}).get(
+                    CURSOR_KEY, AssetDaemonCursor.empty().serialize()
                 ),
                 self.asset_graph,
             )
             new_run_requests = [
                 run_request(
-                    list(run.asset_selection or []), partition_key=run.tags.get(PARTITION_NAME_TAG)
-                )
+                    list(run.asset_selection or []),
+                    partition_key=run.tags.get(PARTITION_NAME_TAG),
+                )._replace(tags=run.tags)
                 for run in self.instance.get_runs(
                     filters=RunsFilter(
                         tags={"dagster/asset_evaluation_id": str(new_cursor.evaluation_id)}
@@ -373,16 +391,6 @@ class AssetDaemonScenarioState(NamedTuple):
             else:
                 new_run_requests, new_cursor, new_evaluations = self._evaluate_tick_fast()
 
-        # make sure these run requests are available on the instance
-        for request in new_run_requests:
-            asset_selection = check.not_none(request.asset_selection)
-            job_def = self.defs.get_implicit_job_def_for_assets(asset_selection)
-            self.instance.create_run_for_job(
-                job_def=check.not_none(job_def),
-                asset_selection=set(asset_selection),
-                tags=request.tags,
-            )
-
         return self._replace(
             run_requests=new_run_requests,
             serialized_cursor=new_cursor.serialize(),
@@ -395,12 +403,47 @@ class AssetDaemonScenarioState(NamedTuple):
         message = f"\nExpected: \n\n{expected_str}\n\nActual: \n\n{actual_str}\n"
         self.logger.error(message)
 
+    def _assert_requested_runs_daemon(self, expected_run_requests: Sequence[RunRequest]) -> None:
+        """Additional assertions for daemon mode. Checks that the most recent tick matches the
+        expected requested asset partitions.
+        """
+        latest_tick = sorted(
+            self.instance.get_ticks(
+                origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
+                selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
+            ),
+            key=lambda tick: tick.tick_id,
+        )[-1]
+
+        expected_requested_asset_partitions = {
+            AssetKeyPartitionKey(asset_key=ak, partition_key=rr.partition_key)
+            for rr in expected_run_requests
+            for ak in (rr.asset_selection or set())
+        }
+        assert (
+            latest_tick.status == TickStatus.SUCCESS
+            if len(expected_requested_asset_partitions) > 0
+            else TickStatus.SKIPPED
+        )
+
+        print(latest_tick)
+        print(expected_requested_asset_partitions)
+        assert latest_tick.requested_asset_materialization_count == len(
+            expected_requested_asset_partitions
+        )
+        assert latest_tick.requested_asset_keys == {
+            asset_partition.asset_key for asset_partition in expected_requested_asset_partitions
+        }
+
     def assert_requested_runs(
         self, *expected_run_requests: RunRequest
     ) -> "AssetDaemonScenarioState":
         """Asserts that the set of runs requested by the previously-evaluated tick is identical to
         the set of runs specified in the expected_run_requests argument.
         """
+        if self.is_daemon and get_auto_materialize_paused(self.instance):
+            assert len(self.run_requests) == 0
+            return self
 
         def sort_run_request_key_fn(run_request) -> Tuple[AssetKey, Optional[str]]:
             return (min(run_request.asset_selection), run_request.partition_key)
@@ -417,7 +460,26 @@ class AssetDaemonScenarioState(NamedTuple):
             self._log_assertion_error(sorted_expected_run_requests, sorted_run_requests)
             raise
 
+        if self.is_daemon:
+            self._assert_requested_runs_daemon(sorted_expected_run_requests)
+
         return self
+
+    def _assert_evaluation_daemon(
+        self, key: AssetKey, actual_evaluation: AutoMaterializeAssetEvaluation
+    ) -> None:
+        """Additional assertions for daemon mode. Checks that the evaluation for the given asset
+        contains the expected run ids.
+        """
+        current_evaluation_id = check.not_none(get_current_evaluation_id(self.instance))
+        new_run_ids_for_asset = {
+            run.run_id
+            for run in self.instance.get_runs(
+                filters=RunsFilter(tags={"dagster/asset_evaluation_id": str(current_evaluation_id)})
+            )
+            if key in (run.asset_selection or set())
+        }
+        assert new_run_ids_for_asset == actual_evaluation.run_ids
 
     def assert_evaluation(
         self,
@@ -435,6 +497,11 @@ class AssetDaemonScenarioState(NamedTuple):
         """
         asset_key = AssetKey.from_coercible(key)
         actual_evaluation = next((e for e in self.evaluations if e.asset_key == asset_key), None)
+
+        if self.is_daemon and get_auto_materialize_paused(self.instance):
+            assert actual_evaluation is None
+            return self
+
         if actual_evaluation is None:
             try:
                 assert len(expected_evaluation_specs) == 0
@@ -484,6 +551,9 @@ class AssetDaemonScenarioState(NamedTuple):
             )
             raise
 
+        if self.is_daemon:
+            self._assert_evaluation_daemon(asset_key, actual_evaluation)
+
         return self
 
 
@@ -503,6 +573,8 @@ class AssetDaemonScenario(NamedTuple):
             self.initial_state._replace(scenario_instance=DagsterInstance.ephemeral())
         )
 
-    def evaluate_daemon(self, instance: DagsterInstance) -> None:
+    def evaluate_daemon(self, instance: DagsterInstance) -> "AssetDaemonScenarioState":
         self.initial_state.logger.setLevel(logging.DEBUG)
-        self.execution_fn(self.initial_state._replace(scenario_instance=instance, is_daemon=True))
+        return self.execution_fn(
+            self.initial_state._replace(scenario_instance=instance, is_daemon=True)
+        )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -1,177 +1,76 @@
+import datetime
+from contextlib import contextmanager
+from typing import Any, Generator, Mapping, Optional, Sequence
+
 import pendulum
 import pytest
-from dagster import AssetKey
-from dagster._core.instance_for_test import instance_for_test
+from dagster import DagsterInstance, instance_for_test
 from dagster._core.scheduler.instigation import (
+    InstigatorTick,
     InstigatorType,
     TickData,
     TickStatus,
 )
-from dagster._core.storage.dagster_run import DagsterRunStatus
-from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._daemon.asset_daemon import (
     FIXED_AUTO_MATERIALIZATION_INSTIGATOR_NAME,
     FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
     FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
-    get_current_evaluation_id,
     set_auto_materialize_paused,
 )
 
-from .scenarios.auto_materialize_policy_scenarios import (
-    auto_materialize_policy_scenarios,
+from dagster_tests.definitions_tests.auto_materialize_tests.asset_daemon_scenario import (
+    AssetDaemonScenario,
 )
-from .scenarios.auto_observe_scenarios import auto_observe_scenarios
-from .scenarios.multi_code_location_scenarios import multi_code_location_scenarios
-from .scenarios.scenarios import ASSET_RECONCILIATION_SCENARIOS
+
+from .test_scenarios import all_scenarios
+from .updated_scenarios.asset_daemon_scenario_states import (
+    two_assets_in_sequence,
+    two_partitions_def,
+)
 
 
-def _assert_run_requests_match(
-    expected_run_requests,
-    run_requests,
-):
-    def sort_run_request_key_fn(run_request):
-        return (min(run_request.asset_selection), run_request.partition_key)
+@contextmanager
+def get_daemon_instance(
+    paused: bool = False,
+    extra_overrides: Optional[Mapping[str, Any]] = None,
+) -> Generator[DagsterInstance, None, None]:
+    with instance_for_test(
+        overrides={
+            "run_launcher": {
+                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
+                "class": "SyncInMemoryRunLauncher",
+            },
+            **(extra_overrides or {}),
+        }
+    ) as instance:
+        set_auto_materialize_paused(instance, paused)
+        yield instance
 
-    sorted_run_requests = sorted(run_requests, key=sort_run_request_key_fn)
-    sorted_expected_run_requests = sorted(expected_run_requests, key=sort_run_request_key_fn)
 
-    for run_request, expected_run_request in zip(sorted_run_requests, sorted_expected_run_requests):
-        assert set(run_request.asset_selection) == set(expected_run_request.asset_selection)
-        assert run_request.partition_key == expected_run_request.partition_key
-
-
-@pytest.fixture
-def instance():
-    with instance_for_test() as the_instance:
-        yield the_instance
+# take an arbitrary 10% of the scenarios to run end-to-end against the daemon
+daemon_scenarios = [scenario for i, scenario in enumerate(all_scenarios) if i % 10 == 0]
 
 
 @pytest.mark.parametrize(
-    "scenario_item",
-    list(ASSET_RECONCILIATION_SCENARIOS.items()),
-    ids=list(ASSET_RECONCILIATION_SCENARIOS.keys()),
+    "scenario", daemon_scenarios, ids=[scenario.id for scenario in daemon_scenarios]
 )
-def test_reconcile_with_external_asset_graph(scenario_item, instance):
-    scenario_name, scenario = scenario_item
-    if not scenario.supports_with_external_asset_graph:
-        pytest.skip("Scenario does not support with_external_asset_graph")
-    run_requests, _, _ = scenario.do_sensor_scenario(
-        instance, scenario_name=scenario_name, with_external_asset_graph=True
-    )
-
-    assert len(run_requests) == len(scenario.expected_run_requests), run_requests
-
-    _assert_run_requests_match(scenario.expected_run_requests, run_requests)
+def test_asset_daemon(scenario: AssetDaemonScenario) -> None:
+    with get_daemon_instance() as instance:
+        scenario.evaluate_daemon(instance)
 
 
-daemon_scenarios = {
-    **auto_materialize_policy_scenarios,
-    **multi_code_location_scenarios,
-    **auto_observe_scenarios,
-}
-
-
-@pytest.fixture
-def daemon_paused_instance():
-    with instance_for_test(
-        overrides={
-            "run_launcher": {
-                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
-                "class": "SyncInMemoryRunLauncher",
-            },
-            "auto_materialize": {
-                "max_tick_retries": 2,
-            },
-        }
-    ) as the_instance:
-        yield the_instance
-
-
-@pytest.fixture
-def daemon_not_paused_instance(daemon_paused_instance):
-    set_auto_materialize_paused(daemon_paused_instance, False)
-    return daemon_paused_instance
-
-
-def test_daemon_ticks(daemon_paused_instance):
-    instance = daemon_paused_instance
-    ticks = instance.get_ticks(
-        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
-        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
-    )
-    assert len(ticks) == 0
-
-    scenario = daemon_scenarios["auto_materialize_policy_lazy_freshness_missing"]
-    scenario.do_daemon_scenario(
-        instance, scenario_name="auto_materialize_policy_lazy_freshness_missing"
-    )
-
-    ticks = instance.get_ticks(
-        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
-        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
-    )
-
-    # Daemon paused, so no ticks
-    assert len(ticks) == 0
-
-    set_auto_materialize_paused(instance, False)
-
-    freeze_datetime = pendulum.now("UTC")
-    with pendulum.test(freeze_datetime):
-        scenario.do_daemon_scenario(
-            instance, scenario_name="auto_materialize_policy_lazy_freshness_missing"
-        )
-        ticks = instance.get_ticks(
+def _get_asset_daemon_ticks(instance: DagsterInstance) -> Sequence[InstigatorTick]:
+    """Returns the set of ticks created by the asset daemon for the given instance."""
+    return sorted(
+        instance.get_ticks(
             origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
             selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
-        )
-
-        assert len(ticks) == 1
-        assert ticks[0]
-        assert ticks[0].status == TickStatus.SUCCESS
-        assert ticks[0].timestamp == freeze_datetime.timestamp()
-        assert ticks[0].tick_data.end_timestamp == freeze_datetime.timestamp()
-        assert len(ticks[0].tick_data.run_ids) == 1
-        assert ticks[0].tick_data.auto_materialize_evaluation_id == 1
-        assert ticks[0].tick_data.run_requests == scenario.expected_run_requests
-
-    freeze_datetime = pendulum.now("UTC").add(seconds=40)
-    with pendulum.test(freeze_datetime):
-        scenario.do_daemon_scenario(
-            instance, scenario_name="auto_materialize_policy_lazy_freshness_missing"
-        )
-        ticks = instance.get_ticks(
-            origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
-            selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
-        )
-
-        # No new runs, so tick is now skipped
-
-        assert len(ticks) == 2
-        assert ticks[0]
-        assert ticks[0].status == TickStatus.SKIPPED
-        assert ticks[0].timestamp == freeze_datetime.timestamp()
-        assert ticks[0].tick_data.end_timestamp == freeze_datetime.timestamp()
-        assert ticks[0].tick_data.auto_materialize_evaluation_id == 2
-        assert ticks[0].tick_data.run_requests == []
+        ),
+        key=lambda tick: tick.tick_id,
+    )
 
 
-@pytest.fixture
-def custom_purge_instance():
-    with instance_for_test(
-        overrides={
-            "run_launcher": {
-                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
-                "class": "SyncInMemoryRunLauncher",
-            },
-            "retention": {"auto_materialize": {"purge_after_days": {"skipped": 2}}},
-        }
-    ) as the_instance:
-        set_auto_materialize_paused(the_instance, False)
-        yield the_instance
-
-
-def _create_tick(instance, status, timestamp):
+def _create_tick(instance: DagsterInstance, status: TickStatus, timestamp: float) -> InstigatorTick:
     return instance.create_tick(
         TickData(
             instigator_origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
@@ -185,299 +84,114 @@ def _create_tick(instance, status, timestamp):
     )
 
 
-def test_auto_materialize_purge(daemon_not_paused_instance):
-    freeze_datetime = pendulum.now("UTC")
+# simple scenario to test the daemon in some more exotic states. does not make any assertions
+# as this state will be evaluated multiple times on the same instance and therefore assertions
+# valid at the start may not be valid when repeated.
+daemon_scenario = AssetDaemonScenario(
+    id="simple_daemon_scenario",
+    initial_state=two_assets_in_sequence.with_asset_properties(
+        partitions_def=two_partitions_def
+    ).with_all_eager(2),
+    execution_fn=lambda state: state.evaluate_tick(),
+)
 
-    tick_1 = _create_tick(
-        daemon_not_paused_instance, TickStatus.SKIPPED, freeze_datetime.subtract(days=1).timestamp()
-    )
-    tick_2 = _create_tick(
-        daemon_not_paused_instance, TickStatus.SKIPPED, freeze_datetime.subtract(days=6).timestamp()
-    )
-    _create_tick(
-        daemon_not_paused_instance, TickStatus.SKIPPED, freeze_datetime.subtract(days=8).timestamp()
-    )
 
-    ticks = daemon_not_paused_instance.get_ticks(
-        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
-        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
-    )
-    assert len(ticks) == 3
+def test_daemon_paused() -> None:
+    with get_daemon_instance(paused=True) as instance:
+        ticks = _get_asset_daemon_ticks(instance)
+        assert len(ticks) == 0
 
-    with pendulum.test(freeze_datetime):
-        scenario = daemon_scenarios["auto_materialize_policy_lazy_freshness_missing"]
-        scenario.do_daemon_scenario(
-            daemon_not_paused_instance,
-            scenario_name="auto_materialize_policy_lazy_freshness_missing",
-        )
+        # Daemon paused, so no ticks
+        state = daemon_scenario.evaluate_daemon(instance)
+        ticks = _get_asset_daemon_ticks(instance)
+        assert len(ticks) == 0
 
-        # creates one SUCCESS tick and purges the old SKIPPED ticks
-        ticks = daemon_not_paused_instance.get_ticks(
-            origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
-            selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
-        )
+        set_auto_materialize_paused(instance, False)
 
-        assert len(ticks) == 3
+        state = daemon_scenario._replace(initial_state=state).evaluate_daemon(instance)
+        ticks = _get_asset_daemon_ticks(instance)
 
+        assert len(ticks) == 1
         assert ticks[0]
         assert ticks[0].status == TickStatus.SUCCESS
-        assert ticks[0].timestamp == freeze_datetime.timestamp()
+        assert ticks[0].timestamp == state.current_time.timestamp()
+        assert ticks[0].tick_data.end_timestamp == state.current_time.timestamp()
+        assert ticks[0].tick_data.auto_materialize_evaluation_id == 1
 
-        assert ticks[1] == tick_1
-        assert ticks[2] == tick_2
+        state = daemon_scenario._replace(initial_state=state).evaluate_daemon(instance)
+        ticks = _get_asset_daemon_ticks(instance)
+
+        # no new runs, so tick is now skipped
+        assert len(ticks) == 2
+        assert ticks[-1].status == TickStatus.SKIPPED
+        assert ticks[-1].timestamp == state.current_time.timestamp()
+        assert ticks[-1].tick_data.end_timestamp == state.current_time.timestamp()
+        assert ticks[-1].tick_data.auto_materialize_evaluation_id == 2
 
 
-def test_custom_purge(custom_purge_instance):
-    freeze_datetime = pendulum.now("UTC")
-
-    tick_1 = _create_tick(
-        custom_purge_instance, TickStatus.SKIPPED, freeze_datetime.subtract(days=1).timestamp()
-    )
-    _create_tick(
-        custom_purge_instance, TickStatus.SKIPPED, freeze_datetime.subtract(days=6).timestamp()
-    )
-    _create_tick(
-        custom_purge_instance, TickStatus.SKIPPED, freeze_datetime.subtract(days=8).timestamp()
-    )
-
-    ticks = custom_purge_instance.get_ticks(
-        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
-        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
-    )
-    assert len(ticks) == 3
-
-    with pendulum.test(freeze_datetime):
-        scenario = daemon_scenarios["auto_materialize_policy_lazy_freshness_missing"]
-        scenario.do_daemon_scenario(
-            custom_purge_instance,
-            scenario_name="auto_materialize_policy_lazy_freshness_missing",
+def test_default_purge() -> None:
+    with get_daemon_instance() as instance:
+        scenario_time = daemon_scenario.initial_state.current_time
+        _create_tick(
+            instance, TickStatus.SKIPPED, (scenario_time - datetime.timedelta(days=8)).timestamp()
         )
+        tick_1 = _create_tick(
+            instance, TickStatus.SKIPPED, (scenario_time - datetime.timedelta(days=6)).timestamp()
+        )
+        tick_2 = _create_tick(
+            instance, TickStatus.SKIPPED, (scenario_time - datetime.timedelta(days=1)).timestamp()
+        )
+
+        ticks = _get_asset_daemon_ticks(instance)
+        assert len(ticks) == 3
+
+        state = daemon_scenario.evaluate_daemon(instance)
+
+        # creates one SUCCESS tick and purges the old SKIPPED tick
+        ticks = _get_asset_daemon_ticks(instance)
+        assert len(ticks) == 3
+
+        assert ticks[-1].status == TickStatus.SUCCESS
+        assert ticks[-1].timestamp == state.current_time.timestamp()
+
+        assert ticks[0] == tick_1
+        assert ticks[1] == tick_2
+
+
+def test_custom_purge() -> None:
+    with get_daemon_instance(
+        extra_overrides={"retention": {"auto_materialize": {"purge_after_days": {"skipped": 2}}}},
+    ) as instance:
+        freeze_datetime = pendulum.now("UTC")
+
+        _create_tick(instance, TickStatus.SKIPPED, freeze_datetime.subtract(days=8).timestamp())
+        _create_tick(instance, TickStatus.SKIPPED, freeze_datetime.subtract(days=6).timestamp())
+        tick_1 = _create_tick(
+            instance, TickStatus.SKIPPED, freeze_datetime.subtract(days=1).timestamp()
+        )
+
+        ticks = _get_asset_daemon_ticks(instance)
+        assert len(ticks) == 3
 
         # creates one SUCCESS tick and purges the old SKIPPED ticks
-        ticks = custom_purge_instance.get_ticks(
-            origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
-            selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
-        )
+        state = daemon_scenario.evaluate_daemon(instance)
+        ticks = _get_asset_daemon_ticks(instance)
 
         assert len(ticks) == 2
 
-        assert ticks[0]
-        assert ticks[0].status == TickStatus.SUCCESS
-        assert ticks[0].timestamp == freeze_datetime.timestamp()
+        assert ticks[-1]
+        assert ticks[-1].status == TickStatus.SUCCESS
+        assert ticks[-1].timestamp == state.current_time.timestamp()
 
-        assert ticks[1] == tick_1
-
-
-@pytest.mark.parametrize(
-    "scenario_item",
-    list(daemon_scenarios.items()),
-    ids=list(daemon_scenarios.keys()),
-)
-def test_daemon(scenario_item, daemon_not_paused_instance):
-    scenario_name, scenario = scenario_item
-    scenario.do_daemon_scenario(daemon_not_paused_instance, scenario_name=scenario_name)
-
-    runs = daemon_not_paused_instance.get_runs()
-
-    expected_runs = 0
-    inner_scenario = scenario
-    while inner_scenario is not None:
-        expected_runs += len(inner_scenario.unevaluated_runs or []) + len(
-            inner_scenario.expected_run_requests
-            if inner_scenario.expected_run_requests and not inner_scenario.expected_error_message
-            else []
-        )
-        inner_scenario = inner_scenario.cursor_from
-
-    assert len(runs) == expected_runs
-
-    for run in runs:
-        if any(
-            op_config["config"].get("fail") for op_config in run.run_config.get("ops", {}).values()
-        ):
-            assert run.status == DagsterRunStatus.FAILURE
-        else:
-            assert run.status == DagsterRunStatus.SUCCESS
-
-    def sort_run_request_key_fn(run_request):
-        return (min(run_request.asset_selection), run_request.partition_key)
-
-    def sort_run_key_fn(run):
-        return (min(run.asset_selection), run.tags.get(PARTITION_NAME_TAG))
-
-    # Get all of the runs that were submitted in the most recent asset evaluation
-    asset_evaluation_id = get_current_evaluation_id(daemon_not_paused_instance)
-    submitted_runs_in_scenario = (
-        [
-            run
-            for run in runs
-            if run.tags.get("dagster/asset_evaluation_id") == str(asset_evaluation_id)
-        ]
-        if asset_evaluation_id
-        else []
-    )
-
-    if scenario.expected_error_message:
-        assert (
-            len(submitted_runs_in_scenario) == 0
-        ), "scenario should have raised an error, but instead it submitted runs"
-    else:
-        assert len(submitted_runs_in_scenario) == len(scenario.expected_run_requests), (
-            "Expected the following run requests to be submitted:"
-            f" {scenario.expected_run_requests} \n"
-            " but instead submitted runs with asset and partition selection:"
-            f" {[(list(run.asset_selection), run.tags.get(PARTITION_NAME_TAG)) for run in submitted_runs_in_scenario]}"
-        )
-
-    sorted_runs = sorted(runs[: len(scenario.expected_run_requests)], key=sort_run_key_fn)
-    sorted_expected_run_requests = sorted(
-        scenario.expected_run_requests, key=sort_run_request_key_fn
-    )
-    for run, expected_run_request in zip(sorted_runs, sorted_expected_run_requests):
-        assert run.asset_selection is not None
-        assert set(run.asset_selection) == set(expected_run_request.asset_selection)
-        assert run.tags.get(PARTITION_NAME_TAG) == expected_run_request.partition_key
-
-    ticks = daemon_not_paused_instance.get_ticks(
-        origin_id=FIXED_AUTO_MATERIALIZATION_ORIGIN_ID,
-        selector_id=FIXED_AUTO_MATERIALIZATION_SELECTOR_ID,
-    )
-    tick = ticks[0]
-    if tick.status == TickStatus.SUCCESS and scenario.expected_evaluations:
-        assert tick.requested_asset_materialization_count == sum(
-            [spec.num_requested for spec in scenario.expected_evaluations]
-        )
-        assert tick.requested_asset_keys == {
-            AssetKey.from_coercible(spec.asset_key)
-            for spec in scenario.expected_evaluations
-            if spec.num_requested > 0
-        }
+        assert ticks[0] == tick_1
 
 
-def test_daemon_run_tags():
-    scenario_name = "auto_materialize_policy_eager_with_freshness_policies"
-    scenario = auto_materialize_policy_scenarios[scenario_name]
-
-    with instance_for_test(
-        overrides={
-            "run_launcher": {
-                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
-                "class": "SyncInMemoryRunLauncher",
-            },
-            "auto_materialize": {"run_tags": {"foo": "bar"}},
-        }
+def test_custom_run_tags() -> None:
+    with get_daemon_instance(
+        extra_overrides={"auto_materialize": {"run_tags": {"foo": "bar"}}}
     ) as instance:
-        set_auto_materialize_paused(instance, False)
-
-        scenario.do_daemon_scenario(instance, scenario_name=scenario_name)
+        daemon_scenario.evaluate_daemon(instance)
 
         runs = instance.get_runs()
-
-        assert len(runs) == len(
-            scenario.expected_run_requests
-            + scenario.unevaluated_runs
-            + (scenario.cursor_from.unevaluated_runs if scenario.cursor_from else [])
-        )
-
         for run in runs:
-            assert run.status == DagsterRunStatus.SUCCESS
-
-        def sort_run_request_key_fn(run_request):
-            return (min(run_request.asset_selection), run_request.partition_key)
-
-        def sort_run_key_fn(run):
-            return (min(run.asset_selection), run.tags.get(PARTITION_NAME_TAG))
-
-        sorted_runs = sorted(runs[: len(scenario.expected_run_requests)], key=sort_run_key_fn)
-        sorted_expected_run_requests = sorted(
-            scenario.expected_run_requests, key=sort_run_request_key_fn
-        )
-        for run, expected_run_request in zip(sorted_runs, sorted_expected_run_requests):
-            assert run.asset_selection is not None
-            assert set(run.asset_selection) == set(expected_run_request.asset_selection)
-            assert run.tags.get(PARTITION_NAME_TAG) == expected_run_request.partition_key
             assert run.tags["foo"] == "bar"
-
-
-def test_daemon_paused():
-    scenario_name = "auto_materialize_policy_eager_with_freshness_policies"
-    scenario = auto_materialize_policy_scenarios[scenario_name]
-
-    with instance_for_test(
-        overrides={
-            "run_launcher": {
-                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
-                "class": "SyncInMemoryRunLauncher",
-            },
-        }
-    ) as instance:
-        scenario.do_daemon_scenario(instance, scenario_name=scenario_name)
-
-        runs = instance.get_runs()
-
-        # daemon is paused by default , so no new runs should have been created
-        assert len(runs) == len(
-            scenario.unevaluated_runs
-            + (scenario.cursor_from.unevaluated_runs if scenario.cursor_from else [])
-        )
-
-        instance.wipe()
-        set_auto_materialize_paused(instance, False)
-        scenario.do_daemon_scenario(instance, scenario_name=scenario_name)
-        runs = instance.get_runs()
-
-        assert len(runs) == len(
-            scenario.expected_run_requests
-            + scenario.unevaluated_runs
-            + (scenario.cursor_from.unevaluated_runs if scenario.cursor_from else [])
-        )
-
-
-def test_run_ids():
-    scenario_name = "auto_materialize_policy_eager_with_freshness_policies"
-    scenario = auto_materialize_policy_scenarios[scenario_name]
-
-    with instance_for_test(
-        overrides={
-            "run_launcher": {
-                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
-                "class": "SyncInMemoryRunLauncher",
-            },
-        }
-    ) as instance:
-        set_auto_materialize_paused(instance, False)
-
-        scenario.do_daemon_scenario(instance, scenario_name=scenario_name)
-
-        runs = instance.get_runs()
-
-        assert len(runs) == len(
-            scenario.expected_run_requests
-            + scenario.unevaluated_runs
-            + (scenario.cursor_from.unevaluated_runs if scenario.cursor_from else [])
-        )
-
-        for run in runs:
-            assert run.status == DagsterRunStatus.SUCCESS
-
-        def sort_run_request_key_fn(run_request):
-            return (min(run_request.asset_selection), run_request.partition_key)
-
-        def sort_run_key_fn(run):
-            return (min(run.asset_selection), run.tags.get(PARTITION_NAME_TAG))
-
-        sorted_runs = sorted(runs[: len(scenario.expected_run_requests)], key=sort_run_key_fn)
-        sorted_expected_run_requests = sorted(
-            scenario.expected_run_requests, key=sort_run_request_key_fn
-        )
-        for run, expected_run_request in zip(sorted_runs, sorted_expected_run_requests):
-            assert run.asset_selection is not None
-            assert set(run.asset_selection) == set(expected_run_request.asset_selection)
-            assert run.tags.get(PARTITION_NAME_TAG) == expected_run_request.partition_key
-
-        evaluations = instance.schedule_storage.get_auto_materialize_asset_evaluations(
-            asset_key=AssetKey("asset4"), limit=100
-        )
-        assert len(evaluations) == 1
-        assert evaluations[0].evaluation.asset_key == AssetKey("asset4")
-        assert evaluations[0].evaluation.run_ids == {run.run_id for run in sorted_runs}

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -22,11 +22,12 @@ from dagster_tests.definitions_tests.auto_materialize_tests.asset_daemon_scenari
     AssetDaemonScenario,
 )
 
-from .test_scenarios import all_scenarios
 from .updated_scenarios.asset_daemon_scenario_states import (
     two_assets_in_sequence,
     two_partitions_def,
 )
+from .updated_scenarios.basic_scenarios import basic_scenarios
+from .updated_scenarios.partition_scenarios import partition_scenarios
 
 
 @contextmanager
@@ -47,8 +48,8 @@ def get_daemon_instance(
         yield instance
 
 
-# take an arbitrary 10% of the scenarios to run end-to-end against the daemon
-daemon_scenarios = [scenario for i, scenario in enumerate(all_scenarios) if i % 10 == 0]
+# just run over a subset of the total scenarios
+daemon_scenarios = [*basic_scenarios, *partition_scenarios]
 
 
 @pytest.mark.parametrize(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
@@ -1,9 +1,4 @@
-from typing import Generator
-
 import pytest
-from dagster import DagsterInstance
-from dagster._core.instance_for_test import instance_for_test
-from dagster._daemon.asset_daemon import set_auto_materialize_paused
 
 from .asset_daemon_scenario import AssetDaemonScenario
 from .updated_scenarios.basic_scenarios import basic_scenarios
@@ -14,25 +9,6 @@ from .updated_scenarios.partition_scenarios import partition_scenarios
 all_scenarios = basic_scenarios + cron_scenarios + freshness_policy_scenarios + partition_scenarios
 
 
-@pytest.fixture
-def daemon_instance() -> Generator[DagsterInstance, None, None]:
-    with instance_for_test(
-        overrides={
-            "run_launcher": {
-                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
-                "class": "SyncInMemoryRunLauncher",
-            }
-        }
-    ) as instance:
-        set_auto_materialize_paused(instance, False)
-        yield instance
-
-
 @pytest.mark.parametrize("scenario", all_scenarios, ids=[scenario.id for scenario in all_scenarios])
 def test_scenario_fast(scenario: AssetDaemonScenario) -> None:
     scenario.evaluate_fast()
-
-
-@pytest.mark.parametrize("scenario", all_scenarios, ids=[scenario.id for scenario in all_scenarios])
-def test_scenario_daemon(scenario: AssetDaemonScenario, daemon_instance: DagsterInstance) -> None:
-    scenario.evaluate_daemon(daemon_instance)


### PR DESCRIPTION
## Summary & Motivation

Changes:
- a lot of repetitive code in this file for making instances with different properties was replaced with a single method for that
- stopped switching between using pytest fixtures and inline functions to create the instances (just use functions, as there isn't much overlap between tests)
- update the AssetDaemonScenario to add more daemon-specific checks when running in "daemon mode". this makes several of the existing tests obsolete, and also helps up our test coverage because we're running these checks against several different scenarios instead of just one.
- run the full end-to-end daemon against an arbitrary 10% of all scenarios. on the fence about this one, I think it's probably fine to just run the end-to-end test against all of the scenarios (just takes a few minutes)

## How I Tested These Changes
