### PR TITLE
[ui] Don’t attempt to launch asset checks into without_checks jobs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -537,7 +537,9 @@ async function stateForLaunchingAssets(
         assetSelection: assets.map((a) => ({assetKey: a.assetKey, opNames: a.opNames})),
         assetChecksAvailable: assets.flatMap((a) =>
           a.assetChecksOrError.__typename === 'AssetChecks'
-            ? a.assetChecksOrError.checks.map((check) => ({...check, assetKey: a.assetKey}))
+            ? a.assetChecksOrError.checks
+                .filter((check) => check.jobNames.includes(jobName))
+                .map((check) => ({...check, assetKey: a.assetKey}))
             : [],
         ),
         includeSeparatelyExecutableChecks: true,
@@ -656,7 +658,7 @@ export function executionParamsForAssetJob(
       repositoryName: repoAddress.name,
       pipelineName: jobName,
       assetSelection: assets.map(asAssetKeyInput),
-      assetCheckSelection: getAssetCheckHandleInputs(assets),
+      assetCheckSelection: getAssetCheckHandleInputs(assets, jobName),
     },
   };
 }
@@ -731,6 +733,7 @@ const LAUNCH_ASSET_EXECUTION_ASSET_NODE_FRAGMENT = gql`
         checks {
           name
           canExecuteIndividually
+          jobNames
         }
       }
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
@@ -8,11 +8,13 @@ import {
   LaunchBackfillParams,
   PartitionDefinitionType,
   PartitionRangeStatus,
+  buildAssetCheck,
   buildAssetChecks,
   buildDaemonHealth,
   buildDaemonStatus,
   buildDimensionDefinitionType,
   buildInstance,
+  buildPartitionSets,
   buildRunLauncher,
 } from '../../graphql/types';
 import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../../instance/backfill/BackfillUtils';
@@ -71,6 +73,16 @@ export const UNPARTITIONED_ASSET: AssetNodeForGraphQueryFragment = {
   assetKey: {
     __typename: 'AssetKey',
     path: ['unpartitioned_asset'],
+  },
+};
+
+export const CHECKED_ASSET: AssetNodeForGraphQueryFragment = {
+  ...UNPARTITIONED_ASSET,
+  id: 'test.py.repo.["checked_asset"]',
+  jobNames: ['__ASSET_JOB_7', 'checks_included_job', 'checks_excluded_job'],
+  assetKey: {
+    __typename: 'AssetKey',
+    path: ['checked_asset'],
   },
 };
 
@@ -393,6 +405,37 @@ export const PartitionHealthAssetWeeklyRootMock: MockedResponse<PartitionHealthQ
       },
     },
   },
+};
+
+export const buildLaunchAssetLoaderGenericJobMock = (jobName: string) => {
+  const result: MockedResponse<LaunchAssetLoaderResourceQuery> = {
+    request: {
+      query: LAUNCH_ASSET_LOADER_RESOURCE_QUERY,
+      variables: {
+        pipelineName: jobName,
+        repositoryLocationName: 'test.py',
+        repositoryName: 'repo',
+      },
+    },
+    result: {
+      data: {
+        __typename: 'Query',
+        partitionSetsOrError: buildPartitionSets({results: []}),
+        pipelineOrError: {
+          id: '8e2d3f9597c4a45bb52fe9ab5656419f4329d4fb',
+          modes: [
+            {
+              id: 'da3055161c528f4c839339deb4a362ec1be4f079-default',
+              resources: [],
+              __typename: 'Mode',
+            },
+          ],
+          __typename: 'Pipeline',
+        },
+      },
+    },
+  };
+  return result;
 };
 
 export const LaunchAssetLoaderResourceJob7Mock: MockedResponse<LaunchAssetLoaderResourceQuery> = {
@@ -925,6 +968,7 @@ const UNPARTITIONED_ASSET_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
   },
   __typename: 'AssetNode',
 };
+
 const UNPARTITIONED_ASSET_OTHER_REPO_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
   ...UNPARTITIONED_ASSET_OTHER_REPO,
   requiredResources: [],
@@ -971,6 +1015,37 @@ const UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG_LOADER_RESULT: LaunchAssetLoaderQ
   __typename: 'AssetNode',
 };
 
+const CHECKED_ASSET_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
+  ...CHECKED_ASSET,
+  requiredResources: [],
+  assetChecksOrError: buildAssetChecks({
+    checks: [
+      buildAssetCheck({
+        name: 'CHECK_1',
+        assetKey: CHECKED_ASSET.assetKey,
+        jobNames: ['checks_included_job', '__ASSET_JOB_0'],
+      }),
+    ],
+  }),
+  backfillPolicy: null,
+  partitionDefinition: null,
+  configField: {
+    name: 'config',
+    isRequired: false,
+    configType: {
+      __typename: 'RegularConfigType',
+      givenName: 'Any',
+      key: 'Any',
+      description: null,
+      isSelector: false,
+      typeParamKeys: [],
+      recursiveConfigTypes: [],
+    },
+    __typename: 'ConfigTypeField',
+  },
+  __typename: 'AssetNode',
+};
+
 export const LOADER_RESULTS = [
   ASSET_DAILY_LOADER_RESULT,
   ASSET_WEEKLY_LOADER_RESULT,
@@ -978,6 +1053,7 @@ export const LOADER_RESULTS = [
   UNPARTITIONED_ASSET_LOADER_RESULT,
   UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG_LOADER_RESULT,
   UNPARTITIONED_ASSET_OTHER_REPO_LOADER_RESULT,
+  CHECKED_ASSET_LOADER_RESULT,
 ];
 
 export const PartitionHealthAssetMocks = [

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -20,6 +20,7 @@ import {
   ASSET_DAILY_PARTITION_KEYS_MISSING,
   ASSET_WEEKLY,
   ASSET_WEEKLY_ROOT,
+  CHECKED_ASSET,
   LaunchAssetCheckUpstreamWeeklyRootMock,
   LaunchAssetLoaderResourceJob7Mock,
   LaunchAssetLoaderResourceJob8Mock,
@@ -33,6 +34,7 @@ import {
   buildConfigPartitionSelectionLatestPartitionMock,
   buildExpectedLaunchBackfillMutation,
   buildExpectedLaunchSingleRunMutation,
+  buildLaunchAssetLoaderGenericJobMock,
   buildLaunchAssetLoaderMock,
   buildLaunchAssetWarningsMock,
 } from '../__fixtures__/LaunchAssetExecutionButton.fixtures';
@@ -157,6 +159,52 @@ describe('LaunchAssetExecutionButton', () => {
       });
       await clickMaterializeButton();
       await waitFor(() => expect(launchMock.result).toHaveBeenCalled());
+    });
+
+    describe('assets with checks', () => {
+      it('should not include checks if the job in context is marked without_checks', async () => {
+        const launchMock = buildExpectedLaunchSingleRunMutation({
+          mode: 'default',
+          executionMetadata: {tags: []},
+          runConfigData: '{}',
+          selector: {
+            repositoryLocationName: 'test.py',
+            repositoryName: 'repo',
+            pipelineName: 'checks_excluded_job',
+            assetSelection: [{path: ['checked_asset']}],
+            assetCheckSelection: [],
+          },
+        });
+        renderButton({
+          scope: {all: [CHECKED_ASSET]},
+          preferredJobName: 'checks_excluded_job',
+          launchMock,
+        });
+        await clickMaterializeButton();
+        await waitFor(() => expect(launchMock.result).toHaveBeenCalled());
+      });
+
+      it('should include checks if the job in context includes them', async () => {
+        const launchMock = buildExpectedLaunchSingleRunMutation({
+          mode: 'default',
+          executionMetadata: {tags: []},
+          runConfigData: '{}',
+          selector: {
+            repositoryLocationName: 'test.py',
+            repositoryName: 'repo',
+            pipelineName: 'checks_included_job',
+            assetSelection: [{path: ['checked_asset']}],
+            assetCheckSelection: [{name: 'CHECK_1', assetKey: {path: ['checked_asset']}}],
+          },
+        });
+        renderButton({
+          scope: {all: [CHECKED_ASSET]},
+          preferredJobName: 'checks_included_job',
+          launchMock,
+        });
+        await clickMaterializeButton();
+        await waitFor(() => expect(launchMock.result).toHaveBeenCalled());
+      });
     });
 
     describe('permissions', () => {
@@ -534,6 +582,8 @@ function renderButton({
   const mocks: MockedResponse<Record<string, any>>[] = [
     LaunchAssetLoaderResourceJob7Mock,
     LaunchAssetLoaderResourceJob8Mock,
+    buildLaunchAssetLoaderGenericJobMock('checks_excluded_job'),
+    buildLaunchAssetLoaderGenericJobMock('checks_included_job'),
     LaunchAssetLoaderResourceMyAssetJobMock,
     LaunchAssetCheckUpstreamWeeklyRootMock,
     ...PartitionHealthAssetMocks,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asInput.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asInput.ts
@@ -4,13 +4,16 @@ import {LaunchAssetExecutionAssetNodeFragment} from './types/LaunchAssetExecutio
 
 export function getAssetCheckHandleInputs(
   assets: Pick<LaunchAssetExecutionAssetNodeFragment, 'assetKey' | 'assetChecksOrError'>[],
+  jobName?: string,
 ): AssetCheckHandleInput[] {
   return assets.flatMap((a) =>
     a.assetChecksOrError.__typename === 'AssetChecks'
-      ? a.assetChecksOrError.checks.map((check) => ({
-          name: check.name,
-          assetKey: {path: a.assetKey.path},
-        }))
+      ? a.assetChecksOrError.checks
+          .filter((check) => !jobName || check.jobNames.includes(jobName))
+          .map((check) => ({
+            name: check.name,
+            assetKey: {path: a.assetKey.path},
+          }))
       : [],
   );
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/LaunchAssetExecutionButton.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/LaunchAssetExecutionButton.types.ts
@@ -59,6 +59,7 @@ export type LaunchAssetExecutionAssetNodeFragment = {
           __typename: 'AssetCheck';
           name: string;
           canExecuteIndividually: Types.AssetCheckCanExecuteIndividually;
+          jobNames: Array<string>;
         }>;
       };
   dependencyKeys: Array<{__typename: 'AssetKey'; path: Array<string>}>;
@@ -667,6 +668,7 @@ export type LaunchAssetLoaderQuery = {
             __typename: 'AssetCheck';
             name: string;
             canExecuteIndividually: Types.AssetCheckCanExecuteIndividually;
+            jobNames: Array<string>;
           }>;
         };
     dependencyKeys: Array<{__typename: 'AssetKey'; path: Array<string>}>;
@@ -1290,6 +1292,7 @@ export type LaunchAssetLoaderJobQuery = {
             __typename: 'AssetCheck';
             name: string;
             canExecuteIndividually: Types.AssetCheckCanExecuteIndividually;
+            jobNames: Array<string>;
           }>;
         };
     dependencyKeys: Array<{__typename: 'AssetKey'; path: Array<string>}>;

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -872,6 +872,7 @@ type AssetCheck {
   name: String!
   assetKey: AssetKey!
   description: String
+  jobNames: [String!]!
   executionForLatestMaterialization: AssetCheckExecution
   canExecuteIndividually: AssetCheckCanExecuteIndividually!
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -130,6 +130,7 @@ export type AssetCheck = {
   canExecuteIndividually: AssetCheckCanExecuteIndividually;
   description: Maybe<Scalars['String']>;
   executionForLatestMaterialization: Maybe<AssetCheckExecution>;
+  jobNames: Array<Scalars['String']>;
   name: Scalars['String'];
 };
 
@@ -4684,6 +4685,7 @@ export const buildAssetCheck = (
         : relationshipsToOmit.has('AssetCheckExecution')
         ? ({} as AssetCheckExecution)
         : buildAssetCheckExecution({}, relationshipsToOmit),
+    jobNames: overrides && overrides.hasOwnProperty('jobNames') ? overrides.jobNames! : [],
     name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : 'dignissimos',
   };
 };

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Union, cast
+from typing import TYPE_CHECKING, Optional, Sequence, Union, cast
 
 import dagster._check as check
 import graphene
@@ -132,6 +132,7 @@ class GrapheneAssetCheck(graphene.ObjectType):
     name = graphene.NonNull(graphene.String)
     assetKey = graphene.NonNull(GrapheneAssetKey)
     description = graphene.String()
+    jobNames = non_null_list(graphene.String)
     executionForLatestMaterialization = graphene.Field(GrapheneAssetCheckExecution)
     canExecuteIndividually = graphene.NonNull(GrapheneAssetCheckCanExecuteIndividually)
 
@@ -156,6 +157,9 @@ class GrapheneAssetCheck(graphene.ObjectType):
 
     def resolve_description(self, _) -> Optional[str]:
         return self._asset_check.description
+
+    def resolve_jobNames(self, _) -> Sequence[str]:
+        return self._asset_check.job_names
 
     def resolve_executionForLatestMaterialization(
         self, _graphene_info: ResolveInfo

--- a/python_modules/dagster-test/dagster_test/toys/asset_checks.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_checks.py
@@ -412,8 +412,18 @@ def downstream_asset():
     return 1
 
 
-just_checks_job = define_asset_job(
-    name="just_checks_job",
+checks_included_job = define_asset_job(
+    name="checks_included_job",
+    selection=AssetSelection.assets(checked_asset),
+)
+
+checks_excluded_job = define_asset_job(
+    name="checks_excluded_job",
+    selection=AssetSelection.assets(checked_asset).without_checks(),
+)
+
+checks_only_job = define_asset_job(
+    name="checks_only_job",
     selection=AssetSelection.checks_for_assets(checked_asset),
 )
 
@@ -438,5 +448,7 @@ def get_checks_and_assets():
         asset_with_1000_checks,
         many_tests_graph_asset,
         many_tests_graph_multi_asset,
-        just_checks_job,
+        checks_included_job,
+        checks_excluded_job,
+        checks_only_job,
     ]


### PR DESCRIPTION
## Summary & Motivation

This PR builds on https://github.com/dagster-io/dagster/pull/18136. When you define an asset job, you can specify an asset selection that with / without checks. The UI can now see which jobs the asset check is in and scope down the materialization.

## How I Tested These Changes

Two new jest tests! Also:

- Created two new toys jobs: `checks_excluded_job`, `checks_included_job`. (I renamed these to all start with `checks_` so they're easier to find in the toys repo jobs sidebar.

- Materialized both A) the whole job) an B) the asset selection, and C)via the launchpad for both included / excluded cases.
