### PR TITLE
[db io managers] support single run backfills and partition mapping for multi-partitioned assets

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -207,6 +207,8 @@ class DbIOManager(IOManager):
                     )
 
                 if isinstance(context.asset_partitions_def, MultiPartitionsDefinition):
+                    print(f"The type of the context is {type(context)}")
+                    print(f"The partition keys are {context.asset_partition_keys}")
                     multi_partition_key_mapping = cast(
                         MultiPartitionKey, context.asset_partition_key
                     ).keys_by_dimension

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -229,7 +229,7 @@ class DbIOManager(IOManager):
                             else:
                                 partitions = partitions[0]
                         else:
-                            partitions = cast(Sequence[str], partition_keys_by_dim[part.name])
+                            partitions = list(partition_keys_by_dim[part.name])
 
                         partition_expr_str = cast(Mapping[str, str], partition_expr).get(part.name)
                         if partition_expr is None:

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -220,11 +220,11 @@ class DbIOManager(IOManager):
                     for part in context.asset_partitions_def.partitions_defs:
                         if isinstance(part.partitions_def, TimeWindowPartitionsDefinition):
                             partitions = part.partitions_def.time_windows_for_partition_keys(
-                                frozenset(partition_keys_by_dim[part.name])
+                                frozenset(partition_keys_by_dim[part.name]), merge=True
                             )
                             if len(partitions) > 1:
                                 raise DagsterInvariantViolationError(
-                                    f"Non-overlapping partition time windows {partitions} cannot be loaded by the {self._io_manager_name}"
+                                    f"Non-overlapping partition time windows {partitions} cannot be handled by the {self._io_manager_name}."
                                 )
                             else:
                                 partitions = partitions[0]

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -584,7 +584,7 @@ def test_multi_partitioned_asset_with_downstream_mapping(tmp_path, io_managers):
         },
         partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"),
         metadata={"partition_expr": "CAST(time as TIMESTAMP)"},
-        schema=["my_schema"],
+        key_prefix=["my_schema"],
     )
     def downstream_of_multi_partitioned(context, multi_partitioned: pd.DataFrame) -> None:
         partition = context.partition_key

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -341,21 +341,11 @@ def test_multi_partitioned_asset(tmp_path, io_managers):
             }
         )
 
-    @asset(
-        partitions_def=partitions_def,
-        key_prefix=["my_schema"],
-        ins={"df": AssetIn(["my_schema", "multi_partitioned"])},
-        # io_manager_key="fs_io",
-    )
-    def downstream_partitioned(df: pd.DataFrame) -> None:
-        # assert that we only get the columns created in multi_partitioned
-        assert len(df.index) == 3
-
     for io_manager in io_managers:
         resource_defs = {"io_manager": io_manager}
 
         materialize(
-            [multi_partitioned, downstream_partitioned],
+            [multi_partitioned],
             partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
             resources=resource_defs,
             run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}},
@@ -367,7 +357,7 @@ def test_multi_partitioned_asset(tmp_path, io_managers):
         duckdb_conn.close()
 
         materialize(
-            [multi_partitioned, downstream_partitioned],
+            [multi_partitioned],
             partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
             resources=resource_defs,
             run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "2"}}}},
@@ -379,7 +369,7 @@ def test_multi_partitioned_asset(tmp_path, io_managers):
         duckdb_conn.close()
 
         materialize(
-            [multi_partitioned, downstream_partitioned],
+            [multi_partitioned],
             partition_key=MultiPartitionKey({"time": "2022-01-02", "color": "red"}),
             resources=resource_defs,
             run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "3"}}}},
