### PR TITLE
Fix #7442 / multi threading dropped log entries issue

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
+++ b/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
@@ -20,6 +20,9 @@ class DispatchingLogHandler(logging.Handler):
     """
 
     def __init__(self, downstream_loggers: List[logging.Logger]):
+        # Setting up a local thread context here to allow the DispatchingLogHandler
+        # to be used in multi threading environments where the handler is called by
+        # different threads with different log messages in parallel.
         self._local_thread_context = threading.local()
         self._local_thread_context.should_capture = True
         self._downstream_loggers = [*downstream_loggers]
@@ -27,6 +30,9 @@ class DispatchingLogHandler(logging.Handler):
 
     def filter(self, record: logging.LogRecord) -> bool:
         if not hasattr(self._local_thread_context, "should_capture"):
+            # Since only the "main" thread gets an initialized
+            # "_local_thread_context.should_capture" variable  through the __init__()
+            # we need to set a default value for all other threads here.
             self._local_thread_context.should_capture = True
         return self._local_thread_context.should_capture
 

--- a/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
+++ b/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
@@ -20,24 +20,24 @@ class DispatchingLogHandler(logging.Handler):
     """
 
     def __init__(self, downstream_loggers: List[logging.Logger]):
-        self.local_thread_context = threading.local()
-        self.local_thread_context._should_capture = True
+        self._local_thread_context = threading.local()
+        self._local_thread_context.should_capture = True
         self._downstream_loggers = [*downstream_loggers]
         super().__init__()
 
     def filter(self, record: logging.LogRecord) -> bool:
-        if not hasattr(self.local_thread_context, "_should_capture"):
-            self.local_thread_context._should_capture = True
-        return self.local_thread_context._should_capture
+        if not hasattr(self._local_thread_context, "should_capture"):
+            self._local_thread_context.should_capture = True
+        return self._local_thread_context.should_capture
 
     def emit(self, record: logging.LogRecord):
         """For any received record, add metadata, and have handlers handle it."""
         try:
-            self.local_thread_context._should_capture = False
+            self._local_thread_context.should_capture = False
             for logger in self._downstream_loggers:
                 logger.handle(record)
         finally:
-            self.local_thread_context._should_capture = True
+            self._local_thread_context.should_capture = True
 
 
 class CapturedLogHandler(logging.Handler):

--- a/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
+++ b/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
@@ -31,7 +31,7 @@ class DispatchingLogHandler(logging.Handler):
     def filter(self, record: logging.LogRecord) -> bool:
         if not hasattr(self._local_thread_context, "should_capture"):
             # Since only the "main" thread gets an initialized
-            # "_local_thread_context.should_capture" variable  through the __init__()
+            # "_local_thread_context.should_capture" variable through the __init__()
             # we need to set a default value for all other threads here.
             self._local_thread_context.should_capture = True
         return self._local_thread_context.should_capture

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -216,6 +216,9 @@ class DagsterLogHandler(logging.Handler):
         self._logging_metadata = logging_metadata
         self._loggers = loggers
         self._handlers = handlers
+        # Setting up a local thread context here to allow the DispatchingLogHandler
+        # to be used in multi threading environments where the handler is called by
+        # different threads with different log messages in parallel.
         self._local_thread_context = threading.local()
         self._local_thread_context.should_capture = True
         super().__init__()
@@ -273,6 +276,9 @@ class DagsterLogHandler(logging.Handler):
         the message is propagated. This filter prevents this from happening.
         """
         if not hasattr(self._local_thread_context, "should_capture"):
+            # Since only the "main" thread gets an initialized
+            # "_local_thread_context.should_capture" variable through the __init__()
+            # we need to set a default value for all other threads here.
             self._local_thread_context.should_capture = True
 
         return self._local_thread_context.should_capture and not isinstance(

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -216,7 +216,7 @@ class DagsterLogHandler(logging.Handler):
         self._logging_metadata = logging_metadata
         self._loggers = loggers
         self._handlers = handlers
-        # Setting up a local thread context here to allow the DispatchingLogHandler
+        # Setting up a local thread context here to allow the DagsterLogHandler
         # to be used in multi threading environments where the handler is called by
         # different threads with different log messages in parallel.
         self._local_thread_context = threading.local()

--- a/python_modules/dagster/dagster_tests/logging_tests/test_logging.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_logging.py
@@ -494,7 +494,7 @@ def test_python_multithread_context_logging():
 
     relevant_logs = [log for log in logs if "Background thread: " in log.user_message]
 
-    # We would expect 4 log messages per our 4 threads
+    # We would expect 3 log messages per our 4 threads
     assert len(relevant_logs) == 3 * 4
 
 


### PR DESCRIPTION
## Summary & Motivation

This MR should (based on my code understanding and testing) fix [issue 7442](https://github.com/dagster-io/dagster/issues/7442). It also fixes in general randomly dropped user written log messages if logs are being recorded from multiple threads. 
Logging is quite important and its quite annoying to work around this limitation/bug.

Maybe @sryza or @OwenKephart can have a look, since they already looked into the 7442 issue.

## How I Tested These Changes

I tested the changes locally with an op/graph, which starts multiple threads and logs multiple messages in each thread.

```python
import logging
import threading
import time

from dagster import AssetKey, AssetMaterialization, Output, job, op, repository

logger = logging.getLogger(__name__)


def background_thread(thread_name):
    for i in range(0, 5):
        logger.info(f"Background thread: {thread_name} {i}")
        time.sleep(0.5)


@op
def op1():
    yield AssetMaterialization(asset_key=AssetKey(["asset1"]))

    threads = []
    for thread_name in range(0, 5):
        thread = threading.Thread(
            name="background_thread",
            target=partial(background_thread, thread_name),
        )
        thread.start()
        threads.append(thread)

    for thread in threads:
        thread.join()
    yield AssetMaterialization(asset_key=AssetKey(["asset2"]))
    yield Output(123)


@op
def op2(arg):
    logger.info(f"Result of op1: {arg}")


@job
def dropped_events_job():
    op2(op1())


@repository
def dropped_events_repository():
    return [dropped_events_job]
```

Without my change i was missing a significant chunk of the expected log messages in the captured log output:
![dropped_logs_without_change](https://github.com/dagster-io/dagster/assets/17649269/d777483a-911b-4010-b2e3-48bf7128437d)

With my change i had the exact amount of log messages in the captured log output that i expected:
![no_dropped_logs_with_change](https://github.com/dagster-io/dagster/assets/17649269/d09f3617-fa86-415c-b7de-0dadab078b5b)

I also tested the original reproducing code from https://github.com/dagster-io/dagster/issues/7442:

Without my change:
![grayed_out_op1_without_change](https://github.com/dagster-io/dagster/assets/17649269/c32c39ea-33a6-4207-a8c1-b8ddd30aa437)


With my change:
![green_op1_with_change](https://github.com/dagster-io/dagster/assets/17649269/fac597a6-4e2c-428b-afa4-f7695667ade7)


I am not that familiar with the dagster code. If you can point me to a place where a unittest for this might go and some info on how to test it in your opinion, than i will have a look at it.
