### PR TITLE
add PipesLambdaClient

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
@@ -1,18 +1,32 @@
+import base64
 import json
 import os
 import random
 import string
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Iterator, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Iterator, Mapping, Optional, Sequence
 
 import boto3
 import dagster._check as check
 from botocore.exceptions import ClientError
+from dagster import PipesClient, ResourceParam
+from dagster._annotations import experimental
+from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
+    PipesClientCompletedInvocation,
     PipesContextInjector,
+    PipesMessageReader,
     PipesParams,
 )
-from dagster._core.pipes.utils import PipesBlobStoreMessageReader, PipesLogReader
+from dagster._core.pipes.context import PipesMessageHandler
+from dagster._core.pipes.utils import (
+    PipesBlobStoreMessageReader,
+    PipesEnvContextInjector,
+    PipesLogReader,
+    extract_message_or_forward_to_stdout,
+    open_pipes_session,
+)
+from dagster_pipes import PipesDefaultMessageWriter
 
 if TYPE_CHECKING:
     from dagster_pipes import PipesContextData
@@ -102,3 +116,130 @@ class PipesS3MessageReader(PipesBlobStoreMessageReader):
             " PipesS3MessageWriter to be explicitly passed to open_dagster_pipes in the external"
             " process."
         )
+
+
+@experimental
+class PipesLambdaLogsMessageReader(PipesMessageReader):
+    """Message reader that consumes buffered pipes messages that were flushed on exit from the
+    final 4k of logs that are returned from issuing a sync lambda invocation. This means messages
+    emitted during the computation will only be processed once the lambda completes.
+
+    Limitations: If the volume of pipes messages exceeds 4k, messages will be lost and it is
+    recommended to switch to PipesS3MessageWriter & PipesS3MessageReader.
+    """
+
+    @contextmanager
+    def read_messages(
+        self,
+        handler: PipesMessageHandler,
+    ) -> Iterator[PipesParams]:
+        self._handler = handler
+        try:
+            # use buffered stdio to shift the pipes messages to the tail of logs
+            yield {PipesDefaultMessageWriter.BUFFERED_STDIO_KEY: PipesDefaultMessageWriter.STDERR}
+        finally:
+            self._handler = None
+
+    def consume_lambda_logs(self, response) -> None:
+        handler = check.not_none(
+            self._handler, "Can only consume logs within context manager scope."
+        )
+
+        log_result = base64.b64decode(response["LogResult"]).decode("utf-8")
+
+        for log_line in log_result.splitlines():
+            extract_message_or_forward_to_stdout(handler, log_line)
+
+    def no_messages_debug_text(self) -> str:
+        return (
+            "Attempted to read messages by extracting them from the tail of lambda logs directly."
+        )
+
+
+@experimental
+class PipesLambdaEventContextInjector(PipesEnvContextInjector):
+    def no_messages_debug_text(self) -> str:
+        return "Attempted to inject context via the lambda event input."
+
+
+@experimental
+class _PipesLambdaClient(PipesClient):
+    """A pipes client for invoking AWS lambda.
+
+    By default context is injected via the lambda input event and messages are parsed out of the
+    4k tail of logs. S3
+
+    Args:
+        client (boto3.client): The boto lambda client used to call invoke.
+        context_injector (Optional[PipesContextInjector]): A context injector to use to inject
+            context into the lambda function. Defaults to :py:class:`PipesLambdaEventContextInjector`.
+        message_reader (Optional[PipesMessageReader]): A message reader to use to read messages
+            from the lambda function. Defaults to :py:class:`PipesLambdaLogsMessageReader`.
+    """
+
+    def __init__(
+        self,
+        client: boto3.client,
+        context_injector: Optional[PipesContextInjector] = None,
+        message_reader: Optional[PipesMessageReader] = None,
+    ):
+        self._client = client
+        self._message_reader = message_reader or PipesLambdaLogsMessageReader()
+        self._context_injector = context_injector or PipesLambdaEventContextInjector()
+
+    @classmethod
+    def _is_dagster_maintained(cls) -> bool:
+        return True
+
+    def run(
+        self,
+        *,
+        function_name: str,
+        event: Mapping[str, Any],
+        context: OpExecutionContext,
+    ):
+        """Synchronously invoke a lambda function, enriched with the pipes protocol.
+
+        Args:
+            function_name (str): The name of the function to use.
+            event (Mapping[str, Any]): A JSON serializable object to pass as input to the lambda.
+            context (OpExecutionContext): The context of the currently executing Dagster op or asset.
+        """
+        with open_pipes_session(
+            context=context,
+            message_reader=self._message_reader,
+            context_injector=self._context_injector,
+        ) as session:
+            other_kwargs = {}
+            if isinstance(self._message_reader, PipesLambdaLogsMessageReader):
+                other_kwargs["LogType"] = "Tail"
+
+            if isinstance(self._context_injector, PipesLambdaEventContextInjector):
+                payload_data = {
+                    **event,
+                    **session.get_bootstrap_env_vars(),
+                }
+            else:
+                payload_data = event
+
+            response = self._client.invoke(
+                FunctionName=function_name,
+                InvocationType="RequestResponse",
+                Payload=json.dumps(payload_data),
+                **other_kwargs,
+            )
+            if isinstance(self._message_reader, PipesLambdaLogsMessageReader):
+                self._message_reader.consume_lambda_logs(response)
+
+            if "FunctionError" in response:
+                err_payload = json.loads(response["Payload"].read().decode("utf-8"))
+
+                raise Exception(
+                    f"Lambda Function Error ({response['FunctionError']}):\n{json.dumps(err_payload, indent=2)}"
+                )
+
+        # should probably have a way to return the lambda result payload
+        return PipesClientCompletedInvocation(session)
+
+
+PipesLambdaClient = ResourceParam[_PipesLambdaClient]

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/fake_lambda.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/fake_lambda.py
@@ -1,0 +1,148 @@
+import base64
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import traceback
+from typing import Any, Dict
+
+import boto3
+from dagster_pipes import PipesMappingParamsLoader, PipesS3MessageWriter, open_dagster_pipes
+
+
+class LambdaFunctions:
+    @staticmethod
+    def trunc_logs(event, context):
+        sys.stdout.write("O" * 1024 * 3)
+        sys.stderr.write("E" * 1024 * 3)
+
+    @staticmethod
+    def small_logs(event, context):
+        print("S" * event["size"])  # noqa: T201
+
+    @staticmethod
+    def pipes_basic(event, _lambda_context):
+        with open_dagster_pipes(params_loader=PipesMappingParamsLoader(event)) as dagster_context:
+            dagster_context.report_asset_materialization(metadata={"meta": "data"})
+
+    @staticmethod
+    def pipes_messy_logs(event, _lambda_context):
+        with open_dagster_pipes(params_loader=PipesMappingParamsLoader(event)) as dagster_context:
+            # without buffering this would get lost
+            dagster_context.report_asset_materialization(metadata={"meta": "data"})
+            sys.stderr.write("E" * 1024 * 4)
+
+    @staticmethod
+    def pipes_s3_messages(event, _lambda_context):
+        s3_client = boto3.client(
+            "s3",
+            region_name="us-east-1",
+            endpoint_url="http://localhost:5193",
+        )
+        with open_dagster_pipes(
+            params_loader=PipesMappingParamsLoader(event),
+            message_writer=PipesS3MessageWriter(
+                client=s3_client,
+                interval=0.001,
+            ),
+        ) as dagster_context:
+            dagster_context.report_asset_materialization(metadata={"meta": "data"})
+
+    @staticmethod
+    def error(event, _lambda_context):
+        raise Exception("boom")
+
+
+class FakeLambdaContext:
+    pass
+
+
+LOG_TAIL_LIMIT = 4096
+
+
+class FakeLambdaClient:
+    def invoke(self, **kwargs):
+        # emulate lambda constraints with a subprocess invocation
+        # * json serialized "Payload" result
+        # * 4k log output as base64 "LogResult"
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            in_path = os.path.join(tempdir, "in.json")
+            out_path = os.path.join(tempdir, "out.json")
+            log_path = os.path.join(tempdir, "logs")
+
+            with open(in_path, "w") as f:
+                f.write(kwargs["Payload"])
+
+            with open(log_path, "w") as log_file:
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        os.path.join(os.path.dirname(__file__), "fake_lambda.py"),
+                        kwargs["FunctionName"],
+                        in_path,
+                        out_path,
+                    ],
+                    check=False,
+                    env={},  # env vars part of lambda fn definition, can't vary at runtime
+                    stdout=log_file,
+                    stderr=log_file,
+                )
+
+            response: Dict[str, Any] = {}
+
+            if result.returncode == 42:
+                response["FunctionError"] = "Unhandled"
+
+            elif result.returncode != 0:
+                with open(log_path, "r") as f:
+                    print(f.read())  # noqa: T201
+                result.check_returncode()
+
+            with open(out_path, "rb") as f:
+                payload = io.BytesIO(f.read())
+
+            response["Payload"] = payload
+
+            if kwargs.get("LogType") == "Tail":
+                logs_len = os.path.getsize(log_path)
+                with open(log_path, "rb") as log_file:
+                    if logs_len > LOG_TAIL_LIMIT:
+                        log_file.seek(-LOG_TAIL_LIMIT, os.SEEK_END)
+
+                    outro = log_file.read()
+
+                log_result = base64.encodebytes(outro)
+
+                response["LogResult"] = log_result
+
+        return response
+
+
+if __name__ == "__main__":
+    assert len(sys.argv) == 4, "python fake_lambda.py <fn_name> <in_path> <out_path>"
+    _, fn_name, in_path, out_path = sys.argv
+
+    event = json.load(open(in_path))
+    fn = getattr(LambdaFunctions, fn_name)
+
+    val = None
+    return_code = 0
+    try:
+        val = fn(event, FakeLambdaContext())
+    except Exception as e:
+        tb = traceback.TracebackException.from_exception(e)
+        val = {
+            "errorMessage": str(tb),
+            "errorType": tb.exc_type.__name__,
+            "stackTrace": tb.stack.format(),
+            "requestId": "fake-request-id",
+        }
+        return_code = 42
+
+    with open(out_path, "w") as f:
+        json.dump(val, f)
+
+    sys.exit(return_code)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_pipes.py
@@ -1,4 +1,6 @@
+import base64
 import inspect
