### PR TITLE
gql pipelineSelector on assetChecksOrError

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -689,7 +689,7 @@ type AssetNode {
   type: DagsterType
   hasMaterializePermission: Boolean!
   hasAssetChecks: Boolean!
-  assetChecksOrError(limit: Int): AssetChecksOrError!
+  assetChecksOrError(limit: Int, pipeline: PipelineSelector): AssetChecksOrError!
   currentAutoMaterializeEvaluationId: Int
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -382,6 +382,7 @@ export type AssetNode = {
 
 export type AssetNodeAssetChecksOrErrorArgs = {
   limit?: InputMaybe<Scalars['Int']>;
+  pipeline?: InputMaybe<PipelineSelector>;
 };
 
 export type AssetNodeAssetMaterializationUsedDataArgs = {

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -38,6 +38,7 @@ from dagster_graphql.implementation.fetch_assets import (
     get_asset_observations,
 )
 from dagster_graphql.schema.config_types import GrapheneConfigTypeField
+from dagster_graphql.schema.inputs import GraphenePipelineSelector
 from dagster_graphql.schema.metadata import GrapheneMetadataEntry
 from dagster_graphql.schema.partition_sets import (
     GrapheneDimensionPartitionKeys,
@@ -283,6 +284,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     assetChecksOrError = graphene.Field(
         graphene.NonNull(GrapheneAssetChecksOrError),
         limit=graphene.Argument(graphene.Int),
+        pipeline=graphene.Argument(GraphenePipelineSelector),
     )
     currentAutoMaterializeEvaluationId = graphene.Int()
 
@@ -1142,10 +1144,13 @@ class GrapheneAssetNode(graphene.ObjectType):
         return has_asset_checks(graphene_info, self._external_asset_node.asset_key)
 
     def resolve_assetChecksOrError(
-        self, graphene_info: ResolveInfo, limit=None
+        self,
+        graphene_info: ResolveInfo,
+        limit=None,
+        pipeline: Optional[GraphenePipelineSelector] = None,
     ) -> AssetChecksOrErrorUnion:
         return self._asset_checks_loader.get_checks_for_asset(
-            self._external_asset_node.asset_key, limit
+            self._external_asset_node.asset_key, limit, pipeline
         )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -44,12 +44,12 @@ query AssetNodeChecksLimitQuery($assetKeys: [AssetKeyInput!], $limit: Int) {
 """
 
 GET_ASSET_CHECK_NAMES_QUERY = """
-query AssetNodeChecksLimitQuery($assetKeys: [AssetKeyInput!], $limit: Int) {
-    assetNodes(assetKeys: $assetKeys) {
+query AssetNodeChecksLimitQuery($assetKeys: [AssetKeyInput!], $limit: Int, $pipelineSelector: PipelineSelector) {
+    assetNodes(assetKeys: $assetKeys, pipeline: $pipelineSelector) {
         assetKey {
             path
         }
-        assetChecksOrError(limit: $limit) {
+        assetChecksOrError(limit: $limit, pipeline: $pipelineSelector) {
             ... on AssetChecks {
                 checks {
                     name
@@ -352,6 +352,43 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                 "assetChecksOrError": {"checks": [{"name": "my_check"}]},
             },
         ]
+
+    def test_asset_check_asset_node_job_selection(self, graphql_context: WorkspaceRequestContext):
+        res = execute_dagster_graphql(
+            graphql_context,
+            GET_ASSET_CHECK_NAMES_QUERY,
+            variables={
+                "pipelineSelector": infer_job_selector(
+                    graphql_context, "fail_partition_materialization_job"
+                )
+            },
+        )
+        assert res.data == {
+            "assetNodes": [
+                {
+                    "assetKey": {"path": ["fail_partition_materialization"]},
+                    "assetChecksOrError": {"checks": []},
+                }
+            ]
+        }
+
+        res = execute_dagster_graphql(
+            graphql_context,
+            GET_ASSET_CHECK_NAMES_QUERY,
+            variables={"pipelineSelector": infer_job_selector(graphql_context, "asset_check_job")},
+        )
+        assert res.data == {
+            "assetNodes": [
+                {
+                    "assetChecksOrError": {"checks": [{"name": "my_check"}]},
+                    "assetKey": {"path": ["asset_1"]},
+                },
+                {
+                    "assetChecksOrError": {"checks": [{"name": "my_check"}]},
+                    "assetKey": {"path": ["check_in_op_asset"]},
+                },
+            ]
+        }
 
     def test_asset_check_execution_cursoring(self, graphql_context: WorkspaceRequestContext):
         graphql_context.instance.wipe()

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -679,10 +679,12 @@ def test_asset_check_multiple_jobs():
 
     repo = resolve_pending_repo_if_required(defs)
     external_repo_data = external_repository_data_from_def(repo)
-
+    assert external_repo_data.external_asset_checks
     assert len(external_repo_data.external_asset_checks) == 2
     assert external_repo_data.external_asset_checks[0].name == "my_asset_check"
     assert external_repo_data.external_asset_checks[1].name == "my_other_asset_check"
+    assert external_repo_data.external_asset_checks[0].job_names == ["__ASSET_JOB"]
+    assert external_repo_data.external_asset_checks[1].job_names == ["__ASSET_JOB", "my_job"]
 
 
 def test_repository_snap_definitions_resources_schedule_sensor_usage():


### PR DESCRIPTION
For https://github.com/dagster-io/dagster/issues/17952: we can use this on the front end to include the correct checks in the selector when launching a job.