### PR TITLE
[auto-materialize][1/n] Create AutoMaterializePolicyEvaluator class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy_evaluator.py
@@ -1,0 +1,221 @@
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, AbstractSet, List, NamedTuple, Optional, Sequence, Tuple, Union
+
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.partition import PartitionsSubset
+
+from .auto_materialize_rule import (
+    DiscardOnMaxMaterializationsExceededRule,
+    RuleEvaluationContext,
+    RuleEvaluationResults,
+)
+from .auto_materialize_rule_evaluation import (
+    AutoMaterializeAssetEvaluation,
+    AutoMaterializeRuleEvaluation,
+)
+
+if TYPE_CHECKING:
+    from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
+
+PartitionsSubsetOrBool = Union[PartitionsSubset, bool]
+
+
+class EvaluationData(NamedTuple):
+    ...
+
+
+class ConditionEvaluation(NamedTuple):
+    """Internal representation of the results of evaluating a node in the evaluation tree."""
+
+    condition: "AutoMaterializeCondition"
+    true: AbstractSet[AssetKeyPartitionKey]
+    results: RuleEvaluationResults = []
+    children: Sequence["ConditionEvaluation"] = []
+
+    @property
+    def all_results(
+        self
+    ) -> Sequence[Tuple[AutoMaterializeRuleEvaluation, AbstractSet[AssetKeyPartitionKey]]]:
+        """This method is a placeholder to allow us to convert this into a shape that other parts
+        of the system understand.
+        """
+        if isinstance(self.condition, RuleCondition):
+            results = [
+                (
+                    AutoMaterializeRuleEvaluation(
+                        rule_snapshot=self.condition.rule.to_snapshot(),
+                        evaluation_data=evaluation_data,
+                    ),
+                    subset,
+                )
+                for evaluation_data, subset in self.results
+            ]
+        else:
+            results = []
+        for child in self.children:
+            results = [*results, *child.all_results]
+        return results
+
+    def to_evaluation(
+        self,
+        asset_key: AssetKey,
+        asset_graph: AssetGraph,
+        instance_queryer: "CachingInstanceQueryer",
+        to_discard: AbstractSet[AssetKeyPartitionKey],
+        discard_results: Sequence[
+            Tuple[AutoMaterializeRuleEvaluation, AbstractSet[AssetKeyPartitionKey]]
+        ],
+        num_skipped: int,
+    ) -> AutoMaterializeAssetEvaluation:
+        """This method is a placeholder to allow us to convert this into a shape that other parts
+        of the system understand.
+        """
+        return AutoMaterializeAssetEvaluation.from_rule_evaluation_results(
+            asset_key=asset_key,
+            asset_graph=asset_graph,
+            asset_partitions_by_rule_evaluation=[*self.all_results, *discard_results],
+            num_requested=len(self.true - to_discard),
+            num_skipped=num_skipped,
+            num_discarded=len(to_discard),
+            dynamic_partitions_store=instance_queryer,
+        )
+
+
+class AutoMaterializeCondition(ABC):
+    @abstractmethod
+    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+        ...
+
+    def __and__(self, other: "AutoMaterializeCondition") -> "AutoMaterializeCondition":
+        # group AndConditions together
+        if isinstance(self, AndCondition):
+            return AndCondition(children=[*self.children, other])
+        return AndCondition(children=[self, other])
+
+    def __or__(self, other: "AutoMaterializeCondition") -> "AutoMaterializeCondition":
+        # group OrConditions together
+        if isinstance(self, OrCondition):
+            return OrCondition(children=[*self.children, other])
+        return OrCondition(children=[self, other])
+
+    def __invert__(self) -> "AutoMaterializeCondition":
+        return InvertCondition(child=self)
+
+
+class RuleCondition(
+    AutoMaterializeCondition, NamedTuple("_RuleCondition", [("rule", AutoMaterializeRule)])
+):
+    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+        context.daemon_context._verbose_log_fn(f"Evaluating rule: {self.rule.to_snapshot()}")  # noqa
+        results = self.rule.evaluate_for_asset(context)
+        true = set()
+        for _, asset_partitions in results:
+            true |= asset_partitions
+        context.daemon_context._verbose_log_fn(f"Rule returned {len(true)} partitions")  # noqa
+        return ConditionEvaluation(condition=self, true=true, results=results)
+
+
+class AndCondition(
+    AutoMaterializeCondition,
+    NamedTuple("_AndCondition", [("children", Sequence[AutoMaterializeCondition])]),
+):
+    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+        child_evaluations: List[ConditionEvaluation] = []
+        subset = context.candidates
+        for child in self.children:
+            context = context.with_candidates(subset)
+            result = child.evaluate(context)
+            child_evaluations.append(result)
+            subset &= result.true
+        return ConditionEvaluation(condition=self, true=subset, children=child_evaluations)
+
+
+class OrCondition(
+    AutoMaterializeCondition,
+    NamedTuple("_OrCondition", [("children", Sequence[AutoMaterializeCondition])]),
+):
+    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+        child_evaluations: List[ConditionEvaluation] = []
+        subset = set()
+        for child in self.children:
+            result = child.evaluate(context)
+            child_evaluations.append(result)
+            subset |= result.true
+        return ConditionEvaluation(condition=self, true=subset, children=child_evaluations)
+
+
+class InvertCondition(
+    AutoMaterializeCondition,
+    NamedTuple("_InvertCondition", [("child", AutoMaterializeCondition)]),
+):
+    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+        child_evaluation = self.child.evaluate(context)
+        return ConditionEvaluation(
+            condition=self,
+            true=context.candidates - child_evaluation.true,
+            children=[child_evaluation],
+        )
+
+
+class AutoMaterializePolicyEvaluator(NamedTuple):
+    """For now, this is an internal class that is used to help transition from the old format to the
+    new. Upstack, the original AutoMaterializePolicy class will be replaced with this.
+    """
+
+    condition: AutoMaterializeCondition
+    max_materializations_per_minute: Optional[int] = 1
+
+    def evaluate(
+        self, context: RuleEvaluationContext, from_legacy: bool
+    ) -> Tuple[
+        AutoMaterializeAssetEvaluation,
+        AbstractSet[AssetKeyPartitionKey],
+        AbstractSet[AssetKeyPartitionKey],
+    ]:
+        """Evaluates the auto materialize policy of a given asset.
+
+        Returns:
+        - An AutoMaterializeAssetEvaluation object representing serializable information about
+        this evaluation.
+        - The set of AssetKeyPartitionKeys that should be materialized.
+        - The set of AssetKeyPartitionKeys that should be discarded.
+        """
+        condition_evaluation = self.condition.evaluate(context)
+
+        # this is treated separately from other rules, for now
+        to_discard, discard_results = set(), []
+        if self.max_materializations_per_minute is not None:
+            discard_context = context.with_candidates(condition_evaluation.true)
+            condition = RuleCondition(
+                DiscardOnMaxMaterializationsExceededRule(limit=self.max_materializations_per_minute)
+            )
+            discard_condition_evaluation = condition.evaluate(discard_context)
+            to_discard = discard_condition_evaluation.true
+            discard_results = discard_condition_evaluation.all_results
+
+        to_materialize = condition_evaluation.true - to_discard
+
+        # hack to get the number of skipped asset partitions
+        num_skipped = 0
+        if (
+            from_legacy
+            and isinstance(self.condition, AndCondition)
+            and len(condition_evaluation.children) == 2
+        ):
+            # the right-hand side of the AndCondition is the inverse of the set of skip rules
+            num_skipped = len(condition_evaluation.children[1].children[0].true)
+
+        return (
+            condition_evaluation.to_evaluation(
+                context.asset_key,
+                context.asset_graph,
+                context.instance_queryer,
+                to_discard,
+                discard_results,
+                num_skipped=num_skipped,
+            ),
+            to_materialize,
+            to_discard,
+        )

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime
 import functools
 from abc import ABC, abstractmethod, abstractproperty
