### PR TITLE
pass in the evaluation ID to AssetDaemonContext instead of assuming it auto-increments

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -92,6 +92,7 @@ def get_implicit_auto_materialize_policy(
 class AssetDaemonContext:
     def __init__(
         self,
+        evaluation_id: int,
         instance: "DagsterInstance",
         asset_graph: AssetGraph,
         cursor: AssetDaemonCursor,
@@ -105,6 +106,7 @@ class AssetDaemonContext:
     ):
         from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
+        self._evaluation_id = evaluation_id
         self._instance_queryer = CachingInstanceQueryer(
             instance, asset_graph, evaluation_time=evaluation_time, logger=logger
         )
@@ -572,7 +574,7 @@ class AssetDaemonContext:
                 asset_graph=self.asset_graph,
                 newly_materialized_root_asset_keys=newly_materialized_root_asset_keys,
                 newly_materialized_root_partitions_by_asset_key=newly_materialized_root_partitions_by_asset_key,
-                evaluation_id=self.cursor.evaluation_id + 1,
+                evaluation_id=self._evaluation_id,
                 newly_observe_requested_asset_keys=[
                     asset_key
                     for run_request in auto_observe_run_requests

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -316,13 +316,16 @@ class AssetDaemonScenarioState(NamedTuple):
     def _evaluate_tick_fast(
         self
     ) -> Tuple[Sequence[RunRequest], AssetDaemonCursor, Sequence[AutoMaterializeAssetEvaluation]]:
+        cursor = AssetDaemonCursor.from_serialized(self.serialized_cursor, self.asset_graph)
+
         new_run_requests, new_cursor, new_evaluations = AssetDaemonContext(
+            evaluation_id=cursor.evaluation_id + 1,
             asset_graph=self.asset_graph,
             target_asset_keys=None,
             instance=self.instance,
             materialize_run_tags={},
             observe_run_tags={},
-            cursor=AssetDaemonCursor.from_serialized(self.serialized_cursor, self.asset_graph),
+            cursor=cursor,
             auto_observe=True,
             respect_materialization_data_versions=False,
             logger=self.logger,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -414,6 +414,7 @@ class AssetReconciliationScenario(
             )
 
             run_requests, cursor, evaluations = AssetDaemonContext(
+                evaluation_id=cursor.evaluation_id + 1,
                 asset_graph=asset_graph,
                 target_asset_keys=target_asset_keys,
                 instance=instance,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_observe.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_observe.py
@@ -105,6 +105,7 @@ def test_reconcile():
     instance = DagsterInstance.ephemeral()
 
     run_requests, cursor, _ = AssetDaemonContext(
+        evaluation_id=1,
         auto_observe=True,
         asset_graph=asset_graph,
         target_asset_keys=set(),


### PR DESCRIPTION
Summary:
A small change to clear the deck for N shared threads/processes all incrementing a shared pool of evaluation IDs. Instead of always assuming the new evaluation Id is the previous one plus 1, pass it in from the asset daemon and thread that evaluation ID through.

Test Plan: existing BK

## Summary & Motivation

## How I Tested These Changes
