### PR TITLE
[auto-materialize][refactor] Use AssetPartitions class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -337,7 +337,7 @@ class AssetDaemonContext:
             ),
             asset_cursor.with_updates(
                 self.asset_graph,
-                materialize_context.newly_materialized_root_partitions,
+                materialize_context.newly_materialized_root_subset,
                 to_materialize,
                 to_discard,
             ),

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -51,8 +51,8 @@ class AssetDaemonAssetCursor(NamedTuple):
         )
         newly_materialized_requested_or_discarded_subset = AssetSubset.from_asset_partitions_set(
             self.asset_key,
-            newly_materialized_requested_or_discarded_asset_partitions,
             asset_graph.get_partitions_def(self.asset_key),
+            newly_materialized_requested_or_discarded_asset_partitions,
         )
         return self._replace(
             materialized_requested_or_discarded_subset=self.materialized_requested_or_discarded_subset

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -38,14 +38,14 @@ class AssetDaemonAssetCursor(NamedTuple):
     def with_updates(
         self,
         asset_graph: AssetGraph,
-        newly_materialized_asset_partitions: AbstractSet[AssetKeyPartitionKey],
+        newly_materialized_subset: AssetSubset,
         requested_asset_partitions: AbstractSet[AssetKeyPartitionKey],
         discarded_asset_partitions: AbstractSet[AssetKeyPartitionKey],
     ) -> "AssetDaemonAssetCursor":
         if self.asset_key not in asset_graph.root_asset_keys:
             return self
         newly_materialized_requested_or_discarded_asset_partitions = (
-            newly_materialized_asset_partitions
+            newly_materialized_subset.asset_partitions
             | requested_asset_partitions
             | discarded_asset_partitions
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -92,8 +92,8 @@ class AssetSubset(NamedTuple):
     @staticmethod
     def from_asset_partitions_set(
         asset_key: AssetKey,
-        asset_partitions_set: AbstractSet[AssetKeyPartitionKey],
         partitions_def: Optional[PartitionsDefinition],
+        asset_partitions_set: AbstractSet[AssetKeyPartitionKey],
     ) -> "AssetSubset":
         if partitions_def is None:
             return AssetSubset(asset_key=asset_key, value=bool(asset_partitions_set))

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 import dagster._check as check
+from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._serdes.serdes import (
     NamedTupleSerializer,
@@ -196,22 +197,15 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
         rule_evaluation: AutoMaterializeRuleEvaluation,
         serialized_subset: Optional[SerializedPartitionsSubset],
         asset_graph: AssetGraph,
-    ) -> Optional[
-        Tuple[Optional[AutoMaterializeRuleEvaluationData], AbstractSet[AssetKeyPartitionKey]]
-    ]:
+    ) -> Optional[Tuple[Optional[AutoMaterializeRuleEvaluationData], AssetSubset]]:
         partitions_def = asset_graph.get_partitions_def(self.asset_key)
         if serialized_subset is None:
             if partitions_def is None:
-                return (rule_evaluation.evaluation_data, {AssetKeyPartitionKey(self.asset_key)})
+                return (rule_evaluation.evaluation_data, AssetSubset(self.asset_key, True))
         elif serialized_subset.can_deserialize(partitions_def) and partitions_def is not None:
             return (
                 rule_evaluation.evaluation_data,
-                {
-                    AssetKeyPartitionKey(self.asset_key, partition_key)
-                    for partition_key in serialized_subset.deserialize(
-                        partitions_def=partitions_def
-                    ).get_partition_keys()
-                },
+                AssetSubset(self.asset_key, serialized_subset.deserialize(partitions_def)),
             )
         # old serialized result is no longer valid
         return None
@@ -229,14 +223,14 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
                 rule_evaluation, serialized_subset, asset_graph
             )
             if deserialized_result:
-                results.append(deserialized_result)
+                results.append((deserialized_result[0], deserialized_result[1].asset_partitions))
         return results
 
-    def _get_asset_partitions_with_decision_type(
+    def _get_subset_with_decision_type(
         self, decision_type: AutoMaterializeDecisionType, asset_graph: AssetGraph
-    ) -> AbstractSet[AssetKeyPartitionKey]:
+    ) -> AssetSubset:
         """Returns the set of asset partitions with a given decision type applied to them."""
-        asset_partitions = set()
+        subset = AssetSubset.empty(self.asset_key, asset_graph.get_partitions_def(self.asset_key))
         for rule_evaluation, serialized_subset in self.partition_subsets_by_condition:
             if rule_evaluation.rule_snapshot.decision_type != decision_type:
                 continue
@@ -245,32 +239,28 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
             )
             if deserialized_result is None:
                 continue
-            asset_partitions.update(deserialized_result[1])
-        return asset_partitions
+            subset |= deserialized_result[1]
+        return subset
 
-    def get_requested_or_discarded_asset_partitions(
-        self, asset_graph: AssetGraph
-    ) -> AbstractSet[AssetKeyPartitionKey]:
+    def get_requested_or_discarded_subset(self, asset_graph: AssetGraph) -> AssetSubset:
         """Returns the set of asset partitions which were either requested or discarded on this
         evaluation.
         """
-        to_materialize = self._get_asset_partitions_with_decision_type(
-            AutoMaterializeDecisionType.MATERIALIZE, asset_graph
+        to_materialize = self._get_subset_with_decision_type(
+            AutoMaterializeDecisionType.MATERIALIZE,
+            asset_graph,
         )
-        if not to_materialize:
-            return set()
-        to_skip = self._get_asset_partitions_with_decision_type(
-            AutoMaterializeDecisionType.SKIP, asset_graph
+        to_skip = self._get_subset_with_decision_type(
+            AutoMaterializeDecisionType.SKIP,
+            asset_graph,
         )
         return to_materialize - to_skip
 
-    def get_evaluated_asset_partitions(
-        self, asset_graph: AssetGraph
-    ) -> AbstractSet[AssetKeyPartitionKey]:
+    def get_evaluated_subset(self, asset_graph: AssetGraph) -> AssetSubset:
         """Returns the set of asset partitions which were evaluated by any rule on this evaluation."""
         # no asset partition can be evaluated by SKIP or DISCARD rules without having at least one
         # materialize rule evaluation
-        return self._get_asset_partitions_with_decision_type(
+        return self._get_subset_with_decision_type(
             AutoMaterializeDecisionType.MATERIALIZE, asset_graph
         )
 


### PR DESCRIPTION
## Summary & Motivation

Makes some progress in refactoring the existing AutoMaterialize code to use the new AssetSubset class. Does not cover every callsite as much of the RuleEvaluation context / AutoMaterializeAssetEvaluation stuff will be refactored anyway.

## How I Tested These Changes
