### PR TITLE
[docs] - Update language around dbt quickstart link

### DIFF
--- a/docs/content/integrations/dbt-cloud.mdx
+++ b/docs/content/integrations/dbt-cloud.mdx
@@ -25,7 +25,7 @@ To get started, you will need to install the `dagster` and `dagster-dbt` Python 
 pip install dagster dagster-dbt
 ```
 
-You'll also want to have a dbt Cloud instance with an existing project that is deployed with a dbt Cloud job. If you don't have one already, you can [set up dbt Cloud with a sample project](https://docs.getdbt.com/docs/get-started/getting-started/set-up-dbt-cloud).
+You'll also want to have a dbt Cloud instance with an existing project that is deployed with a dbt Cloud job. If you don't have one already, you can set up dbt Cloud with a sample project. Refer to the dbt documentation for a quickstart guide [specific to your data warehouse](https://docs.getdbt.com/docs/get-started/getting-started/set-up-dbt-cloud).
 
 To manage the dbt Cloud job from Dagster, you'll need three values:
 


### PR DESCRIPTION
## Summary & Motivation

The original page that the sample dbt project link pointed to has changed to be a bunch of quickstart guides. This PR updates the language surrounding this link to specify that users should select the guide for their data warehouse.

## How I Tested These Changes

👀 
