### PR TITLE
[pythonic resources][fix] fix behavior of IAttachDifferentObjectToOpContext w/ schedules, sensors

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -463,7 +463,7 @@ def validate_and_get_schedule_resource_dict(
                 f"Resource with key '{k}' required by schedule '{schedule_name}' was not provided."
             )
 
-    return {k: resources._original_resource_dict.get(k) for k in required_resource_keys}  # noqa:SLF001
+    return {k: resources.original_resource_dict.get(k) for k in required_resource_keys}
 
 
 @deprecated_param(

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -463,7 +463,7 @@ def validate_and_get_schedule_resource_dict(
                 f"Resource with key '{k}' required by schedule '{schedule_name}' was not provided."
             )
 
-    return {k: getattr(resources, k) for k in required_resource_keys}
+    return {k: resources._original_resource_dict.get(k) for k in required_resource_keys}  # noqa:SLF001
 
 
 @deprecated_param(

--- a/python_modules/dagster/dagster/_core/definitions/scoped_resources_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/scoped_resources_builder.py
@@ -29,7 +29,7 @@ class Resources:
         raise DagsterUnknownResourceError(name)
 
     @property
-    def _original_resource_dict(self) -> Mapping[str, object]:
+    def original_resource_dict(self) -> Mapping[str, object]:
         raise NotImplementedError()
 
 
@@ -106,7 +106,7 @@ class ScopedResourcesBuilder(
                 IContainsGenerator,
             ):
                 @property
-                def _original_resource_dict(self) -> Mapping[str, object]:
+                def original_resource_dict(self) -> Mapping[str, object]:
                     return resource_instance_dict
 
             return _ScopedResourcesContainsGenerator(**resources_to_attach_to_context)
@@ -118,7 +118,7 @@ class ScopedResourcesBuilder(
                 Resources,
             ):
                 @property
-                def _original_resource_dict(self) -> Mapping[str, object]:
+                def original_resource_dict(self) -> Mapping[str, object]:
                     return resource_instance_dict
 
             return _ScopedResources(**resources_to_attach_to_context)

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -417,7 +417,7 @@ def validate_and_get_resource_dict(
                 f"Resource with key '{k}' required by sensor '{sensor_name}' was not provided."
             )
 
-    return {k: getattr(resources, k) for k in required_resource_keys}
+    return {k: resources._original_resource_dict.get(k) for k in required_resource_keys}  # noqa:SLF001
 
 
 def _check_dynamic_partitions_requests(

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -417,7 +417,7 @@ def validate_and_get_resource_dict(
                 f"Resource with key '{k}' required by sensor '{sensor_name}' was not provided."
             )
 
-    return {k: resources._original_resource_dict.get(k) for k in required_resource_keys}  # noqa:SLF001
+    return {k: resources.original_resource_dict.get(k) for k in required_resource_keys}
 
 
 def _check_dynamic_partitions_requests(

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -120,7 +120,7 @@ def invoke_compute_fn(
             args_to_pass["config"] = context.op_config
     if resource_args:
         for resource_name, arg_name in resource_args.items():
-            args_to_pass[arg_name] = context.resources._original_resource_dict[resource_name]  # noqa: SLF001
+            args_to_pass[arg_name] = context.resources.original_resource_dict[resource_name]
 
     return fn(context, **args_to_pass) if context_arg_provided else fn(**args_to_pass)
 


### PR DESCRIPTION
## Summary

Addresses #18338 - ensures that resources with `IAttachDifferentObjectToOpContext` are not converted to the `get_object_to_set_on_execution_context` when passed to the resource argument.

See above issue for more context.

## Test Plan

New unit tests to verify expected behavior.
