### PR TITLE
[asset backfill] Fix perf regression from modifying AllPartitionsSubset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1269,9 +1269,7 @@ class AllPartitionsSubset(
         )
 
     def __and__(self, other: "PartitionsSubset") -> "PartitionsSubset":
-        return other.empty_subset(other.partitions_def).with_partition_keys(
-            set(self.get_partition_keys()) & set(other.get_partition_keys())
-        )
+        return other
 
     def __sub__(self, other: "PartitionsSubset") -> "PartitionsSubset":
         if self == other:

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -36,7 +36,6 @@ from dagster._core.definitions.assets_job import is_base_asset_job_name
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition import (
-    AllPartitionsSubset,
     PartitionsDefinition,
     PartitionsSubset,
 )
@@ -799,10 +798,9 @@ def _check_target_partitions_subset_is_valid(
         else:
             # Check that all target partitions still exist. If so, the backfill can continue.a
             existent_partitions_subset = (
-                AllPartitionsSubset(
-                    partitions_def,
-                    dynamic_partitions_store=instance_queryer,
+                partitions_def.subset_with_all_partitions(
                     current_time=instance_queryer.evaluation_time,
+                    dynamic_partitions_store=instance_queryer,
                 )
                 & target_partitions_subset
             )


### PR DESCRIPTION
Modifying `AllPartitionsSubset` to fetch partition keys caused perf regressions in auto-materialize.

This change was previously used in asset backfills to check if all keys in a subset were valid. For now changing asset backfill implementation to just fetch the valid partition keys.