### PR TITLE
Add "env" key to K8sRunLauncher / k8s_job_executor

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -75,7 +75,7 @@ deployments:
     volumeMounts: []
 
     # Additional environment variables to set.
-    # These will be directly applied to the daemon container. See
+    # These will be directly applied to the container. See
     # https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
     #
     # Example:

--- a/helm/dagster/templates/helpers/instance/_run-launcher.tpl
+++ b/helm/dagster/templates/helpers/instance/_run-launcher.tpl
@@ -151,6 +151,10 @@ config:
     {{- end }}
   {{- end }}
 
+  {{- if $k8sRunLauncherConfig.env }}
+  env: {{- $k8sRunLauncherConfig.env | toYaml | nindent 4 }}
+  {{- end }}
+
 {{- end }}
 
 {{- define "dagsterYaml.runLauncher.custom" }}

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -497,6 +497,19 @@ runLauncher:
       #   - "BAR_ENV_VAR=baz_value" (Will set the value of BAR_ENV_VAR to baz_value)
       envVars: []
 
+      # Additional environment variables to set using Kubernetes EnvVar dictionaries.
+      # These will be directly applied to the container.
+      # See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#envvar-v1-core"
+
+      # Example:
+      #
+      # env:
+      # - name: ENV_ONE
+      #   value: "one"
+      # - name: ENV_TWO
+      #   value: "two"
+      env: []
+
       # Additional volumes that should be included in the Job's Pod. See:
       # https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core
       #

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
@@ -231,6 +231,7 @@ class K8sContainerContext(
                     run_k8s_config=UserDefinedDagsterK8sConfig.from_dict(
                         run_launcher.run_k8s_config or {}
                     ),
+                    env=run_launcher.env,
                 )
             )
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -143,6 +143,7 @@ def k8s_job_executor(init_context: InitExecutorContext) -> Executor:
         # step_k8s_config feeds into the run_k8s_config field because it is merged
         # with any configuration for the run that was set on the run launcher or code location
         run_k8s_config=UserDefinedDagsterK8sConfig.from_dict(exc_cfg.get("step_k8s_config", {})),
+        env=exc_cfg.get("env"),  # type: ignore
     )
 
     if "load_incluster_config" in exc_cfg:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -303,9 +303,9 @@ class DagsterK8sJobConfig(
             image. Should not be specified if using userDeployments.
         volume_mounts (Optional[Sequence[Permissive]]): A list of volume mounts to include in the job's
             container. Default: ``[]``. See:
-            https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core
+            https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core
         volumes (Optional[List[Permissive]]): A list of volumes to include in the Job's Pod. Default: ``[]``. See:
-            https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core
+            https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core
         labels (Optional[Mapping[str, str]]): Additional labels that should be included in the Job's Pod. See:
             https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
         resources (Optional[Mapping[str, Any]]) Compute resource requirements for the container. See:
@@ -521,6 +521,21 @@ class DagsterK8sJobConfig(
                     "https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables"
                 ),
             ),
+            "env": Field(
+                Array(
+                    Permissive(
+                        {
+                            "name": str,
+                        }
+                    )
+                ),
+                is_required=False,
+                description=(
+                    "A list of Kubernetes EnvVar dictionaries to inject into the Job's main container. "
+                    "See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#envvar-v1-core"
+                ),
+                default_value=[],
+            ),
             "volume_mounts": Field(
                 Array(
                     # Can supply either snake_case or camelCase, but in typeaheads based on the
@@ -541,7 +556,7 @@ class DagsterK8sJobConfig(
                 description=(
                     "A list of volume mounts to include in the job's container. Default: ``[]``."
                     " See: "
-                    "https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core"
+                    "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#envvar-v1-core"
                 ),
             ),
             "volumes": Field(
@@ -557,7 +572,7 @@ class DagsterK8sJobConfig(
                 description=(
                     "A list of volumes to include in the Job's Pod. Default: ``[]``. For the many "
                     "possible volume source types that can be included, see: "
-                    "https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core"
+                    "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core"
                 ),
             ),
             "labels": Field(
@@ -632,17 +647,6 @@ class DagsterK8sJobConfig(
                     ),
                     is_required=False,
                     description="Raw Kubernetes configuration for launched code servers.",
-                ),
-                "env": Field(
-                    Array(
-                        Permissive(
-                            {
-                                "name": str,
-                            }
-                        )
-                    ),
-                    is_required=False,
-                    default_value=[],
                 ),
             },
         )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -67,6 +67,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         scheduler_name=None,
         security_context=None,
         run_k8s_config=None,
+        env=None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.job_namespace = check.str_param(job_namespace, "job_namespace")
@@ -118,6 +119,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         self._scheduler_name = check.opt_str_param(scheduler_name, "scheduler_name")
         self._security_context = check.opt_dict_param(security_context, "security_context")
         self._run_k8s_config = check.opt_dict_param(run_k8s_config, "run_k8s_config")
+        self._env = check.opt_list_param(env, "env")
         super().__init__()
 
     @property
@@ -167,6 +169,10 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
     @property
     def env_vars(self) -> Sequence[str]:
         return self._env_vars
+
+    @property
+    def env(self) -> Sequence[Mapping[str, Any]]:
+        return self._env
 
     @property
     def labels(self) -> Mapping[str, str]:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -161,6 +161,7 @@ def execute_k8s_job(
     job_spec_config: Optional[Dict[str, Any]] = None,
     k8s_job_name: Optional[str] = None,
     merge_behavior: K8sConfigMergeBehavior = K8sConfigMergeBehavior.SHALLOW,
+    env: Optional[Dict[str, Any]] = None,
 ):
     """This function is a utility for executing a Kubernetes job from within a Dagster op.
 
@@ -236,6 +237,8 @@ def execute_k8s_job(
             are shallowly merged - any shared values in the dictionaries will be replaced by the
             values set on this op. Setting it to DEEP will recursively merge the two dictionaries,
             appending list fields together andmerging dictionary fields.
+        env (Optional[Dict[str, Any]]): A list of Kubernetes EnvVar dictionaries to inject into
+            the Job's main container. See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#envvar-v1-core"
     """
     run_container_context = K8sContainerContext.create_for_run(
         context.dagster_run,
@@ -274,6 +277,7 @@ def execute_k8s_job(
                 "merge_behavior": merge_behavior.value,
             }
         ),
+        env=env,
     )
 
     container_context = run_container_context.merge(op_container_context)


### PR DESCRIPTION
Summary:
Right now this is only settable at the code location / container context level, add a flag at the instance and executor level as well so that we can thread it through everywhere. Duplication with env_vars is somewhat unfortunate but the field description attempts to clarify the difference..

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
