### PR TITLE
[Test sensor dialog] Show the RunRequest's job name in test sensor dialog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2379,6 +2379,7 @@ type RunRequest {
   tags: [PipelineTag!]!
   runConfigYaml: String!
   assetSelection: [AssetKey!]
+  jobName: String
 }
 
 type DryRunInstigationTicks {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -3648,6 +3648,7 @@ export type RunOrError = PythonError | Run | RunNotFoundError;
 export type RunRequest = {
   __typename: 'RunRequest';
   assetSelection: Maybe<Array<AssetKey>>;
+  jobName: Maybe<Scalars['String']>;
   runConfigYaml: Scalars['String'];
   runKey: Maybe<Scalars['String']>;
   tags: Array<PipelineTag>;
@@ -11311,6 +11312,7 @@ export const buildRunRequest = (
     __typename: 'RunRequest',
     assetSelection:
       overrides && overrides.hasOwnProperty('assetSelection') ? overrides.assetSelection! : [],
+    jobName: overrides && overrides.hasOwnProperty('jobName') ? overrides.jobName! : 'saepe',
     runConfigYaml:
       overrides && overrides.hasOwnProperty('runConfigYaml') ? overrides.runConfigYaml! : 'ut',
     runKey: overrides && overrides.hasOwnProperty('runKey') ? overrides.runKey! : 'eius',

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/DryRunRequestTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/DryRunRequestTable.tsx
@@ -31,7 +31,7 @@ export const RunRequestTable = ({runRequests, isJob, repoAddress, mode, jobName}
             <td>
               <Box flex={{alignItems: 'center', gap: 8}}>
                 <PipelineReference
-                  pipelineName={jobName}
+                  pipelineName={request.jobName ?? jobName}
                   pipelineHrefContext={repoAddress}
                   isJob={!!repo && isJob}
                   showIcon
@@ -52,7 +52,7 @@ export const RunRequestTable = ({runRequests, isJob, repoAddress, mode, jobName}
                 target="_blank"
                 to={workspacePathFromAddress(
                   repoAddress,
-                  `/pipeline_or_job/${jobName}/playground/setup?${qs.stringify({
+                  `/pipeline_or_job/${request.jobName ?? jobName}/playground/setup?${qs.stringify({
                     mode,
                     config: request.runConfigYaml,
                     tags: request.tags,

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/RunRequestFragment.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/RunRequestFragment.tsx
@@ -8,6 +8,7 @@ export const RUN_REQUEST_FRAGMENT = gql`
       value
     }
     runKey
+    jobName
     assetSelection {
       path
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/types/EvaluateScheduleDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/types/EvaluateScheduleDialog.types.ts
@@ -35,6 +35,7 @@ export type ScheduleDryRunMutation = {
             __typename: 'RunRequest';
             runConfigYaml: string;
             runKey: string | null;
+            jobName: string | null;
             tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
             assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
           }> | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/types/RunRequestFragment.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/types/RunRequestFragment.types.ts
@@ -6,6 +6,7 @@ export type RunRequestFragment = {
   __typename: 'RunRequest';
   runConfigYaml: string;
   runKey: string | null;
+  jobName: string | null;
   tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
   assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/types/SensorDryRunDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/types/SensorDryRunDialog.types.ts
@@ -21,6 +21,7 @@ export type SensorDryRunMutation = {
             __typename: 'RunRequest';
             runConfigYaml: string;
             runKey: string | null;
+            jobName: string | null;
             tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
             assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
           }> | null;

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -475,6 +475,7 @@ class GrapheneRunRequest(graphene.ObjectType):
     tags = non_null_list(GraphenePipelineTag)
     runConfigYaml = graphene.NonNull(graphene.String)
     assetSelection = graphene.List(graphene.NonNull(GrapheneAssetKey))
+    jobName = graphene.String()
 
     _run_request: RunRequest
 
@@ -502,6 +503,9 @@ class GrapheneRunRequest(graphene.ObjectType):
                 for asset_key in self._run_request.asset_selection
             ]
         return None
+    
+    def resolve_jobName(self, _graphene_info: ResolveInfo):
+        return self._run_request.job_name
 
 
 class GrapheneDryRunInstigationTicks(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -503,7 +503,7 @@ class GrapheneRunRequest(graphene.ObjectType):
                 for asset_key in self._run_request.asset_selection
             ]
         return None
-    
+
     def resolve_jobName(self, _graphene_info: ResolveInfo):
         return self._run_request.job_name
 


### PR DESCRIPTION
## Summary & Motivation
Currently we're defaulting to the [first target of a sensor](https://github.com/dagster-io/dagster/blob/master/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx#L128) when displaying the jobName in this dialog, we should instead use the jobName from the RunRequest if it's available, otherwise we default to the first target if the RunRequest doesn't specify for some reason


## How I Tested These Changes

locally 