### PR TITLE
[doc] dagster essentials - fix typo WeeklyPartitionDefinition to WeeklyPartitionsDefinition

### DIFF
--- a/docs/dagster-university/pages/dagster-essentials/lesson-8/coding-practice-weekly-partition.md
+++ b/docs/dagster-university/pages/dagster-essentials/lesson-8/coding-practice-weekly-partition.md
@@ -6,7 +6,7 @@ lesson: '8'
 
 # Practice: Create a weekly partition
 
-To practice what you’ve learned, create a `weekly_partition` using Dagster’s `WeeklyPartitionDefinition` with the same start and end dates.
+To practice what you’ve learned, create a `weekly_partition` using Dagster’s `WeeklyPartitionsDefinition` with the same start and end dates.
 
 ---
 


### PR DESCRIPTION
## Summary & Motivation

Fixes typo of `WeeklyPartitionsDefinition` in problem statement; if a user copy and pastes this reference (like myself) they will be met with the error:

```
dagster._core.errors.DagsterImportError: Encountered ImportError: `cannot import name 'WeeklyPartitionDefinition' from 'dagster'
```

Reference: https://docs.dagster.io/_apidocs/partitions#dagster.WeeklyPartitionsDefinition

## How I Tested These Changes

Viewed rendered markdown and confirmed typo fix.
