### PR TITLE
[db io managers] Update how the schema is determined to allow overriding the default config

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -173,7 +173,7 @@ class DbIOManager(IOManager):
         if context.has_asset_key:
             asset_key_path = context.asset_key.path
             table = asset_key_path[-1]
-            # schema order of precedence: metadata, key_prefix, I/O manager 'schema' config
+            # schema order of precedence: metadata, I/O manager 'schema' config, key_prefix
             if output_context_metadata.get("schema"):
                 if self._schema:
                     context.log.warn(
@@ -192,17 +192,17 @@ class DbIOManager(IOManager):
                         " will be used."
                     )
                 schema = cast(str, output_context_metadata["schema"])
-            elif len(asset_key_path) > 1:
-                if self._schema:
+            elif self._schema:
+                if len(asset_key_path) > 1:
                     context.log.warn(
-                        f"Schema {asset_key_path[-2]} specified via key prefix, and schema"
-                        f"{self._schema} was provided as config to the I/O manager."
-                        f" The schema set via key prefix, {asset_key_path[:-1]}"
+                        f"Schema {self._schema} was provided as config to the I/O manager and "
+                        f"schema {asset_key_path[-2]} specified via key prefix."
+                        f" The schema set via I/O manager config, {self._schema}"
                         " will be used."
                     )
-                schema = asset_key_path[-2]
-            elif self._schema:
                 schema = self._schema
+            elif len(asset_key_path) > 1:
+                schema = asset_key_path[-2]
             else:
                 schema = "public"
 

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -175,31 +175,8 @@ class DbIOManager(IOManager):
             table = asset_key_path[-1]
             # schema order of precedence: metadata, I/O manager 'schema' config, key_prefix
             if output_context_metadata.get("schema"):
-                if self._schema:
-                    context.log.warn(
-                        f"Schema {output_context_metadata.get('schema')}"
-                        f" specified via metadata, and schema {self._schema}"
-                        " was provided as config to the I/O manager."
-                        f" The schema set via metadata, {output_context_metadata.get('schema')}"
-                        " will be used."
-                    )
-                if len(asset_key_path) > 1:
-                    context.log.warn(
-                        f"Schema {output_context_metadata.get('schema')}"
-                        f" specified via metadata, and schema {asset_key_path[:-1]}"
-                        " was specified in the key prefix."
-                        f" The schema set via metadata, {output_context_metadata.get('schema')}"
-                        " will be used."
-                    )
                 schema = cast(str, output_context_metadata["schema"])
             elif self._schema:
-                if len(asset_key_path) > 1:
-                    context.log.warn(
-                        f"Schema {self._schema} was provided as config to the I/O manager and "
-                        f"schema {asset_key_path[-2]} specified via key prefix."
-                        f" The schema set via I/O manager config, {self._schema}"
-                        " will be used."
-                    )
                 schema = self._schema
             elif len(asset_key_path) > 1:
                 schema = asset_key_path[-2]
@@ -264,14 +241,6 @@ class DbIOManager(IOManager):
         else:
             table = output_context.name
             if output_context_metadata.get("schema"):
-                if self._schema:
-                    context.log.warn(
-                        f"Schema {output_context_metadata.get('schema')}"
-                        f" specified via metadata, and schema {self._schema}"
-                        " was provided as config to the I/O manager."
-                        f" The schema set via metadata, {output_context_metadata.get('schema')}"
-                        " will be used."
-                    )
                 schema = cast(str, output_context_metadata["schema"])
             elif self._schema:
                 schema = self._schema

--- a/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
@@ -5,7 +5,6 @@ from dagster import AssetKey, InputContext, OutputContext, asset, build_output_c
 from dagster._check import CheckError
 from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition, TimeWindow
-from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.storage.db_io_manager import (
     DbClient,
     DbIOManager,
@@ -423,10 +422,8 @@ def test_asset_schema_defaults():
     output_context = build_output_context(
         asset_key=asset_key, resource_config=resource_config_w_schema
     )
-    with pytest.raises(DagsterInvalidDefinitionError):
-        table_slice = manager_w_schema._get_table_slice(  # noqa: SLF001
-            output_context, output_context
-        )
+    table_slice = manager_w_schema._get_table_slice(output_context, output_context)  # noqa: SLF001
+    assert table_slice.schema == "schema1"
 
     asset_key = AssetKey(["table1"])
     output_context = build_output_context(
@@ -435,10 +432,8 @@ def test_asset_schema_defaults():
         resource_config=resource_config_w_schema,
     )
 
-    with pytest.raises(DagsterInvalidDefinitionError):
-        table_slice = manager_w_schema._get_table_slice(  # noqa: SLF001
-            output_context, output_context
-        )
+    table_slice = manager_w_schema._get_table_slice(output_context, output_context)  # noqa: SLF001
+    assert table_slice.schema == "schema1"
 
 
 def test_output_schema_defaults():
@@ -480,10 +475,8 @@ def test_output_schema_defaults():
     output_context = build_output_context(
         name="table1", metadata={"schema": "schema1"}, resource_config=resource_config_w_schema
     )
-    with pytest.raises(DagsterInvalidDefinitionError):
-        table_slice = manager_w_schema._get_table_slice(  # noqa: SLF001
-            output_context, output_context
-        )
+    table_slice = manager_w_schema._get_table_slice(output_context, output_context)  # noqa: SLF001
+    assert table_slice.schema == "schema1"
 
 
 def test_handle_none_output():

--- a/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
@@ -423,7 +423,7 @@ def test_asset_schema_defaults():
         asset_key=asset_key, resource_config=resource_config_w_schema
     )
     table_slice = manager_w_schema._get_table_slice(output_context, output_context)  # noqa: SLF001
-    assert table_slice.schema == "schema1"
+    assert table_slice.schema == "my_schema"
 
     asset_key = AssetKey(["table1"])
     output_context = build_output_context(


### PR DESCRIPTION
## Summary & Motivation
resolves https://github.com/dagster-io/dagster/issues/15937

Pretty much since the DB IO managers have been released, users have been asking for more control over how the schema was determined. Right now you have to pick either setting the schema for every asset using the key prefix, or you can set it once via IO manager config and that schema is used everywhere.

Then PR https://github.com/dagster-io/dagster/pull/17413  added the ability to set the schema via metadata as an alternative to using the key prefix. Right now, the three methods of setting the schema are mutually exclusive, except that if you set the schema via metadata, you can set the key_prefix and the schema will be what was set in the metadata

This PR proposes allowing users to use any of the methods for setting the schema and the schema will be determined based on precedence rules:
1. If the schema is set via metadata, use that as the schema
2. Otherwise, if the `key_prefix` is set, use that as the schema. Eventually I see us deprecating setting schema via key prefix, and moving this case to metadata. This would allow users to use the key_prefix for organization/uuid etc without affecting how their data is stored
3. Otherwise, if the schema is set as config on the I/O manager, use that as the schema
4. Otherwise default to PUBLIC

This should NOT be a breaking change:
Case 1: user already setting schema via key prefix - no change for them, since they are already not using the schema config. They would be able to set schema config to catch any assets that aren't given a key_prefix

Case 2: user setting schema via config - no change for them, since they can't be using key_prefix. They would continue being unable to use key_prefix, except in cases when they want to override the default schema

Case 3: user setting schema via metadata (unlikely that there are many users for this new feature) - no change for them since they are already overriding any key prefix. They would be able to set the schema config to catch any assets that aren't given a key_prefix or metadata

## How I Tested These Changes
updated unit tests to reflect the changes