### PR TITLE
make sure to use run_id fixture in mysql store event test

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -4234,7 +4234,7 @@ class TestEventLogStorage:
         assert mats
         assert mats[key].asset_materialization.metadata["was"].value == "here"
 
-    def test_large_asset_metadata(self, storage):
+    def test_large_asset_metadata(self, storage, test_run_id):
         key = AssetKey("test_asset")
 
         large_metadata = {
@@ -4245,7 +4245,7 @@ class TestEventLogStorage:
                 error_info=None,
                 user_message="",
                 level="debug",
-                run_id=make_new_run_id(),
+                run_id=test_run_id,
                 timestamp=time.time(),
                 dagster_event=DagsterEvent(
                     event_type_value=DagsterEventType.ASSET_MATERIALIZATION.value,


### PR DESCRIPTION
## Summary & Motivation
Cloud tests assert that we only store events for runs that exist in run storage.

## How I Tested These Changes
BK