### PR TITLE
[asset-partitions] to_serializable_subset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -49,7 +49,7 @@ class PartitionsSubsetMappingNamedTupleSerializer(NamedTupleSerializer):
             ):
                 # PartitionKeysTimeWindowPartitionsSubsets are not serializable, so
                 # we convert them to TimeWindowPartitionsSubsets
-                subsets_by_key = {k: v.to_serializable_susbet() for k, v in field_value.items()}
+                subsets_by_key = {k: v.to_serializable_subset() for k, v in field_value.items()}
 
                 # If the mapping is keyed by AssetKey wrap it in a SerializableNonScalarKeyMapping
                 # so it can be serialized. This can be expanded to other key types in the future.

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -20,7 +20,6 @@ from dagster._core.definitions.partition import (
     PartitionsDefinition,
     PartitionsSubset,
 )
-from dagster._core.definitions.time_window_partitions import PartitionKeysTimeWindowPartitionsSubset
 from dagster._core.errors import (
     DagsterDefinitionChangedDeserializationError,
 )
@@ -50,12 +49,7 @@ class PartitionsSubsetMappingNamedTupleSerializer(NamedTupleSerializer):
             ):
                 # PartitionKeysTimeWindowPartitionsSubsets are not serializable, so
                 # we convert them to TimeWindowPartitionsSubsets
-                subsets_by_key = {
-                    k: v.to_time_window_partitions_subset()
-                    if isinstance(v, PartitionKeysTimeWindowPartitionsSubset)
-                    else v
-                    for k, v in field_value.items()
-                }
+                subsets_by_key = {k: v.to_serializable_susbet() for k, v in field_value.items()}
 
                 # If the mapping is keyed by AssetKey wrap it in a SerializableNonScalarKeyMapping
                 # so it can be serialized. This can be expanded to other key types in the future.

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1321,4 +1321,6 @@ class AllPartitionsSubset(
         check.failed("Cannot create an empty AllPartitionsSubset")
 
     def to_serializable_subset(self) -> PartitionsSubset:
-        return self.partitions_def.subset_with_partition_keys(self.get_partition_keys())
+        return self.partitions_def.subset_with_partition_keys(
+            self.get_partition_keys()
+        ).to_serializable_subset()

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1028,6 +1028,9 @@ class PartitionsSubset(ABC, Generic[T_str]):
     ) -> "PartitionsSubset[T_str]":
         ...
 
+    def to_serializable_subset(self) -> "PartitionsSubset":
+        return self
+
 
 @whitelist_for_serdes
 class SerializedPartitionsSubset(NamedTuple):
@@ -1316,3 +1319,6 @@ class AllPartitionsSubset(
         self, partitions_def: Optional[PartitionsDefinition] = None
     ) -> "PartitionsSubset[T_str]":
         check.failed("Cannot create an empty AllPartitionsSubset")
+
+    def to_serializable_subset(self) -> PartitionsSubset:
+        return self.partitions_def.subset_with_partition_keys(self.get_partition_keys())

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1988,8 +1988,20 @@ class PartitionKeysTimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
         return f"PartitionKeysTimeWindowPartitionsSubset({self.get_partition_key_ranges(self.partitions_def)})"
 
     def to_serializable_subset(self) -> "TimeWindowPartitionsSubset":
+        from dagster._core.host_representation.external_data import (
+            external_time_window_partitions_definition_from_def,
+        )
+
+        # in cases where we're dealing with (e.g.) HourlyPartitionsDefinition, we need to convert
+        # this partitions definition into a raw TimeWindowPartitionsDefinition to make it
+        # serializable. to do this, we just convert it to its external representation and back.
+        partitions_def = self.partitions_def
+        if type(self.partitions_def) != TimeWindowPartitionsSubset:
+            partitions_def = external_time_window_partitions_definition_from_def(
+                partitions_def
+            ).get_partitions_definition()
         return TimeWindowPartitionsSubset(
-            self.partitions_def, self.num_partitions, self.included_time_windows
+            partitions_def, self.num_partitions, self.included_time_windows
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1987,7 +1987,7 @@ class PartitionKeysTimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
     def __repr__(self) -> str:
         return f"PartitionKeysTimeWindowPartitionsSubset({self.get_partition_key_ranges(self.partitions_def)})"
 
-    def to_time_window_partitions_subset(self) -> "TimeWindowPartitionsSubset":
+    def to_serializable_subset(self) -> "TimeWindowPartitionsSubset":
         return TimeWindowPartitionsSubset(
             self.partitions_def, self.num_partitions, self.included_time_windows
         )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -159,6 +159,10 @@ def test_all_partitions_subset_static_partitions_def() -> None:
     assert all_subset - abc_subset == DefaultPartitionsSubset({"d"})
     assert abc_subset - all_subset == DefaultPartitionsSubset(set())
 
+    round_trip_subset = deserialize_value(serialize_value(all_subset.to_serializable_subset()))  # type: ignore
+    assert isinstance(round_trip_subset, DefaultPartitionsSubset)
+    assert set(round_trip_subset.get_partition_keys()) == set(all_subset.get_partition_keys())
+
 
 def test_all_partitions_subset_time_window_partitions_def() -> None:
     with pendulum.test(create_pendulum_time(2020, 1, 6, hour=10)):
@@ -188,3 +192,7 @@ def test_all_partitions_subset_time_window_partitions_def() -> None:
         assert subset - all_subset == PartitionKeysTimeWindowPartitionsSubset(
             time_window_partitions_def, included_partition_keys=set()
         )
+
+        round_trip_subset = deserialize_value(serialize_value(all_subset.to_serializable_subset()))  # type: ignore
+        assert isinstance(round_trip_subset, TimeWindowPartitionsSubset)
+        assert set(round_trip_subset.get_partition_keys()) == set(all_subset.get_partition_keys())


### PR DESCRIPTION
## Summary & Motivation

Simplifies the serializer codepath, and allows us to handle the AllPartitionsSubset as well. 

Note that I uncovered a slight bug with the existing implementation, in which we don't guard against cases where we try to serialize a `PartitionKeysTimeWindowPartitionSubset` that has an (e.g.) `HourlyPartitionsDefinition`, which is not serializable. This bug could never surface in practice in today's world, as we never create AssetGraphSubsets using PartitionsDefinitions which haven't already gone through a serde layer, but figured it was worth removing the potential landmine.

## How I Tested These Changes
