### PR TITLE
rfc: check result targets future materialization

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
@@ -30,6 +30,7 @@ class AssetCheckResult(
             ("check_name", PublicAttr[Optional[str]]),
             ("metadata", PublicAttr[Mapping[str, MetadataValue]]),
             ("severity", PublicAttr[AssetCheckSeverity]),
+            ("targets_future_materialization", PublicAttr[bool]),
         ],
     )
 ):
@@ -48,7 +49,9 @@ class AssetCheckResult(
             list, and one of the data classes returned by a MetadataValue static method.
         severity (AssetCheckSeverity):
             Severity of the check. Defaults to ERROR.
-
+        targets_future_materialization (bool):
+            Whether the check targets a future materialization instead of the most recent. Defaults
+            to False.
     """
 
     def __new__(
@@ -59,6 +62,7 @@ class AssetCheckResult(
         check_name: Optional[str] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         severity: AssetCheckSeverity = AssetCheckSeverity.ERROR,
+        targets_future_materialization: bool = False,
     ):
         normalized_metadata = normalize_metadata(
             check.opt_mapping_param(metadata, "metadata", key_type=str),
@@ -70,6 +74,9 @@ class AssetCheckResult(
             passed=check.bool_param(passed, "passed"),
             metadata=normalized_metadata,
             severity=check.inst_param(severity, "severity", AssetCheckSeverity),
+            targets_future_materialization=check.bool_param(
+                targets_future_materialization, "targets_future_materialization"
+            ),
         )
 
     def to_asset_check_evaluation(


### PR DESCRIPTION
Add `AssetCheckResult(passed=True, targets_future_materialization=True)` to support the WAP pattern. If this is set, we won't hide the check result when the asset is materialized and we won't show the wrong info in the 'target materialization' column of the checks tab.

@rexledesma has made a pretty good case against boolean flags in the past. Would an enum of FUTURE_MATERILIAZATION, LATEST_MATERIALIZATION be any better? The only other option I can imagine that not covering is reporting check results on historical materializations, which hasn't been requested

---

This is an alternative to the approach I proposed of logging the same check result twice for WAP (once for audit, then again for promote). This is more explicit so we don't have wrong info in the 'target materialization' ui.