### PR TITLE
[fix] pin botocore !=1.32.1

### DIFF
--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=find_packages(exclude=["dagster_aws_tests*"]),
     include_package_data=True,
     install_requires=[
-        "boto3!=1.29.1",
+        "boto3",
         f"dagster{pin}",
         "packaging",
         "requests",
@@ -43,7 +43,7 @@ setup(
         "redshift": ["psycopg2-binary"],
         "pyspark": ["dagster-pyspark"],
         "test": [
-            "botocore",
+            "botocore!=1.32.1",
             "moto[s3,server]>=2.2.8",
             "requests-mock",
             "xmltodict==0.12.0",  # pinned until moto>=3.1.9 (https://github.com/spulec/moto/issues/5112)

--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=find_packages(exclude=["dagster_aws_tests*"]),
     include_package_data=True,
     install_requires=[
-        "boto3",
+        "boto3!=1.29.1",
         f"dagster{pin}",
         "packaging",
         "requests",

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
@@ -93,7 +93,7 @@ class DeltalakeBaseArrowTypeHandler(DbTypeHandler[T], Generic[T]):
                     TableSchema(
                         columns=[
                             TableColumn(name=name, type=str(dtype))
-                            for name, dtype in zip(reader.schema.names, reader.schema.types)  # type: ignore pyarrow does not expose types
+                            for name, dtype in zip(reader.schema.names, reader.schema.types)
                         ]
                     )
                 ),


### PR DESCRIPTION
## Summary

pins botocore != the newest version, which is causing test failures: https://buildkite.com/dagster/dagster/builds/70829#018bd4da-aa83-45e4-87b0-1013c9d7be9e (this may be an issue w/ moto3 not being updated)

