### PR TITLE
Include the logs from all containers, not just the dagster container, when diagnosing failed run workers

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_utils.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_utils.py
@@ -122,9 +122,7 @@ def test_pod_debug_info_failure(cluster_provider, namespace, should_cleanup):
 
         pod_names = api_client.get_pod_names_in_job("resourcelimit", namespace=namespace)
 
-        pod_debug_info = api_client.get_pod_debug_info(
-            pod_names[0], namespace=namespace, container_name="resourcelimit"
-        )
+        pod_debug_info = api_client.get_pod_debug_info(pod_names[0], namespace=namespace)
 
         print(str(pod_debug_info))  # noqa
 
@@ -132,6 +130,8 @@ def test_pod_debug_info_failure(cluster_provider, namespace, should_cleanup):
             f"""Debug information for pod {pod_names[0]}:
 
 Pod status: Pending
+
+No logs for container 'resourcelimit'.
 
 Warning events for pod:
 FailedScheduling: 0/1 nodes are available: 1 Insufficient memory."""
@@ -153,9 +153,7 @@ FailedScheduling: 0/1 nodes are available: 1 Insufficient memory."""
 
             pod_names = api_client.get_pod_names_in_job("waitforever", namespace=namespace)
             if pod_names:
-                pod_debug_info = api_client.get_pod_debug_info(
-                    pod_names[0], namespace=namespace, container_name="waitforever"
-                )
+                pod_debug_info = api_client.get_pod_debug_info(pod_names[0], namespace=namespace)
                 if "time for sleep" in pod_debug_info:
                     break
 
@@ -169,7 +167,7 @@ FailedScheduling: 0/1 nodes are available: 1 Insufficient memory."""
 Pod status: Running
 Container 'waitforever' status: Ready
 
-Last 25 log lines:"""
+Last 25 log lines for container 'waitforever':"""
         )
 
         assert "No warning events for pod." in pod_debug_info
@@ -190,9 +188,7 @@ Last 25 log lines:"""
 
         pod_names = api_client.get_pod_names_in_job("execformaterror", namespace=namespace)
 
-        pod_debug_info = api_client.get_pod_debug_info(
-            pod_names[0], namespace=namespace, container_name="execformaterror"
-        )
+        pod_debug_info = api_client.get_pod_debug_info(pod_names[0], namespace=namespace)
 
         print(str(pod_debug_info))  # noqa
 
@@ -202,10 +198,10 @@ Last 25 log lines:"""
 Pod status: Failed
 Container 'execformaterror' status: Terminated with exit code 1: Error
 
-Pod logs contained `exec format error`, which usually means that your Docker image was built using the wrong architecture.
+Logs for container 'execformaterror' contained `exec format error`, which usually means that your Docker image was built using the wrong architecture.
 Try rebuilding your docker image with the `--platform linux/amd64` flag set.
 
-Last 25 log lines:
+Last 25 log lines for container 'execformaterror':
 """
         )
 
@@ -238,17 +234,13 @@ Last 25 log lines:
             pod_names = api_client.get_pod_names_in_job("missingsecret", namespace=namespace)
 
             if pod_names:
-                pod_debug_info = api_client.get_pod_debug_info(
-                    pod_names[0], namespace=namespace, container_name="missingsecret"
-                )
+                pod_debug_info = api_client.get_pod_debug_info(pod_names[0], namespace=namespace)
                 if "CreateContainerConfigError" in pod_debug_info:
                     break
 
             time.sleep(5)
 
-        pod_debug_info = api_client.get_pod_debug_info(
-            pod_names[0], namespace=namespace, container_name="missingsecret"
-        )
+        pod_debug_info = api_client.get_pod_debug_info(pod_names[0], namespace=namespace)
 
         print(str(pod_debug_info))  # noqa
 
@@ -257,6 +249,8 @@ Last 25 log lines:
 
 Pod status: Pending
 Container 'missingsecret' status: Waiting: CreateContainerConfigError: secret "missing-secret" not found
+
+No logs for container 'missingsecret'.
 
 Warning events for pod:"""
         )
@@ -277,9 +271,7 @@ Warning events for pod:"""
             pod_names = api_client.get_pod_names_in_job("pullfail", namespace=namespace)
 
             if pod_names:
-                pod_debug_info = api_client.get_pod_debug_info(
-                    pod_names[0], namespace=namespace, container_name="pullfail"
-                )
+                pod_debug_info = api_client.get_pod_debug_info(pod_names[0], namespace=namespace)
                 if "ImagePullBackOff" in pod_debug_info:
                     break
 
@@ -291,6 +283,8 @@ Warning events for pod:"""
 
 Pod status: Pending
 Container 'pullfail' status: Waiting: ErrImagePull: rpc error: code = Unknown desc = failed to pull and unpack image "docker.io/library/fakeimage:latest": failed to resolve reference "docker.io/library/fakeimage:latest": pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