@@ -391,7 +381,7 @@ def test_multi_partitioned_asset(tmp_path, io_managers):
         duckdb_conn.close()
 
         materialize(
-            [multi_partitioned, downstream_partitioned],
+            [multi_partitioned],
             partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
             resources=resource_defs,
             run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "4"}}}},

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -10,6 +10,7 @@ from dagster import (
     DynamicPartitionsDefinition,
     MultiPartitionKey,
     MultiPartitionsDefinition,
+    MultiToSingleDimensionPartitionMapping,
     Out,
     StaticPartitionsDefinition,
     TimeWindowPartitionMapping,
@@ -315,35 +316,48 @@ def test_static_partitioned_asset(tmp_path, io_managers):
         duckdb_conn.close()
 
 
-@asset(
+
+def test_multi_partitioned_asset(tmp_path, io_managers):
+
     partitions_def=MultiPartitionsDefinition(
         {
             "time": DailyPartitionsDefinition(start_date="2022-01-01"),
             "color": StaticPartitionsDefinition(["red", "yellow", "blue"]),
         }
-    ),
-    key_prefix=["my_schema"],
-    metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
-    config_schema={"value": str},
-)
-def multi_partitioned(context) -> pd.DataFrame:
-    partition = context.partition_key.keys_by_dimension
-    value = context.op_config["value"]
-    return pd.DataFrame(
-        {
-            "color": [partition["color"], partition["color"], partition["color"]],
-            "time": [partition["time"], partition["time"], partition["time"]],
-            "a": [value, value, value],
-        }
     )
 
+    @asset(
+        partitions_def=partitions_def,
+        key_prefix=["my_schema"],
+        metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
+        config_schema={"value": str},
+    )
+    def multi_partitioned(context) -> pd.DataFrame:
+        partition = context.partition_key.keys_by_dimension
+        value = context.op_config["value"]
+        return pd.DataFrame(
+            {
+                "color": [partition["color"], partition["color"], partition["color"]],
+                "time": [partition["time"], partition["time"], partition["time"]],
+                "a": [value, value, value],
+            }
+        )
 
-def test_multi_partitioned_asset(tmp_path, io_managers):
+    @asset(
+        partitions_def=partitions_def,
+        key_prefix=["my_schema"],
+        ins={"df": AssetIn(["my_schema", "multi_partitioned"])},
+        # io_manager_key="fs_io",
+    )
+    def downstream_partitioned(df: pd.DataFrame) -> None:
+        # assert that we only get the columns created in multi_partitioned
+        assert len(df.index) == 3
+
     for io_manager in io_managers:
         resource_defs = {"io_manager": io_manager}
 
         materialize(
-            [multi_partitioned],
+            [multi_partitioned, downstream_partitioned],
             partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
             resources=resource_defs,
             run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}},
@@ -355,7 +369,7 @@ def test_multi_partitioned_asset(tmp_path, io_managers):
         duckdb_conn.close()
 
         materialize(
-            [multi_partitioned],
+            [multi_partitioned, downstream_partitioned],
             partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
             resources=resource_defs,
             run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "2"}}}},
@@ -367,7 +381,7 @@ def test_multi_partitioned_asset(tmp_path, io_managers):
         duckdb_conn.close()
 
         materialize(
-            [multi_partitioned],
+            [multi_partitioned, downstream_partitioned],
             partition_key=MultiPartitionKey({"time": "2022-01-02", "color": "red"}),
             resources=resource_defs,
             run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "3"}}}},
@@ -379,7 +393,7 @@ def test_multi_partitioned_asset(tmp_path, io_managers):
         duckdb_conn.close()
 
         materialize(
-            [multi_partitioned],
+            [multi_partitioned, downstream_partitioned],
             partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
             resources=resource_defs,
             run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "4"}}}},
@@ -543,4 +557,81 @@ def test_self_dependent_asset(tmp_path, io_managers):
 
         # drop table so we start with an empty db for the next io manager
         duckdb_conn.execute("DELETE FROM my_schema.self_dependent_asset")
