### PR TITLE
Create AllPartitionsSubset class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1212,7 +1212,6 @@ class DefaultPartitionsSubset(
 
 
 class AllPartitionsSubset(
-    PartitionsSubset,
     NamedTuple(
         "_AllPartitionsSubset",
         [
@@ -1220,6 +1219,7 @@ class AllPartitionsSubset(
             ("dynamic_partitions_store", Optional[DynamicPartitionsStore]),
         ],
     ),
+    PartitionsSubset,
 ):
     """This is an in-memory (i.e. not serializable) convenience class that represents all partitions
     of a given PartitionsDefinition, allowing set operations to be taken without having to load
@@ -1234,10 +1234,6 @@ class AllPartitionsSubset(
         return super().__new__(
             cls, partitions_def=partitions_def, dynamic_partitions_store=dynamic_partitions_store
         )
-
-    @property
-    def partitions_def(self) -> PartitionsDefinition:
-        return self._asdict()["partitions_def"]
 
     def get_partition_keys(self, current_time: Optional[datetime] = None) -> Iterable[str]:
         return self.partitions_def.get_partition_keys(current_time, self.dynamic_partitions_store)

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1209,3 +1209,117 @@ class DefaultPartitionsSubset(
         cls, partitions_def: Optional[PartitionsDefinition] = None
     ) -> "DefaultPartitionsSubset":
         return cls()
+
+
+class AllPartitionsSubset(
+    PartitionsSubset,
+    NamedTuple(
+        "_AllPartitionsSubset",
+        [
+            ("partitions_def", PartitionsDefinition),
+            ("dynamic_partitions_store", Optional[DynamicPartitionsStore]),
+        ],
+    ),
+):
+    """This is an in-memory (i.e. not serializable) convenience class that represents all partitions
+    of a given PartitionsDefinition, allowing set operations to be taken without having to load
+    all partition keys immediately.
+    """
+
+    def __new__(
+        cls,
+        partitions_def: PartitionsDefinition,
+        dynamic_partitions_store: Optional[DynamicPartitionsStore],
+    ):
+        return super().__new__(
+            cls, partitions_def=partitions_def, dynamic_partitions_store=dynamic_partitions_store
+        )
+
+    @property
+    def partitions_def(self) -> PartitionsDefinition:
+        return self._asdict()["partitions_def"]
+
+    def get_partition_keys(self, current_time: Optional[datetime] = None) -> Iterable[str]:
+        return self.partitions_def.get_partition_keys(current_time, self.dynamic_partitions_store)
+
+    def get_partition_keys_not_in_subset(
+        self,
+        partitions_def: PartitionsDefinition,
+        current_time: Optional[datetime] = None,
+        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+    ) -> Iterable[str]:
+        return set()
+
+    def get_partition_key_ranges(
+        self,
+        partitions_def: PartitionsDefinition,
+        current_time: Optional[datetime] = None,
+        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+    ) -> Sequence[PartitionKeyRange]:
+        first_key = partitions_def.get_first_partition_key(current_time, dynamic_partitions_store)
+        last_key = partitions_def.get_last_partition_key(current_time, dynamic_partitions_store)
+        if first_key and last_key:
+            return [PartitionKeyRange(first_key, last_key)]
+        return []
+
+    def with_partition_keys(self, partition_keys: Iterable[str]) -> "AllPartitionsSubset":
+        return self
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, AllPartitionsSubset) and other.partitions_def == self.partitions_def
+        )
+
+    def __and__(self, other: "PartitionsSubset") -> "PartitionsSubset":
+        return other
+
+    def __sub__(self, other: "PartitionsSubset") -> "PartitionsSubset":
+        if self == other:
+            return self.partitions_def.empty_subset()
+        return self.partitions_def.empty_subset().with_partition_keys(
+            set(self.get_partition_keys()).difference(set(other.get_partition_keys()))
+        )
+
+    def __or__(self, other: "PartitionsSubset") -> "PartitionsSubset":
+        return self
+
+    def __len__(self) -> int:
+        return len(
+            self.partitions_def.subset_with_all_partitions(
+                dynamic_partitions_store=self.dynamic_partitions_store
+            )
+        )
+
+    def __contains__(self, value) -> bool:
+        return self.partitions_def.has_partition_key(
+            partition_key=value,
+            current_time=None,
+            dynamic_partitions_store=self.dynamic_partitions_store,
+        )
+
+    def __repr__(self) -> str:
+        return f"AllPartitionsSubset(partitions_def={self.partitions_def})"
+
+    @classmethod
+    def can_deserialize(
+        cls,
+        partitions_def: PartitionsDefinition,
+        serialized: str,
+        serialized_partitions_def_unique_id: Optional[str],
+        serialized_partitions_def_class_name: Optional[str],
+    ) -> bool:
+        return False
+
+    def serialize(self) -> str:
+        raise NotImplementedError()
+
+    @classmethod
+    def from_serialized(
+        cls, partitions_def: PartitionsDefinition[T_str], serialized: str
+    ) -> "PartitionsSubset[T_str]":
+        raise NotImplementedError()
+
+    def empty_subset(
+        self, partitions_def: Optional[PartitionsDefinition] = None
+    ) -> "PartitionsSubset[T_str]":
+        check.failed("Cannot create an empty AllPartitionsSubset")

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1220,7 +1220,7 @@ class AllPartitionsSubset(
         "_AllPartitionsSubset",
         [
             ("partitions_def", PartitionsDefinition),
-            ("instance_queryer", Optional["CachingInstanceQueryer"]),
+            ("instance_queryer", "CachingInstanceQueryer"),
         ],
     ),
     PartitionsSubset,
@@ -1275,18 +1275,12 @@ class AllPartitionsSubset(
         return self
 
     def __len__(self) -> int:
-        return len(
-            self.get_partition_keys(
-                current_time=self.instance_queryer.evaluation_time
-                if self.instance_queryer
-                else None
-            )
-        )
+        return len(self.get_partition_keys(current_time=self.instance_queryer.evaluation_time))
 
     def __contains__(self, value) -> bool:
         return self.partitions_def.has_partition_key(
             partition_key=value,
-            current_time=self.instance_queryer.evaluation_time if self.instance_queryer else None,
+            current_time=self.instance_queryer.evaluation_time,
             dynamic_partitions_store=self.instance_queryer,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1231,7 +1231,10 @@ class AllPartitionsSubset(
     """
 
     def get_partition_keys(self, current_time: Optional[datetime] = None) -> Sequence[str]:
-        return self.partitions_def.get_partition_keys(current_time, self.instance_queryer)
+        check.param_invariant(current_time is None, "current_time")
+        return self.partitions_def.get_partition_keys(
+            self.instance_queryer.evaluation_time, self.instance_queryer
+        )
 
     def get_partition_keys_not_in_subset(
         self,
@@ -1247,8 +1250,14 @@ class AllPartitionsSubset(
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Sequence[PartitionKeyRange]:
-        first_key = partitions_def.get_first_partition_key(current_time, dynamic_partitions_store)
-        last_key = partitions_def.get_last_partition_key(current_time, dynamic_partitions_store)
+        check.param_invariant(current_time is None, "current_time")
+        check.param_invariant(dynamic_partitions_store is None, "dynamic_partitions_store")
+        first_key = partitions_def.get_first_partition_key(
+            self.instance_queryer.evaluation_time, self.instance_queryer
+        )
+        last_key = partitions_def.get_last_partition_key(
+            self.instance_queryer.evaluation_time, self.instance_queryer
+        )
         if first_key and last_key:
             return [PartitionKeyRange(first_key, last_key)]
         return []
@@ -1275,7 +1284,7 @@ class AllPartitionsSubset(
         return self
 
     def __len__(self) -> int:
-        return len(self.get_partition_keys(current_time=self.instance_queryer.evaluation_time))
+        return len(self.get_partition_keys())
 
     def __contains__(self, value) -> bool:
         return self.partitions_def.has_partition_key(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -152,11 +152,11 @@ def test_all_partitions_subset_static_partitions_def() -> None:
     assert set(all_subset.get_partition_keys()) == {"a", "b", "c", "d"}
     assert all_subset == AllPartitionsSubset(static_partitions_def, None)
 
-    abc_subset = DefaultPartitionsSubset(static_partitions_def, {"a", "b", "c"})
+    abc_subset = DefaultPartitionsSubset({"a", "b", "c"})
     assert all_subset & abc_subset == abc_subset
     assert all_subset | abc_subset == all_subset
-    assert all_subset - abc_subset == DefaultPartitionsSubset(static_partitions_def, {"d"})
-    assert abc_subset - all_subset == DefaultPartitionsSubset(static_partitions_def, set())
+    assert all_subset - abc_subset == DefaultPartitionsSubset({"d"})
+    assert abc_subset - all_subset == DefaultPartitionsSubset(set())
 
 
 def test_all_partitions_subset_time_window_partitions_def() -> None:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -147,12 +147,11 @@ def test_time_window_partitions_subset_num_partitions_serialization():
 
 
 def test_all_partitions_subset_static_partitions_def() -> None:
-    instance_queryer = Mock()
     static_partitions_def = StaticPartitionsDefinition(["a", "b", "c", "d"])
-    all_subset = AllPartitionsSubset(static_partitions_def, instance_queryer)
+    all_subset = AllPartitionsSubset(static_partitions_def, Mock(), pendulum.now("UTC"))
     assert len(all_subset) == 4
     assert set(all_subset.get_partition_keys()) == {"a", "b", "c", "d"}
-    assert all_subset == AllPartitionsSubset(static_partitions_def, instance_queryer)
+    assert all_subset == AllPartitionsSubset(static_partitions_def, Mock(), pendulum.now("UTC"))
 
     abc_subset = DefaultPartitionsSubset({"a", "b", "c"})
     assert all_subset & abc_subset == abc_subset
@@ -163,10 +162,8 @@ def test_all_partitions_subset_static_partitions_def() -> None:
 
 def test_all_partitions_subset_time_window_partitions_def() -> None:
     with pendulum.test(create_pendulum_time(2020, 1, 6, hour=10)):
-        instance_queryer = Mock()
-        instance_queryer.evaluation_time = pendulum.now("UTC")
         time_window_partitions_def = DailyPartitionsDefinition(start_date="2020-01-01")
-        all_subset = AllPartitionsSubset(time_window_partitions_def, instance_queryer)
+        all_subset = AllPartitionsSubset(time_window_partitions_def, Mock(), pendulum.now("UTC"))
         assert len(all_subset) == 5
         assert set(all_subset.get_partition_keys()) == {
             "2020-01-01",
@@ -175,7 +172,9 @@ def test_all_partitions_subset_time_window_partitions_def() -> None:
             "2020-01-04",
             "2020-01-05",
         }
-        assert all_subset == AllPartitionsSubset(time_window_partitions_def, instance_queryer)
+        assert all_subset == AllPartitionsSubset(
+            time_window_partitions_def, Mock(), pendulum.now("UTC")
+        )
 
         subset = PartitionKeysTimeWindowPartitionsSubset(
             time_window_partitions_def,


### PR DESCRIPTION
## Summary & Motivation

Create an AllPartitionsSubset class which we can take set operations (&, |, -) on without having to (in many cases) hydrate the full set of partition keys.

This is not serializable because:

a) there are too many edge cases in which "all partitions" of a partitions def at T0 is no longer the full set of partitions at T1 (e.g. time window partitions defs add new partitions)

b) we need a dynamic partitions store in order to actually hydrate the set of asset partitions in some of our operators, so that needs to live on the class

## How I Tested These Changes

unit tests