### PR TITLE
[config] correct BaseModel inheritance ordering

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/io_manager.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/io_manager.py
@@ -177,7 +177,7 @@ class ConfigurableIOManagerFactory(ConfigurableResourceFactory, Generic[TResValu
         """Returns a partially initialized copy of the IO manager, with remaining config fields
         set at runtime.
         """
-        return PartialIOManager(cls, data=kwargs)
+        return PartialIOManager(resource_cls=cls, data=kwargs)
 
     @cached_method
     def get_resource_definition(self) -> ConfigurableIOManagerFactoryResourceDefinition:
@@ -206,14 +206,10 @@ class ConfigurableIOManagerFactory(ConfigurableResourceFactory, Generic[TResValu
         return None
 
 
-class PartialIOManager(Generic[TResValue], PartialResource[TResValue]):
-    def __init__(
-        self,
-        resource_cls: Type[ConfigurableResourceFactory[TResValue]],
-        data: Dict[str, Any],
-    ):
-        PartialResource.__init__(self, resource_cls, data)
-
+class PartialIOManager(
+    PartialResource[TResValue],
+    Generic[TResValue],
+):
     @cached_method
     def get_resource_definition(self) -> ConfigurableIOManagerFactoryResourceDefinition:
         input_config_schema = None

--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -45,7 +45,11 @@ class LateBoundTypesForResourceTypeChecking:
 
     @staticmethod
     def get_partial_resource_type(base: Type) -> Type:
-        return LateBoundTypesForResourceTypeChecking._PartialResource[base]
+        # LateBoundTypesForResourceTypeChecking._PartialResource[base] would be the more
+        # correct thing to return, but to enable that deeper pydantic integration
+        # needs to be done on the PartialResource class
+        # https://github.com/dagster-io/dagster/issues/18017
+        return LateBoundTypesForResourceTypeChecking._PartialResource
 
     @staticmethod
     def set_actual_types_for_type_checking(

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
@@ -188,14 +188,22 @@ def test_annotate_with_resource_factory() -> None:
         def create_resource(self, context: None) -> str:
             return "hello"
 
+    # https://github.com/dagster-io/dagster/issues/18017
+    if USING_PYDANTIC_2:  # pydantic 2 causing issues with Generic
+        target = "an unknown"  # should be "a '<class 'str'>'"
+        ttype = "Any"  # should be "str"
+    else:
+        target = "a '<class 'str'>'"
+        ttype = "str"
+
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=(
             "Resource param 'my_string' is annotated as '<class"
             " 'test_errors.test_annotate_with_resource_factory.<locals>.MyStringFactory'>', but"
             " '<class 'test_errors.test_annotate_with_resource_factory.<locals>.MyStringFactory'>'"
-            " outputs a '<class 'str'>' value to user code such as @ops and @assets. This"
-            " annotation should instead be 'ResourceParam\\[str\\]'"
+            f" outputs {target} value to user code such as @ops and @assets. This"
+            f" annotation should instead be 'ResourceParam\\[{ttype}\\]'"
         ),
     ):
 
@@ -209,8 +217,8 @@ def test_annotate_with_resource_factory() -> None:
             "Resource param 'my_string' is annotated as '<class"
             " 'test_errors.test_annotate_with_resource_factory.<locals>.MyStringFactory'>', but"
             " '<class 'test_errors.test_annotate_with_resource_factory.<locals>.MyStringFactory'>'"
-            " outputs a '<class 'str'>' value to user code such as @ops and @assets. This"
-            " annotation should instead be 'ResourceParam\\[str\\]'"
+            f" outputs {target} value to user code such as @ops and @assets. This"
+            f" annotation should instead be 'ResourceParam\\[{ttype}\\]'"
         ),
     ):
 
@@ -260,6 +268,14 @@ def test_annotate_with_resource_factory_schedule_sensor() -> None:
         def create_resource(self, context: None) -> str:
             return "hello"
 
+    # https://github.com/dagster-io/dagster/issues/18017
+    if USING_PYDANTIC_2:  # pydantic 2 causing issues with Generic
+        target = "an unknown"  # should be "a '<class 'str'>'"
+        ttype = "Any"  # should be "str"
+    else:
+        target = "a '<class 'str'>'"
+        ttype = "str"
+
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=(
@@ -267,8 +283,8 @@ def test_annotate_with_resource_factory_schedule_sensor() -> None:
             " 'test_errors.test_annotate_with_resource_factory_schedule_sensor.<locals>.MyStringFactory'>',"
             " but '<class"
             " 'test_errors.test_annotate_with_resource_factory_schedule_sensor.<locals>.MyStringFactory'>'"
-            " outputs a '<class 'str'>' value to user code such as @ops and @assets. This"
-            " annotation should instead be 'ResourceParam\\[str\\]'"
+            f" outputs {target} value to user code such as @ops and @assets. This"
+            f" annotation should instead be 'ResourceParam\\[{ttype}\\]'"
         ),
     ):
 
@@ -283,8 +299,8 @@ def test_annotate_with_resource_factory_schedule_sensor() -> None:
             " 'test_errors.test_annotate_with_resource_factory_schedule_sensor.<locals>.MyStringFactory'>',"
             " but '<class"
             " 'test_errors.test_annotate_with_resource_factory_schedule_sensor.<locals>.MyStringFactory'>'"
-            " outputs a '<class 'str'>' value to user code such as @ops and @assets. This"
-            " annotation should instead be 'ResourceParam\\[str\\]'"
+            f" outputs {target} value to user code such as @ops and @assets. This"
+            f" annotation should instead be 'ResourceParam\\[{ttype}\\]'"
         ),
     ):
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
@@ -1082,3 +1082,26 @@ def test_telemetry_dagster_resource():
             return True
 
     assert MyResource(my_value="foo")._is_dagster_maintained()  # noqa: SLF001
