### PR TITLE
[Asset graph] Fix infinite loop when there are no kind tags

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -98,7 +98,10 @@ const emptyArray: any[] = [];
 
 export const AssetGraphExplorer = (props: Props) => {
   const {fetchResult, assetGraphData, fullAssetGraphData, graphQueryItems, allAssetKeys} =
-    useAssetGraphData(props.explorerPath.opsQuery, props.fetchOptions);
+    useAssetGraphData(props.explorerPath.opsQuery, {
+      ...props.fetchOptions,
+      computeKinds: props.filters?.computeKindTags,
+    });
 
   const {visibleRepos} = React.useContext(WorkspaceContext);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -94,12 +94,11 @@ type Props = {
 export const MINIMAL_SCALE = 0.6;
 export const GROUPS_ONLY_SCALE = 0.15;
 
+const emptyArray: any[] = [];
+
 export const AssetGraphExplorer = (props: Props) => {
   const {fetchResult, assetGraphData, fullAssetGraphData, graphQueryItems, allAssetKeys} =
-    useAssetGraphData(props.explorerPath.opsQuery, {
-      ...props.fetchOptions,
-      computeKinds: props.filters?.computeKindTags,
-    });
+    useAssetGraphData(props.explorerPath.opsQuery, props.fetchOptions);
 
   const {visibleRepos} = React.useContext(WorkspaceContext);
 
@@ -124,7 +123,7 @@ export const AssetGraphExplorer = (props: Props) => {
       (groups: AssetGroupSelector[]) => props.setFilters?.({...props.filters, groups}),
       [props],
     ),
-    computeKindTags: props.filters?.computeKindTags || [],
+    computeKindTags: props.filters?.computeKindTags || emptyArray,
     setComputeKindTags: React.useCallback(
       (tags: string[]) =>
         props.setFilters?.({

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
@@ -33,6 +33,8 @@ type Props = {
   nodes: GraphNode[];
 } & OptionalFilters;
 
+const emptyArray: any[] = [];
+
 export function useAssetGraphExplorerFilters({
   nodes,
   assetGroups,
@@ -157,7 +159,7 @@ export function useAssetGraphExplorerFilters({
       </Box>
     ),
     getStringValue: (value) => value,
-    initialState: computeKindTags ?? [],
+    initialState: computeKindTags ?? emptyArray,
     onStateChanged: (values) => {
       setComputeKindTags?.(Array.from(values));
     },


### PR DESCRIPTION
## Summary & Motivation

As titled, fixes an infinite loop causing by passing a new empty array and trigger onStateChanged on the inner useFilter.

## How I Tested These Changes
locally