+        duckdb_conn.close()
+
+
+def test_multi_partitioned_asset_with_downstream_mapping(tmp_path, io_managers):
+    partitions_def=MultiPartitionsDefinition(
+        {
+            "time": DailyPartitionsDefinition(start_date="2022-01-01"),
+            "color": StaticPartitionsDefinition(["red", "yellow", "blue"]),
+        }
+    )
+
+    @asset(
+        partitions_def=partitions_def,
+        key_prefix=["my_schema"],
+        metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
+        config_schema={"value": str},
+    )
+    def multi_partitioned(context) -> pd.DataFrame:
+        partition = context.partition_key.keys_by_dimension
+        value = context.op_config["value"]
+        return pd.DataFrame(
+            {
+                "color": [partition["color"], partition["color"], partition["color"]],
+                "time": [partition["time"], partition["time"], partition["time"]],
+                "a": [value, value, value],
+            }
+        )
+
+    @asset(
+        ins={
+            "multi_partitioned": AssetIn(
+                key="multi_partitioned",
+                partition_mapping=MultiToSingleDimensionPartitionMapping(
+                    partition_dimension_name="time"
+                )
+            ),
+        },
+        partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"),
+        metadata={"partition_expr": "CAST(time as TIMESTAMP)"},
+    )
+    def downstream_of_multi_partitioned(context, multi_partitioned: pd.DataFrame) -> None:
+        partition = context.partition_key
+        assert "red" in multi_partitioned.color
+        assert "blue" in multi_partitioned.color
+        assert partition in multi_partitioned.time
+        return None
+
+    for io_manager in io_managers:
+        resource_defs = {"io_manager": io_manager}
+
+        with instance_for_test() as inst:
+
+                materialize(
+                    [multi_partitioned],
+                    partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
+                    resources=resource_defs,
+                    run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}},
+                    instance=inst
+                )
+                materialize(
+                    [multi_partitioned],
+                    partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
+                    resources=resource_defs,
+                    run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}},
+                    instance=inst
+                )
+                materialize(
+                    [multi_partitioned.to_source_asset(), downstream_of_multi_partitioned],
+                    partition_key="2022-01-01",
+                    resources=resource_defs,
+                    instance=inst
+                )
+
+        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+
+        # drop table so we start with an empty db for the next io manager
+        duckdb_conn.execute("DELETE FROM my_schema.multi_partitioned")
         duckdb_conn.close()

--- a/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars_tests/test_type_handler.py
@@ -10,6 +10,7 @@ from dagster import (
     DynamicPartitionsDefinition,
     MultiPartitionKey,
     MultiPartitionsDefinition,
+    MultiToSingleDimensionPartitionMapping,
     Out,
     StaticPartitionsDefinition,
     TimeWindowPartitionMapping,
@@ -577,4 +578,80 @@ def test_self_dependent_asset(tmp_path, io_managers):
 
         # drop table so we start with an empty db for the next io manager
         duckdb_conn.execute("DELETE FROM my_schema.self_dependent_asset")
+        duckdb_conn.close()
+
+
+def test_multi_partitioned_asset_with_downstream_mapping(tmp_path, io_managers):
+    partitions_def = MultiPartitionsDefinition(
+        {
+            "time": DailyPartitionsDefinition(start_date="2022-01-01"),
+            "color": StaticPartitionsDefinition(["red", "yellow", "blue"]),
+        }
+    )
+
+    @asset(
+        partitions_def=partitions_def,
+        key_prefix=["my_schema"],
+        metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
+        config_schema={"value": str},
+    )
+    def multi_partitioned(context) -> pl.DataFrame:
+        partition = context.partition_key.keys_by_dimension
+        value = context.op_config["value"]
+        return pl.DataFrame(
+            {
+                "color": [partition["color"], partition["color"], partition["color"]],
+                "time": [partition["time"], partition["time"], partition["time"]],
+                "a": [value, value, value],
+            }
+        )
+
+    @asset(
+        ins={
+            "multi_partitioned": AssetIn(
+                key="multi_partitioned",
+                partition_mapping=MultiToSingleDimensionPartitionMapping(
+                    partition_dimension_name="time"
+                ),
+            ),
+        },
+        partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"),
+        metadata={"partition_expr": "CAST(time as TIMESTAMP)"},
+    )
+    def downstream_of_multi_partitioned(context, multi_partitioned: pl.DataFrame) -> None:
+        partition = context.partition_key
+        assert "red" in list(multi_partitioned.select("color"))
+        assert "blue" in list(multi_partitioned.select("color"))
+        assert partition in list(multi_partitioned.select("time"))
+        return None
+
+    for io_manager in io_managers:
+        resource_defs = {"io_manager": io_manager}
+
+        with instance_for_test() as inst:
+            materialize(
+                [multi_partitioned],
+                partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
+                resources=resource_defs,
+                run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}},
+                instance=inst,
+            )
+            materialize(
+                [multi_partitioned],
+                partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
+                resources=resource_defs,
+                run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}},
+                instance=inst,
+            )
+            materialize(
+                [multi_partitioned.to_source_asset(), downstream_of_multi_partitioned],
+                partition_key="2022-01-01",
+                resources=resource_defs,
+                instance=inst,
+            )
+
+        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+
+        # drop table so we start with an empty db for the next io manager
+        duckdb_conn.execute("DELETE FROM my_schema.multi_partitioned")
         duckdb_conn.close()

