### PR TITLE
feat(dbt): make `dbt parse` quiet in a scaffolded project

### DIFF
--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -96,8 +96,14 @@ dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at runtime.
 # Otherwise, we expect a manifest to be present in the project's target directory.
 if os.getenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD"):
-    dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
-    dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
+    dbt_manifest_path = (
+        dbt.cli(
+            ["--quiet", "parse"],
+            target_path=Path("target"),
+        )
+        .wait()
+        .target_path.joinpath("manifest.json")
+    )
 else:
     dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")
 ```

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/load-dbt-models.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/load-dbt-models.mdx
@@ -123,8 +123,14 @@ dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at run time.
 # Otherwise, we expect a manifest to be present in the project's target directory.
 if os.getenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD"):
-    dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
-    dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
+    dbt_manifest_path = (
+        dbt.cli(
+            ["--quiet", "parse"],
+            target_path=Path("target"),
+        )
+        .wait()
+        .target_path.joinpath("manifest.json")
+    )
 else:
     dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")
 ```

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -16,8 +16,14 @@ def scope_compile_dbt_manifest(manifest):
     # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at runtime.
     # Otherwise, we expect a manifest to be present in the project's target directory.
     if os.getenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD"):
-        dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
-        dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
+        dbt_manifest_path = (
+            dbt.cli(
+                ["--quiet", "parse"],
+                target_path=Path("target"),
+            )
+            .wait()
+            .target_path.joinpath("manifest.json")
+        )
     else:
         dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")
     # end_compile_dbt_manifest

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/downstream_assets/constants.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/downstream_assets/constants.py
@@ -10,7 +10,13 @@ dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at run time.
 # Otherwise, we expect a manifest to be present in the project's target directory.
 if os.getenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD"):
-    dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
-    dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
+    dbt_manifest_path = (
+        dbt.cli(
+            ["--quiet", "parse"],
+            target_path=Path("target"),
+        )
+        .wait()
+        .target_path.joinpath("manifest.json")
+    )
 else:
     dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/load_dbt_models/constants.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/load_dbt_models/constants.py
@@ -11,8 +11,14 @@ dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at run time.
 # Otherwise, we expect a manifest to be present in the project's target directory.
 if os.getenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD"):
-    dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
-    dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
+    dbt_manifest_path = (
+        dbt.cli(
+            ["--quiet", "parse"],
+            target_path=Path("target"),
+        )
+        .wait()
+        .target_path.joinpath("manifest.json")
+    )
 else:
     dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")
 

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/upstream_assets/constants.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/upstream_assets/constants.py
@@ -10,7 +10,13 @@ dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at run time.
 # Otherwise, we expect a manifest to be present in the project's target directory.
 if os.getenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD"):
-    dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
-    dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
+    dbt_manifest_path = (
+        dbt.cli(
+            ["--quiet", "parse"],
+            target_path=Path("target"),
+        )
+        .wait()
+        .target_path.joinpath("manifest.json")
+    )
 else:
     dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
@@ -139,7 +139,7 @@ def copy_scaffold(
         f'"{part}"' for part in dbt_project_dir_relative_path.parts
     ]
 
-    dbt_parse_command = ['"parse"']
+    dbt_parse_command = ['"--quiet", "parse"']
     if version.parse(dbt_version) < version.parse("1.5.0"):
         dbt_parse_command += ['"--write-manifest"']
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/constants.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/constants.py.jinja
@@ -13,7 +13,13 @@ dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at run time.
 # Otherwise, we expect a manifest to be present in the project's target directory.
 if os.getenv("DAGSTER_DBT_PARSE_PROJECT_ON_LOAD"):
-    dbt_parse_invocation = dbt.cli([{{ dbt_parse_command | join(', ')}}], target_path=Path("target")).wait()
-    dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
+    dbt_manifest_path = (
+        dbt.cli(
+            [{{ dbt_parse_command | join(', ')}}],
+            target_path=Path("target"),
+        )
+        .wait()
+        .target_path.joinpath("manifest.json")
+    )
 else:
     dbt_manifest_path = dbt_project_dir.joinpath("target", "manifest.json")


### PR DESCRIPTION
## Summary & Motivation
Should have thought of this earlier. Now, with #18328, there is neither spam in the logs nor spam in the `target/` directory.

## How I Tested These Changes
existing tests, scaffold a new project and see no `dbt parse` logs

```
Mac (3)/Downloads/projects 🐍 (dagster)
❯ dagster-dbt project scaffold --project-name quietparse --dbt-project-dir jaffle_shop
Running with dagster-dbt version: 1!0+dev.
Initializing Dagster project quietparse in the current working directory for dbt project directory /Users/rexledesma/Dropbox/Mac
(3)/Downloads/projects/jaffle_shop
Using profiles.yml found in /Users/rexledesma/Dropbox/Mac (3)/Downloads/projects/jaffle_shop/profiles.yml.
Your Dagster project has been initialized. To view your dbt project in Dagster, run the following commands:

 cd '/Users/rexledesma/Dropbox/Mac (3)/Downloads/projects/quietparse'
 DAGSTER_DBT_PARSE_PROJECT_ON_LOAD=1 dagster dev


Mac (3)/Downloads/projects 🐍 (dagster)
❯  cd '/Users/rexledesma/Dropbox/Mac (3)/Downloads/projects/quietparse'
 DAGSTER_DBT_PARSE_PROJECT_ON_LOAD=1 dagster dev
2023-12-05 10:23:19 -0500 - dagster - INFO - Using temporary directory /Users/rexledesma/Dropbox/Mac (3)/Downloads/projects/quietparse/tmp69n83xb6 for storage. This will be removed when dagster dev exits.
2023-12-05 10:23:19 -0500 - dagster - INFO - To persist information across sessions, set the environment variable DAGSTER_HOME to a directory to use.
2023-12-05 10:23:19 -0500 - dagster - INFO - Launching Dagster services...
2023-12-05 10:23:23 -0500 - dagster.daemon - INFO - Instance is configured with the following daemons: ['AssetDaemon', 'BackfillDaemon', 'SchedulerDaemon', 'SensorDaemon']
2023-12-05 10:23:23 -0500 - dagster-webserver - INFO - Serving dagster-webserver on http://127.0.0.1:3000 in process 75002
```
