### PR TITLE
[ui] Make "Remove all" launchpad tab sticky

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadTabs.tsx
@@ -4,6 +4,7 @@ import {
   colorAccentGray,
   colorAccentPrimary,
   colorAccentPrimaryHover,
+  colorBackgroundDefault,
   colorBackgroundLight,
   colorBackgroundLighter,
   colorTextLight,
@@ -158,15 +159,22 @@ export const LaunchpadTabs = (props: LaunchpadTabsProps) => {
         ))}
         <LaunchpadTab title="+ Add..." onClick={onCreate} />
         {sessionKeys.length > REMOVE_ALL_THRESHOLD ? (
-          <ButtonLink color={colorTextRed()} onClick={onRemoveAll}>
-            <Box
-              flex={{direction: 'row', gap: 4, alignItems: 'center'}}
-              style={{whiteSpace: 'nowrap'}}
-            >
-              <Icon name="delete" color={colorTextRed()} />
-              <div>Remove all</div>
-            </Box>
-          </ButtonLink>
+          <Box
+            background={colorBackgroundDefault()}
+            padding={{top: 8, left: 8, right: 12}}
+            border="bottom"
+            style={{position: 'sticky', right: 0}}
+          >
+            <ButtonLink color={colorTextRed()} onClick={onRemoveAll}>
+              <Box
+                flex={{direction: 'row', gap: 4, alignItems: 'center'}}
+                style={{whiteSpace: 'nowrap'}}
+              >
+                <Icon name="delete" color={colorTextRed()} />
+                <div>Remove all</div>
+              </Box>
+            </ButtonLink>
+          </Box>
         ) : null}
       </LaunchpadTabsContainer>
     </Box>
@@ -182,6 +190,10 @@ const LaunchpadTabsContainer = styled.div`
   flex-direction: row;
   padding-left: 12px;
   overflow-x: auto;
+
+  ::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
+  }
 `;
 
 const TabContainer = styled.div<{$active: boolean}>`


### PR DESCRIPTION
## Summary & Motivation

Resolves https://github.com/dagster-io/dagster/issues/18433.

When there are a lot of tabs on a launchpad, the "Remove all" is unhelpfully pushed off the viewport.

Make the button sticky so that it's always visible even when there is a large number of tabs.

<img width="1158" alt="Screenshot 2023-12-04 at 10 24 46 AM" src="https://github.com/dagster-io/dagster/assets/2823852/00561ce3-0542-4b26-a0d6-1e8d2e43a75b">
<img width="1159" alt="Screenshot 2023-12-04 at 10 24 33 AM" src="https://github.com/dagster-io/dagster/assets/2823852/afe5a26c-db29-49b6-bb74-b1475a593e60">


## How I Tested These Changes

View Launchpad for a job, add tons of tabs. Verify that the "Remove all" tab remains sticky and visible, and that I can still scroll the tab container.

Remove tabs, verify that the "Remove all" tab moves with the tabs and does not remain rooted to the viewport edge.
