### PR TITLE
Extract run concurrency content to be reused by cloud concurrency page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -9,7 +9,6 @@ export const DAGSTER_FLAGS_KEY = 'DAGSTER_FLAGS';
 export const FeatureFlag = {
   flagDebugConsoleLogging: 'flagDebugConsoleLogging' as const,
   flagDisableWebsockets: 'flagDisableWebsockets' as const,
-  flagInstanceConcurrencyLimits: 'flagInstanceConcurrencyLimits' as const,
   flagSensorScheduleLogging: 'flagSensorScheduleLogging' as const,
   flagSidebarResources: 'flagSidebarResources' as const,
   flagDisableAutoLoadDefaults: 'flagDisableAutoLoadDefaults' as const,

--- a/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
@@ -30,10 +30,6 @@ export const getVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagSensorScheduleLogging,
   },
   {
-    key: 'Experimental instance-level concurrency limits',
-    flagType: FeatureFlag.flagInstanceConcurrencyLimits,
-  },
-  {
     key: 'Display resources in navigation sidebar',
     flagType: FeatureFlag.flagSidebarResources,
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceTabs.tsx
@@ -22,7 +22,6 @@ export const InstanceTabs = <TData extends Record<string, any>>(props: Props<TDa
 
   const {healthTitle} = React.useContext(InstancePageContext);
   const canSeeConfig = useCanSeeConfig();
-  const {flagInstanceConcurrencyLimits} = useFeatureFlags();
 
   return (
     <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
@@ -34,7 +33,7 @@ export const InstanceTabs = <TData extends Record<string, any>>(props: Props<TDa
           icon={<WorkspaceStatus placeholder={false} />}
         />
         <TabLink id="health" title={healthTitle} to="/health" icon={<InstanceWarningIcon />} />
-        {canSeeConfig && flagInstanceConcurrencyLimits ? (
+        {canSeeConfig ? (
           <TabLink id="concurrency" title="Concurrency limits" to="/concurrency" />
         ) : null}
         {canSeeConfig ? <TabLink id="config" title="Configuration" to="/config" /> : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceTabs.tsx
@@ -2,7 +2,6 @@ import {QueryResult} from '@apollo/client';
 import {Box, Tabs} from '@dagster-io/ui-components';
 import * as React from 'react';
 
-import {useFeatureFlags} from '../app/Flags';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {InstanceWarningIcon} from '../nav/InstanceWarningIcon';
 import {WorkspaceStatus} from '../nav/WorkspaceStatus';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunConfigDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunConfigDialog.tsx
@@ -19,7 +19,6 @@ import styled from 'styled-components';
 
 import {AppContext} from '../app/AppContext';
 import {showSharedToaster} from '../app/DomUtils';
-import {useFeatureFlags} from '../app/Flags';
 import {useCopyToClipboard} from '../app/browser';
 import {FREE_CONCURRENCY_SLOTS_MUTATION} from '../instance/InstanceConcurrency';
 import {
@@ -41,7 +40,6 @@ type VisibleDialog = 'config' | 'delete' | 'terminate' | 'free_slots' | null;
 
 export const RunConfigDialog = ({run, isJob}: {run: RunFragment; isJob: boolean}) => {
   const {runConfigYaml} = run;
-  const {flagInstanceConcurrencyLimits} = useFeatureFlags();
   const [visibleDialog, setVisibleDialog] = React.useState<VisibleDialog>(null);
 
   const {rootServerURI} = React.useContext(AppContext);
@@ -115,9 +113,7 @@ export const RunConfigDialog = ({run, isJob}: {run: RunFragment; isJob: boolean}
                   onClick={() => window.open(`${rootServerURI}/download_debug/${run.id}`)}
                 />
               </Tooltip>
-              {flagInstanceConcurrencyLimits &&
-              run.hasConcurrencyKeySlots &&
-              doneStatuses.has(run.status) ? (
+              {run.hasConcurrencyKeySlots && doneStatuses.has(run.status) ? (
                 <MenuItem
                   text="Free concurrency slots"
                   icon={<Icon name="lock" />}


### PR DESCRIPTION
## Summary & Motivation
Main changes improving the concurrency page:
* Removes the feature flagging, since we show the experimental tag on the global op concurrency content anyway
* Exports the RunConcurrencyContent component, to be reused in Cloud
* Sorts the concurrency limit rows by key (so things don't shift around)

Also changed the style of the buttons to show up in the header and took off the primary intent.

<img width="1904" alt="Screen Shot 2023-12-01 at 9 33 29 AM" src="https://github.com/dagster-io/dagster/assets/1040172/3d95e670-189e-4f8a-ba44-17f233d86f64">


## How I Tested These Changes
Rendered in OSS, and in Cloud