### PR TITLE
[branching io manager][fix] Fix loading partitioned parent assets in BranchingIOManager

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
@@ -70,7 +70,11 @@ class BranchingIOManager(ConfigurableIOManager):
             return self.branch_io_manager.load_input(context)
         else:
             # we are dealing with an asset input
-            partition_key = None
+            partition_key = (
+                context.upstream_output.partition_key
+                if context.upstream_output and context.upstream_output.has_partition_key
+                else None
+            )
             try:
                 partition_key = context.asset_partition_key
             except CheckError:

--- a/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
@@ -71,8 +71,9 @@ class BranchingIOManager(ConfigurableIOManager):
             # we are dealing with an asset input
 
             partition_keys = []
-            if context.has_partition_key:
+            if context.has_asset_partitions:
                 partition_keys = context.asset_partition_keys
+
             if len(partition_keys) == 0:
                 partition_keys = [None]
 

--- a/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional
 
 from dagster import InputContext, OutputContext
+from dagster._check import CheckError
 from dagster._config.pythonic_config import (
     ConfigurableIOManager,
     ResourceDependency,
@@ -69,10 +70,16 @@ class BranchingIOManager(ConfigurableIOManager):
             return self.branch_io_manager.load_input(context)
         else:
             # we are dealing with an asset input
+            partition_key = None
+            try:
+                partition_key = context.asset_partition_key
+            except CheckError:
+                pass
+
             event_log_entry = latest_materialization_log_entry(
                 instance=context.instance,
                 asset_key=context.asset_key,
-                partition_key=context.partition_key if context.has_partition_key else None,
+                partition_key=(partition_key),
             )
             if (
                 event_log_entry

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/test_branching_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/test_branching_io_manager.py
@@ -267,7 +267,12 @@ def test_job_op_usecase() -> Any:
     with DefinitionsRunner.ephemeral(
         Definitions(
             jobs=[now_time_job],
-            resources={"io_manager": AssetBasedInMemoryIOManager()},
+            resources={
+                "io_manager": BranchingIOManager(
+                    parent_io_manager=AssetBasedInMemoryIOManager(),
+                    branch_io_manager=AssetBasedInMemoryIOManager(),
+                )
+            },
         ),
     ) as runner:
         assert (

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
@@ -102,8 +102,15 @@ class AssetBasedInMemoryIOManager(IOManager):
         return self.values.get(self._get_key(AssetKey.from_coercible(asset_key), partition_key))
 
     def _key_from_context(self, context: Union[InputContext, OutputContext]):
+        if not context.has_asset_key:
+            return None
+
         if isinstance(context, InputContext):
-            partition_key = None
+            partition_key = (
+                context.upstream_output.partition_key
+                if context.upstream_output and context.upstream_output.has_partition_key
+                else None
+            )
             try:
                 partition_key = context.asset_partition_key
             except CheckError:
@@ -153,7 +160,11 @@ class ConfigurableAssetBasedInMemoryIOManager(ConfigurableIOManager):
 
     def _key_from_context(self, context: Union[InputContext, OutputContext]):
         if isinstance(context, InputContext):
-            partition_key = None
+            partition_key = (
+                context.upstream_output.partition_key
+                if context.upstream_output and context.upstream_output.has_partition_key
+                else None
+            )
             try:
                 partition_key = context.asset_partition_key
             except CheckError:

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
@@ -10,7 +10,6 @@ from dagster import (
     IOManager,
     OutputContext,
 )
-from dagster._check import CheckError
 from dagster._config.pythonic_config.io_manager import ConfigurableIOManager
 from dagster._core.definitions.events import CoercibleToAssetKey
 from dagster._core.event_api import EventLogRecord, EventRecordsFilter
@@ -86,12 +85,15 @@ class AssetBasedInMemoryIOManager(IOManager):
         self.values = {}
 
     def handle_output(self, context: OutputContext, obj: Any):
-        key = self._key_from_context(context)
-        self.values[key] = obj
+        keys = self._keys_from_context(context)
+        for key in keys:
+            self.values[key] = obj
 
     def load_input(self, context: InputContext) -> Any:
-        key = self._key_from_context(context)
-        return self.values[key]
+        keys = self._keys_from_context(context)
+        return (
+            {key[-1]: self.values[key] for key in keys} if len(keys) > 1 else self.values[keys[0]]
+        )
 
     def has_value(
         self, asset_key: CoercibleToAssetKey, partition_key: Optional[str] = None
@@ -101,24 +103,12 @@ class AssetBasedInMemoryIOManager(IOManager):
     def get_value(self, asset_key: CoercibleToAssetKey, partition_key: Optional[str] = None) -> Any:
         return self.values.get(self._get_key(AssetKey.from_coercible(asset_key), partition_key))
 
-    def _key_from_context(self, context: Union[InputContext, OutputContext]):
+    def _keys_from_context(self, context: Union[InputContext, OutputContext]):
         if not context.has_asset_key:
-            return None
+            return [None]
 
-        if isinstance(context, InputContext):
-            partition_key = (
-                context.upstream_output.partition_key
-                if context.upstream_output and context.upstream_output.has_partition_key
-                else None
-            )
-            try:
-                partition_key = context.asset_partition_key
-            except CheckError:
-                pass
-        else:
-            partition_key = context.partition_key if context.has_partition_key else None
-
-        return self._get_key(context.asset_key, partition_key)
+        partition_keys = context.asset_partition_keys if context.has_asset_partitions else [None]
+        return [self._get_key(context.asset_key, partition_key) for partition_key in partition_keys]
 
     def _get_key(self, asset_key: AssetKey, partition_key: Optional[str]) -> tuple:
         return tuple([*asset_key.path] + [partition_key] if partition_key is not None else [])
@@ -143,12 +133,15 @@ class ConfigurableAssetBasedInMemoryIOManager(ConfigurableIOManager):
         LOG.append(f"teardown_after_execution {self.name}")
 
     def handle_output(self, context: OutputContext, obj: Any):
-        key = self._key_from_context(context)
-        self._values[key] = obj
+        keys = self._keys_from_context(context)
+        for key in keys:
+            self._values[key] = obj
 
     def load_input(self, context: InputContext) -> Any:
-        key = self._key_from_context(context)
-        return self._values[key]
+        keys = self._keys_from_context(context)
+        return (
+            {key[-1]: self._values[key] for key in keys} if len(keys) > 1 else self._values[keys[0]]
+        )
 
     def has_value(
         self, asset_key: CoercibleToAssetKey, partition_key: Optional[str] = None
@@ -158,20 +151,12 @@ class ConfigurableAssetBasedInMemoryIOManager(ConfigurableIOManager):
     def get_value(self, asset_key: CoercibleToAssetKey, partition_key: Optional[str] = None) -> Any:
         return self._values.get(self._get_key(AssetKey.from_coercible(asset_key), partition_key))
 
-    def _key_from_context(self, context: Union[InputContext, OutputContext]):
-        if isinstance(context, InputContext):
-            partition_key = (
-                context.upstream_output.partition_key
-                if context.upstream_output and context.upstream_output.has_partition_key
-                else None
-            )
-            try:
-                partition_key = context.asset_partition_key
-            except CheckError:
-                pass
-        else:
-            partition_key = context.partition_key if context.has_partition_key else None
-        return self._get_key(context.asset_key, partition_key=partition_key)
+    def _keys_from_context(self, context: Union[InputContext, OutputContext]):
+        if not context.has_asset_key:
+            return [None]
+
+        partition_keys = context.asset_partition_keys if context.has_asset_partitions else [None]
+        return [self._get_key(context.asset_key, partition_key) for partition_key in partition_keys]
 
     def _get_key(self, asset_key: AssetKey, partition_key: Optional[str]) -> tuple:
         return tuple([*asset_key.path] + [partition_key] if partition_key is not None else [])


### PR DESCRIPTION
## Summary

Tweak of fix in #17303 which uses the upstream asset partition rather than the current asset partition when using the branching IO manager. Uses `context.asset_partition_key` rather than the upstream output's partition key, which can sometimes be `None` when the upstream output is not available.

## Test Plan

Adds a new unit test with a non-standard partition mapping, which previously failed.