### PR TITLE
Log materialization planned event for run with partition range

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -47,7 +47,10 @@ def do_launch(
         check.str_param(execution_metadata.root_run_id, "root_run_id")
         check.str_param(execution_metadata.parent_run_id, "parent_run_id")
     external_job = get_external_job_or_raise(graphene_info, execution_params.selector)
-    dagster_run = create_valid_pipeline_run(graphene_info, external_job, execution_params)
+    code_location = graphene_info.context.get_code_location(execution_params.selector.location_name)
+    dagster_run = create_valid_pipeline_run(
+        graphene_info, external_job, execution_params, code_location
+    )
 
     return graphene_info.context.instance.submit_run(
         dagster_run.run_id,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -112,7 +112,9 @@ def create_valid_pipeline_run(
         status=DagsterRunStatus.NOT_STARTED,
         external_job_origin=external_pipeline.get_external_origin(),
         job_code_origin=external_pipeline.get_python_origin(),
-        code_location=code_location,
+        external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
+            external_pipeline
+        ),
     )
 
     return dagster_run

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -112,9 +112,7 @@ def create_valid_pipeline_run(
         status=DagsterRunStatus.NOT_STARTED,
         external_job_origin=external_pipeline.get_external_origin(),
         job_code_origin=external_pipeline.get_python_origin(),
-        external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
-            external_pipeline
-        ),
+        asset_job_partitions_def=code_location.get_asset_job_partitions_def(external_pipeline),
     )
 
     return dagster_run

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Optional, Sequence, Tuple, cast
 import dagster._check as check
 from dagster._core.errors import DagsterRunNotFoundError
 from dagster._core.execution.plan.state import KnownExecutionState
+from dagster._core.host_representation import CodeLocation
 from dagster._core.host_representation.external import ExternalJob
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
@@ -60,6 +61,7 @@ def create_valid_pipeline_run(
     graphene_info: "ResolveInfo",
     external_pipeline: ExternalJob,
     execution_params: ExecutionParams,
+    code_location: CodeLocation,
 ) -> DagsterRun:
     ensure_valid_config(external_pipeline, execution_params.run_config)
 
@@ -110,6 +112,7 @@ def create_valid_pipeline_run(
         status=DagsterRunStatus.NOT_STARTED,
         external_job_origin=external_pipeline.get_external_origin(),
         job_code_origin=external_pipeline.get_python_origin(),
+        code_location=code_location,
     )
 
     return dagster_run

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -558,7 +558,9 @@ def _create_external_run(
         job_code_origin=external_job.get_python_origin(),
         asset_selection=None,
         asset_check_selection=None,
-        code_location=code_location,
+        external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
+            external_job
+        ),
     )
 
 

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -558,9 +558,7 @@ def _create_external_run(
         job_code_origin=external_job.get_python_origin(),
         asset_selection=None,
         asset_check_selection=None,
-        external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
-            external_job
-        ),
+        asset_job_partitions_def=code_location.get_asset_job_partitions_def(external_job),
     )
 
 

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -558,6 +558,7 @@ def _create_external_run(
         job_code_origin=external_job.get_python_origin(),
         asset_selection=None,
         asset_check_selection=None,
+        code_location=code_location,
     )
 
 

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -1451,6 +1451,24 @@ class DagsterEvent(
             ),
         )
 
