### PR TITLE
[ui] Remove light gray text color default on RowCell

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors} from '@dagster-io/ui-components';
+import {Box} from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled from 'styled-components';
 
@@ -28,7 +28,7 @@ export const RowCell = ({
   <CellBox
     padding={12}
     flex={{direction: 'column', justifyContent: 'flex-start'}}
-    style={{color: Colors.Gray500, overflow: 'hidden', ...(style || {})}}
+    style={{overflow: 'hidden', ...(style || {})}}
     border="right"
   >
     {children}


### PR DESCRIPTION
## Summary & Motivation

This looks like a longstanding oversight: the default row cell color in virtualized tables is `Gray500`, which is really too light for body color. Remove this setting.

## How I Tested These Changes

View some virtualized tables, verify that the text colors look fine.
