### PR TITLE
Don't allow non-numeric priority tags

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -9,7 +9,7 @@ import yaml
 import dagster._check as check
 import dagster._seven as seven
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
-from dagster._core.storage.tags import check_reserved_tags
+from dagster._core.storage.tags import PRIORITY_TAG, check_reserved_tags
 from dagster._utils.yaml_utils import merge_yaml_strings, merge_yamls
 
 DEFAULT_OUTPUT = "result"
@@ -96,6 +96,14 @@ def validate_tags(
 ) -> Mapping[str, str]:
     valid_tags: Dict[str, str] = {}
     for key, value in check.opt_mapping_param(tags, "tags", key_type=str).items():
+        if key == PRIORITY_TAG:
+            try:
+                int(value)
+            except ValueError:
+                raise DagsterInvalidDefinitionError(
+                    f'Invalid value for tag "{key}": "{value}". Priority tags must coerce to an integer'
+                )
+
         if not isinstance(value, str):
             valid = False
             err_reason = f'Could not JSON encode value "{value}"'

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -98,10 +98,10 @@ def validate_tags(
     for key, value in check.opt_mapping_param(tags, "tags", key_type=str).items():
         if key == PRIORITY_TAG:
             try:
-                int(value)
+                float(value)
             except ValueError:
                 raise DagsterInvalidDefinitionError(
-                    f'Invalid value for tag "{key}": "{value}". Priority tags must coerce to an integer'
+                    f'Invalid value for tag "{key}": "{value}". Priority tags must coerce to a float'
                 )
 
         if not isinstance(value, str):

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -41,6 +41,7 @@ from dagster._core.errors import (
     DagsterInvalidConfigError,
     DagsterInvalidDefinitionError,
 )
+from dagster._core.storage.tags import PRIORITY_TAG
 from dagster._core.test_utils import instance_for_test
 from dagster._loggers import json_console_logger
 
@@ -693,6 +694,22 @@ def test_job_and_graph_tags():
         assert result.success
         run = instance.get_runs()[0]
         assert run.tags == {"a": "y", "b": "z", "c": "q"}
+
+
+def test_tags_validation():
+    with pytest.raises(Exception):
+
+        @graph(tags={PRIORITY_TAG: "important"})
+        def tagged_with_str_priority():
+            pass
+
+    @graph(tags={PRIORITY_TAG: "1"})
+    def tagged_with_int_priority():
+        pass
+
+    @graph(tags={PRIORITY_TAG: "1.0"})
+    def tagged_with_float_priority():
+        pass
 
 
 def test_output_for_node_non_standard_name():

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -252,19 +252,6 @@ def test_priority(instance, workspace_context, job_handle, daemon):
     ]
 
 
-def test_priority_on_malformed_tag(instance, workspace_context, job_handle, daemon):
-    create_queued_run(
-        instance,
-        job_handle,
-        run_id="bad-pri-run",
-        tags={PRIORITY_TAG: "foobar"},
-    )
-
-    list(daemon.run_iteration(workspace_context))
-
-    assert get_run_ids(instance.run_launcher.queue()) == ["bad-pri-run"]
-
-
 @pytest.mark.parametrize(
     "use_threads",
     [False, True],


### PR DESCRIPTION
We need these to be sortable and if we prevent this at tag creation time, we could avoid introducing this potentially expensive regex calculation:

https://github.com/dagster-io/dagster/pull/18172