+    @staticmethod
+    def build_asset_materialization_planned_event(
+        job_name: str,
+        step_key: str,
+        asset_materialization_planned_data: "AssetMaterializationPlannedData",
+    ) -> "DagsterEvent":
+        """Constructs an asset materialization planned event, to be logged by the caller."""
+        event = DagsterEvent(
+            event_type_value=DagsterEventType.ASSET_MATERIALIZATION_PLANNED.value,
+            job_name=job_name,
+            message=(
+                f"{job_name} intends to materialize asset {asset_materialization_planned_data.asset_key.to_string()}"
+            ),
+            event_specific_data=asset_materialization_planned_data,
+            step_key=step_key,
+        )
+        return event
+
 
 def get_step_output_event(
     events: Sequence[DagsterEvent], step_key: str, output_name: Optional[str] = "result"

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1101,9 +1101,8 @@ def submit_run_request(
 
     selector_id = hash_collection(pipeline_selector)
 
+    code_location = workspace.get_code_location(repo_handle.code_location_origin.location_name)
     if selector_id not in pipeline_and_execution_plan_cache:
-        code_location = workspace.get_code_location(repo_handle.code_location_origin.location_name)
-
         external_job = code_location.get_external_job(pipeline_selector)
 
         external_execution_plan = code_location.get_external_execution_plan(
@@ -1138,6 +1137,7 @@ def submit_run_request(
         job_code_origin=external_job.get_python_origin(),
         asset_selection=frozenset(run_request.asset_selection),
         asset_check_selection=None,
+        code_location=code_location,
     )
 
     instance.submit_run(run.run_id, workspace)

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1137,7 +1137,9 @@ def submit_run_request(
         job_code_origin=external_job.get_python_origin(),
         asset_selection=frozenset(run_request.asset_selection),
         asset_check_selection=None,
-        code_location=code_location,
+        external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
+            external_job
+        ),  # TODO store this in the pipeline_and_execution_plan_cache?
     )
 
     instance.submit_run(run.run_id, workspace)

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -335,9 +335,7 @@ def create_backfill_run(
             frozenset(backfill_job.asset_selection) if backfill_job.asset_selection else None
         ),
         asset_check_selection=None,
-        external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
-            external_pipeline
-        ),
+        asset_job_partitions_def=code_location.get_asset_job_partitions_def(external_pipeline),
     )
 
 

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -335,7 +335,9 @@ def create_backfill_run(
             frozenset(backfill_job.asset_selection) if backfill_job.asset_selection else None
         ),
         asset_check_selection=None,
-        code_location=code_location,
+        external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
+            external_pipeline
+        ),
     )
 
 

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -335,6 +335,7 @@ def create_backfill_run(
             frozenset(backfill_job.asset_selection) if backfill_job.asset_selection else None
         ),
         asset_check_selection=None,
+        code_location=code_location,
     )
 
 

--- a/python_modules/dagster/dagster/_core/host_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/code_location.py
@@ -38,8 +38,8 @@ from dagster._core.host_representation.external_data import (
     ExternalPartitionNamesData,
     ExternalScheduleExecutionErrorData,
     ExternalSensorExecutionErrorData,
-    external_repository_data_from_def,
     external_partition_set_name_for_job_name,
+    external_repository_data_from_def,
 )
 from dagster._core.host_representation.grpc_server_registry import GrpcServerRegistry
 from dagster._core.host_representation.handle import JobHandle, RepositoryHandle

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1920,24 +1920,6 @@ def external_schedule_data_from_def(schedule_def: ScheduleDefinition) -> Externa
     )
 
 
