### PR TITLE
Paginate through queued runs

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1726,8 +1726,9 @@ class DagsterInstance(DynamicPartitionsStore):
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
         bucket_by: Optional[Union[JobBucket, TagBucket]] = None,
+        ascending: bool = False,
     ) -> Sequence[DagsterRun]:
-        return self._run_storage.get_runs(filters, cursor, limit, bucket_by)
+        return self._run_storage.get_runs(filters, cursor, limit, bucket_by, ascending)
 
     @traced
     def get_run_ids(

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -206,8 +206,9 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
         bucket_by: Optional[Union["JobBucket", "TagBucket"]] = None,
+        ascending: bool = False,
     ) -> Iterable["DagsterRun"]:
-        return self._storage.run_storage.get_runs(filters, cursor, limit, bucket_by)
+        return self._storage.run_storage.get_runs(filters, cursor, limit, bucket_by, ascending)
 
     def get_run_ids(
         self,

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -69,6 +69,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
         bucket_by: Optional[Union[JobBucket, TagBucket]] = None,
+        ascending: bool = False,
     ) -> Sequence[DagsterRun]:
         """Return all the runs present in the storage that match the given filters.
 
@@ -78,6 +79,8 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
                 runs
             cursor (Optional[str]): Starting cursor (run_id) of range of runs
             limit (Optional[int]): Number of results to get. Defaults to infinite.
+            ascending (bool): Sort the result in ascending order if True, descending
+                otherwise. Defaults to descending.
 
         Returns:
             List[PipelineRun]

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -226,7 +226,10 @@ class SqlRunStorage(RunStorage):
         """Helper function to deal with cursor/limit pagination args."""
         if cursor:
             cursor_query = db_select([RunsTable.c.id]).where(RunsTable.c.run_id == cursor)
-            query = query.where(RunsTable.c.id < db_scalar_subquery(cursor_query))
+            if ascending:
+                query = query.where(RunsTable.c.id > db_scalar_subquery(cursor_query))
+            else:
+                query = query.where(RunsTable.c.id < db_scalar_subquery(cursor_query))
 
         if limit:
             query = query.limit(limit)
@@ -333,8 +336,9 @@ class SqlRunStorage(RunStorage):
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
         bucket_by: Optional[Union[JobBucket, TagBucket]] = None,
+        ascending: bool = False,
     ) -> Sequence[DagsterRun]:
-        query = self._runs_query(filters, cursor, limit, bucket_by=bucket_by)
+        query = self._runs_query(filters, cursor, limit, bucket_by=bucket_by, ascending=ascending)
         rows = self.fetchall(query)
         return self._rows_to_runs(rows)
 

--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -35,13 +35,15 @@ from dagster._daemon.daemon import DaemonIterator, IntervalDaemon
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.tags import TagConcurrencyLimitsCounter
 
+PAGE_SIZE = 100
+
 
 class QueuedRunCoordinatorDaemon(IntervalDaemon):
     """Used with the QueuedRunCoordinator on the instance. This process finds queued runs from the run
     store and launches them.
     """
 
-    def __init__(self, interval_seconds, page_size=25) -> None:
+    def __init__(self, interval_seconds, page_size=PAGE_SIZE) -> None:
         self._exit_stack = ExitStack()
         self._executor: Optional[ThreadPoolExecutor] = None
         self._location_timeouts_lock = threading.Lock()

--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -229,7 +229,10 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
                 " Temporarily skipping runs from the following locations due to a user code error: "
                 + ",".join(list(paused_location_names))
             )
-
+        self._logger.info(
+            "Priority sorting and checking tag concurrency limits for queued runs."
+            + locations_clause
+        )
         # Paginate through our runs list so we don't need to hold every run
         # in memory at once. The maximum number of runs we'll hold in memory is
         # max_runs_to_launch + page_size.
@@ -243,16 +246,10 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
             has_more = len(queued_runs) >= self._page_size
 
             if not queued_runs:
-                self._logger.debug("Poll returned no queued runs.")
                 has_more = False
                 return batch
 
             cursor = queued_runs[-1].run_id
-
-            self._logger.info(
-                f"Retrieved %d queued runs, checking limits.{locations_clause}",
-                len(queued_runs),
-            )
 
             tag_concurrency_limits_counter = TagConcurrencyLimitsCounter(
                 tag_concurrency_limits, in_progress_runs

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -30,9 +30,13 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     def instance(self, run_coordinator_config):
         raise NotImplementedError
 
+    @pytest.fixture(params=[1, 25])
+    def page_size(self, request):
+        yield request.param
+
     @abstractmethod
     @pytest.fixture()
-    def daemon(self):
+    def daemon(self, page_size):
         raise NotImplementedError
 
     @pytest.fixture()
@@ -923,5 +927,5 @@ class TestQueuedRunCoordinatorDaemon(QueuedRunCoordinatorDaemonTests):
             yield instance
 
     @pytest.fixture()
-    def daemon(self):
-        return QueuedRunCoordinatorDaemon(interval_seconds=1)
+    def daemon(self, page_size):
+        return QueuedRunCoordinatorDaemon(interval_seconds=1, page_size=page_size)

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -868,6 +868,23 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         list(daemon.run_iteration(workspace_context))
         assert self.get_run_ids(instance.run_launcher.queue()) == ["run-1"]
 
+    def test_key_limit_with_priority(self, workspace_context, daemon, job_handle, instance):
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id="high-priority",
+            tags={"test": "value", PRIORITY_TAG: "100"},
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id="low-priority",
+            tags={"test": "value", PRIORITY_TAG: "-100"},
+        )
+
+        list(daemon.run_iteration(workspace_context))
+        assert self.get_run_ids(instance.run_launcher.queue()) == ["high-priority"]
+
 
 class TestQueuedRunCoordinatorDaemon(QueuedRunCoordinatorDaemonTests):
     @pytest.fixture

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -868,18 +868,32 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         list(daemon.run_iteration(workspace_context))
         assert self.get_run_ids(instance.run_launcher.queue()) == ["run-1"]
 
-    def test_key_limit_with_priority(self, workspace_context, daemon, job_handle, instance):
-        self.create_queued_run(
-            instance,
-            job_handle,
-            run_id="high-priority",
-            tags={"test": "value", PRIORITY_TAG: "100"},
-        )
+    @pytest.mark.parametrize(
+        "run_coordinator_config",
+        [
+            dict(
+                max_concurrent_runs=2,
+                tag_concurrency_limits=[
+                    {"key": "test", "limit": 1},
+                ],
+                dequeue_use_threads=True,
+            ),
+        ],
+    )
+    def test_key_limit_with_priority(
+        self, workspace_context, daemon, job_handle, instance, run_coordinator_config
+    ):
         self.create_queued_run(
             instance,
             job_handle,
             run_id="low-priority",
             tags={"test": "value", PRIORITY_TAG: "-100"},
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id="high-priority",
+            tags={"test": "value", PRIORITY_TAG: "100"},
         )
 
         list(daemon.run_iteration(workspace_context))


### PR DESCRIPTION
This is an alternate memory management improvement for the queued run coordinator daemon that sacrifices returning early in exchange for pushing less work down to our database.

The constraints we need to juggle are:
- We need to know the run tags to apply priority ordering and concurrency limits
- We rely on the internal db storage ID to enforce FIFO ordering

Historically, we've solved this by loading all runs into memory and applying sort and concurrency limits to them within our daemon. For most cases, this is fine. But for a large backfill, you might load tens of thousands of runs into memory on each iteration.

Initially, I tried to solve this by pushing the priority sort down to the database:

https://github.com/dagster-io/dagster/pull/18126

Once we know the runs are in priority order, we only need check concurrency tags until we reach `max_runs_to_launch`. However, it's difficult to test how our various database implementation will perform at scale with the complicated sort. In all cases, priority sorting involves type casting and digging into JSON blobs. For Postgres, it additionally involves applying a regex to make sure the tag is a valid number. The worry is that we'd be trading daemon memory against database CPU.

This change instead paginates over a list of all run ids and applies sorting and concurrency limits entirely in the daemon process. We aren't able to short circuit our pagination because we need to iterate over every queued run to know that our priority sort is accurate. But instead of holding all runs in memory at once, we only `page_size + max_runs_to_launch` in memory.

In the case of a very large backfill, we'd fetch each run from the databsae in pages but we'll throw most of them out.