### PR TITLE
[auto-materialize][refactor] Introduce (temporary) AssetAutomationEvaluator class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_automation_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_automation_evaluator.py
@@ -1,0 +1,227 @@
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, AbstractSet, List, NamedTuple, Optional, Sequence, Tuple
+
+from dagster._core.definitions.asset_daemon_cursor import AssetDaemonAssetCursor
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+
+from .asset_subset import AssetSubset
+from .auto_materialize_rule import (
+    DiscardOnMaxMaterializationsExceededRule,
+    RuleEvaluationContext,
+    RuleEvaluationResults,
+)
+from .auto_materialize_rule_evaluation import (
+    AutoMaterializeAssetEvaluation,
+    AutoMaterializeRuleEvaluation,
+)
+
+if TYPE_CHECKING:
+    from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
+
+
+class ConditionEvaluation(NamedTuple):
+    """Internal representation of the results of evaluating a node in the evaluation tree."""
+
+    condition: "AutomationCondition"
+    true_subset: AssetSubset
+    results: RuleEvaluationResults = []
+    children: Sequence["ConditionEvaluation"] = []
+
+    @property
+    def all_results(
+        self
+    ) -> Sequence[Tuple[AutoMaterializeRuleEvaluation, AbstractSet[AssetKeyPartitionKey]]]:
+        """This method is a placeholder to allow us to convert this into a shape that other parts
+        of the system understand.
+        """
+        if isinstance(self.condition, RuleCondition):
+            results = [
+                (
+                    AutoMaterializeRuleEvaluation(
+                        rule_snapshot=self.condition.rule.to_snapshot(),
+                        evaluation_data=evaluation_data,
+                    ),
+                    subset,
+                )
+                for evaluation_data, subset in self.results
+            ]
+        else:
+            results = []
+        for child in self.children:
+            results = [*results, *child.all_results]
+        return results
+
+    def to_evaluation(
+        self,
+        asset_key: AssetKey,
+        asset_graph: AssetGraph,
+        instance_queryer: "CachingInstanceQueryer",
+        to_discard: AssetSubset,
+        discard_results: Sequence[
+            Tuple[AutoMaterializeRuleEvaluation, AbstractSet[AssetKeyPartitionKey]]
+        ],
+        num_skipped: int,
+    ) -> AutoMaterializeAssetEvaluation:
+        """This method is a placeholder to allow us to convert this into a shape that other parts
+        of the system understand.
+        """
+        return AutoMaterializeAssetEvaluation.from_rule_evaluation_results(
+            asset_key=asset_key,
+            asset_graph=asset_graph,
+            asset_partitions_by_rule_evaluation=[*self.all_results, *discard_results],
+            num_requested=(self.true_subset - to_discard).size,
+            num_skipped=num_skipped,
+            num_discarded=to_discard.size,
+            dynamic_partitions_store=instance_queryer,
+        )
+
+
+class AutomationCondition(ABC):
+    @abstractmethod
+    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+        ...
+
+    def __and__(self, other: "AutomationCondition") -> "AutomationCondition":
+        # group AndAutomationConditions together
+        if isinstance(self, AndAutomationCondition):
+            return AndAutomationCondition(children=[*self.children, other])
+        return AndAutomationCondition(children=[self, other])
+
+    def __or__(self, other: "AutomationCondition") -> "AutomationCondition":
+        # group OrAutomationConditions together
+        if isinstance(self, OrAutomationCondition):
+            return OrAutomationCondition(children=[*self.children, other])
+        return OrAutomationCondition(children=[self, other])
+
+    def __invert__(self) -> "AutomationCondition":
+        return InvertAutomationCondition(child=self)
+
+
+class RuleCondition(
+    AutomationCondition, NamedTuple("_RuleCondition", [("rule", AutoMaterializeRule)])
+):
+    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+        context.daemon_context._verbose_log_fn(f"Evaluating rule: {self.rule.to_snapshot()}")  # noqa
+        results = self.rule.evaluate_for_asset(context)
+        true_subset = context.empty_subset()
+        for _, asset_partitions in results:
+            true_subset |= AssetSubset.from_asset_partitions_set(
+                context.asset_key, context.partitions_def, asset_partitions
+            )
+        context.daemon_context._verbose_log_fn(f"Rule returned {true_subset.size} partitions")  # noqa
+        return ConditionEvaluation(condition=self, true_subset=true_subset, results=results)
+
+
+class AndAutomationCondition(
+    AutomationCondition,
+    NamedTuple("_AndAutomationCondition", [("children", Sequence[AutomationCondition])]),
+):
+    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+        child_evaluations: List[ConditionEvaluation] = []
+        true_subset = context.candidate_subset
+        for child in self.children:
+            context = context.with_candidate_subset(true_subset)
+            result = child.evaluate(context)
+            child_evaluations.append(result)
+            true_subset &= result.true_subset
+        return ConditionEvaluation(
+            condition=self, true_subset=true_subset, children=child_evaluations
+        )
+
+
+class OrAutomationCondition(
+    AutomationCondition,
+    NamedTuple("_OrAutomationCondition", [("children", Sequence[AutomationCondition])]),
+):
+    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+        child_evaluations: List[ConditionEvaluation] = []
+        true_subset = context.empty_subset()
+        for child in self.children:
+            result = child.evaluate(context)
+            child_evaluations.append(result)
+            true_subset |= result.true_subset
+        return ConditionEvaluation(
+            condition=self, true_subset=true_subset, children=child_evaluations
+        )
+
+
+class InvertAutomationCondition(
+    AutomationCondition,
+    NamedTuple("_InvertAutomationCondition", [("child", AutomationCondition)]),
+):
+    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+        child_evaluation = self.child.evaluate(context)
+        return ConditionEvaluation(
+            condition=self,
+            true_subset=context.candidate_subset - child_evaluation.true_subset,
+            children=[child_evaluation],
+        )
+
+
+class AssetAutomationEvaluator(NamedTuple):
+    """For now, this is an internal class that is used to help transition from the old format to the
+    new. Upstack, the original AutoMaterializePolicy class will be replaced with this.
+    """
+
+    condition: AutomationCondition
+    max_materializations_per_minute: Optional[int] = 1
+
+    def evaluate(
+        self, context: RuleEvaluationContext, from_legacy: bool
+    ) -> Tuple[
+        AutoMaterializeAssetEvaluation,
+        AssetDaemonAssetCursor,
+        AbstractSet[AssetKeyPartitionKey],
+    ]:
+        """Evaluates the auto materialize policy of a given asset.
+
+        Returns:
+        - An AutoMaterializeAssetEvaluation object representing serializable information about
+        this evaluation.
+        - The set of AssetKeyPartitionKeys that should be materialized.
+        - The set of AssetKeyPartitionKeys that should be discarded.
+        """
+        condition_evaluation = self.condition.evaluate(context)
+
+        # this is treated separately from other rules, for now
+        to_discard, discard_results = context.empty_subset(), []
+        if self.max_materializations_per_minute is not None:
+            discard_context = context.with_candidate_subset(condition_evaluation.true_subset)
+            condition = RuleCondition(
+                DiscardOnMaxMaterializationsExceededRule(limit=self.max_materializations_per_minute)
+            )
+            discard_condition_evaluation = condition.evaluate(discard_context)
+            to_discard = discard_condition_evaluation.true_subset
+            discard_results = discard_condition_evaluation.all_results
+
+        to_materialize = condition_evaluation.true_subset - to_discard
+
+        # hack to get the number of skipped asset partitions
+        num_skipped = 0
+        if (
+            from_legacy
+            and isinstance(self.condition, AndAutomationCondition)
+            and len(condition_evaluation.children) == 2
+        ):
+            # the right-hand side of the AndAutomationCondition is the inverse of the set of skip rules
+            num_skipped = condition_evaluation.children[1].children[0].true_subset.size
+
+        return (
+            condition_evaluation.to_evaluation(
+                context.asset_key,
+                context.asset_graph,
+                context.instance_queryer,
+                to_discard,
+                discard_results,
+                num_skipped=num_skipped,
+            ),
+            context.cursor.with_updates(
+                asset_graph=context.asset_graph,
+                newly_materialized_subset=context.newly_materialized_root_subset,
+                requested_asset_partitions=to_materialize.asset_partitions,
+                discarded_asset_partitions=to_discard.asset_partitions,
+            ),
+            to_materialize.asset_partitions,
+        )

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -272,7 +272,7 @@ class AssetDaemonContext:
             daemon_context=self,
         )
 
