### PR TITLE
Update contributing.mdx

### DIFF
--- a/docs/content/community/contributing.mdx
+++ b/docs/content/community/contributing.mdx
@@ -120,7 +120,7 @@ In `.mdx` files, you'll see a code snippet with `python file=/path/to/file.py st
 
 <Image src="/images/community/md-code-block.png" width={1434} height={368} />
 
-You can find the corresponding Python file at `dagster/examples/docs_snippets/docs_snippets/concepts/asset/asset_dependenyy.py`. The code included in each snippet is the code in the file between the `# start_marker` and `# end_marker` comments.
+You can find the corresponding Python file at `dagster/examples/docs_snippets/docs_snippets/concepts/asset/asset_dependency.py`. The code included in each snippet is the code in the file between the `# start_marker` and `# end_marker` comments.
 
 <Image src="/images/community/py-code-block.png" width={736} height={496} />
 


### PR DESCRIPTION
in line 123, the reference is currently listed as  `dagster/examples/docs_snippets/docs_snippets/concepts/asset/asset_dependenyy.py`. The correct reference is  `dagster/examples/docs_snippets/docs_snippets/concepts/asset/asset_dependency.py` as is confirmed in https://github.com/dagster-io/dagster/tree/3eb39ae77a2ea08701c99b1b3b6fd9c6f247fedd/examples/docs_snippets/docs_snippets/concepts/assets

## Summary & Motivation
A very small spelling error, likely a mistype. It's a very minor change but every bit helps. 
## How I Tested These Changes
manual verification by navigating the dagster project folders to confirm the correct spelling