### PR TITLE
Update image in README to use updated asset nodes

### DIFF
--- a/python_modules/dagster/README.md
+++ b/python_modules/dagster/README.md
@@ -61,7 +61,7 @@ def continent_stats(country_populations: DataFrame, continent_change_model: Line
 The graph loaded into Dagster's web UI:
 
 <p align="center">
-  <img width="432" alt="image" src="https://github.com/dagster-io/dagster/assets/654855/5b302b1b-4cc9-49bf-8689-232f7de87d31">
+  <img width="432" alt="An example asset graph as rendered in the Dagster UI" src="https://github.com/dagster-io/dagster/assets/654855/5b302b1b-4cc9-49bf-8689-232f7de87d31">
 </p>
 
 Dagster is built to be used at every stage of the data development lifecycle - local development, unit tests, integration tests, staging environments, all the way up to production.

--- a/python_modules/dagster/README.md
+++ b/python_modules/dagster/README.md
@@ -61,7 +61,7 @@ def continent_stats(country_populations: DataFrame, continent_change_model: Line
 The graph loaded into Dagster's web UI:
 
 <p align="center">
-  <img width="400px" alt="An example asset graph as rendered in the Dagster UI" src="https://user-images.githubusercontent.com/654855/183537484-48dde394-91f2-4de0-9b17-a70b3e9a3823.png">
+  <img width="432" alt="image" src="https://github.com/dagster-io/dagster/assets/654855/5b302b1b-4cc9-49bf-8689-232f7de87d31">
 </p>
 
 Dagster is built to be used at every stage of the data development lifecycle - local development, unit tests, integration tests, staging environments, all the way up to production.


### PR DESCRIPTION
## Summary & Motivation

The current README has an outdated version of our asset graph UI.

Old: https://github.com/dagster-io/dagster
New: https://github.com/dagster-io/dagster/tree/readme-updated-asset-nodes

## How I Tested These Changes
