### PR TITLE
[ui] Use tick ID for runs requested dialog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/InstigationUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/InstigationUtils.tsx
@@ -110,6 +110,7 @@ export const DYNAMIC_PARTITIONS_REQUEST_RESULT_FRAGMENT = gql`
 export const HISTORY_TICK_FRAGMENT = gql`
   fragment HistoryTick on InstigationTick {
     id
+    tickId
     status
     timestamp
     endTimestamp

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
@@ -34,17 +34,15 @@ import {HISTORY_TICK_FRAGMENT} from './InstigationUtils';
 import {HistoryTickFragment} from './types/InstigationUtils.types';
 import {SelectedTickQuery, SelectedTickQueryVariables} from './types/TickDetailsDialog.types';
 
-type Props = {
-  timestamp: number | undefined;
-  instigationSelector: InstigationSelector;
+interface DialogProps extends InnerProps {
   onClose: () => void;
   isOpen: boolean;
-};
+}
 
-export const TickDetailsDialog = ({timestamp, isOpen, instigationSelector, onClose}: Props) => {
+export const TickDetailsDialog = ({tickId, isOpen, instigationSelector, onClose}: DialogProps) => {
   return (
     <Dialog isOpen={isOpen} onClose={onClose} style={{width: '90vw'}}>
-      <TickDetailsDialogImpl timestamp={timestamp} instigationSelector={instigationSelector} />
+      <TickDetailsDialogImpl tickId={tickId} instigationSelector={instigationSelector} />
       <DialogFooter>
         <Button onClick={onClose}>Close</Button>
       </DialogFooter>
@@ -52,13 +50,15 @@ export const TickDetailsDialog = ({timestamp, isOpen, instigationSelector, onClo
   );
 };
 
-const TickDetailsDialogImpl = ({
-  timestamp,
-  instigationSelector,
-}: Omit<Props, 'isOpen' | 'onClose'>) => {
+interface InnerProps {
+  tickId: number | undefined;
+  instigationSelector: InstigationSelector;
+}
+
+const TickDetailsDialogImpl = ({tickId, instigationSelector}: InnerProps) => {
   const {data} = useQuery<SelectedTickQuery, SelectedTickQueryVariables>(JOB_SELECTED_TICK_QUERY, {
-    variables: {instigationSelector, timestamp: timestamp || 0},
-    skip: !timestamp,
+    variables: {instigationSelector, tickId: tickId || 0},
+    skip: !tickId,
   });
 
   const tick =
@@ -195,7 +195,7 @@ export function TickDetailSummary({tick}: {tick: HistoryTickFragment | AssetDaem
           <div>
             {tick?.endTimestamp
               ? formatElapsedTime(tick.endTimestamp * 1000 - tick.timestamp * 1000)
-              : '–'}
+              : '\u2013'}
           </div>
         </Box>
       </div>
@@ -208,7 +208,7 @@ function PartitionsTable({partitions}: {partitions: DynamicPartitionsRequestResu
     <Table>
       <thead>
         <tr>
-          <th>Partition Definition</th>
+          <th>Partition definition</th>
           <th>Partition</th>
         </tr>
       </thead>
@@ -232,11 +232,11 @@ function PartitionsTable({partitions}: {partitions: DynamicPartitionsRequestResu
 }
 
 const JOB_SELECTED_TICK_QUERY = gql`
-  query SelectedTickQuery($instigationSelector: InstigationSelector!, $timestamp: Float!) {
+  query SelectedTickQuery($instigationSelector: InstigationSelector!, $tickId: Int!) {
     instigationStateOrError(instigationSelector: $instigationSelector) {
       ... on InstigationState {
         id
-        tick(timestamp: $timestamp) {
+        tick(tickId: $tickId) {
           id
           ...HistoryTick
         }

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -293,9 +293,9 @@ export const TickHistoryTimeline = ({
   afterTimestamp?: number;
   statuses?: InstigationTickStatus[];
 }) => {
-  const [selectedTime, setSelectedTime] = useQueryPersistedState<number | undefined>({
-    encode: (timestamp) => ({time: timestamp}),
-    decode: (qs) => (qs['time'] ? Number(qs['time']) : undefined),
+  const [selectedTickId, setSelectedTickId] = useQueryPersistedState<number | undefined>({
+    encode: (tickId) => ({tickId}),
+    decode: (qs) => (qs['tickId'] ? Number(qs['tickId']) : undefined),
   });
 
   const [pollingPaused, pausePolling] = React.useState<boolean>(false);
@@ -347,8 +347,9 @@ export const TickHistoryTimeline = ({
   const {ticks = []} = data.instigationStateOrError;
 
   const onTickClick = (tick?: InstigationTick) => {
-    setSelectedTime(tick ? tick.timestamp : undefined);
+    setSelectedTickId(tick ? Number(tick.id) : undefined);
   };
+
   const onTickHover = (tick?: InstigationTick) => {
     if (!tick) {
       pausePolling(false);
@@ -361,8 +362,8 @@ export const TickHistoryTimeline = ({
   return (
     <>
       <TickDetailsDialog
-        isOpen={!!selectedTime}
-        timestamp={selectedTime}
+        isOpen={!!selectedTickId}
+        tickId={selectedTickId}
         instigationSelector={instigationSelector}
         onClose={() => onTickClick(undefined)}
       />
@@ -493,7 +494,7 @@ function TickRow({
             ) : null}
             <TickDetailsDialog
               isOpen={showResults}
-              timestamp={tick.timestamp}
+              tickId={Number(tick.tickId)}
               instigationSelector={instigationSelector}
               onClose={() => {
                 setShowResults(false);

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/types/InstigationUtils.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/types/InstigationUtils.types.ts
@@ -61,6 +61,7 @@ export type DynamicPartitionsRequestResultFragment = {
 export type HistoryTickFragment = {
   __typename: 'InstigationTick';
   id: string;
+  tickId: string;
   status: Types.InstigationTickStatus;
   timestamp: number;
   endTimestamp: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/types/TickDetailsDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/types/TickDetailsDialog.types.ts
@@ -4,7 +4,7 @@ import * as Types from '../../graphql/types';
 
 export type SelectedTickQueryVariables = Types.Exact<{
   instigationSelector: Types.InstigationSelector;
-  timestamp: Types.Scalars['Float'];
+  tickId: Types.Scalars['Int'];
 }>;
 
 export type SelectedTickQuery = {
@@ -16,6 +16,7 @@ export type SelectedTickQuery = {
         tick: {
           __typename: 'InstigationTick';
           id: string;
+          tickId: string;
           status: Types.InstigationTickStatus;
           timestamp: number;
           endTimestamp: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/types/TickHistory.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/types/TickHistory.types.ts
@@ -22,6 +22,7 @@ export type TickHistoryQuery = {
         ticks: Array<{
           __typename: 'InstigationTick';
           id: string;
+          tickId: string;
           status: Types.InstigationTickStatus;
           timestamp: number;
           endTimestamp: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/TickLogDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/TickLogDialog.tsx
@@ -30,7 +30,7 @@ export const TickLogDialog = ({
   onClose: () => void;
 }) => {
   const {data} = useQuery<TickLogEventsQuery, TickLogEventsQueryVariables>(TICK_LOG_EVENTS_QUERY, {
-    variables: {instigationSelector, timestamp: tick.timestamp},
+    variables: {instigationSelector, tickId: Number(tick.tickId)},
     notifyOnNetworkStatusChange: true,
   });
 
@@ -118,11 +118,11 @@ const TickLogRow = ({event}: {event: TickLogEventFragment}) => {
 };
 
 const TICK_LOG_EVENTS_QUERY = gql`
-  query TickLogEventsQuery($instigationSelector: InstigationSelector!, $timestamp: Float!) {
+  query TickLogEventsQuery($instigationSelector: InstigationSelector!, $tickId: Int!) {
     instigationStateOrError(instigationSelector: $instigationSelector) {
       ... on InstigationState {
         id
-        tick(timestamp: $timestamp) {
+        tick(tickId: $tickId) {
           id
           status
           timestamp

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/types/TickLogDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/types/TickLogDialog.types.ts
@@ -4,7 +4,7 @@ import * as Types from '../../graphql/types';
 
 export type TickLogEventsQueryVariables = Types.Exact<{
   instigationSelector: Types.InstigationSelector;
-  timestamp: Types.Scalars['Float'];
+  tickId: Types.Scalars['Int'];
 }>;
 
 export type TickLogEventsQuery = {


### PR DESCRIPTION
## Summary & Motivation

Instead of using a timestamp to retrieve a tick, use the `tickId`. This will allow us to open the tick details from a Run.

## How I Tested These Changes

View Sensor ticks, click to open the requested runs for the tick. Verify success.
