### PR TITLE
fix: add missing volumes and volumeMounts in job-instance-migrate.yaml

### DIFF
--- a/helm/dagster/schema/schema_tests/test_instance_migrate.py
+++ b/helm/dagster/schema/schema_tests/test_instance_migrate.py
@@ -2,6 +2,9 @@ import subprocess
 
 import pytest
 from kubernetes.client import models
+from kubernetes import client as k8s_client
+
+from dagster_k8s.models import k8s_model_from_dict, k8s_snake_case_dict
 from schema.charts.dagster.subschema.migrate import Migrate
 from schema.charts.dagster.subschema.webserver import (
     Webserver,
@@ -68,3 +71,45 @@ def test_job_instance_migrate_keeps_annotations(template: HelmTemplate):
 
     assert job.metadata.annotations == annotations
     assert job.spec.template.metadata.annotations == annotations
+
+def test_job_instance_migrate_keeps_volumes_and_volumeMounts(template: HelmTemplate):
+    volumes = [
+        {"name": "test-volume", "configMap": {"name": "test-volume-configmap"}},
+        {"name": "test-pvc", "persistentVolumeClaim": {"claimName": "my_claim", "readOnly": False}},
+    ]
+
+    volume_mounts = [
+        {
+            "name": "test-volume",
+            "mountPath": "/opt/dagster/test_mount_path/volume_mounted_file.yaml",
+            "subPath": "volume_mounted_file.yaml",
+        }
+    ]
+
+    helm_values_migrate_enabled = DagsterHelmValues.construct(
+        migrate=Migrate(enabled=True),
+        dagsterWebserver=Webserver.construct(volumes=volumes, volumeMounts=volume_mounts),
+    )
+
+    jobs = template.render(helm_values_migrate_enabled)
+
+    assert len(jobs) == 1
+
+    job = jobs[0]
+    job_volume_mounts = job.spec.template.spec.containers[0].volume_mounts
+
+    assert job_volume_mounts[1:] == [
+        k8s_model_from_dict(
+            k8s_client.models.V1VolumeMount,
+            k8s_snake_case_dict(k8s_client.models.V1VolumeMount, volume_mount),
+        )
+        for volume_mount in volume_mounts
+    ]
+
+    job_volumes = job.spec.template.spec.volumes
+    assert job_volumes[1:] == [
+        k8s_model_from_dict(
+            k8s_client.models.V1Volume, k8s_snake_case_dict(k8s_client.models.V1Volume, volume)
+        )
+        for volume in volumes
+    ]

--- a/helm/dagster/schema/schema_tests/test_instance_migrate.py
+++ b/helm/dagster/schema/schema_tests/test_instance_migrate.py
@@ -1,10 +1,9 @@
 import subprocess
 
 import pytest
-from kubernetes.client import models
-from kubernetes import client as k8s_client
-
 from dagster_k8s.models import k8s_model_from_dict, k8s_snake_case_dict
+from kubernetes import client as k8s_client
+from kubernetes.client import models
 from schema.charts.dagster.subschema.migrate import Migrate
 from schema.charts.dagster.subschema.webserver import (
     Webserver,
@@ -71,6 +70,7 @@ def test_job_instance_migrate_keeps_annotations(template: HelmTemplate):
 
     assert job.metadata.annotations == annotations
     assert job.spec.template.metadata.annotations == annotations
+
 
 def test_job_instance_migrate_keeps_volumes_and_volumeMounts(template: HelmTemplate):
     volumes = [

--- a/helm/dagster/templates/job-instance-migrate.yaml
+++ b/helm/dagster/templates/job-instance-migrate.yaml
@@ -51,11 +51,21 @@ spec:
             - name: dagster-instance
               mountPath: "{{ .Values.global.dagsterHome }}/dagster.yaml"
               subPath: dagster.yaml
+            {{- if .Values.dagsterWebserver.volumeMounts }}
+            {{- range $volumeMount := .Values.dagsterWebserver.volumeMounts }}
+            - {{- $volumeMount | toYaml | nindent 14 }}
+            {{- end }}
+            {{- end }}
           resources: {{ $_.Values.dagsterWebserver.resources | toYaml | nindent 12 }}
       volumes:
         - name: dagster-instance
           configMap:
             name: {{ template "dagster.fullname" . }}-instance
+        {{- if .Values.dagsterWebserver.volumes }}
+        {{- range $volume := .Values.dagsterWebserver.volumes }}
+        - {{- $volume | toYaml | nindent 10 }}
+        {{- end }}
+        {{- end }}
       nodeSelector: {{ $_.Values.dagsterWebserver.nodeSelector | toYaml | nindent 8 }}
       affinity: {{ $_.Values.dagsterWebserver.affinity | toYaml | nindent 8 }}
       tolerations: {{ $_.Values.dagsterWebserver.tolerations | toYaml | nindent 8 }}


### PR DESCRIPTION
## Summary & Motivation

Hi community,

This is a small PR related to an issue I got yesterday migrating the Dagster instance in our environment.

I followed the documentation [here](https://docs.dagster.io/deployment/guides/kubernetes/how-to-migrate-your-instance) but the migration failed because our environment use an **external Postgres DB** (running in GCP Cloud SQL). 

The instance is configured to **only accepts SSL connections** so the `values.yaml` I use is mounting a `volume` (and a `volumeMount`) for the dagster services accessing the Database (e.g `daemon`, `webserver`...)

The issue is the `job-instance-migrate.yaml` template does not include the snippets to add the `volume` and `volumeMount`.

## How I Tested These Changes

I copied my `values.yaml` with the `volume` and `volumeMounts`.

Then I just run in the `helm/dagster` directory: 

```bash
helm template dagster . \
          --set "migrate.enabled=true" \
          --show-only templates/job-instance-migrate.yaml \
          --values values.yaml
```
