### PR TITLE
[ui] Add option to “Launch new run” to the job actions menu

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -309,7 +309,7 @@ export const useMaterializationAction = (preferredJobName?: string) => {
       assetKeysOrJob instanceof Array
         ? await client.query<LaunchAssetLoaderQuery, LaunchAssetLoaderQueryVariables>({
             query: LAUNCH_ASSET_LOADER_QUERY,
-            variables: {assetKeys: assetKeysOrJob},
+            variables: {assetKeys: assetKeysOrJob.map(asAssetKeyInput)},
           })
         : await client.query<LaunchAssetLoaderJobQuery, LaunchAssetLoaderJobQueryVariables>({
             query: LAUNCH_ASSET_LOADER_JOB_QUERY,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -22,6 +22,7 @@ import {
   sortAssetKeys,
   tokenForAssetKey,
 } from '../asset-graph/Utils';
+import {PipelineSelector} from '../graphql/types';
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
 import {AssetLaunchpad} from '../launchpad/LaunchpadRoot';
 import {LaunchPipelineExecutionMutationVariables} from '../runs/types/RunUtils.types';
@@ -42,6 +43,8 @@ import {
   LaunchAssetCheckUpstreamQuery,
   LaunchAssetCheckUpstreamQueryVariables,
   LaunchAssetExecutionAssetNodeFragment,
+  LaunchAssetLoaderJobQuery,
+  LaunchAssetLoaderJobQueryVariables,
   LaunchAssetLoaderQuery,
   LaunchAssetLoaderQueryVariables,
   LaunchAssetLoaderResourceQuery,
@@ -299,8 +302,24 @@ export const useMaterializationAction = (preferredJobName?: string) => {
 
   const [state, setState] = React.useState<LaunchAssetsState>({type: 'none'});
 
+  const onLoad = async (
+    assetKeysOrJob: AssetKey[] | PipelineSelector,
+  ): Promise<LaunchAssetLoaderQuery | LaunchAssetLoaderJobQuery> => {
+    const result =
+      assetKeysOrJob instanceof Array
+        ? await client.query<LaunchAssetLoaderQuery, LaunchAssetLoaderQueryVariables>({
+            query: LAUNCH_ASSET_LOADER_QUERY,
+            variables: {assetKeys: assetKeysOrJob},
+          })
+        : await client.query<LaunchAssetLoaderJobQuery, LaunchAssetLoaderJobQueryVariables>({
+            query: LAUNCH_ASSET_LOADER_JOB_QUERY,
+            variables: {job: assetKeysOrJob},
+          });
+    return result.data;
+  };
+
   const onClick = async (
-    assetKeys: AssetKey[],
+    assetKeysOrJob: AssetKey[] | PipelineSelector,
     e: React.MouseEvent<any>,
     _forceLaunchpad = false,
   ) => {
@@ -309,18 +328,15 @@ export const useMaterializationAction = (preferredJobName?: string) => {
     }
     setState({type: 'loading'});
 
-    const result = await client.query<LaunchAssetLoaderQuery, LaunchAssetLoaderQueryVariables>({
-      query: LAUNCH_ASSET_LOADER_QUERY,
-      variables: {assetKeys: assetKeys.map(asAssetKeyInput)},
-    });
+    const data = await onLoad(assetKeysOrJob);
 
-    if (result.data.assetNodeDefinitionCollisions.length) {
-      showCustomAlert(buildAssetCollisionsAlert(result.data));
+    if ('assetNodeDefinitionCollisions' in data && data.assetNodeDefinitionCollisions.length) {
+      showCustomAlert(buildAssetCollisionsAlert(data));
       setState({type: 'none'});
       return;
     }
 
-    const assets = result.data.assetNodes;
+    const assets = data.assetNodes;
     const forceLaunchpad = e.shiftKey || _forceLaunchpad;
 
     const next = await stateForLaunchingAssets(client, assets, forceLaunchpad, preferredJobName);
@@ -390,15 +406,8 @@ export const useMaterializationAction = (preferredJobName?: string) => {
           open={true}
           setOpen={() => setState({type: 'none'})}
           refetch={async () => {
-            const result = await client.query<
-              LaunchAssetLoaderQuery,
-              LaunchAssetLoaderQueryVariables
-            >({
-              query: LAUNCH_ASSET_LOADER_QUERY,
-              variables: {assetKeys: state.assets.map(asAssetKeyInput)},
-            });
-            const assets = result.data.assetNodes;
-            const next = await stateForLaunchingAssets(client, assets, false, preferredJobName);
+            const {assetNodes} = await onLoad(state.assets.map(asAssetKeyInput));
+            const next = await stateForLaunchingAssets(client, assetNodes, false, preferredJobName);
             if (next.type === 'error') {
               showCustomAlert({
                 title: 'Unable to Materialize',
@@ -765,7 +774,16 @@ export const LAUNCH_ASSET_LOADER_QUERY = gql`
       }
     }
   }
+  ${LAUNCH_ASSET_EXECUTION_ASSET_NODE_FRAGMENT}
+`;
 
+export const LAUNCH_ASSET_LOADER_JOB_QUERY = gql`
+  query LaunchAssetLoaderJobQuery($job: PipelineSelector!) {
+    assetNodes(pipeline: $job) {
+      id
+      ...LaunchAssetExecutionAssetNodeFragment
+    }
+  }
   ${LAUNCH_ASSET_EXECUTION_ASSET_NODE_FRAGMENT}
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/LaunchAssetExecutionButton.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/LaunchAssetExecutionButton.types.ts
@@ -1246,6 +1246,619 @@ export type LaunchAssetLoaderQuery = {
   }>;
 };
 
+export type LaunchAssetLoaderJobQueryVariables = Types.Exact<{
+  job: Types.PipelineSelector;
+}>;
+
+export type LaunchAssetLoaderJobQuery = {
+  __typename: 'Query';
+  assetNodes: Array<{
+    __typename: 'AssetNode';
+    id: string;
+    opNames: Array<string>;
+    jobNames: Array<string>;
+    graphName: string | null;
+    hasMaterializePermission: boolean;
+    isObservable: boolean;
+    isExecutable: boolean;
+    isSource: boolean;
+    partitionDefinition: {
+      __typename: 'PartitionDefinition';
+      description: string;
+      type: Types.PartitionDefinitionType;
+      name: string | null;
+      dimensionTypes: Array<{
+        __typename: 'DimensionDefinitionType';
+        name: string;
+        dynamicPartitionsDefinitionName: string | null;
+      }>;
+    } | null;
+    backfillPolicy: {
+      __typename: 'BackfillPolicy';
+      maxPartitionsPerRun: number | null;
+      description: string;
+      policyType: Types.BackfillPolicyType;
+    } | null;
+    assetKey: {__typename: 'AssetKey'; path: Array<string>};
+    assetChecksOrError:
+      | {__typename: 'AssetCheckNeedsAgentUpgradeError'}
+      | {__typename: 'AssetCheckNeedsMigrationError'}
+      | {__typename: 'AssetCheckNeedsUserCodeUpgrade'}
+      | {
+          __typename: 'AssetChecks';
+          checks: Array<{
+            __typename: 'AssetCheck';
+            name: string;
+            canExecuteIndividually: Types.AssetCheckCanExecuteIndividually;
+          }>;
+        };
+    dependencyKeys: Array<{__typename: 'AssetKey'; path: Array<string>}>;
+    repository: {
+      __typename: 'Repository';
+      id: string;
+      name: string;
+      location: {__typename: 'RepositoryLocation'; id: string; name: string};
+    };
+    requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
+    configField: {
+      __typename: 'ConfigTypeField';
+      name: string;
+      isRequired: boolean;
+      configType:
+        | {
+            __typename: 'ArrayConfigType';
+            key: string;
+            description: string | null;
+            isSelector: boolean;
+            typeParamKeys: Array<string>;
+            recursiveConfigTypes: Array<
+              | {
+                  __typename: 'ArrayConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'CompositeConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                  fields: Array<{
+                    __typename: 'ConfigTypeField';
+                    name: string;
+                    description: string | null;
+                    isRequired: boolean;
+                    configTypeKey: string;
+                    defaultValueAsJson: string | null;
+                  }>;
+                }
+              | {
+                  __typename: 'EnumConfigType';
+                  givenName: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                  values: Array<{
+                    __typename: 'EnumConfigValue';
+                    value: string;
+                    description: string | null;
+                  }>;
+                }
+              | {
+                  __typename: 'MapConfigType';
+                  keyLabelName: string | null;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'NullableConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'RegularConfigType';
+                  givenName: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'ScalarUnionConfigType';
+                  scalarTypeKey: string;
+                  nonScalarTypeKey: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+            >;
+          }
+        | {
+            __typename: 'CompositeConfigType';
+            key: string;
+            description: string | null;
+            isSelector: boolean;
+            typeParamKeys: Array<string>;
+            recursiveConfigTypes: Array<
+              | {
+                  __typename: 'ArrayConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'CompositeConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                  fields: Array<{
+                    __typename: 'ConfigTypeField';
+                    name: string;
+                    description: string | null;
+                    isRequired: boolean;
+                    configTypeKey: string;
+                    defaultValueAsJson: string | null;
+                  }>;
+                }
+              | {
+                  __typename: 'EnumConfigType';
+                  givenName: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                  values: Array<{
+                    __typename: 'EnumConfigValue';
+                    value: string;
+                    description: string | null;
+                  }>;
+                }
+              | {
+                  __typename: 'MapConfigType';
+                  keyLabelName: string | null;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'NullableConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'RegularConfigType';
+                  givenName: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'ScalarUnionConfigType';
+                  scalarTypeKey: string;
+                  nonScalarTypeKey: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+            >;
+            fields: Array<{
+              __typename: 'ConfigTypeField';
+              name: string;
+              description: string | null;
+              isRequired: boolean;
+              configTypeKey: string;
+              defaultValueAsJson: string | null;
+            }>;
+          }
+        | {
+            __typename: 'EnumConfigType';
+            givenName: string;
+            key: string;
+            description: string | null;
+            isSelector: boolean;
+            typeParamKeys: Array<string>;
+            recursiveConfigTypes: Array<
+              | {
+                  __typename: 'ArrayConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'CompositeConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                  fields: Array<{
+                    __typename: 'ConfigTypeField';
+                    name: string;
+                    description: string | null;
+                    isRequired: boolean;
+                    configTypeKey: string;
+                    defaultValueAsJson: string | null;
+                  }>;
+                }
+              | {
+                  __typename: 'EnumConfigType';
+                  givenName: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                  values: Array<{
+                    __typename: 'EnumConfigValue';
+                    value: string;
+                    description: string | null;
+                  }>;
+                }
+              | {
+                  __typename: 'MapConfigType';
+                  keyLabelName: string | null;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'NullableConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'RegularConfigType';
+                  givenName: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'ScalarUnionConfigType';
+                  scalarTypeKey: string;
+                  nonScalarTypeKey: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+            >;
+            values: Array<{
+              __typename: 'EnumConfigValue';
+              value: string;
+              description: string | null;
+            }>;
+          }
+        | {
+            __typename: 'MapConfigType';
+            keyLabelName: string | null;
+            key: string;
+            description: string | null;
+            isSelector: boolean;
+            typeParamKeys: Array<string>;
+            recursiveConfigTypes: Array<
+              | {
+                  __typename: 'ArrayConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'CompositeConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                  fields: Array<{
+                    __typename: 'ConfigTypeField';
+                    name: string;
+                    description: string | null;
+                    isRequired: boolean;
+                    configTypeKey: string;
+                    defaultValueAsJson: string | null;
+                  }>;
+                }
+              | {
+                  __typename: 'EnumConfigType';
+                  givenName: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                  values: Array<{
+                    __typename: 'EnumConfigValue';
+                    value: string;
+                    description: string | null;
+                  }>;
+                }
+              | {
+                  __typename: 'MapConfigType';
+                  keyLabelName: string | null;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'NullableConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'RegularConfigType';
+                  givenName: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'ScalarUnionConfigType';
+                  scalarTypeKey: string;
+                  nonScalarTypeKey: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+            >;
+          }
+        | {
+            __typename: 'NullableConfigType';
+            key: string;
+            description: string | null;
+            isSelector: boolean;
+            typeParamKeys: Array<string>;
+            recursiveConfigTypes: Array<
+              | {
+                  __typename: 'ArrayConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'CompositeConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                  fields: Array<{
+                    __typename: 'ConfigTypeField';
+                    name: string;
+                    description: string | null;
+                    isRequired: boolean;
+                    configTypeKey: string;
+                    defaultValueAsJson: string | null;
+                  }>;
+                }
+              | {
+                  __typename: 'EnumConfigType';
+                  givenName: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                  values: Array<{
+                    __typename: 'EnumConfigValue';
+                    value: string;
+                    description: string | null;
+                  }>;
+                }
+              | {
+                  __typename: 'MapConfigType';
+                  keyLabelName: string | null;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'NullableConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'RegularConfigType';
+                  givenName: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'ScalarUnionConfigType';
+                  scalarTypeKey: string;
+                  nonScalarTypeKey: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+            >;
+          }
+        | {
+            __typename: 'RegularConfigType';
+            givenName: string;
+            key: string;
+            description: string | null;
+            isSelector: boolean;
+            typeParamKeys: Array<string>;
+            recursiveConfigTypes: Array<
+              | {
+                  __typename: 'ArrayConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'CompositeConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                  fields: Array<{
+                    __typename: 'ConfigTypeField';
+                    name: string;
+                    description: string | null;
+                    isRequired: boolean;
+                    configTypeKey: string;
+                    defaultValueAsJson: string | null;
+                  }>;
+                }
+              | {
+                  __typename: 'EnumConfigType';
+                  givenName: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                  values: Array<{
+                    __typename: 'EnumConfigValue';
+                    value: string;
+                    description: string | null;
+                  }>;
+                }
+              | {
+                  __typename: 'MapConfigType';
+                  keyLabelName: string | null;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'NullableConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'RegularConfigType';
+                  givenName: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'ScalarUnionConfigType';
+                  scalarTypeKey: string;
+                  nonScalarTypeKey: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+            >;
+          }
+        | {
+            __typename: 'ScalarUnionConfigType';
+            scalarTypeKey: string;
+            nonScalarTypeKey: string;
+            key: string;
+            description: string | null;
+            isSelector: boolean;
+            typeParamKeys: Array<string>;
+            recursiveConfigTypes: Array<
+              | {
+                  __typename: 'ArrayConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'CompositeConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                  fields: Array<{
+                    __typename: 'ConfigTypeField';
+                    name: string;
+                    description: string | null;
+                    isRequired: boolean;
+                    configTypeKey: string;
+                    defaultValueAsJson: string | null;
+                  }>;
+                }
+              | {
+                  __typename: 'EnumConfigType';
+                  givenName: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                  values: Array<{
+                    __typename: 'EnumConfigValue';
+                    value: string;
+                    description: string | null;
+                  }>;
+                }
+              | {
+                  __typename: 'MapConfigType';
+                  keyLabelName: string | null;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'NullableConfigType';
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'RegularConfigType';
+                  givenName: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+              | {
+                  __typename: 'ScalarUnionConfigType';
+                  scalarTypeKey: string;
+                  nonScalarTypeKey: string;
+                  key: string;
+                  description: string | null;
+                  isSelector: boolean;
+                  typeParamKeys: Array<string>;
+                }
+            >;
+          };
+    } | null;
+  }>;
+};
+
 export type LaunchAssetLoaderResourceQueryVariables = Types.Exact<{
   pipelineName: Types.Scalars['String'];
   repositoryLocationName: Types.Scalars['String'];

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/JobMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/JobMenu.tsx
@@ -1,11 +1,12 @@
 import {gql, useLazyQuery} from '@apollo/client';
-import {Button, Icon, Menu, MenuItem, Popover, Tooltip} from '@dagster-io/ui-components';
+import {Button, Icon, Menu, MenuItem, Popover, Spinner, Tooltip} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {usePermissionsForLocation} from '../app/Permissions';
+import {useMaterializationAction} from '../assets/LaunchAssetExecutionButton';
+import {EXECUTION_PLAN_TO_GRAPH_FRAGMENT} from '../gantt/toGraphQueryItems';
 import {ReexecutionStrategy} from '../graphql/types';
 import {canRunAllSteps, canRunFromFailure} from '../runs/RunActionButtons';
-import {RUN_FRAGMENT} from '../runs/RunFragments';
 import {RunTimeFragment} from '../runs/types/RunUtils.types';
 import {useJobReexecution} from '../runs/useJobReExecution';
 import {MenuLink} from '../ui/MenuLink';
@@ -17,6 +18,7 @@ import {RunReExecutionQuery, RunReExecutionQueryVariables} from './types/JobMenu
 interface Props {
   job: {isJob: boolean; name: string; runs: RunTimeFragment[]};
   repoAddress: RepoAddress;
+  isAssetJob: boolean | 'loading';
 }
 
 /**
@@ -24,10 +26,19 @@ interface Props {
  * whether re-execution is possible.
  */
 export const JobMenu = (props: Props) => {
-  const {job, repoAddress} = props;
+  const {job, isAssetJob, repoAddress} = props;
   const lastRun = job.runs.length ? job.runs[0] : null;
+  const pipelineSelector = {
+    pipelineName: job.name,
+    repositoryName: repoAddress.name,
+    repositoryLocationName: repoAddress.location,
+  };
+
+  const materialize = useMaterializationAction(job.name);
+  const onReexecute = useJobReexecution();
+
   const {
-    permissions: {canLaunchPipelineReexecution},
+    permissions: {canLaunchPipelineReexecution, canLaunchPipelineExecution},
     disabledReasons,
   } = usePermissionsForLocation(repoAddress.location);
 
@@ -36,15 +47,37 @@ export const JobMenu = (props: Props) => {
     RunReExecutionQueryVariables
   >(RUN_RE_EXECUTION_QUERY);
 
-  const run = data?.pipelineRunOrError.__typename === 'Run' ? data?.pipelineRunOrError : null;
-
   const fetchIfPossible = React.useCallback(() => {
     if (lastRun?.id) {
       fetchHasExecutionPlan({variables: {runId: lastRun.id}});
     }
   }, [lastRun, fetchHasExecutionPlan]);
 
-  const onReexecute = useJobReexecution();
+  const run = data?.pipelineRunOrError.__typename === 'Run' ? data?.pipelineRunOrError : null;
+  const executeItem =
+    isAssetJob === 'loading' ? (
+      <MenuItem icon="execute" text="Loading..." disabled={true} />
+    ) : isAssetJob === true ? (
+      <MenuItem
+        icon={materialize.loading ? <Spinner purpose="caption-text" /> : 'execute'}
+        text="Launch new run"
+        disabled={!canLaunchPipelineExecution}
+        onClick={(e) => materialize.onClick(pipelineSelector, e)}
+      />
+    ) : (
+      <MenuLink
+        icon="execute"
+        text="Launch new run"
+        disabled={!canLaunchPipelineExecution}
+        to={workspacePipelinePath({
+          repoName: repoAddress.name,
+          repoLocation: repoAddress.location,
+          pipelineName: job.name,
+          isJob: job.isJob,
+          path: '/playground',
+        })}
+      />
+    );
 
   const reExecuteAllItem = (
     <MenuItem
@@ -65,51 +98,61 @@ export const JobMenu = (props: Props) => {
   );
 
   return (
-    <Popover
-      onOpened={() => fetchIfPossible()}
-      content={
-        <Menu>
-          <MenuLink
-            to={workspacePipelinePath({
-              repoName: repoAddress.name,
-              repoLocation: repoAddress.location,
-              pipelineName: job.name,
-              isJob: job.isJob,
-            })}
-            icon="job"
-            text="View job"
-          />
-          <MenuLink
-            to={workspacePipelinePath({
-              repoName: repoAddress.name,
-              repoLocation: repoAddress.location,
-              pipelineName: job.name,
-              isJob: job.isJob,
-              path: '/runs',
-            })}
-            icon="checklist"
-            text="View all recent runs"
-          />
-          {canLaunchPipelineReexecution ? (
-            reExecuteAllItem
-          ) : (
-            <Tooltip content={disabledReasons.canLaunchPipelineReexecution} display="block">
-              {reExecuteAllItem}
-            </Tooltip>
-          )}
-          {canLaunchPipelineReexecution ? (
-            reExecuteFromFailureItem
-          ) : (
-            <Tooltip content={disabledReasons.canLaunchPipelineReexecution} display="block">
-              {reExecuteFromFailureItem}
-            </Tooltip>
-          )}
-        </Menu>
-      }
-      position="bottom-left"
-    >
-      <Button icon={<Icon name="expand_more" />} />
-    </Popover>
+    <>
+      {materialize.launchpadElement}
+      <Popover
+        onOpened={() => fetchIfPossible()}
+        content={
+          <Menu>
+            <MenuLink
+              to={workspacePipelinePath({
+                repoName: repoAddress.name,
+                repoLocation: repoAddress.location,
+                pipelineName: job.name,
+                isJob: job.isJob,
+              })}
+              icon="job"
+              text="View job"
+            />
+            <MenuLink
+              to={workspacePipelinePath({
+                repoName: repoAddress.name,
+                repoLocation: repoAddress.location,
+                pipelineName: job.name,
+                isJob: job.isJob,
+                path: '/runs',
+              })}
+              icon="checklist"
+              text="View all recent runs"
+            />
+            {canLaunchPipelineExecution ? (
+              executeItem
+            ) : (
+              <Tooltip content={disabledReasons.canLaunchPipelineExecution} display="block">
+                {executeItem}
+              </Tooltip>
+            )}
+            {canLaunchPipelineReexecution ? (
+              reExecuteAllItem
+            ) : (
+              <Tooltip content={disabledReasons.canLaunchPipelineReexecution} display="block">
+                {reExecuteAllItem}
+              </Tooltip>
+            )}
+            {canLaunchPipelineReexecution ? (
+              reExecuteFromFailureItem
+            ) : (
+              <Tooltip content={disabledReasons.canLaunchPipelineReexecution} display="block">
+                {reExecuteFromFailureItem}
+              </Tooltip>
+            )}
+          </Menu>
+        }
+        position="bottom-left"
+      >
+        <Button icon={<Icon name="expand_more" />} />
+      </Popover>
+    </>
   );
 };
 
@@ -118,11 +161,14 @@ const RUN_RE_EXECUTION_QUERY = gql`
     pipelineRunOrError(runId: $runId) {
       ... on Run {
         id
-        parentPipelineSnapshotId
-        ...RunFragment
+        status
+        pipelineName
+        executionPlan {
+          artifactsPersisted
+          ...ExecutionPlanToGraphFragment
+        }
       }
     }
   }
-
-  ${RUN_FRAGMENT}
+  ${EXECUTION_PLAN_TO_GRAPH_FRAGMENT}
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/JobMenu.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/JobMenu.types.ts
@@ -13,42 +13,8 @@ export type RunReExecutionQuery = {
     | {
         __typename: 'Run';
         id: string;
-        parentPipelineSnapshotId: string | null;
-        runConfigYaml: string;
-        canTerminate: boolean;
-        hasReExecutePermission: boolean;
-        hasTerminatePermission: boolean;
-        hasDeletePermission: boolean;
         status: Types.RunStatus;
-        mode: string;
-        rootRunId: string | null;
-        parentRunId: string | null;
         pipelineName: string;
-        solidSelection: Array<string> | null;
-        pipelineSnapshotId: string | null;
-        stepKeysToExecute: Array<string> | null;
-        updateTime: number | null;
-        startTime: number | null;
-        endTime: number | null;
-        hasConcurrencyKeySlots: boolean;
-        repositoryOrigin: {
-          __typename: 'RepositoryOrigin';
-          id: string;
-          repositoryName: string;
-          repositoryLocationName: string;
-        } | null;
-        tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
-        assets: Array<{
-          __typename: 'Asset';
-          id: string;
-          key: {__typename: 'AssetKey'; path: Array<string>};
-        }>;
-        assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
-        assetCheckSelection: Array<{
-          __typename: 'AssetCheckhandle';
-          name: string;
-          assetKey: {__typename: 'AssetKey'; path: Array<string>};
-        }> | null;
         executionPlan: {
           __typename: 'ExecutionPlan';
           artifactsPersisted: boolean;
@@ -62,23 +28,6 @@ export type RunReExecutionQuery = {
             }>;
           }>;
         } | null;
-        stepStats: Array<{
-          __typename: 'RunStepStats';
-          stepKey: string;
-          status: Types.StepEventStatus | null;
-          startTime: number | null;
-          endTime: number | null;
-          attempts: Array<{
-            __typename: 'RunMarker';
-            startTime: number | null;
-            endTime: number | null;
-          }>;
-          markers: Array<{
-            __typename: 'RunMarker';
-            startTime: number | null;
-            endTime: number | null;
-          }>;
-        }>;
       }
     | {__typename: 'RunNotFoundError'};
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionButtons.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionButtons.tsx
@@ -99,8 +99,8 @@ function stepSelectionFromRunTags(
   );
 }
 
-export const canRunAllSteps = (run: RunFragment) => doneStatuses.has(run.status);
-export const canRunFromFailure = (run: RunFragment) =>
+export const canRunAllSteps = (run: Pick<RunFragment, 'status'>) => doneStatuses.has(run.status);
+export const canRunFromFailure = (run: Pick<RunFragment, 'status' | 'executionPlan'>) =>
   run.executionPlan && failedStatuses.has(run.status);
 
 export const RunActionButtons = (props: RunActionButtonsProps) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedJobRow.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedJobRow.types.ts
@@ -15,6 +15,7 @@ export type SingleJobQuery = {
         id: string;
         name: string;
         isJob: boolean;
+        isAssetJob: boolean;
         description: string | null;
         runs: Array<{
           __typename: 'Run';


### PR DESCRIPTION
## Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/17627

<img width="457" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/80d33efb-6107-43db-a3ca-1b9623a777aa">


For asset jobs, this opens the Materialize modal for all the assets in the run if partitions or config are required, and immediately launches a run otherwise. To do this efficiently I made a few modifications to the `useMaterializationAction` so that you can pass a pipelineSelector instead of a set of assetKeys.

For op jobs, this takes you to the launchpad where you can add / review config and click launch run.  I think there may be a way to skip the launchpad if no config is required, but I don't think we have any other UIs that do a "single-click launch" of fresh op jobs and I'm not sure this should be the first.

## How I Tested These Changes
Tested this manually and verified that the storybooks still look good.