### PR TITLE
[auto-materialize] Frontload parent updated queries

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -198,7 +198,6 @@ class AssetDaemonContext:
                         AssetKeyPartitionKey(asset_key=asset_key)
                     )
                     for asset_key in self.target_asset_keys_and_parents
-                    if not self.asset_graph.is_source(asset_key)
                 ),
             ),
             default=None,

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -543,7 +543,7 @@ class AssetDaemonContext:
         return (
             run_requests,
             self.cursor.with_updates(
-                latest_storage_id=self.instance_queryer.instance.event_log_storage.get_maximum_record_id(),
+                latest_storage_id=self.get_latest_storage_id(),
                 to_materialize=to_materialize,
                 to_discard=to_discard,
                 asset_graph=self.asset_graph,

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -494,8 +494,10 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
     def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
         return partition_key in self.get_dynamic_partitions(partitions_def_name)
 
+    @cached_method
     def asset_partitions_with_newly_updated_parents(
         self,
+        *,
         latest_storage_id: Optional[int],
         child_asset_key: AssetKey,
         map_old_time_partitions: bool = True,


### PR DESCRIPTION
## Summary & Motivation

This helps avoid some (but not all) of the risk of missing a parent update. Imagine you have an asset that is evaluated near the beginning of a tick, and no updated parents are found. During the course of the tick, one of the parents updates. At the end of the tick, the cursor will be moved past that parent update, and it will be lost. 

This helps minimize this risk by minimizing the amount of time between the parent update calculation and the cursor advancement. 

To totally fix this problem, we'll want to store a per-asset cursor so that things can be updated independently, so this is more of a temporary solution.

## How I Tested These Changes
