### PR TITLE
feat(instigator-backlink): add tick id as GraphQL field for ticks

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2456,6 +2456,7 @@ union InstigationStatesOrError = InstigationStates | PythonError
 
 type InstigationTick {
   id: ID!
+  tickId: ID!
   status: InstigationTickStatus!
   timestamp: Float!
   runIds: [String!]!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -1615,6 +1615,7 @@ export type InstigationTick = {
   runs: Array<Run>;
   skipReason: Maybe<Scalars['String']>;
   status: InstigationTickStatus;
+  tickId: Scalars['ID'];
   timestamp: Scalars['Float'];
 };
 
@@ -7557,6 +7558,10 @@ export const buildInstigationTick = (
       overrides && overrides.hasOwnProperty('status')
         ? overrides.status!
         : InstigationTickStatus.FAILURE,
+    tickId:
+      overrides && overrides.hasOwnProperty('tickId')
+        ? overrides.tickId!
+        : '664bf548-9cd0-4a28-8f90-61c0e5d4d811',
     timestamp: overrides && overrides.hasOwnProperty('timestamp') ? overrides.timestamp! : 6.06,
   };
 };

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_ticks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_ticks.py
@@ -63,12 +63,8 @@ def get_instigation_ticks(
             )
         else:
             raise Exception(f"Unexpected instigator type {instigator_type}")
-
-        return [GrapheneInstigationTick(graphene_info, tick) for tick in ticks]
-
-    return [
-        GrapheneInstigationTick(graphene_info, tick)
-        for tick in graphene_info.context.instance.get_ticks(
+    else:
+        ticks = graphene_info.context.instance.get_ticks(
             instigator_origin_id,
             selector_id,
             before=before,
@@ -76,4 +72,5 @@ def get_instigation_ticks(
             limit=limit,
             statuses=statuses,
         )
-    ]
+
+    return [GrapheneInstigationTick(tick) for tick in ticks]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -234,6 +234,7 @@ class GrapheneRequestedMaterializationsForAsset(graphene.ObjectType):
 
 class GrapheneInstigationTick(graphene.ObjectType):
     id = graphene.NonNull(graphene.ID)
+    tickId = graphene.NonNull(graphene.ID)
     status = graphene.NonNull(GrapheneInstigationTickStatus)
     timestamp = graphene.NonNull(graphene.Float)
     runIds = non_null_list(graphene.String)
@@ -256,7 +257,7 @@ class GrapheneInstigationTick(graphene.ObjectType):
     class Meta:
         name = "InstigationTick"
 
-    def __init__(self, _, tick):
+    def __init__(self, tick: InstigatorTick):
         self._tick = check.inst_param(tick, "tick", InstigatorTick)
 
         super().__init__(
@@ -276,6 +277,9 @@ class GrapheneInstigationTick(graphene.ObjectType):
 
     def resolve_id(self, _):
         return "%s:%s" % (self._tick.instigator_origin_id, self._tick.timestamp)
+
+    def resolve_tickId(self, _: ResolveInfo) -> str:
+        return str(self._tick.tick_id)
 
     def resolve_runs(self, graphene_info: ResolveInfo):
         from .pipelines.pipeline import GrapheneRun
@@ -664,7 +668,7 @@ class GrapheneInstigationState(graphene.ObjectType):
             after=timestamp - 1,
             limit=1,
         )
-        return GrapheneInstigationTick(graphene_info, matches[0]) if matches else None
+        return GrapheneInstigationTick(matches[0]) if matches else None
 
     def resolve_ticks(
         self,


### PR DESCRIPTION
## Summary & Motivation
The current GraphQL id is not the tick id. Instead, it is a concatenation of tick attributes, used as a cursor object.

This should change in the future because this is confusing. In the meanwhile, we'll keep the status quo, and expose the actual tick id in a separate `tickId` field.

Next, we'll thread this id through the instigated runs as a tag.

## How I Tested These Changes
See what breaks in bk, fix
