### PR TITLE
Solving issue #17409 with InputContext and Multipartitions

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -21,7 +21,6 @@ from dagster._core.definitions.metadata import (
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import (
-    BaseTimeWindowPartitionsSubset,
     TimeWindow,
 )
 from dagster._core.errors import DagsterInvariantViolationError

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -396,7 +396,8 @@ class InputContext:
 
         Raises an error if either of the following are true:
         - The input asset has no partitioning.
-        - The input asset is not partitioned with a TimeWindowPartitionsDefinition.
+        - The input asset is not partitioned with a TimeWindowPartitionsDefinition or a
+        MultiPartitionsDefinition with one time-partitioned dimension.
         """
         subset = self._asset_partitions_subset
 
@@ -405,20 +406,7 @@ class InputContext:
                 "Tried to access asset_partitions_time_window, but the asset is not partitioned.",
             )
 
-        if not isinstance(subset, BaseTimeWindowPartitionsSubset):
-            check.failed(
-                "Tried to access asset_partitions_time_window, but the asset is not partitioned"
-                " with time windows.",
-            )
-
-        time_windows = subset.included_time_windows
-        if len(time_windows) != 1:
-            check.failed(
-                "Tried to access asset_partitions_time_window, but there are "
-                f"({len(time_windows)}) time windows associated with this input.",
-            )
-
-        return time_windows[0]
+        return self.step_context.asset_partitions_time_window_for_input(self.name)
 
     @public
     def get_identifier(self) -> Sequence[str]:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -11,11 +11,13 @@ from dagster import (
     DagsterInvalidDefinitionError,
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    InputContext,
     IOManager,
     IOManagerDefinition,
     MultiPartitionKey,
     MultiPartitionsDefinition,
     Output,
+    OutputContext,
     PartitionsDefinition,
     SourceAsset,
     StaticPartitionsDefinition,
@@ -24,8 +26,6 @@ from dagster import (
     define_asset_job,
     hourly_partitioned_config,
     materialize,
-    InputContext,
-    OutputContext,
 )
 from dagster._check import CheckError
 from dagster._core.definitions import asset, build_assets_job, multi_asset
@@ -679,6 +679,7 @@ def test_multipartition_range_single_run():
         MultiPartitionKey({"date": "2020-01-03", "abc": "a"}),
     }
 
+
 def test_multipartitioned_asset_partitions_time_window():
     partitions_def = MultiPartitionsDefinition(
         {
@@ -691,7 +692,6 @@ def test_multipartitioned_asset_partitions_time_window():
     def multipartitioned_asset(context) -> None:
         pass
 
-
     class CustomIOManager(IOManager):
         def handle_output(self, context: OutputContext, obj):
             assert context.asset_partitions_time_window == TimeWindow(
@@ -703,12 +703,12 @@ def test_multipartitioned_asset_partitions_time_window():
                 pendulum.parse("2023-01-01"), pendulum.parse("2023-01-02")
             )
 
-
     assert materialize(
         assets=[multipartitioned_asset],
         resources={"io_manager": IOManagerDefinition.hardcoded_io_manager(CustomIOManager())},
         partition_key="a|2023-01-01",
     ).success
+
 
 def test_error_on_nonexistent_upstream_partition():
     @asset(partitions_def=DailyPartitionsDefinition(start_date="2020-01-01"))

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -24,6 +24,8 @@ from dagster import (
     define_asset_job,
     hourly_partitioned_config,
     materialize,
+    InputContext,
+    OutputContext,
 )
 from dagster._check import CheckError
 from dagster._core.definitions import asset, build_assets_job, multi_asset
@@ -677,6 +679,36 @@ def test_multipartition_range_single_run():
         MultiPartitionKey({"date": "2020-01-03", "abc": "a"}),
     }
 
+def test_multipartitioned_asset_partitions_time_window():
+    partitions_def = MultiPartitionsDefinition(
+        {
+            "date": DailyPartitionsDefinition(start_date="2023-01-01"),
+            "abc": StaticPartitionsDefinition(["a", "b", "c"]),
+        }
+    )
+
+    @asset(partitions_def=partitions_def)
+    def multipartitioned_asset(context) -> None:
+        pass
+
+
+    class CustomIOManager(IOManager):
+        def handle_output(self, context: OutputContext, obj):
+            assert context.asset_partitions_time_window == TimeWindow(
+                pendulum.parse("2023-01-01"), pendulum.parse("2023-01-02")
+            )
+
+        def load_input(self, context: InputContext):
+            assert context.asset_partitions_time_window == TimeWindow(
+                pendulum.parse("2023-01-01"), pendulum.parse("2023-01-02")
+            )
+
+
+    assert materialize(
+        assets=[multipartitioned_asset],
+        resources={"io_manager": IOManagerDefinition.hardcoded_io_manager(CustomIOManager())},
+        partition_key="a|2023-01-01",
+    ).success
 
 def test_error_on_nonexistent_upstream_partition():
     @asset(partitions_def=DailyPartitionsDefinition(start_date="2020-01-01"))


### PR DESCRIPTION
## Summary & Motivation
A bug was detected when implementing MultiPartitionsDefinition with one time-partitioned dimension. The input context was not able to access the start and end time of the partitioned asset. The issue was reported and explained here:

https://github.com/dagster-io/dagster/issues/17409

## How I Tested These Changes
The proposed change is easy and it was tested with the same multipartition implementation that was giving the error before. I can access the start and end time of the partitioned asset from the input context, the same as from the output context.