### PR TITLE
add prettier to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,12 @@ yamllint:
 	yamllint -c .yamllint.yaml --strict \
     `git ls-files 'helm/*.yml' 'helm/*.yaml' ':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml'`
 
+check_prettier:
+	npm --prefix js_modules/dagster-ui/packages/eslint-config exec -- prettier `git ls-files 'python_modules/*.yml' 'python_modules/*.yaml'` --check
+
+prettier:
+	npm --prefix js_modules/dagster-ui/packages/eslint-config exec -- prettier `git ls-files 'python_modules/*.yml' 'python_modules/*.yaml'` --write
+
 install_dev_python_modules:
 	python scripts/install_dev_python_modules.py -qqq
 

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ yamllint:
     `git ls-files 'helm/*.yml' 'helm/*.yaml' ':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml'`
 
 check_prettier:
-	npm --prefix js_modules/dagster-ui/packages/eslint-config exec -- prettier `git ls-files 'python_modules/*.yml' 'python_modules/*.yaml'` --check
+	yarn exec --cwd js_modules/dagster-ui/packages/eslint-config -- prettier `git ls-files 'python_modules/*.yml' 'python_modules/*.yaml'` --check
 
 prettier:
-	npm --prefix js_modules/dagster-ui/packages/eslint-config exec -- prettier `git ls-files 'python_modules/*.yml' 'python_modules/*.yaml'` --write
+	yarn exec --cwd js_modules/dagster-ui/packages/eslint-config -- prettier `git ls-files 'python_modules/*.yml' 'python_modules/*.yaml'` --write
 
 install_dev_python_modules:
 	python scripts/install_dev_python_modules.py -qqq


### PR DESCRIPTION
Add prettier for formatting yaml. More context: https://dagsterlabs.slack.com/archives/C03A0D72A6T/p1700081251053029

`npm --prefix ... exec` means we'll use the same version of prettier (3.0.3) as defined in the dagster-ui project. Eventually we might be able to put the various prettier steps in to one command, but I think this is easier to adopt for now. Related, I considered `.prettierignore` at the root instead of passing files with git ls-files. It was 1, way slower with the same selection (30s instead of 2). I didn't dig in to why. And 2, We have different prettier invocations currently. An ignore file probably makes more sense once we consolidate them