### PR TITLE
[auto-materialize] Raise a more informative error message when getting a partition mapping failure

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -182,7 +182,9 @@ class TimeWindowPartitionMapping(
             )
 
         if to_partitions_def.timezone != from_partitions_def.timezone:
-            raise DagsterInvalidDefinitionError("Timezones don't match")
+            raise DagsterInvalidDefinitionError(
+                f"Timezones {to_partitions_def.timezone} and {from_partitions_def.timezone} don't match"
+            )
 
         result = self._do_cheap_partition_mapping_if_possible(
             from_partitions_def=from_partitions_def,

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -34,7 +34,10 @@ from dagster._core.definitions.time_window_partitions import (
     get_time_partition_key,
     get_time_partitions_def,
 )
-from dagster._core.errors import DagsterDefinitionChangedDeserializationError
+from dagster._core.errors import (
+    DagsterDefinitionChangedDeserializationError,
+    DagsterInvalidDefinitionError,
+)
 from dagster._core.events import DagsterEventType
 from dagster._core.instance import DagsterInstance, DynamicPartitionsStore
 from dagster._core.storage.dagster_run import (
@@ -595,8 +598,12 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
                                     current_time=self.evaluation_time,
                                 )
                             )
-                        except Exception as e:  # pylint: disable=broad-except
-                            raise Exception("Could not map partitions between {...}") from e
+                        except DagsterInvalidDefinitionError as e:
+                            # add a more helpful error message to the stack
+                            raise DagsterInvalidDefinitionError(
+                                f"Could not map partitions between parent {asset_key.to_string()} "
+                                f"and child {child.to_string()}."
+                            ) from e
                         for child_partition in child_partitions_subset.get_partition_keys():
                             # we need to see if the child is planned for the same run, but this is
                             # expensive, so we try to avoid doing so in as many situations as possible

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -586,14 +586,17 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
                         # we are mapping from the partitions of the parent asset to the partitions of
                         # the child asset
                         partition_mapping = self.asset_graph.get_partition_mapping(child, asset_key)
-                        child_partitions_subset = (
-                            partition_mapping.get_downstream_partitions_for_partitions(
-                                partitions_subset,
-                                downstream_partitions_def=child_partitions_def,
-                                dynamic_partitions_store=self,
-                                current_time=self.evaluation_time,
+                        try:
+                            child_partitions_subset = (
+                                partition_mapping.get_downstream_partitions_for_partitions(
+                                    partitions_subset,
+                                    downstream_partitions_def=child_partitions_def,
+                                    dynamic_partitions_store=self,
+                                    current_time=self.evaluation_time,
+                                )
                             )
-                        )
+                        except Exception as e:  # pylint: disable=broad-except
+                            raise Exception("Could not map partitions between {...}") from e
                         for child_partition in child_partitions_subset.get_partition_keys():
                             # we need to see if the child is planned for the same run, but this is
                             # expensive, so we try to avoid doing so in as many situations as possible


### PR DESCRIPTION
## Summary & Motivation

When doing an AMP tick, it's generally necessary to calculate the set of assets with updated parents. To do so, we need to get the set of updated asset partitions, then map those to the children that those updates impact.

If there's an error during partition mapping, it can be hard to know exactly which two assets this failure happened between, which can be very hard to debug in cases where there are hundreds or thousands of assets.

This PR adds extra context to the error message, giving the names of the assets for which the partition mapping failed.

As a bonus, adds a bit more information to a specific partition mapping error.

## How I Tested These Changes

Verified that the following error message is surfaced in the UI upon this type of failure:

```
dagster._core.errors.DagsterInvalidDefinitionError: Could not map partitions between parent ["foo"] and child ["bar"].
  File "/Users/owen/src/dagster/python_modules/dagster/dagster/_daemon/asset_daemon.py", line 379, in _run_iteration_impl
    ).evaluate()
      ^^^^^^^^^^
  File "/Users/owen/src/dagster/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py", line 550, in evaluate
    ) = self.get_auto_materialize_asset_evaluations()
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/owen/src/dagster/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py", line 465, in get_auto_materialize_asset_evaluations
    ) = self.evaluate_asset(asset_key, will_materialize_mapping, expected_data_time_mapping)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/owen/src/dagster/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py", line 349, in evaluate_asset
    for evaluation_data, asset_partitions in materialize_rule.evaluate_for_asset(
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/owen/src/dagster/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py", line 655, in evaluate_for_asset
    ) in context.daemon_context.get_asset_partitions_with_newly_updated_parents_for_key(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/owen/src/dagster/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py", line 291, in get_asset_partitions_with_newly_updated_parents_for_key
    ) = self._get_asset_partitions_with_newly_updated_parents_by_key_and_new_latest_storage_id()
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/owen/src/dagster/python_modules/dagster/dagster/_utils/cached_method.py", line 66, in _cached_method_wrapper
    result = method(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/owen/src/dagster/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py", line 263, in _get_asset_partitions_with_newly_updated_parents_by_key_and_new_latest_storage_id
    ) = self.instance_queryer.asset_partitions_with_newly_updated_parents_and_new_latest_storage_id(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/owen/src/dagster/python_modules/dagster/dagster/_utils/caching_instance_queryer.py", line 603, in asset_partitions_with_newly_updated_parents_and_new_latest_storage_id
    raise DagsterInvalidDefinitionError(
The above exception was caused by the following exception:
dagster._core.errors.DagsterInvalidDefinitionError: Timezones UTC and US/Central don't match
  File "/Users/owen/src/dagster/python_modules/dagster/dagster/_utils/caching_instance_queryer.py", line 594, in asset_partitions_with_newly_updated_parents_and_new_latest_storage_id
    partition_mapping.get_downstream_partitions_for_partitions(
  File "/Users/owen/src/dagster/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py", line 138, in get_downstream_partitions_for_partitions
    return self._map_partitions(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/owen/src/dagster/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py", line 185, in _map_partitions
    raise DagsterInvalidDefinitionError(
```