### PR TITLE
[auto-materialize] Create new AssetDaemonAssetCursor object

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -32,6 +32,7 @@ from dagster._core.definitions.time_window_partitions import (
     get_time_partitions_def,
 )
 from dagster._core.instance import DynamicPartitionsStore
+from dagster._utils.cached_method import cached_method
 
 from ... import PartitionKeyRange
 from ..storage.tags import ASSET_PARTITION_RANGE_END_TAG, ASSET_PARTITION_RANGE_START_TAG
@@ -48,10 +49,7 @@ from .auto_materialize_rule_evaluation import (
 )
 from .backfill_policy import BackfillPolicy, BackfillPolicyType
 from .freshness_based_auto_materialize import get_expected_data_time_for_asset_key
-from .partition import (
-    PartitionsDefinition,
-    ScheduleType,
-)
+from .partition import PartitionsDefinition, ScheduleType
 
 if TYPE_CHECKING:
     from dagster._core.instance import DagsterInstance

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -331,7 +331,10 @@ class AssetDaemonContext:
                 dynamic_partitions_store=self.instance_queryer,
             ),
             asset_cursor.with_updates(
-                self.asset_graph, materialize_context.newly_materialized_root_partitions
+                self.asset_graph,
+                materialize_context.newly_materialized_root_partitions,
+                to_materialize,
+                to_discard,
             ),
             to_materialize,
         )
@@ -400,6 +403,7 @@ class AssetDaemonContext:
             )
 
             evaluations_by_key[asset_key] = evaluation
+            asset_cursors.append(asset_cursor_for_asset)
             will_materialize_mapping[asset_key] = to_materialize_for_asset
 
             expected_data_time = get_expected_data_time_for_asset_key(

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -242,7 +242,9 @@ class AssetDaemonContext:
         to_skip: Set[AssetKeyPartitionKey] = set()
         to_discard: Set[AssetKeyPartitionKey] = set()
 
-        asset_cursor = self.cursor.asset_cursor_for_key(asset_key)
+        asset_cursor = self.cursor.asset_cursor_for_key(
+            asset_key, self.asset_graph.get_partitions_def(asset_key)
+        )
 
         materialize_context = RuleEvaluationContext(
             asset_key=asset_key,

--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -109,6 +109,24 @@ class AssetSubset(NamedTuple):
                 ),
             )
 
+    def inverse(
+        self,
+        partitions_def: Optional[PartitionsDefinition],
+        current_time: Optional[datetime.datetime] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
+    ) -> "AssetSubset":
+        if partitions_def is None:
+            return self._replace(value=not self.bool_value)
+        else:
+            value = partitions_def.subset_with_partition_keys(
+                self.subset_value.get_partition_keys_not_in_subset(
+                    partitions_def,
+                    current_time=current_time,
+                    dynamic_partitions_store=dynamic_partitions_store,
+                )
+            )
+            return self._replace(value=value)
+
     def _oper(self, other: "AssetSubset", oper: Callable) -> "AssetSubset":
         value = oper(self.value, other.value)
         return self._replace(value=value)

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -53,16 +53,13 @@ from .asset_graph import AssetGraph, sort_key_for_asset_partition
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
-    from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
-    from dagster._core.definitions.auto_materialize_rule_evaluation import (
-        AutoMaterializeAssetEvaluation,
-    )
+    from dagster._core.definitions.asset_daemon_cursor import AssetDaemonAssetCursor
 
 
 @dataclass(frozen=True)
 class RuleEvaluationContext:
     asset_key: AssetKey
-    cursor: "AssetDaemonCursor"
+    cursor: "AssetDaemonAssetCursor"
     instance_queryer: CachingInstanceQueryer
     data_time_resolver: CachingDataTimeResolver
     # Tracks which asset partitions are already slated for materialization in this tick. The asset
@@ -75,11 +72,6 @@ class RuleEvaluationContext:
     @property
     def asset_graph(self) -> AssetGraph:
         return self.instance_queryer.asset_graph
-
-    @property
-    def previous_tick_evaluation(self) -> Optional["AutoMaterializeAssetEvaluation"]:
-        """Returns the evaluation of the asset on the previous tick."""
-        return self.cursor.latest_evaluation_by_asset_key.get(self.asset_key)
 
     @property
     def evaluation_time(self) -> datetime.datetime:
@@ -98,9 +90,9 @@ class RuleEvaluationContext:
         self,
     ) -> AbstractSet[AssetKeyPartitionKey]:
         """Returns the set of asset partitions that were requested or discarded on the previous tick."""
-        if not self.previous_tick_evaluation:
+        if not self.cursor.latest_evaluation:
             return set()
-        return self.previous_tick_evaluation.get_requested_or_discarded_asset_partitions(
+        return self.cursor.latest_evaluation.get_requested_or_discarded_asset_partitions(
             asset_graph=self.asset_graph
         )
 
@@ -109,17 +101,17 @@ class RuleEvaluationContext:
         self,
     ) -> AbstractSet[AssetKeyPartitionKey]:
         """Returns the set of asset partitions that were evaluated on the previous tick."""
