### PR TITLE
Set minimum pendulum version to 0.7.0

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -86,7 +86,7 @@ setup(
         f"grpcio>={GRPC_VERSION_FLOOR}",
         f"grpcio-health-checking>={GRPC_VERSION_FLOOR}",
         "packaging>=20.9",
-        "pendulum<3",
+        "pendulum>=0.7.0,<3",
         "protobuf>=3.20.0",  # min protobuf version to be compatible with both protobuf 3 and 4
         "python-dateutil",
         "python-dotenv",


### PR DESCRIPTION
## Summary & Motivation

Earlier versions of pendulum had a `Pendulum.timestamp` property, that was incompatible with the standard library's `datetime.timestamp()` medhod.
Since dagster uses the `timestamp()` method in multiple places[^1], the minimum pendulum version should be set to 0.7.0, which restored compatibility[^2] with the standard library.

I discovered this when installing a dagster-based project with python3.11 using `pip install --prefer-binary`. Pip then resolved pendulum to version `0.4.0`, which is the "latest" version that has binaries for python3 without minor version constraints on PyPi[^3]. All newer versions of pendulum just have binaries for python2.7 up to python3.9[^4].

[^1]: [sql_run_storage.py#L186](https://github.com/dagster-io/dagster/blob/1.5.6/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py#L186), [snapshot_schedule.py#L57](https://github.com/dagster-io/dagster/blob/1.5.6/python_modules/dagster/dagster/_api/snapshot_schedule.py#L57), [time_window_partitions.py#L165](https://github.com/dagster-io/dagster/blob/1.5.6/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py#L165)
[^2]: https://github.com/sdispater/pendulum/commit/a79cb2b111370d1cd333fc821475ef7476921b14
[^3]: https://pypi.org/project/pendulum/0.4/#files
[^4]: https://pypi.org/project/pendulum/2.1.1/#files

## How I Tested These Changes

Installing `dagster>=1.5` with `pendulum==0.4` and running pipelines produces errors like:

```
File "/usr/local/lib/python3.11/site-packages/dagster/_core/events/__init__.py", line 1026, in job_start
    return DagsterEvent.from_job(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/dagster/_core/events/__init__.py", line 455, in from_job
    log_job_event(job_context, event)
  File "/usr/local/lib/python3.11/site-packages/dagster/_core/events/__init__.py", line 320, in log_job_event
    job_context.log.log_dagster_event(
  File "/usr/local/lib/python3.11/site-packages/dagster/_core/log_manager.py", line 407, in log_dagster_event
    self.log(level=level, msg=msg, extra={DAGSTER_META_KEY: dagster_event})
  File "/usr/local/lib/python3.11/site-packages/dagster/_core/log_manager.py", line 422, in log
    self._log(level, msg, args, **kwargs)
  File "/usr/local/lib/python3.11/logging/__init__.py", line 1634, in _log
    self.handle(record)
  File "/usr/local/lib/python3.11/logging/__init__.py", line 1644, in handle
    self.callHandlers(record)
  File "/usr/local/lib/python3.11/logging/__init__.py", line 1706, in callHandlers
    hdlr.handle(record)
  File "/usr/local/lib/python3.11/logging/__init__.py", line 978, in handle
    self.emit(record)
  File "/usr/local/lib/python3.11/site-packages/dagster/_core/log_manager.py", line 288, in emit
    handler.handle(dagster_record)
  File "/usr/local/lib/python3.11/logging/__init__.py", line 978, in handle
    self.emit(record)
  File "/usr/local/lib/python3.11/site-packages/dagster/_core/instance/__init__.py", line 229, in emit
    self._instance.handle_new_event(event)
  File "/usr/local/lib/python3.11/site-packages/dagster/_core/instance/__init__.py", line 2253, in handle_new_event
    self._run_storage.handle_run_event(run_id, event.get_dagster_event())
  File "/usr/local/lib/python3.11/site-packages/dagster/_core/storage/runs/sql_run_storage.py", line 186, in handle_run_event
    kwargs["start_time"] = now.timestamp()
                           ^^^^^^^^^^^^^^^
TypeError: 'int' object is not callable
```

But installing `dagster>=1.5` with `pendulum>=0.7` works as intended.