### PR TITLE
Move currentEvaluationId to a field on GrapheneAssetNode rather than GrapheneAutoMaterializeAssetEvaluationRecords

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AssetAutomaterializePolicyPage.tsx
@@ -24,19 +24,23 @@ export const AssetAutomaterializePolicyPage = ({
 
   useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
 
-  const {evaluations, currentEvaluationId} = React.useMemo(() => {
+  const {evaluations, currentAutoMaterializeEvaluationId} = React.useMemo(() => {
     if (
       queryResult.data?.autoMaterializeAssetEvaluationsOrError?.__typename ===
-      'AutoMaterializeAssetEvaluationRecords'
+        'AutoMaterializeAssetEvaluationRecords' &&
+      queryResult.data?.assetNodeOrError?.__typename === 'AssetNode'
     ) {
       return {
         evaluations: queryResult.data?.autoMaterializeAssetEvaluationsOrError.records,
-        currentEvaluationId:
-          queryResult.data.autoMaterializeAssetEvaluationsOrError.currentEvaluationId,
+        currentAutoMaterializeEvaluationId:
+          queryResult.data.assetNodeOrError.currentAutoMaterializeEvaluationId,
       };
     }
-    return {evaluations: [], currentEvaluationId: null};
-  }, [queryResult.data?.autoMaterializeAssetEvaluationsOrError]);
+    return {evaluations: [], currentAutoMaterializeEvaluationId: null};
+  }, [
+    queryResult.data?.autoMaterializeAssetEvaluationsOrError,
+    queryResult.data?.assetNodeOrError,
+  ]);
 
   const isFirstPage = !paginationProps.hasPrevCursor;
   const isLastPage = !paginationProps.hasNextCursor;
@@ -44,13 +48,13 @@ export const AssetAutomaterializePolicyPage = ({
   const evaluationsIncludingEmpty = React.useMemo(
     () =>
       getEvaluationsWithEmptyAdded({
-        currentEvaluationId,
+        currentAutoMaterializeEvaluationId,
         evaluations,
         isFirstPage,
         isLastPage,
         isLoading,
       }),
-    [currentEvaluationId, evaluations, isFirstPage, isLastPage, isLoading],
+    [currentAutoMaterializeEvaluationId, evaluations, isFirstPage, isLastPage, isLoading],
   );
 
   const [selectedEvaluationId, setSelectedEvaluationId] = useQueryPersistedState<

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/GetEvaluationsQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/GetEvaluationsQuery.tsx
@@ -13,12 +13,12 @@ export const GET_EVALUATIONS_QUERY = gql`
             className
           }
         }
+        currentAutoMaterializeEvaluationId
       }
     }
 
     autoMaterializeAssetEvaluationsOrError(assetKey: $assetKey, limit: $limit, cursor: $cursor) {
       ... on AutoMaterializeAssetEvaluationRecords {
-        currentEvaluationId
         records {
           id
           ...AutoMaterializeEvaluationRecordItem

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__fixtures__/AutoMaterializePolicyPage.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__fixtures__/AutoMaterializePolicyPage.fixtures.ts
@@ -283,9 +283,9 @@ export const Evaluations = {
           autoMaterializePolicy: buildAutoMaterializePolicy({
             rules: BASE_AUTOMATERIALIZE_RULES,
           }),
+          currentAutoMaterializeEvaluationId: 1000,
         }),
         autoMaterializeAssetEvaluationsOrError: buildAutoMaterializeAssetEvaluationRecords({
-          currentEvaluationId: 1000,
           records: [],
         }),
       },

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/AutomaterializeLeftList.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/AutomaterializeLeftList.stories.tsx
@@ -22,7 +22,7 @@ export const WithPartitions = () => {
   const evaluations = buildEvaluationRecordsWithPartitions();
   const evaluationsWithEmpty = getEvaluationsWithEmptyAdded({
     evaluations,
-    currentEvaluationId: evaluations[0]!.evaluationId,
+    currentAutoMaterializeEvaluationId: evaluations[0]!.evaluationId,
     isLastPage: true,
     isFirstPage: true,
     isLoading: false,
@@ -48,7 +48,7 @@ export const NoPartitions = () => {
   const evaluations = buildEvaluationRecordsWithoutPartitions();
   const evaluationsWithEmpty = getEvaluationsWithEmptyAdded({
     evaluations,
-    currentEvaluationId: evaluations[0]!.evaluationId,
+    currentAutoMaterializeEvaluationId: evaluations[0]!.evaluationId,
     isLastPage: true,
     isFirstPage: true,
     isLoading: false,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__tests__/getEvaluationsWithEmptyAdded.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__tests__/getEvaluationsWithEmptyAdded.test.tsx
@@ -27,7 +27,7 @@ describe('getEvaluationsWithEmptyAdded', () => {
 
     const actual = getEvaluationsWithEmptyAdded({
       evaluations,
-      currentEvaluationId: 3,
+      currentAutoMaterializeEvaluationId: 3,
       isFirstPage: false,
       isLastPage: false,
       isLoading: true,
@@ -41,7 +41,7 @@ describe('getEvaluationsWithEmptyAdded', () => {
 
     const actual = getEvaluationsWithEmptyAdded({
       evaluations,
-      currentEvaluationId: null,
+      currentAutoMaterializeEvaluationId: null,
       isFirstPage: true,
       isLastPage: true,
       isLoading: false,
@@ -63,7 +63,7 @@ describe('getEvaluationsWithEmptyAdded', () => {
 
     const actual = getEvaluationsWithEmptyAdded({
       evaluations,
-      currentEvaluationId: null,
+      currentAutoMaterializeEvaluationId: null,
       isFirstPage: true,
       isLastPage: true,
       isLoading: false,
@@ -81,7 +81,7 @@ describe('getEvaluationsWithEmptyAdded', () => {
   });
 
   it(
-    'should return a skipped entry on top if its the first page and the currentEvaluationId is greater' +
+    'should return a skipped entry on top if its the first page and the currentAutoMaterializeEvaluationId is greater' +
       "than the last evaluation's ID + at the bottom if its the last page and the last evaluation ID is not 1",
     () => {
       const evaluations = [
@@ -107,7 +107,7 @@ describe('getEvaluationsWithEmptyAdded', () => {
 
       const actual = getEvaluationsWithEmptyAdded({
         evaluations,
-        currentEvaluationId: 10,
+        currentAutoMaterializeEvaluationId: 10,
         isFirstPage: true,
         isLastPage: true,
         isLoading: false,
@@ -157,7 +157,7 @@ describe('getEvaluationsWithEmptyAdded', () => {
 
     const actual = getEvaluationsWithEmptyAdded({
       evaluations,
-      currentEvaluationId: 3,
+      currentAutoMaterializeEvaluationId: 3,
       isFirstPage: true,
       isLastPage: true,
       isLoading: false,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/getEvaluationsWithEmptyAdded.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/getEvaluationsWithEmptyAdded.tsx
@@ -3,7 +3,7 @@ import {AutoMaterializeEvaluationRecordItemFragment} from './types/GetEvaluation
 
 type Config = {
   evaluations: AutoMaterializeEvaluationRecordItemFragment[];
-  currentEvaluationId: number | null;
+  currentAutoMaterializeEvaluationId: number | null;
   isFirstPage: boolean;
   isLastPage: boolean;
   isLoading: boolean;
@@ -11,7 +11,7 @@ type Config = {
 
 export const getEvaluationsWithEmptyAdded = ({
   isLoading,
-  currentEvaluationId,
+  currentAutoMaterializeEvaluationId,
   evaluations,
   isFirstPage,
   isLastPage,
@@ -23,8 +23,8 @@ export const getEvaluationsWithEmptyAdded = ({
   const evalsWithSkips = [];
 
   let current =
-    isFirstPage && currentEvaluationId !== null
-      ? currentEvaluationId
+    isFirstPage && currentAutoMaterializeEvaluationId !== null
+      ? currentAutoMaterializeEvaluationId
       : evaluations[0]?.evaluationId || 1;
 
   evaluations.forEach((evaluation, i) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
@@ -14,6 +14,7 @@ export type GetEvaluationsQuery = {
     | {
         __typename: 'AssetNode';
         id: string;
+        currentAutoMaterializeEvaluationId: number | null;
         autoMaterializePolicy: {
           __typename: 'AutoMaterializePolicy';
           rules: Array<{
@@ -29,7 +30,6 @@ export type GetEvaluationsQuery = {
     | {__typename: 'AutoMaterializeAssetEvaluationNeedsMigrationError'; message: string}
     | {
         __typename: 'AutoMaterializeAssetEvaluationRecords';
-        currentEvaluationId: number | null;
         records: Array<{
           __typename: 'AutoMaterializeAssetEvaluationRecord';
           id: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -690,6 +690,7 @@ type AssetNode {
   hasMaterializePermission: Boolean!
   hasAssetChecks: Boolean!
   assetChecksOrError(limit: Int): AssetChecksOrError!
+  currentAutoMaterializeEvaluationId: Int
 }
 
 type MaterializationUpstreamDataVersion {
@@ -3300,7 +3301,6 @@ union AutoMaterializeAssetEvaluationRecordsOrError =
 
 type AutoMaterializeAssetEvaluationRecords {
   records: [AutoMaterializeAssetEvaluationRecord!]!
-  currentEvaluationId: Int
 }
 
 type AutoMaterializeAssetEvaluationRecord {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -339,6 +339,7 @@ export type AssetNode = {
   backfillPolicy: Maybe<BackfillPolicy>;
   computeKind: Maybe<Scalars['String']>;
   configField: Maybe<ConfigTypeField>;
+  currentAutoMaterializeEvaluationId: Maybe<Scalars['Int']>;
   dataVersion: Maybe<Scalars['String']>;
   dataVersionByPartition: Array<Maybe<Scalars['String']>>;
   dependedBy: Array<AssetDependency>;
@@ -505,7 +506,6 @@ export type AutoMaterializeAssetEvaluationRecord = {
 
 export type AutoMaterializeAssetEvaluationRecords = {
   __typename: 'AutoMaterializeAssetEvaluationRecords';
-  currentEvaluationId: Maybe<Scalars['Int']>;
   records: Array<AutoMaterializeAssetEvaluationRecord>;
 };
 
@@ -5144,6 +5144,10 @@ export const buildAssetNode = (
         : relationshipsToOmit.has('ConfigTypeField')
         ? ({} as ConfigTypeField)
         : buildConfigTypeField({}, relationshipsToOmit),
+    currentAutoMaterializeEvaluationId:
+      overrides && overrides.hasOwnProperty('currentAutoMaterializeEvaluationId')
+        ? overrides.currentAutoMaterializeEvaluationId!
+        : 6693,
     dataVersion:
       overrides && overrides.hasOwnProperty('dataVersion') ? overrides.dataVersion! : 'a',
     dataVersionByPartition:
@@ -5423,10 +5427,6 @@ export const buildAutoMaterializeAssetEvaluationRecords = (
   relationshipsToOmit.add('AutoMaterializeAssetEvaluationRecords');
   return {
     __typename: 'AutoMaterializeAssetEvaluationRecords',
-    currentEvaluationId:
-      overrides && overrides.hasOwnProperty('currentEvaluationId')
-        ? overrides.currentEvaluationId!
-        : 9797,
     records: overrides && overrides.hasOwnProperty('records') ? overrides.records! : [],
   };
 };

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -284,6 +284,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         graphene.NonNull(GrapheneAssetChecksOrError),
         limit=graphene.Argument(graphene.Int),
     )
+    currentAutoMaterializeEvaluationId = graphene.Int()
 
     class Meta:
         name = "AssetNode"
@@ -831,6 +832,11 @@ class GrapheneAssetNode(graphene.ObjectType):
         if self._external_asset_node.auto_materialize_policy:
             return GrapheneAutoMaterializePolicy(self._external_asset_node.auto_materialize_policy)
         return None
+
+    def resolve_currentAutoMaterializeEvaluationId(self, graphene_info):
+        from dagster._daemon.asset_daemon import get_current_evaluation_id
+
+        return get_current_evaluation_id(graphene_info.context.instance)
 
     def resolve_backfillPolicy(
         self, _graphene_info: ResolveInfo

--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -217,17 +217,9 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
 
 class GrapheneAutoMaterializeAssetEvaluationRecords(graphene.ObjectType):
     records = non_null_list(GrapheneAutoMaterializeAssetEvaluationRecord)
-    currentEvaluationId = graphene.Int()
 
     class Meta:
         name = "AutoMaterializeAssetEvaluationRecords"
-
-    def resolve_currentEvaluationId(self, graphene_info):
-        from dagster._daemon.asset_daemon import get_current_evaluation_id
-
-        # TODO Move to its own top-level field rather than a field
-        # on GrapheneAutoMaterializeAssetEvaluationRecords
-        return get_current_evaluation_id(graphene_info.context.instance)
 
 
 class GrapheneAutoMaterializeAssetEvaluationNeedsMigrationError(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
@@ -207,6 +207,11 @@ class TestAutoMaterializeTicks(ExecutingGraphQLContextTestMatrix):
 
 QUERY = """
 query GetEvaluationsQuery($assetKey: AssetKeyInput!, $limit: Int!, $cursor: String) {
+    assetNodeOrError(assetKey: $assetKey) {
+        ... on AssetNode {
+            currentAutoMaterializeEvaluationId
+        }
+    }
     autoMaterializeAssetEvaluationsOrError(assetKey: $assetKey, limit: $limit, cursor: $cursor) {
         ... on AutoMaterializeAssetEvaluationRecords {
             records {
@@ -255,7 +260,6 @@ query GetEvaluationsQuery($assetKey: AssetKeyInput!, $limit: Int!, $cursor: Stri
                     path
                 }
             }
-            currentEvaluationId
         }
     }
 }
@@ -311,7 +315,6 @@ query GetEvaluationsForEvaluationIdQuery($evaluationId: Int!) {
                     path
                 }
             }
-            currentEvaluationId
         }
     }
 }
@@ -459,6 +462,9 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
         )
 
         assert results.data == {
+            "assetNodeOrError": {
+                "currentAutoMaterializeEvaluationId": None,
+            },
             "autoMaterializeAssetEvaluationsOrError": {
                 "records": [
                     {
@@ -482,8 +488,7 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
                         "assetKey": {"path": ["upstream_static_partitioned_asset"]},
                     }
                 ],
-                "currentEvaluationId": None,
-            }
+            },
         }
 
     def _test_get_evaluations(self, graphql_context: WorkspaceRequestContext):
@@ -493,7 +498,7 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
             variables={"assetKey": {"path": ["foo"]}, "limit": 10, "cursor": None},
         )
         assert results.data == {
-            "autoMaterializeAssetEvaluationsOrError": {"records": [], "currentEvaluationId": None}
+            "autoMaterializeAssetEvaluationsOrError": {"records": []},
         }
 
         check.not_none(
@@ -567,6 +572,9 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
             variables={"assetKey": {"path": ["asset_one"]}, "limit": 10, "cursor": None},
         )
         assert results.data == {
+            "assetNodeOrError": {
+                "currentAutoMaterializeEvaluationId": None,
+            },
             "autoMaterializeAssetEvaluationsOrError": {
                 "records": [
                     {
@@ -576,8 +584,7 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
                         "rulesWithRuleEvaluations": [],
                     }
                 ],
-                "currentEvaluationId": None,
-            }
+            },
         }
 
         results = execute_dagster_graphql(
@@ -586,6 +593,9 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
             variables={"assetKey": {"path": ["asset_two"]}, "limit": 10, "cursor": None},
         )
         assert results.data == {
+            "assetNodeOrError": {
+                "currentAutoMaterializeEvaluationId": None,
+            },
             "autoMaterializeAssetEvaluationsOrError": {
                 "records": [
                     {
@@ -605,8 +615,7 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
                         ],
                     }
                 ],
-                "currentEvaluationId": None,
-            }
+            },
         }
 
         results = execute_dagster_graphql(
@@ -615,6 +624,9 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
             variables={"assetKey": {"path": ["asset_three"]}, "limit": 10, "cursor": None},
         )
         assert results.data == {
+            "assetNodeOrError": {
+                "currentAutoMaterializeEvaluationId": None,
+            },
             "autoMaterializeAssetEvaluationsOrError": {
                 "records": [
                     {
@@ -636,8 +648,7 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
                         ],
                     }
                 ],
-                "currentEvaluationId": None,
-            }
+            },
         }
 
         results = execute_dagster_graphql(
@@ -646,6 +657,9 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
             variables={"assetKey": {"path": ["asset_four"]}, "limit": 10, "cursor": None},
         )
         assert results.data == {
+            "assetNodeOrError": {
+                "currentAutoMaterializeEvaluationId": None,
+            },
             "autoMaterializeAssetEvaluationsOrError": {
                 "records": [
                     {
@@ -668,8 +682,7 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
                         ],
                     }
                 ],
-                "currentEvaluationId": None,
-            }
+            },
         }
 
     def _test_get_evaluations_with_partitions(self, graphql_context: WorkspaceRequestContext):
@@ -683,7 +696,10 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
             },
         )
         assert results.data == {
-            "autoMaterializeAssetEvaluationsOrError": {"records": [], "currentEvaluationId": None}
+            "assetNodeOrError": {
+                "currentAutoMaterializeEvaluationId": None,
+            },
+            "autoMaterializeAssetEvaluationsOrError": {"records": []},
         }
 
         check.not_none(
@@ -796,6 +812,9 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
             },
         )
         assert results.data == {
+            "assetNodeOrError": {
+                "currentAutoMaterializeEvaluationId": None,
+            },
             "autoMaterializeAssetEvaluationsOrError": {
                 "records": [
                     {
@@ -820,8 +839,7 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
                         ],
                     }
                 ],
-                "currentEvaluationId": None,
-            }
+            },
         }
 
         results_by_evaluation_id = execute_dagster_graphql(
@@ -848,10 +866,12 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
             variables={"assetKey": {"path": ["asset_two"]}, "limit": 10, "cursor": None},
         )
         assert results.data == {
+            "assetNodeOrError": {
+                "currentAutoMaterializeEvaluationId": 0,
+            },
             "autoMaterializeAssetEvaluationsOrError": {
                 "records": [],
-                "currentEvaluationId": 0,
-            }
+            },
         }
 
         graphql_context.instance.daemon_cursor_storage.set_cursor_values(
@@ -870,8 +890,10 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
             variables={"assetKey": {"path": ["asset_two"]}, "limit": 10, "cursor": None},
         )
         assert results.data == {
+            "assetNodeOrError": {
+                "currentAutoMaterializeEvaluationId": 42,
+            },
             "autoMaterializeAssetEvaluationsOrError": {
                 "records": [],
-                "currentEvaluationId": 42,
-            }
+            },
         }


### PR DESCRIPTION
Summary:
Right now, currentEvaluationId is a field on the AutoMaterializeAssetEvaluationRecords object. This is a little odd to begin with, but gets odder once you can have assets in different evaluation groups, each with their own evaluation ID. So instead, move the field onto the GrapheneAssetNode object instead to pave the way for making that change.

Test Plan: BK, view AMP evaluations page, no change

## Summary & Motivation

## How I Tested These Changes
