### PR TITLE
[1/n] Manually instrument runs page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/performance.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/performance.tsx
@@ -44,8 +44,6 @@ class PointToPointInstrumentation {
         detail: trace,
       }),
     );
-
-    console.log('completed', trace);
   }
 }
 
@@ -57,7 +55,10 @@ export function useStartTrace(name: string) {
 
   instrumentation.startTrace(traceId, name);
 
-  return {
-    endTrace: instrumentation.endTrace.bind(instrumentation, traceId),
-  };
+  return React.useMemo(
+    () => ({
+      endTrace: instrumentation.endTrace.bind(instrumentation, traceId),
+    }),
+    [traceId],
+  );
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/performance.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/performance.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+type Trace = {
+  name: string;
+  startTime: number;
+  endTime: number | null;
+};
+
+class PointToPointInstrumentation {
+  private traces: {[traceId: string]: Trace} = {};
+
+  startTrace(traceId: string, name: string): void {
+    if (!traceId) {
+      console.error('Trace ID is required to start a trace.');
+      return;
+    }
+
+    if (this.traces[traceId]) {
+      return;
+    }
+
+    const startTime = performance.now();
+    this.traces[traceId] = {name, startTime, endTime: null};
+  }
+
+  endTrace(traceId: string): void {
+    if (!traceId) {
+      return;
+    }
+
+    const trace = this.traces[traceId];
+
+    if (!trace) {
+      return;
+    }
+
+    if (trace.endTime) {
+      return;
+    }
+
+    trace.endTime = performance.now();
+    document.dispatchEvent(
+      new CustomEvent('PerformanceTrace', {
+        detail: trace,
+      }),
+    );
+
+    console.log('completed', trace);
+  }
+}
+
+const instrumentation = new PointToPointInstrumentation();
+
+let counter = 0;
+export function useStartTrace(name: string) {
+  const traceId = React.useMemo(() => `${counter++}:${name}`, [name]);
+
+  instrumentation.startTrace(traceId, name);
+
+  return {
+    endTrace: instrumentation.endTrace.bind(instrumentation, traceId),
+  };
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsRoot.tsx
@@ -211,64 +211,63 @@ export const RunsRoot = () => {
           }}
         >
           {({pipelineRunsOrError}) => {
-            function Wrapper() {
-              React.useLayoutEffect(() => {
-                if (pipelineRunsOrError.__typename === 'Runs') {
-                  trace.endTrace();
-                }
-              }, []);
-
-              if (pipelineRunsOrError.__typename !== 'Runs') {
-                return (
-                  <Box padding={{vertical: 64}}>
-                    <NonIdealState
-                      icon="error"
-                      title="Query Error"
-                      description={pipelineRunsOrError.message}
-                    />
-                  </Box>
-                );
-              }
-
+            if (pipelineRunsOrError.__typename !== 'Runs') {
               return (
-                <>
-                  <StickyTableContainer $top={0}>
-                    <RunTable
-                      runs={pipelineRunsOrError.results.slice(0, PAGE_SIZE)}
-                      onAddTag={onAddTag}
-                      filter={filter}
-                      actionBarComponents={actionBar()}
-                      belowActionBarComponents={
-                        currentTab === 'queued' || activeFiltersJsx.length ? (
-                          <>
-                            {currentTab === 'queued' && <QueuedRunsBanners />}
-                            {activeFiltersJsx.length > 0 && (
-                              <>
-                                {activeFiltersJsx}
-                                <ButtonLink onClick={() => setFilterTokensWithStatus([])}>
-                                  Clear all
-                                </ButtonLink>
-                              </>
-                            )}
-                          </>
-                        ) : null
-                      }
-                    />
-                  </StickyTableContainer>
-                  {pipelineRunsOrError.results.length > 0 ? (
-                    <div style={{marginTop: '16px'}}>
-                      <CursorHistoryControls {...paginationProps} />
-                    </div>
-                  ) : null}
-                </>
+                <Box padding={{vertical: 64}}>
+                  <NonIdealState
+                    icon="error"
+                    title="Query Error"
+                    description={pipelineRunsOrError.message}
+                  />
+                </Box>
               );
             }
-            return <Wrapper />;
+
+            return (
+              <>
+                <RunsRootPerformanceEmitter trace={trace} />
+                <StickyTableContainer $top={0}>
+                  <RunTable
+                    runs={pipelineRunsOrError.results.slice(0, PAGE_SIZE)}
+                    onAddTag={onAddTag}
+                    filter={filter}
+                    actionBarComponents={actionBar()}
+                    belowActionBarComponents={
+                      currentTab === 'queued' || activeFiltersJsx.length ? (
+                        <>
+                          {currentTab === 'queued' && <QueuedRunsBanners />}
+                          {activeFiltersJsx.length > 0 && (
+                            <>
+                              {activeFiltersJsx}
+                              <ButtonLink onClick={() => setFilterTokensWithStatus([])}>
+                                Clear all
+                              </ButtonLink>
+                            </>
+                          )}
+                        </>
+                      ) : null
+                    }
+                  />
+                </StickyTableContainer>
+                {pipelineRunsOrError.results.length > 0 ? (
+                  <div style={{marginTop: '16px'}}>
+                    <CursorHistoryControls {...paginationProps} />
+                  </div>
+                ) : null}
+              </>
+            );
           }}
         </Loading>
       </RunsQueryRefetchContext.Provider>
     </Page>
   );
+};
+
+const RunsRootPerformanceEmitter = ({trace}: {trace: ReturnType<typeof useStartTrace>}) => {
+  React.useLayoutEffect(() => {
+    trace.endTrace();
+  }, [trace]);
+  return null;
 };
 
 // Imported via React.lazy, which requires a default export.


### PR DESCRIPTION
## Summary & Motivation

Implements a basic abstraction for creating traces with a start/end timestamp.
In the future we will likely expand on the trace concept allowing for adding metadata, custom points (to mark the start/end of queries/mutations, etc.).

I looked into using OpenTelemetry with the Context zone API but it is still too experimental and heavy weight at least for our initial use case.

The idea here is that cypress will load the page and listen for the Performance event to record performance metrics.

## How I Tested These Changes

Locally console.logging to make sure the event is emitted.