### PR TITLE
[ui] Turn “prior events” link on asset details into a button, make it more obvious

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AllIndividualEventsButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AllIndividualEventsButton.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Button,
-  ButtonLink,
   Colors,
   DialogFooter,
   Dialog,
@@ -226,11 +225,11 @@ const EventGroupRow = React.memo((props: EventGroupRowProps) => {
           <Group direction="column" spacing={4}>
             <Timestamp timestamp={{ms: Number(timestamp)}} />
             {all?.length > 1 ? (
-              <AllIndividualEventsLink
+              <AllIndividualEventsButton
                 hasPartitions={hasPartitions}
                 hasLineage={hasLineage}
                 events={all}
-              >{`View ${all.length} events`}</AllIndividualEventsLink>
+              >{`View ${all.length} events`}</AllIndividualEventsButton>
             ) : latest.__typename === 'MaterializationEvent' ? (
               <Box flex={{gap: 8, alignItems: 'center'}} style={{color: Colors.Gray600}}>
                 <Icon name="materialization" size={16} color={Colors.Gray600} />
@@ -293,15 +292,18 @@ interface PredecessorDialogProps {
   hasLineage: boolean;
   hasPartitions: boolean;
   events: (AssetMaterializationFragment | AssetObservationFragment)[];
-  children: React.ReactNode;
 }
 
-export const AllIndividualEventsLink = ({
+export const AllIndividualEventsButton = ({
+  disabled,
   hasLineage,
   hasPartitions,
   events,
   children,
-}: PredecessorDialogProps) => {
+}: PredecessorDialogProps & {
+  children: React.ReactNode;
+  disabled?: boolean;
+}) => {
   const [open, setOpen] = React.useState(false);
   const [focused, setFocused] = React.useState<AssetEventGroup | undefined>();
   const groups = React.useMemo(
@@ -326,7 +328,9 @@ export const AllIndividualEventsLink = ({
 
   return (
     <>
-      <ButtonLink onClick={() => setOpen(true)}>{children}</ButtonLink>
+      <Button disabled={disabled} onClick={() => setOpen(true)}>
+        {children}
+      </Button>
       <Dialog
         isOpen={open}
         canEscapeKeyClose

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
@@ -68,7 +68,7 @@ export const AssetEventDetail = ({
         {event.partition && (
           <Box flex={{gap: 4, direction: 'column'}}>
             <Subheading>Partition</Subheading>
-            <Box flex={{gap: 4}}>{event.partition}</Box>
+            <Link to={`?view=partitions&partition=${event.partition}`}>{event.partition}</Link>
           </Box>
         )}
         <Box flex={{gap: 4, direction: 'column'}} style={{minHeight: 64}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
@@ -24,7 +24,7 @@ import {titleForRun, linkToRunEvent} from '../runs/RunUtils';
 import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
-import {AllIndividualEventsLink} from './AllIndividualEventsLink';
+import {AllIndividualEventsButton} from './AllIndividualEventsButton';
 import {AssetEventMetadataEntriesTable} from './AssetEventMetadataEntriesTable';
 import {AssetEventSystemTags} from './AssetEventSystemTags';
 import {AssetMaterializationUpstreamData} from './AssetMaterializationUpstreamData';
@@ -223,8 +223,6 @@ export const AssetPartitionDetail = ({
         )
       : [];
 
-  const prior = latest ? all.slice(all.indexOf(latest)) : all;
-
   return (
     <Box padding={{horizontal: 24, bottom: 24}} style={{flex: 1}}>
       <Box padding={{vertical: 24}} border="bottom" flex={{alignItems: 'center'}}>
@@ -310,11 +308,6 @@ export const AssetPartitionDetail = ({
                 <Icon name="observation" />
               )}
               <Timestamp timestamp={{ms: Number(latest.timestamp)}} />
-              {prior.length > 0 && (
-                <AllIndividualEventsLink hasPartitions hasLineage={hasLineage} events={all}>
-                  {`(${prior.length - 1} prior ${prior.length - 1 === 1 ? 'event' : 'events'})`}
-                </AllIndividualEventsLink>
-              )}
             </Box>
           </Box>
         )}
@@ -352,6 +345,16 @@ export const AssetPartitionDetail = ({
           ) : (
             'None'
           )}
+        </Box>
+        <Box style={{textAlign: 'right'}}>
+          <AllIndividualEventsButton
+            hasPartitions
+            hasLineage={hasLineage}
+            events={all}
+            disabled={all.length === 0}
+          >
+            {`View all historical events (${all.length})`}
+          </AllIndividualEventsButton>
         </Box>
       </Box>
       <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>


### PR DESCRIPTION
Fixes #16601

## Summary & Motivation

Recently we’ve had several folks ask how to filter asset runs by partition because our partitions UI only shows the most recent run/materialization for each partition.

This PR converts the existing “(4 prior events)” link (that does what people are looking for) into a large “View all historical events (4)” button. It moves it to the far right of the partition details row so we don’t have to put it under either “run” or “latest materialization” and shows it all the time, disabling it rather than hiding it when there is nothing to display.

This PR also makes the parititon key on Asset > Events click through to the partitions page, so that folks trying to use that tab and filter by partition are more likely to find this Partitions page.

<img width="1398" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/338f4455-6203-40a3-8639-a5653935434e">

## How I Tested These Changes

Just visual changes here, tested manually