### PR TITLE
add longtext support for event blob / materialization blob in mysql

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -15,7 +15,7 @@ SqlEventLogStorageTable = db.Table(
         autoincrement=True,
     ),
     db.Column("run_id", db.String(255)),
-    db.Column("event", db.Text, nullable=False),
+    db.Column("event", MySQLCompatabilityTypes.LongText, nullable=False),
     db.Column("dagster_event_type", db.Text),
     db.Column("timestamp", db.types.TIMESTAMP),
     db.Column("step_key", db.Text),
@@ -56,7 +56,7 @@ AssetKeyTable = db.Table(
         autoincrement=True,
     ),
     db.Column("asset_key", MySQLCompatabilityTypes.UniqueText, unique=True),
-    db.Column("last_materialization", db.Text),
+    db.Column("last_materialization", MySQLCompatabilityTypes.LongText),
     db.Column("last_run_id", db.String(255)),
     db.Column("asset_details", db.Text),
     db.Column("wipe_timestamp", db.types.TIMESTAMP),  # guarded by secondary index check

--- a/python_modules/dagster/dagster/_core/storage/sql.py
+++ b/python_modules/dagster/dagster/_core/storage/sql.py
@@ -205,5 +205,20 @@ def add_precision_to_mysql_FLOAT(_element, _compiler, **_kw) -> str:
     return f"FLOAT({MYSQL_FLOAT_PRECISION})"
 
 
+class LongText(db.Text):
+    """Allows customization of certain fields to map to LONGTEXT in MySQL.  For Postgres, all text
+    fields are mapped to TEXT, which is unbounded in length, so the distinction is not neccessary.
+    In MySQL, however, TEXT is limited to 64KB, so LONGTEXT (4GB) is required for certain fields.
+    """
+
+    pass
+
+
+@compiles(LongText, "mysql")
+def compile_longtext_mysql(_element, _compiler, **_kw) -> str:
+    return "LONGTEXT"
+
+
 class MySQLCompatabilityTypes:
     UniqueText = db.String(512)
+    LongText = LongText

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -1,6 +1,8 @@
 import datetime
 import logging  # noqa: F401; used by mock in string form
+import random
 import re
+import string
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -4231,3 +4233,26 @@ class TestEventLogStorage:
         mats = storage.get_latest_materialization_events([key])
         assert mats
         assert mats[key].asset_materialization.metadata["was"].value == "here"
+
+    def test_large_asset_metadata(self, storage):
+        key = AssetKey("test_asset")
+
+        large_metadata = {
+            f"key_{i}": "".join(random.choices(string.ascii_uppercase, k=1000)) for i in range(300)
+        }
+        storage.store_event(
+            EventLogEntry(
+                error_info=None,
+                user_message="",
+                level="debug",
+                run_id=make_new_run_id(),
+                timestamp=time.time(),
+                dagster_event=DagsterEvent(
+                    event_type_value=DagsterEventType.ASSET_MATERIALIZATION.value,
+                    job_name=RUNLESS_JOB_NAME,
+                    event_specific_data=StepMaterializationData(
+                        materialization=AssetMaterialization(asset_key=key, metadata=large_metadata)
+                    ),
+                ),
+            )
+        )


### PR DESCRIPTION
## Summary & Motivation
For arbitrary large metadata blobs in events, the 64kb limit in mysql text cols is overly restrictive.  Converting these to longtext will provide similar behavior to postgres TEXT columns.

https://github.com/dagster-io/dagster/issues/17982

[GH Discussion](https://github.com/dagster-io/dagster/discussions/18313) 

We don't have optional schema changes, so was thinking that I would not add a schema migration because this would be a pretty expensive, blocking operation.  We can add some guidance to users running into this to manually migrate the column, but new DBs will be spun up with the appropriate column types on MySQL.

## How I Tested These Changes
BK