### PR TITLE
split up auto_materialize_rule.py

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -4,7 +4,7 @@ from typing import Optional, Sequence, Tuple
 import dagster._check as check
 import graphene
 from dagster import PartitionsDefinition
-from dagster._core.definitions.auto_materialize_rule import (
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeDecisionType,
     AutoMaterializeRuleEvaluation,
     AutoMaterializeRuleEvaluationData,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
@@ -4,9 +4,9 @@ import dagster._check as check
 import pendulum
 from dagster import AssetKey, RunRequest
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
-from dagster._core.definitions.auto_materialize_rule import (
+from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeAssetEvaluation,
-    AutoMaterializeRule,
     AutoMaterializeRuleEvaluation,
     ParentUpdatedRuleEvaluationData,
     WaitingOnAssetsRuleEvaluationData,

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -39,11 +39,13 @@ from ..storage.tags import ASSET_PARTITION_RANGE_END_TAG, ASSET_PARTITION_RANGE_
 from .asset_daemon_cursor import AssetDaemonCursor
 from .asset_graph import AssetGraph
 from .auto_materialize_rule import (
-    AutoMaterializeAssetEvaluation,
     AutoMaterializeRule,
-    AutoMaterializeRuleEvaluation,
     DiscardOnMaxMaterializationsExceededRule,
     RuleEvaluationContext,
+)
+from .auto_materialize_rule_evaluation import (
+    AutoMaterializeAssetEvaluation,
+    AutoMaterializeRuleEvaluation,
 )
 from .backfill_policy import BackfillPolicy, BackfillPolicyType
 from .freshness_based_auto_materialize import get_expected_data_time_for_asset_key

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -16,7 +16,9 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster._core.definitions.auto_materialize_rule import AutoMaterializeAssetEvaluation
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
+    AutoMaterializeAssetEvaluation,
+)
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsDefinition,

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -3,26 +3,30 @@ import functools
 from abc import ABC, abstractmethod, abstractproperty
 from collections import defaultdict
 from dataclasses import dataclass
-from enum import Enum
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
     Callable,
     Dict,
-    FrozenSet,
     Mapping,
     NamedTuple,
     Optional,
     Sequence,
     Set,
-    Tuple,
-    cast,
 )
 
 import pytz
 
 import dagster._check as check
 from dagster._annotations import public
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
+    AutoMaterializeDecisionType,
+    AutoMaterializeRuleEvaluationData,
+    AutoMaterializeRuleSnapshot,
+    ParentUpdatedRuleEvaluationData,
+    RuleEvaluationResults,
+    WaitingOnAssetsRuleEvaluationData,
+)
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.freshness_based_auto_materialize import (
@@ -33,10 +37,6 @@ from dagster._core.definitions.partition_mapping import IdentityPartitionMapping
 from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
 from dagster._core.definitions.time_window_partitions import get_time_partitions_def
 from dagster._serdes.serdes import (
-    NamedTupleSerializer,
-    UnpackContext,
-    UnpackedValue,
-    WhitelistMap,
     whitelist_for_serdes,
 )
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
@@ -47,88 +47,13 @@ from dagster._utils.schedules import (
 )
 
 from .asset_graph import AssetGraph, sort_key_for_asset_partition
-from .partition import SerializedPartitionsSubset
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
     from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
-    from dagster._core.instance import DynamicPartitionsStore
-
-
-@whitelist_for_serdes
-class AutoMaterializeDecisionType(Enum):
-    """Represents the set of results of the auto-materialize logic.
-
-    MATERIALIZE: The asset should be materialized by a run kicked off on this tick
-    SKIP: The asset should not be materialized by a run kicked off on this tick, because future
-        ticks are expected to materialize it.
-    DISCARD: The asset should not be materialized by a run kicked off on this tick, but future
-        ticks are not expected to materialize it.
-    """
-
-    MATERIALIZE = "MATERIALIZE"
-    SKIP = "SKIP"
-    DISCARD = "DISCARD"
-
-
-class AutoMaterializeRuleEvaluationData(ABC):
-    pass
-
-
-@whitelist_for_serdes
-class TextRuleEvaluationData(
-    AutoMaterializeRuleEvaluationData,
-    NamedTuple("_TextRuleEvaluationData", [("text", str)]),
-):
-    pass
-
-
-@whitelist_for_serdes
-class ParentUpdatedRuleEvaluationData(
-    AutoMaterializeRuleEvaluationData,
-    NamedTuple(
-        "_ParentUpdatedRuleEvaluationData",
-        [
-            ("updated_asset_keys", FrozenSet[AssetKey]),
-            ("will_update_asset_keys", FrozenSet[AssetKey]),
-        ],
-    ),
-):
-    pass
-
-
-@whitelist_for_serdes
-class WaitingOnAssetsRuleEvaluationData(
-    AutoMaterializeRuleEvaluationData,
-    NamedTuple(
-        "_WaitingOnParentRuleEvaluationData",
-        [("waiting_on_asset_keys", FrozenSet[AssetKey])],
-    ),
-):
-    pass
-
-
-@whitelist_for_serdes
-class AutoMaterializeRuleSnapshot(NamedTuple):
-    """A serializable snapshot of an AutoMaterializeRule for historical evaluations."""
-
-    class_name: str
-    description: str
-    decision_type: AutoMaterializeDecisionType
-
-    @staticmethod
-    def from_rule(rule: "AutoMaterializeRule") -> "AutoMaterializeRuleSnapshot":
-        return AutoMaterializeRuleSnapshot(
-            class_name=rule.__class__.__name__,
-            description=rule.description,
-            decision_type=rule.decision_type,
-        )
-
-
-@whitelist_for_serdes
-class AutoMaterializeRuleEvaluation(NamedTuple):
-    rule_snapshot: AutoMaterializeRuleSnapshot
-    evaluation_data: Optional[AutoMaterializeRuleEvaluationData]
+    from dagster._core.definitions.auto_materialize_rule_evaluation import (
+        AutoMaterializeAssetEvaluation,
+    )
 
 
 @dataclass(frozen=True)
@@ -303,9 +228,6 @@ class RuleEvaluationContext:
             asset_partitions_by_asset_key[parent.asset_key].add(parent)
 
         return asset_partitions_by_asset_key
-
-
-RuleEvaluationResults = Sequence[Tuple[Optional[AutoMaterializeRuleEvaluationData], AbstractSet]]
 
 
 class AutoMaterializeRule(ABC):
@@ -490,7 +412,11 @@ class AutoMaterializeRule(ABC):
 
     def to_snapshot(self) -> AutoMaterializeRuleSnapshot:
         """Returns a serializable snapshot of this rule for historical evaluations."""
-        return AutoMaterializeRuleSnapshot.from_rule(self)
+        return AutoMaterializeRuleSnapshot(
+            class_name=self.__class__.__name__,
+            description=self.description,
+            decision_type=self.decision_type,
+        )
 
     def __eq__(self, other) -> bool:
         # override the default NamedTuple __eq__ method to factor in types
@@ -1026,301 +952,3 @@ class DiscardOnMaxMaterializationsExceededRule(
         if rate_limited_asset_partitions:
             return [(None, rate_limited_asset_partitions)]
         return []
-
-
-@whitelist_for_serdes
-class AutoMaterializeAssetEvaluation(NamedTuple):
-    """Represents the results of the auto-materialize logic for a single asset.
-
-    Properties:
-        asset_key (AssetKey): The asset key that was evaluated.
-        partition_subsets_by_condition: The rule evaluations that impact if the asset should be
-            materialized, skipped, or discarded. If the asset is partitioned, this will be a list of
-            tuples, where the first element is the condition and the second element is the
-            serialized subset of partitions that the condition applies to. If it's not partitioned,
-            the second element will be None.
-        num_requested (int): The number of asset partitions that were requested to be materialized
-        num_skipped (int): The number of asset partitions that were skipped
-        num_discarded (int): The number of asset partitions that were discarded
-        run_ids (Set[str]): The set of run IDs created for this evaluation
-        rule_snapshots (Optional[Sequence[AutoMaterializeRuleSnapshot]]): The snapshots of the
-            rules on the policy at the time it was evaluated.
-    """
-
-    asset_key: AssetKey
-    partition_subsets_by_condition: Sequence[
-        Tuple["AutoMaterializeRuleEvaluation", Optional[SerializedPartitionsSubset]]
-    ]
-    num_requested: int
-    num_skipped: int
-    num_discarded: int
-    run_ids: Set[str] = set()
-    rule_snapshots: Optional[Sequence[AutoMaterializeRuleSnapshot]] = None
-
-    @property
-    def is_empty(self) -> bool:
-        return (
-            sum([self.num_requested, self.num_skipped, self.num_discarded]) == 0
-            and len(self.partition_subsets_by_condition) == 0
-        )
-
-    @staticmethod
-    def from_rule_evaluation_results(
-        asset_graph: AssetGraph,
-        asset_key: AssetKey,
-        asset_partitions_by_rule_evaluation: Sequence[
-            Tuple[AutoMaterializeRuleEvaluation, AbstractSet[AssetKeyPartitionKey]]
-        ],
-        num_requested: int,
-        num_skipped: int,
-        num_discarded: int,
-        dynamic_partitions_store: "DynamicPartitionsStore",
-    ) -> "AutoMaterializeAssetEvaluation":
-        auto_materialize_policy = asset_graph.auto_materialize_policies_by_key.get(asset_key)
-
-        if not auto_materialize_policy:
-            check.failed(f"Expected auto materialize policy on asset {asset_key}")
-
-        partitions_def = asset_graph.get_partitions_def(asset_key)
-        if partitions_def is None:
-            return AutoMaterializeAssetEvaluation(
-                asset_key=asset_key,
-                partition_subsets_by_condition=[
-                    (rule_evaluation, None)
-                    for rule_evaluation, _ in asset_partitions_by_rule_evaluation
-                ],
-                num_requested=num_requested,
-                num_skipped=num_skipped,
-                num_discarded=num_discarded,
-                rule_snapshots=auto_materialize_policy.rule_snapshots,
-            )
-        else:
-            return AutoMaterializeAssetEvaluation(
-                asset_key=asset_key,
-                partition_subsets_by_condition=[
-                    (
-                        rule_evaluation,
-                        SerializedPartitionsSubset.from_subset(
-                            subset=partitions_def.empty_subset().with_partition_keys(
-                                check.not_none(ap.partition_key) for ap in asset_partitions
-                            ),
-                            partitions_def=partitions_def,
-                            dynamic_partitions_store=dynamic_partitions_store,
-                        ),
-                    )
-                    for rule_evaluation, asset_partitions in asset_partitions_by_rule_evaluation
-                ],
-                num_requested=num_requested,
-                num_skipped=num_skipped,
-                num_discarded=num_discarded,
-                rule_snapshots=auto_materialize_policy.rule_snapshots,
-            )
-
-    def _deserialize_rule_evaluation_result(
-        self,
-        rule_evaluation: AutoMaterializeRuleEvaluation,
-        serialized_subset: Optional[SerializedPartitionsSubset],
-        asset_graph: AssetGraph,
-    ) -> Optional[
-        Tuple[Optional[AutoMaterializeRuleEvaluationData], AbstractSet[AssetKeyPartitionKey]]
-    ]:
-        partitions_def = asset_graph.get_partitions_def(self.asset_key)
-        if serialized_subset is None:
-            if partitions_def is None:
-                return (rule_evaluation.evaluation_data, {AssetKeyPartitionKey(self.asset_key)})
-        elif serialized_subset.can_deserialize(partitions_def) and partitions_def is not None:
-            return (
-                rule_evaluation.evaluation_data,
-                {
-                    AssetKeyPartitionKey(self.asset_key, partition_key)
-                    for partition_key in serialized_subset.deserialize(
-                        partitions_def=partitions_def
-                    ).get_partition_keys()
-                },
-            )
-        # old serialized result is no longer valid
-        return None
-
-    def get_rule_evaluation_results(
-        self, rule_snapshot: AutoMaterializeRuleSnapshot, asset_graph: AssetGraph
-    ) -> RuleEvaluationResults:
-        """For a given rule snapshot, returns the calculated evaluations for that rule."""
-        results = []
-        for rule_evaluation, serialized_subset in self.partition_subsets_by_condition:
-            # filter for the same rule
-            if rule_evaluation.rule_snapshot != rule_snapshot:
-                continue
-            deserialized_result = self._deserialize_rule_evaluation_result(
-                rule_evaluation, serialized_subset, asset_graph
-            )
-            if deserialized_result:
-                results.append(deserialized_result)
-        return results
-
-    def _get_asset_partitions_with_decision_type(
-        self, decision_type: AutoMaterializeDecisionType, asset_graph: AssetGraph
-    ) -> AbstractSet[AssetKeyPartitionKey]:
-        """Returns the set of asset partitions with a given decision type applied to them."""
-        asset_partitions = set()
-        for rule_evaluation, serialized_subset in self.partition_subsets_by_condition:
-            if rule_evaluation.rule_snapshot.decision_type != decision_type:
-                continue
-            deserialized_result = self._deserialize_rule_evaluation_result(
-                rule_evaluation, serialized_subset, asset_graph
-            )
-            if deserialized_result is None:
-                continue
-            asset_partitions.update(deserialized_result[1])
-        return asset_partitions
-
-    def get_requested_or_discarded_asset_partitions(
-        self, asset_graph: AssetGraph
-    ) -> AbstractSet[AssetKeyPartitionKey]:
-        """Returns the set of asset partitions which were either requested or discarded on this
-        evaluation.
-        """
-        to_materialize = self._get_asset_partitions_with_decision_type(
-            AutoMaterializeDecisionType.MATERIALIZE, asset_graph
-        )
-        if not to_materialize:
-            return set()
-        to_skip = self._get_asset_partitions_with_decision_type(
-            AutoMaterializeDecisionType.SKIP, asset_graph
-        )
-        return to_materialize - to_skip
-
-    def get_evaluated_asset_partitions(
-        self, asset_graph: AssetGraph
-    ) -> AbstractSet[AssetKeyPartitionKey]:
-        """Returns the set of asset partitions which were evaluated by any rule on this evaluation."""
-        # no asset partition can be evaluated by SKIP or DISCARD rules without having at least one
-        # materialize rule evaluation
-        return self._get_asset_partitions_with_decision_type(
-            AutoMaterializeDecisionType.MATERIALIZE, asset_graph
-        )
-
-    def equivalent_to_stored_evaluation(
-        self, stored_evaluation: Optional["AutoMaterializeAssetEvaluation"], asset_graph: AssetGraph
-    ) -> bool:
-        """This function returns if a stored record is equivalent to this one. To do so, we can't
-        just use regular namedtuple equality, as the serialized partition subsets will be
-        potentially have different string values.
-        """
-        if stored_evaluation is None:
-            # empty evaluations are not stored on the cursor
-            return self.is_empty
-        return (
-            self.asset_key == stored_evaluation.asset_key
-            and set(self.rule_snapshots or []) == set(stored_evaluation.rule_snapshots or [])
-            # if num_requested / num_discarded > 0 on the stored evaluation, then something changed
-            # in the global state on the previous tick
-            and stored_evaluation.num_requested == 0
-            and stored_evaluation.num_discarded == 0
-            and stored_evaluation.num_skipped == self.num_skipped
-            # when rule evaluation results are deserialized from json, they are lists instead of
-            # tuples, so we must convert them before comparing
-            and sorted(self.partition_subsets_by_condition)
-            == sorted([tuple(x) for x in stored_evaluation.partition_subsets_by_condition])
-        )
-
-
-# BACKCOMPAT GRAVEYARD
-
-
-class BackcompatAutoMaterializeConditionSerializer(NamedTupleSerializer):
-    """This handles backcompat for the old AutoMaterializeCondition objects, turning them into the
-    proper AutoMaterializeRuleEvaluation objects. This is necessary because old
-    AutoMaterializeAssetEvaluation objects will have serialized AutoMaterializeCondition objects,
-    and we need to be able to deserialize them.
-
-    In theory, as these serialized objects happen to be purged periodically, we can remove this
-    backcompat logic at some point in the future.
-    """
-
-    def unpack(
-        self,
-        unpacked_dict: Dict[str, UnpackedValue],
-        whitelist_map: WhitelistMap,
-        context: UnpackContext,
-    ) -> AutoMaterializeRuleEvaluation:
-        if self.klass in (
-            FreshnessAutoMaterializeCondition,
-            DownstreamFreshnessAutoMaterializeCondition,
-        ):
-            return AutoMaterializeRuleEvaluation(
-                rule_snapshot=AutoMaterializeRule.materialize_on_required_for_freshness().to_snapshot(),
-                evaluation_data=None,
-            )
-        elif self.klass == MissingAutoMaterializeCondition:
-            return AutoMaterializeRuleEvaluation(
-                rule_snapshot=AutoMaterializeRule.materialize_on_missing().to_snapshot(),
-                evaluation_data=None,
-            )
-        elif self.klass == ParentMaterializedAutoMaterializeCondition:
-            updated_asset_keys = unpacked_dict.get("updated_asset_keys")
-            if isinstance(updated_asset_keys, set):
-                updated_asset_keys = cast(FrozenSet[AssetKey], frozenset(updated_asset_keys))
-            else:
-                updated_asset_keys = frozenset()
-            will_update_asset_keys = unpacked_dict.get("will_update_asset_keys")
-            if isinstance(will_update_asset_keys, set):
-                will_update_asset_keys = cast(
-                    FrozenSet[AssetKey], frozenset(will_update_asset_keys)
-                )
-            else:
-                will_update_asset_keys = frozenset()
-            return AutoMaterializeRuleEvaluation(
-                rule_snapshot=AutoMaterializeRule.materialize_on_parent_updated().to_snapshot(),
-                evaluation_data=ParentUpdatedRuleEvaluationData(
-                    updated_asset_keys=updated_asset_keys,
-                    will_update_asset_keys=will_update_asset_keys,
-                ),
-            )
-        elif self.klass == ParentOutdatedAutoMaterializeCondition:
-            waiting_on_asset_keys = unpacked_dict.get("waiting_on_asset_keys")
-            if isinstance(waiting_on_asset_keys, set):
-                waiting_on_asset_keys = cast(FrozenSet[AssetKey], frozenset(waiting_on_asset_keys))
-            else:
-                waiting_on_asset_keys = frozenset()
-            return AutoMaterializeRuleEvaluation(
-                rule_snapshot=AutoMaterializeRule.skip_on_parent_outdated().to_snapshot(),
-                evaluation_data=WaitingOnAssetsRuleEvaluationData(
-                    waiting_on_asset_keys=waiting_on_asset_keys
-                ),
-            )
-        elif self.klass == MaxMaterializationsExceededAutoMaterializeCondition:
-            return AutoMaterializeRuleEvaluation(
-                rule_snapshot=DiscardOnMaxMaterializationsExceededRule(limit=1).to_snapshot(),
-                evaluation_data=None,
-            )
-        check.failed(f"Unexpected class {self.klass}")
-
-
-@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
-class FreshnessAutoMaterializeCondition(NamedTuple):
-    ...
-
-
-@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
-class DownstreamFreshnessAutoMaterializeCondition(NamedTuple):
-    ...
-
-
-@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
-class ParentMaterializedAutoMaterializeCondition(NamedTuple):
-    ...
-
-
-@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
-class MissingAutoMaterializeCondition(NamedTuple):
-    ...
-
-
-@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
-class ParentOutdatedAutoMaterializeCondition(NamedTuple):
-    ...
-
-
-@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
-class MaxMaterializationsExceededAutoMaterializeCondition(NamedTuple):
-    ...

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
@@ -1,0 +1,404 @@
+from abc import ABC
+from enum import Enum
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Dict,
+    FrozenSet,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    cast,
+)
+
+import dagster._check as check
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._serdes.serdes import (
+    NamedTupleSerializer,
+    UnpackContext,
+    UnpackedValue,
+    WhitelistMap,
+    whitelist_for_serdes,
+)
+
+from .asset_graph import AssetGraph
+from .partition import SerializedPartitionsSubset
+
+if TYPE_CHECKING:
+    from dagster._core.instance import DynamicPartitionsStore
+
+
+@whitelist_for_serdes
+class AutoMaterializeDecisionType(Enum):
+    """Represents the set of results of the auto-materialize logic.
+
+    MATERIALIZE: The asset should be materialized by a run kicked off on this tick
+    SKIP: The asset should not be materialized by a run kicked off on this tick, because future
+        ticks are expected to materialize it.
+    DISCARD: The asset should not be materialized by a run kicked off on this tick, but future
+        ticks are not expected to materialize it.
+    """
+
+    MATERIALIZE = "MATERIALIZE"
+    SKIP = "SKIP"
+    DISCARD = "DISCARD"
+
+
+@whitelist_for_serdes
+class AutoMaterializeRuleSnapshot(NamedTuple):
+    """A serializable snapshot of an AutoMaterializeRule for historical evaluations."""
+
+    class_name: str
+    description: str
+    decision_type: AutoMaterializeDecisionType
+
+
+class AutoMaterializeRuleEvaluationData(ABC):
+    pass
+
+
+@whitelist_for_serdes
+class TextRuleEvaluationData(
+    AutoMaterializeRuleEvaluationData,
+    NamedTuple("_TextRuleEvaluationData", [("text", str)]),
+):
+    pass
+
+
+@whitelist_for_serdes
+class ParentUpdatedRuleEvaluationData(
+    AutoMaterializeRuleEvaluationData,
+    NamedTuple(
+        "_ParentUpdatedRuleEvaluationData",
+        [
+            ("updated_asset_keys", FrozenSet[AssetKey]),
+            ("will_update_asset_keys", FrozenSet[AssetKey]),
+        ],
+    ),
+):
+    pass
+
+
+@whitelist_for_serdes
+class WaitingOnAssetsRuleEvaluationData(
+    AutoMaterializeRuleEvaluationData,
+    NamedTuple(
+        "_WaitingOnParentRuleEvaluationData",
+        [("waiting_on_asset_keys", FrozenSet[AssetKey])],
+    ),
+):
+    pass
+
+
+RuleEvaluationResults = Sequence[Tuple[Optional[AutoMaterializeRuleEvaluationData], AbstractSet]]
+
+
+@whitelist_for_serdes
+class AutoMaterializeRuleEvaluation(NamedTuple):
+    rule_snapshot: AutoMaterializeRuleSnapshot
+    evaluation_data: Optional[AutoMaterializeRuleEvaluationData]
+
+
+@whitelist_for_serdes
+class AutoMaterializeAssetEvaluation(NamedTuple):
+    """Represents the results of the auto-materialize logic for a single asset.
+
+    Properties:
+        asset_key (AssetKey): The asset key that was evaluated.
+        partition_subsets_by_condition: The rule evaluations that impact if the asset should be
+            materialized, skipped, or discarded. If the asset is partitioned, this will be a list of
+            tuples, where the first element is the condition and the second element is the
+            serialized subset of partitions that the condition applies to. If it's not partitioned,
+            the second element will be None.
+        num_requested (int): The number of asset partitions that were requested to be materialized
+        num_skipped (int): The number of asset partitions that were skipped
+        num_discarded (int): The number of asset partitions that were discarded
+        run_ids (Set[str]): The set of run IDs created for this evaluation
+        rule_snapshots (Optional[Sequence[AutoMaterializeRuleSnapshot]]): The snapshots of the
+            rules on the policy at the time it was evaluated.
+    """
+
+    asset_key: AssetKey
+    partition_subsets_by_condition: Sequence[
+        Tuple["AutoMaterializeRuleEvaluation", Optional[SerializedPartitionsSubset]]
+    ]
+    num_requested: int
+    num_skipped: int
+    num_discarded: int
+    run_ids: Set[str] = set()
+    rule_snapshots: Optional[Sequence[AutoMaterializeRuleSnapshot]] = None
+
+    @property
+    def is_empty(self) -> bool:
+        return (
+            sum([self.num_requested, self.num_skipped, self.num_discarded]) == 0
+            and len(self.partition_subsets_by_condition) == 0
+        )
+
+    @staticmethod
+    def from_rule_evaluation_results(
+        asset_graph: AssetGraph,
+        asset_key: AssetKey,
+        asset_partitions_by_rule_evaluation: Sequence[
+            Tuple[AutoMaterializeRuleEvaluation, AbstractSet[AssetKeyPartitionKey]]
+        ],
+        num_requested: int,
+        num_skipped: int,
+        num_discarded: int,
+        dynamic_partitions_store: "DynamicPartitionsStore",
+    ) -> "AutoMaterializeAssetEvaluation":
+        auto_materialize_policy = asset_graph.auto_materialize_policies_by_key.get(asset_key)
+
+        if not auto_materialize_policy:
+            check.failed(f"Expected auto materialize policy on asset {asset_key}")
+
+        partitions_def = asset_graph.get_partitions_def(asset_key)
+        if partitions_def is None:
+            return AutoMaterializeAssetEvaluation(
+                asset_key=asset_key,
+                partition_subsets_by_condition=[
+                    (rule_evaluation, None)
+                    for rule_evaluation, _ in asset_partitions_by_rule_evaluation
+                ],
+                num_requested=num_requested,
+                num_skipped=num_skipped,
+                num_discarded=num_discarded,
+                rule_snapshots=auto_materialize_policy.rule_snapshots,
+            )
+        else:
+            return AutoMaterializeAssetEvaluation(
+                asset_key=asset_key,
+                partition_subsets_by_condition=[
+                    (
+                        rule_evaluation,
+                        SerializedPartitionsSubset.from_subset(
+                            subset=partitions_def.empty_subset().with_partition_keys(
+                                check.not_none(ap.partition_key) for ap in asset_partitions
+                            ),
+                            partitions_def=partitions_def,
+                            dynamic_partitions_store=dynamic_partitions_store,
+                        ),
+                    )
+                    for rule_evaluation, asset_partitions in asset_partitions_by_rule_evaluation
+                ],
+                num_requested=num_requested,
+                num_skipped=num_skipped,
+                num_discarded=num_discarded,
+                rule_snapshots=auto_materialize_policy.rule_snapshots,
+            )
+
+    def _deserialize_rule_evaluation_result(
+        self,
+        rule_evaluation: AutoMaterializeRuleEvaluation,
+        serialized_subset: Optional[SerializedPartitionsSubset],
+        asset_graph: AssetGraph,
+    ) -> Optional[
+        Tuple[Optional[AutoMaterializeRuleEvaluationData], AbstractSet[AssetKeyPartitionKey]]
+    ]:
+        partitions_def = asset_graph.get_partitions_def(self.asset_key)
+        if serialized_subset is None:
+            if partitions_def is None:
+                return (rule_evaluation.evaluation_data, {AssetKeyPartitionKey(self.asset_key)})
+        elif serialized_subset.can_deserialize(partitions_def) and partitions_def is not None:
+            return (
+                rule_evaluation.evaluation_data,
+                {
+                    AssetKeyPartitionKey(self.asset_key, partition_key)
+                    for partition_key in serialized_subset.deserialize(
+                        partitions_def=partitions_def
+                    ).get_partition_keys()
+                },
+            )
+        # old serialized result is no longer valid
+        return None
+
+    def get_rule_evaluation_results(
+        self, rule_snapshot: AutoMaterializeRuleSnapshot, asset_graph: AssetGraph
+    ) -> RuleEvaluationResults:
+        """For a given rule snapshot, returns the calculated evaluations for that rule."""
+        results = []
+        for rule_evaluation, serialized_subset in self.partition_subsets_by_condition:
+            # filter for the same rule
+            if rule_evaluation.rule_snapshot != rule_snapshot:
+                continue
+            deserialized_result = self._deserialize_rule_evaluation_result(
+                rule_evaluation, serialized_subset, asset_graph
+            )
+            if deserialized_result:
+                results.append(deserialized_result)
+        return results
+
+    def _get_asset_partitions_with_decision_type(
+        self, decision_type: AutoMaterializeDecisionType, asset_graph: AssetGraph
+    ) -> AbstractSet[AssetKeyPartitionKey]:
+        """Returns the set of asset partitions with a given decision type applied to them."""
+        asset_partitions = set()
+        for rule_evaluation, serialized_subset in self.partition_subsets_by_condition:
+            if rule_evaluation.rule_snapshot.decision_type != decision_type:
+                continue
+            deserialized_result = self._deserialize_rule_evaluation_result(
+                rule_evaluation, serialized_subset, asset_graph
+            )
+            if deserialized_result is None:
+                continue
+            asset_partitions.update(deserialized_result[1])
+        return asset_partitions
+
+    def get_requested_or_discarded_asset_partitions(
+        self, asset_graph: AssetGraph
+    ) -> AbstractSet[AssetKeyPartitionKey]:
+        """Returns the set of asset partitions which were either requested or discarded on this
+        evaluation.
+        """
+        to_materialize = self._get_asset_partitions_with_decision_type(
+            AutoMaterializeDecisionType.MATERIALIZE, asset_graph
+        )
+        if not to_materialize:
+            return set()
+        to_skip = self._get_asset_partitions_with_decision_type(
+            AutoMaterializeDecisionType.SKIP, asset_graph
+        )
+        return to_materialize - to_skip
+
+    def get_evaluated_asset_partitions(
+        self, asset_graph: AssetGraph
+    ) -> AbstractSet[AssetKeyPartitionKey]:
+        """Returns the set of asset partitions which were evaluated by any rule on this evaluation."""
+        # no asset partition can be evaluated by SKIP or DISCARD rules without having at least one
+        # materialize rule evaluation
+        return self._get_asset_partitions_with_decision_type(
+            AutoMaterializeDecisionType.MATERIALIZE, asset_graph
+        )
+
+    def equivalent_to_stored_evaluation(
+        self, stored_evaluation: Optional["AutoMaterializeAssetEvaluation"], asset_graph: AssetGraph
+    ) -> bool:
+        """This function returns if a stored record is equivalent to this one. To do so, we can't
+        just use regular namedtuple equality, as the serialized partition subsets will be
+        potentially have different string values.
+        """
+        if stored_evaluation is None:
+            # empty evaluations are not stored on the cursor
+            return self.is_empty
+        return (
+            self.asset_key == stored_evaluation.asset_key
+            and set(self.rule_snapshots or []) == set(stored_evaluation.rule_snapshots or [])
+            # if num_requested / num_discarded > 0 on the stored evaluation, then something changed
+            # in the global state on the previous tick
+            and stored_evaluation.num_requested == 0
+            and stored_evaluation.num_discarded == 0
+            and stored_evaluation.num_skipped == self.num_skipped
+            # when rule evaluation results are deserialized from json, they are lists instead of
+            # tuples, so we must convert them before comparing
+            and sorted(self.partition_subsets_by_condition)
+            == sorted([tuple(x) for x in stored_evaluation.partition_subsets_by_condition])
+        )
+
+
+# BACKCOMPAT GRAVEYARD
+
+
+class BackcompatAutoMaterializeConditionSerializer(NamedTupleSerializer):
+    """This handles backcompat for the old AutoMaterializeCondition objects, turning them into the
+    proper AutoMaterializeRuleEvaluation objects. This is necessary because old
+    AutoMaterializeAssetEvaluation objects will have serialized AutoMaterializeCondition objects,
+    and we need to be able to deserialize them.
+
+    In theory, as these serialized objects happen to be purged periodically, we can remove this
+    backcompat logic at some point in the future.
+    """
+
+    def unpack(
+        self,
+        unpacked_dict: Dict[str, UnpackedValue],
+        whitelist_map: WhitelistMap,
+        context: UnpackContext,
+    ) -> AutoMaterializeRuleEvaluation:
+        from .auto_materialize_rule import (
+            AutoMaterializeRule,
+            DiscardOnMaxMaterializationsExceededRule,
+        )
+
+        if self.klass in (
+            FreshnessAutoMaterializeCondition,
+            DownstreamFreshnessAutoMaterializeCondition,
+        ):
+            return AutoMaterializeRuleEvaluation(
+                rule_snapshot=AutoMaterializeRule.materialize_on_required_for_freshness().to_snapshot(),
+                evaluation_data=None,
+            )
+        elif self.klass == MissingAutoMaterializeCondition:
+            return AutoMaterializeRuleEvaluation(
+                rule_snapshot=AutoMaterializeRule.materialize_on_missing().to_snapshot(),
+                evaluation_data=None,
+            )
+        elif self.klass == ParentMaterializedAutoMaterializeCondition:
+            updated_asset_keys = unpacked_dict.get("updated_asset_keys")
+            if isinstance(updated_asset_keys, set):
+                updated_asset_keys = cast(FrozenSet[AssetKey], frozenset(updated_asset_keys))
+            else:
+                updated_asset_keys = frozenset()
+            will_update_asset_keys = unpacked_dict.get("will_update_asset_keys")
+            if isinstance(will_update_asset_keys, set):
+                will_update_asset_keys = cast(
+                    FrozenSet[AssetKey], frozenset(will_update_asset_keys)
+                )
+            else:
+                will_update_asset_keys = frozenset()
+            return AutoMaterializeRuleEvaluation(
+                rule_snapshot=AutoMaterializeRule.materialize_on_parent_updated().to_snapshot(),
+                evaluation_data=ParentUpdatedRuleEvaluationData(
+                    updated_asset_keys=updated_asset_keys,
+                    will_update_asset_keys=will_update_asset_keys,
+                ),
+            )
+        elif self.klass == ParentOutdatedAutoMaterializeCondition:
+            waiting_on_asset_keys = unpacked_dict.get("waiting_on_asset_keys")
+            if isinstance(waiting_on_asset_keys, set):
+                waiting_on_asset_keys = cast(FrozenSet[AssetKey], frozenset(waiting_on_asset_keys))
+            else:
+                waiting_on_asset_keys = frozenset()
+            return AutoMaterializeRuleEvaluation(
+                rule_snapshot=AutoMaterializeRule.skip_on_parent_outdated().to_snapshot(),
+                evaluation_data=WaitingOnAssetsRuleEvaluationData(
+                    waiting_on_asset_keys=waiting_on_asset_keys
+                ),
+            )
+        elif self.klass == MaxMaterializationsExceededAutoMaterializeCondition:
+            return AutoMaterializeRuleEvaluation(
+                rule_snapshot=DiscardOnMaxMaterializationsExceededRule(limit=1).to_snapshot(),
+                evaluation_data=None,
+            )
+        check.failed(f"Unexpected class {self.klass}")
+
+
+@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
+class FreshnessAutoMaterializeCondition(NamedTuple):
+    ...
+
+
+@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
+class DownstreamFreshnessAutoMaterializeCondition(NamedTuple):
+    ...
+
+
+@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
+class ParentMaterializedAutoMaterializeCondition(NamedTuple):
+    ...
+
+
+@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
+class MissingAutoMaterializeCondition(NamedTuple):
+    ...
+
+
+@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
+class ParentOutdatedAutoMaterializeCondition(NamedTuple):
+    ...
+
+
+@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
+class MaxMaterializationsExceededAutoMaterializeCondition(NamedTuple):
+    ...

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -21,7 +21,7 @@ from .asset_graph import AssetGraph
 if TYPE_CHECKING:
     from dagster._core.definitions.data_time import CachingDataTimeResolver
 
-    from .auto_materialize_rule import RuleEvaluationResults, TextRuleEvaluationData
+    from .auto_materialize_rule_evaluation import RuleEvaluationResults, TextRuleEvaluationData
 
 
 def get_execution_period_for_policy(
@@ -69,7 +69,7 @@ def get_execution_period_and_evaluation_data_for_policies(
     """Determines a range of times for which you can kick off an execution of this asset to solve
     the most pressing constraint, alongside a maximum number of additional constraints.
     """
-    from .auto_materialize_rule import TextRuleEvaluationData
+    from .auto_materialize_rule_evaluation import TextRuleEvaluationData
 
     merged_period = None
     contains_local = False

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -6,7 +6,9 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._core.definitions import RunRequest
-from dagster._core.definitions.auto_materialize_rule import AutoMaterializeAssetEvaluation
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
+    AutoMaterializeAssetEvaluation,
+)
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 
 # re-export

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -13,7 +13,9 @@ from dagster import (
     _check as check,
 )
 from dagster._config.config_schema import UserConfigSchema
-from dagster._core.definitions.auto_materialize_rule import AutoMaterializeAssetEvaluation
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
+    AutoMaterializeAssetEvaluation,
+)
 from dagster._core.definitions.events import AssetKey
 from dagster._core.event_api import EventHandlerFn
 from dagster._core.storage.asset_check_execution_record import (

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -2,7 +2,9 @@ import abc
 from typing import Mapping, Optional, Sequence, Set
 
 from dagster import AssetKey
-from dagster._core.definitions.auto_materialize_rule import AutoMaterializeAssetEvaluation
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
+    AutoMaterializeAssetEvaluation,
+)
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
 from dagster._core.scheduler.instigation import (

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -20,7 +20,9 @@ import sqlalchemy.exc as db_exc
 from sqlalchemy.engine import Connection
 
 import dagster._check as check
-from dagster._core.definitions.auto_materialize_rule import AutoMaterializeAssetEvaluation
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
+    AutoMaterializeAssetEvaluation,
+)
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.errors import DagsterInvariantViolationError

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -5,9 +5,9 @@ import pendulum
 import pytest
 
 from dagster import StaticPartitionsDefinition
-from dagster._core.definitions.auto_materialize_rule import (
+from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeAssetEvaluation,
-    AutoMaterializeRule,
     AutoMaterializeRuleEvaluation,
 )
 from dagster._core.definitions.events import AssetKey

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -34,9 +34,9 @@ from dagster._core.definitions.asset_daemon_context import (
 )
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.auto_materialize_rule import (
+from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeAssetEvaluation,
-    AutoMaterializeRule,
     AutoMaterializeRuleEvaluation,
     AutoMaterializeRuleEvaluationData,
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -51,10 +51,10 @@ from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
-from dagster._core.definitions.auto_materialize_rule import (
+from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeAssetEvaluation,
     AutoMaterializeDecisionType,
-    AutoMaterializeRule,
     AutoMaterializeRuleEvaluation,
     AutoMaterializeRuleEvaluationData,
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -9,8 +9,10 @@ from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.auto_materialize_rule import (
     AutoMaterializeRule,
-    AutoMaterializeRuleEvaluation,
     DiscardOnMaxMaterializationsExceededRule,
+)
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
+    AutoMaterializeRuleEvaluation,
     ParentUpdatedRuleEvaluationData,
     WaitingOnAssetsRuleEvaluationData,
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/freshness_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/freshness_policy_scenarios.py
@@ -5,8 +5,8 @@ from dagster import (
     DailyPartitionsDefinition,
     SourceAsset,
 )
-from dagster._core.definitions.auto_materialize_rule import (
-    AutoMaterializeRule,
+from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
     ParentUpdatedRuleEvaluationData,
     TextRuleEvaluationData,
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/observable_source_asset_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/observable_source_asset_scenarios.py
@@ -1,8 +1,8 @@
 import datetime
 
 from dagster import PartitionKeyRange
-from dagster._core.definitions.auto_materialize_rule import (
-    AutoMaterializeRule,
+from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeRuleEvaluation,
     ParentUpdatedRuleEvaluationData,
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
@@ -6,10 +6,8 @@ from dagster import (
     StaticPartitionsDefinition,
 )
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
-from dagster._core.definitions.auto_materialize_rule import (
-    AutoMaterializeRule,
-    AutoMaterializeRuleEvaluation,
-)
+from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
+from dagster._core.definitions.auto_materialize_rule_evaluation import AutoMaterializeRuleEvaluation
 from dagster._core.definitions.partition import (
     DynamicPartitionsDefinition,
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
@@ -9,7 +9,7 @@ from dagster import (
     op,
 )
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.auto_materialize_rule import (
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeAssetEvaluation,
 )
 from dagster._core.definitions.time_window_partitions import (

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_materialize_asset_evaluation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_materialize_asset_evaluation.py
@@ -1,8 +1,8 @@
 from dagster import AssetKey, AutoMaterializePolicy, StaticPartitionsDefinition, asset
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.auto_materialize_rule import (
+from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeAssetEvaluation,
-    AutoMaterializeRule,
     AutoMaterializeRuleEvaluation,
     ParentUpdatedRuleEvaluationData,
     WaitingOnAssetsRuleEvaluationData,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_materialize_policy.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_materialize_policy.py
@@ -4,8 +4,10 @@ from dagster._check import CheckError
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicyType
 from dagster._core.definitions.auto_materialize_rule import (
     AutoMaterializeRule,
-    AutoMaterializeRuleEvaluation,
     DiscardOnMaxMaterializationsExceededRule,
+)
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
+    AutoMaterializeRuleEvaluation,
     ParentUpdatedRuleEvaluationData,
     WaitingOnAssetsRuleEvaluationData,
 )

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -6,7 +6,9 @@ import sqlalchemy as db
 import sqlalchemy.dialects as db_dialects
 import sqlalchemy.pool as db_pool
 from dagster._config.config_schema import UserConfigSchema
-from dagster._core.definitions.auto_materialize_rule import AutoMaterializeAssetEvaluation
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
+    AutoMaterializeAssetEvaluation,
+)
 from dagster._core.storage.config import MySqlStorageConfig, mysql_config
 from dagster._core.storage.schedules import ScheduleStorageSqlMetadata, SqlScheduleStorage
 from dagster._core.storage.schedules.schema import (

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -6,7 +6,9 @@ import sqlalchemy as db
 import sqlalchemy.dialects as db_dialects
 import sqlalchemy.pool as db_pool
 from dagster._config.config_schema import UserConfigSchema
-from dagster._core.definitions.auto_materialize_rule import AutoMaterializeAssetEvaluation
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
+    AutoMaterializeAssetEvaluation,
+)
 from dagster._core.scheduler.instigation import InstigatorState
 from dagster._core.storage.config import PostgresStorageConfig, pg_config
 from dagster._core.storage.schedules import ScheduleStorageSqlMetadata, SqlScheduleStorage


### PR DESCRIPTION
## Summary & Motivation

I was looking into adding an auto-materialize rule, and auto_materialize_rule.py felt unwieldy.

This separates the rule evaluation logic (still in auto_materialize_rule.py) from the serializable result objects (now in auto_materialize_rule_evaluation.py)

## How I Tested These Changes
