### PR TITLE
support Asset and Op ExecutionContexts in standard execution path

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -75,8 +75,8 @@ class ExecutionProperties(
         ],
     )
 ):
-    """Information to be used by dagster internals during execution. Contains:
-    * A description of the step.
+    """Information to be used by dagster internals during execution.
+    You should not need to access these attributes directly.
     """
 
     def __new__(cls, step_description: str, op_execution_context: "OpExecutionContext"):

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1477,7 +1477,7 @@ class AssetExecutionContext(OpExecutionContext):
     def execution_properties(self) -> ExecutionProperties:
         if self._execution_props is None:
             self._execution_props = ExecutionProperties(
-                step_description=f"asset {self.assets_def.node_def.name}",
+                step_description=f"asset {self.op_execution_context.node_handle}",
                 op_execution_context=self._op_execution_context,
             )
         return self._execution_props

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1452,7 +1452,10 @@ class AssetExecutionContext(OpExecutionContext):
             retry_number=self._op_execution_context.retry_number,
         )
 
-        self._execution_props = None
+        self._execution_props = ExecutionProperties(
+            step_description=f"asset {self.assets_def.node_def.name}",
+            op_execution_context=self._op_execution_context,
+        )
 
     @staticmethod
     def get() -> "AssetExecutionContext":
@@ -1471,12 +1474,6 @@ class AssetExecutionContext(OpExecutionContext):
 
     @property
     def execution_properties(self) -> ExecutionProperties:
-        if self._execution_props is None:
-            self._execution_props = ExecutionProperties(
-                step_description=f"asset {self.assets_def.node_def.name}",
-                op_execution_context=self._op_execution_context,
-            )
-
         return self._execution_props
 
     ######## Deprecated methods

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -91,17 +91,64 @@ class AbstractComputeMetaclass(ABCMeta):
 
 
 class AbstractComputeExecutionContext(ABC, metaclass=AbstractComputeMetaclass):
-    """Base class for op context implemented by OpExecutionContext, AssetExecutionContext,
+    """Base class for op context implemented by OpExecutionContext,
     and DagstermillExecutionContext.
     """
 
+    """Base class for op context implemented by OpExecutionContext and DagstermillExecutionContext."""
+
+    @abstractmethod
+    def has_tag(self, key: str) -> bool:
+        """Implement this method to check if a logging tag is set."""
+
+    @abstractmethod
+    def get_tag(self, key: str) -> Optional[str]:
+        """Implement this method to get a logging tag."""
+
+    @property
+    @abstractmethod
+    def run_id(self) -> str:
+        """The run id for the context."""
+
+    @property
+    @abstractmethod
+    def op_def(self) -> OpDefinition:
+        """The op definition corresponding to the execution step being executed."""
+
+    @property
+    @abstractmethod
+    def job_def(self) -> JobDefinition:
+        """The job being executed."""
+
+    @property
+    @abstractmethod
+    def run(self) -> DagsterRun:
+        """The DagsterRun object corresponding to the execution."""
+
+    @property
+    @abstractmethod
+    def resources(self) -> Any:
+        """Resources available in the execution context."""
+
+    @property
+    @abstractmethod
+    def log(self) -> DagsterLogManager:
+        """The log manager available in the execution context."""
+
+    @property
+    @abstractmethod
+    def op_config(self) -> Any:
+        """The parsed config specific to this op."""
+
+
+class HasExecutionInfo(ABC):
     @property
     @abstractmethod
     def execution_info(self) -> ExecutionInfo:
         """Implement this method to check if a logging tag is set."""
 
 
-class OpExecutionContextMetaClass(AbstractComputeMetaclass):
+class OpExecutionContextMetaClass(AbstractComputeMetaclass, HasExecutionInfo):
     def __instancecheck__(cls, instance) -> bool:
         # This makes isinstance(context, OpExecutionContext) throw a deprecation warning when
         # context is an AssetExecutionContext. This metaclass can be deleted once AssetExecutionContext

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1452,10 +1452,9 @@ class AssetExecutionContext(OpExecutionContext):
             retry_number=self._op_execution_context.retry_number,
         )
 
