### PR TITLE
[ui] Add missing empty state, make expanded asset groups less opaque

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ExpandedGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ExpandedGroupNode.tsx
@@ -39,7 +39,7 @@ const GroupOutline = styled.div<{$minimal: boolean}>`
   inset: 0;
   top: 60px;
   position: absolute;
-  background: ${Colors.White};
+  background: rgba(255, 255, 255, 0.35);
   width: 100%;
   border-radius: 10px;
   border-top-left-radius: 0;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMaterializationUpstreamData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMaterializationUpstreamData.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Box, Colors, Icon, MiddleTruncate} from '@dagster-io/ui-components';
+import {Box, Caption, Colors, Icon, MiddleTruncate} from '@dagster-io/ui-components';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import React from 'react';
@@ -154,6 +154,10 @@ export const AssetMaterializationUpstreamData = ({
     variables: {assetKey: {path: assetKey.path}, timestamp},
     skip: !timestamp,
   });
+
+  if (!timestamp) {
+    return <Caption color={Colors.Gray500}>None</Caption>;
+  }
 
   const data =
     result.data?.assetNodeOrError.__typename === 'AssetNode'

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -465,7 +465,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
                 {target.type === 'pureWithAnchorAsset' ? (
                   <span /> // we won't know until runtime
                 ) : (
-                  <span>{partitionCountString(keyCountInSelections(selections))}</span>
+                  <span>{partitionCountString(keysFiltered.length)}</span>
                 )}
               </Box>
             }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -82,11 +82,7 @@ import {
   PartitionDefinitionForLaunchAssetFragment,
 } from './types/LaunchAssetExecutionButton.types';
 import {usePartitionDimensionSelections} from './usePartitionDimensionSelections';
-import {
-  PartitionDimensionSelection,
-  keyCountInSelections,
-  usePartitionHealthData,
-} from './usePartitionHealthData';
+import {PartitionDimensionSelection, usePartitionHealthData} from './usePartitionHealthData';
 
 const MISSING_FAILED_STATUSES = [AssetPartitionStatus.MISSING, AssetPartitionStatus.FAILED];
 


### PR DESCRIPTION
## Summary & Motivation

- If you check “only failed and missing”, use the failed and missing (computed) partition count in the dialog header so you know it work #17839

- Fix “Source Data: Loading” state when there is no materialization

- Make the white background of expanded asset groups slightly transparent so that the "dots" grid can just barely be seen.
 
## How I Tested These Changes

Tested these changes visually