### PR TITLE
[ui] Fix a couple of data-tooltip styles

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
@@ -4,7 +4,6 @@ import {
   Icon,
   colorBackgroundLight,
   colorBackgroundLightHover,
-  colorBackgroundLighter,
   colorLineageGroupNodeBorder,
   colorTextLight,
   colorTextLighter,
@@ -95,7 +94,7 @@ export const CollapsedGroupNode = ({
 
 export const GroupNameTooltipStyle = JSON.stringify({
   ...NameTooltipCSS,
-  background: colorBackgroundLighter(),
+  background: colorBackgroundLight(),
   border: `none`,
   borderRadius: '4px',
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/SectionedLeftNav.tsx
@@ -9,7 +9,6 @@ import {
   colorBackgroundGray,
   colorBackgroundLight,
   colorBackgroundLightHover,
-  colorBackgroundLighterHover,
   colorKeylineDefault,
   colorTextDefault,
   colorTextDisabled,
@@ -433,7 +432,7 @@ const ItemRow = (props: ItemRowProps) => {
 };
 
 const CodeLocationTooltipStyles = JSON.stringify({
-  background: colorBackgroundLighterHover(),
+  background: colorBackgroundLightHover(),
   filter: `brightness(97%)`,
   color: colorTextDefault(),
   fontWeight: 500,


### PR DESCRIPTION
## Summary & Motivation

Be sure to use non-translucent colors for data tooltip styles in a couple places.

## How I Tested These Changes

Hover over asset group nodes and left nav code location names.
