### PR TITLE
[7/n subset refactor] Use new asset backfill data serialization format

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -300,7 +300,7 @@ def cancel_partition_backfill(
     if not backfill:
         check.failed(f"No backfill found for id: {backfill_id}")
 
-    if backfill.serialized_asset_backfill_data:
+    if backfill.is_asset_backfill:
         asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
         _assert_permission_for_asset_graph(
             graphene_info,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -454,11 +454,11 @@ def test_remove_partitions_defs_after_backfill():
             assert get_backfills_result.data
             backfill_results = get_backfills_result.data["partitionBackfillsOrError"]["results"]
             assert len(backfill_results) == 1
-            assert backfill_results[0]["numPartitions"] == 0
+            assert backfill_results[0]["numPartitions"] == 2
             assert backfill_results[0]["id"] == backfill_id
             assert backfill_results[0]["partitionSet"] is None
             assert backfill_results[0]["partitionSetName"] is None
-            assert set(backfill_results[0]["partitionNames"]) == set()
+            assert set(backfill_results[0]["partitionNames"]) == {"a", "b"}
 
             # on PartitionBackfill
             single_backfill_result = execute_dagster_graphql(
@@ -790,11 +790,9 @@ def _get_backfill_data(
     assert len(backfills) == 1
     backfill = backfills[0]
     assert backfill.backfill_id == backfill_id
-    assert backfill.serialized_asset_backfill_data
+    assert backfill.asset_backfill_data
 
-    return backfill_id, AssetBackfillData.from_serialized(
-        backfill.serialized_asset_backfill_data, repo.asset_graph, backfill.backfill_timestamp
-    )
+    return backfill_id, backfill.asset_backfill_data
 
 
 def _get_error_message(launch_backfill_result: GqlResult) -> Optional[str]:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -1,5 +1,6 @@
 from typing import Optional, Tuple
 
+import mock
 from dagster import (
     AssetKey,
     DailyPartitionsDefinition,
@@ -419,6 +420,71 @@ def test_launch_asset_backfill():
             assert (
                 single_backfill_result.data["partitionBackfillOrError"]["partitionStatuses"] is None
             )
+
+
+def test_remove_partitions_defs_after_backfill_backcompat():
+    repo = get_repo()
+    all_asset_keys = repo.asset_graph.materializable_asset_keys
+
+    with instance_for_test() as instance:
+        with define_out_of_process_context(__file__, "get_repo", instance) as context:
+            launch_backfill_result = execute_dagster_graphql(
+                context,
+                LAUNCH_PARTITION_BACKFILL_MUTATION,
+                variables={
+                    "backfillParams": {
+                        "partitionNames": ["a", "b"],
+                        "assetSelection": [key.to_graphql_input() for key in all_asset_keys],
+                    }
+                },
+            )
+            backfill_id, asset_backfill_data = _get_backfill_data(
+                launch_backfill_result, instance, repo
+            )
+            assert asset_backfill_data.target_subset.asset_keys == all_asset_keys
+
+        # Replace the asset backfill data with the backcompat serialization
+        backfill = instance.get_backfills()[0]
+        backcompat_backfill = backfill._replace(
+            asset_backfill_data=None,
+            serialized_asset_backfill_data=backfill.asset_backfill_data.serialize(
+                instance, asset_graph=repo.asset_graph
+            ),
+        )
+
+        with mock.patch(
+            "dagster._core.instance.DagsterInstance.get_backfills",
+            return_value=[backcompat_backfill],
+        ):
+            # When the partitions defs are unchanged, the backfill data can be fetched
+            with define_out_of_process_context(__file__, "get_repo", instance) as context:
+                get_backfills_result = execute_dagster_graphql(
+                    context, GET_PARTITION_BACKFILLS_QUERY, variables={}
+                )
+                assert not get_backfills_result.errors
+                assert get_backfills_result.data
+
+                backfill_results = get_backfills_result.data["partitionBackfillsOrError"]["results"]
+                assert len(backfill_results) == 1
+                assert backfill_results[0]["numPartitions"] == 2
+                assert backfill_results[0]["id"] == backfill_id
+                assert set(backfill_results[0]["partitionNames"]) == {"a", "b"}
+
+            # When the partitions defs are changed, the backfill data cannot be fetched
+            with define_out_of_process_context(
+                __file__, "get_repo_with_non_partitioned_asset", instance
+            ) as context:
+                get_backfills_result = execute_dagster_graphql(
+                    context, GET_PARTITION_BACKFILLS_QUERY, variables={}
+                )
+                assert not get_backfills_result.errors
+                assert get_backfills_result.data
+
+                backfill_results = get_backfills_result.data["partitionBackfillsOrError"]["results"]
+                assert len(backfill_results) == 1
+                assert backfill_results[0]["numPartitions"] == 0
+                assert backfill_results[0]["id"] == backfill_id
+                assert set(backfill_results[0]["partitionNames"]) == set()
 
 
 def test_remove_partitions_defs_after_backfill():

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -13,7 +13,6 @@ from dagster import (
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.execution.asset_backfill import (
-    AssetBackfillData,
     AssetBackfillIterationResult,
     execute_asset_backfill_iteration,
     execute_asset_backfill_iteration_inner,
@@ -209,9 +208,7 @@ def _execute_asset_backfill_iteration_no_side_effects(
     However, does not execute side effects i.e. launching runs.
     """
     backfill = graphql_context.instance.get_backfill(backfill_id)
-    asset_backfill_data = AssetBackfillData.from_serialized(
-        backfill.serialized_asset_backfill_data, asset_graph, backfill.backfill_timestamp
-    )
+    asset_backfill_data = backfill.asset_backfill_data
     result = None
     for result in execute_asset_backfill_iteration_inner(
         backfill_id=backfill_id,

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1266,7 +1266,9 @@ class AllPartitionsSubset(
         )
 
     def __and__(self, other: "PartitionsSubset") -> "PartitionsSubset":
-        return other
+        return other.empty_subset(other.partitions_def).with_partition_keys(
+            set(self.get_partition_keys()) & set(other.get_partition_keys())
+        )
 
     def __sub__(self, other: "PartitionsSubset") -> "PartitionsSubset":
         if self == other:

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -47,7 +47,6 @@ from dagster._seven.compat.pendulum import (
     create_pendulum_time,
     to_timezone,
 )
-from dagster._utils import utc_datetime_from_timestamp
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
 from dagster._utils.schedules import (
     cron_string_iterator,
@@ -200,9 +199,7 @@ class DatetimeFieldSerializer(FieldSerializer):
                 whitelist_map,
                 context,
             )
-            unpacked_datetime = pendulum.instance(
-                utc_datetime_from_timestamp(unpacked.timestamp), tz=unpacked.timezone
-            ).in_tz(tz=unpacked.timezone)
+            unpacked_datetime = pendulum.from_timestamp(unpacked.timestamp, unpacked.timezone)
             check.invariant(unpacked_datetime.tzinfo is not None)
             return unpacked_datetime
 

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -924,7 +924,9 @@ def execute_asset_backfill_iteration(
         # Refetch, in case the backfill was canceled in the meantime
         backfill = cast(PartitionBackfill, instance.get_backfill(backfill.backfill_id))
         updated_backfill = backfill.with_asset_backfill_data(
-            updated_asset_backfill_data, dynamic_partitions_store=instance, asset_graph=asset_graph
+            updated_asset_backfill_data,
+            dynamic_partitions_store=instance,
+            asset_graph=asset_graph,
         )
         if updated_asset_backfill_data.is_complete():
             # The asset backfill is complete when all runs to be requested have finished (success,
@@ -975,7 +977,9 @@ def execute_asset_backfill_iteration(
             )
 
         updated_backfill = backfill.with_asset_backfill_data(
-            updated_asset_backfill_data, dynamic_partitions_store=instance, asset_graph=asset_graph
+            updated_asset_backfill_data,
+            dynamic_partitions_store=instance,
+            asset_graph=asset_graph,
         )
         # The asset backfill is successfully canceled when all requested runs have finished (success,
         # failure, or cancellation). Since the AssetBackfillData object stores materialization states

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -871,7 +871,7 @@ def execute_asset_backfill_iteration(
     if not backfill.is_asset_backfill:
         check.failed("Backfill must be an asset backfill")
 
-    backfill_start_time = utc_datetime_from_timestamp(backfill.backfill_timestamp)
+    backfill_start_time = pendulum.from_timestamp(backfill.backfill_timestamp, "UTC")
     instance_queryer = CachingInstanceQueryer(
         instance=instance, asset_graph=asset_graph, evaluation_time=backfill_start_time
     )

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -372,6 +372,7 @@ class PartitionBackfill(
         dynamic_partitions_store: DynamicPartitionsStore,
         asset_graph: AssetGraph,
     ) -> "PartitionBackfill":
+        is_backcompat = self.serialized_asset_backfill_data is not None
         return PartitionBackfill(
             status=self.status,
             backfill_id=self.backfill_id,
@@ -384,8 +385,12 @@ class PartitionBackfill(
             last_submitted_partition_name=self.last_submitted_partition_name,
             error=self.error,
             asset_selection=self.asset_selection,
-            serialized_asset_backfill_data=None,
-            asset_backfill_data=asset_backfill_data,
+            serialized_asset_backfill_data=asset_backfill_data.serialize(
+                dynamic_partitions_store=dynamic_partitions_store, asset_graph=asset_graph
+            )
+            if is_backcompat
+            else None,
+            asset_backfill_data=asset_backfill_data if not is_backcompat else None,
         )
 
     @classmethod

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Mapping, NamedTuple, Optional, Sequence, Union, cast
+from typing import Mapping, NamedTuple, Optional, Sequence, Union
 
 from dagster import _check as check
 from dagster._core.definitions import AssetKey
@@ -56,7 +56,7 @@ class PartitionBackfill(
             ("reexecution_steps", Optional[Sequence[str]]),
             # only used by asset backfills
             ("serialized_asset_backfill_data", Optional[str]),
-            ("asset_backfill_data", Optional[AssetBackfillData])
+            ("asset_backfill_data", Optional[AssetBackfillData]),
         ],
     ),
 ):
@@ -112,7 +112,9 @@ class PartitionBackfill(
 
     @property
     def is_asset_backfill(self) -> bool:
-        return self.serialized_asset_backfill_data is not None or self.asset_backfill_data is not None
+        return (
+            self.serialized_asset_backfill_data is not None or self.asset_backfill_data is not None
+        )
 
     @property
     def bulk_action_type(self) -> BulkActionType:
@@ -138,7 +140,8 @@ class PartitionBackfill(
         if self.is_asset_backfill:
             if self.serialized_asset_backfill_data:
                 return AssetBackfillData.is_valid_serialization(
-                    self.serialized_asset_backfill_data, ExternalAssetGraph.from_workspace(workspace)
+                    self.serialized_asset_backfill_data,
+                    ExternalAssetGraph.from_workspace(workspace),
                 )
             else:
                 return True
@@ -168,7 +171,9 @@ class PartitionBackfill(
             elif self.asset_backfill_data:
                 asset_backfill_data = self.asset_backfill_data
             else:
-                check.failed("Expected either serialized_asset_backfill_data or asset_backfill_data")
+                check.failed(
+                    "Expected either serialized_asset_backfill_data or asset_backfill_data"
+                )
 
             return asset_backfill_data.get_backfill_status_per_asset_key(asset_graph)
         else:
@@ -193,7 +198,9 @@ class PartitionBackfill(
             elif self.asset_backfill_data:
                 asset_backfill_data = self.asset_backfill_data
             else:
-                check.failed("Expected either serialized_asset_backfill_data or asset_backfill_data")
+                check.failed(
+                    "Expected either serialized_asset_backfill_data or asset_backfill_data"
+                )
 
             return asset_backfill_data.get_target_partitions_subset(asset_key)
         else:
@@ -219,7 +226,9 @@ class PartitionBackfill(
             elif self.asset_backfill_data:
                 asset_backfill_data = self.asset_backfill_data
             else:
-                check.failed("Expected either serialized_asset_backfill_data or asset_backfill_data")
+                check.failed(
+                    "Expected either serialized_asset_backfill_data or asset_backfill_data"
+                )
 
             return asset_backfill_data.get_target_root_partitions_subset(asset_graph)
         else:
@@ -242,7 +251,9 @@ class PartitionBackfill(
             elif self.asset_backfill_data:
                 asset_backfill_data = self.asset_backfill_data
             else:
-                check.failed("Expected either serialized_asset_backfill_data or asset_backfill_data")
+                check.failed(
+                    "Expected either serialized_asset_backfill_data or asset_backfill_data"
+                )
 
             return asset_backfill_data.get_num_partitions()
         else:
@@ -268,7 +279,9 @@ class PartitionBackfill(
             elif self.asset_backfill_data:
                 asset_backfill_data = self.asset_backfill_data
             else:
-                check.failed("Expected either serialized_asset_backfill_data or asset_backfill_data")
+                check.failed(
+                    "Expected either serialized_asset_backfill_data or asset_backfill_data"
+                )
 
             return asset_backfill_data.get_partition_names()
         else:

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -162,9 +162,7 @@ class PartitionBackfill(
             if self.serialized_asset_backfill_data:
                 try:
                     asset_backfill_data = AssetBackfillData.from_serialized(
-                        self.serialized_asset_backfill_data,
-                        asset_graph,
-                        self.backfill_timestamp,
+                        self.serialized_asset_backfill_data, asset_graph, self.backfill_timestamp
                     )
                 except DagsterDefinitionChangedDeserializationError:
                     return []

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from typing import Mapping, NamedTuple, Optional, Sequence, Union
 
+import pendulum
+
 from dagster import _check as check
 from dagster._core.definitions import AssetKey
 from dagster._core.definitions.asset_graph import AssetGraph
@@ -13,7 +15,6 @@ from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.storage.tags import USER_TAG
 from dagster._core.workspace.workspace import IWorkspace
 from dagster._serdes import whitelist_for_serdes
-from dagster._utils import utc_datetime_from_timestamp
 from dagster._utils.error import SerializableErrorInfo
 
 from ..definitions.selector import PartitionsByAssetSelector
@@ -419,7 +420,7 @@ class PartitionBackfill(
             asset_selection=asset_selection,
             dynamic_partitions_store=dynamic_partitions_store,
             all_partitions=all_partitions,
-            backfill_start_time=utc_datetime_from_timestamp(backfill_timestamp),
+            backfill_start_time=pendulum.from_timestamp(backfill_timestamp, tz="UTC"),
         )
         return cls(
             backfill_id=backfill_id,
@@ -445,7 +446,7 @@ class PartitionBackfill(
         asset_backfill_data = AssetBackfillData.from_partitions_by_assets(
             asset_graph=asset_graph,
             dynamic_partitions_store=dynamic_partitions_store,
-            backfill_start_time=utc_datetime_from_timestamp(backfill_timestamp),
+            backfill_start_time=pendulum.from_timestamp(backfill_timestamp, tz="UTC"),
             partitions_by_assets=partitions_by_assets,
         )
         return cls(

--- a/python_modules/dagster/dagster/_serdes/__init__.py
+++ b/python_modules/dagster/dagster/_serdes/__init__.py
@@ -6,6 +6,7 @@ from .config_class import (
 from .serdes import (
     EnumSerializer as EnumSerializer,
     NamedTupleSerializer as NamedTupleSerializer,
+    SerializableNonScalarKeyMapping as SerializableNonScalarKeyMapping,
     WhitelistMap as WhitelistMap,
     deserialize_value as deserialize_value,
     pack_value as pack_value,

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -429,7 +429,6 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         """Returns an AssetGraphSubset representing the set of assets that are currently targeted by
         an active asset backfill.
         """
-        from dagster._core.execution.asset_backfill import AssetBackfillData
         from dagster._core.execution.backfill import BulkActionStatus
 
         asset_backfills = [
@@ -440,26 +439,15 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
 
         result = AssetGraphSubset()
         for asset_backfill in asset_backfills:
-            if asset_backfill.serialized_asset_backfill_data:
-                try:
-                    asset_backfill_data = AssetBackfillData.from_serialized(
-                        asset_backfill.serialized_asset_backfill_data,
-                        self.asset_graph,
-                        asset_backfill.backfill_timestamp,
-                    )
-                except DagsterDefinitionChangedDeserializationError:
-                    self._logger.warning(
-                        f"Not considering assets in backfill {asset_backfill.backfill_id} since its"
-                        " data could not be deserialized"
-                    )
-                    # Backfill can't be loaded, so no risk of the assets interfering
-                    continue
-            elif asset_backfill.asset_backfill_data:
-                asset_backfill_data = asset_backfill.asset_backfill_data
-            else:
-                check.failed(
-                    "Expected either serialized_asset_backfill_data or asset_backfill_data field"
+            try:
+                asset_backfill_data = asset_backfill.get_asset_backfill_data(self.asset_graph)
+            except DagsterDefinitionChangedDeserializationError:
+                self._logger.warning(
+                    f"Not considering assets in backfill {asset_backfill.backfill_id} since its"
+                    " data could not be deserialized"
                 )
+                # Backfill can't be loaded, so no risk of the assets interfering
+                continue
 
             result |= asset_backfill_data.target_subset
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -291,7 +291,10 @@ def test_scenario_to_completion(scenario: AssetBackfillScenario, failures: str, 
                 assert False
 
             backfill_data = AssetBackfillData.empty(
-                target_subset, scenario.evaluation_time, asset_graph
+                target_subset,
+                scenario.evaluation_time,
+                asset_graph,
+                dynamic_partitions_store=instance,
             )
 
             if failures == "no_failures":
@@ -425,7 +428,12 @@ def make_backfill_data(
     else:
         assert False
 
-    return AssetBackfillData.empty(target_subset, current_time or pendulum.now("UTC"), asset_graph)
+    return AssetBackfillData.empty(
+        target_subset,
+        current_time or pendulum.now("UTC"),
+        asset_graph,
+        dynamic_partitions_store=instance,
+    )
 
 
 def make_random_subset(

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -290,7 +290,9 @@ def test_scenario_to_completion(scenario: AssetBackfillScenario, failures: str, 
             else:
                 assert False
 
-            backfill_data = AssetBackfillData.empty(target_subset, scenario.evaluation_time)
+            backfill_data = AssetBackfillData.empty(
+                target_subset, scenario.evaluation_time, asset_graph
+            )
 
             if failures == "no_failures":
                 fail_asset_partitions: Set[AssetKeyPartitionKey] = set()
@@ -423,7 +425,7 @@ def make_backfill_data(
     else:
         assert False
 
-    return AssetBackfillData.empty(target_subset, current_time or pendulum.now("UTC"))
+    return AssetBackfillData.empty(target_subset, current_time or pendulum.now("UTC"), asset_graph)
 
 
 def make_random_subset(

--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -100,3 +100,53 @@ def unloadable_location_fixture(instance_module_scoped) -> Iterator[WorkspacePro
         workspace_load_target=invalid_workspace_load_target(), instance=instance_module_scoped
     ) as workspace_context:
         yield workspace_context
+
+
+def partitions_def_changes_workspace_1_load_target(attribute=None):
+    return InProcessTestWorkspaceLoadTarget(
+        InProcessCodeLocationOrigin(
+            loadable_target_origin=LoadableTargetOrigin(
+                executable_path=sys.executable,
+                module_name="dagster_tests.daemon_tests.test_locations.partitions_defs_changes_locations.location_1",
+                working_directory=os.getcwd(),
+                attribute=attribute,
+            ),
+            location_name="partitions_def_changes_1",
+        )
+    )
+
+
+@pytest.fixture(name="partitions_defs_changes_location_1_workspace_context", scope="module")
+def partitions_defs_changes_location_1_fixture(
+    instance_module_scoped
+) -> Iterator[WorkspaceProcessContext]:
+    with create_test_daemon_workspace_context(
+        workspace_load_target=partitions_def_changes_workspace_1_load_target(),
+        instance=instance_module_scoped,
+    ) as workspace_context:
+        yield workspace_context
+
+
+def partitions_def_changes_workspace_2_load_target(attribute=None):
+    return InProcessTestWorkspaceLoadTarget(
+        InProcessCodeLocationOrigin(
+            loadable_target_origin=LoadableTargetOrigin(
+                executable_path=sys.executable,
+                module_name="dagster_tests.daemon_tests.test_locations.partitions_defs_changes_locations.location_2",
+                working_directory=os.getcwd(),
+                attribute=attribute,
+            ),
+            location_name="partitions_def_changes_1",
+        )
+    )
+
+
+@pytest.fixture(name="partitions_defs_changes_location_2_workspace_context", scope="module")
+def partitions_defs_changes_location_2_fixture(
+    instance_module_scoped
+) -> Iterator[WorkspaceProcessContext]:
+    with create_test_daemon_workspace_context(
+        workspace_load_target=partitions_def_changes_workspace_2_load_target(),
+        instance=instance_module_scoped,
+    ) as workspace_context:
+        yield workspace_context

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -1340,13 +1340,14 @@ def test_raise_error_on_partitions_defs_removed(
 
     instance.add_backfill(backfill)
 
-    errors = list(
-        execute_backfill_iteration(
+    errors = [
+        e
+        for e in execute_backfill_iteration(
             partitions_defs_changes_location_2_workspace_context,
             get_default_daemon_logger("BackfillDaemon"),
         )
-    )
-
+        if e is not None
+    ]
     assert len(errors) == 1
     assert ("had a PartitionsDefinition at storage-time, but no longer does") in errors[0].message
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -1409,6 +1409,4 @@ def test_raise_error_on_target_static_partition_removed(
         if e is not None
     ]
     assert len(errors) == 1
-    assert (
-        "Partition c for asset AssetKey(['static_partition_removed']) existed at storage-time, but no longer does."
-    ) in errors[0].message
+    assert ("The following partitions were removed: {'c'}.") in errors[0].message

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_locations/partitions_defs_changes_locations/location_1.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_locations/partitions_defs_changes_locations/location_1.py
@@ -1,0 +1,15 @@
+from dagster import DailyPartitionsDefinition, asset
+
+
+@asset(
+    partitions_def=DailyPartitionsDefinition("2023-01-01"),
+)
+def one():
+    pass
+
+
+@asset(
+    partitions_def=DailyPartitionsDefinition("2023-01-01"),
+)
+def two():
+    pass

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_locations/partitions_defs_changes_locations/location_1.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_locations/partitions_defs_changes_locations/location_1.py
@@ -1,15 +1,22 @@
-from dagster import DailyPartitionsDefinition, asset
+from dagster import DailyPartitionsDefinition, StaticPartitionsDefinition, asset
 
 
 @asset(
     partitions_def=DailyPartitionsDefinition("2023-01-01"),
 )
-def one():
+def time_partitions_def_changes():
     pass
 
 
 @asset(
     partitions_def=DailyPartitionsDefinition("2023-01-01"),
 )
-def two():
+def partitions_def_removed():
+    pass
+
+
+@asset(
+    partitions_def=StaticPartitionsDefinition(["a", "b", "c"]),
+)
+def static_partition_removed():
     pass

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_locations/partitions_defs_changes_locations/location_2.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_locations/partitions_defs_changes_locations/location_2.py
@@ -1,13 +1,20 @@
-from dagster import DailyPartitionsDefinition, asset
+from dagster import DailyPartitionsDefinition, StaticPartitionsDefinition, asset
 
 
 @asset(  # partitions def changed to start in June instead of Jan
     partitions_def=DailyPartitionsDefinition("2023-06-01"),
 )
-def one():
+def time_partitions_def_changes():
     pass
 
 
 @asset  # partitions def removed
-def two():
+def partitions_def_removed():
+    pass
+
+
+@asset(  # partition "c" removed
+    partitions_def=StaticPartitionsDefinition(["a", "b"]),
+)
+def static_partition_removed():
     pass

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_locations/partitions_defs_changes_locations/location_2.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_locations/partitions_defs_changes_locations/location_2.py
@@ -1,0 +1,13 @@
+from dagster import DailyPartitionsDefinition, asset
+
+
+@asset(  # partitions def changed to start in June instead of Jan
+    partitions_def=DailyPartitionsDefinition("2023-06-01"),
+)
+def one():
+    pass
+
+
+@asset  # partitions def removed
+def two():
+    pass

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -319,6 +319,12 @@ class AssetReconciliationScenario(
                     partitions_subsets_by_asset_key={},
                     non_partitioned_asset_keys=set(),
                 )
+                partition_ids_by_serialized_asset_key = {
+                    asset_key.to_string(): check.not_none(
+                        repo.asset_graph.get_partitions_def(asset_key)
+                    ).get_serializable_unique_identifier(dynamic_partitions_store=instance)
+                    for asset_key in target_subset.partitions_subsets_by_asset_key.keys()
+                }
                 asset_backfill_data = AssetBackfillData(
                     latest_storage_id=0,
                     target_subset=target_subset,
@@ -327,6 +333,7 @@ class AssetReconciliationScenario(
                     requested_subset=empty_subset,
                     failed_and_downstream_subset=empty_subset,
                     backfill_start_time=test_time,
+                    partitions_ids_by_serialized_asset_key=partition_ids_by_serialized_asset_key,
                 )
                 backfill = PartitionBackfill(
                     backfill_id=f"backfill{i}",

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -319,8 +319,8 @@ class AssetReconciliationScenario(
                     partitions_subsets_by_asset_key={},
                     non_partitioned_asset_keys=set(),
                 )
-                partition_ids_by_serialized_asset_key = {
-                    asset_key.to_string(): check.not_none(
+                partitions_defs_ids_by_asset_key = {
+                    asset_key: check.not_none(
                         repo.asset_graph.get_partitions_def(asset_key)
                     ).get_serializable_unique_identifier(dynamic_partitions_store=instance)
                     for asset_key in target_subset.partitions_subsets_by_asset_key.keys()
@@ -333,7 +333,7 @@ class AssetReconciliationScenario(
                     requested_subset=empty_subset,
                     failed_and_downstream_subset=empty_subset,
                     backfill_start_time=test_time,
-                    partitions_ids_by_serialized_asset_key=partition_ids_by_serialized_asset_key,
+                    partitions_defs_ids_by_asset_key=partitions_defs_ids_by_asset_key,
                 )
                 backfill = PartitionBackfill(
                     backfill_id=f"backfill{i}",

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -333,7 +333,7 @@ class AssetReconciliationScenario(
                     requested_subset=empty_subset,
                     failed_and_downstream_subset=empty_subset,
                     backfill_start_time=test_time,
-                    partitions_defs_ids_by_asset_key=partitions_defs_ids_by_asset_key,
+                    partitions_def_ids_by_asset_key=partitions_defs_ids_by_asset_key,
                 )
                 backfill = PartitionBackfill(
                     backfill_id=f"backfill{i}",

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -319,12 +319,6 @@ class AssetReconciliationScenario(
                     partitions_subsets_by_asset_key={},
                     non_partitioned_asset_keys=set(),
                 )
-                partitions_defs_ids_by_asset_key = {
-                    asset_key: check.not_none(
-                        repo.asset_graph.get_partitions_def(asset_key)
-                    ).get_serializable_unique_identifier(dynamic_partitions_store=instance)
-                    for asset_key in target_subset.partitions_subsets_by_asset_key.keys()
-                }
                 asset_backfill_data = AssetBackfillData(
                     latest_storage_id=0,
                     target_subset=target_subset,
@@ -333,7 +327,6 @@ class AssetReconciliationScenario(
                     requested_subset=empty_subset,
                     failed_and_downstream_subset=empty_subset,
                     backfill_start_time=test_time,
-                    partitions_def_ids_by_asset_key=partitions_defs_ids_by_asset_key,
                 )
                 backfill = PartitionBackfill(
                     backfill_id=f"backfill{i}",


### PR DESCRIPTION
At long last, we have arrived to the final part in this stack. This PR migrates `PartitionBackfill` logic to use the new serialization format of `AssetBackfillData`.

When new backfills are created from now on, the UI will be able to display the asset backfill page even if the partitions defs are changed/removed. For old backfills, the UI continue to show the "partitions def has changed" message, and the asset backfill page will be blank.

Description of changes:
- Adds an additional `asset_backfill_data` field to `PartitionBackfill`
    - Asset backfills from now on will use this field with the new serialization
    - Existing backfills will continue to use `serialized_asset_backfill_data`. We could force the daemon to migrate these objects mid-backfill, but that value add is pretty low. It also improves debug-ability by forcing old backfills to use the old serialization, and new backfills to use the new serialization.

- Serializes the unique ID of each partitions def in a field on `AssetBackfillData`. Adds a new method in asset backfill execution that uses the unique ID to check if partitions defs have changed, in which case we should stop execution.
    - This previously existed in the old serialization version of `AssetGraphSubset`, but was unfortunately duplicated across each subset type (materialized, in-progress, failed)

- Adds tests cases to cover this new surface area