-def can_build_external_partitions_definition_from_def(partitions_def: PartitionsDefinition):
-    return (
-        isinstance(partitions_def, TimeWindowPartitionsDefinition)
-        or isinstance(partitions_def, StaticPartitionsDefinition)
-        or (
-            isinstance(partitions_def, MultiPartitionsDefinition)
-            and all(
-                can_build_external_partitions_definition_from_def(dimension.partitions_def)
-                for dimension in partitions_def.partitions_defs
-            )
-        )
-        or (
-            isinstance(partitions_def, DynamicPartitionsDefinition)
-            and partitions_def.name is not None
-        )
-    )
-
-
 def external_partitions_definition_from_def(
     partitions_def: PartitionsDefinition,
 ) -> ExternalPartitionsDefinitionData:

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -151,7 +151,7 @@ def create_run_for_test(
     asset_selection=None,
     asset_check_selection=None,
     op_selection=None,
-    external_partitions_definition_data=None,
+    asset_job_partitions_def=None,
 ):
     return instance.create_run(
         job_name=job_name,
@@ -171,7 +171,7 @@ def create_run_for_test(
         asset_selection=asset_selection,
         asset_check_selection=asset_check_selection,
         op_selection=op_selection,
-        external_partitions_definition_data=external_partitions_definition_data,
+        asset_job_partitions_def=asset_job_partitions_def,
     )
 
 

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -151,6 +151,7 @@ def create_run_for_test(
     asset_selection=None,
     asset_check_selection=None,
     op_selection=None,
+    code_location=None,
 ):
     return instance.create_run(
         job_name=job_name,
@@ -170,6 +171,7 @@ def create_run_for_test(
         asset_selection=asset_selection,
         asset_check_selection=asset_check_selection,
         op_selection=op_selection,
+        code_location=code_location,
     )
 
 

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -151,7 +151,7 @@ def create_run_for_test(
     asset_selection=None,
     asset_check_selection=None,
     op_selection=None,
-    code_location=None,
+    external_partitions_definition_data=None,
 ):
     return instance.create_run(
         job_name=job_name,
@@ -171,7 +171,7 @@ def create_run_for_test(
         asset_selection=asset_selection,
         asset_check_selection=asset_check_selection,
         op_selection=op_selection,
-        code_location=code_location,
+        external_partitions_definition_data=external_partitions_definition_data,
     )
 
 

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -609,9 +609,7 @@ def submit_asset_run(
             job_code_origin=external_job.get_python_origin(),
             asset_selection=frozenset(asset_keys),
             asset_check_selection=None,
-            external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
-                external_job
-            ),
+            asset_job_partitions_def=code_location.get_asset_job_partitions_def(external_job),
         )
 
     check_for_debug_crash(debug_crash_flags, "RUN_CREATED")

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -609,7 +609,9 @@ def submit_asset_run(
             job_code_origin=external_job.get_python_origin(),
             asset_selection=frozenset(asset_keys),
             asset_check_selection=None,
-            code_location=code_location,
+            external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
+                external_job
+            ),
         )
 
     check_for_debug_crash(debug_crash_flags, "RUN_CREATED")

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -609,6 +609,7 @@ def submit_asset_run(
             job_code_origin=external_job.get_python_origin(),
             asset_selection=frozenset(asset_keys),
             asset_check_selection=None,
+            code_location=code_location,
         )
 
     check_for_debug_crash(debug_crash_flags, "RUN_CREATED")

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -1093,7 +1093,5 @@ def _create_sensor_run(
             frozenset(run_request.asset_selection) if run_request.asset_selection else None
         ),
         asset_check_selection=None,
-        external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
-            external_job
-        ),
+        asset_job_partitions_def=code_location.get_asset_job_partitions_def(external_job),
     )

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -1093,4 +1093,5 @@ def _create_sensor_run(
             frozenset(run_request.asset_selection) if run_request.asset_selection else None
         ),
         asset_check_selection=None,
+        code_location=code_location,
     )

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -1093,5 +1093,7 @@ def _create_sensor_run(
             frozenset(run_request.asset_selection) if run_request.asset_selection else None
         ),
         asset_check_selection=None,
-        code_location=code_location,
+        external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
+            external_job
+        ),
     )

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -904,7 +904,9 @@ def _create_scheduler_run(
             frozenset(run_request.asset_selection) if run_request.asset_selection else None
         ),
         asset_check_selection=None,
-        code_location=code_location,
+        external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
+            external_job
+        ),
     )
 
 

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -904,9 +904,7 @@ def _create_scheduler_run(
             frozenset(run_request.asset_selection) if run_request.asset_selection else None
         ),
         asset_check_selection=None,
-        external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
-            external_job
-        ),
+        asset_job_partitions_def=code_location.get_asset_job_partitions_def(external_job),
     )
 
 

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -904,6 +904,7 @@ def _create_scheduler_run(
             frozenset(run_request.asset_selection) if run_request.asset_selection else None
         ),
         asset_check_selection=None,
+        code_location=code_location,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -33,9 +33,6 @@ from dagster._core.errors import (
 from dagster._core.event_api import EventRecordsFilter
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import create_execution_plan
-from dagster._core.host_representation.external_data import (
-    external_partitions_definition_from_def,
-)
 from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.instance.config import DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
 from dagster._core.launcher import LaunchRunContext, RunLauncher
@@ -330,10 +327,6 @@ def test_create_run_with_asset_partitions():
             execution_plan, noop_asset_job.get_job_snapshot_id()
         )
 
