### PR TITLE
[sensors] fix SensorResult cursor overwrite

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -485,7 +485,7 @@ class TestSensors(NonLaunchableGraphQLContextTestMatrix):
         assert result.data
         assert result.data["sensorDryRun"]["__typename"] == "DryRunInstigationTick"
         evaluation_result = result.data["sensorDryRun"]["evaluationResult"]
-        assert evaluation_result["cursor"] is None
+        assert evaluation_result["cursor"] == "blah"
         assert len(evaluation_result["runRequests"]) == 1
         assert evaluation_result["runRequests"][0]["runConfigYaml"] == "{}\n"
         assert evaluation_result["skipReason"] is None

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -753,11 +753,13 @@ class SensorDefinition(IHasInternalInit):
                 )
                 dynamic_partitions_requests = item.dynamic_partitions_requests or []
 
-                if item.cursor and context.cursor_updated:
+                if context.cursor_updated and item.cursor:
                     raise DagsterInvariantViolationError(
                         "SensorResult.cursor cannot be set if context.update_cursor() was called."
                     )
-                updated_cursor = item.cursor
+                elif item.cursor:
+                    updated_cursor = item.cursor  # overwrite value set from context above
+
                 asset_events = item.asset_events
 
             elif isinstance(item, RunRequest):


### PR DESCRIPTION
When a `SensorResult` was returned we were always overwriting the `cursor` to what it passed even if it was set on the context instead.

resolves https://github.com/dagster-io/dagster/issues/17957

## How I Tested These Changes

updated test to fail before the fix was applied 