### PR TITLE
[auto-materialize] enable ignoring parent updates based on run tags

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -130,8 +130,8 @@ from dagster._core.definitions.auto_materialize_policy import (
     AutoMaterializePolicy as AutoMaterializePolicy,
 )
 from dagster._core.definitions.auto_materialize_rule import (
+    AutoMaterializeAssetPartitionFilter as AutoMaterializeAssetPartitionFilter,
     AutoMaterializeRule as AutoMaterializeRule,
-    LatestMaterializationHasRunTag as LatestMaterializationHasRunTag,
 )
 from dagster._core.definitions.backfill_policy import BackfillPolicy as BackfillPolicy
 from dagster._core.definitions.composition import PendingNodeInvocation as PendingNodeInvocation

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -131,6 +131,7 @@ from dagster._core.definitions.auto_materialize_policy import (
 )
 from dagster._core.definitions.auto_materialize_rule import (
     AutoMaterializeRule as AutoMaterializeRule,
+    LatestMaterializationHasRunTag as LatestMaterializationHasRunTag,
 )
 from dagster._core.definitions.backfill_policy import BackfillPolicy as BackfillPolicy
 from dagster._core.definitions.composition import PendingNodeInvocation as PendingNodeInvocation

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -130,7 +130,7 @@ from dagster._core.definitions.auto_materialize_policy import (
     AutoMaterializePolicy as AutoMaterializePolicy,
 )
 from dagster._core.definitions.auto_materialize_rule import (
-    AutoMaterializeAssetPartitionFilter as AutoMaterializeAssetPartitionFilter,
+    AutoMaterializeAssetPartitionsFilter as AutoMaterializeAssetPartitionsFilter,
     AutoMaterializeRule as AutoMaterializeRule,
 )
 from dagster._core.definitions.backfill_policy import BackfillPolicy as BackfillPolicy

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -338,14 +338,21 @@ class AutoMaterializeRule(ABC):
 
     @public
     @staticmethod
-    def materialize_on_parent_updated() -> "MaterializeOnParentUpdatedRule":
+    def materialize_on_parent_updated(
+        ignore_updates: Optional["LatestMaterializationHasRunTag"] = None
+    ) -> "MaterializeOnParentUpdatedRule":
         """Materialize an asset partition if one of its parents has been updated more recently
         than it has.
 
         Note: For time-partitioned or dynamic-partitioned assets downstream of an unpartitioned
         asset, this rule will only fire for the most recent partition of the downstream.
+
+        Args:
+            ignore_updates (Optional[LatestMaterializationHasRunTag]): Filter to apply to updated
+                parents. If a parent was updated but matches the filter criteria, then it won't
+                count as updated for the sake of this rule.
         """
-        return MaterializeOnParentUpdatedRule()
+        return MaterializeOnParentUpdatedRule(ignore_updates=ignore_updates)
 
     @public
     @staticmethod
