### PR TITLE
[ui] Use color-scheme to set light/dark controls and scrollbars

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/palettes/ColorName.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/palettes/ColorName.tsx
@@ -1,4 +1,5 @@
 export enum ColorName {
+  BrowserColorScheme = 'BrowserColorScheme',
   KeylineDefault = 'KeylineDefault',
   LinkDefault = 'LinkDefault',
   LinkHover = 'LinkHover',

--- a/js_modules/dagster-ui/packages/ui-components/src/palettes/DarkPalette.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/palettes/DarkPalette.tsx
@@ -2,6 +2,7 @@ import {ColorName} from './ColorName';
 import {CoreColors, DataVizColors, TranslucentColors} from './Colors';
 
 export const DarkPalette = {
+  [ColorName.BrowserColorScheme]: 'dark',
   [ColorName.KeylineDefault]: TranslucentColors.Gray15,
   [ColorName.LinkDefault]: CoreColors.Blue200,
   [ColorName.LinkHover]: CoreColors.Blue400,

--- a/js_modules/dagster-ui/packages/ui-components/src/palettes/LegacyPalette.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/palettes/LegacyPalette.tsx
@@ -4,6 +4,7 @@ import {ColorName} from './ColorName';
 import {CoreColors, DataVizColors} from './Colors';
 
 export const LegacyPalette = {
+  [ColorName.BrowserColorScheme]: 'light',
   [ColorName.KeylineDefault]: LegacyColors.KeylineGray,
   [ColorName.LinkDefault]: LegacyColors.Link,
   [ColorName.LinkHover]: LegacyColors.Link,

--- a/js_modules/dagster-ui/packages/ui-components/src/palettes/LightPalette.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/palettes/LightPalette.tsx
@@ -2,6 +2,7 @@ import {ColorName} from './ColorName';
 import {CoreColors, DataVizColors, TranslucentColors} from './Colors';
 
 export const LightPalette = {
+  [ColorName.BrowserColorScheme]: 'light',
   [ColorName.KeylineDefault]: TranslucentColors.Gray15,
   [ColorName.LinkDefault]: CoreColors.Blue700,
   [ColorName.LinkHover]: CoreColors.Blue500,

--- a/js_modules/dagster-ui/packages/ui-components/src/theme/color.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/theme/color.tsx
@@ -9,6 +9,7 @@ const color = memoize((semanticName: ColorName): string => {
   return palette[semanticName];
 });
 
+export const browserColorScheme = () => color(ColorName.BrowserColorScheme);
 export const colorKeylineDefault = () => color(ColorName.KeylineDefault);
 export const colorLinkDefault = () => color(ColorName.LinkDefault);
 export const colorLinkHover = () => color(ColorName.LinkHover);

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -21,6 +21,7 @@ import {
   colorLinkDefault,
   colorBackgroundDefault,
   colorTextDefault,
+  browserColorScheme,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
 import {BrowserRouter} from 'react-router-dom';
@@ -59,6 +60,7 @@ const GlobalStyle = createGlobalStyle`
   }
 
   html, body, #root {
+    color-scheme: ${browserColorScheme()};
     background-color: ${colorBackgroundDefault()};
     color: ${colorTextDefault()};
     width: 100vw;


### PR DESCRIPTION
## Summary & Motivation

Use the `color-scheme` CSS property to apply theme styles to controls and scrollbars. https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme

<img width="470" alt="Screenshot 2023-12-05 at 9 44 08 AM" src="https://github.com/dagster-io/dagster/assets/2823852/d5b4a001-2c84-4c77-954f-218499ad1498">
<img width="451" alt="Screenshot 2023-12-05 at 9 43 49 AM" src="https://github.com/dagster-io/dagster/assets/2823852/3bd62648-3a8a-4168-8082-767f30770f1d">

## How I Tested These Changes

Force scrollbar to appear for legacy, light, and dark.
