### PR TITLE
feat(dbt): create manifest in static target path at run time

### DIFF
--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -96,7 +96,7 @@ dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at runtime.
 # Otherwise, we expect a manifest to be present in the project's target directory.
 if os.getenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD"):
-    dbt_parse_invocation = dbt.cli(["parse"]).wait()
+    dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
     dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
 else:
     dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/load-dbt-models.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/load-dbt-models.mdx
@@ -123,7 +123,7 @@ dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at run time.
 # Otherwise, we expect a manifest to be present in the project's target directory.
 if os.getenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD"):
-    dbt_parse_invocation = dbt.cli(["parse"]).wait()
+    dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
     dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
 else:
     dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -16,7 +16,7 @@ def scope_compile_dbt_manifest(manifest):
     # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at runtime.
     # Otherwise, we expect a manifest to be present in the project's target directory.
     if os.getenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD"):
-        dbt_parse_invocation = dbt.cli(["parse"]).wait()
+        dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
         dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
     else:
         dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/downstream_assets/constants.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/downstream_assets/constants.py
@@ -10,7 +10,7 @@ dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at run time.
 # Otherwise, we expect a manifest to be present in the project's target directory.
 if os.getenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD"):
-    dbt_parse_invocation = dbt.cli(["parse"]).wait()
+    dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
     dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
 else:
     dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/load_dbt_models/constants.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/load_dbt_models/constants.py
@@ -11,7 +11,7 @@ dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at run time.
 # Otherwise, we expect a manifest to be present in the project's target directory.
 if os.getenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD"):
-    dbt_parse_invocation = dbt.cli(["parse"]).wait()
+    dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
     dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
 else:
     dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/upstream_assets/constants.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/upstream_assets/constants.py
@@ -10,7 +10,7 @@ dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at run time.
 # Otherwise, we expect a manifest to be present in the project's target directory.
 if os.getenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD"):
-    dbt_parse_invocation = dbt.cli(["parse"]).wait()
+    dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
     dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
 else:
     dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/constants.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/constants.py.jinja
@@ -13,7 +13,7 @@ dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at run time.
 # Otherwise, we expect a manifest to be present in the project's target directory.
 if os.getenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD"):
-    dbt_parse_invocation = dbt.cli([{{ dbt_parse_command | join(', ')}}]).wait()
+    dbt_parse_invocation = dbt.cli([{{ dbt_parse_command | join(', ')}}], target_path=Path("target")).wait()
     dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
 else:
     dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")


### PR DESCRIPTION
## Summary & Motivation
With https://github.com/dagster-io/dagster/issues/16951, we now have the tools to re-parse the dbt manifest in a static directory.

Invocations of dbt commands in asset or job executions should continue to use unique dbt target paths to retain references to dbt artifacts. But for local development, the dbt target path should be static to:

- Reduce confusion about the necessity of the unique target path, as its presence is exposed early on in local development. This should only be known at materialization time.
- Reduce the memory footprint of local development. Since the Dagster project is reloaded every so often, the previous behavior was that the dbt project's `target/` folder could be clogged up with all the re-parsed manifests.

## How I Tested These Changes
pytest, local
