### PR TITLE
[gql] Expose partition mapping on AssetDependency

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -717,7 +717,7 @@ type AssetDependency {
 }
 
 type PartitionMapping {
-  name: String!
+  className: String!
   description: String!
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -713,6 +713,12 @@ enum BackfillPolicyType {
 type AssetDependency {
   asset: AssetNode!
   inputName: String!
+  partitionMapping: PartitionMapping
+}
+
+type PartitionMapping {
+  name: String!
+  description: String!
 }
 
 type AssetFreshnessInfo {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2457,8 +2457,8 @@ export type PartitionKeysOrError = PartitionKeys | PartitionSubsetDeserializatio
 
 export type PartitionMapping = {
   __typename: 'PartitionMapping';
+  className: Scalars['String'];
   description: Scalars['String'];
-  name: Scalars['String'];
 };
 
 export type PartitionRangeSelector = {
@@ -9138,11 +9138,11 @@ export const buildPartitionMapping = (
   relationshipsToOmit.add('PartitionMapping');
   return {
     __typename: 'PartitionMapping',
+    className: overrides && overrides.hasOwnProperty('className') ? overrides.className! : 'quos',
     description:
       overrides && overrides.hasOwnProperty('description')
         ? overrides.description!
         : 'voluptatibus',
-    name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : 'non',
   };
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -253,6 +253,7 @@ export type AssetDependency = {
   __typename: 'AssetDependency';
   asset: AssetNode;
   inputName: Scalars['String'];
+  partitionMapping: Maybe<PartitionMapping>;
 };
 
 export enum AssetEventType {
@@ -2453,6 +2454,12 @@ export type PartitionKeys = {
 };
 
 export type PartitionKeysOrError = PartitionKeys | PartitionSubsetDeserializationError;
+
+export type PartitionMapping = {
+  __typename: 'PartitionMapping';
+  description: Scalars['String'];
+  name: Scalars['String'];
+};
 
 export type PartitionRangeSelector = {
   end: Scalars['String'];
@@ -4895,6 +4902,12 @@ export const buildAssetDependency = (
         : buildAssetNode({}, relationshipsToOmit),
     inputName:
       overrides && overrides.hasOwnProperty('inputName') ? overrides.inputName! : 'aspernatur',
+    partitionMapping:
+      overrides && overrides.hasOwnProperty('partitionMapping')
+        ? overrides.partitionMapping!
+        : relationshipsToOmit.has('PartitionMapping')
+        ? ({} as PartitionMapping)
+        : buildPartitionMapping({}, relationshipsToOmit),
   };
 };
 
@@ -9114,6 +9127,22 @@ export const buildPartitionKeys = (
     __typename: 'PartitionKeys',
     partitionKeys:
       overrides && overrides.hasOwnProperty('partitionKeys') ? overrides.partitionKeys! : [],
+  };
+};
+
+export const buildPartitionMapping = (
+  overrides?: Partial<PartitionMapping>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'PartitionMapping'} & PartitionMapping => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('PartitionMapping');
+  return {
+    __typename: 'PartitionMapping',
+    description:
+      overrides && overrides.hasOwnProperty('description')
+        ? overrides.description!
+        : 'voluptatibus',
+    name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : 'non',
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -167,7 +167,9 @@ class GrapheneAssetDependency(graphene.ObjectType):
             materialization_loader=self._latest_materialization_loader,
         )
 
-    def resolve_partitionMapping(self, _graphene_info: ResolveInfo):
+    def resolve_partitionMapping(
+        self, _graphene_info: ResolveInfo
+    ) -> Optional[GraphenePartitionMapping]:
         if self._partition_mapping:
             return GraphenePartitionMapping(self._partition_mapping)
         return None

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -132,7 +132,6 @@ class GrapheneAssetDependency(graphene.ObjectType):
         depended_by_loader: Optional[CrossRepoAssetDependedByLoader] = None,
         partition_mapping: Optional[PartitionMapping] = None,
     ):
-        print(partition_mapping)
         self._repository_location = check.inst_param(
             repository_location, "repository_location", CodeLocation
         )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_mappings.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_mappings.py
@@ -3,7 +3,7 @@ from dagster._core.definitions.partition_mapping import PartitionMapping
 
 
 class GraphenePartitionMapping(graphene.ObjectType):
-    name = graphene.NonNull(graphene.String)
+    className = graphene.NonNull(graphene.String)
     description = graphene.NonNull(graphene.String)
 
     class Meta:
@@ -14,6 +14,6 @@ class GraphenePartitionMapping(graphene.ObjectType):
         partition_mapping: PartitionMapping,
     ):
         super().__init__(
-            name=type(partition_mapping).__name__,
-            description=str(partition_mapping),
+            className=type(partition_mapping).__name__,
+            description=partition_mapping.description,
         )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_mappings.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_mappings.py
@@ -1,0 +1,19 @@
+import graphene
+from dagster._core.definitions.partition_mapping import PartitionMapping
+
+
+class GraphenePartitionMapping(graphene.ObjectType):
+    name = graphene.NonNull(graphene.String)
+    description = graphene.NonNull(graphene.String)
+
+    class Meta:
+        name = "PartitionMapping"
+
+    def __init__(
+        self,
+        partition_mapping: PartitionMapping,
+    ):
+        super().__init__(
+            name=type(partition_mapping).__name__,
+            description=str(partition_mapping),
+        )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -16,6 +16,7 @@ from dagster import (
     AssetCheckResult,
     AssetCheckSpec,
     AssetExecutionContext,
+    AssetIn,
     AssetKey,
     AssetMaterialization,
     AssetObservation,
@@ -59,6 +60,7 @@ from dagster import (
     TableConstraints,
     TableRecord,
     TableSchema,
+    TimeWindowPartitionMapping,
     WeeklyPartitionsDefinition,
     _check as check,
     asset,
@@ -1464,7 +1466,12 @@ def upstream_time_partitioned_asset():
     return 1
 
 
-@asset(partitions_def=hourly_partition)
+@asset(
+    partitions_def=hourly_partition,
+    ins={
+        "upstream_time_partitioned_asset": AssetIn(partition_mapping=TimeWindowPartitionMapping())
+    },
+)
 def downstream_time_partitioned_asset(
     upstream_time_partitioned_asset,
 ):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -660,7 +660,7 @@ GET_ASSET_DEPENDENCIES_PARTITION_MAPPING = """
                         }
                     }
                     partitionMapping {
-                        name
+                        className
                         description
                     }
                 }
@@ -2414,7 +2414,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         dependencies = result.data["assetNodeOrError"]["dependencies"]
         assert len(dependencies) == 1
         assert dependencies[0]["asset"]["assetKey"]["path"] == ["upstream_time_partitioned_asset"]
-        assert dependencies[0]["partitionMapping"]["name"] == "TimeWindowPartitionMapping"
+        assert dependencies[0]["partitionMapping"]["className"] == "TimeWindowPartitionMapping"
         assert (
             dependencies[0]["partitionMapping"]["description"]
             == "Maps a downstream partition to any upstream partition with an overlapping time window."

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -939,7 +939,10 @@ class StaticPartitionMapping(
         return UpstreamPartitionsResult(upstream_subset.with_partition_keys(upstream_keys), [])
 
     def __str__(self) -> str:
-        return f"Upstream partitions are dependencies of downstream partitions according to the following mapping: \n{self.downstream_partition_keys_by_upstream_partition_key}"
+        return (
+            f"Maps upstream partitions to their downstream dependencies according to the "
+            f"following mapping: \n{self.downstream_partition_keys_by_upstream_partition_key}"
+        )
 
 
 class InferSingleToMultiDimensionDepsResult(

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -903,6 +903,9 @@ class StaticPartitionMapping(
 
         return UpstreamPartitionsResult(upstream_subset.with_partition_keys(upstream_keys), [])
 
+    def __str__(self) -> str:
+        return f"Upstream partitions are dependencies of downstream partitions according to the following mapping: \n{self.downstream_partition_keys_by_upstream_partition_key}"
+
 
 class InferSingleToMultiDimensionDepsResult(
     NamedTuple(

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -101,7 +101,8 @@ class PartitionMapping(ABC):
 
     @abstractproperty
     def description(self) -> str:
-        """A human-readable description of the partition mapping, displayed in the Dagster UI"""
+        """A human-readable description of the partition mapping, displayed in the Dagster UI."""
+        raise NotImplementedError()
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -105,6 +105,16 @@ class TimeWindowPartitionMapping(
             ),
         )
 
+    def __str__(self) -> str:
+        description = (
+            "Maps a downstream partition to any upstream partition with an overlapping time window."
+        )
+
+        if self.start_offset != 0 or self.end_offset != 0:
+            description += f"The start and end of the upstream time window is offsetted by {self.start_offset} and {self.end_offset} partitions respectively."
+
+        return description
+
     def get_upstream_mapped_partitions_result_for_partitions(
         self,
         downstream_partitions_subset: Optional[PartitionsSubset],

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -105,18 +105,19 @@ class TimeWindowPartitionMapping(
             ),
         )
 
-    def __str__(self) -> str:
-        description = (
+    @property
+    def description(self) -> str:
+        description_str = (
             "Maps a downstream partition to any upstream partition with an overlapping time window."
         )
 
         if self.start_offset != 0 or self.end_offset != 0:
-            description += (
+            description_str += (
                 f" The start and end of the upstream time window is offsetted by "
                 f"{self.start_offset} and {self.end_offset} partitions respectively."
             )
 
-        return description
+        return description_str
 
     def get_upstream_mapped_partitions_result_for_partitions(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -111,7 +111,10 @@ class TimeWindowPartitionMapping(
         )
 
         if self.start_offset != 0 or self.end_offset != 0:
-            description += f"The start and end of the upstream time window is offsetted by {self.start_offset} and {self.end_offset} partitions respectively."
+            description += (
+                f" The start and end of the upstream time window is offsetted by "
+                f"{self.start_offset} and {self.end_offset} partitions respectively."
+            )
 
         return description
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -91,6 +91,10 @@ def test_access_partition_keys_from_context_non_identity_partition_mapping():
         ) -> PartitionsSubset:
             raise NotImplementedError()
 
+        @property
+        def description(self) -> str:
+            raise NotImplementedError()
+
     class MyIOManager(IOManager):
         def handle_output(self, context, obj):
             assert context.asset_partition_key == "2"

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -953,3 +953,26 @@ def test_dynamic_dimension_multipartition_mapping():
         dynamic_partitions_store=instance,
     )
     assert result.partitions_subset == foo_bar.empty_subset().with_partition_keys(["2|a", "1|a"])
+
+
+def test_description():
+    description = MultiPartitionMapping(
+        {
+            "abc": DimensionPartitionMapping(
+                dimension_name="abc", partition_mapping=IdentityPartitionMapping()
+            ),
+            "daily": DimensionPartitionMapping(
+                dimension_name="weekly",
+                partition_mapping=TimeWindowPartitionMapping(),
+            ),
+        }
+    ).description
+    assert (
+        "'abc' mapped to downstream dimension 'abc' using IdentityPartitionMapping" in description
+    )
+    assert (
+        "'daily' mapped to downstream dimension 'weekly' using TimeWindowPartitionMapping"
+        in description
+    )
+
+    assert MultiPartitionMapping({}).description == ""

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -240,6 +240,10 @@ def test_custom_unsupported_partition_mapping():
         ) -> PartitionsSubset:
             raise NotImplementedError()
 
+        @property
+        def description(self) -> str:
+            raise NotImplementedError()
+
     @asset(partitions_def=StaticPartitionsDefinition(["1", "2", "3"]))
     def parent():
         ...

--- a/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
@@ -312,6 +312,10 @@ def test_fs_io_manager_partitioned_no_partitions():
             ):
                 raise NotImplementedError()
 
+            @property
+            def description(self) -> str:
+                raise NotImplementedError()
+
         partitions_def = DailyPartitionsDefinition(start_date="2020-02-01")
 
         @asset(partitions_def=partitions_def)


### PR DESCRIPTION
Adds backend support to resolve https://github.com/dagster-io/dagster/issues/15720

This PR exposes the partition mapping on `GrapheneAssetDependency`, which represents the "edge" in between an asset and its upstream. The partition mapping is only returned if it is defined on the asset (and not inferred). The reasoning here is to avoid introducing complexity in the UI when the user hasn't provided an explicit definition.

It adds descriptions for partition mappings in case if we'd like to display that.