### PR TITLE
[docs] - Fix formatting in Airbyte guide callout

### DIFF
--- a/docs/content/guides/dagster/airbyte-ingestion-as-code.mdx
+++ b/docs/content/guides/dagster/airbyte-ingestion-as-code.mdx
@@ -2,14 +2,18 @@
 title: Airbyte ingestion as code | Dagster Docs
 ---
 
-# Airbyte ingestion as code
+# Airbyte ingestion as code <Deprecated />
 
-<Deprecated />
 <Note>
   This feature is <strong>experimental</strong> and <strong>deprecated</strong>{" "}
-  and will be removed with a future release. We suggest using the [Airbyte
-  terraform
-  provider](https://reference.airbyte.com/reference/using-the-terraform-provider)
+  and will be removed with a future release. We suggest using the{" "}
+  <a
+    href="https://reference.airbyte.com/reference/using-the-terraform-provider"
+    target="new"
+  >
+    Airbyte terraform provider
+  </a>{" "}
+  instead.
 </Note>
 
 This guide provides an introduction to using Dagster to configure your [Airbyte](/integrations/airbyte) connections. This allows you to centralize the configuration for your data stack, specifying configuration in Python code. You can check-in and version your config with version control or programmatically generate config for more complex use cases.


### PR DESCRIPTION
## Summary & Motivation

This PR fixes the formatting of the 'deprecated' callout in the Airbyte ingestion guide. Markdown doesn't currently render inside of components, leading this to display as plaintext.

## How I Tested These Changes

👀 
