### PR TITLE
change concurrency info to have finer-grained step info

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2322,12 +2322,27 @@ type Instance {
 type ConcurrencyKeyInfo {
   concurrencyKey: String!
   slotCount: Int!
+  claimedSlots: [ClaimedConcurrencySlot!]!
+  pendingSteps: [PendingConcurrencyStep!]!
   activeSlotCount: Int!
   activeRunIds: [String!]!
   pendingStepCount: Int!
   pendingStepRunIds: [String!]!
   assignedStepCount: Int!
   assignedStepRunIds: [String!]!
+}
+
+type ClaimedConcurrencySlot {
+  runId: String!
+  stepKey: String!
+}
+
+type PendingConcurrencyStep {
+  runId: String!
+  stepKey: String!
+  enqueuedTimestamp: Float!
+  assignedTimestamp: Float
+  priority: Int
 }
 
 type RunLauncher {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -611,6 +611,12 @@ export type CapturedLogsMetadata = {
   stdoutLocation: Maybe<Scalars['String']>;
 };
 
+export type ClaimedConcurrencySlot = {
+  __typename: 'ClaimedConcurrencySlot';
+  runId: Scalars['String'];
+  stepKey: Scalars['String'];
+};
+
 export type CompositeConfigType = ConfigType & {
   __typename: 'CompositeConfigType';
   description: Maybe<Scalars['String']>;
@@ -675,9 +681,11 @@ export type ConcurrencyKeyInfo = {
   activeSlotCount: Scalars['Int'];
   assignedStepCount: Scalars['Int'];
   assignedStepRunIds: Array<Scalars['String']>;
+  claimedSlots: Array<ClaimedConcurrencySlot>;
   concurrencyKey: Scalars['String'];
   pendingStepCount: Scalars['Int'];
   pendingStepRunIds: Array<Scalars['String']>;
+  pendingSteps: Array<PendingConcurrencyStep>;
   slotCount: Scalars['Int'];
 };
 
@@ -2585,6 +2593,15 @@ export type PathMetadataEntry = MetadataEntry & {
   description: Maybe<Scalars['String']>;
   label: Scalars['String'];
   path: Scalars['String'];
+};
+
+export type PendingConcurrencyStep = {
+  __typename: 'PendingConcurrencyStep';
+  assignedTimestamp: Maybe<Scalars['Float']>;
+  enqueuedTimestamp: Scalars['Float'];
+  priority: Maybe<Scalars['Int']>;
+  runId: Scalars['String'];
+  stepKey: Scalars['String'];
 };
 
 export type Permission = {
@@ -5602,6 +5619,19 @@ export const buildCapturedLogsMetadata = (
   };
 };
 
+export const buildClaimedConcurrencySlot = (
+  overrides?: Partial<ClaimedConcurrencySlot>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'ClaimedConcurrencySlot'} & ClaimedConcurrencySlot => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('ClaimedConcurrencySlot');
+  return {
+    __typename: 'ClaimedConcurrencySlot',
+    runId: overrides && overrides.hasOwnProperty('runId') ? overrides.runId! : 'ullam',
+    stepKey: overrides && overrides.hasOwnProperty('stepKey') ? overrides.stepKey! : 'ut',
+  };
+};
+
 export const buildCompositeConfigType = (
   overrides?: Partial<CompositeConfigType>,
   _relationshipsToOmit: Set<string> = new Set(),
@@ -5726,6 +5756,8 @@ export const buildConcurrencyKeyInfo = (
       overrides && overrides.hasOwnProperty('assignedStepRunIds')
         ? overrides.assignedStepRunIds!
         : [],
+    claimedSlots:
+      overrides && overrides.hasOwnProperty('claimedSlots') ? overrides.claimedSlots! : [],
     concurrencyKey:
       overrides && overrides.hasOwnProperty('concurrencyKey') ? overrides.concurrencyKey! : 'quasi',
     pendingStepCount:
@@ -5734,6 +5766,8 @@ export const buildConcurrencyKeyInfo = (
       overrides && overrides.hasOwnProperty('pendingStepRunIds')
         ? overrides.pendingStepRunIds!
         : [],
+    pendingSteps:
+      overrides && overrides.hasOwnProperty('pendingSteps') ? overrides.pendingSteps! : [],
     slotCount: overrides && overrides.hasOwnProperty('slotCount') ? overrides.slotCount! : 455,
   };
 };
@@ -9379,6 +9413,28 @@ export const buildPathMetadataEntry = (
       overrides && overrides.hasOwnProperty('description') ? overrides.description! : 'et',
     label: overrides && overrides.hasOwnProperty('label') ? overrides.label! : 'rerum',
     path: overrides && overrides.hasOwnProperty('path') ? overrides.path! : 'soluta',
+  };
+};
+
+export const buildPendingConcurrencyStep = (
+  overrides?: Partial<PendingConcurrencyStep>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'PendingConcurrencyStep'} & PendingConcurrencyStep => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('PendingConcurrencyStep');
+  return {
+    __typename: 'PendingConcurrencyStep',
+    assignedTimestamp:
+      overrides && overrides.hasOwnProperty('assignedTimestamp')
+        ? overrides.assignedTimestamp!
+        : 9.29,
+    enqueuedTimestamp:
+      overrides && overrides.hasOwnProperty('enqueuedTimestamp')
+        ? overrides.enqueuedTimestamp!
+        : 1.74,
+    priority: overrides && overrides.hasOwnProperty('priority') ? overrides.priority! : 8863,
+    runId: overrides && overrides.hasOwnProperty('runId') ? overrides.runId! : 'facere',
+    stepKey: overrides && overrides.hasOwnProperty('stepKey') ? overrides.stepKey! : 'fuga',
   };
 };
 

--- a/python_modules/dagster/dagster/_cli/instance.py
+++ b/python_modules/dagster/dagster/_cli/instance.py
@@ -127,7 +127,7 @@ def get_concurrency(key, **kwargs):
 
 def concurrency_print_key(instance: DagsterInstance, key: str):
     key_info = instance.event_log_storage.get_concurrency_info(key)
-    click.echo(f'"{key}": {key_info.active_slot_count} / {key_info.slot_count} slots occupied')
+    click.echo(f'"{key}": {len(key_info.claimed_slots)} / {key_info.slot_count} slots occupied')
 
 
 @concurrency_cli.command(name="set", help="Set op concurrency limits")

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -77,9 +77,11 @@ from dagster._utils import (
     utc_datetime_from_timestamp,
 )
 from dagster._utils.concurrency import (
+    ClaimedSlotInfo,
     ConcurrencyClaimStatus,
     ConcurrencyKeyInfo,
     ConcurrencySlotStatus,
+    PendingStepInfo,
 )
 
 from ..dagster_run import DagsterRunStatsSnapshot
@@ -2474,59 +2476,47 @@ class SqlEventLogStorage(EventLogStorage):
                 db_select(
                     [
                         ConcurrencySlotsTable.c.run_id,
+                        ConcurrencySlotsTable.c.step_key,
                         ConcurrencySlotsTable.c.deleted,
-                        db.func.count().label("count"),
                     ]
                 )
                 .select_from(ConcurrencySlotsTable)
                 .where(ConcurrencySlotsTable.c.concurrency_key == concurrency_key)
-                .group_by(ConcurrencySlotsTable.c.run_id, ConcurrencySlotsTable.c.deleted)
             )
             slot_rows = db_fetch_mappings(conn, slot_query)
             pending_query = (
                 db_select(
                     [
                         PendingStepsTable.c.run_id,
-                        db_case(
-                            [(PendingStepsTable.c.assigned_timestamp.is_(None), False)],
-                            else_=True,
-                        ).label("is_assigned"),
-                        db.func.count().label("count"),
+                        PendingStepsTable.c.step_key,
+                        PendingStepsTable.c.assigned_timestamp,
+                        PendingStepsTable.c.create_timestamp,
+                        PendingStepsTable.c.priority,
                     ]
                 )
                 .select_from(PendingStepsTable)
                 .where(PendingStepsTable.c.concurrency_key == concurrency_key)
-                .group_by(PendingStepsTable.c.run_id, "is_assigned")
             )
             pending_rows = db_fetch_mappings(conn, pending_query)
 
             return ConcurrencyKeyInfo(
                 concurrency_key=concurrency_key,
-                slot_count=sum(
-                    [
-                        cast(int, slot_row["count"])
-                        for slot_row in slot_rows
-                        if not slot_row["deleted"]
-                    ]
-                ),
-                active_slot_count=sum(
-                    [cast(int, slot_row["count"]) for slot_row in slot_rows if slot_row["run_id"]]
-                ),
-                active_run_ids={
-                    cast(str, slot_row["run_id"]) for slot_row in slot_rows if slot_row["run_id"]
-                },
-                pending_step_count=sum(
-                    [cast(int, row["count"]) for row in pending_rows if not row["is_assigned"]]
-                ),
-                pending_run_ids={
-                    cast(str, row["run_id"]) for row in pending_rows if not row["is_assigned"]
-                },
-                assigned_step_count=sum(
-                    [cast(int, row["count"]) for row in pending_rows if row["is_assigned"]]
-                ),
-                assigned_run_ids={
-                    cast(str, row["run_id"]) for row in pending_rows if row["is_assigned"]
-                },
+                slot_count=len([slot_row for slot_row in slot_rows if not slot_row["deleted"]]),
+                claimed_slots=[
+                    ClaimedSlotInfo(slot_row["run_id"], slot_row["step_key"])
+                    for slot_row in slot_rows
+                    if slot_row["run_id"]
+                ],
+                pending_steps=[
+                    PendingStepInfo(
+                        run_id=row["run_id"],
+                        step_key=row["step_key"],
+                        enqueued_timestamp=row["create_timestamp"],
+                        assigned_timestamp=row["assigned_timestamp"],
+                        priority=row["priority"],
+                    )
+                    for row in pending_rows
+                ],
             )
 
     def get_concurrency_run_ids(self) -> Set[str]:

