### PR TITLE
[ui] Fix nav expansion button colors

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav.tsx
@@ -7,7 +7,7 @@ import {
   colorNavText,
   colorNavTextSelected,
   colorNavTextHover,
-  colorBackgroundLight,
+  colorNavButton,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link, NavLink, useHistory} from 'react-router-dom';
@@ -331,7 +331,7 @@ const NavButton = styled.button`
   outline: none;
   padding: 6px;
   border: none;
-  background: transparent;
+  background: ${colorNavBackground()};
   display: block;
 
   ${IconWrapper} {
@@ -347,6 +347,6 @@ const NavButton = styled.button`
   }
 
   :focus {
-    background: ${colorBackgroundLight()};
+    background: ${colorNavButton()};
   }
 `;


### PR DESCRIPTION
## Summary & Motivation

The background color on the left nav expansion button is incorrect in Legacy theme. Fix it.

Before:

<img width="107" alt="Screenshot 2023-12-05 at 4 10 21 PM" src="https://github.com/dagster-io/dagster/assets/2823852/0d164824-8db1-43ec-9003-ab8256a5d3e7">

After:

<img width="112" alt="Screenshot 2023-12-05 at 4 10 06 PM" src="https://github.com/dagster-io/dagster/assets/2823852/99f35226-f862-4762-97e7-947b65fcdd22">


## How I Tested These Changes

Hover and focus on button in all three themes. Verify that it looks correct.