-        self._execution_props = ExecutionProperties(
-            step_description=f"asset {self.assets_def.node_def.name}",
-            op_execution_context=self._op_execution_context,
-        )
+        # start execution_props as None since enter_execution_context builds an AssetExecutionContext
+        # for all steps (including ops) and ops will fail on self.assets_def call
+        self._execution_props = None
 
     @staticmethod
     def get() -> "AssetExecutionContext":
@@ -1474,6 +1473,11 @@ class AssetExecutionContext(OpExecutionContext):
 
     @property
     def execution_properties(self) -> ExecutionProperties:
+        if self._execution_props is None:
+            self._execution_props = ExecutionProperties(
+                step_description=f"asset {self.assets_def.node_def.name}",
+                op_execution_context=self._op_execution_context,
+            )
         return self._execution_props
 
     ######## Deprecated methods

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -71,6 +71,7 @@ class ExecutionProperties(
         "_ExecutionProperties",
         [
             ("step_description", PublicAttr[str]),
+            ("node_type", PublicAttr[str]),
             ("op_execution_context", PublicAttr["OpExecutionContext"]),
         ],
     )
@@ -79,9 +80,14 @@ class ExecutionProperties(
     You should not need to access these attributes directly.
     """
 
-    def __new__(cls, step_description: str, op_execution_context: "OpExecutionContext"):
+    def __new__(
+        cls, step_description: str, node_type: str, op_execution_context: "OpExecutionContext"
+    ):
         return super(ExecutionProperties, cls).__new__(
-            cls, step_description=step_description, op_execution_context=op_execution_context
+            cls,
+            step_description=step_description,
+            node_type=node_type,
+            op_execution_context=op_execution_context,
         )
 
 
@@ -1478,6 +1484,7 @@ class AssetExecutionContext(OpExecutionContext):
         if self._execution_props is None:
             self._execution_props = ExecutionProperties(
                 step_description=f"asset {self.op_execution_context.node_handle}",
+                node_type="asset",
                 op_execution_context=self._op_execution_context,
             )
         return self._execution_props

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -141,7 +141,7 @@ class AbstractComputeExecutionContext(ABC, metaclass=AbstractComputeMetaclass):
         """The parsed config specific to this op."""
 
 
-class HasExecutionProperties(ABC):
+class ContextHasExecutionProperties(ABC):
     @property
     @abstractmethod
     def execution_properties(self) -> ExecutionProperties:
@@ -167,7 +167,9 @@ class OpExecutionContextMetaClass(AbstractComputeMetaclass):
 
 
 class OpExecutionContext(
-    AbstractComputeExecutionContext, HasExecutionProperties, metaclass=OpExecutionContextMetaClass
+    AbstractComputeExecutionContext,
+    ContextHasExecutionProperties,
+    metaclass=OpExecutionContextMetaClass,
 ):
     """The ``context`` object that can be made available as the first argument to the function
     used for computing an op or asset.
@@ -587,7 +589,7 @@ class OpExecutionContext(
         return self._step_execution_context.previous_attempt_count
 
     def describe_op(self) -> str:
-        return self.execution_info.step_description
+        return self.execution_properties.step_description
 
     @public
     def get_mapping_key(self) -> Optional[str]:

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -128,10 +128,6 @@ class AbstractComputeMetaclass(ABCMeta):
 
 
 class AbstractComputeExecutionContext(ABC, metaclass=AbstractComputeMetaclass):
-    """Base class for op context implemented by OpExecutionContext,
-    and DagstermillExecutionContext.
-    """
-
     """Base class for op context implemented by OpExecutionContext and DagstermillExecutionContext."""
 
     @abstractmethod
@@ -532,8 +528,6 @@ class OpExecutionContext(
 
         If consume_events has not yet been called, this will yield all logged events since the beginning of the op's computation. If consume_events has been called, it will yield all events since the last time consume_events was called. Designed for internal use. Users should never need to invoke this method.
         """
-        # events = self.execution_properties.events
-        # self._events = []
         yield from self.execution_properties.consume_events()
 
     @public

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -404,9 +404,8 @@ class RunlessOpExecutionContext(OpExecutionContext):
             op_config=op_config,
             step_description=step_description,
         )
-
         self._execution_props = ExecutionProperties(
-            step_description=f'op "{op_def.name}"', op_execution_context=self
+            step_description=f'op "{op_def.name}"', node_type="op", op_execution_context=self
         )
         return self
 

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -404,8 +404,9 @@ class RunlessOpExecutionContext(OpExecutionContext):
             op_config=op_config,
             step_description=step_description,
         )
+
         self._execution_props = ExecutionProperties(
-            step_description=f"op {alias}", op_execution_context=self
+            step_description=f'op "{op_def.name}"', op_execution_context=self
         )
         return self
 

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -56,7 +56,7 @@ from dagster._utils.forked_pdb import ForkedPdb
 from dagster._utils.merger import merge_dicts
 from dagster._utils.warnings import deprecation_warning
 
-from .compute import ExecutionInfo, OpExecutionContext
+from .compute import ExecutionProperties, OpExecutionContext
 from .system import StepExecutionContext, TypeCheckContext
 
 
@@ -294,6 +294,8 @@ class RunlessOpExecutionContext(OpExecutionContext):
         # my_op(ctx) # ctx._execution_properties is cleared at the beginning of the next invocation
         self._execution_properties = RunlessExecutionProperties()
 
+        self._execution_props = None
+
     def __enter__(self):
         self._cm_scope_entered = True
         return self
@@ -402,14 +404,14 @@ class RunlessOpExecutionContext(OpExecutionContext):
             op_config=op_config,
             step_description=step_description,
         )
-        self._execution_info = ExecutionInfo(
+        self._execution_props = ExecutionProperties(
             step_description=f"op {alias}", op_execution_context=self
         )
         return self
 
     def unbind(self):
         self._bound_properties = None
-        self._execution_info = None
+        self._execution_props = None
 
     @property
     def is_bound(self) -> bool:

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -56,7 +56,7 @@ from dagster._utils.forked_pdb import ForkedPdb
 from dagster._utils.merger import merge_dicts
 from dagster._utils.warnings import deprecation_warning
 
-from .compute import OpExecutionContext
+from .compute import ExecutionInfo, OpExecutionContext
 from .system import StepExecutionContext, TypeCheckContext
 
 
@@ -402,11 +402,14 @@ class RunlessOpExecutionContext(OpExecutionContext):
             op_config=op_config,
             step_description=step_description,
         )
-
+        self._execution_info = ExecutionInfo(
+            step_description=f"op {alias}", op_execution_context=self
+        )
         return self
 
     def unbind(self):
         self._bound_properties = None
+        self._execution_info = None
 
     @property
     def is_bound(self) -> bool:

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -56,7 +56,7 @@ from dagster._utils.forked_pdb import ForkedPdb
 from dagster._utils.merger import merge_dicts
 from dagster._utils.warnings import deprecation_warning
 
-from .compute import ExecutionProperties, OpExecutionContext
+from .compute import OpExecutionContext
 from .system import StepExecutionContext, TypeCheckContext
 
 
@@ -294,8 +294,6 @@ class RunlessOpExecutionContext(OpExecutionContext):
         # my_op(ctx) # ctx._execution_properties is cleared at the beginning of the next invocation
         self._execution_properties = RunlessExecutionProperties()
 
-        self._execution_props = None
-
     def __enter__(self):
         self._cm_scope_entered = True
         return self
@@ -404,14 +402,11 @@ class RunlessOpExecutionContext(OpExecutionContext):
             op_config=op_config,
             step_description=step_description,
         )
-        self._execution_props = ExecutionProperties(
-            step_description=f'op "{op_def.name}"', node_type="op", op_execution_context=self
-        )
+
         return self
 
     def unbind(self):
         self._bound_properties = None
-        self._execution_props = None
 
     @property
     def is_bound(self) -> bool:

--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -193,7 +193,7 @@ def _yield_compute_results(
         yield _validate_event(event, step_context)
 
     if compute_context.execution_properties.op_execution_context.has_events():
-        yield from compute_context.consume_events()
+        yield from compute_context.execution_properties.op_execution_context.consume_events()
 
 
 def execute_core_compute(

--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -188,12 +188,12 @@ def _yield_compute_results(
         ),
         user_event_generator,
     ):
-        if compute_context.execution_properties.op_execution_context.has_events():
-            yield from compute_context.execution_properties.op_execution_context.consume_events()
+        if compute_context.execution_properties.has_events():
+            yield from compute_context.execution_properties.consume_events()
         yield _validate_event(event, step_context)
 
-    if compute_context.execution_properties.op_execution_context.has_events():
-        yield from compute_context.execution_properties.op_execution_context.consume_events()
+    if compute_context.execution_properties.has_events():
+        yield from compute_context.execution_properties.consume_events()
 
 
 def execute_core_compute(

--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -176,12 +176,12 @@ def _yield_compute_results(
     if inspect.isasyncgen(user_event_generator):
         user_event_generator = gen_from_async_gen(user_event_generator)
 
-    op_label = step_context.describe_op()
+    step_label = compute_context.execution_info.step_description
 
     for event in iterate_with_context(
         lambda: op_execution_error_boundary(
             DagsterExecutionStepExecutionError,
-            msg_fn=lambda: f"Error occurred while executing {op_label}:",
+            msg_fn=lambda: f"Error occurred while executing {step_label}:",
             step_context=step_context,
             step_key=step_context.step.key,
             op_def_name=step_context.op_def.name,
@@ -189,11 +189,11 @@ def _yield_compute_results(
         ),
         user_event_generator,
     ):
-        if compute_context.has_events():
-            yield from compute_context.consume_events()
+        if compute_context.execution_info.op_execution_context.has_events():
+            yield from compute_context.execution_info.op_execution_context.consume_events()
         yield _validate_event(event, step_context)
 
-    if compute_context.has_events():
+    if compute_context.execution_info.op_execution_context.has_events():
         yield from compute_context.consume_events()
 
 

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -120,10 +120,12 @@ def invoke_compute_fn(
     if config_arg_cls:
         # config_arg_cls is either a Config class or a primitive type
         if issubclass(config_arg_cls, Config):
-            to_pass = config_arg_cls._get_non_default_public_field_values_cls(context.op_config)  # noqa: SLF001
+            to_pass = config_arg_cls._get_non_default_public_field_values_cls(  # noqa: SLF001
+                context.execution_properties.op_config
+            )
             args_to_pass["config"] = config_arg_cls(**to_pass)
         else:
-            args_to_pass["config"] = context.op_config
+            args_to_pass["config"] = context.execution_properties.op_config
     if resource_args:
         for resource_name, arg_name in resource_args.items():
             args_to_pass[arg_name] = context.resources.original_resource_dict[resource_name]

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -36,7 +36,10 @@ from dagster._core.types.dagster_type import DagsterTypeKind, is_generic_output_
 from dagster._utils import is_named_tuple_instance
 from dagster._utils.warnings import disable_dagster_warnings
 
-from ..context.compute import AssetExecutionContext, OpExecutionContext
+from ..context.compute import (
+    ContextHasExecutionProperties,
+    OpExecutionContext,
+)
 
 
 def create_op_compute_wrapper(
@@ -137,7 +140,7 @@ def _coerce_op_compute_fn_to_iterator(
 
 def _zip_and_iterate_op_result(
     result: Any,
-    context: Union[OpExecutionContext, AssetExecutionContext],
+    context: ContextHasExecutionProperties,
     output_defs: Sequence[OutputDefinition],
 ) -> Iterator[Tuple[int, Any, OutputDefinition]]:
     # Filtering the expected output defs here is an unfortunate temporary solution to deal with the
@@ -166,7 +169,7 @@ def _zip_and_iterate_op_result(
 # MaterializeResult.
 def _filter_expected_output_defs(
     result: Any,
-    context: Union[OpExecutionContext, AssetExecutionContext],
+    context: ContextHasExecutionProperties,
     output_defs: Sequence[OutputDefinition],
 ) -> Sequence[OutputDefinition]:
     result_tuple = (
@@ -184,7 +187,7 @@ def _filter_expected_output_defs(
 
 
 def _validate_multi_return(
-    context: Union[OpExecutionContext, AssetExecutionContext],
+    context: ContextHasExecutionProperties,
     result: Any,
     output_defs: Sequence[OutputDefinition],
 ) -> Any:
@@ -200,7 +203,7 @@ def _validate_multi_return(
     # When returning from an op with multiple outputs, the returned object must be a tuple of the same length as the number of outputs. At the time of the op's construction, we verify that a provided annotation is a tuple with the same length as the number of outputs, so if the result matches the number of output defs on the op, it will transitively also match the annotation.
     if not isinstance(result, tuple):
         raise DagsterInvariantViolationError(
-            f"{context.execution_info.step_description} has multiple outputs, but only one "
+            f"{context.execution_properties.step_description} has multiple outputs, but only one "
             f"output was returned of type {type(result)}. When using "
             "multiple outputs, either yield each output, or return a tuple "
             "containing a value for each output. Check out the "
@@ -211,9 +214,9 @@ def _validate_multi_return(
     if not len(output_tuple) == len(output_defs):
         raise DagsterInvariantViolationError(
             "Length mismatch between returned tuple of outputs and number of "
-            f"output defs on {context.execution_info.step_description}. Output tuple has "
+            f"output defs on {context.execution_properties.step_description}. Output tuple has "
             f"{len(output_tuple)} outputs, while "
-            f"{context.execution_info.step_description} has {len(output_defs)} outputs."
+            f"{context.execution_properties.step_description} has {len(output_defs)} outputs."
         )
     return result
 
@@ -247,7 +250,7 @@ def _check_output_object_name(
 
 def validate_and_coerce_op_result_to_iterator(
     result: Any,
-    context: Union[AssetExecutionContext, OpExecutionContext],
+    context: ContextHasExecutionProperties,
     output_defs: Sequence[OutputDefinition],
 ) -> Iterator[Any]:
     if inspect.isgenerator(result):
@@ -256,7 +259,7 @@ def validate_and_coerce_op_result_to_iterator(
             yield event
     elif isinstance(result, (AssetMaterialization, ExpectationResult)):
         raise DagsterInvariantViolationError(
-            f"Error in {context.execution_info.step_description}: If you are "
+            f"Error in {context.execution_properties.step_description}: If you are "
             "returning an AssetMaterialization "
             "or an ExpectationResult from "
             "an op you must yield them "
@@ -269,8 +272,8 @@ def validate_and_coerce_op_result_to_iterator(
         yield result
     elif result is not None and not output_defs:
         raise DagsterInvariantViolationError(
-            f"Error in {context.execution_info.step_description}: Unexpectedly returned output of type"
-            f" {type(result)}. {context.execution_info.step_description} is explicitly defined to"
+            f"Error in {context.execution_properties.step_description}: Unexpectedly returned output of type"
+            f" {type(result)}. {context.execution_properties.step_description} is explicitly defined to"
             " return no results."
         )
     # `requires_typed_event_stream` is a mode where we require users to return/yield exactly the
@@ -295,7 +298,7 @@ def validate_and_coerce_op_result_to_iterator(
             if output_def.is_dynamic:
                 if not isinstance(element, list):
                     raise DagsterInvariantViolationError(
-                        f"Error with output for {context.execution_info.step_description}: "
+                        f"Error with output for {context.execution_properties.step_description}: "
                         f"dynamic output '{output_def.name}' expected a list of "
                         "DynamicOutput objects, but instead received instead an "
                         f"object of type {type(element)}."
@@ -303,7 +306,7 @@ def validate_and_coerce_op_result_to_iterator(
                 for item in element:
                     if not isinstance(item, DynamicOutput):
                         raise DagsterInvariantViolationError(
-                            f"Error with output for {context.execution_info.step_description}: "
+                            f"Error with output for {context.execution_properties.step_description}: "
                             f"dynamic output '{output_def.name}' at position {position} expected a "
                             "list of DynamicOutput objects, but received an "
                             f"item with type {type(item)}."
@@ -325,7 +328,7 @@ def validate_and_coerce_op_result_to_iterator(
                     annotation
                 ):
                     raise DagsterInvariantViolationError(
-                        f"Error with output for {context.execution_info.step_description}: received Output object for"
+                        f"Error with output for {context.execution_properties.step_description}: received Output object for"
                         f" output '{output_def.name}' which does not have an Output annotation."
                         f" Annotation has type {annotation}."
                     )
@@ -343,7 +346,7 @@ def validate_and_coerce_op_result_to_iterator(
                 # output object was not received, throw an error.
                 if is_generic_output_annotation(annotation):
                     raise DagsterInvariantViolationError(
-                        f"Error with output for {context.execution_info.step_description}: output "
+                        f"Error with output for {context.execution_properties.step_description}: output "
                         f"'{output_def.name}' has generic output annotation, "
                         "but did not receive an Output object for this output. "
                         f"Received instead an object of type {type(element)}."
@@ -351,7 +354,7 @@ def validate_and_coerce_op_result_to_iterator(
                 if result is None and output_def.is_required is False:
                     context.log.warning(
                         'Value "None" returned for non-required output '
-                        f'"{output_def.name}" of {context.execution_info.step_description}. '
+                        f'"{output_def.name}" of {context.execution_properties.step_description}. '
                         "This value will be passed to downstream "
                         f"{context.op_def.node_type_str}s. For conditional "
                         "execution, results must be yielded: "

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -114,6 +114,8 @@ def invoke_compute_fn(
     config_arg_cls: Optional[Type[Config]],
     resource_args: Optional[Dict[str, str]] = None,
 ) -> Any:
+    # TODO - this is a possible execution pathway for both direct invocation and normal execution. Need to figure
+    # out the implications for the context
     args_to_pass = {**kwargs}
     if config_arg_cls:
         # config_arg_cls is either a Config class or a primitive type

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -18,7 +18,6 @@ from typing import (
 
 from typing_extensions import get_args
 
-from dagster import AssetExecutionContext
 from dagster._config.pythonic_config import Config
 from dagster._core.definitions import (
     AssetCheckResult,
@@ -37,7 +36,7 @@ from dagster._core.types.dagster_type import DagsterTypeKind, is_generic_output_
 from dagster._utils import is_named_tuple_instance
 from dagster._utils.warnings import disable_dagster_warnings
 
-from ..context.compute import OpExecutionContext
+from ..context.compute import AssetExecutionContext, OpExecutionContext
 
 
 def create_op_compute_wrapper(

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_execution_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_execution_context.py
@@ -98,6 +98,8 @@ def test_deprecation_warnings():
         "is_subset",
         "partition_keys",
         "get",
+        "execution_info",
+        "_execution_info",
     ]
 
     other_ignores = [

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_execution_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_execution_context.py
@@ -98,8 +98,8 @@ def test_deprecation_warnings():
         "is_subset",
         "partition_keys",
         "get",
-        "execution_info",
-        "_execution_info",
+        "execution_properties",
+        "_execution_props",
     ]
 
     other_ignores = [


### PR DESCRIPTION
## Summary & Motivation
This PR is not strictly required to merge https://github.com/dagster-io/dagster/pull/17339. However, as we deprecate more methods, we will begin to deprecate context methods that are called in the main execution pathway. 

This PR proposes adding a subobject to both AssetExecutionContext and OpExecutionContext that contains all methods/properties that need to be accessed in the execution code path. 
 

## How I Tested These Changes
