### PR TITLE
[ui] Fold asset graph feature flags together, add “Try the new UI!” notice

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -12,7 +12,6 @@ export const FeatureFlag = {
   flagInstanceConcurrencyLimits: 'flagInstanceConcurrencyLimits' as const,
   flagSensorScheduleLogging: 'flagSensorScheduleLogging' as const,
   flagSidebarResources: 'flagSidebarResources' as const,
-  flagHorizontalDAGs: 'flagHorizontalDAGs' as const,
   flagDisableAutoLoadDefaults: 'flagDisableAutoLoadDefaults' as const,
   flagDAGSidebar: 'flagDAGSidebar' as const,
   flagDisableDAGCache: 'flagDisableDAGCache' as const,

--- a/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
@@ -8,38 +8,10 @@ import {FeatureFlag} from './Flags';
  */
 export const getVisibleFeatureFlagRows = () => [
   {
-    key: 'Debug console logging',
-    flagType: FeatureFlag.flagDebugConsoleLogging,
-  },
-  {
-    key: 'Disable WebSockets',
-    flagType: FeatureFlag.flagDisableWebsockets,
-  },
-  {
-    key: 'Display resources in navigation sidebar',
-    flagType: FeatureFlag.flagSidebarResources,
-  },
-  {
-    key: 'Disable automatically loading default config in launchpad',
-    flagType: FeatureFlag.flagDisableAutoLoadDefaults,
-  },
-  {
-    key: 'Experimental schedule/sensor logging view',
-    flagType: FeatureFlag.flagSensorScheduleLogging,
-  },
-  {
-    key: 'Experimental instance-level concurrency limits',
-    flagType: FeatureFlag.flagInstanceConcurrencyLimits,
-  },
-  {
-    key: 'Experimental horizontal asset DAGs',
-    flagType: FeatureFlag.flagHorizontalDAGs,
-  },
-  {
-    key: 'New asset lineage sidebar and grouped asset graph',
+    key: 'Experimental asset graph experience',
     label: (
       <Box flex={{direction: 'column'}}>
-        New asset lineage sidebar and grouped asset graph,
+        Experimental asset graph experience
         <div>
           <a
             href="https://github.com/dagster-io/dagster/discussions/16657"
@@ -54,15 +26,19 @@ export const getVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagDAGSidebar,
   },
   {
-    key: 'Disable Asset Graph caching',
-    flagType: FeatureFlag.flagDisableDAGCache,
+    key: 'Experimental schedule/sensor logging view',
+    flagType: FeatureFlag.flagSensorScheduleLogging,
   },
   {
-    key: 'Experimental longest path DAG algorithm (Faster)',
+    key: 'Experimental instance-level concurrency limits',
+    flagType: FeatureFlag.flagInstanceConcurrencyLimits,
+  },
+  {
+    key: 'Experimental longest path DAG algorithm (faster)',
     flagType: FeatureFlag.flagLongestPathDag,
     label: (
       <Box flex={{direction: 'column'}}>
-        Experimental longest path asset graph algorithm (Faster).
+        Experimental longest path asset graph algorithm (faster)
         <div>
           <a
             href="https://github.com/dagster-io/dagster/discussions/17240"
@@ -74,5 +50,25 @@ export const getVisibleFeatureFlagRows = () => [
         </div>
       </Box>
     ),
+  },
+  {
+    key: 'Display resources in navigation sidebar',
+    flagType: FeatureFlag.flagSidebarResources,
+  },
+  {
+    key: 'Disable Asset Graph caching',
+    flagType: FeatureFlag.flagDisableDAGCache,
+  },
+  {
+    key: 'Disable WebSockets',
+    flagType: FeatureFlag.flagDisableWebsockets,
+  },
+  {
+    key: 'Disable automatically loading default config in launchpad',
+    flagType: FeatureFlag.flagDisableAutoLoadDefaults,
+  },
+  {
+    key: 'Debug console logging',
+    flagType: FeatureFlag.flagDebugConsoleLogging,
   },
 ];

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -46,6 +46,7 @@ import {CollapsedGroupNode} from './CollapsedGroupNode';
 import {ExpandedGroupNode} from './ExpandedGroupNode';
 import {AssetNodeLink} from './ForeignNode';
 import {SidebarAssetInfo} from './SidebarAssetInfo';
+import {TryTheFeatureFlagNotice} from './TryTheFeatureFlagNotice';
 import {
   GraphData,
   graphHasCycles,
@@ -136,7 +137,7 @@ const AssetGraphExplorerWithData = ({
   allAssetKeys,
 }: WithDataProps) => {
   const findAssetLocation = useFindAssetLocation();
-  const {flagHorizontalDAGs, flagDAGSidebar} = useFeatureFlags();
+  const {flagDAGSidebar} = useFeatureFlags();
 
   const [highlighted, setHighlighted] = React.useState<string | null>(null);
 
@@ -367,6 +368,7 @@ const AssetGraphExplorerWithData = ({
       firstMinSize={400}
       first={
         <ErrorBoundary region="graph">
+          {!flagDAGSidebar ? <TryTheFeatureFlagNotice /> : undefined}
           {graphQueryItems.length === 0 ? (
             <EmptyDAGNotice nodeType="asset" isGraph />
           ) : Object.keys(assetGraphData.nodes).length === 0 ? (
@@ -377,7 +379,7 @@ const AssetGraphExplorerWithData = ({
           ) : (
             <SVGViewport
               ref={(r) => (viewportEl.current = r || undefined)}
-              defaultZoom={flagHorizontalDAGs ? 'zoom-to-fit-width' : 'zoom-to-fit'}
+              defaultZoom={flagDAGSidebar ? 'zoom-to-fit-width' : 'zoom-to-fit'}
               interactor={SVGViewport.Interactors.PanAndZoom}
               graphWidth={layout.width}
               graphHeight={layout.height}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/TryTheFeatureFlagNotice.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/TryTheFeatureFlagNotice.tsx
@@ -1,0 +1,56 @@
+import {Body, Box, Button, Colors, Subtitle1} from '@dagster-io/ui-components';
+import uniq from 'lodash/uniq';
+import React from 'react';
+import styled from 'styled-components';
+
+import {FeatureFlag, getFeatureFlags, setFeatureFlags} from '../app/Flags';
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
+
+const TITLE = 'Try the new asset graph';
+
+const MESSAGE =
+  "We're building a better asset graph experience with faster rendering, a new sidebar, collapsible groups, and more. You can opt-in to this experimental feature at any time from user settings.";
+
+export const TryTheFeatureFlagNotice = () => {
+  const [dismissed, setDismissed] = useStateWithStorage<boolean>(
+    'new-graph-feature-flag',
+    (val) => !!val,
+  );
+
+  if (dismissed) {
+    return <span />;
+  }
+  return (
+    <Container>
+      <Box flex={{direction: 'column', gap: 4}}>
+        <Subtitle1>{TITLE}</Subtitle1>
+        <Body color={Colors.Gray700}>{MESSAGE}</Body>
+        <Box flex={{gap: 8}} margin={{top: 12}}>
+          <Button
+            intent="primary"
+            onClick={() => {
+              setFeatureFlags(uniq([...getFeatureFlags(), FeatureFlag.flagDAGSidebar]));
+              window.location.reload();
+            }}
+          >
+            Try it now
+          </Button>
+          <Button onClick={() => setDismissed(true)}>No thanks</Button>
+        </Box>
+      </Box>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  position: absolute;
+  left: 16px;
+  bottom: 16px;
+  z-index: 2;
+  width: 700px;
+  max-width: 50vw;
+  border: 1px solid ${Colors.Blue100};
+  border-radius: 16px;
+  background: ${Colors.Blue50};
+  padding: 24px;
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -118,7 +118,7 @@ export const graphHasCycles = (graphData: GraphData) => {
   return hasCycles;
 };
 
-export const buildSVGPath = featureEnabled(FeatureFlag.flagHorizontalDAGs)
+export const buildSVGPath = featureEnabled(FeatureFlag.flagDAGSidebar)
   ? pathHorizontalDiagonal({
       source: (s: any) => s.source,
       target: (s: any) => s.target,

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -186,7 +186,7 @@ export function useAssetLayout(_graphData: GraphData, expandedGroups: string[]) 
 
   const opts = React.useMemo(
     () => ({
-      horizontalDAGs: flags.flagHorizontalDAGs,
+      horizontalDAGs: flags.flagDAGSidebar,
       longestPath: flags.flagLongestPathDag,
     }),
     [flags],


### PR DESCRIPTION
## Summary & Motivation

- Merges `Horizontal DAG` into the `Experimental asset sidebar` feature flag and renames it to reflect that it unlocks all the new asset graph features! The combined feature flag is still called `flagDAGSidebar`, but I don't think it's worth changing because I'd like for people who already opted in to remain opted in.

- Adds a new banner that appears on asset group, asset job, and global asset graph pages letting you know you should try out the feature flag. If you click "Not Now" it saves that state in local storage and will not appear again.

- Re-orders our feature flags so that the debug-type options are at the bottom and the experimental-type options are at the top. 

<img width="570" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/3f652e23-b503-4432-af00-f97a5b575564">

<img width="1728" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/9ed65aa6-ae2c-49c2-bd49-cc5624bcedb3">

## How I Tested These Changes

I fiddled with local storage to try the buttons and verified that the new banner works properly. I also tried various screen sizes and made sure that the max-width of 50vw is appropriate.