@@ -114,6 +115,11 @@ class RuleEvaluationContext:
         return self.previous_tick_evaluation.get_evaluated_asset_partitions(
             asset_graph=self.asset_graph
         )
+
+    def with_candidates(
+        self, candidates: AbstractSet[AssetKeyPartitionKey]
+    ) -> "RuleEvaluationContext":
+        return dataclasses.replace(self, candidates=candidates)
 
     def get_previous_tick_results(self, rule: "AutoMaterializeRule") -> "RuleEvaluationResults":
         """Returns the results that were calculated for a given rule on the previous tick."""

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -1136,7 +1136,10 @@ class SkipOnRequiredButNonexistentParentsRule(
     def evaluate_for_asset(self, context: RuleEvaluationContext) -> RuleEvaluationResults:
         asset_partitions_by_evaluation_data = defaultdict(set)
 
-        candidates_to_evaluate = context.get_candidates_not_evaluated_by_rule_on_previous_tick()
+        candidates_to_evaluate = (
+            context.get_candidates_not_evaluated_by_rule_on_previous_tick()
+            | context.get_candidates_with_updated_or_will_update_parents()
+        )
         for candidate in candidates_to_evaluate.get_asset_partitions(context.asset_key):
             nonexistent_parent_partitions = context.asset_graph.get_parents_partitions(
                 context.instance_queryer,

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1211,3 +1211,117 @@ class DefaultPartitionsSubset(PartitionsSubset[T_str]):
     @classmethod
     def empty_subset(cls, partitions_def: PartitionsDefinition[T_str]) -> "PartitionsSubset[T_str]":
         return cls(partitions_def=partitions_def)
+
+
+class AllPartitionsSubset(
+    PartitionsSubset,
+    NamedTuple(
+        "_AllPartitionsSubset",
+        [
+            ("partitions_def", PartitionsDefinition),
+            ("dynamic_partitions_store", Optional[DynamicPartitionsStore]),
+        ],
+    ),
+):
+    """This is an in-memory (i.e. not serializable) convenience class that represents all partitions
+    of a given PartitionsDefinition, allowing set operations to be taken without having to load
+    all partition keys immediately.
+    """
+
+    def __new__(
+        cls,
+        partitions_def: PartitionsDefinition,
+        dynamic_partitions_store: Optional[DynamicPartitionsStore],
+    ):
+        return super().__new__(
+            cls, partitions_def=partitions_def, dynamic_partitions_store=dynamic_partitions_store
+        )
+
+    @property
+    def partitions_def(self) -> PartitionsDefinition:
+        return self._asdict()["partitions_def"]
+
+    def get_partition_keys(self, current_time: Optional[datetime] = None) -> Iterable[str]:
+        return self.partitions_def.get_partition_keys(current_time, self.dynamic_partitions_store)
+
+    def get_partition_keys_not_in_subset(
+        self,
+        partitions_def: PartitionsDefinition,
+        current_time: Optional[datetime] = None,
+        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+    ) -> Iterable[str]:
+        return set()
+
+    def get_partition_key_ranges(
+        self,
+        partitions_def: PartitionsDefinition,
+        current_time: Optional[datetime] = None,
+        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+    ) -> Sequence[PartitionKeyRange]:
+        first_key = partitions_def.get_first_partition_key(current_time, dynamic_partitions_store)
+        last_key = partitions_def.get_last_partition_key(current_time, dynamic_partitions_store)
+        if first_key and last_key:
+            return [PartitionKeyRange(first_key, last_key)]
+        return []
+
+    def with_partition_keys(self, partition_keys: Iterable[str]) -> "AllPartitionsSubset":
+        return self
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, AllPartitionsSubset) and other.partitions_def == self.partitions_def
+        )
+
+    def __and__(self, other: "PartitionsSubset") -> "PartitionsSubset":
+        return other
+
+    def __sub__(self, other: "PartitionsSubset") -> "PartitionsSubset":
+        if self == other:
+            return self.partitions_def.empty_subset()
+        return self.partitions_def.empty_subset().with_partition_keys(
+            set(self.get_partition_keys()).difference(set(other.get_partition_keys()))
+        )
+
+    def __or__(self, other: "PartitionsSubset") -> "PartitionsSubset":
+        return self
+
+    def __len__(self) -> int:
+        return len(
+            self.partitions_def.subset_with_all_partitions(
+                dynamic_partitions_store=self.dynamic_partitions_store
+            )
+        )
+
+    def __contains__(self, value) -> bool:
+        return self.partitions_def.has_partition_key(
+            partition_key=value,
+            current_time=None,
+            dynamic_partitions_store=self.dynamic_partitions_store,
+        )
+
+    def __repr__(self) -> str:
+        return f"AllPartitionsSubset(partitions_def={self.partitions_def})"
+
+    @classmethod
+    def can_deserialize(
+        cls,
+        partitions_def: PartitionsDefinition,
+        serialized: str,
+        serialized_partitions_def_unique_id: Optional[str],
+        serialized_partitions_def_class_name: Optional[str],
+    ) -> bool:
+        return False
+
+    def serialize(self) -> str:
+        raise NotImplementedError()
+
+    @classmethod
+    def from_serialized(
+        cls, partitions_def: PartitionsDefinition[T_str], serialized: str
+    ) -> "PartitionsSubset[T_str]":
+        raise NotImplementedError()
+
+    def empty_subset(
+        self, partitions_def: Optional[PartitionsDefinition] = None
+    ) -> "PartitionsSubset[T_str]":
+        check.failed("Cannot create an empty AllPartitionsSubset")

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1214,7 +1214,6 @@ class DefaultPartitionsSubset(PartitionsSubset[T_str]):
 
 
 class AllPartitionsSubset(
-    PartitionsSubset,
     NamedTuple(
         "_AllPartitionsSubset",
         [
@@ -1222,6 +1221,7 @@ class AllPartitionsSubset(
             ("dynamic_partitions_store", Optional[DynamicPartitionsStore]),
         ],
     ),
+    PartitionsSubset,
 ):
     """This is an in-memory (i.e. not serializable) convenience class that represents all partitions
     of a given PartitionsDefinition, allowing set operations to be taken without having to load
@@ -1236,10 +1236,6 @@ class AllPartitionsSubset(
         return super().__new__(
             cls, partitions_def=partitions_def, dynamic_partitions_store=dynamic_partitions_store
         )
-
-    @property
-    def partitions_def(self) -> PartitionsDefinition:
-        return self._asdict()["partitions_def"]
 
     def get_partition_keys(self, current_time: Optional[datetime] = None) -> Iterable[str]:
         return self.partitions_def.get_partition_keys(current_time, self.dynamic_partitions_store)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_observe_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_observe_scenarios.py
@@ -9,6 +9,7 @@ from dagster import (
     observable_source_asset,
 )
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 
 from ..base_scenario import AssetReconciliationScenario, run_request
 
@@ -26,7 +27,9 @@ def asset2():
 @asset(
     partitions_def=StaticPartitionsDefinition(["a", "b", "c"]),
     # this is just a dummy policy, as we don't want this to actually impact the logic
-    auto_materialize_policy=AutoMaterializePolicy(rules=set()),
+    auto_materialize_policy=AutoMaterializePolicy(
+        rules={AutoMaterializeRule.skip_on_parent_missing()}
+    ),
 )
 def partitioned_dummy_asset():
     return 1


### PR DESCRIPTION
## Summary & Motivation

First of several PRs to enable arbitrary boolean expressions of AutoMaterializeConditions (or other name). For now, this attempts to slot in as unobtrusively as possible into the current ecosystem, and does not modify the AutoMaterializePolicy class.

However, this new class will eventually replace the AutoMaterializePolicy class.

Note that this fails some perf regression tests, as explained by the comment. This is addressed in the next PR in this stack.

## How I Tested These Changes
