### PR TITLE
[docs] dagster essentials - fixes relative partitions import for taxi trips

### DIFF
--- a/docs/dagster-university/pages/dagster-essentials/lesson-8/adding-partitions-to-assets.md
+++ b/docs/dagster-university/pages/dagster-essentials/lesson-8/adding-partitions-to-assets.md
@@ -78,7 +78,7 @@ To add the partition to the asset:
 After following the steps above, the `taxi_trips_file` asset should look similar to the code snippet below:
 
 ```python
-from .partitions import monthly_partition
+from ..partitions import monthly_partition
 
 @asset(
   partitions_def=monthly_partition

--- a/docs/dagster-university/pages/dagster-essentials/lesson-8/coding-practice-partition-taxi-trips.md
+++ b/docs/dagster-university/pages/dagster-essentials/lesson-8/coding-practice-partition-taxi-trips.md
@@ -37,7 +37,7 @@ The updated asset should look similar to the following code. Click **View answer
 
 ```python {% obfuscated="true" %}
 from dagster import asset
-from .partitions import monthly_partitions
+from ..partitions import monthly_partitions
 
 @asset(
   deps=["taxi_trips_file"],


### PR DESCRIPTION
## Summary & Motivation

Imports of `monthly_partition` should use `..partitions` to import the `monthly_partitions` object.

Without this, the following error is thrown:

```
The above exception was caused by the following exception:
ModuleNotFoundError: No module named 'dagster_university.assets.partitions'
```

Cheers!

## How I Tested These Changes

Viewed rendered markdown in web browser.
