### PR TITLE
[ui] Fix the DAG height of non-observable source assets, center mini nodes

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -514,6 +514,7 @@ const AssetGraphExplorerWithData = ({
                               <AssetNodeMinimal
                                 definition={graphNode.definition}
                                 selected={selectedGraphNodes.includes(graphNode)}
+                                height={bounds.height}
                               />
                             </AssetNodeContextMenuWrapper>
                           ) : (

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -312,9 +312,11 @@ const AssetNodeChecksRow = ({
 export const AssetNodeMinimal = ({
   selected,
   definition,
+  height,
 }: {
   selected: boolean;
   definition: AssetNodeFragment;
+  height: number;
 }) => {
   const {isSource, assetKey} = definition;
   const {liveData} = useAssetLiveData(assetKey);
@@ -323,7 +325,7 @@ export const AssetNodeMinimal = ({
 
   return (
     <AssetInsetForHoverEffect>
-      <MinimalAssetNodeContainer $selected={selected}>
+      <MinimalAssetNodeContainer $selected={selected} style={{paddingTop: (height - 64) / 2}}>
         <TooltipStyled
           content={displayName}
           canShow={displayName.length > 14}
@@ -460,8 +462,6 @@ const AssetNodeSpinnerContainer = styled.div`
 `;
 
 const MinimalAssetNodeContainer = styled(AssetNodeContainer)`
-  padding-top: 30px;
-  padding-bottom: 42px;
   height: 100%;
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
@@ -44,7 +44,7 @@ export const LiveStates = () => {
         </div>
         <div style={{position: 'relative', width: dimensions.width, height: 82}}>
           <div style={{position: 'absolute', width: dimensions.width, height: 82}}>
-            <AssetNodeMinimal definition={definitionCopy} selected={false} />
+            <AssetNodeMinimal definition={definitionCopy} selected={false} height={82} />
           </div>
         </div>
         <code>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -285,22 +285,20 @@ export const getAssetNodeDimensions = (def: {
 }) => {
   const width = 265;
 
-  if (def.isSource && !def.isObservable) {
-    return {width, height: 102};
+  let height = 100; // top tags area + name + description
+
+  if (def.isSource && def.isObservable) {
+    height += 30; // status row
+  } else if (def.isSource) {
+    height += 0; // no status row
   } else {
-    let height = 100; // top tags area + name + description
-
-    if (def.isSource) {
-      height += 30; // last observed
-    } else {
-      height += 26; // status row
-      if (def.isPartitioned) {
-        height += 40;
-      }
+    height += 26; // status row
+    if (def.isPartitioned) {
+      height += 40;
     }
-
-    height += 30; // tags beneath
-
-    return {width, height};
   }
+
+  height += 30; // tags beneath
+
+  return {width, height};
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -136,6 +136,7 @@ export const AssetNodeLineageGraph = ({
                       <AssetNodeMinimal
                         definition={graphNode.definition}
                         selected={graphNode.id === assetGraphId}
+                        height={bounds.height}
                       />
                     </AssetNodeContextMenuWrapper>
                   ) : (


### PR DESCRIPTION
## Summary & Motivation

Fixes #18234

Before:

<img width="776" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/9526847b-018c-4a30-9b7d-e38107438197">


<img width="356" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/2905666d-fa19-4e2c-9423-fa0bab0d8d5a">


After:
<img width="548" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/1eb598f5-7ce2-4a74-b206-7a78ded08cfe">


<img width="355" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/9fc1a5f6-fbeb-4037-bcf0-1aace6286f9d">


## How I Tested These Changes