--- a/python_modules/dagster/dagster/_utils/concurrency.py
+++ b/python_modules/dagster/dagster/_utils/concurrency.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import NamedTuple, Optional, Set
+from typing import List, NamedTuple, Optional, Set
 
 from dagster import _check as check
 
@@ -71,18 +71,61 @@ class ConcurrencyClaimStatus(
         )
 
 
+class PendingStepInfo(
+    NamedTuple(
+        "_PendingStepInfo",
+        [
+            ("run_id", str),
+            ("step_key", str),
+            ("enqueued_timestamp", datetime),
+            ("assigned_timestamp", Optional[datetime]),
+            ("priority", Optional[int]),
+        ],
+    )
+):
+    def __new__(
+        cls,
+        run_id: int,
+        step_key: str,
+        enqueued_timestamp: datetime,
+        assigned_timestamp: Optional[datetime],
+        priority: Optional[int],
+    ):
+        return super(PendingStepInfo, cls).__new__(
+            cls,
+            check.str_param(run_id, "run_id"),
+            check.str_param(step_key, "step_key"),
+            check.inst_param(enqueued_timestamp, "enqueued_timestamp", datetime),
+            check.opt_inst_param(assigned_timestamp, "assigned_timestamp", datetime),
+            check.opt_int_param(priority, "priority"),
+        )
+
+
+class ClaimedSlotInfo(
+    NamedTuple(
+        "_ClaimedSlotInfo",
+        [
+            ("run_id", str),
+            ("step_key", str),
+        ],
+    )
+):
+    def __new__(cls, run_id: int, step_key: str):
+        return super(ClaimedSlotInfo, cls).__new__(
+            cls,
+            check.str_param(run_id, "run_id"),
+            check.str_param(step_key, "step_key"),
+        )
+
+
 class ConcurrencyKeyInfo(
     NamedTuple(
         "_ConcurrencyKeyInfo",
         [
             ("concurrency_key", str),
             ("slot_count", int),
-            ("active_slot_count", int),
-            ("active_run_ids", Set[str]),
-            ("pending_step_count", int),
-            ("pending_run_ids", Set[str]),
-            ("assigned_step_count", int),
-            ("assigned_run_ids", Set[str]),
+            ("claimed_slots", List[ClaimedSlotInfo]),
+            ("pending_steps", List[PendingStepInfo]),
         ],
     )
 ):
