### PR TITLE
[pipes] more defensive extras access in databricks log path retrieval

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -336,7 +336,7 @@ class PipesDbfsLogReader(PipesChunkedLogReader):
     # job has finished.
     def _get_log_path(self, params: PipesParams) -> Optional[str]:
         if self.log_path is None:
-            cluster_driver_log_root = params["extras"].get("cluster_driver_log_root")
+            cluster_driver_log_root = params.get("extras", {}).get("cluster_driver_log_root")
             if cluster_driver_log_root is None:
                 return None
             try:


### PR DESCRIPTION
from user report that an exception was observed when `extras` was not available 

## How I Tested These Changes

eyes, bk