--- a/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars_tests/test_type_handler.py
@@ -620,7 +620,7 @@ def test_multi_partitioned_asset_with_downstream_mapping(tmp_path, io_managers):
         key_prefix=["my_schema"],
     )
     def downstream_of_multi_partitioned(context, multi_partitioned: pl.DataFrame) -> None:
-        num_rows = multi_partitioned.select(pl.count())[0, 0] == 6
+        num_rows = multi_partitioned.select(pl.count())[0, 0]
         assert num_rows == 6
         return None
 

--- a/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars_tests/test_type_handler.py
@@ -609,7 +609,7 @@ def test_multi_partitioned_asset_with_downstream_mapping(tmp_path, io_managers):
     @asset(
         ins={
             "multi_partitioned": AssetIn(
-                key="multi_partitioned",
+                key=["my_schema", "multi_partitioned"],
                 partition_mapping=MultiToSingleDimensionPartitionMapping(
                     partition_dimension_name="time"
                 ),
@@ -617,12 +617,11 @@ def test_multi_partitioned_asset_with_downstream_mapping(tmp_path, io_managers):
         },
         partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"),
         metadata={"partition_expr": "CAST(time as TIMESTAMP)"},
+        schema=["my_schema"],
     )
     def downstream_of_multi_partitioned(context, multi_partitioned: pl.DataFrame) -> None:
-        partition = context.partition_key
-        assert "red" in list(multi_partitioned.select("color"))
-        assert "blue" in list(multi_partitioned.select("color"))
-        assert partition in list(multi_partitioned.select("time"))
+        num_rows = multi_partitioned.select(pl.count())[0, 0] == 6
+        assert num_rows == 6
         return None
 
     for io_manager in io_managers:
@@ -639,6 +638,13 @@ def test_multi_partitioned_asset_with_downstream_mapping(tmp_path, io_managers):
             materialize(
                 [multi_partitioned],
                 partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
+                resources=resource_defs,
+                run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}},
+                instance=inst,
+            )
+            materialize(
+                [multi_partitioned],
+                partition_key=MultiPartitionKey({"time": "2022-01-02", "color": "blue"}),
                 resources=resource_defs,
                 run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}},
                 instance=inst,

--- a/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars_tests/test_type_handler.py
@@ -617,7 +617,7 @@ def test_multi_partitioned_asset_with_downstream_mapping(tmp_path, io_managers):
         },
         partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"),
         metadata={"partition_expr": "CAST(time as TIMESTAMP)"},
-        schema=["my_schema"],
+        key_prefix=["my_schema"],
     )
     def downstream_of_multi_partitioned(context, multi_partitioned: pl.DataFrame) -> None:
         num_rows = multi_partitioned.select(pl.count())[0, 0] == 6

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark_tests/test_type_handler.py
@@ -10,6 +10,7 @@ from dagster import (
     DynamicPartitionsDefinition,
     MultiPartitionKey,
     MultiPartitionsDefinition,
+    MultiToSingleDimensionPartitionMapping,
     Out,
     StaticPartitionsDefinition,
     TimeWindowPartitionMapping,
@@ -536,4 +537,79 @@ def test_self_dependent_asset(tmp_path, io_managers):
 
         # drop table so we start with an empty db for the next io manager
         duckdb_conn.execute("DELETE FROM my_schema.self_dependent_asset")
+        duckdb_conn.close()
+
+
+def test_multi_partitioned_asset_with_downstream_mapping(tmp_path, io_managers):
+    partitions_def = MultiPartitionsDefinition(
+        {
+            "time": DailyPartitionsDefinition(start_date="2022-01-01"),
+            "color": StaticPartitionsDefinition(["red", "yellow", "blue"]),
+        }
+    )
+
+    @asset(
+        partitions_def=partitions_def,
+        key_prefix=["my_schema"],
+        metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
+        config_schema={"value": str},
+    )
+    def multi_partitioned(context) -> SparkDF:
+        partition = context.partition_key.keys_by_dimension
+        value = context.op_config["value"]
+        pd_df = pd.DataFrame(
+            {
+                "color": [partition["color"], partition["color"], partition["color"]],
+                "time": [partition["time"], partition["time"], partition["time"]],
+                "a": [value, value, value],
+            }
+        )
+        spark = SparkSession.builder.getOrCreate()  # type: ignore
+        return spark.createDataFrame(pd_df)
+
+    @asset(
+        ins={
+            "multi_partitioned": AssetIn(
+                key="multi_partitioned",
+                partition_mapping=MultiToSingleDimensionPartitionMapping(
+                    partition_dimension_name="time"
+                ),
+            ),
+        },
+        partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"),
+        metadata={"partition_expr": "CAST(time as TIMESTAMP)"},
+    )
+    def downstream_of_multi_partitioned(multi_partitioned: SparkDF) -> None:
+        assert multi_partitioned.count() == 6
+        return None
+
+    for io_manager in io_managers:
+        resource_defs = {"io_manager": io_manager}
+
+        with instance_for_test() as inst:
+            materialize(
+                [multi_partitioned],
+                partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
+                resources=resource_defs,
+                run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}},
+                instance=inst,
+            )
+            materialize(
+                [multi_partitioned],
+                partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
+                resources=resource_defs,
+                run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}},
+                instance=inst,
+            )
+            materialize(
+                [multi_partitioned.to_source_asset(), downstream_of_multi_partitioned],
+                partition_key="2022-01-01",
+                resources=resource_defs,
+                instance=inst,
+            )
+
+        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+
+        # drop table so we start with an empty db for the next io manager
+        duckdb_conn.execute("DELETE FROM my_schema.multi_partitioned")
         duckdb_conn.close()

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark_tests/test_type_handler.py
@@ -578,7 +578,7 @@ def test_multi_partitioned_asset_with_downstream_mapping(tmp_path, io_managers):
         },
         partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"),
         metadata={"partition_expr": "CAST(time as TIMESTAMP)"},
