### PR TITLE
refactor(instigation-backlink): remove timestamp as query parameter for tick

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2415,7 +2415,7 @@ type InstigationState {
   typeSpecificData: InstigationTypeSpecificData
   runs(limit: Int): [Run!]!
   runsCount: Int!
-  tick(timestamp: Float, tickId: Int): InstigationTick
+  tick(tickId: Int!): InstigationTick!
   ticks(
     dayRange: Int
     dayOffset: Int

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -1550,7 +1550,7 @@ export type InstigationState = {
   runsCount: Scalars['Int'];
   selectorId: Scalars['String'];
   status: InstigationStatus;
-  tick: Maybe<InstigationTick>;
+  tick: InstigationTick;
   ticks: Array<InstigationTick>;
   typeSpecificData: Maybe<InstigationTypeSpecificData>;
 };
@@ -1560,8 +1560,7 @@ export type InstigationStateRunsArgs = {
 };
 
 export type InstigationStateTickArgs = {
-  tickId?: InputMaybe<Scalars['Int']>;
-  timestamp?: InputMaybe<Scalars['Float']>;
+  tickId: Scalars['Int'];
 };
 
 export type InstigationStateTicksArgs = {

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/types/TickDetailsDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/types/TickDetailsDialog.types.ts
@@ -45,7 +45,7 @@ export type SelectedTickQuery = {
             skippedPartitionKeys: Array<string>;
             type: Types.DynamicPartitionsRequestType;
           }>;
-        } | null;
+        };
       }
     | {__typename: 'InstigationStateNotFoundError'}
     | {__typename: 'PythonError'};

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/types/TickLogDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/types/TickLogDialog.types.ts
@@ -27,7 +27,7 @@ export type TickLogEventsQuery = {
               level: Types.LogLevel;
             }>;
           };
-        } | null;
+        };
       }
     | {__typename: 'InstigationStateNotFoundError'}
     | {__typename: 'PythonError'};

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -536,9 +536,8 @@ class GrapheneInstigationState(graphene.ObjectType):
     )
     runsCount = graphene.NonNull(graphene.Int)
     tick = graphene.Field(
-        GrapheneInstigationTick,
-        timestamp=graphene.Float(),
-        tickId=graphene.Int(),
+        graphene.NonNull(GrapheneInstigationTick),
+        tickId=graphene.NonNull(graphene.Int),
     )
     ticks = graphene.Field(
         non_null_list(GrapheneInstigationTick),
@@ -666,25 +665,12 @@ class GrapheneInstigationState(graphene.ObjectType):
     def resolve_tick(
         self,
         graphene_info: ResolveInfo,
-        timestamp: Optional[float] = None,
-        tickId: Optional[int] = None,
-    ):
-        if tickId:
-            schedule_storage = check.not_none(graphene_info.context.instance.schedule_storage)
-            tick = schedule_storage.get_tick(tickId)
+        tickId: int,
+    ) -> GrapheneInstigationTick:
+        schedule_storage = check.not_none(graphene_info.context.instance.schedule_storage)
+        tick = schedule_storage.get_tick(tickId)
 
-            return GrapheneInstigationTick(tick)
-
-        timestamp = check.float_param(timestamp, "timestamp")
-
-        matches = graphene_info.context.instance.get_ticks(
-            self._instigator_state.instigator_origin_id,
-            self._instigator_state.selector_id,
-            before=timestamp + 1,
-            after=timestamp - 1,
-            limit=1,
-        )
-        return GrapheneInstigationTick(matches[0]) if matches else None
+        return GrapheneInstigationTick(tick)
 
     def resolve_ticks(
         self,


### PR DESCRIPTION
## Summary & Motivation
With https://github.com/dagster-io/dagster/pull/18453 landed, no queries pass `$timestamp` as an argument when fetching a single tick. So remove it from the graphql interface. 

## How I Tested These Changes
bk