-        external_partitions_def_data = external_partitions_definition_from_def(
-            noop_asset_job.partitions_def
-        )
-
         with pytest.raises(
             Exception,
             match=(
@@ -347,7 +340,7 @@ def test_create_run_with_asset_partitions():
                 execution_plan_snapshot=ep_snapshot,
                 job_snapshot=noop_asset_job.get_job_snapshot(),
                 tags={ASSET_PARTITION_RANGE_START_TAG: "partition_0"},
-                external_partitions_definition_data=external_partitions_def_data,
+                partitions_def=noop_asset_job.partitions_def,
             )
 
         with pytest.raises(
@@ -363,7 +356,7 @@ def test_create_run_with_asset_partitions():
                 execution_plan_snapshot=ep_snapshot,
                 job_snapshot=noop_asset_job.get_job_snapshot(),
                 tags={ASSET_PARTITION_RANGE_END_TAG: "partition_0"},
-                external_partitions_definition_data=external_partitions_def_data,
+                partitions_def=noop_asset_job.partitions_def,
             )
 
         create_run_for_test(
@@ -372,7 +365,7 @@ def test_create_run_with_asset_partitions():
             execution_plan_snapshot=ep_snapshot,
             job_snapshot=noop_asset_job.get_job_snapshot(),
             tags={ASSET_PARTITION_RANGE_START_TAG: "bar", ASSET_PARTITION_RANGE_END_TAG: "foo"},
-            external_partitions_definition_data=external_partitions_def_data,
+            partitions_def=noop_asset_job.partitions_def,
         )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -340,7 +340,7 @@ def test_create_run_with_asset_partitions():
                 execution_plan_snapshot=ep_snapshot,
                 job_snapshot=noop_asset_job.get_job_snapshot(),
                 tags={ASSET_PARTITION_RANGE_START_TAG: "partition_0"},
-                partitions_def=noop_asset_job.partitions_def,
+                asset_job_partitions_def=noop_asset_job.partitions_def,
             )
 
         with pytest.raises(
@@ -356,7 +356,7 @@ def test_create_run_with_asset_partitions():
                 execution_plan_snapshot=ep_snapshot,
                 job_snapshot=noop_asset_job.get_job_snapshot(),
                 tags={ASSET_PARTITION_RANGE_END_TAG: "partition_0"},
-                partitions_def=noop_asset_job.partitions_def,
+                asset_job_partitions_def=noop_asset_job.partitions_def,
             )
 
         create_run_for_test(
@@ -365,7 +365,7 @@ def test_create_run_with_asset_partitions():
             execution_plan_snapshot=ep_snapshot,
             job_snapshot=noop_asset_job.get_job_snapshot(),
             tags={ASSET_PARTITION_RANGE_START_TAG: "bar", ASSET_PARTITION_RANGE_END_TAG: "foo"},
-            partitions_def=noop_asset_job.partitions_def,
+            asset_job_partitions_def=noop_asset_job.partitions_def,
         )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_asset_events.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_asset_events.py
@@ -231,3 +231,43 @@ def test_subset_on_asset_materialization_planned_event_for_single_run_backfill_n
         record = records[0]
         assert record.event_log_entry.dagster_event.event_specific_data.partitions_subset is None
         assert record.event_log_entry.dagster_event.event_specific_data.partition is None
+
+
+def test_single_run_backfill_with_unpartitioned_and_partitioned_mix():
+    partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
+
+    @asset(partitions_def=partitions_def)
+    def partitioned():
+        return 0
+
+    @asset
+    def unpartitioned():
+        return 0
+
+    with instance_for_test() as instance:
+
+        class FakeCloudInstance(DagsterInstance):
+            @property
+            def is_cloud_instance(self) -> bool:
+                return True
+
+        instance.__class__ = FakeCloudInstance
+
+        materialize_to_memory(
+            [partitioned, unpartitioned],
+            instance=instance,
+            tags={ASSET_PARTITION_RANGE_START_TAG: "a", ASSET_PARTITION_RANGE_END_TAG: "b"},
+        )
+
+        [record] = instance.get_event_records(
+            EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION_PLANNED, partitioned.key)
+        )
+        assert (
+            record.event_log_entry.dagster_event.event_specific_data.partitions_subset
+            == partitions_def.subset_with_partition_keys(["a", "b"])
+        )
+
+        [record] = instance.get_event_records(
+            EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION_PLANNED, unpartitioned.key)
+        )
+        assert record.event_log_entry.dagster_event.event_specific_data.partitions_subset is None

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
@@ -223,6 +223,7 @@ def test_successful_run_from_pending(
         asset_selection=None,
         op_selection=None,
         asset_check_selection=None,
+        code_location=code_location,
     )
 
     run_id = created_run.run_id

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
@@ -223,9 +223,7 @@ def test_successful_run_from_pending(
         asset_selection=None,
         op_selection=None,
         asset_check_selection=None,
-        external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
-            external_job
-        ),
+        asset_job_partitions_def=code_location.get_asset_job_partitions_def(external_job),
     )
 
     run_id = created_run.run_id

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
@@ -223,7 +223,9 @@ def test_successful_run_from_pending(
         asset_selection=None,
         op_selection=None,
         asset_check_selection=None,
-        code_location=code_location,
+        external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
+            external_job
+        ),
     )
 
     run_id = created_run.run_id

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
@@ -149,6 +149,7 @@ def test_run_from_pending_repository():
                     asset_selection=None,
                     op_selection=None,
                     asset_check_selection=None,
