### PR TITLE
pin botocore

### DIFF
--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -43,7 +43,7 @@ setup(
         "redshift": ["psycopg2-binary"],
         "pyspark": ["dagster-pyspark"],
         "test": [
-            "botocore!=1.32.1",
+            "botocore<1.32.1",
             "moto[s3,server]>=2.2.8",
             "requests-mock",
             "xmltodict==0.12.0",  # pinned until moto>=3.1.9 (https://github.com/spulec/moto/issues/5112)


### PR DESCRIPTION
## Summary & Motivation
Incompatibility with moto causing issues... moto is currently pinned to deal with another bug w/ cloudwatch mocks. For now, in the release branch, pin botocore (until moto can be unpinned).


## How I Tested These Changes
BK