@@ -90,21 +133,44 @@ class ConcurrencyKeyInfo(
         cls,
         concurrency_key: str,
         slot_count: int,
-        active_slot_count: int,
-        active_run_ids: Set[str],
-        pending_step_count: int,
-        pending_run_ids: Set[str],
-        assigned_step_count: int,
-        assigned_run_ids: Set[str],
+        claimed_slots: List[ClaimedSlotInfo],
+        pending_steps: List[PendingStepInfo],
     ):
         return super(ConcurrencyKeyInfo, cls).__new__(
             cls,
             check.str_param(concurrency_key, "concurrency_key"),
             check.int_param(slot_count, "slot_count"),
-            check.int_param(active_slot_count, "active_slot_count"),
-            check.set_param(active_run_ids, "active_run_ids", of_type=str),
-            check.int_param(pending_step_count, "pending_step_count"),
-            check.set_param(pending_run_ids, "pending_run_ids", of_type=str),
-            check.int_param(assigned_step_count, "assigned_step_count"),
-            check.set_param(assigned_run_ids, "assigned_run_ids", of_type=str),
+            check.list_param(claimed_slots, "claimed_slots", of_type=ClaimedSlotInfo),
+            check.list_param(pending_steps, "pending_steps", of_type=PendingStepInfo),
+        )
+
+    ###################################################
+    # Fields that we need to keep around for backcompat
+    ###################################################
+    @property
+    def active_slot_count(self) -> int:
+        return len(self.claimed_slots)
+
+    @property
+    def active_run_ids(self) -> Set[str]:
+        return set([slot.run_id for slot in self.claimed_slots])
+
+    @property
+    def pending_step_count(self) -> int:
+        # here pending steps are steps that are not assigned
+        return len([step for step in self.pending_steps if step.assigned_timestamp is None])
+
+    @property
+    def pending_run_ids(self) -> Set[str]:
+        # here pending steps are steps that are not assigned
+        return set([step.run_id for step in self.pending_steps if step.assigned_timestamp is None])
+
+    @property
+    def assigned_step_count(self) -> int:
+        return len([step for step in self.pending_steps if step.assigned_timestamp is not None])
+
+    @property
+    def assigned_run_ids(self) -> Set[str]:
+        return set(
+            [step.run_id for step in self.pending_steps if step.assigned_timestamp is not None]
         )

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -3872,6 +3872,12 @@ class TestEventLogStorage:
         foo_info = storage.get_concurrency_info("foo")
         assert foo_info.active_slot_count == 1
         assert foo_info.active_run_ids == {run_id}
+        assert len(foo_info.claimed_slots) == 1
+        assert foo_info.claimed_slots[0].step_key == "a"
+        assert len(foo_info.pending_steps) == 5
+        assigned_steps = [step for step in foo_info.pending_steps if step.assigned_timestamp]
+        assert len(assigned_steps) == 1
+        assert assigned_steps[0].step_key == "a"
 
         # a is assigned, has the active slot, the rest are not assigned
         assert storage.check_concurrency_claim("foo", run_id, "a").assigned_timestamp is not None


### PR DESCRIPTION
## Summary & Motivation
Server-side changes to add more detailed concurrency info.  Should power a more powerful instance concurrency page.

Changes include:
* returning full per-slot, per-step info for concurrency keys, instead of just summary counts

This should enable a frontend that shows raw slots / queued steps and a way to take action on them instead of reusing the runs table and run-based operations.

## How I Tested These Changes
BK