### PR TITLE
[time-window-partitions] Fix issue where no partition key mapped to certain hours during fall dst transition.

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -19,7 +19,6 @@ from typing import (
     cast,
 )
 
-import pendulum
 import toposort
 
 import dagster._check as check
@@ -754,7 +753,7 @@ class InternalAssetGraph(AssetGraph):
 
 def sort_key_for_asset_partition(
     asset_graph: AssetGraph, asset_partition: AssetKeyPartitionKey
-) -> int:
+) -> float:
     """Returns an integer sort key such that asset partitions are sorted in the order in which they
     should be materialized. For assets without a time window partition dimension, this is always 0.
     Assets with a time window partition dimension will be sorted from newest to oldest, unless they
@@ -767,9 +766,8 @@ def sort_key_for_asset_partition(
 
     # A sort key such that time window partitions are sorted from oldest to newest
     time_partition_key = get_time_partition_key(partitions_def, asset_partition.partition_key)
-    partition_timestamp = pendulum.instance(
-        datetime.strptime(time_partition_key, time_partitions_def.fmt),
-        tz=time_partitions_def.timezone,
+    partition_timestamp = time_partitions_def.start_time_for_partition_key(
+        time_partition_key
     ).timestamp()
 
     if asset_graph.has_self_dependency(asset_partition.asset_key):

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -209,8 +209,14 @@ class TimeWindowPartitionsDefinition(
         timezone (Optional[str]): The timezone in which each time should exist.
             Supported strings for timezones are the ones provided by the
             `IANA time zone database <https://www.iana.org/time-zones>` - e.g. "America/Los_Angeles".
+
         end (datetime): The last partition (excluding) in the set.
-        fmt (str): The date format to use for partition_keys.
+        fmt (str): The date format to use for partition_keys. Note that if a non-UTC timezone is
+            used, and the cron schedule repeats every hour or faster, the date format must include
+            a timezone offset to disambiguate between multiple instances of the same time before and
+            after the Fall DST transition. If the format does not contain this offset, the second
+            instance of the ambiguous time partition key will have the UTC offset automatically
+            appended to it.
         end_offset (int): Extends the partition set by a number of partitions equal to the value
             passed. If end_offset is 0 (the default), the last partition ends before the current
             time. If end_offset is 1, the second-to-last partition ends before the current time,

--- a/python_modules/dagster/dagster/_seven/compat/pendulum.py
+++ b/python_modules/dagster/dagster/_seven/compat/pendulum.py
@@ -43,8 +43,10 @@ def create_pendulum_time(year, month, day, *args, **kwargs):
             return pendulum.instance(datetime.datetime(year, month, day, *args, **kwargs))
         else:
             return pendulum.create(year, month, day, *args, **kwargs)
-
-    return pendulum.datetime(year, month, day, *args, **kwargs)
+    else:
+        if "tzinfo" in kwargs:
+            kwargs["tz"] = kwargs.pop("tzinfo")
+        return pendulum.datetime(year, month, day, *args, **kwargs)
 
 
 PendulumDateTime: TypeAlias = (

--- a/python_modules/dagster/dagster/_seven/compat/pendulum.py
+++ b/python_modules/dagster/dagster/_seven/compat/pendulum.py
@@ -22,31 +22,28 @@ def mock_pendulum_timezone(override_timezone):
 
 
 def create_pendulum_time(year, month, day, *args, **kwargs):
-    if not _IS_PENDULUM_2:
-        if "tz" in kwargs and "dst_rule" in kwargs:
-            tz = pendulum.timezone(kwargs.pop("tz"))
-            dst_rule = kwargs.pop("dst_rule")
+    if "tz" in kwargs and "dst_rule" in kwargs and not _IS_PENDULUM_2:
+        tz = pendulum.timezone(kwargs.pop("tz"))
+        dst_rule = kwargs.pop("dst_rule")
 
-            return pendulum.instance(
-                tz.convert(
-                    datetime.datetime(
-                        year,
-                        month,
-                        day,
-                        *args,
-                        **kwargs,
-                    ),
-                    dst_rule=dst_rule,
-                )
+        return pendulum.instance(
+            tz.convert(
+                datetime.datetime(
+                    year,
+                    month,
+                    day,
+                    *args,
+                    **kwargs,
+                ),
+                dst_rule=dst_rule,
             )
-        elif "tzinfo" in kwargs:
-            return pendulum.instance(datetime.datetime(year, month, day, *args, **kwargs))
-        else:
-            return pendulum.create(year, month, day, *args, **kwargs)
-    else:
-        if "tzinfo" in kwargs:
-            kwargs["tz"] = kwargs.pop("tzinfo")
-        return pendulum.datetime(year, month, day, *args, **kwargs)
+        )
+
+    return (
+        pendulum.datetime(year, month, day, *args, **kwargs)
+        if _IS_PENDULUM_2
+        else pendulum.create(year, month, day, *args, **kwargs)
+    )
 
 
 PendulumDateTime: TypeAlias = (

--- a/python_modules/dagster/dagster/_seven/compat/pendulum.py
+++ b/python_modules/dagster/dagster/_seven/compat/pendulum.py
@@ -22,28 +22,33 @@ def mock_pendulum_timezone(override_timezone):
 
 
 def create_pendulum_time(year, month, day, *args, **kwargs):
-    if "tz" in kwargs and "dst_rule" in kwargs and not _IS_PENDULUM_2:
-        tz = pendulum.timezone(kwargs.pop("tz"))
-        dst_rule = kwargs.pop("dst_rule")
+    if not _IS_PENDULUM_2:
+        if "tz" in kwargs and "dst_rule" in kwargs:
+            tz = pendulum.timezone(kwargs.pop("tz"))
+            dst_rule = kwargs.pop("dst_rule")
 
-        return pendulum.instance(
-            tz.convert(
-                datetime.datetime(
-                    year,
-                    month,
-                    day,
-                    *args,
-                    **kwargs,
-                ),
-                dst_rule=dst_rule,
+            return pendulum.instance(
+                tz.convert(
+                    datetime.datetime(
+                        year,
+                        month,
+                        day,
+                        *args,
+                        **kwargs,
+                    ),
+                    dst_rule=dst_rule,
+                )
             )
-        )
+        elif "tzinfo" in kwargs:
+            dt = datetime.datetime(year, month, day, *args, **kwargs)
+            print("d", dt.timestamp(), dt.tzinfo)
+            ret = pendulum.instance(datetime.datetime(year, month, day, *args, **kwargs))
+            print("r", ret.timestamp(), ret.tzinfo)
+            return ret
+        else:
+            return pendulum.create(year, month, day, *args, **kwargs)
 
-    return (
-        pendulum.datetime(year, month, day, *args, **kwargs)
-        if _IS_PENDULUM_2
-        else pendulum.create(year, month, day, *args, **kwargs)
-    )
+    return pendulum.datetime(year, month, day, *args, **kwargs)
 
 
 PendulumDateTime: TypeAlias = (

--- a/python_modules/dagster/dagster/_seven/compat/pendulum.py
+++ b/python_modules/dagster/dagster/_seven/compat/pendulum.py
@@ -40,11 +40,7 @@ def create_pendulum_time(year, month, day, *args, **kwargs):
                 )
             )
         elif "tzinfo" in kwargs:
-            dt = datetime.datetime(year, month, day, *args, **kwargs)
-            print("d", dt.timestamp(), dt.tzinfo)
-            ret = pendulum.instance(datetime.datetime(year, month, day, *args, **kwargs))
-            print("r", ret.timestamp(), ret.tzinfo)
-            return ret
+            return pendulum.instance(datetime.datetime(year, month, day, *args, **kwargs))
         else:
             return pendulum.create(year, month, day, *args, **kwargs)
 

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -618,7 +618,7 @@ def _timezone_aware_cron_iter(
                 cron_iter=cron_iter,
                 next_date=next_date,
                 timezone_str=timezone_str,
-                repeats_every_hour=cron_string_repeats_every_hour(cron_string),
+                repeats_every_hour=repeats_every_hour,
                 ascending=ascending,
             )
 

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -77,6 +77,12 @@ def is_valid_cron_schedule(cron_schedule: Union[str, Sequence[str]]) -> bool:
     )
 
 
+def cron_string_repeats_every_hour(cron_string: str) -> bool:
+    """Returns if the given cron schedule repeats every hour."""
+    cron_parts, nth_weekday_of_month, *_ = CroniterShim.expand(cron_string)
+    return len(cron_parts[1]) == 1 and cron_parts[1][0] == "*"
+
+
 def _replace_date_fields(
     pendulum_date: PendulumDateTime,
     hour: int,
@@ -545,8 +551,7 @@ def _timezone_aware_cron_iter(
     # entirely and just move on to the next matching time (instead of returning
     # the end time of the non-existant interval), and when there are two times that match the cron
     # string, they return both instead of picking the latter time.
-    cron_parts, nth_weekday_of_month, *_ = CroniterShim.expand(cron_string)
-    repeats_every_hour = len(cron_parts[1]) == 1 and cron_parts[1][0] == "*"
+    repeats_every_hour = cron_string_repeats_every_hour(cron_string)
 
     # Chronological order of dates to return
     dates_to_consider = []
@@ -613,7 +618,7 @@ def _timezone_aware_cron_iter(
                 cron_iter=cron_iter,
                 next_date=next_date,
                 timezone_str=timezone_str,
-                repeats_every_hour=repeats_every_hour,
+                repeats_every_hour=cron_string_repeats_every_hour(cron_string),
                 ascending=ascending,
             )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1026,6 +1026,36 @@ def test_time_window_partitions_contains():
     assert "2015-01-11" not in subset
 
 
+def test_dst_transition_15_minute_partitions() -> None:
+    partitions_def = TimeWindowPartitionsDefinition(
+        cron_schedule="*/15 * * * *",
+        start="2020-11-01-00:30",
+        end="2020-11-01-2:30",
+        timezone="US/Pacific",
+        fmt="%Y-%m-%d-%H:%M",
+    )
+    subset = partitions_def.subset_with_all_partitions()
+    assert set(subset.get_partition_keys()) == {
+        "2020-11-01-00:30",
+        "2020-11-01-00:45",
+        "2020-11-01-01:00",
+        "2020-11-01-01:15",
+        "2020-11-01-01:30",
+        "2020-11-01-01:45",
+        "2020-11-01-01:00" + POST_DST_TRANSITION_SUFFIX,
+        "2020-11-01-01:15" + POST_DST_TRANSITION_SUFFIX,
+        "2020-11-01-01:30" + POST_DST_TRANSITION_SUFFIX,
+        "2020-11-01-01:45" + POST_DST_TRANSITION_SUFFIX,
+        "2020-11-01-02:00",
+        "2020-11-01-02:15",
+    }
+    assert subset.get_partition_keys_not_in_subset() == []
+    assert (
+        partitions_def.deserialize_subset(subset.serialize()).get_partition_keys_not_in_subset()
+        == []
+    )
+
+
 def test_dst_transition_hourly_partitions() -> None:
     partitions_def = HourlyPartitionsDefinition(
         start_date="2020-10-31-23:00", end_date="2020-11-01-5:00", timezone="US/Pacific"

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -20,6 +20,7 @@ from dagster import (
 )
 from dagster._check import CheckError
 from dagster._core.definitions.time_window_partitions import (
+    POST_DST_TRANSITION_SUFFIX,
     BaseTimeWindowPartitionsSubset,
     PartitionKeysTimeWindowPartitionsSubset,
     ScheduleType,
@@ -676,7 +677,7 @@ def test_time_partitions_weekly_partitions(
             [
                 "2021-11-07-00:00",
                 "2021-11-07-01:00",
-                "2021-11-07-01:00",
+                "2021-11-07-01:00_POST_DST_TRANSITION",
                 "2021-11-07-02:00",
                 "2021-11-07-03:00",
             ],
@@ -1023,6 +1024,27 @@ def test_time_window_partitions_contains():
     assert "2015-01-05" not in subset
     assert "2015-01-09" not in subset
     assert "2015-01-11" not in subset
+
+
+def test_dst_transition_time_window_partitions() -> None:
+    partitions_def = HourlyPartitionsDefinition(
+        start_date="2020-10-31-23:00", end_date="2020-11-01-5:00", timezone="US/Pacific"
+    )
+    subset = partitions_def.subset_with_all_partitions()
+    assert set(subset.get_partition_keys()) == {
+        "2020-10-31-23:00",
+        "2020-11-01-00:00",
+        "2020-11-01-01:00",
+        "2020-11-01-01:00" + POST_DST_TRANSITION_SUFFIX,
+        "2020-11-01-02:00",
+        "2020-11-01-03:00",
+        "2020-11-01-04:00",
+    }
+    assert subset.get_partition_keys_not_in_subset() == []
+    assert (
+        partitions_def.deserialize_subset(subset.serialize()).get_partition_keys_not_in_subset()
+        == []
+    )
 
 
 def test_unique_identifier():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1076,7 +1076,7 @@ def test_dst_transition_hourly_partitions() -> None:
     )
 
 
-def test_dst_transition_hourly_partitions_with_utc_offset() -> None:
+def test_dst_transition_hourly__partitions_with_utc_offset() -> None:
     partitions_def = HourlyPartitionsDefinition(
         start_date="2020-10-31-23:00:00-0700",
         end_date="2020-11-01-5:00:00-0800",
@@ -1394,7 +1394,6 @@ def test_partition_with_end_date(
         == last_partition_window_
     )
     assert not partitions_def.get_next_partition_window(last_partition_window_.end)
-    # get_partition_keys
     assert len(partitions_def.get_partition_keys()) == number_of_partitions
     assert partitions_def.get_partition_keys()[0] == first_partition_window[0]
     assert partitions_def.get_partition_keys()[-1] == last_partition_window[0]

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1076,7 +1076,7 @@ def test_dst_transition_hourly_partitions() -> None:
     )
 
 
-def test_dst_transition_hourly__partitions_with_utc_offset() -> None:
+def test_dst_transition_hourly_partitions_with_utc_offset() -> None:
     partitions_def = HourlyPartitionsDefinition(
         start_date="2020-10-31-23:00:00-0700",
         end_date="2020-11-01-5:00:00-0800",

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1026,7 +1026,7 @@ def test_time_window_partitions_contains():
     assert "2015-01-11" not in subset
 
 
-def test_dst_transition_time_window_partitions() -> None:
+def test_dst_transition_hourly_partitions() -> None:
     partitions_def = HourlyPartitionsDefinition(
         start_date="2020-10-31-23:00", end_date="2020-11-01-5:00", timezone="US/Pacific"
     )
@@ -1039,6 +1039,28 @@ def test_dst_transition_time_window_partitions() -> None:
         "2020-11-01-02:00",
         "2020-11-01-03:00",
         "2020-11-01-04:00",
+    }
+    assert subset.get_partition_keys_not_in_subset() == []
+    assert (
+        partitions_def.deserialize_subset(subset.serialize()).get_partition_keys_not_in_subset()
+        == []
+    )
+
+
+def test_dst_transition_daily_partitions() -> None:
+    partitions_def = DailyPartitionsDefinition(
+        start_date="2020-10-30-01:00",
+        end_date="2020-11-03-01:00",
+        timezone="US/Pacific",
+        hour_offset=1,
+        fmt="%Y-%m-%d-%H:%M",
+    )
+    subset = partitions_def.subset_with_all_partitions()
+    assert set(subset.get_partition_keys()) == {
+        "2020-10-30-01:00",
+        "2020-10-31-01:00",
+        "2020-11-01-01:00",
+        "2020-11-02-01:00",
     }
     assert subset.get_partition_keys_not_in_subset() == []
     assert (


### PR DESCRIPTION
## Summary & Motivation

In certain timezones, there can be multiple instances of the same hour (one before DST transition, one after). In these cases, we need separate partition keys to represent these different times. This PR accomplishes this by appending the second instance of this timestamp with a UTC offset param. This requires updating all strftime / strptime call sites to use the updated method.

It was also discovered that the comparison operators (>, <, ==) are not completely reliable when comparing Pendulum datetime instances, and in order to get accurate comparisons, you need to actually compare the timestamps.

This all does have some negative perf implications (~15% slowdown in hourly partition operations in non-UTC timezones). There are some clever things we can do to sand this down but I didn't want to include that sort of logic into this PR.

## How I Tested These Changes