@@ -562,8 +569,42 @@ class MaterializeOnCronRule(
 
 
 @whitelist_for_serdes
+class LatestMaterializationHasRunTag(NamedTuple):
+    run_tag_key: str
+    run_tag_value: Optional[str] = None
+
+    def matches(
+        self, context: RuleEvaluationContext, asset_partition: AssetKeyPartitionKey
+    ) -> bool:
+        if asset_partition in context.will_materialize_mapping.get(
+            asset_partition.asset_key, set()
+        ):
+            return True
+
+        materialization_record = (
+            context.instance_queryer.get_latest_materialization_or_observation_record(
+                asset_partition, after_cursor=context.cursor.latest_storage_id
+            )
+        )
+        if materialization_record is None:
+            check.failed(
+                f"LatestMaterializationHasRunTag was invoked for asset partition {asset_partition},"
+                " which was not updated since previous tick. It should only be invoked for asset"
+                " partitions updated since the previous tick."
+            )
+
+        return context.instance_queryer.run_has_tag(
+            materialization_record.run_id, self.run_tag_key, self.run_tag_value
+        )
+
+
+@whitelist_for_serdes
 class MaterializeOnParentUpdatedRule(
-    AutoMaterializeRule, NamedTuple("_MaterializeOnParentUpdatedRule", [])
+    AutoMaterializeRule,
+    NamedTuple(
+        "_MaterializeOnParentUpdatedRule",
+        [("ignore_updates", Optional[LatestMaterializationHasRunTag])],
+    ),
 ):
     @property
     def decision_type(self) -> AutoMaterializeDecisionType:
@@ -606,7 +647,11 @@ class MaterializeOnParentUpdatedRule(
                 # rematerializations from causing a chain of materializations to be kicked off
                 ignored_parent_keys={context.asset_key},
             )
-            updated_parents = {parent.asset_key for parent in updated_parent_asset_partitions}
+            updated_parents = {
+                parent.asset_key
+                for parent in updated_parent_asset_partitions
+                if self.ignore_updates is None or not self.ignore_updates.matches(context, parent)
+            }
             will_update_parents = will_update_parents_by_asset_partition[asset_partition]
 
             if updated_parents or will_update_parents:

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -350,8 +350,12 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             return run_record.dagster_run
         return None
 
-    def run_has_tag(self, run_id: str, tag_key: str, tag_value: str) -> bool:
-        return cast(DagsterRun, self._get_run_by_id(run_id)).tags.get(tag_key) == tag_value
+    def run_has_tag(self, run_id: str, tag_key: str, tag_value: Optional[str]) -> bool:
+        run_tags = cast(DagsterRun, self._get_run_by_id(run_id)).tags
+        if tag_value is None:
+            return tag_key in run_tags
+        else:
+            return run_tags.get(tag_key) == tag_value
 
     @cached_method
     def _get_planned_materializations_for_run_from_events(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -600,11 +600,12 @@ def run_request(
     asset_keys: Sequence[CoercibleToAssetKey],
     partition_key: Optional[str] = None,
     fail_keys: Optional[Sequence[str]] = None,
+    tags: Optional[Mapping[str, str]] = None,
 ) -> RunRequest:
     return RunRequest(
         asset_selection=[AssetKey.from_coercible(key) for key in asset_keys],
         partition_key=partition_key,
-        tags={FAIL_TAG: json.dumps(fail_keys)} if fail_keys else {},
+        tags={**(tags or {}), **({FAIL_TAG: json.dumps(fail_keys)} if fail_keys else {})},
     )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
@@ -4,9 +4,18 @@ from .asset_daemon_scenario import AssetDaemonScenario
 from .updated_scenarios.basic_scenarios import basic_scenarios
 from .updated_scenarios.cron_scenarios import cron_scenarios
 from .updated_scenarios.freshness_policy_scenarios import freshness_policy_scenarios
+from .updated_scenarios.latest_materialization_run_tag_scenarios import (
+    latest_materialization_run_tag_scenarios,
+)
 from .updated_scenarios.partition_scenarios import partition_scenarios
 
-all_scenarios = basic_scenarios + cron_scenarios + freshness_policy_scenarios + partition_scenarios
+all_scenarios = (
+    basic_scenarios
+    + cron_scenarios
+    + freshness_policy_scenarios
+    + partition_scenarios
+    + latest_materialization_run_tag_scenarios
+)
 
 
 @pytest.mark.parametrize("scenario", all_scenarios, ids=[scenario.id for scenario in all_scenarios])

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/basic_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/basic_scenarios.py
@@ -1,5 +1,7 @@
 from dagster import AssetSpec, AutoMaterializeRule
-from dagster._core.definitions.auto_materialize_rule import ParentUpdatedRuleEvaluationData
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
+    ParentUpdatedRuleEvaluationData,
+)
 
 from ..asset_daemon_scenario import (
     AssetDaemonScenario,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/latest_materialization_run_tag_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/latest_materialization_run_tag_scenarios.py
@@ -1,16 +1,20 @@
-from dagster import AutoMaterializeAssetPartitionFilter, AutoMaterializePolicy, AutoMaterializeRule
+from dagster import AutoMaterializeAssetPartitionsFilter, AutoMaterializePolicy, AutoMaterializeRule
 
 from ..asset_daemon_scenario import AssetDaemonScenario
 from ..base_scenario import run_request
-from .asset_daemon_scenario_states import one_asset_depends_on_two, two_assets_in_sequence
+from .asset_daemon_scenario_states import (
+    one_asset_depends_on_two,
+    three_assets_in_sequence,
+    two_assets_in_sequence,
+)
 
 filter_latest_run_tag_key_policy = (
     AutoMaterializePolicy.eager()
     .without_rules(AutoMaterializeRule.materialize_on_parent_updated())
     .with_rules(
         AutoMaterializeRule.materialize_on_parent_updated(
-            updated_parent_filter=AutoMaterializeAssetPartitionFilter(
-                latest_materialization_run_forbidden_tag_keys={"some_key"}
+            updated_parent_filter=AutoMaterializeAssetPartitionsFilter(
+                latest_run_required_tags={"dagster/auto_materialize": "true"}
             )
         )
     )
@@ -19,61 +23,113 @@ filter_latest_run_tag_key_policy = (
 
 latest_materialization_run_tag_scenarios = [
     AssetDaemonScenario(
-        id="latest_parent_materialization_does_not_have_ignored_tag",
+        id="latest_parent_materialization_has_required_tag",
+        initial_state=two_assets_in_sequence.with_asset_properties(
+            auto_materialize_policy=filter_latest_run_tag_key_policy
+        ),
+        execution_fn=lambda state: state.with_runs(
+            run_request(["A", "B"]), run_request(["A"], tags={"dagster/auto_materialize": "true"})
+        )
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["B"])),
+    ),
+    AssetDaemonScenario(
+        id="latest_parent_materialization_missing_required_tag",
         initial_state=two_assets_in_sequence.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(run_request(["A", "B"]), run_request(["A"]))
         .evaluate_tick()
-        .assert_requested_runs(run_request(["B"])),
+        .assert_requested_runs(),
     ),
     AssetDaemonScenario(
-        id="latest_parent_materialization_has_ignored_tag",
+        id="latest_parent_materialization_missing_one_of_required_tags",
         initial_state=two_assets_in_sequence.with_asset_properties(
-            auto_materialize_policy=filter_latest_run_tag_key_policy
+            auto_materialize_policy=AutoMaterializePolicy.eager()
+            .without_rules(AutoMaterializeRule.materialize_on_parent_updated())
+            .with_rules(
+                AutoMaterializeRule.materialize_on_parent_updated(
+                    updated_parent_filter=AutoMaterializeAssetPartitionsFilter(
+                        latest_run_required_tags={
+                            "dagster/auto_materialize": "true",
+                            "some_other_key": "some_other_value",
+                        }
+                    )
+                )
+            )
         ),
         execution_fn=lambda state: state.with_runs(
-            run_request(["A", "B"]), run_request(["A"], tags={"some_key": "some_value"})
+            run_request(["A", "B"]), run_request(["A"], tags={"dagster/auto_materialize": "true"})
         )
         .evaluate_tick()
         .assert_requested_runs(),
     ),
     AssetDaemonScenario(
-        id="earlier_parent_materialization_has_ignored_tag",
+        id="earlier_parent_materialization_missing_required_tag",
         initial_state=two_assets_in_sequence.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(
             run_request(["A", "B"]),
-            run_request(["A"], tags={"some_key": "some_value"}),
             run_request(["A"]),
+            run_request(["A"], tags={"dagster/auto_materialize": "true"}),
         )
         .evaluate_tick()
         .assert_requested_runs(run_request(["B"])),
     ),
     AssetDaemonScenario(
-        id="only_updated_parent_has_ignored_tag",
+        id="only_updated_parent_missing_required_tag",
         initial_state=one_asset_depends_on_two.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(
             run_request(["A", "B", "C"]),
-            run_request(["A"], tags={"some_key": "some_value"}),
+            run_request(["A"]),
         )
         .evaluate_tick()
         .assert_requested_runs(),
     ),
     AssetDaemonScenario(
-        id="one_updated_parent_has_ignored_tag_but_other_does_not",
+        id="one_updated_parent_has_required_tag_but_other_does_not",
         initial_state=one_asset_depends_on_two.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(
             run_request(["A", "B", "C"]),
-            run_request(["A"], tags={"some_key": "some_value"}),
+            run_request(["A"], tags={"dagster/auto_materialize": "true"}),
             run_request(["B"]),
         )
         .evaluate_tick()
         .assert_requested_runs(run_request(["C"])),
+    ),
+    AssetDaemonScenario(
+        id="latest_materialization_missing_required_tag_but_will_update",
+        initial_state=three_assets_in_sequence.with_asset_properties(
+            auto_materialize_policy=filter_latest_run_tag_key_policy
+        ),
+        execution_fn=lambda state: state.with_runs(
+            run_request(["A", "B", "C"]),
+            run_request(["A", "B"]),
+            run_request(["A"], tags={"dagster/auto_materialize": "true"}),
+        )
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["B", "C"])),
+    ),
+    AssetDaemonScenario(
+        # this ensures that updates that happened prior to the cursor of the current tick
+        # get ignored if they're missing the required keys
+        id="latest_materialization_missing_required_tag_previous_tick",
+        initial_state=one_asset_depends_on_two.with_asset_properties(
+            auto_materialize_policy=filter_latest_run_tag_key_policy
+        ),
+        execution_fn=lambda state: state.with_runs(
+            run_request(["A", "B", "C"]),
+            run_request(["A"]),
+        )
+        .evaluate_tick()
+        .assert_requested_runs()
+        .with_runs(run_request(["B"]))
+        .evaluate_tick()
+        .assert_requested_runs(),
     ),
 ]

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/latest_materialization_run_tag_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/latest_materialization_run_tag_scenarios.py
@@ -1,0 +1,98 @@
+from dagster import AutoMaterializePolicy, AutoMaterializeRule, LatestMaterializationHasRunTag
+
+from ..asset_daemon_scenario import AssetDaemonScenario
+from ..base_scenario import run_request
+from .asset_daemon_scenario_states import one_asset_depends_on_two, two_assets_in_sequence
+
+filter_latest_run_tag_key_policy = (
+    AutoMaterializePolicy.eager()
+    .without_rules(AutoMaterializeRule.materialize_on_parent_updated())
+    .with_rules(
+        AutoMaterializeRule.materialize_on_parent_updated(
+            ignore_updates=LatestMaterializationHasRunTag("some_key")
+        )
+    )
+)
+
+filter_latest_run_tag_key_and_value_policy = (
+    AutoMaterializePolicy.eager()
+    .without_rules(AutoMaterializeRule.materialize_on_parent_updated())
+    .with_rules(
+        AutoMaterializeRule.materialize_on_parent_updated(
+            ignore_updates=LatestMaterializationHasRunTag("some_key", "some_value")
+        )
+    )
+)
+
+
+latest_materialization_run_tag_scenarios = [
+    AssetDaemonScenario(
+        id="latest_parent_materialization_does_not_have_ignored_tag",
+        initial_state=two_assets_in_sequence.with_asset_properties(
+            auto_materialize_policy=filter_latest_run_tag_key_policy
+        ),
+        execution_fn=lambda state: state.with_runs(run_request(["A", "B"]), run_request(["A"]))
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["B"])),
+    ),
+    AssetDaemonScenario(
+        id="latest_parent_materialization_has_ignored_tag",
+        initial_state=two_assets_in_sequence.with_asset_properties(
+            auto_materialize_policy=filter_latest_run_tag_key_policy
+        ),
+        execution_fn=lambda state: state.with_runs(
+            run_request(["A", "B"]), run_request(["A"], tags={"some_key": "some_value"})
+        )
+        .evaluate_tick()
+        .assert_requested_runs(),
+    ),
+    AssetDaemonScenario(
+        id="latest_parent_materialization_has_ignored_key_but_not_value",
+        initial_state=two_assets_in_sequence.with_asset_properties(
+            auto_materialize_policy=filter_latest_run_tag_key_and_value_policy
+        ),
+        execution_fn=lambda state: state.with_runs(
+            run_request(["A", "B"]), run_request(["A"], tags={"some_key": "some_other_value"})
+        )
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["B"])),
+    ),
+    AssetDaemonScenario(
+        id="earlier_parent_materialization_has_ignored_tag",
+        initial_state=two_assets_in_sequence.with_asset_properties(
+            auto_materialize_policy=filter_latest_run_tag_key_policy
+        ),
+        execution_fn=lambda state: state.with_runs(
+            run_request(["A", "B"]),
+            run_request(["A"], tags={"some_key": "some_value"}),
+            run_request(["A"]),
+        )
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["B"])),
+    ),
+    AssetDaemonScenario(
+        id="only_updated_parent_has_ignored_tag",
+        initial_state=one_asset_depends_on_two.with_asset_properties(
+            auto_materialize_policy=filter_latest_run_tag_key_policy
+        ),
+        execution_fn=lambda state: state.with_runs(
+            run_request(["A", "B", "C"]),
+            run_request(["A"], tags={"some_key": "some_value"}),
+        )
+        .evaluate_tick()
+        .assert_requested_runs(),
+    ),
+    AssetDaemonScenario(
+        id="one_updated_parent_has_ignored_tag_but_other_does_not",
+        initial_state=one_asset_depends_on_two.with_asset_properties(
+            auto_materialize_policy=filter_latest_run_tag_key_policy
+        ),
+        execution_fn=lambda state: state.with_runs(
+            run_request(["A", "B", "C"]),
+            run_request(["A"], tags={"some_key": "some_value"}),
+            run_request(["B"]),
+        )
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["C"])),
+    ),
+]


### PR DESCRIPTION
## Summary & Motivation

Adds the ability to customize the `materialize_on_parent_updated` auto-materialize rule to only care about updates that correspond to parents whose latest materialization has the provided run tag. This is useful if, for example, you don't want to auto-materialize in response to backfills.

#### SkipOnLatestParentMaterializationHasRunTag?

I originally tried implementing this as its own auto-materialize rule: `SkipOnLatestParentMaterializationHasRunTag`. But I had trouble getting the semantics to achieve the desired behavior.  If an asset has multiple parents, then we'd need to decide whether we:
- skip in the case that ALL parents have the run tag 
  - Problem case: both parents and child were originally auto-materialized. One parent then gets backfilled. Other parent does not have backfill tag, but we still want to skip the child.
- skip in the case that ANY parent has the run tag
  - Problem case: both parents and child were originally backfilled. One parent then gets auto-materialized. Other parent has backfill tag, but we still want to auto-materialize the child.


## How I Tested These Changes
