### PR TITLE
Fixup `--python-version` serverless CLI example

### DIFF
--- a/docs/content/dagster-cloud/deployment/serverless.mdx
+++ b/docs/content/dagster-cloud/deployment/serverless.mdx
@@ -168,7 +168,7 @@ The default version of Python for Serverless deployments is Python 3.8. Versions
 - **With the CLI**: Add the `--python-version` CLI argument to the deploy command to specify the registry path to the desired base image:
 
   ```shell
-  dagster-cloud serverless deploy --location-name=my_location --python-version=3.9
+  dagster-cloud serverless deploy-python-executable --location-name=my_location --python-version=3.9
   ```
 
 ### Using a different base image or using native dependencies


### PR DESCRIPTION
Pretty sure this is supposed to be `deploy-python-executable`, not just `deploy`. Based on reverse engineering what's happening here:

https://github.com/dagster-io/dagster-cloud-action/blob/main/src/deploy_pex.py