+                    code_location=code_location,
                 )
 
                 run_id = dagster_run.run_id

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
@@ -149,7 +149,7 @@ def test_run_from_pending_repository():
                     asset_selection=None,
                     op_selection=None,
                     asset_check_selection=None,
-                    external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
+                    asset_job_partitions_def=code_location.get_asset_job_partitions_def(
                         external_job
                     ),
                 )

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
@@ -149,7 +149,9 @@ def test_run_from_pending_repository():
                     asset_selection=None,
                     op_selection=None,
                     asset_check_selection=None,
-                    code_location=code_location,
+                    external_partitions_definition_data=code_location.get_external_partitions_def_data_for_job(
+                        external_job
+                    ),
                 )
 
                 run_id = dagster_run.run_id

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -452,6 +452,9 @@ class TestEventLogStorage:
         # Whether the storage is allowed to watch the event log
         return True
 
+    def has_asset_partitions_table(self) -> bool:
+        return False
+
     def test_event_log_storage_store_events_and_wipe(self, test_run_id, storage):
         assert len(storage.get_logs_for_run(test_run_id)) == 0
         storage.store_event(
@@ -2676,6 +2679,134 @@ class TestEventLogStorage:
             record = records[0]
             assert record.partition_key is None
             assert record.event_log_entry.dagster_event.partitions_subset == partitions_subset
+
+    def test_partitions_methods_on_materialization_planned_event_with_partitions_subset(
+        self, storage, instance
+    ) -> None:
+        a = AssetKey(["a"])
+        gen_events_run_id = make_new_run_id()
+        subset_event_run_id = make_new_run_id()
+
+        @op
+        def gen_op():
+            yield AssetMaterialization(asset_key=a, partition="2023-01-05")
+            yield Output(1)
+
+        partitions_def = DailyPartitionsDefinition("2023-01-01")
+        partitions_subset = (
+            external_partitions_definition_from_def(partitions_def)
+            .get_partitions_definition()
+            .subset_with_partition_keys(
+                partitions_def.get_partition_keys_in_range(
+                    PartitionKeyRange("2023-01-05", "2023-01-06")
+                )
+            )
+            .to_serializable_subset()
+        )
+
+        with instance_for_test() as created_instance:
+            if not storage.has_instance:
+                storage.register_instance(created_instance)
+
+            with create_and_delete_test_runs(instance, [gen_events_run_id, subset_event_run_id]):
+                events_one, _ = _synthesize_events(
+                    lambda: gen_op(), instance=created_instance, run_id=gen_events_run_id
+                )
+                for event in events_one:
+                    storage.store_event(event)
+
+                storage.store_event(
+                    EventLogEntry(
+                        error_info=None,
+                        level="debug",
+                        user_message="",
+                        run_id=subset_event_run_id,
+                        timestamp=time.time(),
+                        dagster_event=DagsterEvent(
+                            DagsterEventType.ASSET_MATERIALIZATION_PLANNED.value,
+                            "nonce",
+                            event_specific_data=AssetMaterializationPlannedData(
+                                a, partition="2023-01-05"
+                            ),
+                        ),
+                    )
+                )
+                storage.store_event(
+                    EventLogEntry(
+                        error_info=None,
+                        level="debug",
+                        user_message="",
+                        run_id=subset_event_run_id,
+                        timestamp=time.time(),
+                        dagster_event=DagsterEvent(
+                            DagsterEventType.ASSET_MATERIALIZATION_PLANNED.value,
+                            "nonce",
+                            event_specific_data=AssetMaterializationPlannedData(
+                                a, partitions_subset=partitions_subset
+                            ),
+                        ),
+                    )
+                )
+
+                records = storage.get_event_records(
+                    EventRecordsFilter(
+                        event_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+                        asset_key=a,
+                    ),
+                    ascending=True,
+                )
+                assert len(records) == 2
+                single_partition_event = records[0]
+                assert (
+                    single_partition_event.event_log_entry.dagster_event.partition == "2023-01-05"
+                )
+
+                partitions_subset_event = records[1]
+                event_id = partitions_subset_event.storage_id
+                assert partitions_subset_event.partition_key is None
+                assert (
+                    partitions_subset_event.event_log_entry.dagster_event.partitions_subset
+                    == partitions_subset
+                )
+
+                assert storage.get_materialized_partitions(a) == {"2023-01-05"}
+                planned_but_no_materialization_partitions = storage.get_latest_asset_partition_materialization_attempts_without_materializations(
+                    a
+                )
+                if self.has_asset_partitions_table():
+                    # When an asset partitions table is present we can fetch planned but not
+                    # materialized partitions when planned events target a partitions subset
+                    assert len(planned_but_no_materialization_partitions) == 2
+                    assert planned_but_no_materialization_partitions.keys() == {
+                        "2023-01-05",
+                        "2023-01-06",
+                    }
+                    assert planned_but_no_materialization_partitions["2023-01-05"] == (
+                        subset_event_run_id,
+                        event_id,
+                    )
+                    assert planned_but_no_materialization_partitions["2023-01-06"] == (
+                        subset_event_run_id,
+                        event_id,
+                    )
+
+                else:
+                    # When an asset partitions table is not present we can only fetch planned but
+                    # not materialized partitions when planned events target a single partition
+                    assert planned_but_no_materialization_partitions.keys() == {"2023-01-05"}
+                    assert planned_but_no_materialization_partitions["2023-01-05"] == (
+                        subset_event_run_id,
+                        single_partition_event.storage_id,
+                    )
+
+                    # When asset partitions table is not present get_latest_storage_id_by_partition
+                    # only returns storage IDs for single-partition events
+                    latest_storage_id_by_partition = storage.get_latest_storage_id_by_partition(
+                        a, DagsterEventType.ASSET_MATERIALIZATION_PLANNED
+                    )
+                    assert latest_storage_id_by_partition == {
+                        "2023-01-05": single_partition_event.storage_id
+                    }
 
     def test_get_latest_asset_partition_materialization_attempts_without_materializations_event_ids(
         self, storage, instance


### PR DESCRIPTION
This PR enables the UI to correctly display failed/in progress status for single-run backfills, in cloud.

This includes two major changes:

### 1. Log a materialization planned event containing a partitions subset for single-run backfills upon run creation

If all of the below conditions apply, we log an partitions subset planned event for each asset:
- Executing instance is a cloud instance
- Run targets a partition range
- Asset is partitioned (available on execution plan snapshot)

Otherwise, we fallback to the status quo behavior:
1. If run has a single partition, log a planned event w/ a partition key for each asset
2. If run targets a partition range, log a planned event w/ `partition=None`. We still log a planned event in this case because in certain places (i.e. asset backfills) we query planned events to see which assets are planned to execute.

### 2. Threads an `assets_job_partitions_def` through the run creation callsites

We need access to the partitions definition of the assets/job in order to build the target partitions subset from the partition range. The alternative would be to serialize a list of targeted partition keys on the execution plan snapshot for partition ranged runs, which bloats the snapshot.

There are two different ways runs are created from jobs:
1. The execution plan is built from the code location
2. Testing contexts; the job definition is passed into `execute_in_process` and the execution plan is created from there

In the first case, the code location holds the external repository data in memory. We can then fetch the external partitions definition of the job, and thread this into `create_run`. We could also fetch the partitions definition per-asset from the code location, but that feels extraneous given that we know (1) the partitions definition on the job and (2) whether each asset is partitioned or not.

In the second case, we don't have access to the code location, so instead this PR constructs the external partitions definition data from the job def and threads that into `create_run`.

### Testing
Tested locally on cloud and OSS.

Corresponding internal PR: https://github.com/dagster-io/internal/pull/7615