### PR TITLE
[pipes] warn on discarded reported results

### DIFF
--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -75,7 +75,7 @@ class PipesClientCompletedInvocation:
 
         Returns: Sequence[PipesExecutionResult]
         """
-        return self._session.get_results(implicit_materializations=implicit_materializations)
+        return tuple(self._session.get_results(implicit_materializations=implicit_materializations))
 
     def get_materialize_result(
         self,


### PR DESCRIPTION
inspired by https://github.com/dagster-io/dagster/pull/18388#pullrequestreview-1757308150

add a hook to warn users if they did not consume information reported via pipes in the orchestration process 

## How I Tested These Changes

added test
