### PR TITLE
fix: path traversal in logs endpoint

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -198,12 +198,6 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
         else:
             location = compute_log_manager.get_captured_local_path(log_key, file_extension)
 
-        if location:
-            location = path.abspath(location)
-
-            if not location.startswith(compute_log_manager._base_dir):
-                raise HTTPException(403, detail="Invalid path")
-
         if not location or not path.exists(location):
             raise HTTPException(404, detail="No log files available for download")
 

--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -198,6 +198,12 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
         else:
             location = compute_log_manager.get_captured_local_path(log_key, file_extension)
 
+        if location:
+            location = path.abspath(location)
+
+            if not location.startswith(compute_log_manager._base_dir):
+                raise HTTPException(403, detail="Invalid path")
+
         if not location or not path.exists(location):
             raise HTTPException(404, detail="No log files available for download")
 

--- a/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_app.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_app.py
@@ -289,3 +289,13 @@ def test_async(test_client: TestClient):
     result = response.json()
     assert result["data"]["test"]["one"] == "slept", result
     assert result["data"]["test"]["two"] == "slept concurrently", result
+
+
+def test_download_captured_logs_not_found(test_client: TestClient):
+    response = test_client.get("/logs/does-not-exist/stdout")
+    assert response.status_code == 404
+
+
+def test_download_captured_logs_forbidden(test_client: TestClient):
+    response = test_client.get("/logs/%2e%2e/secret/txt")
+    assert response.status_code == 403

--- a/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_app.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_app.py
@@ -296,6 +296,6 @@ def test_download_captured_logs_not_found(test_client: TestClient):
     assert response.status_code == 404
 
 
-def test_download_captured_logs_forbidden(test_client: TestClient):
-    response = test_client.get("/logs/%2e%2e/secret/txt")
-    assert response.status_code == 403
+def test_download_captured_logs_invalid_path(test_client: TestClient):
+    with pytest.raises(ValueError, match="Invalid path"):
+        test_client.get("/logs/%2e%2e/secret/txt")

--- a/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
@@ -226,7 +226,11 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
             filename = f"{filename}.partial"
         if len(filename) > MAX_FILENAME_LENGTH:
             filename = "{}.{}".format(hashlib.md5(filebase.encode("utf-8")).hexdigest(), extension)
-        return os.path.join(self._base_dir, *namespace, filename)
+        location = os.path.join(self._base_dir, *namespace, filename)
+        location = os.path.abspath(location)
+        if not location.startswith(self._base_dir):
+            raise ValueError("Invalid path")
+        return location
 
     def subscribe(
         self, log_key: Sequence[str], cursor: Optional[str] = None


### PR DESCRIPTION
## Summary & Motivation

Its currently possible to read arbitrary files with the `/logs` endpoint in `dagster-webserver`. The only restriction is that the filename must contain a "dot".

For example, this cURL invocation allows me to read my `.bash_history` file when running `dagster-webserver` locally:

```
curl -vvv -X GET 'http://localhost:3333/logs/%2e%2e/%2e%2e/%2e%2e/%2e%2e//bash_history'
```

The proposed fix calls `os.path.abspath` [1] on paths constructed in`get_captured_local_path`. If the normalized path does not start with the logs dir, a `ValueError` is raised.

[1] https://docs.python.org/3/library/os.path.html#os.path.abspath

## How I Tested These Changes

See added unit tests