### PR TITLE
[auto-materialize] enforce monotonic storage id

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -190,12 +190,13 @@ class AssetDaemonContext:
         return max(
             filter(
                 None,
-                (
+                [
                     self.instance_queryer.get_latest_materialization_or_observation_storage_id(
                         AssetKeyPartitionKey(asset_key=asset_key)
                     )
                     for asset_key in self.target_asset_keys_and_parents
-                ),
+                ]
+                + [self.cursor.latest_storage_id],
             ),
             default=None,
         )


### PR DESCRIPTION
## Summary & Motivation

We changed how we get the latest_storage_id for the cursor to only look at the maximum materialization storage id across the assets. In a previous commit, it was looking for the maximum storage id across all events. If you serialized a cursor with a high storage id, then changed to the new system, you'd cause an error because we always expect the storage id to increase

## How I Tested These Changes