+
+
+def test_partial_resource_checks() -> None:
+    class IntResource(ConfigurableResource):
+        my_int: int
+
+    class StrResource(ConfigurableResource):
+        my_str: str
+
+    class MergeResource(ConfigurableResource):
+        str_res: StrResource
+        int_res: IntResource
+
+    MergeResource(
+        str_res=StrResource.configure_at_launch(),
+        int_res=IntResource.configure_at_launch(),
+    )
+
+    # this should fail but does not https://github.com/dagster-io/dagster/issues/18017
+    MergeResource(
+        int_res=StrResource.configure_at_launch(),  # type: ignore # type checker catches it though
+        str_res=IntResource.configure_at_launch(),  # type: ignore
+    )


### PR DESCRIPTION
resolves https://github.com/dagster-io/dagster/issues/17999

correcting inheritance ordering revealed a failure in runtime validation of `PartialResource` that we preserve here https://github.com/dagster-io/dagster/issues/18017

## How I Tested These Changes
before
```
dagster --version
/Users/alangenfeld/dagster/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py:78: GenericBeforeBaseModelWarning: Classes should inherit from `BaseModel` before generic classes (e.g. `typing.Generic[T]`) for pydantic generics to work properly.
  return super().__new__(cls, name, bases, namespaces, **kwargs)
/Users/alangenfeld/dagster/python_modules/dagster/dagster/_config/pythonic_config/resource.py:748: GenericBeforeBaseModelWarning: Classes should inherit from `BaseModel` before generic classes (e.g. `typing.Generic[T]`) for pydantic generics to work properly.
  class PartialResource(Generic[TResValue], AllowDelayedDependencies, MakeConfigCacheable):
/Users/alangenfeld/dagster/python_modules/dagster/dagster/_config/pythonic_config/io_manager.py:209: GenericBeforeBaseModelWarning: Classes should inherit from `BaseModel` before generic classes (e.g. `typing.Generic[T]`) for pydantic generics to work properly.
  class PartialIOManager(Generic[TResValue], PartialResource[TResValue]):
/Users/alangenfeld/dagster/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py:78: GenericBeforeBaseModelWarning: Classes should inherit from `BaseModel` before generic classes (e.g. `typing.Generic[T]`) for pydantic generics to work properly.
  return super().__new__(cls, name, bases, namespaces, **kwargs)
dagster, version 1!0+dev
```

after

```
dagster --version
dagster, version 1!0+dev
```

also checked `dagster dev` on the repo root (toys definitions) and see now more warning spam after the fix 