### PR TITLE
allow configuration of scheduler tick retries in helm

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/scheduler.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/scheduler.py
@@ -11,7 +11,13 @@ class SchedulerType(str, Enum):
     CUSTOM = "CustomScheduler"
 
 
+class DaemonSchedulerConfig(BaseModel):
+    maxCatchupRuns: Optional[int]
+    maxTickRetries: Optional[int]
+
+
 class SchedulerConfig(BaseModel):
+    daemonScheduler: Optional[DaemonSchedulerConfig]
     customScheduler: Optional[ConfigurableClass]
 
     class Config:

--- a/helm/dagster/schema/schema_tests/test_scheduler.py
+++ b/helm/dagster/schema/schema_tests/test_scheduler.py
@@ -1,0 +1,42 @@
+import pytest
+import yaml
+from kubernetes.client import models
+from schema.charts.dagster.subschema.scheduler import (
+    DaemonSchedulerConfig,
+    Scheduler,
+    SchedulerConfig,
+    SchedulerType,
+)
+from schema.charts.dagster.values import DagsterHelmValues
+from schema.utils.helm_template import HelmTemplate
+
+
+@pytest.fixture(name="template")
+def helm_template() -> HelmTemplate:
+    return HelmTemplate(
+        helm_dir_path="helm/dagster",
+        subchart_paths=["charts/dagster-user-deployments"],
+        output="templates/configmap-instance.yaml",
+        model=models.V1ConfigMap,
+        namespace="test-namespace",
+    )
+
+
+def test_scheduler_config(template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(
+        scheduler=Scheduler.construct(
+            type=SchedulerType.DAEMON,
+            config=SchedulerConfig.construct(
+                daemonScheduler=DaemonSchedulerConfig.construct(
+                    maxCatchupRuns=2,
+                    maxTickRetries=2,
+                ),
+            ),
+        )
+    )
+    configmaps = template.render(helm_values)
+    assert len(configmaps) == 1
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+    assert instance["scheduler"]["class"] == "DagsterDaemonScheduler"
+    assert instance["scheduler"]["config"]["max_catchup_runs"] == 2
+    assert instance["scheduler"]["config"]["max_tick_retries"] == 2

--- a/helm/dagster/templates/helpers/instance/_scheduler.tpl
+++ b/helm/dagster/templates/helpers/instance/_scheduler.tpl
@@ -1,6 +1,16 @@
 {{- define "dagsterYaml.scheduler.daemon" }}
+{{- $daemonSchedulerConfig := .Values.scheduler.config.daemonScheduler }}
 module: dagster.core.scheduler
 class: DagsterDaemonScheduler
+{{- if not (empty (compact (values $daemonSchedulerConfig))) }}
+config:
+  {{- if $daemonSchedulerConfig.maxCatchupRuns }}
+  max_catchup_runs: {{ $daemonSchedulerConfig.maxCatchupRuns }}
+  {{- end }}
+  {{- if $daemonSchedulerConfig.maxTickRetries }}
+  max_tick_retries: {{ $daemonSchedulerConfig.maxTickRetries }}
+  {{- end }}
+{{- end }}
 {{- end }}
 
 {{- define "dagsterYaml.scheduler.custom" }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1719,10 +1719,49 @@
             ],
             "type": "string"
         },
+        "DaemonSchedulerConfig": {
+            "title": "DaemonSchedulerConfig",
+            "type": "object",
+            "properties": {
+                "maxCatchupRuns": {
+                    "title": "Maxcatchupruns",
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "maxTickRetries": {
+                    "title": "Maxtickretries",
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            }
+        },
         "SchedulerConfig": {
             "title": "SchedulerConfig",
             "type": "object",
             "properties": {
+                "daemonScheduler": {
+                    "title": "DaemonSchedulerConfig",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DaemonSchedulerConfig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
                 "customScheduler": {
                     "title": "ConfigurableClass",
                     "anyOf": [

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -424,15 +424,19 @@ scheduler:
   #   CustomScheduler,
   #  ]
   type: DagsterDaemonScheduler
-
   config: {}
-  ## Uncomment this configuration will only be used if the CustomScheduler is selected.
-  ## Using this setting requires a custom webserver image that defines the user specified
-  ## scheduler in an installed python module.
-  #   customScheduler:
-  #     module: ~
-  #     class: ~
-  #     config: {}
+    ## This configuration will only be used if the DagsterDaemonScheduler is selected.
+    # daemonScheduler:
+    #   maxCatchupRuns: 5
+    #   maxTickRetries: 0
+
+    ## This configuration will only be used if the CustomScheduler is selected.
+    ## Using this setting requires a custom webserver image that defines the user specified
+    ## scheduler in an installed python module.
+    #   customScheduler:
+    #     module: ~
+    #     class: ~
+    #     config: {}
 
 ####################################################################################################
 # Run Launcher: Configuration for run launcher


### PR DESCRIPTION
## Summary & Motivation
We don't retry scheduler ticks by default using the daemon scheduler.  This allows this setting to be set within helm.

For https://github.com/dagster-io/dagster/discussions/18067

## How I Tested These Changes
BK