### PR TITLE
Support asset backfills in UI that target only unpartitioned assets

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2703,7 +2703,7 @@ type PartitionKeyRange {
 
 type AssetBackfillData {
   assetBackfillStatuses: [AssetBackfillStatus!]!
-  rootTargetedPartitions: AssetBackfillTargetPartitions!
+  rootTargetedPartitions: AssetBackfillTargetPartitions
 }
 
 union AssetBackfillStatus = AssetPartitionsStatusCounts | UnpartitionedAssetStatus

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -108,7 +108,7 @@ export type AssetAssetObservationsArgs = {
 export type AssetBackfillData = {
   __typename: 'AssetBackfillData';
   assetBackfillStatuses: Array<AssetBackfillStatus>;
-  rootTargetedPartitions: AssetBackfillTargetPartitions;
+  rootTargetedPartitions: Maybe<AssetBackfillTargetPartitions>;
 };
 
 export type AssetBackfillPreviewParams = {

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/TargetPartitionsDisplay.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/TargetPartitionsDisplay.tsx
@@ -13,7 +13,7 @@ export const TargetPartitionsDisplay = ({
   targetPartitions,
 }: {
   targetPartitionCount?: number;
-  targetPartitions?: Pick<AssetBackfillTargetPartitions, 'partitionKeys' | 'ranges'>;
+  targetPartitions?: Pick<AssetBackfillTargetPartitions, 'partitionKeys' | 'ranges'> | null;
 }) => {
   const [isDialogOpen, setIsDialogOpen] = React.useState(false);
 
@@ -95,6 +95,12 @@ export const TargetPartitionsDisplay = ({
   }
 
   return (
-    <div>{targetPartitionCount === 1 ? '1 partition' : `${targetPartitionCount} partitions`}</div>
+    <div>
+      {targetPartitionCount === 0
+        ? '-'
+        : targetPartitionCount === 1
+        ? '1 partition'
+        : `${targetPartitionCount} partitions`}
+    </div>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPage.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPage.types.ts
@@ -38,7 +38,7 @@ export type BackfillStatusesByAssetQuery = {
             __typename: 'AssetBackfillTargetPartitions';
             partitionKeys: Array<string> | null;
             ranges: Array<{__typename: 'PartitionKeyRange'; start: string; end: string}> | null;
-          };
+          } | null;
           assetBackfillStatuses: Array<
             | {
                 __typename: 'AssetPartitionsStatusCounts';
@@ -108,7 +108,7 @@ export type PartitionBackfillFragment = {
       __typename: 'AssetBackfillTargetPartitions';
       partitionKeys: Array<string> | null;
       ranges: Array<{__typename: 'PartitionKeyRange'; start: string; end: string}> | null;
-    };
+    } | null;
     assetBackfillStatuses: Array<
       | {
           __typename: 'AssetPartitionsStatusCounts';

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -171,7 +171,7 @@ class GrapheneAssetBackfillData(graphene.ObjectType):
     assetBackfillStatuses = non_null_list(
         "dagster_graphql.schema.partition_sets.GrapheneAssetBackfillStatus"
     )
-    rootTargetedPartitions = graphene.NonNull(
+    rootTargetedPartitions = graphene.Field(
         "dagster_graphql.schema.backfill.GrapheneAssetBackfillTargetPartitions",
     )
 

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -267,7 +267,9 @@ class AssetBackfillData(NamedTuple):
         # Return the targeted partitions for the root partitioned asset keys
         return self.target_subset.get_partitions_subset(asset_key)
 
-    def get_target_root_partitions_subset(self, asset_graph: AssetGraph) -> PartitionsSubset:
+    def get_target_root_partitions_subset(
+        self, asset_graph: AssetGraph
+    ) -> Optional[PartitionsSubset]:
         """Returns the most upstream partitions subset that was targeted by the backfill."""
         partitioned_asset_keys = {
             asset_key
@@ -280,7 +282,10 @@ class AssetBackfillData(NamedTuple):
         )
 
         # Return the targeted partitions for the root partitioned asset keys
-        return self.target_subset.get_partitions_subset(next(iter(root_partitioned_asset_keys)))
+        if root_partitioned_asset_keys:
+            return self.target_subset.get_partitions_subset(next(iter(root_partitioned_asset_keys)))
+
+        return None
 
     def get_num_partitions(self) -> Optional[int]:
         """Only valid when the same number of partitions are targeted in every asset.


### PR DESCRIPTION
Fixes https://github.com/dagster-io/dagster/issues/15173

Previously, a graphQL error would be raised when attempting to display a backfill that targets only unpartitioned assets. This is because we assumed in a resolver that at least 1 partition would be targeted.

This PR fixes the issue:

<img width="1450" alt="image" src="https://github.com/dagster-io/dagster/assets/29110579/3916e1ed-5660-462b-a730-e352461e68b6">

I also went through the UI and confirmed that all other pages were displaying correctly, so looks like this is the only spot where we assume partitioned asset(s) are targeted by the backfill.

