### PR TITLE
Make external_repository_origin on ExternalInstigatorOrigin optional

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -190,7 +190,7 @@ def get_schedule_next_tick(
     if not schedule_state.is_running:
         return None
 
-    repository_origin = schedule_state.origin.external_repository_origin
+    repository_origin = check.not_none(schedule_state.origin.external_repository_origin)
     if not graphene_info.context.has_code_location(
         repository_origin.code_location_origin.location_name
     ):

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -173,7 +173,7 @@ def get_sensor_next_tick(
 
     check.inst_param(sensor_state, "sensor_state", InstigatorState)
 
-    repository_origin = sensor_state.origin.external_repository_origin
+    repository_origin = check.not_none(sensor_state.origin.external_repository_origin)
     if not graphene_info.context.has_code_location(
         repository_origin.code_location_origin.location_name
     ):

--- a/python_modules/dagster/dagster/_core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/host_representation/origin.py
@@ -473,17 +473,22 @@ class ExternalJobOrigin(
 class ExternalInstigatorOrigin(
     NamedTuple(
         "_ExternalInstigatorOrigin",
-        [("external_repository_origin", ExternalRepositoryOrigin), ("instigator_name", str)],
+        [
+            ("external_repository_origin", Optional[ExternalRepositoryOrigin]),
+            ("instigator_name", str),
+        ],
     )
 ):
     """Serializable representation of an ExternalJob that can be used to
     uniquely it or reload it in across process boundaries.
     """
 
-    def __new__(cls, external_repository_origin: ExternalRepositoryOrigin, instigator_name: str):
+    def __new__(
+        cls, external_repository_origin: Optional[ExternalRepositoryOrigin], instigator_name: str
+    ):
         return super(ExternalInstigatorOrigin, cls).__new__(
             cls,
-            check.inst_param(
+            check.opt_inst_param(
                 external_repository_origin,
                 "external_repository_origin",
                 ExternalRepositoryOrigin,

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -588,7 +588,7 @@ def _submit_run_request(
     code_location = _get_code_location_for_sensor(workspace_process_context, external_sensor)
     job_subset_selector = JobSubsetSelector(
         location_name=code_location.name,
-        repository_name=sensor_origin.external_repository_origin.repository_name,
+        repository_name=check.not_none(sensor_origin.external_repository_origin).repository_name,
         job_name=target_data.job_name,
         op_selection=target_data.op_selection,
         asset_selection=run_request.asset_selection,
@@ -629,7 +629,7 @@ def _get_code_location_for_sensor(
 ):
     sensor_origin = external_sensor.get_external_origin()
     return workspace_process_context.create_request_context().get_code_location(
-        sensor_origin.external_repository_origin.code_location_origin.location_name
+        check.not_none(sensor_origin.external_repository_origin).code_location_origin.location_name
     )
 
 
@@ -907,7 +907,9 @@ def _fetch_existing_runs(
         elif (
             run.external_job_origin is not None
             and run.external_job_origin.external_repository_origin.get_selector_id()
-            == external_sensor.get_external_origin().external_repository_origin.get_selector_id()
+            == check.not_none(
+                external_sensor.get_external_origin().external_repository_origin
+            ).get_selector_id()
             and run.tags.get(SENSOR_NAME_TAG) == external_sensor.name
         ):
             valid_runs.append(run)

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -633,9 +633,10 @@ def _submit_run_request(
                 f"Run {run.run_id} already created for this execution of {external_schedule.name}"
             )
     else:
+        repository_origin = check.not_none(schedule_origin.external_repository_origin)
         job_subset_selector = JobSubsetSelector(
-            location_name=schedule_origin.external_repository_origin.code_location_origin.location_name,
-            repository_name=schedule_origin.external_repository_origin.repository_name,
+            location_name=repository_origin.code_location_origin.location_name,
+            repository_name=repository_origin.repository_name,
             job_name=external_schedule.job_name,
             op_selection=external_schedule.op_selection,
             asset_selection=run_request.asset_selection,
@@ -687,7 +688,9 @@ def _get_code_location_for_schedule(
 ):
     schedule_origin = external_schedule.get_external_origin()
     return workspace_process_context.create_request_context().get_code_location(
-        schedule_origin.external_repository_origin.code_location_origin.location_name
+        check.not_none(
+            schedule_origin.external_repository_origin
+        ).code_location_origin.location_name
     )
 
 
@@ -807,7 +810,9 @@ def _get_existing_run_for_request(
             matching_runs.append(run)
         # otherwise prevent the same named schedule (with the same execution time) across repos from effecting each other
         elif (
-            external_schedule.get_external_origin().external_repository_origin.get_selector_id()
+            check.not_none(
+                external_schedule.get_external_origin().external_repository_origin
+            ).get_selector_id()
             == run.external_job_origin.external_repository_origin.get_selector_id()
         ):
             matching_runs.append(run)

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -7,6 +7,7 @@ from contextlib import ExitStack
 from typing import Any
 from unittest import mock
 
+import dagster._check as check
 import pendulum
 import pytest
 from dagster import (
@@ -1038,7 +1039,9 @@ def test_sensors_keyed_on_selector_not_origin(
 
         existing_origin = external_sensor.get_external_origin()
 
-        code_location_origin = existing_origin.external_repository_origin.code_location_origin
+        code_location_origin = check.not_none(
+            existing_origin.external_repository_origin
+        ).code_location_origin
         assert isinstance(code_location_origin, ManagedGrpcPythonEnvCodeLocationOrigin)
         modified_loadable_target_origin = code_location_origin.loadable_target_origin._replace(
             executable_path="/different/executable_path"
@@ -1046,7 +1049,9 @@ def test_sensors_keyed_on_selector_not_origin(
 
         # Change metadata on the origin that shouldn't matter for execution
         modified_origin = existing_origin._replace(
-            external_repository_origin=existing_origin.external_repository_origin._replace(
+            external_repository_origin=check.not_none(
+                existing_origin.external_repository_origin
+            )._replace(
                 code_location_origin=code_location_origin._replace(
                     loadable_target_origin=modified_loadable_target_origin
                 )
@@ -1090,7 +1095,7 @@ def test_bad_load_sensor_repository(
         # Swap out a new repository name
         invalid_repo_origin = ExternalInstigatorOrigin(
             ExternalRepositoryOrigin(
-                valid_origin.external_repository_origin.code_location_origin,
+                check.not_none(valid_origin.external_repository_origin).code_location_origin,
                 "invalid_repo_name",
             ),
             valid_origin.instigator_name,


### PR DESCRIPTION
## Summary & Motivation
To allow for a world where auto-materialize ticks use instigators, despite not having a singular repository (or even code location) for each of their instigators.

## How I Tested These Changes
