### PR TITLE
Short-circuit in AutoMaterializeAssetPartitionsFilter if an empty set is passed into passes()

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -610,7 +610,7 @@ class AutoMaterializeAssetPartitionsFilter(
     def passes(
         self, context: RuleEvaluationContext, asset_partitions: Iterable[AssetKeyPartitionKey]
     ) -> Iterable[AssetKeyPartitionKey]:
-        if self.latest_run_required_tags is None:
+        if self.latest_run_required_tags is None or not asset_partitions:
             return asset_partitions
 
         will_update_asset_partitions: Set[AssetKeyPartitionKey] = set()


### PR DESCRIPTION
Summary:
If an empty set is passed in, there is no need to do the DB query here, right? (Which makes me worried that just doing a dry-run on a tick with no parents materialized is not sufficient to get a sense of worst-case performance)

## Summary & Motivation

## How I Tested These Changes
