### PR TITLE
[auto-materialize][2/n] Create PartitionsSubsetWrapper class to enable efficient set operations

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -39,6 +39,7 @@ from .asset_daemon_cursor import AssetDaemonCursor
 from .asset_graph import AssetGraph
 from .auto_materialize_rule import (
     AutoMaterializeRule,
+    PartitionsSubsetWrapper,
     RuleEvaluationContext,
 )
 from .auto_materialize_rule_evaluation import (
@@ -320,22 +321,6 @@ class AssetDaemonContext:
             self.asset_graph.auto_materialize_policies_by_key.get(asset_key)
         ).to_auto_materialize_policy_evaluator()
 
-        # NOTE: this is expensive, as it forces us to produce every single partition key for every
-        # single partitions definition on each tick. this will be worked around upstack with a
-        # wrapper class that can represent "all partitions" without having to always generate the
-        # keys
-        partitions_def = self.asset_graph.get_partitions_def(asset_key)
-        initial_candidates = {
-            AssetKeyPartitionKey(asset_key, partition_key)
-            for partition_key in (
-                partitions_def.get_partition_keys(
-                    current_time=self.instance_queryer.evaluation_time,
-                    dynamic_partitions_store=self.instance_queryer,
-                )
-                if partitions_def is not None
-                else [None]
-            )
-        }
         context = RuleEvaluationContext(
             asset_key=asset_key,
             cursor=self.cursor,
@@ -343,7 +328,7 @@ class AssetDaemonContext:
             data_time_resolver=self.data_time_resolver,
             will_materialize_mapping=will_materialize_mapping,
             expected_data_time_mapping=expected_data_time_mapping,
-            candidates=initial_candidates,
+            candidates=PartitionsSubsetWrapper.all(asset_key, self.instance_queryer),
             daemon_context=self,
         )
 


### PR DESCRIPTION
## Summary & Motivation

In the previous PR of this stack, perf tests were failing (as noted in the comment). This was because the new evaluation method works on a notion of explicit sets of "candidates". The initial state of the set of candidates is "all partitions of an asset", as without any prior knowledge, any partition could potentially need to be kicked off. However, if we were to explicitly create this set of all asset partitions for an asset for each asset on each tick, this would be extremely slow, as there can be millions of partitions in an asset graph, and on any given tick we just need a small subset of this.

This class allows us to represent a partitions subset that contains "all partitions" of a given partitions definition and do operations (__and__, __or__, __sub__) against that set, in most cases bypassing the need to fully hydrate the set of asset partitions.

## How I Tested These Changes
