### PR TITLE
Update code-of-conduct.mdx to fix a typo.

### DIFF
--- a/docs/content/community/code-of-conduct.mdx
+++ b/docs/content/community/code-of-conduct.mdx
@@ -49,7 +49,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the Dagster core team responsible for enforcement at <conduct@dagsterlabs.com>. All complaints will be reviewed and investigated promptly and fairly. The Dagster core team obligated to respect the privacy and security of the reporter of any incident.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the Dagster core team responsible for enforcement at <conduct@dagsterlabs.com>. All complaints will be reviewed and investigated promptly and fairly. The Dagster core team is obligated to respect the privacy and security of the reporter of any incident.
 
 ## Enforcement Guidelines
 


### PR DESCRIPTION
There is a typo; The word 'is' is missing.

