### PR TITLE
[embedded-elt] Resolve EnvVars passed to permissive config

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -161,6 +161,8 @@ def ensure_env_vars_set_post_init(set_value: T, input_value: Any) -> T:
     """
     if isinstance(set_value, dict) and isinstance(input_value, dict):
         for key, value in input_value.items():
+            if key not in set_value:
+                continue
             if isinstance(value, (EnvVar, IntEnvVar)):
                 set_value[key] = value
             elif isinstance(value, (dict, list)):

--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -161,12 +161,12 @@ def ensure_env_vars_set_post_init(set_value: T, input_value: Any) -> T:
     """
     if isinstance(set_value, dict) and isinstance(input_value, dict):
         for key, value in input_value.items():
-            if key not in set_value:
-                continue
             if isinstance(value, (EnvVar, IntEnvVar)):
                 set_value[key] = value
-            elif isinstance(value, (dict, list)):
-                set_value[key] = ensure_env_vars_set_post_init(set_value[key], value)
+            elif isinstance(value, dict):
+                set_value[key] = ensure_env_vars_set_post_init(set_value.get(key) or {}, value)
+            elif isinstance(value, list):
+                set_value[key] = ensure_env_vars_set_post_init(set_value.get(key) or [], value)
     if isinstance(set_value, List) and isinstance(input_value, List):
         for i in range(len(set_value)):
             value = input_value[i]

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
@@ -1,8 +1,7 @@
 import os
 
 import pytest
-from dagster import Definitions, EnvVar, RunConfig, asset
-from dagster._config.pythonic_config import Config
+from dagster import Config, Definitions, EnvVar, RunConfig, asset
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.test_utils import environ
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_resource.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_resource.py
@@ -2,7 +2,8 @@ import os
 import sqlite3
 import tempfile
 
-from dagster import asset, file_relative_path, materialize
+from dagster import EnvVar, asset, file_relative_path, materialize
+from dagster._core.test_utils import environ
 from dagster_embedded_elt.sling import SlingMode, SlingResource
 from dagster_embedded_elt.sling.resources import (
     SlingSourceConnection,
@@ -76,3 +77,38 @@ def test_resource_connection_with_source_options():
                 )
             },
         )
+
+
+def test_env_var_for_permissive_field():
+    with tempfile.TemporaryDirectory() as tmpdir_path:
+        sqllitepath = os.path.join(tmpdir_path, "sqlite.db")
+
+        @asset
+        def run_sync(context, sling: SlingResource):
+            res = sling.sync(
+                source_stream=os.path.join(file_relative_path(__file__, "test.csv")),
+                target_object="main.events",
+                mode=SlingMode.FULL_REFRESH,
+            )
+            # Consume the generator by printing to stdout
+            for stdout in res:
+                context.log.debug(stdout)
+            counts = sqlite3.connect(sqllitepath).execute("SELECT count(1) FROM events").fetchone()
+            assert counts[0] == 3
+
+        source = SlingSourceConnection(
+            type="file",
+        )
+        with environ({"SQLLITE_PATH": sqllitepath}):
+            target = SlingTargetConnection(type="sqlite", instance=EnvVar("SQLLITE_PATH"))
+
+            materialize(
+                [run_sync],
+                resources={
+                    "sling": SlingResource(
+                        source_connection=source,
+                        target_connection=target,
+                        mode=SlingMode.TRUNCATE,
+                    )
+                },
+            )


### PR DESCRIPTION
## Summary

Stopgap fix for #18188 which resolves all `EnvVars` passed to non-specified permissive config fields as string env vars.

This is a bit tricky to solve at a global level, but this fixes this behavior for `dagster-embedded-elt`.

## Test Plan

New unit test.
