### PR TITLE
Fix edge case in DatetimeFieldSerializer

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -168,10 +168,15 @@ class DatetimeFieldSerializer(FieldSerializer):
         self, datetime: Optional[datetime], whitelist_map: WhitelistMap, descent_path: str
     ) -> Optional[Mapping[str, Any]]:
         if datetime:
-            check.invariant(datetime.tzinfo is not None)
-            pendulum_datetime = pendulum.instance(datetime, tz=datetime.tzinfo)
+            check.invariant(
+                isinstance(datetime, pendulum.DateTime),
+                "Datetime must be a pendulum datetime",
+            )
+            timezone_name = cast(pendulum.DateTime, datetime).timezone.name
+            check.invariant(timezone_name in pendulum.timezones)
+
             return pack_value(
-                TimestampWithTimezone(datetime.timestamp(), str(pendulum_datetime.timezone.name)),
+                TimestampWithTimezone(datetime.timestamp(), timezone_name),
                 whitelist_map,
                 descent_path,
             )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1451,7 +1451,7 @@ def test_datetime_field_serializer():
     utc_datetime_with_no_timezone = Foo(
         dt=utc_datetime_from_timestamp(pendulum.now("UTC").timestamp())
     )
-    with pytest.raises(CheckError, match="pendulum datetime"):
+    with pytest.raises(CheckError, match="not a valid IANA timezone"):
         serialize_value(utc_datetime_with_no_timezone)
 
 


### PR DESCRIPTION
Hit a bug in the partitions subset stack when a raw datetime (not pendulum datetime) was passed into the `DatetimeFieldSerializer`. Its `tzinfo` field did exist, but since it was an offset (`"+00:00"`) rather than a timezone (`"UTC"`), an error was raised during deserialization.

This PR adjusts existing behavior to assert that the timezone provided is a valid IANA timezone.