+
+No logs for container 'pullfail'.
 
 Warning events for pod:"""
         )
@@ -311,9 +305,7 @@ Warning events for pod:"""
 
         pod_names = api_client.get_pod_names_in_job("failpoddebug", namespace=namespace)
 
-        pod_debug_info = api_client.get_pod_debug_info(
-            pod_names[0], namespace=namespace, container_name="failpoddebug"
-        )
+        pod_debug_info = api_client.get_pod_debug_info(pod_names[0], namespace=namespace)
 
         print(pod_debug_info)  # noqa
 
@@ -323,7 +315,7 @@ Warning events for pod:"""
 Pod status: Failed
 Container 'failpoddebug' status: Terminated with exit code 1: Error
 
-Last 25 log lines:"""
+Last 25 log lines for container 'failpoddebug':"""
         )
         assert " whoops!\n" in pod_debug_info
         assert pod_debug_info.endswith("No warning events for pod.")
@@ -336,9 +328,7 @@ Last 25 log lines:"""
 
         pod_names = api_client.get_pod_names_in_job("goodpod1", namespace=namespace)
 
-        pod_debug_info = api_client.get_pod_debug_info(
-            pod_names[0], namespace=namespace, container_name="goodpod1"
-        )
+        pod_debug_info = api_client.get_pod_debug_info(pod_names[0], namespace=namespace)
         print(pod_debug_info)  # noqa
 
         assert pod_debug_info.startswith(
@@ -347,10 +337,60 @@ Last 25 log lines:"""
 Pod status: Succeeded
 Container 'goodpod1' status: Terminated with exit code 0: Completed
 
-Last 25 log lines:"""
+Last 25 log lines for container 'goodpod1':"""
         )
         assert "hello world" in pod_debug_info
         assert "No warning events for pod." in pod_debug_info
+
+        # Test sidecars
+        api_client.batch_api.create_namespaced_job(
+            body=kubernetes.client.V1Job(
+                api_version="batch/v1",
+                kind="Job",
+                metadata=kubernetes.client.V1ObjectMeta(name="goodpod2"),
+                spec=kubernetes.client.V1JobSpec(
+                    template=kubernetes.client.V1PodTemplateSpec(
+                        spec=kubernetes.client.V1PodSpec(
+                            restart_policy="Never",
+                            containers=[
+                                kubernetes.client.V1Container(
+                                    name="goodcontainer1",
+                                    image="busybox",
+                                    args=["/bin/sh", "-c", 'echo "hello world"'],
+                                ),
+                                kubernetes.client.V1Container(
+                                    name="goodcontainer2",
+                                    image="busybox",
+                                    args=["/bin/sh", "-c", 'echo "hello again world"'],
+                                ),
+                            ],
+                        )
+                    ),
+                    backoff_limit=0,
+                ),
+            ),
+            namespace=namespace,
+        )
+        api_client.wait_for_job_success("goodpod2", namespace=namespace)
+
+        pod_names = api_client.get_pod_names_in_job("goodpod2", namespace=namespace)
+
+        pod_debug_info = api_client.get_pod_debug_info(pod_names[0], namespace=namespace)
+        print(pod_debug_info)  # noqa
+
+        assert pod_debug_info.startswith(
+            f"""Debug information for pod {pod_names[0]}:
+
+Pod status: Succeeded
+Container 'goodcontainer1' status: Terminated with exit code 0: Completed
+Container 'goodcontainer2' status: Terminated with exit code 0: Completed"""
+        )
+
+        assert "Last 25 log lines for container 'goodcontainer1':" in pod_debug_info
+        assert "Last 25 log lines for container 'goodcontainer2':" in pod_debug_info
+
+        assert "hello world" in pod_debug_info
+        assert "hello again world" in pod_debug_info
 
     finally:
         if should_cleanup:
@@ -359,7 +399,7 @@ Last 25 log lines:"""
                 "pullfail",
                 "missingsecret",
                 "goodpod1",
-                "waitforever",
+                "goodpod2" "waitforever",
                 "execformaterror",
                 "resourcelimit",
             ]:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -362,16 +362,11 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
 
         job_name = get_job_name_from_run_id(run.run_id, resume_attempt_number=resume_attempt_number)
         namespace = container_context.namespace
-        user_defined_k8s_config = container_context.run_k8s_config
-        container_name = user_defined_k8s_config.container_config.get("name", "dagster")
         pod_names = self._api_client.get_pod_names_in_job(job_name, namespace=namespace)
         full_msg = ""
         try:
             pod_debug_info = [
-                self._api_client.get_pod_debug_info(
-                    pod_name, namespace, container_name=container_name
-                )
-                for pod_name in pod_names
+                self._api_client.get_pod_debug_info(pod_name, namespace) for pod_name in pod_names
             ]
             full_msg = "\n".join(pod_debug_info)
         except Exception:


### PR DESCRIPTION
Summary:
If a sidecar fails, sometimes the reason why is buried in that sidecar. Include all containers, not just the main dagster one, when sending along diagnostic information.

## Summary & Motivation

## How I Tested These Changes
