### PR TITLE
[ui] Offer a backfill preview when using “failed and missing only"

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -421,6 +421,32 @@ const LaunchAssetChoosePartitionsDialogBody = ({
     );
   };
 
+  const previewNotice = (() => {
+    const notices: string[] = [];
+    if (target.type === 'pureWithAnchorAsset') {
+      notices.push(
+        `Dagster will materialize all partitions downstream of the ` +
+          `selected partitions for the selected assets, using separate runs 
+                ${backfillPolicyVaries ? `and obeying backfill policies.` : `as needed.`}`,
+      );
+    } else if (backfillPolicyVaries) {
+      notices.push(
+        `Dagster will materialize the selected partitions for the ` +
+          `selected assets using varying backfill policies.`,
+      );
+    } else if (assets[0]?.backfillPolicy) {
+      notices.push(`${assets[0].backfillPolicy.description}.`);
+    }
+    if (missingFailedOnly) {
+      notices.push(
+        `Only ${partitionCountString(
+          keysFiltered.length,
+        )} failed and missing partitions will be materialized.`,
+      );
+    }
+    return notices.join(' ');
+  })();
+
   return (
     <>
       <div data-testid={testId('choose-partitions-dialog')}>
@@ -520,34 +546,6 @@ const LaunchAssetChoosePartitionsDialogBody = ({
                 />
               </Box>
             ))}
-
-            <BackfillPreviewModal
-              assets={assets}
-              keysFiltered={keysFiltered}
-              isOpen={previewOpen}
-              setOpen={setPreviewOpen}
-            />
-
-            {target.type === 'pureWithAnchorAsset' ? (
-              <PartitionSelectionNotice
-                onShowPreview={() => setPreviewOpen(true)}
-                text={
-                  `Dagster will materialize all partitions downstream of the ` +
-                  `selected partitions for the selected assets, using separate runs 
-                  ${backfillPolicyVaries ? `and obeying backfill policies.` : `as needed.`}`
-                }
-              />
-            ) : backfillPolicyVaries ? (
-              <PartitionSelectionNotice
-                onShowPreview={() => setPreviewOpen(true)}
-                text={
-                  `Dagster will materialize the selected partitions for the ` +
-                  `selected assets using varying backfill policies.`
-                }
-              />
-            ) : assets[0]?.backfillPolicy ? (
-              <PartitionSelectionNotice text={assets[0].backfillPolicy.description} />
-            ) : undefined}
           </ToggleableSection>
         )}
         <ToggleableSection
@@ -642,8 +640,19 @@ const LaunchAssetChoosePartitionsDialogBody = ({
         )}
       </div>
 
+      <BackfillPreviewModal
+        assets={assets}
+        keysFiltered={keysFiltered}
+        isOpen={previewOpen}
+        setOpen={setPreviewOpen}
+      />
+
+      {previewNotice && (
+        <PartitionSelectionNotice onShowPreview={() => setPreviewOpen(true)} text={previewNotice} />
+      )}
+
       <DialogFooter
-        topBorder
+        topBorder={!previewNotice}
         left={
           'partitionSetName' in target && (
             <RunningBackfillsNotice partitionSetName={target.partitionSetName} />
@@ -840,20 +849,17 @@ const PartitionSelectionNotice = ({
   onShowPreview?: () => void;
 }) => {
   return (
-    <Box padding={{horizontal: 16, bottom: 16}} border="bottom">
-      <Alert
-        intent="info"
-        title={
-          <Box flex={{gap: 12, alignItems: 'flex-start'}}>
-            <span>{text}</span>
-            {onShowPreview && (
-              <Button data-testid={testId('backfill-preview-button')} onClick={onShowPreview}>
-                Preview
-              </Button>
-            )}
-          </Box>
-        }
-      />
+    <Box padding={{horizontal: 16, top: 16, bottom: 8}} style={{position: 'relative'}} border="top">
+      <Alert intent="info" title={<Box style={{marginRight: 100, minHeight: 24}}>{text}</Box>} />
+      <div style={{position: 'absolute', top: 24, right: 24, zIndex: 4}}>
+        <Button
+          data-testid={testId('backfill-preview-button')}
+          intent="none"
+          onClick={onShowPreview}
+        >
+          Preview
+        </Button>
+      </div>
     </Box>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -296,8 +296,19 @@ describe('LaunchAssetExecutionButton', () => {
       await clickMaterializeButton();
       await screen.findByTestId('choose-partitions-dialog');
 
+      // verify that the preview option is not shown
+      expect(screen.queryByTestId('backfill-preview-button')).toBeNull();
+
       // verify that checking "missing only" triggers the mutation with fewer partitions
       await userEvent.click(screen.getByTestId('missing-only-checkbox'));
+
+      // Verify that the preview option is now shown
+      const preview = await screen.findByTestId('backfill-preview-button');
+      await preview.click();
+
+      // Expect the modal to be displayed. We have separate test coverage for
+      // for the content of this modal
+      await screen.findByTestId('backfill-preview-modal-content');
 
       // verify that the executed mutation is correct
       await expectLaunchExecutesMutationAndCloses('Launch backfill', launchMock);


### PR DESCRIPTION
## Summary & Motivation

Fixes  #17839

When you check the "backfill only failed and missing" option, the preview banner appears and the preview button allows you to see exactly which ranges the UI is going to request.

<img width="844" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/4006ca42-a8e4-4d8d-a75c-206b8241f3ab">

<img width="1288" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/115cb596-962a-42e0-807e-f7deae0e749d">

## How I Tested These Changes

We show this preview banner in a handful of cases and with this addition, there are sometimes for multiple reasons for it to show. I updated the tests accordingly!
