### PR TITLE
Add more tick lines on tick timeline

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/LiveTickTimeline2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/LiveTickTimeline2.tsx
@@ -105,7 +105,8 @@ export const LiveTickTimeline = <T extends HistoryTickFragment | AssetDaemonTick
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [minX, now, ticksReversed, fullRange, viewport.width]);
 
-  const tickGridDelta = Math.max((maxX - minX) / 25, tickGrid);
+  const timeTickGridDelta = Math.max((maxX - minX) / 25, tickGrid);
+  const tickGridDelta = timeTickGridDelta / 5;
   const startTickGridX = Math.ceil(minX / tickGridDelta) * tickGridDelta;
   const gridTicks = React.useMemo(() => {
     const ticks = [];
@@ -113,11 +114,11 @@ export const LiveTickTimeline = <T extends HistoryTickFragment | AssetDaemonTick
       ticks.push({
         time: i,
         x: getX(i, viewport.width, minX, fullRange),
-        showLabel: i % tickGridDelta === 0,
+        showLabel: i % timeTickGridDelta === 0,
       });
     }
     return ticks;
-  }, [startTickGridX, maxX, tickGridDelta, viewport.width, minX, fullRange]);
+  }, [maxX, startTickGridX, tickGridDelta, viewport.width, minX, fullRange, timeTickGridDelta]);
 
   const {
     timezone: [timezone],


### PR DESCRIPTION
## How I Tested These Changes

AMP:


before:
<img width="1352" alt="Screenshot 2023-11-17 at 3 17 01 PM" src="https://github.com/dagster-io/dagster/assets/2286579/a6fa3265-a1bd-41ba-ae9c-709bfac94dde">


after:
<img width="1239" alt="Screenshot 2023-11-17 at 3 17 44 PM" src="https://github.com/dagster-io/dagster/assets/2286579/1eedd81b-eec2-4475-b867-3bfcb8bd9856">



Sensors:

before:
<img width="1352" alt="Screenshot 2023-11-17 at 3 18 19 PM" src="https://github.com/dagster-io/dagster/assets/2286579/d23bf746-0978-439c-8a11-fa022a444a96">

after:
<img width="1232" alt="Screenshot 2023-11-17 at 3 18 53 PM" src="https://github.com/dagster-io/dagster/assets/2286579/e4be122c-ff16-456c-be8d-7845fe5a0324">
