### PR TITLE
Bugfix for BaseTimeWindowPartitionsSubset._add_partitions_to_time_windows

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1575,6 +1575,8 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
             else:
                 if result_windows and window.start == result_windows[0].start:
                     result_windows[0] = TimeWindow(window.start, included_window.end)  # type: ignore
+                elif result_windows and window.end == result_windows[0].start:
+                    result_windows[0] = TimeWindow(window.start, included_window.end)  # type: ignore
                 else:
                     result_windows.insert(0, window)
 
@@ -1812,6 +1814,9 @@ class PartitionKeysTimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
             partitions_def=partitions_def,
             included_partition_keys=self._included_partition_keys,
         )
+
+    def __repr__(self) -> str:
+        return f"PartitionKeysTimeWindowPartitionsSubset({self.get_partition_key_ranges()})"
 
 
 class TimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1345,3 +1345,18 @@ def test_cannot_pickle_time_window_partitions_def():
 
     with pytest.raises(DagsterInvariantViolationError, match="not pickleable"):
         pickle.loads(pickle.dumps(partitions_def))
+
+
+def test_time_window_partitions_subset_add_partition_to_front():
+    partitions_def = DailyPartitionsDefinition("2023-01-01")
+    partition_keys_subset = PartitionKeysTimeWindowPartitionsSubset(partitions_def, {"2023-01-01"})
+    time_windows_subset = TimeWindowPartitionsSubset(
+        partitions_def,
+        num_partitions=1,
+        included_time_windows=[time_window("2023-01-02", "2023-01-03")],
+    )
+
+    combined = time_windows_subset | partition_keys_subset
+    assert combined == PartitionKeysTimeWindowPartitionsSubset(
+        partitions_def, {"2023-01-01", "2023-01-02"}
+    )


### PR DESCRIPTION
Was seeing a transient error occur in a test suite where a `TimeWindowPartitionsSubset` was being created with multiple time windows for a contiguous range, i.e. 
```python
TimeWindowPartitionsSubset(
    [
        PartitionKeyRange(start="2023-01-01", end="2023-01-01"),
        PartitionKeyRange(start="2023-01-02", end="2023-01-02"),
    ]
)
```

The source of this was a missing piece of logic in `BaseTimeWindowsPartitionsSubset._add_partitions_to_time_windows`, which this PR adds.