### PR TITLE
prefix asset check specs on asset defs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -980,6 +980,8 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         ] = None,
         backfill_policy: Optional[BackfillPolicy] = None,
         is_subset: bool = False,
+        check_specs_by_output_name: Optional[Mapping[str, AssetCheckSpec]] = None,
+        selected_asset_check_keys: Optional[AbstractSet[AssetCheckKey]] = None,
     ) -> "AssetsDefinition":
         output_asset_key_replacements = check.opt_mapping_param(
             output_asset_key_replacements,
@@ -1125,6 +1127,12 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             backfill_policy=backfill_policy if backfill_policy else self.backfill_policy,
             descriptions_by_key=replaced_descriptions_by_key,
             is_subset=is_subset,
+            check_specs_by_output_name=check_specs_by_output_name
+            if check_specs_by_output_name
+            else self.check_specs_by_output_name,
+            selected_asset_check_keys=selected_asset_check_keys
+            if selected_asset_check_keys
+            else self._selected_asset_check_keys,
         )
 
         return self.__class__(**merge_dicts(self.get_attributes_dict(), replaced_attributes))

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -360,7 +360,7 @@ def prefix_assets(
     source_assets: Sequence[SourceAsset],
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix],
 ) -> Tuple[Sequence[AssetsDefinition], Sequence[SourceAsset]]:
-    """Given a list of assets, prefix the input and output asset keys with key_prefix.
+    """Given a list of assets, prefix the input and output asset keys and check specs with key_prefix.
     The prefix is not added to source assets.
 
     Input asset keys that reference other assets within assets_defs are "brought along" -
@@ -417,11 +417,21 @@ def prefix_assets(
                 input_asset_key_replacements[dep_asset_key] = AssetKey(
                     [*source_key_prefix, *dep_asset_key.path]
                 )
+        check_specs_by_output_name = {
+            output_name: check_spec.with_asset_key_prefix(key_prefix)
+            for output_name, check_spec in assets_def.check_specs_by_output_name.items()
+        }
+
+        selected_asset_check_keys = {
+            key.with_asset_key_prefix(key_prefix) for key in assets_def.check_keys
+        }
 
         result_assets.append(
             assets_def.with_attributes(
                 output_asset_key_replacements=output_asset_key_replacements,
                 input_asset_key_replacements=input_asset_key_replacements,
+                check_specs_by_output_name=check_specs_by_output_name,
+                selected_asset_check_keys=selected_asset_check_keys,
             )
         )
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules_with_checks.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules_with_checks.py
@@ -1,0 +1,52 @@
+from dagster import (
+    AssetCheckResult,
+    AssetCheckSpec,
+    AssetExecutionContext,
+    AssetKey,
+    Output,
+    asset,
+    load_assets_from_current_module,
+    materialize,
+)
+
+
+@asset(check_specs=[AssetCheckSpec(name="my_check", asset="my_asset")])
+def my_asset(context: AssetExecutionContext):
+    yield Output("foo")
+    yield AssetCheckResult(passed=True)
+
+
+def test_load():
+    assets = load_assets_from_current_module()
+
+    assert len(assets) == 1
+    assert assets[0].key == AssetKey(["my_asset"])
+    assert len(assets[0].check_specs) == 1
+    assert next(iter(assets[0].check_specs)).asset_key == AssetKey(["my_asset"])
+
+
+def test_materialize():
+    result = materialize(load_assets_from_current_module())
+
+    assert len(result.get_asset_materialization_events()) == 1
+    assert result.get_asset_materialization_events()[0].asset_key == AssetKey(["my_asset"])
+    assert len(result.get_asset_check_evaluations()) == 1
+    assert result.get_asset_check_evaluations()[0].asset_key == AssetKey(["my_asset"])
+
+
+def test_prefix_load():
+    assets = load_assets_from_current_module(key_prefix="foo")
+
+    assert len(assets) == 1
+    assert assets[0].key == AssetKey(["foo", "my_asset"])
+    assert len(assets[0].check_specs) == 1
+    assert next(iter(assets[0].check_specs)).asset_key == AssetKey(["foo", "my_asset"])
+
+
+def test_prefix_materialize():
+    result = materialize(load_assets_from_current_module(key_prefix="foo"))
+
+    assert len(result.get_asset_materialization_events()) == 1
+    assert result.get_asset_materialization_events()[0].asset_key == AssetKey(["foo", "my_asset"])
+    assert len(result.get_asset_check_evaluations()) == 1
+    assert result.get_asset_check_evaluations()[0].asset_key == AssetKey(["foo", "my_asset"])


### PR DESCRIPTION
closes https://github.com/dagster-io/dagster/issues/16233.

One caveat is that if you return `AssetCheckResult(asset_key=...)`, the key you pass in needs to be the prefixed key, or else you get `dagster._core.errors.DagsterInvariantViolationError: Received unexpected AssetCheckResult. It targets asset 'my_asset' which is not targeted by any of the checks currently being evaluated. Targeted assets: ['foo/my_asset'].`.

Maybe we could do some runtime mapping to resolve that?