### PR TITLE
[embedded-elt] Decoupling connections from resource allocation

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/__init__.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/__init__.py
@@ -1,5 +1,6 @@
-from dagster_embedded_elt.sling.asset_defs import build_sling_asset
+from dagster_embedded_elt.sling.asset_defs import build_assets_from_sling_stream, build_sling_asset
 from dagster_embedded_elt.sling.resources import (
+    SlingConnectionResource,
     SlingMode,
     SlingResource,
     SlingSourceConnection,
@@ -10,6 +11,8 @@ __all__ = [
     "SlingResource",
     "SlingMode",
     "build_sling_asset",
+    "build_assets_from_sling_stream",
     "SlingSourceConnection",
     "SlingTargetConnection",
+    "SlingConnectionResource",
 ]

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_defs.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_defs.py
@@ -1,3 +1,4 @@
+import json
 import re
 from typing import Any, Dict, List, Optional, Union
 
@@ -9,8 +10,9 @@ from dagster import (
     multi_asset,
 )
 from dagster._annotations import experimental
+from dagster._utils.env import environ
 
-from dagster_embedded_elt.sling.resources import SlingMode, SlingResource
+from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingMode, SlingResource
 
 
 @experimental
@@ -99,3 +101,17 @@ def build_sling_asset(
         )
 
     return sync
+
+
+@experimental
+def build_assets_from_sling_stream(source: SlingConnectionResource, target: SlingConnectionResource, source_stream: str) -> AssetsDefinition:
+
+    sling_resource = SlingResource(
+        source_connection=source,
+        target_connection=target,
+    )
+
+    @multi_asset
+    def _sling_assets():
+
+        

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_defs.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_defs.py
@@ -111,13 +111,58 @@ def build_assets_from_sling_stream(
     source: SlingConnectionResource,
     target: SlingConnectionResource,
     stream: str,
-    target_object: str = "{ {{target_schema}}.{{stream_schema}}_{{stream_table}} }",
+    target_object: str = "{{target_schema}}.{{stream_schema}}_{{stream_table}}",
     mode: SlingMode = SlingMode.FULL_REFRESH,
     primary_key: Optional[Union[str, List[str]]] = None,
     update_key: Optional[str] = None,
     source_options: Optional[Dict[str, Any]] = None,
     target_options: Optional[Dict[str, Any]] = None,
 ) -> AssetsDefinition:
+    """Asset Factory for using Sling to sync data from a source stream to a target object.
+
+    Args:
+        source (SlingConnectionResource): The source SlingConnectionResource to use.
+        target (SlingConnectionResource): The target SlingConnectionResource to use.
+        stream (str): The source stream to sync from. This can be a table, a query, or a path.
+        target_object (str, optional): The target object to sync to. This can be a table, or a path. Defaults to the template of "{{target_schema}}.{{stream_schema}}_{{stream_table}}". See the Sling documentation for more information. https://docs.slingdata.io/sling-cli/replication
+        mode (SlingMode, optional): The sync mode to use when syncing. Defaults to `full-refresh`.
+        primary_key (Optional[Union[str, List[str]]], optional): The optional primary key to use when syncing.
+        update_key (Optional[str], optional): The optional update key to use when syncing.
+        source_options (Optional[Dict[str, Any]], optional): Any optional Sling source options to use when syncing.
+        target_options (Optional[Dict[str, Any]], optional): Any optional target options to use when syncing.
+
+    Examples:
+        Creating a Sling asset that syncs from a database to a data warehouse:
+
+        .. code-block:: python
+
+            source = SlingConnectionResource(
+                type="postgres",
+                host=EnvVar("POSTGRES_HOST"),
+                port=EnvVar("POSTGRES_PORT"),
+                user=EnvVar("POSTGRES_USER"),
+                password=EnvVar("POSTGRES_PASSWORD"),
+                database=EnvVar("POSTGRES_DATABASE"),
+            )
+
+            target = SlingConnectionResource(
+                type="snowflake",
+                account=EnvVar("SNOWFLAKE_ACCOUNT"),
+                user=EnvVar("SNOWFLAKE_USER"),
+                password=EnvVar("SNOWFLAKE_PASSWORD"),
+                database=EnvVar("SNOWFLAKE_DATABASE"),
+                warehouse=EnvVar("SNOWFLAKE_WAREHOUSE"),
+            )
+
+            asset_def = build_assets_from_sling_stream(
+                    source=source,
+                    target=target,
+                    stream="main.orders",
+                    target_object="main.orders",
+                    mode=SlingMode.INCREMENTAL,
+                    primary_key="id"
+            )
+    """
     if primary_key is not None and not isinstance(primary_key, list):
         primary_key = [primary_key]
 
@@ -126,18 +171,15 @@ def build_assets_from_sling_stream(
         target_connection=target,
     )
 
-    asset_name = [stream]
-    if stream.startswith("file://"):
-        asset_name = stream.split("/")[-1].replace(".", "_")
+    # sanitize the stream name to a valid asset name, matching the regex A-Za-z0-9_
+    asset_name = stream.replace(".", "_")
+
+    if asset_name.startswith("file://"):
+        asset_name = asset_name.split("/")[-1]
 
     specs = [AssetSpec(asset_name)]
 
-    @multi_asset(
-        name=f"sling_sync__{asset_name}",
-        compute_kind="sling",
-        specs=specs,
-        # required_resource_keys={source.???, target.???}, TODO: How do you get the resource key at this point in time?
-    )
+    @multi_asset(name=f"sling_sync__{asset_name}", compute_kind="sling", specs=specs)
     def _sling_assets(context: AssetExecutionContext) -> MaterializeResult:
         last_row_count_observed = None
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_defs.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_defs.py
@@ -118,6 +118,9 @@ def build_assets_from_sling_stream(
     source_options: Optional[Dict[str, Any]] = None,
     target_options: Optional[Dict[str, Any]] = None,
 ) -> AssetsDefinition:
+    if primary_key is not None and not isinstance(primary_key, list):
+        primary_key = [primary_key]
+
     sling_replicator = SlingStreamReplicator(
         source_connection=source,
         target_connection=target,

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -357,7 +357,6 @@ class SlingStreamReplicator(SlingSyncBase):
         self.source_connection = source_connection
         self.target_connection = target_connection
 
-    # TODO: - use the Replication command rather than Single Task,  modify the log parsing to parse that stdout instead
     def _sync(
         self,
         source_stream: str,
@@ -414,6 +413,8 @@ class SlingStreamReplicator(SlingSyncBase):
             cmd = sling_cli._prep_cmd() # noqa: SLF001
 
             # `_prep_cmd` only works with the Single Task command, so we need to replace it with the Replication command
+            # TODO: Unfortunately, _prep_cmd doesn't expose a way to add streams, so we'll need to override it ourselves
+            # We'll also need to parse the logs differently, since the output is different
             # cmd = cmd.replace(" -c ", " -r ")
 
             yield from self._exec_sling_cmd(cmd, encoding=encoding)

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -411,7 +411,7 @@ class SlingStreamReplicator(SlingSyncBase):
 
             sling_cli = Sling(**config)
             logger.info("Starting Sling sync with mode: %s", mode)
-            cmd = sling_cli._prep_cmd()
+            cmd = sling_cli._prep_cmd() # noqa: SLF001
 
             # `_prep_cmd` only works with the Single Task command, so we need to replace it with the Replication command
             # cmd = cmd.replace(" -c ", " -r ")

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -1,6 +1,7 @@
 import contextlib
 import json
 import re
+from abc import abstractmethod
 from enum import Enum
 from subprocess import PIPE, STDOUT, Popen
 from typing import IO, Any, AnyStr, Dict, Generator, Iterator, List, Optional
@@ -8,7 +9,7 @@ from typing import IO, Any, AnyStr, Dict, Generator, Iterator, List, Optional
 from dagster import ConfigurableResource, PermissiveConfig, get_dagster_logger
 from dagster._annotations import experimental
 from dagster._utils.env import environ
-from pydantic import Field
+from pydantic import ConfigDict, Extra, Field
 from sling import Sling
 
 logger = get_dagster_logger()
@@ -95,8 +96,48 @@ class SlingTargetConnection(PermissiveConfig):
     )
 
 
+class SlingSyncBase():
+
+    def process_stdout(self, stdout: IO[AnyStr], encoding="utf8") -> Iterator[str]:
+        """Process stdout from the Sling CLI."""
+        ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+        for line in stdout:
+            assert isinstance(line, bytes)
+            fmt_line = bytes.decode(line, encoding=encoding, errors="replace")
+            clean_line: str = ansi_escape.sub("", fmt_line).replace("INF", "")
+            yield clean_line
+
+    def _exec_sling_cmd(
+        self, cmd, stdin=None, stdout=PIPE, stderr=STDOUT, encoding="utf8"
+    ) -> Generator[str, None, None]:
+        with Popen(cmd, shell=True, stdin=stdin, stdout=stdout, stderr=stderr) as proc:
+            if proc.stdout:
+                for line in self.process_stdout(proc.stdout, encoding=encoding):
+                    yield line
+
+            proc.wait()
+            if proc.returncode != 0:
+                raise Exception("Sling command failed with error code %s", proc.returncode)
+            
+    @abstractmethod
+    def _sync(
+        self,
+        source_stream: str,
+        target_object: str,
+        mode: SlingMode = SlingMode.FULL_REFRESH,
+        primary_key: Optional[List[str]] = None,
+        update_key: Optional[str] = None,
+        source_options: Optional[Dict[str, Any]] = None,
+        target_options: Optional[Dict[str, Any]] = None,
+        encoding: str = "utf8",
+    ) -> Generator[str, None, None]:
+        """Runs a Sling sync from the given source table to the given destination table. Generates
+        output lines from the Sling CLI.
+        """
+        raise NotImplementedError()
+
 @experimental
-class SlingResource(ConfigurableResource):
+class SlingResource(ConfigurableResource, SlingSyncBase):
     """Resource for interacting with the Sling package.
 
     Examples:
@@ -139,27 +180,6 @@ class SlingResource(ConfigurableResource):
             }
         ):
             yield
-
-    def process_stdout(self, stdout: IO[AnyStr], encoding="utf8") -> Iterator[str]:
-        """Process stdout from the Sling CLI."""
-        ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
-        for line in stdout:
-            assert isinstance(line, bytes)
-            fmt_line = bytes.decode(line, encoding=encoding, errors="replace")
-            clean_line: str = ansi_escape.sub("", fmt_line).replace("INF", "")
-            yield clean_line
-
-    def _exec_sling_cmd(
-        self, cmd, stdin=None, stdout=PIPE, stderr=STDOUT, encoding="utf8"
-    ) -> Generator[str, None, None]:
-        with Popen(cmd, shell=True, stdin=stdin, stdout=stdout, stderr=stderr) as proc:
-            if proc.stdout:
-                for line in self.process_stdout(proc.stdout, encoding=encoding):
-                    yield line
-
-            proc.wait()
-            if proc.returncode != 0:
-                raise Exception("Sling command failed with error code %s", proc.returncode)
 
     def _sync(
         self,
@@ -206,85 +226,100 @@ class SlingResource(ConfigurableResource):
 
             yield from self._exec_sling_cmd(cmd, encoding=encoding)
 
-    def sync(
+class SlingConnectionResource(ConfigurableResource):
+    """A representation a connection to a database or file to be used by Sling. This resource can be used as a source or a target for a Sling sync.
+
+    This resource is responsible for the managing how Sling connects to a resource. To manage how Sling uses this connection (as a source or target), see the specific source_options or target_options in the `build_assets_from_sling_stream` function.
+
+    Examples:
+        Creating a Sling Connection for a file, such as CSV or JSON:
+
+        .. code-block:: python
+
+             source = SlingConnectionResource(type="file")
+
+        Create a Sling Connection for a Postgres database, using a connection string:
+
+        .. code-block:: python
+
+            source = SlingConnectionResource(type="postgres", connection_string=EnvVar("POSTGRES_CONNECTION_STRING"))
+            source = SlingConnectionResource(type="mysql", connection_string="mysql://user:password@host:port/schema")
+
+        Create a Sling Connection for a Postgres or Snowflake database, using keyword arguments, as described here:
+        https://docs.slingdata.io/connections/database-connections/postgres
+
+        .. code-block::python
+
+            source = SlingConnectionResource(type="postgres", host="host", user="hunter42", password=EnvVar("POSTGRES_PASSWORD"))
+            source = SlingConnectionResource(type="snowflake", host=EnvVar("SNOWFLAKE_HOST"), user=EnvVar("SNOWFLAKE_USER"), database=EnvVar("SNOWFLAKE_DATABASE"), password=EnvVar("SNOWFLAKE_PASSWORD"), role=EnvVar("SNOWFLAKE_ROLE"))
+    """
+    model_config = ConfigDict(extra=Extra.allow)
+
+    type: str = Field(description="Type of the source connection. Use 'file' for local storage.")
+    connection_string: Optional[str] = Field(
+        description="The connection string for the source database.",
+        default=None,
+    )
+
+class SlingStreamReplicator(SlingSyncBase):
+    """A utility class for running a Sling sync from outside of a Dagster resource to enable parity between the SlingResource and SlingStreamSync.
+
+    Inherits from :py:class:`~dagster_elt.sling.SlingSyncBase` and implements `_sync` to run a sync using 2 SlingConnectionResources and no SlingResource.
+    """
+
+    def __init__(
+        self,
+        source_connection: SlingConnectionResource,
+        target_connection: SlingConnectionResource,
+    ):
+        self.source_connection = source_connection
+        self.target_connection = target_connection
+
+    # TODO: Finish implementing this to:
+    # TODO: - mirror the SlingResource setup_config to set the env using SlingConnectionResources (rather than SlingSource/TaargetConnections)
+    # TODO: - Afterwards, finish the factory function to use this class.
+    # TODO: - use the Replication command rather than Single Task,  modify the log parsing to parse that stdout instead
+    def _sync(
         self,
         source_stream: str,
         target_object: str,
-        mode: SlingMode,
+        mode: SlingMode = SlingMode.FULL_REFRESH,
         primary_key: Optional[List[str]] = None,
         update_key: Optional[str] = None,
         source_options: Optional[Dict[str, Any]] = None,
         target_options: Optional[Dict[str, Any]] = None,
         encoding: str = "utf8",
     ) -> Generator[str, None, None]:
-        """Initiate a Sling Sync between a source stream and a target object.
-
-        Args:
-            source_stream (str):  The source stream to read from. For database sources, the source stream can be either
-                a table name, a SQL statement or a path to a SQL file e.g. `TABLE1` or `SCHEMA1.TABLE2` or
-                `SELECT * FROM TABLE`. For file sources, the source stream is a path or an url to a file.
-                For file targets, the target object is a path or a url to a file, e.g. file:///tmp/file.csv or
-                s3://my_bucket/my_folder/file.csv
-            target_object (str): The target object to write into. For database targets, the target object is a table
-                name, e.g. TABLE1, SCHEMA1.TABLE2. For file targets, the target object is a path or an url to a file.
-            mode (SlingMode): The Sling mode to use when syncing, i.e. incremental, full-refresh
-                See the Sling docs for more information: https://docs.slingdata.io/sling-cli/running-tasks#modes.
-            primary_key (List[str]): For incremental syncs, a primary key is used during merge statements to update
-                existing rows.
-            update_key (str): For incremental syncs, an update key is used to stream records after max(update_key)
-            source_options (Dict[str, Any]): Other source options to pass to Sling,
-                see https://docs.slingdata.io/sling-cli/running-tasks#source-options-src-options-flag-source.options-key
-                for details
-            target_options (Dict[str, Any[): Other target options to pass to Sling,
-                see https://docs.slingdata.io/sling-cli/running-tasks#target-options-tgt-options-flag-target.options-key
-                for details
-            encoding (str): The encoding to use when reading from stdout, defautls to utf-8. By default, will replace
-                non-utf-8 characters with the unicode replacement character.
-
-        Examples:
-            Sync from a source file to a sqlite database:
-
-            .. code-block:: python
-
-                sqllite_path = "/path/to/sqlite.db"
-                csv_path = "/path/to/file.csv"
-
-                @asset
-                def run_sync(context, sling: SlingResource):
-                    res = sling.sync(
-                        source_stream=csv_path,
-                        target_object="events",
-                        mode=SlingMode.FULL_REFRESH,
-                    )
-                    for stdout in res:
-                        context.log.debug(stdout)
-                    counts = sqlite3.connect(sqllitepath).execute("SELECT count(1) FROM events").fetchone()
-                    assert counts[0] == 3
-
-                source = SlingSourceConnection(
-                    type="file",
-                )
-                target = SlingTargetConnection(type="sqlite", instance=sqllitepath)
-
-                materialize(
-                    [run_sync],
-                    resources={
-                        "sling": SlingResource(
-                            source_connection=source,
-                            target_connection=target,
-                            mode=SlingMode.TRUNCATE,
-                        )
-                    },
-                )
-
+        """Runs a Sling sync from the given source table to the given destination table. Generates
+        output lines from the Sling CLI.
         """
-        yield from self._sync(
-            source_stream=source_stream,
-            target_object=target_object,
-            mode=mode,
-            primary_key=primary_key,
-            update_key=update_key,
-            source_options=source_options,
-            target_options=target_options,
-            encoding=encoding,
-        )
+        if self.source_connection.type == "file" and not source_stream.startswith("file://"):
+            source_stream = "file://" + source_stream
+
+        if self.target_connection.type == "file" and not target_object.startswith("file://"):
+            target_object = "file://" + target_object
+
+        sling_source = self.source_connection.dict()
+        sling_target = self.target_connection.dict()
+
+        config = {
+            "mode": mode,
+            "source": {
+                "conn": "SLING_SOURCE",
+                "stream": source_stream,
+                "primary_key": primary_key,
+                "update_key": update_key,
+                "options": source_options,
+            },
+            "target": {
+                "conn": "SLING_TARGET",
+                "object": target_object,
+                "options": target_options,
+            },
+        }
+        config["source"] = {k: v for k, v in config["source"].items() if v is not None}
+        config["target"] = {k: v for k, v in config["target"].items() if v is not None}
+
+        sling_cli = Sling(**config)
+        logger.info("Starting Sling sync with mode: %s", mode)
+        cmd = sling_cli._prep_cmd()

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -96,7 +96,9 @@ class SlingTargetConnection(PermissiveConfig):
     )
 
 
-class SlingSyncBase:
+class _SlingSyncBase:
+    """Base class for Sling syncs. Handles the execution of the Sling CLI and processing of the output. Classes that inherit from this class must implement how to sync themselves ,but can use the `_exec_sling_cmd` and `process_stdout` methods to handle the execution and processing of the output."""
+
     def process_stdout(self, stdout: IO[AnyStr], encoding="utf8") -> Iterator[str]:
         """Process stdout from the Sling CLI."""
         ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
@@ -216,7 +218,7 @@ class SlingSyncBase:
 
 
 @experimental
-class SlingResource(ConfigurableResource, SlingSyncBase):
+class SlingResource(ConfigurableResource, _SlingSyncBase):
     """Resource for interacting with the Sling package.
 
     Examples:
@@ -343,10 +345,10 @@ class SlingConnectionResource(ConfigurableResource):
     )
 
 
-class SlingStreamReplicator(SlingSyncBase):
+class SlingStreamReplicator(_SlingSyncBase):
     """A utility class for running a Sling sync from outside of a Dagster resource to enable parity between the SlingResource and SlingStreamSync.
 
-    Inherits from :py:class:`~dagster_elt.sling.SlingSyncBase` and implements `_sync` to run a sync using 2 SlingConnectionResources and no SlingResource.
+    Inherits from :py:class:`~dagster_elt.sling._SlingSyncBase` and implements `_sync` to run a sync using 2 SlingConnectionResources and no SlingResource.
     """
 
     def __init__(

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -410,7 +410,7 @@ class SlingStreamReplicator(SlingSyncBase):
 
             sling_cli = Sling(**config)
             logger.info("Starting Sling sync with mode: %s", mode)
-            cmd = sling_cli._prep_cmd() # noqa: SLF001
+            cmd = sling_cli._prep_cmd()  # noqa: SLF001
 
             # `_prep_cmd` only works with the Single Task command, so we need to replace it with the Replication command
             # TODO: Unfortunately, _prep_cmd doesn't expose a way to add streams, so we'll need to override it ourselves

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/staging_test.csv
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/staging_test.csv
@@ -1,0 +1,5 @@
+SPECIES_CODE,SPECIES_NAME,UPDATED_AT
+youtube,domestic short hair,1
+ferngully,scottish fold,2
+landbeforetime,an orange one,2
+an-american-tail,abyssinian,2

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_assets.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_assets.py
@@ -23,6 +23,7 @@ from dagster_embedded_elt.sling.resources import (
 def test_csv():
     return os.path.abspath(file_relative_path(__file__, "test.csv"))
 
+
 @pytest.fixture
 def test_staging_csv():
     return os.path.abspath(file_relative_path(__file__, "staging_test.csv"))
@@ -48,6 +49,7 @@ def sling_sqlite_resource(temp_db):
 @pytest.fixture
 def sling_file_connection():
     return SlingConnectionResource(type="file")
+
 
 @pytest.fixture
 def sling_staging_file_connection():
@@ -238,6 +240,7 @@ def test_build_assets_from_sling_stream(
         counts = sqlite_connection.execute("SELECT count(1) FROM main.tbl").fetchone()[0]
     assert counts == expected
 
+
 def test_reuse_sling_connection_resource(
     test_csv: str,
     test_staging_csv: str,
@@ -279,6 +282,7 @@ def test_reuse_sling_connection_resource(
     assert res.success
     assert sqlite_connection.execute("SELECT count(1) FROM main.tbl").fetchone()[0] == 3
     assert sqlite_connection.execute("SELECT count(1) FROM main.staging_tbl").fetchone()[0] == 4
+
 
 def test_update_mode_from_stream(
     test_csv: str,

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_assets.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_assets.py
@@ -6,8 +6,14 @@ import tempfile
 import pytest
 from dagster import AssetSpec, Definitions, file_relative_path
 from dagster._core.definitions import build_assets_job
-from dagster_embedded_elt.sling import SlingMode, SlingResource, build_sling_asset
+from dagster_embedded_elt.sling import (
+    SlingMode,
+    SlingResource,
+    build_assets_from_sling_stream,
+    build_sling_asset,
+)
 from dagster_embedded_elt.sling.resources import (
+    SlingConnectionResource,
     SlingSourceConnection,
     SlingTargetConnection,
 )
@@ -16,6 +22,10 @@ from dagster_embedded_elt.sling.resources import (
 @pytest.fixture
 def test_csv():
     return os.path.abspath(file_relative_path(__file__, "test.csv"))
+
+@pytest.fixture
+def test_staging_csv():
+    return os.path.abspath(file_relative_path(__file__, "staging_test.csv"))
 
 
 @pytest.fixture
@@ -33,6 +43,20 @@ def sling_sqlite_resource(temp_db):
             type="sqlite", connection_string=f"sqlite://{temp_db}"
         ),
     )
+
+
+@pytest.fixture
+def sling_file_connection():
+    return SlingConnectionResource(type="file")
+
+@pytest.fixture
+def sling_staging_file_connection():
+    return SlingConnectionResource(type="file")
+
+
+@pytest.fixture
+def sling_sqlite_connection(temp_db):
+    return SlingConnectionResource(type="sqlite", connection_string=f"sqlite://{temp_db}")
 
 
 @pytest.fixture
@@ -175,3 +199,141 @@ def test_update_mode(
 def test_non_unicode_stdout(text, encoding, expected, sling_sqlite_resource: SlingResource):
     lines = sling_sqlite_resource.process_stdout(text, encoding)
     assert list(lines) == expected
+
+
+@pytest.mark.parametrize(
+    "mode,runs,expected", [(SlingMode.INCREMENTAL, 1, 3), (SlingMode.SNAPSHOT, 2, 6)]
+)
+def test_build_assets_from_sling_stream(
+    test_csv: str,
+    sling_file_connection: SlingConnectionResource,
+    sling_sqlite_connection: SlingConnectionResource,
+    mode: SlingMode,
+    runs: int,
+    expected: int,
+    sqlite_connection: sqlite3.Connection,
+):
+    asset_def = build_assets_from_sling_stream(
+        sling_file_connection,
+        sling_sqlite_connection,
+        stream=f"file://{test_csv}",
+        target_object="main.tbl",
+        mode=mode,
+        primary_key="SPECIES_CODE",
+    )
+
+    sling_job = build_assets_job(
+        "sling_job",
+        [asset_def],
+        resource_defs={
+            "sling_file_connection": sling_file_connection,
+            "sling_sqlite_connection": sling_sqlite_connection,
+        },
+    )
+
+    counts = None
+    for _ in range(runs):
+        res = sling_job.execute_in_process()
+        assert res.success
+        counts = sqlite_connection.execute("SELECT count(1) FROM main.tbl").fetchone()[0]
+    assert counts == expected
+
+def test_reuse_sling_connection_resource(
+    test_csv: str,
+    test_staging_csv: str,
+    sling_file_connection: SlingConnectionResource,
+    sling_staging_file_connection: SlingConnectionResource,
+    sling_sqlite_connection: SlingConnectionResource,
+    sqlite_connection: sqlite3.Connection,
+):
+    """Create two assets that target the same SlingConnectionResource."""
+    asset_def = build_assets_from_sling_stream(
+        sling_file_connection,
+        sling_sqlite_connection,
+        stream=f"file://{test_csv}",
+        target_object="main.tbl",
+        mode=SlingMode.FULL_REFRESH,
+        primary_key="SPECIES_CODE",
+    )
+
+    asset_def_two = build_assets_from_sling_stream(
+        sling_staging_file_connection,
+        sling_sqlite_connection,
+        stream=f"file://{test_staging_csv}",
+        target_object="main.staging_tbl",
+        mode=SlingMode.FULL_REFRESH,
+        primary_key="SPECIES_CODE",
+    )
+
+    sling_job = build_assets_job(
+        "sling_job",
+        [asset_def, asset_def_two],
+        resource_defs={
+            "sling_file_connection": sling_file_connection,
+            "sling_staging_file_connection": sling_staging_file_connection,
+            "sling_sqlite_connection": sling_sqlite_connection,
+        },
+    )
+
+    res = sling_job.execute_in_process()
+    assert res.success
+    assert sqlite_connection.execute("SELECT count(1) FROM main.tbl").fetchone()[0] == 3
+    assert sqlite_connection.execute("SELECT count(1) FROM main.staging_tbl").fetchone()[0] == 4
+
+def test_update_mode_from_stream(
+    test_csv: str,
+    sling_file_connection: SlingConnectionResource,
+    sling_sqlite_connection: SlingConnectionResource,
+    sqlite_connection: sqlite3.Connection,
+):
+    """Creates a Sling sync using Full Refresh, manually increments the UPDATE KEY to be a higher value,
+    which should cause the next run not to append new rows.
+    """
+    asset_def_base = build_assets_from_sling_stream(
+        sling_file_connection,
+        sling_sqlite_connection,
+        stream=f"file://{test_csv}",
+        target_object="main.tbl",
+        mode=SlingMode.FULL_REFRESH,
+    )
+
+    asset_def_update = build_assets_from_sling_stream(
+        sling_file_connection,
+        sling_sqlite_connection,
+        stream=f"file://{test_csv}",
+        target_object="main.tbl",
+        mode=SlingMode.INCREMENTAL,
+        primary_key="SPECIES_NAME",
+        update_key="UPDATED_AT",
+    )
+
+    sling_job_base = build_assets_job(
+        "sling_job",
+        [asset_def_base],
+        resource_defs={
+            "sling_file_connection": sling_file_connection,
+            "sling_sqlite_connection": sling_sqlite_connection,
+        },
+    )
+
+    # First run should have 3 new rows
+    res = sling_job_base.execute_in_process()
+    assert res.success
+    assert sqlite_connection.execute("SELECT count(1) FROM main.tbl").fetchone()[0] == 3
+
+    # Next, manually set the UPDATED_AT to a higher value, this should prevent an append job from adding new rows.
+    cur = sqlite_connection.cursor()
+    cur.execute("UPDATE main.tbl set UPDATED_AT=999")
+    sqlite_connection.commit()
+
+    sling_job_update = build_assets_job(
+        "sling_job_update",
+        [asset_def_update],
+        resource_defs={
+            "sling_file_connection": sling_file_connection,
+            "sling_sqlite_connection": sling_sqlite_connection,
+        },
+    )
+    res = sling_job_update.execute_in_process()
+    assert res.success
+    assert sqlite_connection.execute("SELECT count(1) FROM main.tbl").fetchone()[0] == 3


### PR DESCRIPTION
## Summary & Motivation

This PR proposes an alternative pattern to using Sling that uses a new Resource called `SlingConnectionResource` and builder method called `build_assets_from_sling_stream`. Names tentative.

Developers that use these objects can compose and mix-and-match the sources and targets interoperably by pushing the coupling down to the builder method. ie. in this snippet from a unit test, two different sources are synced to the same target database.

```python
sling_file_connection=SlingConnectionResource(type="file")
sling_staging_file_connection=SlingConnectionResource(type="file")
sling_sqlite_connection=SlingConnectionResource(type="sqlite", connection_string=f"sqlite://{temp_db}")
asset_def = build_assets_from_sling_stream(
    sling_file_connection,
    sling_sqlite_connection,
    stream=f"file://{test_csv}",
    target_object="main.tbl",
    mode=SlingMode.FULL_REFRESH,
    primary_key="SPECIES_CODE",
)

asset_def_two = build_assets_from_sling_stream(
    sling_staging_file_connection,
    sling_sqlite_connection,
    stream=f"file://{test_staging_csv}",
    target_object="main.staging_tbl",
    mode=SlingMode.FULL_REFRESH,
    primary_key="SPECIES_CODE",
)
```

## How I Tested These Changes
Unit tests
