### PR TITLE
Changing the first example to a functional api.

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
@@ -54,13 +54,13 @@ Before continuing, you should be familiar with:
 
 A Software-defined Asset can be assigned a <PyObject object="PartitionsDefinition" />, which determines the set of partitions that compose it. If the asset is stored in a filesystem or an object store, then each partition will typically correspond to a file or object. If the asset is stored in a database, then each partition will typically correspond to a range of values in a table that fall within a particular window.
 
-The following example demonstrates creating an asset that has a partition for each day since the first day of 2023. Materializing partition `2023-11-13` of this asset would result in fetching data from the URL `https://api.nasa.gov/planetary/apod?date=2023-11-13` and storing it at the path `nasa/2023-11-13.csv`. Note that `api_key=DEMO_KEY` is used but has a limited number of calls:
+The following example demonstrates creating an asset that has a partition for each day since October 1st, 2023. Materializing partition `2023-11-13` of this asset would result in fetching data from the URL `https://api.nasa.gov/planetary/apod?date=2023-11-13` and storing it at the path `nasa/2023-11-13.csv`. Note that `api_key=DEMO_KEY` is used but has a limited number of calls:
 
 ```python file=/concepts/partitions_schedules_sensors/partitioned_asset.py
 import urllib.request
 import os
 
-# Create a new 'nasa' directory
+# Create a new 'nasa' directory if needed
 dir_name = "nasa"
 if not os.path.exists(dir_name):
     os.makedirs(dir_name)

--- a/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
@@ -54,7 +54,7 @@ Before continuing, you should be familiar with:
 
 A Software-defined Asset can be assigned a <PyObject object="PartitionsDefinition" />, which determines the set of partitions that compose it. If the asset is stored in a filesystem or an object store, then each partition will typically correspond to a file or object. If the asset is stored in a database, then each partition will typically correspond to a range of values in a table that fall within a particular window.
 
-The following example demonstrates creating an asset that has a partition for each day since the first day of 2023. Materializing partition `2023-07-23` of this asset would result in fetching data from the URL `https://api.nasa.gov/planetary/apod?date=2023-07-23`and storing it at the path `nasa/2023-07-23.csv`. Note that `api_key=DEMO_KEY` is used but has a limited number of calls:
+The following example demonstrates creating an asset that has a partition for each day since the first day of 2023. Materializing partition `2023-11-13` of this asset would result in fetching data from the URL `https://api.nasa.gov/planetary/apod?date=2023-11-13` and storing it at the path `nasa/2023-11-13.csv`. Note that `api_key=DEMO_KEY` is used but has a limited number of calls:
 
 ```python file=/concepts/partitions_schedules_sensors/partitioned_asset.py
 import urllib.request

--- a/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
@@ -57,8 +57,8 @@ A Software-defined Asset can be assigned a <PyObject object="PartitionsDefinitio
 The following example demonstrates creating an asset that has a partition for each day since October 1st, 2023. Materializing partition `2023-11-13` of this asset would result in fetching data from the URL `https://api.nasa.gov/planetary/apod?date=2023-11-13` and storing it at the path `nasa/2023-11-13.csv`. Note that `api_key=DEMO_KEY` is used but has a limited number of calls:
 
 ```python file=/concepts/partitions_schedules_sensors/partitioned_asset.py
-import urllib.request
 import os
+import urllib.request
 
 # Create a new 'nasa' directory if needed
 dir_name = "nasa"

--- a/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
@@ -54,20 +54,26 @@ Before continuing, you should be familiar with:
 
 A Software-defined Asset can be assigned a <PyObject object="PartitionsDefinition" />, which determines the set of partitions that compose it. If the asset is stored in a filesystem or an object store, then each partition will typically correspond to a file or object. If the asset is stored in a database, then each partition will typically correspond to a range of values in a table that fall within a particular window.
 
-The following example demonstrates creating an asset that has a partition for each day since the first day of 2022. Materializing partition `2022-07-23` of this asset would result in fetching data from the URL `coolweatherwebsite.com/weather_obs\&=2022-07-23`and storing it at the path `weather_observations/2022-07-23.csv`:
+The following example demonstrates creating an asset that has a partition for each day since the first day of 2023. Materializing partition `2023-07-23` of this asset would result in fetching data from the URL `https://api.nasa.gov/planetary/apod?date=2023-07-23`and storing it at the path `nasa/2023-07-23.csv`. Note that `api_key=DEMO_KEY` is used but has a limited number of calls:
 
 ```python file=/concepts/partitions_schedules_sensors/partitioned_asset.py
 import urllib.request
+import os
+
+# Create a new 'nasa' directory
+dir_name = "nasa"
+if not os.path.exists(dir_name):
+    os.makedirs(dir_name)
 
 from dagster import AssetExecutionContext, DailyPartitionsDefinition, asset
 
 
-@asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
+@asset(partitions_def=DailyPartitionsDefinition(start_date="2023-10-01"))
 def my_daily_partitioned_asset(context: AssetExecutionContext) -> None:
     partition_date_str = context.asset_partition_key_for_output()
 
-    url = f"coolweatherwebsite.com/weather_obs&date={partition_date_str}"
-    target_location = f"weather_observations/{partition_date_str}.csv"
+    url = f"https://api.nasa.gov/planetary/apod?api_key=DEMO_KEY&date={partition_date_str}"
+    target_location = f"nasa/{partition_date_str}.csv"
 
     urllib.request.urlretrieve(url, target_location)
 ```

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_asset.py
@@ -1,13 +1,19 @@
 import urllib.request
