### PR TITLE
added dynamodb source class

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/generated/sources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/generated/sources.py
@@ -7,6 +7,38 @@ from dagster._annotations import public
 from dagster_airbyte.managed.types import GeneratedAirbyteSource
 
 
+class DynamoDbSource(GeneratedAirbyteSource):
+    @public
+    def __init__(
+        self,
+        name: str,
+        access_key_id: str,
+        secret_access_key: str,
+        endpoint: str,
+        region: str,
+        reserved_attribute_names: Optional[str] = None,
+    ):
+        """Airbyte Source for DynamoDB.
+
+        Documentation can be found at https://docs.airbyte.com/integrations/sources/dynamodb/
+
+        Args:
+            name (str): The name of the destination.
+            access_key_id (str): AWS access key
+            secret_access_key (str): AWS secret access key
+            endpoint (str): optional endpoint
+            region (str): region name in AWS
+        """
+        self.access_key_id = check.opt_str_param(access_key_id, "access_key_id")
+        self.secret_access_key = check.str_param(secret_access_key, "secret_access_key")
+        self.endpoint = check.str_param(endpoint, "endpoint")
+        self.region = check.str_param(region, "region")
+        self.reserved_attribute_names = check.opt_str_param(
+            reserved_attribute_names, "reserved_attribute_names"
+        )
+        super().__init__("dynamodb", name)
+
+
 class StravaSource(GeneratedAirbyteSource):
     @public
     def __init__(


### PR DESCRIPTION
source class compatible with airbyte's api added

## Summary & Motivation

As a developer I would need to have ability to use dynamodb source in dagster-airbyte

**Context:**

Airbyte can handle dynamodb as a source and there is API available that allows using dynamodb source in connections as well. However it is currently not available in Dagster (dagster-airbyte).

https://docs.airbyte.com/integrations/sources/dynamodb

Idea of implementing is simple:

It seems that it should simply be defined as a class derived from GeneratedAirbyteSource.

As far as I can see there is neither open nor resolved issue that regards this problem. Since I would like to contribute in Dagster project I think also it would be a good astart. (I think currently there are no "good first issues" so it would be a good first PR to contribute)

## How I Tested These Changes

Implemented locally first and tested using open source version of Dagster (dagster-airbyte). I was able to successfully use dynamodb source and populate data from it to redshift database.