### PR TITLE
Use the latest storage ID across all event types in asset backfills, rather than specifically the latest materialization

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1104,9 +1104,7 @@ def execute_asset_backfill_iteration_inner(
 
         yield None
 
-        next_latest_storage_id = instance_queryer.get_latest_storage_id_for_event_type(
-            event_type=DagsterEventType.ASSET_MATERIALIZATION
-        )
+        next_latest_storage_id = instance_queryer.instance.event_log_storage.get_maximum_record_id()
 
         updated_materialized_subset = AssetGraphSubset(asset_graph)
         failed_and_downstream_subset = AssetGraphSubset(asset_graph)

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -199,30 +199,6 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         return next(iter(records), None)
 
     @cached_method
-    def get_latest_storage_id_for_event_type(
-        self, *, event_type: DagsterEventType
-    ) -> Optional[int]:
-        """Returns the latest storage id across all events of the given event_type.
-
-        Args:
-            event_type (DagsterEventType): The event type to query for.
-        """
-        from dagster._core.event_api import EventRecordsFilter
-
-        latest_record = next(
-            iter(
-                self.instance.get_event_records(
-                    event_records_filter=EventRecordsFilter(event_type=event_type),
-                    limit=1,
-                )
-            ),
-            None,
-        )
-        if latest_record is not None:
-            return latest_record.storage_id
-        return None
-
-    @cached_method
     def _get_latest_materialization_or_observation_storage_ids_by_asset_partition(
         self, *, asset_key: AssetKey
     ) -> Mapping[AssetKeyPartitionKey, Optional[int]]:


### PR DESCRIPTION
Summary:
This ID is just used as a cursor to fetch more materializations, so there is no downside (and a performance upside) to making it fetch the most recent record across all event types.

Test Plan: Existing asset backfill tests (double check that this provides coverage / changing this to an incorrect value causes tests to fail)

## Summary & Motivation

## How I Tested These Changes