+import os
+
+# Create a new 'nasa' directory if needed
+dir_name = "nasa"
+if not os.path.exists(dir_name):
+    os.makedirs(dir_name)
 
 from dagster import AssetExecutionContext, DailyPartitionsDefinition, asset
 
 
-@asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
+@asset(partitions_def=DailyPartitionsDefinition(start_date="2023-10-01"))
 def my_daily_partitioned_asset(context: AssetExecutionContext) -> None:
     partition_date_str = context.asset_partition_key_for_output()
 
-    url = f"coolweatherwebsite.com/weather_obs&date={partition_date_str}"
-    target_location = f"weather_observations/{partition_date_str}.csv"
+    url = f"https://api.nasa.gov/planetary/apod?api_key=DEMO_KEY&date={partition_date_str}"
+    target_location = f"nasa/{partition_date_str}.csv"
 
     urllib.request.urlretrieve(url, target_location)

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/partitioned_asset.py
@@ -1,5 +1,5 @@
-import urllib.request
 import os
+import urllib.request
 
 # Create a new 'nasa' directory if needed
 dir_name = "nasa"

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_partitioned_asset.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_partitioned_asset.py
@@ -9,9 +9,9 @@ from docs_snippets.concepts.partitions_schedules_sensors.partitioned_asset impor
 @patch("urllib.request.urlretrieve")
 def test_partitioned_asset(mock_urlretrieve):
     assert materialize_to_memory(
-        [my_daily_partitioned_asset], partition_key="2022-01-01"
+        [my_daily_partitioned_asset], partition_key="2023-10-01"
     ).success
     assert mock_urlretrieve.call_args[0] == (
-        "coolweatherwebsite.com/weather_obs&date=2022-01-01",
-        "weather_observations/2022-01-01.csv",
+        "https://api.nasa.gov/planetary/apod?api_key=DEMO_KEY&date=",
+        "nasa/2023-10-01.csv",
     )

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_partitioned_asset.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_partitioned_asset.py
@@ -12,6 +12,6 @@ def test_partitioned_asset(mock_urlretrieve):
         [my_daily_partitioned_asset], partition_key="2023-10-01"
     ).success
     assert mock_urlretrieve.call_args[0] == (
-        "https://api.nasa.gov/planetary/apod?api_key=DEMO_KEY&date=",
+        "https://api.nasa.gov/planetary/apod?api_key=DEMO_KEY&date=2023-10-01",
         "nasa/2023-10-01.csv",
     )


### PR DESCRIPTION
## Summary & Motivation

The current example for partitioned assets is fictitious and does not run. This is confusing.
This change swaps out the example for one that can be run and provides a daily partitioned asset against a public NASA API that accepts `api_key=DEMO_KEY`

## How I Tested These Changes

I implemented the code in a local instance of DAGSTER using the most recent version (1.5.9). And materialized the asset, and ran the backfill.
I updated the docs document and proofed it locally in .mdx format.

<img width="308" alt="image" src="https://github.com/dagster-io/dagster/assets/8226282/ef308293-f83c-44aa-baa7-6c8441bb583c">
