### PR TITLE
Fix IdentityPartitionMapping perf optimization

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -122,7 +122,7 @@ class IdentityPartitionMapping(PartitionMapping, NamedTuple("_IdentityPartitionM
         if downstream_partitions_subset is None:
             check.failed("downstream asset is not partitioned")
 
-        if downstream_partitions_subset.partitions_def == upstream_partitions_def:
+        if downstream_partitions_def == upstream_partitions_def:
             return UpstreamPartitionsResult(downstream_partitions_subset, [])
 
         upstream_partition_keys = set(
@@ -150,7 +150,7 @@ class IdentityPartitionMapping(PartitionMapping, NamedTuple("_IdentityPartitionM
         if upstream_partitions_subset is None:
             check.failed("upstream asset is not partitioned")
 
-        if upstream_partitions_subset.partitions_def == downstream_partitions_def:
+        if upstream_partitions_def == downstream_partitions_def:
             return upstream_partitions_subset
 
         upstream_partition_keys = set(upstream_partitions_subset.get_partition_keys())


### PR DESCRIPTION
## Summary & Motivation
https://github.com/dagster-io/dagster/pull/17703 removed partitions_def from DefaultPartitionMapping, which these optimizations were relying on existing.

We should probably remove that field from the base class now that it is no longer reliably there and is only available on time based partition mapping - but that is out of scope for this fix

## How I Tested These Changes
Dry run for an asset graph involving multi-partitions finishes quickly again