### PR TITLE
[pythonic resources][fix] fix direct invocation of run status sensor with resources

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -1164,6 +1164,7 @@ def get_sensor_context_from_args_or_kwargs(
 def get_or_create_sensor_context(
     fn: Callable,
     *args: Any,
+    context_type: Type = SensorEvaluationContext,
     **kwargs: Any,
 ) -> SensorEvaluationContext:
     """Based on the passed resource function and the arguments passed to it, returns the
@@ -1173,12 +1174,7 @@ def get_or_create_sensor_context(
     function requires a context parameter but none is passed.
     """
     context = (
-        get_sensor_context_from_args_or_kwargs(
-            fn,
-            args,
-            kwargs,
-            context_type=SensorEvaluationContext,
-        )
+        get_sensor_context_from_args_or_kwargs(fn, args, kwargs, context_type)
         or build_sensor_context()
     )
     resource_args_from_kwargs = {}


### PR DESCRIPTION
## Summary

Fixes an issue where run status sensors could not be directly invoked with resources provided by name. Instead, they required that resources were provided in the context.

```python
class MyResource(ConfigurableResource):
    a_str: str

@run_status_sensor(run_status=DagsterRunStatus.SUCCESS)
def status_sensor(context, my_resource: MyResource):
    pass

context = build_run_status_sensor_context(...)

status_sensor(context, my_resource=MyResource(a_str="bar"))
```


## Test Plan

New unit test, previously failing, now succeeds.
