### PR TITLE
replace helm yamllint with prettier

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -31,6 +31,7 @@ def build_repo_wide_steps() -> List[BuildkiteStep]:
         *build_repo_wide_check_manifest_steps(),
         *build_repo_wide_pyright_steps(),
         *build_repo_wide_ruff_steps(),
+        *build_repo_wide_prettier_steps(),
     ]
 
 
@@ -66,6 +67,20 @@ def build_repo_wide_ruff_steps() -> List[CommandStep]:
         )
         .on_test_image(AvailablePythonVersion.get_default())
         .with_skip(skip_if_no_python_changes())
+        .build(),
+    ]
+
+
+def build_repo_wide_prettier_steps() -> List[CommandStep]:
+    return [
+        CommandStepBuilder(":prettier: prettier")
+        .run(
+            "pushd js_modules/dagster-ui/packages/eslint-config",
+            "yarn install",
+            "popd",
+            "make check_prettier",
+        )
+        .on_test_image(AvailablePythonVersion.get_default())
         .build(),
     ]
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -14,6 +14,7 @@ from ..utils import (
     is_release_branch,
     safe_getenv,
     skip_if_no_python_changes,
+    skip_if_no_yaml_changes,
 )
 from .helm import build_helm_steps
 from .integration import build_integration_steps
@@ -81,6 +82,7 @@ def build_repo_wide_prettier_steps() -> List[CommandStep]:
             "make check_prettier",
         )
         .on_test_image(AvailablePythonVersion.get_default())
+        .with_skip(skip_if_no_yaml_changes())
         .build(),
     ]
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/helm.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/helm.py
@@ -49,14 +49,6 @@ def build_helm_steps() -> List[BuildkiteStep]:
 
 def _build_lint_steps(package_spec) -> List[CommandStep]:
     return [
-        CommandStepBuilder(":yaml: :lint-roller:")
-        .run(
-            "pip install yamllint",
-            "make yamllint",
-        )
-        .with_skip(skip_if_no_helm_changes() and package_spec.skip_reason)
-        .on_test_image(AvailablePythonVersion.get_default())
-        .build(),
         CommandStepBuilder("dagster-json-schema")
         .run(
             "pip install -e helm/dagster/schema",

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -203,6 +203,16 @@ def skip_if_no_python_changes():
     return "No python changes"
 
 
+def skip_if_no_yaml_changes():
+    if not is_feature_branch():
+        return None
+
+    if any(path.suffix in [".yml", ".yaml"] for path in ChangedFiles.all):
+        return None
+
+    return "No yaml changes"
+
+
 @functools.lru_cache(maxsize=None)
 def has_helm_changes():
     return any(Path("helm") in path.parents for path in ChangedFiles.all)

--- a/Makefile
+++ b/Makefile
@@ -32,15 +32,15 @@ check_ruff:
 	ruff .
 	ruff format --check .
 
-yamllint:
-	yamllint -c .yamllint.yaml --strict \
-    `git ls-files 'helm/*.yml' 'helm/*.yaml' ':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml'`
-
 check_prettier:
-	yarn exec --cwd js_modules/dagster-ui/packages/eslint-config -- prettier `git ls-files 'python_modules/*.yml' 'python_modules/*.yaml'` --check
+	yarn exec --cwd js_modules/dagster-ui/packages/eslint-config -- prettier `git ls-files \
+	'python_modules/*.yml' 'python_modules/*.yaml' 'helm/*.yml' 'helm/*.yaml' \
+	':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml'` --check
 
 prettier:
-	yarn exec --cwd js_modules/dagster-ui/packages/eslint-config -- prettier `git ls-files 'python_modules/*.yml' 'python_modules/*.yaml'` --write
+	yarn exec --cwd js_modules/dagster-ui/packages/eslint-config -- prettier `git ls-files \
+	'python_modules/*.yml' 'python_modules/*.yaml' 'helm/*.yml' 'helm/*.yaml' \
+	':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml'` --write
 
 install_dev_python_modules:
 	python scripts/install_dev_python_modules.py -qqq

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -1,4 +1,3 @@
-# yamllint disable rule:line-length
 # README:
 # - If using a fixed tag for images, changing the image pull policy to anything other than "Always"
 #   will use a cached/stale image.
@@ -424,7 +423,8 @@ scheduler:
   #   CustomScheduler,
   #  ]
   type: DagsterDaemonScheduler
-  config: {}
+  config:
+    {}
     ## This configuration will only be used if the DagsterDaemonScheduler is selected.
     # daemonScheduler:
     #   maxCatchupRuns: 5


### PR DESCRIPTION
Test plan: add bad spacing to values.yaml

```
make check_prettier
npm --prefix js_modules/dagster-ui/packages/eslint-config exec -- prettier `git ls-files \
        'python_modules/*.yml' 'python_modules/*.yaml' 'helm/*.yml' 'helm/*.yaml' \
        ':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml'` --check
Checking formatting...
[warn] helm/dagster/values.yaml
[warn] Code style issues found in the above file. Run Prettier to fix.
make: *** [check_prettier] Error 1
```