### PR TITLE
[pipes] add method to report arbitrary user data

### DIFF
--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -54,7 +54,14 @@ PipesParams = Mapping[str, Any]
 
 # ##### MESSAGE
 
-Method = Literal["opened", "closed", "log", "report_asset_materialization", "report_asset_check"]
+Method = Literal[
+    "opened",
+    "closed",
+    "log",
+    "report_asset_materialization",
+    "report_asset_check",
+    "report_custom_message",
+]
 
 
 def _make_message(method: Method, params: Optional[Mapping[str, Any]]) -> "PipesMessage":
@@ -1296,6 +1303,9 @@ class PipesContext:
                 "severity": severity,
             },
         )
+
+    def report_custom_message(self, payload: Any):
+        self._write_message("report_custom_message", {"payload": payload})
 
     @property
     def log(self) -> logging.Logger:

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Sequence
 
 from dagster_pipes import (
     DagsterPipesError,
@@ -109,6 +109,9 @@ class PipesClientCompletedInvocation:
         Returns: AssetCheckResult
         """
         return _check_result_from_pipes_results(self.get_results())
+
+    def get_custom_messages(self) -> Sequence[Any]:
+        return self._session.get_custom_messages()
 
 
 @experimental


### PR DESCRIPTION
Provide a means to pass non dagster data along the pipes channel back to the orchestrating process to use for whatever. This is done via the added `report_custom_message` and `get_custom_messages` methods.

resolves https://github.com/dagster-io/dagster/issues/18201

## How I Tested These Changes

added test