### PR TITLE
Get prioritized run ids

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1736,14 +1736,8 @@ class DagsterInstance(DynamicPartitionsStore):
         filters: Optional[RunsFilter] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
-        prioritized: bool = False,
     ) -> Sequence[str]:
-        return self._run_storage.get_run_ids(
-            filters,
-            cursor=cursor,
-            limit=limit,
-            prioritized=prioritized,
-        )
+        return self._run_storage.get_run_ids(filters, cursor=cursor, limit=limit)
 
     @traced
     def get_runs_count(self, filters: Optional[RunsFilter] = None) -> int:

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1736,8 +1736,14 @@ class DagsterInstance(DynamicPartitionsStore):
         filters: Optional[RunsFilter] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
+        prioritized: bool = False,
     ) -> Sequence[str]:
-        return self._run_storage.get_run_ids(filters, cursor=cursor, limit=limit)
+        return self._run_storage.get_run_ids(
+            filters,
+            cursor=cursor,
+            limit=limit,
+            prioritized=prioritized,
+        )
 
     @traced
     def get_runs_count(self, filters: Optional[RunsFilter] = None) -> int:

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -214,8 +214,14 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
         filters: Optional["RunsFilter"] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
+        prioritized: bool = False,
     ) -> Iterable[str]:
-        return self._storage.run_storage.get_run_ids(filters, cursor=cursor, limit=limit)
+        return self._storage.run_storage.get_run_ids(
+            filters,
+            cursor=cursor,
+            limit=limit,
+            prioritized=prioritized,
+        )
 
     def get_runs_count(self, filters: Optional["RunsFilter"] = None) -> int:
         return self._storage.run_storage.get_runs_count(filters)

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -214,14 +214,14 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
         filters: Optional["RunsFilter"] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
-        prioritized: bool = False,
     ) -> Iterable[str]:
