### PR TITLE
[docs] Fix docs sidebar extra indent

### DIFF
--- a/docs/next/components/Sidebar.tsx
+++ b/docs/next/components/Sidebar.tsx
@@ -214,7 +214,7 @@ const RecursiveNavigation = ({
   return (
     <div
       className={cx({
-        'mt-0 ml-1 space-y-0': lvl >= 2,
+        'mt-0 space-y-0': lvl >= 2,
       })}
       role="group"
       aria-labelledby={`${lvl + 1}-level-nav`}


### PR DESCRIPTION
## Summary & Motivation

Fixes extra sidebar indent for level 2 nav items with children.

Before:

![image](https://github.com/dagster-io/dagster/assets/1531373/beb9c3fa-e9ad-4efa-8d1c-9596d0a501d4)

After:

<img width="323" alt="image" src="https://github.com/dagster-io/dagster/assets/1531373/b5742fb5-0706-4000-8a7c-ec651edc3351">


## How I Tested These Changes

Eyes
