### PR TITLE
[dagster-databricks] Fix polling code to handle null API response

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/types.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/types.py
@@ -49,14 +49,14 @@ class DatabricksRunState(NamedTuple):
 
     def has_terminated(self) -> bool:
         """Has the job terminated?"""
-        return self.life_cycle_state.has_terminated()  # type: ignore  # (possible none)
+        return self.life_cycle_state is not None and self.life_cycle_state.has_terminated()
 
     def is_skipped(self) -> bool:
-        return self.life_cycle_state.is_skipped()  # type: ignore  # (possible none)
+        return self.life_cycle_state is not None and self.life_cycle_state.is_skipped()
 
     def is_successful(self) -> bool:
         """Was the job successful?"""
-        return bool(self.result_state and self.result_state.is_successful())
+        return self.result_state is not None and self.result_state.is_successful()
 
     @classmethod
     def from_databricks(cls, run_state: jobs.RunState) -> "DatabricksRunState":


### PR DESCRIPTION
## Summary & Motivation

The Databricks API can sometimes return a null for `RunState.life_cycle_state`. Our best hypothesis is that this occurs if a job is queued, which will happen when one is over the concurrency limit. See: https://dagsterlabs.slack.com/archives/C05HE0RG8SU/p1701401715458069

This PR changes our polling code to assume that if a `life_cycle_state` is null, we should keep polling. Previously it would crash.

## How I Tested These Changes

BK
