### PR TITLE
[pipes] implicit materialization opt out

### DIFF
--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -113,7 +113,7 @@ class _PipesSubprocess(PipesClient):
                 raise DagsterPipesExecutionError(
                     f"External execution process failed with code {process.returncode}"
                 )
-        return PipesClientCompletedInvocation(tuple(pipes_session.get_results()))
+        return PipesClientCompletedInvocation(pipes_session)
 
 
 PipesSubprocessClient = ResourceParam[_PipesSubprocess]

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -619,6 +619,7 @@ def open_pipes_session(
                 message_handler=message_handler,
                 context_injector_params=ci_params,
                 message_reader_params=mr_params,
+                context=context,
             )
     finally:
         if not message_handler.received_opened_message:

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/in_process_client.py
@@ -123,7 +123,7 @@ class _InProcessPipesClient(PipesClient):
             ) as session:
                 fn(pipes_context)
 
-        return PipesClientCompletedInvocation(list(session.get_results()))
+        return PipesClientCompletedInvocation(session)
 
 
 InProcessPipesClient = ResourceParam[_InProcessPipesClient]

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -166,7 +166,7 @@ class _PipesDatabricksClient(PipesClient):
                         f"Error running Databricks job: {run.state.state_message}"
                     )
                 time.sleep(_RUN_POLL_INTERVAL)
-        return PipesClientCompletedInvocation(tuple(pipes_session.get_results()))
+        return PipesClientCompletedInvocation(pipes_session)
 
 
 PipesDatabricksClient = ResourceParam[_PipesDatabricksClient]

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -188,7 +188,7 @@ class _PipesDockerClient(PipesClient):
                     raise DagsterPipesError(f"Container exited with non-zero status code: {result}")
             finally:
                 container.stop()
-        return PipesClientCompletedInvocation(tuple(pipes_session.get_results()))
+        return PipesClientCompletedInvocation(pipes_session)
 
     def _create_container(
         self,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -272,7 +272,7 @@ class _PipesK8sClient(PipesClient):
                 )
             finally:
                 client.core_api.delete_namespaced_pod(pod_name, namespace)
-        return PipesClientCompletedInvocation(tuple(pipes_session.get_results()))
+        return PipesClientCompletedInvocation(pipes_session)
 
 
 def build_pod_body(


### PR DESCRIPTION
Give users an opt out for the current behavior to produce implicit `MaterializeResult` s for assets which receive no events.

motivated by https://github.com/dagster-io/dagster/issues/17868

## How I Tested These Changes

added test
