### PR TITLE
[multiproc] move step_worker_started to before execution plan creation / job import

### DIFF
--- a/python_modules/dagster/dagster/_core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/_core/executor/multiprocess.py
@@ -75,13 +75,6 @@ class MultiprocessExecutorChildProcessCommand(ChildProcessCommand):
         recon_job = self.recon_pipeline
         with DagsterInstance.from_ref(self.instance_ref) as instance:
             start_termination_thread(self.term_event)
-            execution_plan = create_execution_plan(
-                job=recon_job,
-                run_config=self.run_config,
-                step_keys_to_execute=[self.step_key],
-                known_state=self.known_state,
-                repository_load_data=self.repository_load_data,
-            )
 
             log_manager = create_context_free_log_manager(instance, self.dagster_run)
 
@@ -94,7 +87,13 @@ class MultiprocessExecutorChildProcessCommand(ChildProcessCommand):
                 },
                 step_key=self.step_key,
             )
-
+            execution_plan = create_execution_plan(
+                job=recon_job,
+                run_config=self.run_config,
+                step_keys_to_execute=[self.step_key],
+                known_state=self.known_state,
+                repository_load_data=self.repository_load_data,
+            )
             yield from execute_plan_iterator(
                 execution_plan,
                 recon_job,


### PR DESCRIPTION
to align with other executors
https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/_cli/api.py#L376

I uesd the name of the event to guide which way to move things to consolidate. The event now emits as close to the start of the process as reasonable.

## How I Tested These Changes

existing coverage
