### PR TITLE
Fix stuck backfill when definition is changed

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -845,7 +845,10 @@ def _check_validity_and_deserialize_asset_backfill_data(
             if unloadable_locations
             else ""
         )
-        if os.environ.get("DAGSTER_BACKFILL_RETRY_DEFINITION_CHANGED_ERROR"):
+        if (
+            os.environ.get("DAGSTER_BACKFILL_RETRY_DEFINITION_CHANGED_ERROR")
+            and unloadable_locations
+        ):
             logger.warning(
                 f"Backfill {backfill.backfill_id} was unable to continue due to a missing asset or"
                 " partition in the asset graph. The backfill will resume once it is available"

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -1410,3 +1410,44 @@ def test_raise_error_on_target_static_partition_removed(
     ]
     assert len(errors) == 1
     assert ("The following partitions were removed: {'c'}.") in errors[0].message
+
+
+def test_partitions_def_changed_backfill_retry_envvar_set(
+    caplog,
+    instance,
+    partitions_defs_changes_location_1_workspace_context,
+    partitions_defs_changes_location_2_workspace_context,
+):
+    asset_selection = [AssetKey("time_partitions_def_changes")]
+    partition_keys = ["2023-01-01"]
+    backfill_id = "dummy_backfill"
+    asset_graph = ExternalAssetGraph.from_workspace(
+        partitions_defs_changes_location_1_workspace_context.create_request_context()
+    )
+
+    backfill = PartitionBackfill.from_asset_partitions(
+        asset_graph=asset_graph,
+        backfill_id=backfill_id,
+        tags={},
+        backfill_timestamp=pendulum.now().timestamp(),
+        asset_selection=asset_selection,
+        partition_names=partition_keys,
+        dynamic_partitions_store=instance,
+        all_partitions=False,
+    )
+
+    instance.add_backfill(backfill)
+
+    with environ({"DAGSTER_BACKFILL_RETRY_DEFINITION_CHANGED_ERROR": "1"}):
+        errors = list(
+            execute_backfill_iteration(
+                partitions_defs_changes_location_2_workspace_context,
+                get_default_daemon_logger("BackfillDaemon"),
+            )
+        )
+
+        assert len(errors) == 1
+        error_msg = check.not_none(errors[0]).message
+        assert ("partitions definition has changed") in error_msg or (
+            "partitions definition for asset AssetKey(['time_partitions_def_changes']) has changed"
+        ) in error_msg


### PR DESCRIPTION
Previously, when the `DAGSTER_BACKFILL_RETRY_DEFINITION_CHANGED_ERROR` env var is set, we never mark the backfill as failed regardless of whether any code location is actually unloadable. This caused certain backfills to be stuck forever in a canceling state when the partitions defs were changed, when they should have been marked as failed.

This PR fixes the issue.