-        schema=["my_schema"],
+        key_prefix=["my_schema"],
     )
     def downstream_of_multi_partitioned(multi_partitioned: SparkDF) -> None:
         assert multi_partitioned.count() == 6

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -580,7 +580,7 @@ def test_multi_partitioned_asset_with_downstream_mapping(io_manager):
         @asset(
             ins={
                 "multi_partitioned": AssetIn(
-                    key="multi_partitioned",
+                    key=[SCHEMA, "multi_partitioned"],
                     partition_mapping=MultiToSingleDimensionPartitionMapping(
                         partition_dimension_name="time"
                     ),
@@ -595,6 +595,7 @@ def test_multi_partitioned_asset_with_downstream_mapping(io_manager):
             assert "red" in list(multi_partitioned.color)
             assert "blue" in list(multi_partitioned.color)
             assert partition in list(multi_partitioned.time)
+            assert multi_partitioned.shape[0] == 6
             return None
 
         asset_full_name = f"{SCHEMA}__{table_name}"
@@ -612,6 +613,13 @@ def test_multi_partitioned_asset_with_downstream_mapping(io_manager):
             materialize(
                 [multi_partitioned],
                 partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
+                resources=resource_defs,
+                run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
+                instance=inst,
+            )
+            materialize(
+                [multi_partitioned],
+                partition_key=MultiPartitionKey({"time": "2022-01-02", "color": "blue"}),
                 resources=resource_defs,
                 run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
                 instance=inst,

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -580,7 +580,7 @@ def test_multi_partitioned_asset_with_downstream_mapping(io_manager):
         @asset(
             ins={
                 "multi_partitioned": AssetIn(
-                    key=[SCHEMA, "multi_partitioned"],
+                    key=[SCHEMA, table_name],
                     partition_mapping=MultiToSingleDimensionPartitionMapping(
                         partition_dimension_name="time"
                     ),

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
@@ -679,7 +679,7 @@ def test_multi_partitioned_asset_with_downstream_mapping(spark, io_manager):
         @asset(
             ins={
                 "multi_partitioned": AssetIn(
-                    key="multi_partitioned",
+                    key=[SCHEMA, "multi_partitioned"],
                     partition_mapping=MultiToSingleDimensionPartitionMapping(
                         partition_dimension_name="time"
                     ),

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
@@ -16,6 +16,7 @@ from dagster import (
     MetadataValue,
     MultiPartitionKey,
     MultiPartitionsDefinition,
+    MultiToSingleDimensionPartitionMapping,
     Out,
     StaticPartitionsDefinition,
     TableColumn,
@@ -631,3 +632,96 @@ def test_self_dependent_asset(spark, io_manager):
             f"SELECT * FROM {bq_table_path}", project_id=SHARED_BUILDKITE_BQ_CONFIG["project"]
         )
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]
+
+
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
+@pytest.mark.parametrize("io_manager", [(old_bigquery_io_manager), (pythonic_bigquery_io_manager)])
+@pytest.mark.integration
+def test_multi_partitioned_asset_with_downstream_mapping(spark, io_manager):
+    with temporary_bigquery_table(
+        schema_name=SCHEMA,
+    ) as table_name:
+        partitions_def = MultiPartitionsDefinition(
+            {
+                "time": DailyPartitionsDefinition(start_date="2022-01-01"),
+                "color": StaticPartitionsDefinition(["red", "yellow", "blue"]),
+            }
+        )
+
+        @asset(
+            partitions_def=partitions_def,
+            key_prefix=SCHEMA,
+            metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
+            config_schema={"value": str},
+            name=table_name,
+        )
+        def multi_partitioned(context) -> DataFrame:
+            partition = context.partition_key.keys_by_dimension
+            value = context.op_config["value"]
+
+            schema = StructType(
+                [
+                    StructField("COLOR", StringType()),
+                    StructField("RAW_TIME", StringType()),
+                    StructField("A", StringType()),
+                ]
+            )
+            data = [
+                (partition["color"], partition["time"], value),
+                (partition["color"], partition["time"], value),
+                (partition["color"], partition["time"], value),
+            ]
+            df = spark.createDataFrame(data, schema=schema)
+            df = df.withColumn("TIME", to_date(col("RAW_TIME")))
+
+            return df
+
+        @asset(
+            ins={
+                "multi_partitioned": AssetIn(
+                    key="multi_partitioned",
+                    partition_mapping=MultiToSingleDimensionPartitionMapping(
+                        partition_dimension_name="time"
+                    ),
+                ),
+            },
+            key_prefix=SCHEMA,
+            partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"),
+            metadata={"partition_expr": "CAST(time as TIMESTAMP)"},
+        )
+        def downstream_of_multi_partitioned(multi_partitioned: DataFrame) -> None:
+            # assert that we only get the correct number of rows
+            assert multi_partitioned.count() == 6
+
+        asset_full_name = f"{SCHEMA}__{table_name}"
+
+        resource_defs = {"io_manager": io_manager}
+
+        with instance_for_test() as inst:
+            materialize(
+                [multi_partitioned],
+                partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
+                resources=resource_defs,
+                run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
+                instance=inst,
+            )
+            materialize(
+                [multi_partitioned],
+                partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
+                resources=resource_defs,
+                run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
+                instance=inst,
+            )
+            materialize(
+                [multi_partitioned],
+                partition_key=MultiPartitionKey({"time": "2022-01-02", "color": "blue"}),
+                resources=resource_defs,
+                run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
+                instance=inst,
+            )
+            materialize(
+                [multi_partitioned.to_source_asset(), downstream_of_multi_partitioned],
+                partition_key="2022-01-01",
+                resources=resource_defs,
+                instance=inst,
+            )

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
@@ -679,7 +679,7 @@ def test_multi_partitioned_asset_with_downstream_mapping(spark, io_manager):
         @asset(
             ins={
                 "multi_partitioned": AssetIn(
-                    key=[SCHEMA, "multi_partitioned"],
+                    key=[SCHEMA, table_name],
                     partition_mapping=MultiToSingleDimensionPartitionMapping(
                         partition_dimension_name="time"
                     ),

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -801,7 +801,7 @@ def test_multi_partitioned_asset_with_downstream_mapping(io_manager):
         @asset(
             ins={
                 "multi_partitioned": AssetIn(
-                    key="multi_partitioned",
+                    key=[SCHEMA, "multi_partitioned"],
                     partition_mapping=MultiToSingleDimensionPartitionMapping(
                         partition_dimension_name="time"
                     ),
@@ -816,6 +816,7 @@ def test_multi_partitioned_asset_with_downstream_mapping(io_manager):
             assert "red" in list(multi_partitioned.color)
             assert "blue" in list(multi_partitioned.color)
             assert partition in list(multi_partitioned.time)
+            assert multi_partitioned.shape[0] == 6
             return None
 
         asset_full_name = f"{SCHEMA}__{table_name}"
@@ -833,6 +834,13 @@ def test_multi_partitioned_asset_with_downstream_mapping(io_manager):
             materialize(
                 [multi_partitioned],
                 partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
+                resources=resource_defs,
+                run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
+                instance=inst,
+            )
+            materialize(
+                [multi_partitioned],
+                partition_key=MultiPartitionKey({"time": "2022-01-02", "color": "blue"}),
                 resources=resource_defs,
                 run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
                 instance=inst,

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -15,6 +15,7 @@ from dagster import (
     MetadataValue,
     MultiPartitionKey,
     MultiPartitionsDefinition,
+    MultiToSingleDimensionPartitionMapping,
     Out,
     StaticPartitionsDefinition,
     TableColumn,
@@ -763,3 +764,82 @@ def test_self_dependent_asset(io_manager):
                 conn.cursor().execute(f"SELECT * FROM {snowflake_table_path}").fetch_pandas_all()
             )
             assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]
+
+
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
+@pytest.mark.parametrize(
+    "io_manager", [(old_snowflake_io_manager), (pythonic_snowflake_io_manager)]
+)
+@pytest.mark.integration
+def test_multi_partitioned_asset_with_downstream_mapping(io_manager):
+    with temporary_snowflake_table(schema_name=SCHEMA, db_name=DATABASE) as table_name:
+        partitions_def = MultiPartitionsDefinition(
+            {
+                "time": DailyPartitionsDefinition(start_date="2022-01-01"),
+                "color": StaticPartitionsDefinition(["red", "yellow", "blue"]),
+            }
+        )
+
+        @asset(
+            partitions_def=partitions_def,
+            key_prefix=SCHEMA,
+            metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
+            config_schema={"value": str},
+            name=table_name,
+        )
+        def multi_partitioned(context) -> DataFrame:
+            partition = context.partition_key.keys_by_dimension
+            value = context.op_config["value"]
+            return DataFrame(
+                {
+                    "color": [partition["color"], partition["color"], partition["color"]],
+                    "time": [partition["time"], partition["time"], partition["time"]],
+                    "a": [value, value, value],
+                }
+            )
+
+        @asset(
+            ins={
+                "multi_partitioned": AssetIn(
+                    key="multi_partitioned",
+                    partition_mapping=MultiToSingleDimensionPartitionMapping(
+                        partition_dimension_name="time"
+                    ),
+                ),
+            },
+            key_prefix=SCHEMA,
+            partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"),
+            metadata={"partition_expr": "CAST(time as TIMESTAMP)"},
+        )
+        def downstream_of_multi_partitioned(context, multi_partitioned: DataFrame) -> None:
+            partition = context.partition_key
+            assert "red" in list(multi_partitioned.color)
+            assert "blue" in list(multi_partitioned.color)
+            assert partition in list(multi_partitioned.time)
+            return None
+
+        asset_full_name = f"{SCHEMA}__{table_name}"
+
+        resource_defs = {"io_manager": io_manager}
+
+        with instance_for_test() as inst:
+            materialize(
+                [multi_partitioned],
+                partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
+                resources=resource_defs,
+                run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
+                instance=inst,
+            )
+            materialize(
+                [multi_partitioned],
+                partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
+                resources=resource_defs,
+                run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
+                instance=inst,
+            )
+            materialize(
+                [multi_partitioned.to_source_asset(), downstream_of_multi_partitioned],
+                partition_key="2022-01-01",
+                resources=resource_defs,
+                instance=inst,
+            )

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -801,7 +801,7 @@ def test_multi_partitioned_asset_with_downstream_mapping(io_manager):
         @asset(
             ins={
                 "multi_partitioned": AssetIn(
-                    key=[SCHEMA, "multi_partitioned"],
+                    key=[SCHEMA, table_name],
                     partition_mapping=MultiToSingleDimensionPartitionMapping(
                         partition_dimension_name="time"
                     ),

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -785,7 +785,7 @@ def test_multi_partitioned_asset_with_downstream_mapping(spark, io_manager):
         @asset(
             ins={
                 "multi_partitioned": AssetIn(
-                    key=[SCHEMA, "multi_partitioned"],
+                    key=[SCHEMA, table_name],
                     partition_mapping=MultiToSingleDimensionPartitionMapping(
                         partition_dimension_name="time"
                     ),

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -15,6 +15,7 @@ from dagster import (
     MetadataValue,
     MultiPartitionKey,
     MultiPartitionsDefinition,
+    MultiToSingleDimensionPartitionMapping,
     Out,
     StaticPartitionsDefinition,
     TableColumn,
@@ -737,3 +738,89 @@ def test_self_dependent_asset(spark, io_manager):
                 .fetch_pandas_all()
             )
             assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]
+
+
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
+@pytest.mark.parametrize(
+    "io_manager", [(old_snowflake_io_manager), (pythonic_snowflake_io_manager)]
+)
+@pytest.mark.integration
+def test_multi_partitioned_asset_with_downstream_mapping(spark, io_manager):
+    with temporary_snowflake_table(schema_name=SCHEMA, db_name=DATABASE) as table_name:
+        partitions_def = MultiPartitionsDefinition(
+            {
+                "time": DailyPartitionsDefinition(start_date="2022-01-01"),
+                "color": StaticPartitionsDefinition(["red", "yellow", "blue"]),
+            }
+        )
+
+        @asset(
+            partitions_def=partitions_def,
+            key_prefix=SCHEMA,
+            metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
+            config_schema={"value": str},
+            name=table_name,
+        )
+        def multi_partitioned(context) -> DataFrame:
+            partition = context.partition_key.keys_by_dimension
+            value = context.op_config["value"]
+
+            schema = StructType(
+                [
+                    StructField("COLOR", StringType()),
+                    StructField("RAW_TIME", StringType()),
+                    StructField("A", StringType()),
+                ]
+            )
+            data = [
+                (partition["color"], partition["time"], value),
+                (partition["color"], partition["time"], value),
+                (partition["color"], partition["time"], value),
+            ]
+            df = spark.createDataFrame(data, schema=schema)
+            df = df.withColumn("TIME", to_date(col("RAW_TIME")))
+
+            return df
+
+        @asset(
+            ins={
+                "multi_partitioned": AssetIn(
+                    key="multi_partitioned",
+                    partition_mapping=MultiToSingleDimensionPartitionMapping(
+                        partition_dimension_name="time"
+                    ),
+                ),
+            },
+            key_prefix=SCHEMA,
+            partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"),
+            metadata={"partition_expr": "CAST(time as TIMESTAMP)"},
+        )
+        def downstream_of_multi_partitioned(context, multi_partitioned: DataFrame) -> None:
+            assert multi_partitioned.count() == 6
+            return None
+
+        asset_full_name = f"{SCHEMA}__{table_name}"
+
+        resource_defs = {"io_manager": io_manager}
+
+        with instance_for_test() as inst:
+            materialize(
+                [multi_partitioned],
+                partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
+                resources=resource_defs,
+                run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
+                instance=inst,
+            )
+            materialize(
+                [multi_partitioned],
+                partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
+                resources=resource_defs,
+                run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
+                instance=inst,
+            )
+            materialize(
+                [multi_partitioned.to_source_asset(), downstream_of_multi_partitioned],
+                partition_key="2022-01-01",
+                resources=resource_defs,
+                instance=inst,
+            )

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -785,7 +785,7 @@ def test_multi_partitioned_asset_with_downstream_mapping(spark, io_manager):
         @asset(
             ins={
                 "multi_partitioned": AssetIn(
-                    key="multi_partitioned",
+                    key=[SCHEMA, "multi_partitioned"],
                     partition_mapping=MultiToSingleDimensionPartitionMapping(
                         partition_dimension_name="time"
                     ),
@@ -814,6 +814,13 @@ def test_multi_partitioned_asset_with_downstream_mapping(spark, io_manager):
             materialize(
                 [multi_partitioned],
                 partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
+                resources=resource_defs,
+                run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
+                instance=inst,
+            )
+            materialize(
+                [multi_partitioned],
+                partition_key=MultiPartitionKey({"time": "2022-01-02", "color": "blue"}),
                 resources=resource_defs,
                 run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
                 instance=inst,


### PR DESCRIPTION
## Summary & Motivation
Single run backfills for Multi-Partitioned assets using a DB IO manager are broken because we are accessing `context.asset_partition_key` in the db_io_manager. This breaks because there are multiple partition keys in the single run backfill. Mapping from a multi partitioned asset to a single partitioned asset was also broken for the same reason

This fix accounts for having multiple partition keys in a backfill and for mapping to a single partitioned asset

## How I Tested These Changes
manually ran some single run backfills of Multi-Partitioned assets using the DuckDB IO manager, updated unit tests to have partition mapping tests