### PR TITLE
[ui] Use dark gray instead of random bg color for OpTags

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graph/OpTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/OpTags.tsx
@@ -379,15 +379,6 @@ export const KNOWN_TAGS = {
   expand: {color: '#D7A540', content: 'Expand'},
 };
 
-function generateColorForLabel(label = '') {
-  return `hsl(${
-    label
-      .split('')
-      .map((c) => c.charCodeAt(0))
-      .reduce((n, a) => n + a, 0) % 360
-  }, 75%, 45%)`;
-}
-
 // google-sheets to googlesheets, Duckdb to duckdb
 function coerceToStandardLabel(label: string) {
   return label.replace(/[ _-]/g, '').toLowerCase();
@@ -427,7 +418,7 @@ export const OpTags = React.memo(({tags, style, reduceColor, reduceText}: OpTags
       {tags.map((tag) => {
         const known = KNOWN_TAGS[coerceToStandardLabel(tag.label) as keyof typeof KNOWN_TAGS];
         const text = known?.content || tag.label;
-        const color = known?.color || generateColorForLabel(tag.label);
+        const color = known?.color || Colors.Gray600;
         const textcolor = known && 'reversed' in known ? Colors.Gray900 : Colors.White;
         return (
           <Box


### PR DESCRIPTION
## Summary & Motivation

Resolves #17570

Instead of generating a random (potentially eyesore) color to serve as the background for unknown op tag types, just render dark gray.

Before:

<img width="579" alt="Screenshot 2023-11-13 at 3 40 08 PM" src="https://github.com/dagster-io/dagster/assets/2823852/f2b13c35-db35-4095-8d19-1ed0e66c3292">

After:

<img width="580" alt="Screenshot 2023-11-13 at 3 12 46 PM" src="https://github.com/dagster-io/dagster/assets/2823852/94978110-f80f-4a4f-822d-92034041507f">


## How I Tested These Changes

Storybook
