### PR TITLE
[ui] Change theme label in User Settings dialog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog.tsx
@@ -135,7 +135,7 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
                 key: 'Theme',
                 label: (
                   <div>
-                    Theme (
+                    Theme (Dark mode) {'\u2013 '}
                     <a
                       href="https://github.com/dagster-io/dagster/discussions/18439"
                       target="_blank"
@@ -143,7 +143,6 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
                     >
                       Learn more
                     </a>
-                    )
                   </div>
                 ),
                 value: (


### PR DESCRIPTION
## Summary & Motivation

To make the setting a little clearer.

<img width="495" alt="Screenshot 2023-12-05 at 8 55 25 AM" src="https://github.com/dagster-io/dagster/assets/2823852/37b104b4-b15d-4468-9637-441d3af8f07d">

## How I Tested These Changes

View the dialog.
