### PR TITLE
Change concurrency UI to show step-specific table

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2311,6 +2311,7 @@ type Instance {
   info: String
   runLauncher: RunLauncher
   runQueuingSupported: Boolean!
+  runQueueConfig: RunQueueConfig
   executablePath: String!
   daemonHealth: DaemonHealth!
   hasInfo: Boolean!
@@ -2318,6 +2319,12 @@ type Instance {
   autoMaterializePaused: Boolean!
   supportsConcurrencyLimits: Boolean!
   concurrencyLimits: [ConcurrencyKeyInfo!]!
+  concurrencyLimit(concurrencyKey: String): ConcurrencyKeyInfo!
+}
+
+type RunQueueConfig {
+  maxConcurrentRuns: Int!
+  tagConcurrencyLimitsYaml: String
 }
 
 type ConcurrencyKeyInfo {
@@ -3417,6 +3424,7 @@ type Mutation {
   setAutoMaterializePaused(paused: Boolean!): Boolean!
   setConcurrencyLimit(concurrencyKey: String!, limit: Int!): Boolean!
   freeConcurrencySlotsForRun(runId: String!): Boolean!
+  freeConcurrencySlots(runId: String!, stepKey: String): Boolean!
 }
 
 input ReexecutionParams {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -1493,6 +1493,7 @@ export type InputTag = {
 export type Instance = {
   __typename: 'Instance';
   autoMaterializePaused: Scalars['Boolean'];
+  concurrencyLimit: ConcurrencyKeyInfo;
   concurrencyLimits: Array<ConcurrencyKeyInfo>;
   daemonHealth: DaemonHealth;
   executablePath: Scalars['String'];
@@ -1501,8 +1502,13 @@ export type Instance = {
   id: Scalars['String'];
   info: Maybe<Scalars['String']>;
   runLauncher: Maybe<RunLauncher>;
+  runQueueConfig: Maybe<RunQueueConfig>;
   runQueuingSupported: Scalars['Boolean'];
   supportsConcurrencyLimits: Scalars['Boolean'];
+};
+
+export type InstanceConcurrencyLimitArgs = {
+  concurrencyKey?: InputMaybe<Scalars['String']>;
 };
 
 export type InstigationEvent = {
@@ -2058,6 +2064,7 @@ export type Mutation = {
   cancelPartitionBackfill: CancelBackfillResult;
   deletePipelineRun: DeletePipelineRunResult;
   deleteRun: DeletePipelineRunResult;
+  freeConcurrencySlots: Scalars['Boolean'];
   freeConcurrencySlotsForRun: Scalars['Boolean'];
   launchPartitionBackfill: LaunchBackfillResult;
   launchPipelineExecution: LaunchRunResult;
@@ -2102,6 +2109,11 @@ export type MutationDeletePipelineRunArgs = {
 
 export type MutationDeleteRunArgs = {
   runId: Scalars['String'];
+};
+
+export type MutationFreeConcurrencySlotsArgs = {
+  runId: Scalars['String'];
+  stepKey?: InputMaybe<Scalars['String']>;
 };
 
 export type MutationFreeConcurrencySlotsForRunArgs = {
@@ -3644,6 +3656,12 @@ export type RunNotFoundError = Error &
   };
 
 export type RunOrError = PythonError | Run | RunNotFoundError;
+
+export type RunQueueConfig = {
+  __typename: 'RunQueueConfig';
+  maxConcurrentRuns: Scalars['Int'];
+  tagConcurrencyLimitsYaml: Maybe<Scalars['String']>;
+};
 
 export type RunRequest = {
   __typename: 'RunRequest';
@@ -7263,6 +7281,12 @@ export const buildInstance = (
       overrides && overrides.hasOwnProperty('autoMaterializePaused')
         ? overrides.autoMaterializePaused!
         : true,
+    concurrencyLimit:
+      overrides && overrides.hasOwnProperty('concurrencyLimit')
+        ? overrides.concurrencyLimit!
+        : relationshipsToOmit.has('ConcurrencyKeyInfo')
+        ? ({} as ConcurrencyKeyInfo)
+        : buildConcurrencyKeyInfo({}, relationshipsToOmit),
     concurrencyLimits:
       overrides && overrides.hasOwnProperty('concurrencyLimits')
         ? overrides.concurrencyLimits!
@@ -7288,6 +7312,12 @@ export const buildInstance = (
         : relationshipsToOmit.has('RunLauncher')
         ? ({} as RunLauncher)
         : buildRunLauncher({}, relationshipsToOmit),
+    runQueueConfig:
+      overrides && overrides.hasOwnProperty('runQueueConfig')
+        ? overrides.runQueueConfig!
+        : relationshipsToOmit.has('RunQueueConfig')
+        ? ({} as RunQueueConfig)
+        : buildRunQueueConfig({}, relationshipsToOmit),
     runQueuingSupported:
       overrides && overrides.hasOwnProperty('runQueuingSupported')
         ? overrides.runQueuingSupported!
@@ -8443,6 +8473,10 @@ export const buildMutation = (
         : relationshipsToOmit.has('DeletePipelineRunSuccess')
         ? ({} as DeletePipelineRunSuccess)
         : buildDeletePipelineRunSuccess({}, relationshipsToOmit),
+    freeConcurrencySlots:
+      overrides && overrides.hasOwnProperty('freeConcurrencySlots')
+        ? overrides.freeConcurrencySlots!
+        : false,
     freeConcurrencySlotsForRun:
       overrides && overrides.hasOwnProperty('freeConcurrencySlotsForRun')
         ? overrides.freeConcurrencySlotsForRun!
@@ -11298,6 +11332,25 @@ export const buildRunNotFoundError = (
     __typename: 'RunNotFoundError',
     message: overrides && overrides.hasOwnProperty('message') ? overrides.message! : 'illo',
     runId: overrides && overrides.hasOwnProperty('runId') ? overrides.runId! : 'non',
+  };
+};
+
+export const buildRunQueueConfig = (
+  overrides?: Partial<RunQueueConfig>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'RunQueueConfig'} & RunQueueConfig => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('RunQueueConfig');
+  return {
+    __typename: 'RunQueueConfig',
+    maxConcurrentRuns:
+      overrides && overrides.hasOwnProperty('maxConcurrentRuns')
+        ? overrides.maxConcurrentRuns!
+        : 9835,
+    tagConcurrencyLimitsYaml:
+      overrides && overrides.hasOwnProperty('tagConcurrencyLimitsYaml')
+        ? overrides.tagConcurrencyLimitsYaml!
+        : 'reprehenderit',
   };
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
@@ -1,8 +1,12 @@
 import {gql, useQuery, useMutation} from '@apollo/client';
 import {
+  Subheading,
+  MetadataTableWIP,
+  StyledRawCodeMirror,
   PageHeader,
   Heading,
   Box,
+  Colors,
   Dialog,
   DialogBody,
   DialogFooter,
@@ -19,19 +23,21 @@ import {
   Button,
   NonIdealState,
   Page,
+  Tooltip,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
-import {Redirect} from 'react-router-dom';
+import {Link, Redirect} from 'react-router-dom';
 
 import {showSharedToaster} from '../app/DomUtils';
 import {useFeatureFlags} from '../app/Flags';
-import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
+import {RunStatus} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
-import {doneStatuses} from '../runs/RunStatuses';
-import {RunTable, RUN_TABLE_RUN_FRAGMENT} from '../runs/RunTable';
-import {RunTableRunFragment} from '../runs/types/RunTable.types';
+import {RunStatusDot} from '../runs/RunStatusDots';
+import {failedStatuses} from '../runs/RunStatuses';
+import {titleForRun} from '../runs/RunUtils';
+import {TimeElapsed} from '../runs/TimeElapsed';
 
 import {InstancePageContext} from './InstancePageContext';
 import {InstanceTabs} from './InstanceTabs';
@@ -41,13 +47,14 @@ import {
   ConcurrencyLimitFragment,
   SetConcurrencyLimitMutation,
   SetConcurrencyLimitMutationVariables,
+  ConcurrencyKeyDetailsQuery,
+  ConcurrencyKeyDetailsQueryVariables,
+  ConcurrencyStepFragment,
   RunsForConcurrencyKeyQuery,
   RunsForConcurrencyKeyQueryVariables,
-  FreeConcurrencySlotsForRunMutation,
-  FreeConcurrencySlotsForRunMutationVariables,
+  FreeConcurrencySlotsMutation,
+  FreeConcurrencySlotsMutationVariables,
 } from './types/InstanceConcurrency.types';
-
-const RUNS_LIMIT = 25;
 
 const InstanceConcurrencyPage = React.memo(() => {
   useTrackPageView();
@@ -65,7 +72,7 @@ const InstanceConcurrencyPage = React.memo(() => {
   const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
   const {data} = queryResult;
 
-  const content = data ? (
+  const op_concurrency_content = data ? (
     flagInstanceConcurrencyLimits ? (
       <ConcurrencyLimits
         instanceConfig={data.instance.info}
@@ -88,7 +95,23 @@ const InstanceConcurrencyPage = React.memo(() => {
         title={<Heading>{pageTitle}</Heading>}
         tabs={<InstanceTabs tab="concurrency" refreshState={refreshState} />}
       />
-      {content}
+      <Box margin={{bottom: 64}}>
+        <RunConcurrencyContent
+          hasRunQueue={!!data?.instance.runQueuingSupported}
+          runQueueConfig={data?.instance.runQueueConfig}
+        />
+      </Box>
+      <Box>
+        <Box padding={{vertical: 16, horizontal: 24}} border="top-and-bottom">
+          <Subheading>
+            <Box flex={{alignItems: 'center', direction: 'row', gap: 8}}>
+              <span>Global op/asset concurrency</span>
+              <Tag>Experimental</Tag>
+            </Box>
+          </Subheading>
+        </Box>
+        {op_concurrency_content}
+      </Box>
     </Page>
   );
 });
@@ -112,6 +135,79 @@ type DialogAction =
     }
   | undefined;
 
+const RunConcurrencyContent = ({
+  hasRunQueue,
+  runQueueConfig,
+}: {
+  hasRunQueue: boolean;
+  runQueueConfig: any;
+}) => {
+  if (!hasRunQueue) {
+    return (
+      <>
+        <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
+          <Subheading>Run concurrency</Subheading>
+        </Box>
+        <Box>
+          Run concurrency is not supported with this run coordinator. To enable run concurrency
+          limits, configure your instance to use the <Mono>QueuedRunCoordinator</Mono> in your{' '}
+          <Mono>dagster.yaml</Mono>. See the{' '}
+          <a href="https://docs.dagster.io/deployment/dagster-instance#queuedruncoordinator">
+            QueuedRunCoordinator documentation
+          </a>{' '}
+          for more information.
+        </Box>
+      </>
+    );
+  }
+
+  const info_content = (
+    <Box padding={{vertical: 16, horizontal: 24}}>
+      Run concurrency can be set in your run queue settings. See the{' '}
+      <a href="https://docs.dagster.io/guides/limiting-concurrency-in-data-pipelines#configuring-run-level-concurrency">
+        run concurrency documentation
+      </a>{' '}
+      for more information.
+    </Box>
+  );
+
+  const settings_content = runQueueConfig ? (
+    <MetadataTableWIP>
+      <tbody>
+        <tr>
+          <td>Max concurrent runs:</td>
+          <td>
+            <Mono>{runQueueConfig.maxConcurrentRuns}</Mono>
+          </td>
+        </tr>
+        <tr>
+          <td>Tag concurrency limits:</td>
+          <td>
+            {runQueueConfig.tagConcurrencyLimitsYaml ? (
+              <StyledRawCodeMirror
+                value={runQueueConfig.tagConcurrencyLimitsYaml}
+                options={{readOnly: true, lineNumbers: true, mode: 'yaml'}}
+              />
+            ) : (
+              '-'
+            )}
+          </td>
+        </tr>
+      </tbody>
+    </MetadataTableWIP>
+  ) : null;
+
+  return (
+    <>
+      <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
+        <Subheading>Run concurrency</Subheading>
+      </Box>
+      {info_content}
+      {settings_content}
+    </>
+  );
+};
+
 export const ConcurrencyLimits = ({
   instanceConfig,
   hasSupport,
@@ -124,12 +220,10 @@ export const ConcurrencyLimits = ({
   hasSupport?: boolean;
 }) => {
   const [action, setAction] = React.useState<DialogAction>();
-  const [selectedRuns, setSelectedRuns] = React.useState<string[] | undefined>(undefined);
   const [selectedKey, setSelectedKey] = React.useState<string | undefined>(undefined);
-  const onRunsDialogClose = React.useCallback(() => {
-    setSelectedRuns(undefined);
+  const onConcurrencyStepsDialogClose = React.useCallback(() => {
     setSelectedKey(undefined);
-  }, [setSelectedKey, setSelectedRuns]);
+  }, [setSelectedKey]);
 
   const limitsByKey = Object.fromEntries(
     limits.map(({concurrencyKey, slotCount}) => [concurrencyKey, slotCount]),
@@ -199,9 +293,10 @@ export const ConcurrencyLimits = ({
             <thead>
               <tr>
                 <th style={{width: '260px'}}>Concurrency key</th>
-                <th style={{width: '20%'}}>Occupied slots</th>
                 <th style={{width: '20%'}}>Total slots</th>
-                <th>Active runs</th>
+                <th style={{width: '20%'}}>Assigned steps</th>
+                <th style={{width: '20%'}}>Pending steps</th>
+                <th style={{width: '20%'}}>All steps</th>
                 <th></th>
               </tr>
             </thead>
@@ -209,24 +304,20 @@ export const ConcurrencyLimits = ({
               {limits.map((limit) => (
                 <tr key={limit.concurrencyKey}>
                   <td>{limit.concurrencyKey}</td>
-                  <td>{limit.activeSlotCount}</td>
                   <td>{limit.slotCount}</td>
+                  <td>{limit.pendingSteps.filter((x) => !!x.assignedTimestamp).length}</td>
+                  <td>{limit.pendingSteps.filter((x) => !x.assignedTimestamp).length}</td>
                   <td>
-                    {limit.activeRunIds.length === 0 ? (
-                      <>&mdash;</>
-                    ) : (
-                      <Tag intent="primary" interactive>
-                        <ButtonLink
-                          onClick={() => {
-                            setSelectedKey(limit.concurrencyKey);
-                            setSelectedRuns(limit.activeRunIds);
-                          }}
-                        >
-                          {limit.activeRunIds.length}{' '}
-                          {limit.activeRunIds.length === 1 ? 'run' : 'runs'}
-                        </ButtonLink>
-                      </Tag>
-                    )}
+                    <span style={{marginRight: 16}}>{limit.pendingSteps.length}</span>
+                    <Tag intent="primary" interactive>
+                      <ButtonLink
+                        onClick={() => {
+                          setSelectedKey(limit.concurrencyKey);
+                        }}
+                      >
+                        View all
+                      </ButtonLink>
+                    </Tag>
                   </td>
                   <td>
                     <ConcurrencyLimitActionMenu
@@ -258,14 +349,15 @@ export const ConcurrencyLimits = ({
         onComplete={refetch}
         concurrencyKey={action?.actionType === 'edit' ? action.concurrencyKey : ''}
       />
-      <ConcurrencyRunsDialog
+      <ConcurrencyStepsDialog
         title={
           <span>
-            Active runs for <strong>{selectedKey}</strong>
+            Concurrency steps for <strong>{selectedKey}</strong>
           </span>
         }
-        onClose={onRunsDialogClose}
-        runIds={selectedRuns}
+        onClose={onConcurrencyStepsDialogClose}
+        concurrencyKey={selectedKey}
+        onUpdate={refetch}
       />
     </>
   );
@@ -512,91 +604,111 @@ const DeleteConcurrencyLimitDialog = ({
   );
 };
 
-const ConcurrencyRunsDialog = ({
-  runIds,
+const ConcurrencyActionMenu = ({
+  pendingStep,
+  onUpdate,
+}: {
+  pendingStep: ConcurrencyStepFragment;
+  onUpdate: () => void;
+}) => {
+  const [freeSlots] = useMutation<
+    FreeConcurrencySlotsMutation,
+    FreeConcurrencySlotsMutationVariables
+  >(FREE_CONCURRENCY_SLOTS_MUTATION);
+
+  return (
+    <Popover
+      content={
+        <Menu>
+          <MenuItem
+            key="free-concurrency-slots-step"
+            icon="status"
+            text="Free concurrency slot for step"
+            onClick={async () => {
+              const resp = await freeSlots({
+                variables: {runId: pendingStep.runId, stepKey: pendingStep.stepKey},
+              });
+              if (resp.data?.freeConcurrencySlots) {
+                onUpdate();
+                await showSharedToaster({
+                  intent: 'success',
+                  icon: 'copy_to_clipboard_done',
+                  message: 'Freed concurrency slot',
+                });
+              }
+            }}
+          />
+          <MenuItem
+            key="free-concurrency-slots-run"
+            icon="status"
+            text="Free all concurrency slots for run"
+            onClick={async () => {
+              const resp = await freeSlots({variables: {runId: pendingStep.runId}});
+              if (resp.data?.freeConcurrencySlots) {
+                onUpdate();
+                await showSharedToaster({
+                  intent: 'success',
+                  icon: 'copy_to_clipboard_done',
+                  message: 'Freed concurrency slots',
+                });
+              }
+            }}
+          />
+        </Menu>
+      }
+      position="bottom-right"
+    >
+      <Button rightIcon={<Icon name="expand_more" />}>Actions</Button>
+    </Popover>
+  );
+};
+
+const ConcurrencyStepsDialog = ({
+  concurrencyKey,
   onClose,
   title,
+  onUpdate,
 }: {
-  runIds?: string[];
+  concurrencyKey?: string;
   title: string | React.ReactNode;
   onClose: () => void;
+  onUpdate: () => void;
 }) => {
-  const {data} = useQuery<RunsForConcurrencyKeyQuery, RunsForConcurrencyKeyQueryVariables>(
-    RUNS_FOR_CONCURRENCY_KEY_QUERY,
+  const queryResult = useQuery<ConcurrencyKeyDetailsQuery, ConcurrencyKeyDetailsQueryVariables>(
+    CONCURRENCY_KEY_DETAILS_QUERY,
     {
       variables: {
-        limit: RUNS_LIMIT,
-        filter: {
-          runIds: runIds || [],
-        },
+        concurrencyKey: concurrencyKey || '',
       },
-      skip: !runIds || !runIds.length,
+      skip: !concurrencyKey,
     },
   );
-
-  const [freeSlots] = useMutation<
-    FreeConcurrencySlotsForRunMutation,
-    FreeConcurrencySlotsForRunMutationVariables
-  >(FREE_CONCURRENCY_SLOTS_FOR_RUN_MUTATION);
-
-  const freeSlotsActionMenuItem = React.useCallback(
-    (run: RunTableRunFragment) => {
-      return doneStatuses.has(run.status)
-        ? [
-            <MenuItem
-              key="free-concurrency-slots"
-              icon="status"
-              text="Free concurrency slots for run"
-              onClick={async () => {
-                const resp = await freeSlots({variables: {runId: run.id}});
-                if (resp.data?.freeConcurrencySlotsForRun) {
-                  await showSharedToaster({
-                    intent: 'success',
-                    icon: 'copy_to_clipboard_done',
-                    message: 'Freed concurrency slots',
-                  });
-                }
-                onClose();
-              }}
-            />,
-          ]
-        : [];
-    },
-    [freeSlots, onClose],
-  );
+  useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
+  const {data} = queryResult;
+  const refetch = React.useCallback(() => {
+    queryResult.refetch();
+    onUpdate();
+  }, [queryResult, onUpdate]);
 
   return (
     <Dialog
-      isOpen={!!runIds && runIds.length > 0}
+      isOpen={!!concurrencyKey}
       title={title}
       onClose={onClose}
-      style={{minWidth: '400px', maxWidth: 'calc(100% - 40px)', width: 'fit-content'}}
+      style={{
+        minWidth: '400px',
+        maxWidth: 'calc(100% - 40px)',
+        width: '90vw',
+        maxHeight: '90vh',
+      }}
     >
-      <Box padding={{vertical: 16}}>
+      <Box padding={{vertical: 16}} flex={{grow: 1}} style={{overflowY: 'auto'}}>
         {!data ? (
           <Box padding={{vertical: 64}}>
             <Spinner purpose="section" />
           </Box>
-        ) : data.pipelineRunsOrError.__typename === 'Runs' ? (
-          <div style={{overflow: 'auto'}}>
-            <RunTable
-              runs={data.pipelineRunsOrError.results}
-              additionalActionsForRun={freeSlotsActionMenuItem}
-            />
-          </div>
         ) : (
-          <Box padding={{vertical: 64}}>
-            <NonIdealState
-              icon="error"
-              title="Query Error"
-              description={
-                data.pipelineRunsOrError.__typename === 'PythonError'
-                  ? data.pipelineRunsOrError.message
-                  : 'There was a problem querying for these runs.'
-              }
-            />
-            ;
-          </Box>
+          <PendingStepsTable keyInfo={data.instance.concurrencyLimit} refresh={refetch} />
         )}
       </Box>
       <DialogFooter>
@@ -608,13 +720,194 @@ const ConcurrencyRunsDialog = ({
   );
 };
 
+const PendingStepsTable = ({
+  keyInfo,
+  refresh,
+}: {
+  keyInfo: ConcurrencyLimitFragment;
+  refresh: () => void;
+}) => {
+  const runIds = [...new Set(keyInfo.pendingSteps.map((step) => step.runId))];
+  const queryResult = useQuery<RunsForConcurrencyKeyQuery, RunsForConcurrencyKeyQueryVariables>(
+    RUNS_FOR_CONCURRENCY_KEY_QUERY,
+    {
+      variables: {
+        filter: {runIds},
+      },
+      skip: !runIds,
+    },
+  );
+  const statusByRunId: {[id: string]: RunStatus} = {};
+  const runs =
+    queryResult.data?.pipelineRunsOrError.__typename === 'Runs'
+      ? queryResult.data.pipelineRunsOrError.results
+      : [];
+  runs.forEach((run) => {
+    statusByRunId[run.id] = run.status;
+  });
+
+  const steps = [...keyInfo.pendingSteps];
+  steps.sort((a, b) => {
+    if (a.priority && b.priority && a.priority !== b.priority) {
+      return a.priority - b.priority;
+    }
+    return a.enqueuedTimestamp - b.enqueuedTimestamp;
+  });
+  const assignedSteps = steps.filter((step) => !!step.assignedTimestamp);
+  const pendingSteps = steps.filter((step) => !step.assignedTimestamp);
+
+  const table_header = (
+    <thead>
+      <tr>
+        <th>Run ID</th>
+        <th>Step key</th>
+        <th>Assigned</th>
+        <th>Queued</th>
+        <th>
+          <Box flex={{alignItems: 'center', direction: 'row', gap: 4}}>
+            Priority
+            <Tooltip
+              placement="top"
+              content="Priority can be set on each op/asset using the 'dagster/priority' tag. Higher priority steps will be assigned slots first."
+            >
+              <Icon name="info" color={Colors.Gray500} />
+            </Tooltip>
+          </Box>
+        </th>
+        <th></th>
+      </tr>
+    </thead>
+  );
+
+  if (!steps.length) {
+    return (
+      <Table>
+        {table_header}
+        <tbody>
+          <tr>
+            <td colSpan={6}>
+              <Box
+                flex={{alignItems: 'center', justifyContent: 'center'}}
+                style={{color: Colors.Gray500}}
+                padding={16}
+              >
+                There are no active or pending steps for this concurrency key.
+              </Box>
+            </td>
+          </tr>
+        </tbody>
+      </Table>
+    );
+  }
+
+  return (
+    <Table>
+      {table_header}
+      <tbody style={{backgroundColor: Colors.Yellow50}}>
+        {assignedSteps.map((step) => (
+          <PendingStepRow
+            key={step.runId + step.stepKey}
+            step={step}
+            statusByRunId={statusByRunId}
+            onUpdate={refresh}
+          />
+        ))}
+      </tbody>
+      <tbody>
+        {pendingSteps.map((step) => (
+          <PendingStepRow
+            key={step.runId + step.stepKey}
+            step={step}
+            statusByRunId={statusByRunId}
+            onUpdate={refresh}
+          />
+        ))}
+      </tbody>
+    </Table>
+  );
+};
+
+const PendingStepRow = ({
+  step,
+  statusByRunId,
+  onUpdate,
+}: {
+  step: ConcurrencyStepFragment;
+  statusByRunId: {[id: string]: RunStatus};
+  onUpdate: () => void;
+}) => {
+  const runStatus = statusByRunId[step.runId];
+  return (
+    <tr key={step.runId + step.stepKey}>
+      <td>
+        {runStatus ? (
+          <Link to={`/runs/${step.runId}`}>
+            <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+              <RunStatusDot status={runStatus} size={10} />
+              <Mono>{titleForRun({id: step.runId})}</Mono>
+              {failedStatuses.has(runStatus) ? (
+                <Tooltip
+                  placement="top"
+                  content="Slots for canceled / failed runs can automatically be freed by configuring a run monitoring setting."
+                >
+                  <Icon name="info" color={Colors.Gray500} />
+                </Tooltip>
+              ) : null}
+            </Box>
+          </Link>
+        ) : (
+          <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+            <Mono>{titleForRun({id: step.runId})}</Mono>
+          </Box>
+        )}
+      </td>
+      <td>
+        <Mono>{step.stepKey}</Mono>
+      </td>
+      <td>
+        {step.assignedTimestamp ? (
+          <TimeElapsed startUnix={step.assignedTimestamp} endUnix={null} />
+        ) : (
+          '-'
+        )}
+      </td>
+      <td>
+        {step.enqueuedTimestamp ? (
+          <TimeElapsed startUnix={step.enqueuedTimestamp} endUnix={null} />
+        ) : (
+          '-'
+        )}
+      </td>
+      <td>{step.priority}</td>
+      <td>
+        <ConcurrencyActionMenu pendingStep={step} onUpdate={onUpdate} />
+      </td>
+    </tr>
+  );
+};
+
+export const CONCURRENCY_STEP_FRAGMENT = gql`
+  fragment ConcurrencyStepFragment on PendingConcurrencyStep {
+    runId
+    stepKey
+    enqueuedTimestamp
+    assignedTimestamp
+    priority
+  }
+`;
 export const CONCURRENCY_LIMIT_FRAGMENT = gql`
   fragment ConcurrencyLimitFragment on ConcurrencyKeyInfo {
     concurrencyKey
     slotCount
-    activeRunIds
-    activeSlotCount
+    claimedSlots {
+      runId
+      stepKey
+    }
+    pendingSteps {
+      ...ConcurrencyStepFragment
+    }
   }
+  ${CONCURRENCY_STEP_FRAGMENT}
 `;
 
 export const INSTANCE_CONCURRENCY_LIMITS_QUERY = gql`
@@ -623,6 +916,11 @@ export const INSTANCE_CONCURRENCY_LIMITS_QUERY = gql`
       id
       info
       supportsConcurrencyLimits
+      runQueuingSupported
+      runQueueConfig {
+        maxConcurrentRuns
+        tagConcurrencyLimitsYaml
+      }
       concurrencyLimits {
         ...ConcurrencyLimitFragment
       }
@@ -638,10 +936,22 @@ const SET_CONCURRENCY_LIMIT_MUTATION = gql`
   }
 `;
 
-export const FREE_CONCURRENCY_SLOTS_FOR_RUN_MUTATION = gql`
-  mutation FreeConcurrencySlotsForRun($runId: String!) {
-    freeConcurrencySlotsForRun(runId: $runId)
+export const FREE_CONCURRENCY_SLOTS_MUTATION = gql`
+  mutation FreeConcurrencySlots($runId: String!, $stepKey: String) {
+    freeConcurrencySlots(runId: $runId, stepKey: $stepKey)
   }
+`;
+
+const CONCURRENCY_KEY_DETAILS_QUERY = gql`
+  query ConcurrencyKeyDetailsQuery($concurrencyKey: String!) {
+    instance {
+      id
+      concurrencyLimit(concurrencyKey: $concurrencyKey) {
+        ...ConcurrencyLimitFragment
+      }
+    }
+  }
+  ${CONCURRENCY_LIMIT_FRAGMENT}
 `;
 
 const RUNS_FOR_CONCURRENCY_KEY_QUERY = gql`
@@ -650,17 +960,9 @@ const RUNS_FOR_CONCURRENCY_KEY_QUERY = gql`
       ... on Runs {
         results {
           id
-          ... on PipelineRun {
-            ...RunTableRunFragment
-          }
+          status
         }
-      }
-      ... on PythonError {
-        ...PythonErrorFragment
       }
     }
   }
-
-  ${RUN_TABLE_RUN_FRAGMENT}
-  ${PYTHON_ERROR_FRAGMENT}
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceConcurrency.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceConcurrency.types.ts
@@ -2,12 +2,28 @@
 
 import * as Types from '../../graphql/types';
 
+export type ConcurrencyStepFragment = {
+  __typename: 'PendingConcurrencyStep';
+  runId: string;
+  stepKey: string;
+  enqueuedTimestamp: number;
+  assignedTimestamp: number | null;
+  priority: number | null;
+};
+
 export type ConcurrencyLimitFragment = {
   __typename: 'ConcurrencyKeyInfo';
   concurrencyKey: string;
   slotCount: number;
-  activeRunIds: Array<string>;
-  activeSlotCount: number;
+  claimedSlots: Array<{__typename: 'ClaimedConcurrencySlot'; runId: string; stepKey: string}>;
+  pendingSteps: Array<{
+    __typename: 'PendingConcurrencyStep';
+    runId: string;
+    stepKey: string;
+    enqueuedTimestamp: number;
+    assignedTimestamp: number | null;
+    priority: number | null;
+  }>;
 };
 
 export type InstanceConcurrencyLimitsQueryVariables = Types.Exact<{[key: string]: never}>;
@@ -19,12 +35,25 @@ export type InstanceConcurrencyLimitsQuery = {
     id: string;
     info: string | null;
     supportsConcurrencyLimits: boolean;
+    runQueuingSupported: boolean;
+    runQueueConfig: {
+      __typename: 'RunQueueConfig';
+      maxConcurrentRuns: number;
+      tagConcurrencyLimitsYaml: string | null;
+    } | null;
     concurrencyLimits: Array<{
       __typename: 'ConcurrencyKeyInfo';
       concurrencyKey: string;
       slotCount: number;
-      activeRunIds: Array<string>;
-      activeSlotCount: number;
+      claimedSlots: Array<{__typename: 'ClaimedConcurrencySlot'; runId: string; stepKey: string}>;
+      pendingSteps: Array<{
+        __typename: 'PendingConcurrencyStep';
+        runId: string;
+        stepKey: string;
+        enqueuedTimestamp: number;
+        assignedTimestamp: number | null;
+        priority: number | null;
+      }>;
     }>;
   };
 };
@@ -36,13 +65,37 @@ export type SetConcurrencyLimitMutationVariables = Types.Exact<{
 
 export type SetConcurrencyLimitMutation = {__typename: 'Mutation'; setConcurrencyLimit: boolean};
 
-export type FreeConcurrencySlotsForRunMutationVariables = Types.Exact<{
+export type FreeConcurrencySlotsMutationVariables = Types.Exact<{
   runId: Types.Scalars['String'];
+  stepKey?: Types.InputMaybe<Types.Scalars['String']>;
 }>;
 
-export type FreeConcurrencySlotsForRunMutation = {
-  __typename: 'Mutation';
-  freeConcurrencySlotsForRun: boolean;
+export type FreeConcurrencySlotsMutation = {__typename: 'Mutation'; freeConcurrencySlots: boolean};
+
+export type ConcurrencyKeyDetailsQueryVariables = Types.Exact<{
+  concurrencyKey: Types.Scalars['String'];
+}>;
+
+export type ConcurrencyKeyDetailsQuery = {
+  __typename: 'Query';
+  instance: {
+    __typename: 'Instance';
+    id: string;
+    concurrencyLimit: {
+      __typename: 'ConcurrencyKeyInfo';
+      concurrencyKey: string;
+      slotCount: number;
+      claimedSlots: Array<{__typename: 'ClaimedConcurrencySlot'; runId: string; stepKey: string}>;
+      pendingSteps: Array<{
+        __typename: 'PendingConcurrencyStep';
+        runId: string;
+        stepKey: string;
+        enqueuedTimestamp: number;
+        assignedTimestamp: number | null;
+        priority: number | null;
+      }>;
+    };
+  };
 };
 
 export type RunsForConcurrencyKeyQueryVariables = Types.Exact<{
@@ -54,49 +107,9 @@ export type RunsForConcurrencyKeyQuery = {
   __typename: 'Query';
   pipelineRunsOrError:
     | {__typename: 'InvalidPipelineRunsFilterError'}
-    | {
-        __typename: 'PythonError';
-        message: string;
-        stack: Array<string>;
-        errorChain: Array<{
-          __typename: 'ErrorChainLink';
-          isExplicitLink: boolean;
-          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
-        }>;
-      }
+    | {__typename: 'PythonError'}
     | {
         __typename: 'Runs';
-        results: Array<{
-          __typename: 'Run';
-          id: string;
-          status: Types.RunStatus;
-          stepKeysToExecute: Array<string> | null;
-          canTerminate: boolean;
-          hasReExecutePermission: boolean;
-          hasTerminatePermission: boolean;
-          hasDeletePermission: boolean;
-          mode: string;
-          rootRunId: string | null;
-          parentRunId: string | null;
-          pipelineSnapshotId: string | null;
-          pipelineName: string;
-          solidSelection: Array<string> | null;
-          startTime: number | null;
-          endTime: number | null;
-          updateTime: number | null;
-          repositoryOrigin: {
-            __typename: 'RepositoryOrigin';
-            id: string;
-            repositoryName: string;
-            repositoryLocationName: string;
-          } | null;
-          assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
-          assetCheckSelection: Array<{
-            __typename: 'AssetCheckhandle';
-            name: string;
-            assetKey: {__typename: 'AssetKey'; path: Array<string>};
-          }> | null;
-          tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
-        }>;
+        results: Array<{__typename: 'Run'; id: string; status: Types.RunStatus}>;
       };
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceConcurrency.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceConcurrency.types.ts
@@ -26,6 +26,12 @@ export type ConcurrencyLimitFragment = {
   }>;
 };
 
+export type RunQueueConfigFragment = {
+  __typename: 'RunQueueConfig';
+  maxConcurrentRuns: number;
+  tagConcurrencyLimitsYaml: string | null;
+};
+
 export type InstanceConcurrencyLimitsQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type InstanceConcurrencyLimitsQuery = {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunConfigDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunConfigDialog.tsx
@@ -21,10 +21,10 @@ import {AppContext} from '../app/AppContext';
 import {showSharedToaster} from '../app/DomUtils';
 import {useFeatureFlags} from '../app/Flags';
 import {useCopyToClipboard} from '../app/browser';
-import {FREE_CONCURRENCY_SLOTS_FOR_RUN_MUTATION} from '../instance/InstanceConcurrency';
+import {FREE_CONCURRENCY_SLOTS_MUTATION} from '../instance/InstanceConcurrency';
 import {
-  FreeConcurrencySlotsForRunMutation,
-  FreeConcurrencySlotsForRunMutationVariables,
+  FreeConcurrencySlotsMutation,
+  FreeConcurrencySlotsMutationVariables,
 } from '../instance/types/InstanceConcurrency.types';
 import {NO_LAUNCH_PERMISSION_MESSAGE} from '../launchpad/LaunchRootExecutionButton';
 import {AnchorButton} from '../ui/AnchorButton';
@@ -51,9 +51,9 @@ export const RunConfigDialog = ({run, isJob}: {run: RunFragment; isJob: boolean}
   const history = useHistory();
 
   const [freeSlots] = useMutation<
-    FreeConcurrencySlotsForRunMutation,
-    FreeConcurrencySlotsForRunMutationVariables
-  >(FREE_CONCURRENCY_SLOTS_FOR_RUN_MUTATION);
+    FreeConcurrencySlotsMutation,
+    FreeConcurrencySlotsMutationVariables
+  >(FREE_CONCURRENCY_SLOTS_MUTATION);
 
   const copyConfig = async () => {
     copy(runConfigYaml);
@@ -66,7 +66,7 @@ export const RunConfigDialog = ({run, isJob}: {run: RunFragment; isJob: boolean}
 
   const freeConcurrencySlots = async () => {
     const resp = await freeSlots({variables: {runId: run.id}});
-    if (resp.data?.freeConcurrencySlotsForRun) {
+    if (resp.data?.freeConcurrencySlots) {
       await showSharedToaster({
         intent: 'success',
         icon: 'check_circle',

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -831,6 +831,29 @@ class GrapheneSetConcurrencyLimitMutation(graphene.Mutation):
         return True
 
 
+class GrapheneFreeConcurrencySlotsMutation(graphene.Mutation):
+    """Frees concurrency slots."""
+
+    Output = graphene.NonNull(graphene.Boolean)
+
+    class Meta:
+        name = "FreeConcurrencySlotsMutation"
+
+    class Arguments:
+        runId = graphene.Argument(graphene.NonNull(graphene.String))
+        stepKey = graphene.Argument(graphene.String)
+
+    @capture_error
+    @check_permission(Permissions.EDIT_CONCURRENCY_LIMIT)
+    def mutate(self, graphene_info, runId: str, stepKey: Optional[str] = None):
+        event_log_storage = graphene_info.context.instance.event_log_storage
+        if stepKey:
+            event_log_storage.free_concurrency_slot_for_step(runId, stepKey)
+        else:
+            event_log_storage.free_concurrency_slots_for_run(runId)
+        return True
+
+
 class GrapheneFreeConcurrencySlotsForRunMutation(graphene.Mutation):
     """Frees the concurrency slots occupied by a specific run."""
 
@@ -885,3 +908,4 @@ class GrapheneMutation(graphene.ObjectType):
     setAutoMaterializePaused = GrapheneSetAutoMaterializePausedMutation.Field()
     setConcurrencyLimit = GrapheneSetConcurrencyLimitMutation.Field()
     freeConcurrencySlotsForRun = GrapheneFreeConcurrencySlotsForRunMutation.Field()
+    freeConcurrencySlots = GrapheneFreeConcurrencySlotsMutation.Field()

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2511,8 +2511,10 @@ class SqlEventLogStorage(EventLogStorage):
                     PendingStepInfo(
                         run_id=row["run_id"],
                         step_key=row["step_key"],
-                        enqueued_timestamp=row["create_timestamp"],
-                        assigned_timestamp=row["assigned_timestamp"],
+                        enqueued_timestamp=utc_datetime_from_naive(row["create_timestamp"]),
+                        assigned_timestamp=utc_datetime_from_naive(row["assigned_timestamp"])
+                        if row["assigned_timestamp"]
+                        else None,
                         priority=row["priority"],
                     )
                     for row in pending_rows


### PR DESCRIPTION
## Summary & Motivation
The concurrency UI page causes some confusion...

This UI rewrite has a couple goals:
* Add more granular control + visibility over concurrency limited runs/steps
* Minimize confusion between op/asset and run-based concurrency
* Add helpful pointers back to the docs page

https://github.com/dagster-io/dagster/assets/1040172/fb202e3b-1eb6-48ea-9e9a-19f1692695d1

## How I Tested These Changes
BK