### PR TITLE
[auto-materialize][perf] Dont fetch run tags so much

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -169,6 +169,10 @@ class AssetDaemonContext:
     def respect_materialization_data_versions(self) -> bool:
         return self._respect_materialization_data_versions
 
+    @property
+    def auto_materialize_run_tags(self) -> Mapping[str, str]:
+        return self._materialize_run_tags or {}
+
     def prefetch(self) -> None:
         """Pre-populate the cached values here to avoid situations in which the new latest_storage_id
         value is calculated using information that comes in after the set of asset partitions with
@@ -494,7 +498,7 @@ class AssetDaemonContext:
             *build_run_requests(
                 asset_partitions=to_materialize,
                 asset_graph=self.asset_graph,
-                run_tags=self._materialize_run_tags,
+                run_tags=self.auto_materialize_run_tags,
             ),
             *auto_observe_run_requests,
         ]

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -97,10 +97,7 @@ class RuleEvaluationContext:
 
     @property
     def auto_materialize_run_tags(self) -> Mapping[str, str]:
-        return {
-            AUTO_MATERIALIZE_TAG: "true",
-            **self.instance_queryer.instance.auto_materialize_run_tags,
-        }
+        return self.daemon_context.auto_materialize_run_tags
 
     @functools.cached_property
     def previous_tick_requested_or_discarded_subset(self) -> AssetSubset:
@@ -701,7 +698,10 @@ class AutoMaterializeAssetPartitionsFilter(
             for asset_partition in run_id_asset_partitions
         }
 
-        if self.latest_run_required_tags.items() <= context.auto_materialize_run_tags.items():
+        if (
+            self.latest_run_required_tags.items()
+            <= {AUTO_MATERIALIZE_TAG: "true", **context.auto_materialize_run_tags}.items()
+        ):
             return will_update_asset_partitions | updated_partitions_with_required_tags
         else:
             return updated_partitions_with_required_tags


### PR DESCRIPTION
## Summary & Motivation

It is not actually free to fetch this information from the instance in a cloud environment. Luckily, we already initialize the outer context with this information, so we can just use that.

## How I Tested These Changes
