### PR TITLE
[UPathIOManager] fix cloud storages on Windows

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -38,7 +38,7 @@ class PickledObjectS3IOManager(UPathIOManager):
 
     def load_from_path(self, context: InputContext, path: UPath) -> Any:
         try:
-            s3_obj = self.s3.get_object(Bucket=self.bucket, Key=str(path))["Body"].read()
+            s3_obj = self.s3.get_object(Bucket=self.bucket, Key=path.as_posix())["Body"].read()
             return pickle.loads(s3_obj)
         except self.s3.exceptions.NoSuchKey:
             raise FileNotFoundError(f"Could not find file {path} in S3 bucket {self.bucket}")
@@ -50,11 +50,11 @@ class PickledObjectS3IOManager(UPathIOManager):
 
         pickled_obj = pickle.dumps(obj, PICKLE_PROTOCOL)
         pickled_obj_bytes = io.BytesIO(pickled_obj)
-        self.s3.upload_fileobj(pickled_obj_bytes, self.bucket, str(path))
+        self.s3.upload_fileobj(pickled_obj_bytes, self.bucket, path.as_posix())
 
     def path_exists(self, path: UPath) -> bool:
         try:
-            self.s3.get_object(Bucket=self.bucket, Key=str(path))
+            self.s3.get_object(Bucket=self.bucket, Key=path.as_posix())
         except self.s3.exceptions.NoSuchKey:
             return False
         return True
@@ -66,7 +66,7 @@ class PickledObjectS3IOManager(UPathIOManager):
         return f"Writing S3 object at: {self._uri_for_path(path)}"
 
     def unlink(self, path: UPath) -> None:
-        self.s3.delete_object(Bucket=self.bucket, Key=str(path))
+        self.s3.delete_object(Bucket=self.bucket, Key=path.as_posix())
 
     def make_directory(self, path: UPath) -> None:
         # It is not necessary to create directories in S3
@@ -80,7 +80,7 @@ class PickledObjectS3IOManager(UPathIOManager):
         return UPath("storage", super().get_op_output_relative_path(context))
 
     def _uri_for_path(self, path: UPath) -> str:
-        return f"s3://{self.bucket}/{path}"
+        return f"s3://{self.bucket}/{path.as_posix()}"
 
 
 class S3PickleIOManager(ConfigurableIOManager):

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -58,7 +58,7 @@ class PickledObjectADLS2IOManager(UPathIOManager):
         return f"Writing ADLS2 object at: {self._uri_for_path(path)}"
 
     def unlink(self, path: UPath) -> None:
-        file_client = self.file_system_client.get_file_client(str(path))
+        file_client = self.file_system_client.get_file_client(path.as_posix())
         with self._acquire_lease(file_client, is_rm=True) as lease:
             file_client.delete_file(lease=lease, recursive=True)
 
@@ -68,7 +68,7 @@ class PickledObjectADLS2IOManager(UPathIOManager):
 
     def path_exists(self, path: UPath) -> bool:
         try:
-            self.file_system_client.get_file_client(str(path)).get_file_properties()
+            self.file_system_client.get_file_client(path.as_posix()).get_file_properties()
         except ResourceNotFoundError:
             return False
         return True
@@ -78,7 +78,7 @@ class PickledObjectADLS2IOManager(UPathIOManager):
             protocol=protocol,
             filesystem=self.file_system_client.file_system_name,
             account=self.file_system_client.account_name,
-            key=path,
+            key=path.as_posix(),
         )
 
     @contextmanager
@@ -95,7 +95,7 @@ class PickledObjectADLS2IOManager(UPathIOManager):
     def load_from_path(self, context: InputContext, path: UPath) -> Any:
         if context.dagster_type.typing_type == type(None):
             return None
-        file = self.file_system_client.get_file_client(str(path))
+        file = self.file_system_client.get_file_client(path.as_posix())
         stream = file.download_file()
         return pickle.loads(stream.readall())
 
@@ -105,7 +105,7 @@ class PickledObjectADLS2IOManager(UPathIOManager):
             self.unlink(path)
 
         pickled_obj = pickle.dumps(obj, PICKLE_PROTOCOL)
-        file = self.file_system_client.create_file(str(path))
+        file = self.file_system_client.create_file(path.as_posix())
         with self._acquire_lease(file) as lease:
             file.upload_data(pickled_obj, lease=lease, overwrite=True)
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
@@ -35,12 +35,12 @@ class PickledObjectGCSIOManager(UPathIOManager):
         super().__init__(base_path=UPath(self.prefix))
 
     def unlink(self, path: UPath) -> None:
-        key = str(path)
+        key = path.as_posix()
         if self.bucket_obj.blob(key).exists():
             self.bucket_obj.blob(key).delete()
 
     def path_exists(self, path: UPath) -> bool:
-        key = str(path)
+        key = path.as_posix()
         blobs = self.client.list_blobs(self.bucket, prefix=key)
         return len(list(blobs)) > 0
 
@@ -57,25 +57,25 @@ class PickledObjectGCSIOManager(UPathIOManager):
         return f"Writing GCS object at: {self._uri_for_path(path)}"
 
     def _uri_for_path(self, path: UPath) -> str:
-        return f"gs://{self.bucket}/{path}"
+        return f"gs://{self.bucket}/{path.as_posix()}"
 
     def make_directory(self, path: UPath) -> None:
         # It is not necessary to create directories in GCP
         return None
 
     def load_from_path(self, context: InputContext, path: UPath) -> Any:
-        bytes_obj = self.bucket_obj.blob(str(path)).download_as_bytes()
+        bytes_obj = self.bucket_obj.blob(path.as_posix()).download_as_bytes()
         return pickle.loads(bytes_obj)
 
     def dump_to_path(self, context: OutputContext, obj: Any, path: UPath) -> None:
         if self.path_exists(path):
-            context.log.warning(f"Removing existing GCS key: {path}")
+            context.log.warning(f"Removing existing GCS key: {path.as_posix()}")
             self.unlink(path)
 
         pickled_obj = pickle.dumps(obj, PICKLE_PROTOCOL)
 
         backoff(
-            self.bucket_obj.blob(str(path)).upload_from_string,
+            self.bucket_obj.blob(path.as_posix()).upload_from_string,
             args=[pickled_obj],
             retry_on=(TooManyRequests, Forbidden, ServiceUnavailable),
         )


### PR DESCRIPTION
resolves https://github.com/dagster-io/dagster/issues/18069

https://github.com/dagster-io/dagster/pull/13855 had sort of a compromised treatment of `UPath` objects for the cloud storage integrations which unfortuntely leads to using windows `\` pathing in the blob storage APIs when the are run from a Windows process.

To resolve this, instead of string casting the UPath we call `as_posix` to get the `/` path string

## How I Tested These Changes

existing coverage, did not explicitly test on Windows 