### PR TITLE
add check that asset event tags are removed post run deletion

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -81,7 +81,6 @@ AssetEventTagsTable = db.Table(
     db.Column(
         "event_id",
         db.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"),
-        db.ForeignKey("event_logs.id", ondelete="CASCADE"),
     ),
     db.Column("asset_key", db.Text, nullable=False),
     db.Column("key", db.Text, nullable=False),

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -3181,6 +3181,11 @@ class TestEventLogStorage:
                 {"dagster/partition/country": "US", "dagster/partition/date": "2022-10-13"}
             ]
 
+        # after the runs are deleted, the event tags should not persist
+        storage.delete_events(run_id)
+        asset_event_tags = storage.get_event_tags_for_asset(key)
+        assert asset_event_tags == []
+
     def test_add_asset_event_tags(self, storage, instance):
         if not storage.supports_add_asset_event_tags():
             pytest.skip("storage does not support adding asset event tags")


### PR DESCRIPTION
## Summary & Motivation
We want the ability to drop the foreign key constraint on asset event tags, so want to make sure that the run deletion works as expected (instead of relying on the cascading delete).

## How I Tested These Changes
BK