### PR TITLE
Add access_key_id to sanitize key keyowrds

### DIFF
--- a/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/types.py
+++ b/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/types.py
@@ -10,7 +10,7 @@ class ManagedElementError(enum.Enum):
     CANNOT_CONNECT = "cannot_connect"
 
 
-SANITIZE_KEY_KEYWORDS = ["password", "token", "secret", "ssh_key", "credentials_json"]
+SANITIZE_KEY_KEYWORDS = ["password", "token", "secret", "ssh_key", "credentials_json", "access_key_id"]
 SANITIZE_KEY_EXACT_MATCHES = ["pat"]
 
 SECRET_MASK_VALUE = "**********"


### PR DESCRIPTION
## Summary
This pull request introduces a crucial update to the credential masking logic in the Dagster repository, specifically aimed at improving the synchronization process with AWS S3.

## Changes
- Extended the `SANITIZE_KEY_KEYWORDS` list to include `access_key_id`.
- Previous list: `["password", "token", "secret", "ssh_key", "credentials_json"]`
- Updated list: `["password", "token", "secret", "ssh_key", "credentials_json", "access_key_id"]`

## Rationale
In the existing implementation, when comparing configurations with tools like Airbyte, Dagster masks certain credential values. However, I observed that when using AWS S3 and providing `access_key_id`, Dagster incorrectly masks this key. This leads to a mismatch (`*******` vs actual `access_key_id`), falsely indicating a sync error. By adding `access_key_id` to the `SANITIZE_KEY_KEYWORDS`, Dagster will handle S3 credentials more accurately, preventing unnecessary error flags during synchronization checks.

## Impact
- Enhances the accuracy of configuration comparison with S3.
- Reduces false positives in sync error reporting.
- Aligns Dagster's credential masking approach more closely with real-world usage scenarios.

This update ensures that Dagster remains robust and accurate in its synchronization process, particularly when interfacing with AWS S3 services.