+import json
 import re
 import shutil
 import textwrap
@@ -8,14 +10,13 @@ from typing import Any, Callable, Iterator
 
 import boto3
 import pytest
+from dagster import asset, materialize, open_pipes_session
 from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSpec
 from dagster._core.definitions.data_version import (
     DATA_VERSION_IS_USER_PROVIDED_TAG,
     DATA_VERSION_TAG,
 )
-from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.materialize import materialize
 from dagster._core.definitions.metadata import (
     MarkdownMetadataValue,
 )
@@ -24,9 +25,17 @@ from dagster._core.instance_for_test import instance_for_test
 from dagster._core.pipes.subprocess import (
     PipesSubprocessClient,
 )
+from dagster._core.pipes.utils import PipesEnvContextInjector
 from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecordStatus
-from dagster_aws.pipes import PipesS3ContextInjector, PipesS3MessageReader
+from dagster_aws.pipes import (
+    PipesLambdaClient,
+    PipesLambdaLogsMessageReader,
+    PipesS3ContextInjector,
+    PipesS3MessageReader,
+)
 from moto.server import ThreadedMotoServer
+
+from .fake_lambda import LOG_TAIL_LIMIT, FakeLambdaClient, LambdaFunctions
 
 _PYTHON_EXECUTABLE = shutil.which("python") or "python"
 
