### PR TITLE
[pythonic resources] Add support for Pythonic resource classes to @configured

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/configurable.py
+++ b/python_modules/dagster/dagster/_core/definitions/configurable.py
@@ -173,6 +173,11 @@ def _check_configurable_param(configurable: ConfigurableDefinition) -> None:
         " the `tag` or `alias` methods. For usage examples, see"
         " https://docs.dagster.io/concepts/configuration/configured",
     )
+    from dagster._config.pythonic_config import ConfigurableResourceFactory, safe_is_subclass
+
+    if safe_is_subclass(configurable, ConfigurableResourceFactory):
+        return
+
     check.inst_param(
         configurable,
         "configurable",
@@ -311,6 +316,16 @@ def configured(
 
     """
     _check_configurable_param(configurable)
+
+    from dagster._config.pythonic_config import ConfigurableResourceFactory, safe_is_subclass
+
+    if safe_is_subclass(configurable, ConfigurableResourceFactory):
+        configurable_inner = (
+            cast(Type[ConfigurableResourceFactory], configurable)
+            .configure_at_launch()
+            .get_resource_definition()
+        )
+        return configured(configurable_inner, config_schema=config_schema, **kwargs)
 
     if isinstance(configurable, NamedConfigurableDefinition):
 

--- a/python_modules/dagster/dagster/_core/definitions/configurable.py
+++ b/python_modules/dagster/dagster/_core/definitions/configurable.py
@@ -325,7 +325,7 @@ def configured(
     if safe_is_subclass(configurable, ConfigurableResourceFactory):
         configurable_inner = cast(
             ResourceDefinition,
-            (
+            (  # type: ignore
                 cast(Type[ConfigurableResourceFactory], configurable)
                 .configure_at_launch()
                 .get_resource_definition()

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_configured.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_configured.py
@@ -1,0 +1,112 @@
+from typing import Any, Dict
+
+import pytest
+from dagster import Config, ConfigurableResource, InitResourceContext, configured, job, op, resource
+from dagster._check import CheckError
+
+
+def test_config_mapping_return_resource_config_dict() -> None:
+    class MyResource(ConfigurableResource):
+        resource_param: str
+
+    @resource(config_schema={"resource_param": str})
+    def my_resource_legacy(context: InitResourceContext) -> MyResource:
+        return MyResource(resource_param=context.resource_config["resource_param"])
+
+    @configured(my_resource_legacy, config_schema={"simplified_param": str})
+    def my_resource_legacy_simplified(config_in) -> Dict[str, Any]:
+        return {"resource_param": config_in["simplified_param"]}
+
+    @op
+    def do_something(my_resource: ConfigurableResource) -> str:
+        return my_resource.resource_param
+
+    @job
+    def do_it_all() -> None:
+        do_something()
+
+    result = do_it_all.execute_in_process(
+        resources={
+            "my_resource": my_resource_legacy_simplified.configured({"simplified_param": "foo"})
+        }
+    )
+    assert result.success
+    assert result.output_for_node("do_something") == "foo"
+
+    class MyResourceSimplifiedConfig(Config):
+        simplified_param: str
+
+    # New, fancy config mapping takes in a Pythonic config object but returns normal config dict
+    @configured(MyResource)
+    def my_resource_simplified(config_in: MyResourceSimplifiedConfig) -> Dict[str, Any]:
+        return {"resource_param": config_in.simplified_param}
+
+    result = do_it_all.execute_in_process(
+        resources={"my_resource": my_resource_simplified.configured({"simplified_param": "foo"})}
+    )
+    assert result.success
+    assert result.output_for_node("do_something") == "foo"
+
+
+def test_config_mapping_return_resource_object() -> None:
+    class MyResource(ConfigurableResource):
+        resource_param: str
+
+    @op
+    def do_something(my_resource: ConfigurableResource) -> str:
+        return my_resource.resource_param
+
+    @job
+    def do_it_all() -> None:
+        do_something()
+
+    class MyResourceSimplifiedConfig(Config):
+        simplified_param: str
+
+    # New, fancy config mapping takes in a Pythonic config object and returns a constructed resource
+    @configured(MyResource)
+    def my_resource_simplified(config_in: MyResourceSimplifiedConfig) -> MyResource:
+        return MyResource(resource_param=config_in.simplified_param)
+
+    result = do_it_all.execute_in_process(
+        resources={"my_resource": my_resource_simplified.configured({"simplified_param": "foo"})}
+    )
+    assert result.success
+    assert result.output_for_node("do_something") == "foo"
+
+
+def test_config_annotation_no_config_schema_err() -> None:
+    class MyResource(ConfigurableResource):
+        resource_param: str
+
+    class MyResourceSimplifiedConfig(Config):
+        simplified_param: str
+
+    # Ensure that we error if we try to provide a config_schema to a @configured function
+    # which has a Config-annotated param - no need to provide a config_schema in this case
+    with pytest.raises(
+        CheckError,
+        match="Cannot provide config_schema to @configured function with Config-annotated param",
+    ):
+
+        @configured(MyResource, config_schema={"simplified_param": str})
+        def my_resource_simplified(config_in: MyResourceSimplifiedConfig):
+            ...
+
+
+def test_config_annotation_extra_param_err() -> None:
+    class MyResource(ConfigurableResource):
+        resource_param: str
+
+    class MyResourceSimplifiedConfig(Config):
+        simplified_param: str
+
+    # Ensure that we error if the @configured function has an extra param
+    with pytest.raises(
+        CheckError,
+        match="@configured function should have exactly one parameter",
+    ):
+
+        @configured(MyResource)
+        def my_resource_simplified(config_in: MyResourceSimplifiedConfig, useless_param: str):
+            ...


### PR DESCRIPTION
## Summary

Responds to functionality request in #18073.

#14624 did most of the heavy lifting for this change, but erroneously updated the apidoc for `@configured` to indicate that it supported Pythonic resources while not actually doing so.

This PR makes a few lightweight changes to the internals of `@configured` to properly handle the differences between the Pythonic resource & config classes.

The following use-cases are now possible:

```python

class MyResource(ConfigurableResource):
  my_string: str

# no args
@configured(MyResource)
def my_resource_noargs(_):
  return MyResource(my_string="foo")

# args, as old-style config dict
@configured(MyResource, {"an_int": int}):
def my_resource_from_int(config):
  return MyResource(my_string=str(config["an_int"]))

# args, as Pythonic config
class FromFloatConfig(Config):
  a_float: float

@configured(MyResource)
def my_resource_from_float(config: FromFloatConfig):
  return MyResource(my_string=str(config.a_float))

defs = Definitions(
  ...
  resources = {
    "noargs": my_resource_noargs,
    "from_int": my_resource_from_int.configured({"an_int": 5})
    "from_float": my_resource_from_float.configured({"a_float": 2.5})
  }
)
```

I think this is nice to support as a migration pattern to plug in new-style resources & the future support burden is pretty low.

That being said, it's worth highlighting there's a fairly native way to do this already (but not documented):

```python

class MyResource(ConfigurableResource):
  my_string: str

class MyResourceNoargs(ConfigurableResource):
    def create_resource(self, context: InitResourceContext) -> Any:
        return MyResource(my_string="foo")

class MyResourceFromInt(ConfigurableResource):
    an_int: int

    def create_resource(self, context: InitResourceContext) -> Any:
        return MyResource(my_string=str(self.an_int))

defs = Definitions(
  ...
  resources = {
    "noargs": MyResourceNoargs(),
    "from_int": MyResourceFromInt(an_int=5)
  }
)
```


## Test Plan

New unit test suite.