### PR TITLE
[Easy] Fix Type Annotation in DbtCliResource docstring

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -510,7 +510,7 @@ class DbtCliResource(ConfigurableResource):
         target (Optional[str]): The target from your dbt `profiles.yml` to use for execution. See
             https://docs.getdbt.com/docs/core/connect-data-platform/connection-profiles for more
             information.
-        dbt_executable (str]): The path to the dbt executable. By default, this is `dbt`.
+        dbt_executable (str): The path to the dbt executable. By default, this is `dbt`.
 
     Examples:
         Creating a dbt resource with only a reference to ``project_dir``:


### PR DESCRIPTION
## Summary & Motivation
<img width="657" alt="image" src="https://github.com/dagster-io/dagster/assets/29241719/463639d9-8bab-4631-a796-82f935e80cd2">

The type annotation for the `dbt_executable` argument in the `DbtCliResource` class is incorrect. There's an extra `]`, in `str]` when it should just be `str`

https://docs.dagster.io/_apidocs/libraries/dagster-dbt#dagster_dbt.DbtCliResource.dbt_executable
