### PR TITLE
[ui] Stop showing dunder repo names on global graph groups

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
@@ -3,13 +3,17 @@ import React from 'react';
 import styled from 'styled-components';
 
 import {withMiddleTruncation} from '../app/Util';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 
 import {AssetDescription, NameTooltipCSS} from './AssetNode';
 import {GroupLayout} from './layout';
 
 export const GroupNodeNameAndRepo = ({group, minimal}: {minimal: boolean; group: GroupLayout}) => {
   const name = `${group.groupName} `;
-  const location = `${group.repositoryName}@${group.repositoryLocationName}`;
+  const location = repoAddressAsHumanString({
+    name: group.repositoryName,
+    location: group.repositoryLocationName,
+  });
 
   if (minimal) {
     return (


### PR DESCRIPTION


## Summary & Motivation
Forgot to use this helper when rendering the repo address! Also verified by grepping `}@${` that we aren’t doing this anywhere else.
## How I Tested These Changes
