### PR TITLE
[pipes] do not set_requires_typed_event_stream for ops

### DIFF
--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -604,7 +604,10 @@ def open_pipes_session(
 
             yield from pipes_session.get_results()
     """
-    context.set_requires_typed_event_stream(error_message=_FAIL_TO_YIELD_ERROR_MESSAGE)
+    # if we are in the context of an asset, set up a defensive check to ensure the event stream got returned
+    if context.get_step_execution_context().is_sda_step:
+        context.set_requires_typed_event_stream(error_message=_FAIL_TO_YIELD_ERROR_MESSAGE)
+
     context_data = build_external_execution_context_data(context, extras)
     message_handler = PipesMessageHandler(context, message_reader)
     try:


### PR DESCRIPTION
Currently, if a user tries to use pipes in an op they will almost certainly hit

```
dagster._core.errors.DagsterInvariantViolationError: op 'just_run' did not yield or return expected outputs {'result'}. Did you forget to `yield from pipes_session.get_results()` or `return <PipesClient>.run(...).get_results`? If using `open_pipes_session`, `pipes_session.get_results` should be called once after the `open_pipes_session` block has exited to yield any remaining buffered results via `<PipesSession>.get_results()`. If using `<PipesClient>.run`, you should always return `<PipesClient>.run(...).get_results()` or `<PipesClient>.run(...).get_materialize_result()`.
```

with the only recourse available being to do

```
@op
def sample(context):
  yield from pipes_client.run().get_results()
  yield Output(...)
```

which the two users who reported this were not able to figure out wihtout help.

To address this, we now only set `set_requires_typed_event_stream` when pipes is used in the context of an asset.


## How I Tested These Changes

added test