### PR TITLE
[1.6] feat(dbt)!: customize `backfill_policy` default using `partitions_def`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -20,6 +20,7 @@ from dagster import (
     DagsterInvalidDefinitionError,
     Nothing,
     PartitionsDefinition,
+    TimeWindowPartitionsDefinition,
     multi_asset,
 )
 from dagster._utils.warnings import (
@@ -80,7 +81,8 @@ def dbt_assets(
         dagster_dbt_translator (Optional[DagsterDbtTranslator]): Allows customizing how to map
             dbt models, seeds, etc. to asset keys and asset metadata.
         backfill_policy (Optional[BackfillPolicy]): If a partitions_def is defined, this determines
-            how to execute backfills that target multiple partitions.
+            how to execute backfills that target multiple partitions. If a time window partition
+            definition is used, this parameter defaults to a single-run policy.
         op_tags (Optional[Dict[str, Any]]): A dictionary of tags for the op that computes the assets.
             Frameworks may expect and require certain metadata to be attached to a op. Values that
             are not strings will be json encoded and must meet the criteria that
@@ -298,6 +300,13 @@ def dbt_assets(
         **({"dagster-dbt/exclude": exclude} if exclude else {}),
         **(op_tags if op_tags else {}),
     }
+
+    if (
+        partitions_def
+        and isinstance(partitions_def, TimeWindowPartitionsDefinition)
+        and not backfill_policy
+    ):
+        backfill_policy = BackfillPolicy.single_run()
 
     def inner(fn) -> AssetsDefinition:
         asset_definition = multi_asset(


### PR DESCRIPTION
## Summary & Motivation
Addresses a comment from https://github.com/dagster-io/dagster/issues/17778#issuecomment-1801268798.

We can have a more sensible default for `backfill_policy` by using `partitions_def`. If the partitions definition is a time window, then we should default to a single-run backfill policy. If the partition definition is static, then we should default to a multi-run backfill policy.

If the `backfill_policy` is explicitly defined, ignore these defaults.

## How I Tested These Changes
pytest
