### PR TITLE
[fix] remove zip(..., strict=True) call (not compat w/ <3.10)

### DIFF
--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
@@ -94,7 +94,8 @@ class DeltalakeBaseArrowTypeHandler(DbTypeHandler[T], Generic[T]):
                         columns=[
                             TableColumn(name=name, type=str(dtype))
                             for name, dtype in zip(  # type: ignore pyarrow does not expose types
-                                reader.schema.names, reader.schema.types, strict=True
+                                reader.schema.names,
+                                reader.schema.types,
                             )
                         ]
                     )


### PR DESCRIPTION
## Summary

Removes a call to `zip(..., strict=True)` introduced in #14764 - this is a PEP that is only available [in 3.10+](https://peps.python.org/pep-0618/).

