### PR TITLE
[pythonic resources] more gracefully handle optional resource deps

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -43,6 +43,7 @@ from .attach_other_object_to_context import (
 from .pydantic_compat_layer import (
     model_fields,
 )
+from .type_check_utils import is_optional
 
 try:
     from functools import cached_property  # type: ignore  # (py37 compat)
@@ -895,6 +896,13 @@ def _is_annotated_as_resource_type(annotation: Type, metadata: List[str]) -> boo
 
     if metadata and metadata[0] == "resource_dependency":
         return True
+
+    if is_optional(annotation):
+        args = get_args(annotation)
+        annotation_inner = next((arg for arg in args if arg is not None), None)
+        if not annotation_inner:
+            return False
+        return _is_annotated_as_resource_type(annotation_inner, [])
 
     is_annotated_as_resource_dependency = get_origin(annotation) == ResourceDependency or getattr(
         annotation, "__metadata__", None

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
@@ -852,7 +852,7 @@ def test_multiple_nested_optional_resources_complex() -> None:
             .execute_in_process()
             .success
         )
-        assert executed["my_asset"] == None
+        assert executed["my_asset"] is None
         executed.clear()
 
     main_resource = MainResource(


### PR DESCRIPTION
## Summary

Partially addresses #17897 by treating `Optional[MyResource]` (where `MyResource` implements `ConfigurableResource`) as `ResourceDependency[Optional[MyResource]]`, so that the resource system correctly detects it as a nested resource. The user can either provide a `None` literal or a resource which produces `Optional[MyResource]` (including a `MyResource` instance).

```python

class MyCredentials(ConfigurableResource):
    username: str
    password: str

class MyResource(ConfigurableResource):
    credentials: Optional[MyCredentials]

defs = Definitions(
    resources={
        "my_resource_auth": MyResource(credentials=MyCredentials(username="foo", password="bar")),
        "my_resource_noauth": MyResource(credentials=None)
    }
)
```

## Test Plan

New unit tests.