-        return auto_materialize_policy_evaluator.evaluate(context, from_legacy=True)
+        return auto_materialize_policy_evaluator.evaluate(context, report_num_skipped=True)
 
     def get_auto_materialize_asset_evaluations(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -40,12 +40,10 @@ from .asset_daemon_cursor import AssetDaemonAssetCursor, AssetDaemonCursor
 from .asset_graph import AssetGraph
 from .auto_materialize_rule import (
     AutoMaterializeRule,
-    DiscardOnMaxMaterializationsExceededRule,
     RuleEvaluationContext,
 )
 from .auto_materialize_rule_evaluation import (
     AutoMaterializeAssetEvaluation,
-    AutoMaterializeRuleEvaluation,
 )
 from .backfill_policy import BackfillPolicy, BackfillPolicyType
 from .freshness_based_auto_materialize import get_expected_data_time_for_asset_key
@@ -252,122 +250,29 @@ class AssetDaemonContext:
             - The set of AssetKeyPartitionKeys that should be materialized.
             - The set of AssetKeyPartitionKeys that should be discarded.
         """
-        auto_materialize_policy = check.not_none(
+        # convert the legacy AutoMaterializePolicy to an Evaluator
+        auto_materialize_policy_evaluator = check.not_none(
             self.asset_graph.auto_materialize_policies_by_key.get(asset_key)
-        )
+        ).to_auto_materialize_policy_evaluator()
 
-        # the results of evaluating individual rules
-        all_results: List[
-            Tuple[AutoMaterializeRuleEvaluation, AbstractSet[AssetKeyPartitionKey]]
-        ] = []
-        # a set of asset partitions that should be materialized, skipped, or discarded
-        to_materialize: Set[AssetKeyPartitionKey] = set()
-        to_skip: Set[AssetKeyPartitionKey] = set()
-        to_discard: Set[AssetKeyPartitionKey] = set()
-
-        asset_cursor = self.cursor.asset_cursor_for_key(
-            asset_key, self.asset_graph.get_partitions_def(asset_key)
-        )
-
-        materialize_context = RuleEvaluationContext(
+        partitions_def = self.asset_graph.get_partitions_def(asset_key)
+        context = RuleEvaluationContext(
             asset_key=asset_key,
-            cursor=asset_cursor,
+            cursor=self.cursor.asset_cursor_for_key(asset_key, partitions_def),
             instance_queryer=self.instance_queryer,
             data_time_resolver=self.data_time_resolver,
             will_materialize_mapping=will_materialize_mapping,
             expected_data_time_mapping=expected_data_time_mapping,
             candidate_subset=AssetSubset.all(
                 asset_key=asset_key,
-                partitions_def=self.asset_graph.get_partitions_def(asset_key),
+                partitions_def=partitions_def,
                 dynamic_partitions_store=self.instance_queryer,
                 current_time=self.instance_queryer.evaluation_time,
             ),
             daemon_context=self,
         )
 
-        for materialize_rule in auto_materialize_policy.materialize_rules:
-            rule_snapshot = materialize_rule.to_snapshot()
-
-            self._verbose_log_fn(f"Evaluating materialize rule: {rule_snapshot}")
-            for evaluation_data, asset_partitions in materialize_rule.evaluate_for_asset(
-                materialize_context
-            ):
-                all_results.append(
-                    (
-                        AutoMaterializeRuleEvaluation(
-                            rule_snapshot=rule_snapshot, evaluation_data=evaluation_data
-                        ),
-                        asset_partitions,
-                    )
-                )
-                self._verbose_log_fn(f"Rule returned {len(asset_partitions)} partitions")
-                to_materialize.update(asset_partitions)
-            self._verbose_log_fn("Done evaluating materialize rule")
-
-        skip_context = materialize_context.with_candidate_subset(to_materialize)
-
-        for skip_rule in auto_materialize_policy.skip_rules:
-            rule_snapshot = skip_rule.to_snapshot()
-            self._verbose_log_fn(f"Evaluating skip rule: {rule_snapshot}")
-            for evaluation_data, asset_partitions in skip_rule.evaluate_for_asset(skip_context):
-                all_results.append(
-                    (
-                        AutoMaterializeRuleEvaluation(
-                            rule_snapshot=rule_snapshot, evaluation_data=evaluation_data
-                        ),
-                        asset_partitions,
-                    )
-                )
-                self._verbose_log_fn(f"Rule returned {len(asset_partitions)} partitions")
-                to_skip.update(asset_partitions)
-            self._verbose_log_fn("Done evaluating skip rule")
-        to_materialize.difference_update(to_skip)
-
-        # this is treated separately from other rules, for now
-        if auto_materialize_policy.max_materializations_per_minute is not None:
-            rule = DiscardOnMaxMaterializationsExceededRule(
-                limit=auto_materialize_policy.max_materializations_per_minute
-            )
-            rule_snapshot = rule.to_snapshot()
-
-            self._verbose_log_fn(f"Evaluating discard rule: {rule_snapshot}")
-
-            for evaluation_data, asset_partitions in rule.evaluate_for_asset(
-                skip_context.with_candidate_subset(to_materialize)
-            ):
-                all_results.append(
-                    (
-                        AutoMaterializeRuleEvaluation(
-                            rule_snapshot=rule_snapshot, evaluation_data=evaluation_data
-                        ),
-                        asset_partitions,
-                    )
-                )
-                self._verbose_log_fn(f"Discard rule returned {len(asset_partitions)} partitions")
-                to_discard.update(asset_partitions)
-            self._verbose_log_fn("Done evaluating discard rule")
-
-        to_materialize.difference_update(to_discard)
-        to_skip.difference_update(to_discard)
-
-        return (
-            AutoMaterializeAssetEvaluation.from_rule_evaluation_results(
-                asset_key=asset_key,
-                asset_graph=self.asset_graph,
-                asset_partitions_by_rule_evaluation=all_results,
-                num_requested=len(to_materialize),
-                num_skipped=len(to_skip),
-                num_discarded=len(to_discard),
-                dynamic_partitions_store=self.instance_queryer,
-            ),
-            asset_cursor.with_updates(
-                self.asset_graph,
-                materialize_context.newly_materialized_root_subset,
-                to_materialize,
-                to_discard,
-            ),
-            to_materialize,
-        )
+        return auto_materialize_policy_evaluator.evaluate(context, from_legacy=True)
 
     def get_auto_materialize_asset_evaluations(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -1,4 +1,6 @@
+import operator
 from enum import Enum
+from functools import reduce
 from typing import TYPE_CHECKING, AbstractSet, Dict, FrozenSet, NamedTuple, Optional, Sequence
 
 import dagster._check as check
@@ -11,6 +13,7 @@ from dagster._serdes.serdes import (
 )
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.asset_automation_evaluator import AssetAutomationEvaluator
     from dagster._core.definitions.auto_materialize_rule import (
         AutoMaterializeRule,
         AutoMaterializeRuleSnapshot,
@@ -132,6 +135,7 @@ class AutoMaterializePolicy(
             "max_materializations_per_minute must be positive. To disable rate-limiting, set it"
             " to None. To disable auto materializing, remove the policy.",
         )
+        check.param_invariant(len(rules) > 0, "rules", "Must specify at least one rule.")
 
         return super(AutoMaterializePolicy, cls).__new__(
             cls,
@@ -250,3 +254,31 @@ class AutoMaterializePolicy(
     @property
     def rule_snapshots(self) -> Sequence["AutoMaterializeRuleSnapshot"]:
         return [rule.to_snapshot() for rule in self.rules]
+
+    def to_auto_materialize_policy_evaluator(self) -> "AssetAutomationEvaluator":
+        """Converts a set of materialize / skip rules into a single binary expression."""
+        from .asset_automation_evaluator import AssetAutomationEvaluator, RuleCondition
+
+        materialize_condition = (
+            reduce(
+                operator.or_,
+                [RuleCondition(rule) for rule in self.materialize_rules],
+            )
+            if self.materialize_rules
+            else None
+        )
+        skip_condition = (
+            ~reduce(
+                operator.or_,
+                [RuleCondition(rule) for rule in self.skip_rules],
+            )
+            if self.skip_rules
+            else None
+        )
+        # results in an expression of the form (m1 | m2 | ... | mn) & ~(s1 | s2 | ... | sn)
+        condition = reduce(operator.and_, filter(None, [materialize_condition, skip_condition]))
+        check.invariant(condition is not None, "must have at least one rule")
+        return AssetAutomationEvaluator(
+            condition=condition,
+            max_materializations_per_minute=self.max_materializations_per_minute,
+        )

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -72,15 +72,8 @@ class RuleEvaluationContext:
     candidate_subset: AssetSubset
     daemon_context: "AssetDaemonContext"
 
-    def with_candidate_subset(
-        self, candidate_subset: AbstractSet[AssetKeyPartitionKey]
-    ) -> "RuleEvaluationContext":
-        return dataclasses.replace(
-            self,
-            candidate_subset=AssetSubset.from_asset_partitions_set(
-                self.asset_key, self.partitions_def, candidate_subset
-            ),
-        )
+    def with_candidate_subset(self, candidate_subset: AssetSubset) -> "RuleEvaluationContext":
+        return dataclasses.replace(self, candidate_subset=candidate_subset)
 
     @property
     def asset_graph(self) -> AssetGraph:

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_observe_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_observe_scenarios.py
@@ -9,6 +9,7 @@ from dagster import (
     observable_source_asset,
 )
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 
 from ..base_scenario import AssetReconciliationScenario, run_request
 
@@ -26,7 +27,9 @@ def asset2():
 @asset(
     partitions_def=StaticPartitionsDefinition(["a", "b", "c"]),
     # this is just a dummy policy, as we don't want this to actually impact the logic
-    auto_materialize_policy=AutoMaterializePolicy(rules=set()),
+    auto_materialize_policy=AutoMaterializePolicy(
+        rules={AutoMaterializeRule.skip_on_parent_missing()}
+    ),
 )
 def partitioned_dummy_asset():
     return 1


### PR DESCRIPTION
## Summary & Motivation

Reviving the spirit of an earlier PR, but now taking advantage of all the new toys that have been added in recently (AllPartitionsSubset, AssetSubset).

This creates a new "Evaluator" class, which handles arbitrary boolean combinations of conditions. These conditions can be built out of the existing AutoMaterializeRules, which allows us to convert an AutoMaterializePolicy's rules into a single boolean expression.

This class is temporary, as the thing that is currently called an "Evaluator" in this PR will eventually replace the existing "AutoMaterializePolicy", once we figure out what the new name for that concept will be.

## How I Tested These Changes
