### PR TITLE
Test for invalid priority tags

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1735,8 +1735,14 @@ class DagsterInstance(DynamicPartitionsStore):
         filters: Optional[RunsFilter] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
+        prioritized: bool = False,
     ) -> Sequence[str]:
-        return self._run_storage.get_run_ids(filters, cursor=cursor, limit=limit)
+        return self._run_storage.get_run_ids(
+            filters,
+            cursor=cursor,
+            limit=limit,
+            prioritized=prioritized,
+        )
 
     @traced
     def get_runs_count(self, filters: Optional[RunsFilter] = None) -> int:

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -214,8 +214,14 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
         filters: Optional["RunsFilter"] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
+        prioritized: bool = False,
     ) -> Iterable[str]:
-        return self._storage.run_storage.get_run_ids(filters, cursor=cursor, limit=limit)
+        return self._storage.run_storage.get_run_ids(
+            filters,
+            cursor=cursor,
+            limit=limit,
+            prioritized=prioritized,
+        )
 
     def get_runs_count(self, filters: Optional["RunsFilter"] = None) -> int:
         return self._storage.run_storage.get_runs_count(filters)

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -89,6 +89,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         filters: Optional[RunsFilter] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
+        prioritized: bool = False,
     ) -> Sequence[str]:
         """Return all the run IDs for runs present in the storage that match the given filters.
 
@@ -98,6 +99,9 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
                 runs
             cursor (Optional[str]): Starting cursor (run_id) of range of runs
             limit (Optional[int]): Number of results to get. Defaults to infinite.
+            prioritized (bool): Order ids using priority tags.
+                https://docs.dagster.io/guides/customizing-run-queue-priority
+                Defaults to False.
 
         Returns:
             Sequence[str]

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -350,7 +350,7 @@ class SqlRunStorage(RunStorage):
                 db.func.coalesce(
                     # try to get the priority tag value
                     db.func.cast(
-                        RunsTable.c.run_body.op("->>")(f'$.tags."{PRIORITY_TAG}"'),
+                        db.func.json_extract(RunsTable.c.run_body, f'$.tags."{PRIORITY_TAG}"'),
                         db.Integer,
                     ),
                     # default to a priority of 0

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -668,10 +668,29 @@ class TestRunStorage:
                 tags={PRIORITY_TAG: "100"},
             )
         )
+        storage.add_run(
+            TestRunStorage.build_run(
+                run_id="bogus-priority",
+                job_name="some_pipeline",
+                tags={PRIORITY_TAG: "boom"},
+            )
+        )
 
         # Default sort is id desc
-        assert storage.get_run_ids() == ["high-priority", "2", "low-priority", "1"]
-        assert storage.get_run_ids(prioritized=True) == ["high-priority", "1", "2", "low-priority"]
+        assert storage.get_run_ids() == [
+            "bogus-priority",
+            "high-priority",
+            "2",
+            "low-priority",
+            "1",
+        ]
+        assert storage.get_run_ids(prioritized=True) == [
+            "high-priority",
+            "1",
+            "2",
+            "bogus-priority",
+            "low-priority",
+        ]
 
     def test_fetch_by_status(self, storage):
         assert storage

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -651,7 +651,7 @@ class TestRunStorage:
         assert storage.get_run_ids(RunsFilter(job_name="some_pipeline")) == [three, two, one]
         assert storage.get_run_ids(RunsFilter(job_name="some_pipeline"), limit=1) == [three]
 
-    def tests_get_run_ids_prioritized(self, storage):
+    def test_get_run_ids_prioritized(self, storage):
         storage.add_run(TestRunStorage.build_run(run_id="1", job_name="some_pipeline"))
         storage.add_run(
             TestRunStorage.build_run(

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -248,9 +248,13 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
                 db.func.coalesce(
                     # try to get the priority tag value
                     db.func.cast(
-                        db.func.cast(RunsTable.c.run_body, db.JSON)
-                        .op("->")("tags")
-                        .op("->>")(PRIORITY_TAG),
+                        db.func.regexp_replace(
+                            db.func.cast(RunsTable.c.run_body, db.JSON)
+                            .op("->")("tags")
+                            .op("->>")(PRIORITY_TAG),
+                            r"^(?!-?\d+$).*",
+                            "0",
+                        ),
                         db.Integer,
                     ),
                     # default to a priority of 0


### PR DESCRIPTION
Sqlite and MySQL both handle invalid priority tags out of the box.

Postgres fails to convert the strings to integers.

This adds a regex replacement to Postgres that will replace any string that doesn't represent an integer with our default value of 0.

An alternative would be to introduce a custom `try_cast` function to Postgres, but we want this to work even if users don't run our migrations.
