### PR TITLE
Add a field on K8sRunLauncher that lets you lock down which raw k8s config fields can be set via config outside of the instance

### DIFF
--- a/python_modules/dagster/dagster/_core/utils.py
+++ b/python_modules/dagster/dagster/_core/utils.py
@@ -115,6 +115,13 @@ def check_dagster_package_version(library_name: str, library_version: str) -> No
             warnings.warn(message)
 
 
+def get_env_var_name(env_var_str: str):
+    if "=" in env_var_str:
+        return env_var_str.split("=", maxsplit=1)[0]
+    else:
+        return env_var_str
+
+
 def parse_env_var(env_var_str: str) -> Tuple[str, str]:
     if "=" in env_var_str:
         split = env_var_str.split("=", maxsplit=1)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -12,6 +12,7 @@ from dagster import (
     BoolSource,
     Enum as DagsterEnum,
     Field,
+    Map,
     Noneable,
     StringSource,
 )
@@ -446,6 +447,38 @@ class DagsterK8sJobConfig(
                     description="Raw Kubernetes configuration for launched runs.",
                 ),
                 "job_namespace": Field(StringSource, is_required=False, default_value="default"),
+                "only_allow_user_defined_k8s_config_fields": Field(
+                    Shape(
+                        {
+                            "container_config": Field(
+                                Map(key_type=str, inner_type=bool), is_required=False
+                            ),
+                            "pod_spec_config": Field(
+                                Map(key_type=str, inner_type=bool), is_required=False
+                            ),
+                            "pod_template_spec_metadata": Field(
+                                Map(key_type=str, inner_type=bool), is_required=False
+                            ),
+                            "job_metadata": Field(
+                                Map(key_type=str, inner_type=bool), is_required=False
+                            ),
+                            "job_spec_config": Field(
+                                Map(key_type=str, inner_type=bool), is_required=False
+                            ),
+                        }
+                    ),
+                    is_required=False,
+                    description="Dictionary of fields that are allowed to be configured on a "
+                    "per-run or per-code-location basis - e.g. using tags on the run. "
+                    "Can be used to prevent user code from being able to set arbitrary kubernetes "
+                    "config on the pods launched by the run launcher.",
+                ),
+                "only_allow_user_defined_env_vars": Field(
+                    Array(str),
+                    is_required=False,
+                    description="List of environment variable names that are allowed to be set on "
+                    "a per-run or per-code-location basis - e.g. using tags on the run. ",
+                ),
             },
         )
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -67,6 +67,8 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         scheduler_name=None,
         security_context=None,
         run_k8s_config=None,
+        only_allow_user_defined_k8s_config_fields=None,
+        only_allow_user_defined_env_vars=None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.job_namespace = check.str_param(job_namespace, "job_namespace")
@@ -118,6 +120,9 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         self._scheduler_name = check.opt_str_param(scheduler_name, "scheduler_name")
         self._security_context = check.opt_dict_param(security_context, "security_context")
         self._run_k8s_config = check.opt_dict_param(run_k8s_config, "run_k8s_config")
+
+        self._only_allow_user_defined_k8s_config_fields = only_allow_user_defined_k8s_config_fields
+        self._only_allow_user_defined_env_vars = only_allow_user_defined_env_vars
         super().__init__()
 
     @property
@@ -179,6 +184,14 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
     @property
     def fail_pod_on_run_failure(self) -> Optional[bool]:
         return self._fail_pod_on_run_failure
+
+    @property
+    def only_allow_user_defined_k8s_config_fields(self) -> Optional[Mapping[str, Any]]:
+        return self._only_allow_user_defined_k8s_config_fields
+
+    @property
+    def only_allow_user_defined_env_vars(self) -> Optional[Sequence[str]]:
+        return self._only_allow_user_defined_env_vars
 
     @classmethod
     def config_type(cls):

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/models.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/models.py
@@ -100,7 +100,7 @@ def _k8s_snake_case_value(val: Any, attr_type: str, attr_name: str) -> Any:
             return k8s_snake_case_dict(klass, val)
 
 
-def k8s_snake_case_dict(model_class: Type[Any], model_dict: Mapping[str, Any]) -> Mapping[str, Any]:
+def k8s_snake_case_keys(model_class, model_dict: Mapping[str, Any]) -> Mapping[str, Any]:
     snake_case_to_camel_case = model_class.attribute_map
     camel_case_to_snake_case = dict((v, k) for k, v in snake_case_to_camel_case.items())
 
@@ -120,6 +120,12 @@ def k8s_snake_case_dict(model_class: Type[Any], model_dict: Mapping[str, Any]) -
 
     if len(invalid_keys):
         raise Exception(f"Unexpected keys in model class {model_class.__name__}: {invalid_keys}")
+
+    return snake_case_dict
+
+
+def k8s_snake_case_dict(model_class: Type[Any], model_dict: Mapping[str, Any]) -> Mapping[str, Any]:
+    snake_case_dict = k8s_snake_case_keys(model_class, model_dict)
 
     final_dict = {}
     for key, val in snake_case_dict.items():


### PR DESCRIPTION
Summary:
Sending this out for any feedback on the top-level API before I harden it / add lots of tests / etc.

Right now you can set tags on runs (or container context on user code deployments) that allow runs to be created with more or less arbitrary k8s configuration.
Orgs that want to lock that down so that runs can e.g. only vary the resources can use this field on K8sRunLauncher to specify an allowlist of configurable fields.

Similarly, if you want to allow some env vars but not allow arbitrary env vars (like, say, PATH) to be set remotely via tags, supply a list of env var names that are allowed to come from the outside world.

## Summary & Motivation

## How I Tested These Changes
