### PR TITLE
Dagster airbyte auto enable multiple streams per connection

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
@@ -14,7 +14,7 @@ from typing import (
 
 import dagster._check as check
 from dagster import AssetKey
-from dagster._annotations import deprecated, experimental, public
+from dagster._annotations import experimental, public
 from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 from dagster._core.definitions.events import CoercibleToAssetKeyPrefix
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
@@ -39,7 +39,6 @@ from dagster_airbyte.asset_defs import (
     _clean_name,
 )
 from dagster_airbyte.managed.types import (
-    MANAGED_ELEMENTS_DEPRECATION_MSG,
     AirbyteConnection,
     AirbyteDestination,
     AirbyteDestinationNamespace,
@@ -54,12 +53,15 @@ from dagster_airbyte.utils import is_basic_normalization_operation
 
 
 def gen_configured_stream_json(
-    source_stream: Mapping[str, Any], user_stream_config: Mapping[str, AirbyteSyncMode]
+    source_stream: Mapping[str, Any], user_stream_config: Mapping[str, AirbyteSyncMode], enable_streams: Optional[bool] = False
 ) -> Mapping[str, Any]:
     """Generates an Airbyte API stream defintiion based on the succinct user-provided config and the
     full stream definition from the source.
     """
-    config = user_stream_config[source_stream["stream"]["name"]]
+    config = user_stream_config[source_stream["stream"]["name"]]    
+    if enable_streams:
+        source_stream["config"]["selected"] = True
+    
     return deep_merge_dicts(
         source_stream,
         {"config": config.to_json()},
@@ -637,7 +639,6 @@ def reconcile_connections_post(
 
 
 @experimental
-@deprecated(breaking_version="2.0", additional_warn_text=MANAGED_ELEMENTS_DEPRECATION_MSG)
 class AirbyteManagedElementReconciler(ManagedElementReconciler):
     """Reconciles Python-specified Airbyte connections with an Airbyte instance.
 
@@ -742,7 +743,6 @@ class AirbyteManagedElementCacheableAssetsDefinition(AirbyteInstanceCacheableAss
 
 
 @experimental
-@deprecated(breaking_version="2.0", additional_warn_text=MANAGED_ELEMENTS_DEPRECATION_MSG)
 def load_assets_from_connections(
     airbyte: Union[AirbyteResource, ResourceDefinition],
     connections: Iterable[AirbyteConnection],

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
@@ -14,7 +14,7 @@ from typing import (
 
 import dagster._check as check
 from dagster import AssetKey
-from dagster._annotations import experimental, public
+from dagster._annotations import deprecated, experimental, public
 from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 from dagster._core.definitions.events import CoercibleToAssetKeyPrefix
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
@@ -39,6 +39,7 @@ from dagster_airbyte.asset_defs import (
     _clean_name,
 )
 from dagster_airbyte.managed.types import (
+    MANAGED_ELEMENTS_DEPRECATION_MSG,
     AirbyteConnection,
     AirbyteDestination,
     AirbyteDestinationNamespace,
@@ -639,6 +640,7 @@ def reconcile_connections_post(
 
 
 @experimental
+@deprecated(breaking_version="2.0", additional_warn_text=MANAGED_ELEMENTS_DEPRECATION_MSG)
 class AirbyteManagedElementReconciler(ManagedElementReconciler):
     """Reconciles Python-specified Airbyte connections with an Airbyte instance.
 
@@ -743,6 +745,7 @@ class AirbyteManagedElementCacheableAssetsDefinition(AirbyteInstanceCacheableAss
 
 
 @experimental
+@deprecated(breaking_version="2.0", additional_warn_text=MANAGED_ELEMENTS_DEPRECATION_MSG)
 def load_assets_from_connections(
     airbyte: Union[AirbyteResource, ResourceDefinition],
     connections: Iterable[AirbyteConnection],

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
@@ -54,15 +54,17 @@ from dagster_airbyte.utils import is_basic_normalization_operation
 
 
 def gen_configured_stream_json(
-    source_stream: Mapping[str, Any], user_stream_config: Mapping[str, AirbyteSyncMode], enable_streams: Optional[bool] = False
+    source_stream: Mapping[str, Any],
+    user_stream_config: Mapping[str, AirbyteSyncMode],
+    enable_streams: Optional[bool] = False,
 ) -> Mapping[str, Any]:
     """Generates an Airbyte API stream defintiion based on the succinct user-provided config and the
     full stream definition from the source.
     """
-    config = user_stream_config[source_stream["stream"]["name"]]    
+    config = user_stream_config[source_stream["stream"]["name"]]
     if enable_streams:
         source_stream["config"]["selected"] = True
-    
+
     return deep_merge_dicts(
         source_stream,
         {"config": config.to_json()},

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/types.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/types.py
@@ -4,7 +4,13 @@ from enum import Enum
 from typing import Any, Dict, List, Mapping, Optional, Union
 
 import dagster._check as check
-from dagster._annotations import public
+from dagster._annotations import deprecated, public
+
+MANAGED_ELEMENTS_DEPRECATION_MSG = (
+    "Dagster is deprecating support for ingestion-as-code."
+    " We suggest using the Airbyte terraform provider:"
+    " https://reference.airbyte.com/reference/using-the-terraform-provider."
+)
 
 
 class AirbyteSyncMode(ABC):
@@ -206,6 +212,7 @@ class AirbyteDestinationNamespace(Enum):
     DESTINATION_DEFAULT = "destination"
 
 
+@deprecated(breaking_version="2.0", additional_warn_text=MANAGED_ELEMENTS_DEPRECATION_MSG)
 class AirbyteConnection:
     """A user-defined Airbyte connection, pairing an Airbyte source and destination and configuring
     which streams to sync.

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/types.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/types.py
@@ -4,13 +4,7 @@ from enum import Enum
 from typing import Any, Dict, List, Mapping, Optional, Union
 
 import dagster._check as check
-from dagster._annotations import deprecated, public
-
-MANAGED_ELEMENTS_DEPRECATION_MSG = (
-    "Dagster is deprecating support for ingestion-as-code."
-    " We suggest using the Airbyte terraform provider:"
-    " https://reference.airbyte.com/reference/using-the-terraform-provider."
-)
+from dagster._annotations import public
 
 
 class AirbyteSyncMode(ABC):
@@ -212,7 +206,6 @@ class AirbyteDestinationNamespace(Enum):
     DESTINATION_DEFAULT = "destination"
 
 
-@deprecated(breaking_version="2.0", additional_warn_text=MANAGED_ELEMENTS_DEPRECATION_MSG)
 class AirbyteConnection:
     """A user-defined Airbyte connection, pairing an Airbyte source and destination and configuring
     which streams to sync.
@@ -261,6 +254,7 @@ class AirbyteConnection:
         destination: AirbyteDestination,
         stream_config: Mapping[str, AirbyteSyncMode],
         normalize_data: Optional[bool] = None,
+        enable_streams: Optional[bool] = None,
         destination_namespace: Optional[
             Union[AirbyteDestinationNamespace, str]
         ] = AirbyteDestinationNamespace.SAME_AS_SOURCE,
@@ -276,6 +270,7 @@ class AirbyteConnection:
         self.destination_namespace = check.opt_inst_param(
             destination_namespace, "destination_namespace", (str, AirbyteDestinationNamespace)
         )
+        self.enable_streams = check.opt_bool_param(enable_streams, "enable_streams")
         self.prefix = check.opt_str_param(prefix, "prefix")
 
     def must_be_recreated(self, other: Optional["AirbyteConnection"]) -> bool:


### PR DESCRIPTION
airbyte streams in connections should be automatically enabled after creation (it is only working when there is one stream per connection)

## Summary & Motivation

When creating connection with multiple streams they are being created always without being activated. (connection activated but streams are not being selected)

## How I Tested These Changes
Locally using reconcilier