-        if not self.previous_tick_evaluation:
+        if not self.cursor.latest_evaluation:
             return set()
-        return self.previous_tick_evaluation.get_evaluated_asset_partitions(
+        return self.cursor.latest_evaluation.get_evaluated_asset_partitions(
             asset_graph=self.asset_graph
         )
 
     def get_previous_tick_results(self, rule: "AutoMaterializeRule") -> "RuleEvaluationResults":
         """Returns the results that were calculated for a given rule on the previous tick."""
-        if not self.previous_tick_evaluation:
+        if not self.cursor.latest_evaluation:
             return []
-        return self.previous_tick_evaluation.get_rule_evaluation_results(
+        return self.cursor.latest_evaluation.get_rule_evaluation_results(
             rule_snapshot=rule.to_snapshot(), asset_graph=self.asset_graph
         )
 
@@ -202,6 +194,38 @@ class RuleEvaluationContext:
             if parent not in self.will_materialize_mapping.get(parent.asset_key, set())
             or not self.materializable_in_same_run(asset_partition.asset_key, parent.asset_key)
         }
+
+    @functools.cached_property
+    def newly_materialized_root_partitions(self) -> AbstractSet[AssetKeyPartitionKey]:
+        if self.asset_key not in self.asset_graph.root_asset_keys:
+            return set()
+        newly_materialized = set()
+        for asset_partition in self.cursor.get_unhandled_asset_partitions(
+            self.asset_graph,
+            dynamic_partitions_store=self.instance_queryer,
+            current_time=self.instance_queryer.evaluation_time,
+        ):
+            if self.instance_queryer.asset_partition_has_materialization_or_observation(
+                asset_partition
+            ):
+                newly_materialized.add(asset_partition)
+
+        return newly_materialized
+
+    @functools.cached_property
+    def never_materialized_requested_or_discarded_root_partitions(
+        self
+    ) -> AbstractSet[AssetKeyPartitionKey]:
+        if self.asset_key not in self.asset_graph.root_asset_keys:
+            return set()
+        return (
+            self.cursor.get_unhandled_asset_partitions(
+                self.asset_graph,
+                dynamic_partitions_store=self.instance_queryer,
+                current_time=self.instance_queryer.evaluation_time,
+            )
+            - self.newly_materialized_root_partitions
+        )
 
     @functools.cached_property
     def asset_partitions_with_updated_parents_since_previous_tick(
@@ -799,9 +823,7 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
         asset_partitions_by_evaluation_data = defaultdict(set)
 
         missing_asset_partitions = set(
-            context.daemon_context.get_never_handled_root_asset_partitions_for_key(
-                context.asset_key
-            )
+            context.never_materialized_requested_or_discarded_root_partitions
         )
         # in addition to missing root asset partitions, check any asset partitions with updated
         # parents to see if they're missing

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -202,7 +202,7 @@ class RuleEvaluationContext:
 
     @functools.cached_property
     def newly_materialized_root_partitions(self) -> AbstractSet[AssetKeyPartitionKey]:
-        if self.asset_key not in self.asset_graph.root_asset_keys:
+        if self.asset_key not in self.asset_graph.root_materializable_or_observable_asset_keys:
             return set()
         newly_materialized = set()
         for asset_partition in self.cursor.materialized_requested_or_discarded_subset.inverse(
@@ -221,7 +221,7 @@ class RuleEvaluationContext:
     def never_materialized_requested_or_discarded_root_partitions(
         self
     ) -> AbstractSet[AssetKeyPartitionKey]:
-        if self.asset_key not in self.asset_graph.root_asset_keys:
+        if self.asset_key not in self.asset_graph.root_materializable_or_observable_asset_keys:
             return set()
         return (
             self.cursor.materialized_requested_or_discarded_subset.inverse(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_cursor.py
@@ -35,16 +35,12 @@ def test_asset_reconciliation_cursor_evaluation_id_backcompat() -> None:
 
     c2 = c.with_updates(
         21,
-        set(),
-        set(),
-        {AssetKey("my_asset")},
-        {AssetKey("my_asset"): {"a"}},
         1,
-        asset_graph,
         [],
         0,
         [],
         datetime.datetime.now(),
+        [],
     )
 
     serdes_c2 = AssetDaemonCursor.from_serialized(c2.serialize(), asset_graph)


### PR DESCRIPTION
## Summary & Motivation

This does not change any serialized objects, but paves the way for doing so in the future. Creates a new AssetDaemonAssetCursor class, which is the new interface for AutoMaterializeRules to interact with / understand data that is  saved between ticks.

Under the hood, we generate an AssetDaemonAssetCursor when evaluating each asset, and then use the set of updated cursors to update the global cursor at the end of the tick.

In the future, these cursors will be stored directly.

This allows a fair amount of junk to be cleared out, as previously we were calculating a bunch of information up front in order to be able to update all of the "materialized requested or discarded" subsets at once.

## How I Tested These Changes
