### PR TITLE
Allow env var sources and default values in instance settings

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/ref.py
+++ b/python_modules/dagster/dagster/_core/instance/ref.py
@@ -21,6 +21,19 @@ if TYPE_CHECKING:
     from dagster._core.storage.runs.base import RunStorage
     from dagster._core.storage.schedules.base import ScheduleStorage
 
+SETTINGS_KEYS = {
+    "telemetry",
+    "python_logs",
+    "run_monitoring",
+    "run_retries",
+    "code_servers",
+    "retention",
+    "sensors",
+    "schedules",
+    "nux",
+    "auto_materialize",
+}
+
 
 def compute_logs_directory(base: str) -> str:
     return os.path.join(base, "storage")
@@ -445,19 +458,7 @@ class InstanceRef(
             defaults["secrets"],
         )
 
-        settings_keys = {
-            "telemetry",
-            "python_logs",
-            "run_monitoring",
-            "run_retries",
-            "code_servers",
-            "retention",
-            "sensors",
-            "schedules",
-            "nux",
-            "auto_materialize",
-        }
-        settings = {key: config_value.get(key) for key in settings_keys if config_value.get(key)}
+        settings = {key: config_value.get(key) for key in SETTINGS_KEYS if config_value.get(key)}
 
         return InstanceRef(
             local_artifact_storage_data=local_artifact_storage_data,  # type: ignore  # (possible none)

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_config.py
@@ -1,7 +1,7 @@
 import pytest
 from dagster import file_relative_path
 from dagster._core.instance.config import dagster_instance_config
-from dagster._core.test_utils import environ
+from dagster._core.test_utils import environ, instance_for_test
 
 
 @pytest.mark.parametrize("config_filename", ("dagster.yaml", "something.yaml"))
@@ -10,3 +10,27 @@ def test_instance_yaml_config_not_set(config_filename, caplog):
     with environ({"DAGSTER_HOME": base_dir}):
         dagster_instance_config(base_dir, config_filename)
         assert "No dagster instance configuration file" in caplog.text
+
+
+def test_instance_default_values_processed():
+    # fields set with a default value are processed
+    with instance_for_test() as instance:
+        assert instance.get_settings("auto_materialize")["max_tick_retries"] == 3
+
+
+def test_instance_source_values_processed():
+    # StringSource/BoolSource/etc. are processed
+    with pytest.raises(
+        Exception,
+        match='You have attempted to fetch the environment variable "SENSORS_NUM_WORKERS" which is not set',
+    ):
+        with instance_for_test(
+            overrides={"sensors": {"num_workers": {"env": "SENSORS_NUM_WORKERS"}}}
+        ) as instance:
+            pass
+
+    with environ({"SENSORS_NUM_WORKERS": "12345"}):
+        with instance_for_test(
+            overrides={"sensors": {"num_workers": {"env": "SENSORS_NUM_WORKERS"}}}
+        ) as instance:
+            assert instance.get_settings("sensors")["num_workers"] == 12345


### PR DESCRIPTION
Summary:
The specific field i want to be able to control via env var is sensors.num_workers, but there's no good reason I can think of to not allow any of these to be env vars if users want to be able to configure them without having to change YAML.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
