### PR TITLE
[partitions] remove current_time arg from PartitionsSubset get_partition_keys() method

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -940,7 +940,7 @@ class PartitionsSubset(ABC, Generic[T_str]):
 
     @abstractmethod
     @public
-    def get_partition_keys(self, current_time: Optional[datetime] = None) -> Iterable[T_str]:
+    def get_partition_keys(self) -> Iterable[T_str]:
         ...
 
     @abstractmethod
@@ -1096,7 +1096,7 @@ class DefaultPartitionsSubset(
             )
         ) - set(self.subset)
 
-    def get_partition_keys(self, current_time: Optional[datetime] = None) -> Iterable[str]:
+    def get_partition_keys(self) -> Iterable[str]:
         return self.subset
 
     def get_partition_key_ranges(

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1902,7 +1902,7 @@ class PartitionKeysTimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
         return len(self._included_partition_keys)
 
     @public
-    def get_partition_keys(self, current_time: Optional[datetime] = None) -> Iterable[str]:
+    def get_partition_keys(self) -> Iterable[str]:
         return list(self._included_partition_keys) if self._included_partition_keys else []
 
     @property
@@ -2105,7 +2105,7 @@ class TimeWindowPartitionsSubset(
         )
 
     @public
-    def get_partition_keys(self, current_time: Optional[datetime] = None) -> Iterable[str]:
+    def get_partition_keys(self) -> Iterable[str]:
         return [
             pk
             for time_window in self.included_time_windows

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -747,15 +747,11 @@ def test_dst_transition_with_daily_partitions(
     upstream = time_partition_mapping.get_upstream_mapped_partitions_result_for_partitions(
         subset, partitions_def, partitions_def, current_time=current_time
     )
-    assert upstream.partitions_subset.get_partition_keys(current_time=current_time) == [
-        expected_upstream_partition_key
-    ]
+    assert upstream.partitions_subset.get_partition_keys() == [expected_upstream_partition_key]
     downstream = time_partition_mapping.get_downstream_partitions_for_partitions(
         subset, partitions_def, partitions_def, current_time=current_time
     )
-    assert downstream.get_partition_keys(current_time=current_time) == [
-        expected_downstream_partition_key
-    ]
+    assert downstream.get_partition_keys() == [expected_downstream_partition_key]
 
 
 def test_mar_2024_dst_transition_with_hourly_partitions():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -765,13 +765,13 @@ def test_mar_2024_dst_transition_with_hourly_partitions():
     upstream = time_partition_mapping.get_upstream_mapped_partitions_result_for_partitions(
         subset, partitions_def, partitions_def, current_time=current_time
     )
-    assert upstream.partitions_subset.get_partition_keys(current_time=current_time) == [
+    assert upstream.partitions_subset.get_partition_keys() == [
         "2024-03-10-01:00",
     ]
     downstream = time_partition_mapping.get_downstream_partitions_for_partitions(
         subset, partitions_def, partitions_def, current_time=current_time
     )
-    assert downstream.get_partition_keys(current_time=current_time) == [
+    assert downstream.get_partition_keys() == [
         "2024-03-10-04:00",
     ]
 
@@ -796,14 +796,10 @@ def test_nov_2023_dst_transition_with_hourly_partitions():
         upstream = time_partition_mapping.get_upstream_mapped_partitions_result_for_partitions(
             subset, partitions_def, partitions_def, current_time=current_time
         )
-        assert upstream.partitions_subset.get_partition_keys(current_time=current_time) == [
-            upstream_key,
-        ]
+        assert upstream.partitions_subset.get_partition_keys() == [upstream_key]
 
         subset = partitions_def.subset_with_partition_keys([upstream_key])
         downstream = time_partition_mapping.get_downstream_partitions_for_partitions(
             subset, partitions_def, partitions_def, current_time=current_time
         )
-        assert downstream.get_partition_keys(current_time=current_time) == [
-            downstream_key,
-        ]
+        assert downstream.get_partition_keys() == [downstream_key]

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -283,13 +283,11 @@ def test_multipartitions_subset_addition(initial, added):
             "static": StaticPartitionsDefinition(static_keys),
         }
     )
-    full_date_set_keys = daily_partitions_def.get_partition_keys(
-        current_time=datetime(year=2015, month=1, day=30)
-    )[: max(len(keys) for keys in initial)]
+    full_date_set_keys = daily_partitions_def.get_partition_keys()[
+        : max(len(keys) for keys in initial)
+    ]
     current_day = datetime.strptime(
-        daily_partitions_def.get_partition_keys(current_time=datetime(year=2015, month=1, day=30))[
-            : max(len(keys) for keys in initial) + 1
-        ][-1],
+        daily_partitions_def.get_partition_keys()[: max(len(keys) for keys in initial) + 1][-1],
         daily_partitions_def.fmt,
     )
 
@@ -316,10 +314,8 @@ def test_multipartitions_subset_addition(initial, added):
     initial_subset = multipartitions_def.empty_subset().with_partition_keys(initial_subset_keys)
     added_subset = initial_subset.with_partition_keys(added_subset_keys)
 
-    assert initial_subset.get_partition_keys(current_time=current_day) == set(initial_subset_keys)
-    assert added_subset.get_partition_keys(current_time=current_day) == set(
-        added_subset_keys + initial_subset_keys
-    )
+    assert initial_subset.get_partition_keys() == set(initial_subset_keys)
+    assert added_subset.get_partition_keys() == set(added_subset_keys + initial_subset_keys)
     assert added_subset.get_partition_keys_not_in_subset(
         multipartitions_def, current_time=current_day
     ) == set(expected_keys_not_in_updated_subset)


### PR DESCRIPTION
## Summary & Motivation

No implementations use this and it's confusing. Conceptually, a partitions subset represents the same set of partitions regardless of the current time.

## How I Tested These Changes
