### PR TITLE
Fix failing test on Windows

### DIFF
--- a/python_modules/dagster/dagster/_seven/compat/pendulum.py
+++ b/python_modules/dagster/dagster/_seven/compat/pendulum.py
@@ -54,4 +54,8 @@ PendulumDateTime: TypeAlias = (
 # Workaround for issue with .in_tz() in pendulum:
 # https://github.com/sdispater/pendulum/issues/535
 def to_timezone(dt: PendulumDateTime, tz: str):
+    timestamp = dt.timestamp()
+    # handle negative timestamps, which are not natively supported on Windows
+    if timestamp < 0:
+        return pendulum.from_timestamp(0, tz=tz) + datetime.timedelta(seconds=timestamp)
     return pendulum.from_timestamp(dt.timestamp(), tz=tz)


### PR DESCRIPTION
## Summary & Motivation

Calling datetime.fromtimestamp() causes an error when running on windows. We had one test where the start date of a partitions def was (probably accidentally) 1900, which failed as this got called somewhere down the stack.

## How I Tested These Changes
