### PR TITLE
[ui] Standardize the appearance + behavior of the run "target" column

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/ButtonLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/ButtonLink.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import styled, {css} from 'styled-components';
 
+import {Box} from './Box';
 import {Colors} from './Colors';
 
 type Color =
@@ -51,6 +52,9 @@ const textDecoration = (underline: Underline) => {
       return css`
         &:hover {
           text-decoration: underline;
+          & > ${Box} {
+            text-decoration: underline;
+          }
         }
       `;
     case 'never':

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
@@ -140,12 +140,10 @@ export const AssetKeyTagCollection = React.memo((props: AssetKeyTagCollectionPro
             {assetKeys.length} assets
           </Tag>
         ) : (
-          <ButtonLink onClick={() => setShowMore(true)}>
+          <ButtonLink onClick={() => setShowMore(true)} underline="hover">
             <Box flex={{direction: 'row', gap: 8, alignItems: 'center', display: 'inline-flex'}}>
               <Icon color={Colors.Gray400} name="asset" size={16} />
-              <Box style={{flex: 1}} flex={{wrap: 'wrap', display: 'inline-flex'}}>
-                {`${assetKeys.length} assets`}
-              </Box>
+              {`${assetKeys.length} assets`}
             </Box>
           </ButtonLink>
         )}
@@ -214,12 +212,10 @@ export const AssetCheckTagCollection = React.memo((props: AssetCheckTagCollectio
             {assetChecks.length} asset checks
           </Tag>
         ) : (
-          <ButtonLink onClick={() => setShowMore(true)}>
+          <ButtonLink onClick={() => setShowMore(true)} underline="hover">
             <Box flex={{direction: 'row', gap: 8, alignItems: 'center', display: 'inline-flex'}}>
               <Icon color={Colors.Gray400} name="asset_check" size={16} />
-              <Box style={{flex: 1}} flex={{wrap: 'wrap', display: 'inline-flex'}}>
-                {`${assetChecks.length} asset checks`}
-              </Box>
+              {`${assetChecks.length} asset checks`}
             </Box>
           </ButtonLink>
         )}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRow.tsx
@@ -8,7 +8,6 @@ import {
   Dialog,
   DialogBody,
   DialogFooter,
-  Icon,
   Mono,
   Tag,
 } from '@dagster-io/ui-components';
@@ -20,11 +19,9 @@ import {ShortcutHandler} from '../app/ShortcutHandler';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {PipelineTag} from '../graphql/types';
 import {PipelineReference} from '../pipelines/PipelineReference';
-import {TagActionsPopover} from '../ui/TagActions';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
 import {useRepositoryForRunWithoutSnapshot} from '../workspace/useRepositoryForRun';
-import {workspacePipelinePath, workspacePipelinePathGuessRepo} from '../workspace/workspacePath';
 
 import {AssetCheckTagCollection, AssetKeyTagCollection} from './AssetTagCollections';
 import {CreatedByTagCell} from './CreatedByTag';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRow.tsx
@@ -20,7 +20,9 @@ import {ShortcutHandler} from '../app/ShortcutHandler';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {PipelineTag} from '../graphql/types';
 import {PipelineReference} from '../pipelines/PipelineReference';
+import {TagActionsPopover} from '../ui/TagActions';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
+import {RepoAddress} from '../workspace/types';
 import {useRepositoryForRunWithoutSnapshot} from '../workspace/useRepositoryForRun';
 import {workspacePipelinePath, workspacePipelinePathGuessRepo} from '../workspace/workspacePath';
 
@@ -163,36 +165,7 @@ export const RunRow = ({
       </td>
       <td style={{position: 'relative'}}>
         <Box flex={{direction: 'column', gap: 5}}>
-          {isHiddenAssetGroupJob(run.pipelineName) ? (
-            <Box flex={{gap: 16}}>
-              <AssetKeyTagCollection assetKeys={assetKeysForRun(run)} />
-              <AssetCheckTagCollection assetChecks={run.assetCheckSelection} />
-            </Box>
-          ) : (
-            <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-              <PipelineReference
-                isJob={isJob}
-                showIcon
-                pipelineName={run.pipelineName}
-                pipelineHrefContext="no-link"
-              />
-              <Link
-                to={
-                  repo
-                    ? workspacePipelinePath({
-                        repoName: repo.match.repository.name,
-                        repoLocation: repo.match.repositoryLocation.name,
-                        pipelineName: run.pipelineName,
-                        isJob,
-                      })
-                    : workspacePipelinePathGuessRepo(run.pipelineName)
-                }
-                target="_blank"
-              >
-                <Icon name="open_in_new" color={Colors.Blue500} />
-              </Link>
-            </Box>
-          )}
+          <RunTargetLink isJob={isJob} run={run} repoAddress={repoAddressGuess} />
           <Box
             flex={{direction: 'row', alignItems: 'center', wrap: 'wrap'}}
             style={{gap: '4px 8px'}}
@@ -291,3 +264,27 @@ const RunTagsWrapper = styled.div`
     display: contents;
   }
 `;
+
+const RunTargetLink = ({
+  run,
+  isJob,
+  repoAddress,
+}: {
+  isJob: boolean;
+  run: RunTableRunFragment;
+  repoAddress: RepoAddress | null;
+}) => {
+  return isHiddenAssetGroupJob(run.pipelineName) ? (
+    <Box flex={{gap: 16, alignItems: 'end', wrap: 'wrap'}}>
+      <AssetKeyTagCollection assetKeys={assetKeysForRun(run)} />
+      <AssetCheckTagCollection assetChecks={run.assetCheckSelection} />
+    </Box>
+  ) : (
+    <PipelineReference
+      isJob={isJob}
+      showIcon
+      pipelineName={run.pipelineName}
+      pipelineHrefContext={repoAddress || 'repo-unknown'}
+    />
+  );
+};


### PR DESCRIPTION
## Summary & Motivation

Resolves #17035


- All appear as blue text with an icon, with an underline when you mouse over
- Click either opens a modal, or goes to the asset / job / check page
- Assets and checks have a hover menu because there can be multiple options,  jobs do not (because it'd just say "View job" and that seems redundant)

<img width="459" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/7fb063fd-5c25-4184-8465-7a4696abd2ee">

## How I Tested These Changes

Just visually tested with asset, check, asset+check and job runs

<img width="794" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/92484cae-8cd9-4e94-865e-b89f598f966f">
