### PR TITLE
store job_names on ExternalAssetCheck

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -679,10 +679,12 @@ def test_asset_check_multiple_jobs():
 
     repo = resolve_pending_repo_if_required(defs)
     external_repo_data = external_repository_data_from_def(repo)
-
+    assert external_repo_data.external_asset_checks
     assert len(external_repo_data.external_asset_checks) == 2
     assert external_repo_data.external_asset_checks[0].name == "my_asset_check"
     assert external_repo_data.external_asset_checks[1].name == "my_other_asset_check"
+    assert external_repo_data.external_asset_checks[0].job_names == ["__ASSET_JOB"]
+    assert external_repo_data.external_asset_checks[1].job_names == ["__ASSET_JOB", "my_job"]
 
 
 def test_repository_snap_definitions_resources_schedule_sensor_usage():


### PR DESCRIPTION
For https://github.com/dagster-io/dagster/issues/17952: store job_names like we do on ExternalAssetNode. We'll use this to be able to filter checks by job over gql