### PR TITLE
Re-render AssetKeysDialog content on open to force MiddleTruncate to re-measure

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AssetKeysDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AssetKeysDialog.tsx
@@ -22,7 +22,7 @@ export const AssetKeysDialog = (props: Props) => {
     <Dialog
       isOpen={isOpen}
       onClose={() => setIsOpen(false)}
-      style={{width: '750px', maxWidth: '80vw', minWidth: '500px'}}
+      style={{width: '750px', maxWidth: '80vw', minWidth: '500px', transform: 'scale(1)'}}
       canOutsideClickClose
       canEscapeKeyClose
     >


### PR DESCRIPTION
## Summary & Motivation

blueprint dialogs have a weird transition on `transform: scale`  that doesn't seem to trigger our resize observer causing asset names to be too truncated. To compensate I force re-render the contents of the dialog after its fully opened (when the transition is done). I also had a version where we do a fancy setInterval and compare frames but it wasn't very reliable and didn't want to do too many fancy things.

## How I Tested These Changes
locally