### PR TITLE
[daggy-u] - Fix deployment for forked branches

### DIFF
--- a/.github/workflows/build-dagster-university.yml
+++ b/.github/workflows/build-dagster-university.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Checkout PR branch
         if: github.event.pull_request
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: ${{ env.PR_FETCH_DEPTH }}
 
       - name: Publish Preview to Vercel
         uses: amondnet/vercel-action@v25


### PR DESCRIPTION
## Summary & Motivation

This PR removes the `with` condition from the checkout step of the Dagster University GitHub Action. Contributions from forked branches caused the GitHub Action that deploys to Vercel to fail with the following error ([example logs](https://github.com/dagster-io/dagster/actions/runs/6895183205/job/18758590678)):

```
Run actions/checkout@v3
Syncing repository: dagster-io/dagster
Getting Git version info
Temporarily overriding HOME='/home/runner/work/_temp/3ad9168b-5e3d-484d-940f-b1398804d86f' before making global git config changes
Adding repository directory to the temporary git global config as a safe directory
/usr/bin/git config --global --add safe.directory /home/runner/work/dagster/dagster
Deleting the contents of '/home/runner/work/dagster/dagster'
Initializing the repository
Disabling automatic garbage collection
Setting up auth
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=2 origin +refs/heads/fix-weekly-partition-practice*:refs/remotes/origin/fix-weekly-partition-practice* +refs/tags/fix-weekly-partition-practice*:refs/tags/fix-weekly-partition-practice*
  The process '/usr/bin/git' failed with exit code 1
```

[This PR](https://github.com/WeblateOrg/weblate/issues/6240) describes a similar problem.

## How I Tested These Changes

I think we'll need to merge this before we can test it, but it's easy enough to change back if there are issues.