### PR TITLE
Remove partitions def field from PartitionsSubset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1,7 +1,7 @@
 import copy
 import hashlib
 import json
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from collections import defaultdict
 from datetime import (
     datetime,
@@ -975,15 +975,15 @@ class PartitionsSubset(ABC, Generic[T_str]):
 
     def __sub__(self, other: "PartitionsSubset") -> "PartitionsSubset[T_str]":
         if self is other:
-            return self.empty_subset(self.partitions_def)
-        return self.empty_subset(self.partitions_def).with_partition_keys(
+            return self.empty_subset()
+        return self.empty_subset().with_partition_keys(
             set(self.get_partition_keys()).difference(set(other.get_partition_keys()))
         )
 
     def __and__(self, other: "PartitionsSubset") -> "PartitionsSubset[T_str]":
         if self is other:
             return self
-        return self.empty_subset(self.partitions_def).with_partition_keys(
+        return self.empty_subset().with_partition_keys(
             set(self.get_partition_keys()) & set(other.get_partition_keys())
         )
 
@@ -1007,10 +1007,6 @@ class PartitionsSubset(ABC, Generic[T_str]):
         serialized_partitions_def_unique_id: Optional[str],
         serialized_partitions_def_class_name: Optional[str],
     ) -> bool:
-        ...
-
-    @abstractproperty
-    def partitions_def(self) -> Optional[PartitionsDefinition[T_str]]:
         ...
 
     @abstractmethod
@@ -1175,10 +1171,6 @@ class DefaultPartitionsSubset(
         return isinstance(data, list) or (
             data.get("subset") is not None and data.get("version") == cls.SERIALIZATION_VERSION
         )
-
-    @property
-    def partitions_def(self) -> Optional[PartitionsDefinition[T_str]]:
-        return None
 
     def __eq__(self, other: object) -> bool:
         return isinstance(other, DefaultPartitionsSubset) and self.subset == other.subset

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1879,6 +1879,25 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
             and self.included_time_windows == other.included_time_windows
         )
 
+    def __or__(self, other: "PartitionsSubset") -> "PartitionsSubset":
+        if self is other:
+            return self
+        return self.with_partition_keys(other.get_partition_keys())
+
+    def __sub__(self, other: "PartitionsSubset") -> "PartitionsSubset":
+        if self is other:
+            return self.empty_subset(self.partitions_def)
+        return self.empty_subset(self.partitions_def).with_partition_keys(
+            set(self.get_partition_keys()).difference(set(other.get_partition_keys()))
+        )
+
+    def __and__(self, other: "PartitionsSubset") -> "PartitionsSubset":
+        if self is other:
+            return self
+        return self.empty_subset(self.partitions_def).with_partition_keys(
+            set(self.get_partition_keys()) & set(other.get_partition_keys())
+        )
+
 
 class PartitionKeysTimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
     """A PartitionsSubset for a TimeWindowPartitionsDefinition, which internally represents the


### PR DESCRIPTION
https://github.com/dagster-io/dagster/pull/18456 fixes optimization breakages caused by the partitions def no longer existing on `DefaultPartitionsSubset`s.

This PR removes the partitions def field in order to prevent future issues like this.