@@ -41,7 +50,7 @@ def temp_script(script_fn: Callable[[], Any]) -> Iterator[str]:
         yield file.name
 
 
-_S3_TEST_BUCKET = "ext-testing"
+_S3_TEST_BUCKET = "pipes-testing"
 _S3_SERVER_PORT = 5193
 _S3_SERVER_URL = f"http://localhost:{_S3_SERVER_PORT}"
 
@@ -138,3 +147,131 @@ def test_s3_pipes_components(
         )
         assert len(asset_check_executions) == 1
         assert asset_check_executions[0].status == AssetCheckExecutionRecordStatus.SUCCEEDED
+
+
+def test_fake_lambda_logs():
+    event = {}
+    response = FakeLambdaClient().invoke(
+        FunctionName=LambdaFunctions.trunc_logs.__name__,
+        InvocationType="RequestResponse",
+        Payload=json.dumps(event),
+        LogType="Tail",
+    )
+
+    log_result = base64.b64decode(response["LogResult"])
+    assert len(log_result) == LOG_TAIL_LIMIT
+
+    small_size = 512
+    response = FakeLambdaClient().invoke(
+        FunctionName=LambdaFunctions.small_logs.__name__,
+        InvocationType="RequestResponse",
+        Payload=json.dumps({"size": small_size}),
+        LogType="Tail",
+    )
+
+    log_result = base64.b64decode(response["LogResult"])
+    assert len(log_result) == small_size + 1  # size + \n
+
+
+def test_manual_fake_lambda_pipes():
+    @asset
+    def fake_lambda_asset(context):
+        context_injector = PipesEnvContextInjector()
+        message_reader = PipesLambdaLogsMessageReader()
+
+        with open_pipes_session(
+            context=context,
+            message_reader=message_reader,
+            context_injector=context_injector,
+        ) as session:
+            user_event = {}
+            response = FakeLambdaClient().invoke(
+                FunctionName=LambdaFunctions.pipes_basic.__name__,
+                InvocationType="RequestResponse",
+                Payload=json.dumps(
+                    {
+                        **user_event,
+                        **session.get_bootstrap_env_vars(),
+                    }
+                ),
+                LogType="Tail",
+            )
+            message_reader.consume_lambda_logs(response)
+            yield from session.get_results()
+
+    result = materialize([fake_lambda_asset])
+    assert result.success
+    mat_evts = result.get_asset_materialization_events()
+    assert len(mat_evts) == 1
+    assert mat_evts[0].materialization.metadata["meta"].value == "data"
+
+
+@pytest.mark.parametrize(
+    "lambda_fn",
+    [
+        LambdaFunctions.pipes_basic.__name__,
+        LambdaFunctions.pipes_messy_logs.__name__,
+    ],
+)
+def test_client_lambda_pipes(lambda_fn):
+    @asset
+    def fake_lambda_asset(context):
+        return (
+            PipesLambdaClient(FakeLambdaClient())
+            .run(
+                context=context,
+                function_name=lambda_fn,
+                event={},
+            )
+            .get_materialize_result()
+        )
+
+    result = materialize([fake_lambda_asset])
+    assert result.success
+    mat_evts = result.get_asset_materialization_events()
+    assert len(mat_evts) == 1
+    assert mat_evts[0].materialization.metadata["meta"].value == "data"
+
+
+def test_fake_client_lambda_error():
+    @asset
+    def fake_lambda_asset(context):
+        yield from (
+            PipesLambdaClient(FakeLambdaClient())
+            .run(
+                context=context,
+                function_name=LambdaFunctions.error.__name__,
+                event={},
+            )
+            .get_results()
+        )
+
+    with pytest.raises(Exception, match="Lambda Function Error"):
+        materialize([fake_lambda_asset])
+
+
+def test_lambda_s3_pipes(s3_client):
+    @asset
+    def fake_lambda_asset(context):
+        return (
+            PipesLambdaClient(
+                FakeLambdaClient(),
+                message_reader=PipesS3MessageReader(
+                    client=s3_client,
+                    bucket=_S3_TEST_BUCKET,
+                    interval=0.01,
+                ),
+            )
+            .run(
+                context=context,
+                function_name=LambdaFunctions.pipes_s3_messages.__name__,
+                event={},
+            )
+            .get_materialize_result()
+        )
+
+    result = materialize([fake_lambda_asset])
+    assert result.success
+    mat_evts = result.get_asset_materialization_events()
+    assert len(mat_evts) == 1
+    assert mat_evts[0].materialization.metadata["meta"].value == "data"

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -75,7 +75,7 @@ class _PipesDockerClient(PipesClient):
             the docker client.
         context_injector (Optional[PipesContextInjector]): A context injector to use to inject
             context into the docker container process. Defaults to :py:class:`PipesEnvContextInjector`.
-        message_reader (Optional[PipesContextInjector]): A message reader to use to read messages
+        message_reader (Optional[PipesMessageReader]): A message reader to use to read messages
             from the docker container process. Defaults to :py:class:`DockerLogsMessageReader`.
     """
 


### PR DESCRIPTION
Create a pipes client for AWS lambda. 

## How I Tested These Changes

added unit tests that use a fake version of lambda
manually tested against a real lambda instance