### PR TITLE
[pipes] fix k8s error handling

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/external_execution/error_example/sleep_and_fail.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/error_example/sleep_and_fail.py
@@ -1,0 +1,9 @@
+import time
+
+from dagster_pipes import open_dagster_pipes
+
+with open_dagster_pipes() as context:
+    n = context.get_extra("sleep_seconds")
+    context.log.info(f"sleeping for {n} seconds")
+    time.sleep(n)
+    raise Exception("oops all errors")


### PR DESCRIPTION
misplaced `else` block prevented us from checking if the pod errored out or not when using the default message reader

## How I Tested These Changes

put exceptions under test 
