### PR TITLE
Bump asset backfill log from debug to info level

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -959,7 +959,9 @@ def execute_asset_backfill_iteration(
         logger.info(
             f"Asset backfill {backfill.backfill_id} completed iteration with status {updated_backfill.status}."
         )
-        logger.debug(f"Updated asset backfill data after execution: {updated_asset_backfill_data}")
+        logger.info(
+            f"Updated asset backfill data for {backfill.backfill_id}: {updated_asset_backfill_data}"
+        )
 
     elif backfill.status == BulkActionStatus.CANCELING:
         if not instance.run_coordinator:


### PR DESCRIPTION
For some reason was not seeing debug level logs pop up in canary for the cloud backfill daemon logger, maybe it's not enabled?

Bumping the log level so we can get access to the asset backfill data logs.