-        return self._storage.run_storage.get_run_ids(
-            filters,
-            cursor=cursor,
-            limit=limit,
-            prioritized=prioritized,
-        )
+        return self._storage.run_storage.get_run_ids(filters, cursor=cursor, limit=limit)
+
+    def get_prioritized_run_ids(
+        self,
+        filters: Optional["RunsFilter"] = None,
+    ) -> Iterable[str]:
+        return self._storage.run_storage.get_prioritized_run_ids(filters=filters)
 
     def get_runs_count(self, filters: Optional["RunsFilter"] = None) -> int:
         return self._storage.run_storage.get_runs_count(filters)

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -89,7 +89,6 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         filters: Optional[RunsFilter] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
-        prioritized: bool = False,
     ) -> Sequence[str]:
         """Return all the run IDs for runs present in the storage that match the given filters.
 
@@ -99,12 +98,27 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
                 runs
             cursor (Optional[str]): Starting cursor (run_id) of range of runs
             limit (Optional[int]): Number of results to get. Defaults to infinite.
-            prioritized (bool): Order ids using priority tags.
-                https://docs.dagster.io/guides/customizing-run-queue-priority
-                Defaults to False.
 
         Returns:
             Sequence[str]
+        """
+
+    @abstractmethod
+    def get_prioritized_run_ids(
+        self,
+        filters: Optional[RunsFilter] = None,
+    ) -> Sequence[str]:
+        """Return run ids in priority order.
+
+        https://docs.dagster.io/guides/customizing-run-queue-priority
+
+        Args:
+            filters (Optional[RunsFilter]) -- The
+                :py:class:`~dagster._core.storage.pipeline_run.RunsFilter` by which to filter
+                runs
+
+        Returns:
+            Sequences[str]
         """
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -89,6 +89,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         filters: Optional[RunsFilter] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
+        prioritized: bool = False,
     ) -> Sequence[str]:
         """Return all the run IDs for runs present in the storage that match the given filters.
 
@@ -98,6 +99,9 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
                 runs
             cursor (Optional[str]): Starting cursor (run_id) of range of runs
             limit (Optional[int]): Number of results to get. Defaults to infinite.
+            prioritized (bool): Order ids using priority tags.
+                https://docs.dagster.io/guides/customizing-run-queue-priority
+                Defaults to False.
 
         Returns:
             Sequence[str]

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -368,12 +368,15 @@ class SqlRunStorage(RunStorage):
         filters: Optional[RunsFilter] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
-        prioritized: Optional[bool] = False,
     ) -> Sequence[str]:
         query = self._runs_query(filters=filters, cursor=cursor, limit=limit, columns=["run_id"])
 
-        if prioritized:
-            query = self._order_by_run_priority(query)
+        rows = self.fetchall(query)
+        return [row["run_id"] for row in rows]
+
+    def get_prioritized_run_ids(self, filters: Optional[RunsFilter] = None):
+        query = self._runs_query(filters=filters, columns=["run_id"])
+        query = self._order_by_run_priority(query)
 
         rows = self.fetchall(query)
         return [row["run_id"] for row in rows]

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -351,7 +351,7 @@ class SqlRunStorage(RunStorage):
                     # try to get the priority tag value
                     db.func.cast(
                         db.func.json_extract(RunsTable.c.run_body, f'$.tags."{PRIORITY_TAG}"'),
-                        db.Integer,
+                        db.Float,
                     ),
                     # default to a priority of 0
                     0,

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -350,7 +350,7 @@ class SqlRunStorage(RunStorage):
                 db.func.coalesce(
                     # try to get the priority tag value
                     db.func.cast(
-                        RunsTable.c.run_body.op("->>")(f'$.tags."{PRIORITY_TAG}"'),
+                        db.func.json_extract(RunsTable.c.run_body, f'$.tags."{PRIORITY_TAG}"'),
                         db.Integer,
                     ),
                     # default to a priority of 0

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -668,11 +668,25 @@ class TestRunStorage:
                 tags={PRIORITY_TAG: "100"},
             )
         )
+        storage.add_run(
+            TestRunStorage.build_run(
+                run_id="decimal-priority",
+                job_name="some_pipeline",
+                tags={PRIORITY_TAG: "0.5"},
+            )
+        )
 
         # Default sort is id desc
-        assert storage.get_run_ids() == ["high-priority", "2", "low-priority", "1"]
+        assert storage.get_run_ids() == [
+            "decimal-priority",
+            "high-priority",
+            "2",
+            "low-priority",
+            "1",
+        ]
         assert storage.get_prioritized_run_ids() == [
             "high-priority",
+            "decimal-priority",
             "1",
             "2",
             "low-priority",

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -671,7 +671,12 @@ class TestRunStorage:
 
         # Default sort is id desc
         assert storage.get_run_ids() == ["high-priority", "2", "low-priority", "1"]
-        assert storage.get_run_ids(prioritized=True) == ["high-priority", "1", "2", "low-priority"]
+        assert storage.get_prioritized_run_ids() == [
+            "high-priority",
+            "1",
+            "2",
+            "low-priority",
+        ]
 
     def test_fetch_by_status(self, storage):
         assert storage

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -651,7 +651,7 @@ class TestRunStorage:
         assert storage.get_run_ids(RunsFilter(job_name="some_pipeline")) == [three, two, one]
         assert storage.get_run_ids(RunsFilter(job_name="some_pipeline"), limit=1) == [three]
 
-    def tests_get_run_ids_prioritized(self, storage):
+    def test_get_run_ids_prioritized(self, storage):
         storage.add_run(TestRunStorage.build_run(run_id="1", job_name="some_pipeline"))
         storage.add_run(
             TestRunStorage.build_run(

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -251,7 +251,7 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
                         db.func.cast(RunsTable.c.run_body, db.JSON)
                         .op("->")("tags")
                         .op("->>")(PRIORITY_TAG),
-                        db.Integer,
+                        db.Float,
                     ),
                     # default to a priority of 0
                     0,


### PR DESCRIPTION
Given the sorting algorithm described in:

https://docs.dagster.io/guides/customizing-run-queue-priority

Postgres has a slightly different path extraction implementation than MySQL and sqlite have.

Shifting this prioritization down to the db unblocks a refactor to the queued run coordinator daemon to prevent needing to load every queued run into memory.
