### PR TITLE
add schema, storage methods for managing concurrency limits table

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/042_46b412388816_add_concurrency_limits_table.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/042_46b412388816_add_concurrency_limits_table.py
@@ -1,0 +1,42 @@
+"""add concurrency limits table
+
+Revision ID: 46b412388816
+Revises: ec80dd91891a
+Create Date: 2023-12-01 14:35:47.622154
+
+"""
+import sqlalchemy as db
+from alembic import op
+from dagster._core.storage.migration.utils import has_table
+from dagster._core.storage.sql import MySQLCompatabilityTypes, get_current_timestamp
+from sqlalchemy.dialects import sqlite
+
+# revision identifiers, used by Alembic.
+revision = "46b412388816"
+down_revision = "ec80dd91891a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not has_table("concurrency_limits"):
+        op.create_table(
+            "concurrency_limits",
+            db.Column(
+                "id",
+                db.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"),
+                primary_key=True,
+                autoincrement=True,
+            ),
+            db.Column(
+                "concurrency_key", MySQLCompatabilityTypes.UniqueText, nullable=False, unique=True
+            ),
+            db.Column("limit", db.Integer, nullable=False),
+            db.Column("update_timestamp", db.DateTime, server_default=get_current_timestamp()),
+            db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+        )
+
+
+def downgrade():
+    if has_table("concurrency_limits"):
+        op.drop_table("concurrency_limits")

--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -103,6 +103,21 @@ DynamicPartitionsTable = db.Table(
     db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
 )
 
+ConcurrencyLimitsTable = db.Table(
+    "concurrency_limits",
+    SqlEventLogStorageMetadata,
+    db.Column(
+        "id",
+        db.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    ),
+    db.Column("concurrency_key", MySQLCompatabilityTypes.UniqueText, nullable=False, unique=True),
+    db.Column("limit", db.Integer, nullable=False),
+    db.Column("update_timestamp", db.DateTime, server_default=get_current_timestamp()),
+    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+)
+
 ConcurrencySlotsTable = db.Table(
     "concurrency_slots",
     SqlEventLogStorageMetadata,

--- a/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
@@ -2,10 +2,13 @@ import multiprocessing
 import os
 import sys
 import tempfile
+import time
 import traceback
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 import sqlalchemy
+import sqlalchemy as db
 from dagster._core.errors import DagsterEventLogInvalidForRun
 from dagster._core.storage.event_log import (
     ConsolidatedSqliteEventLogStorage,
@@ -14,9 +17,13 @@ from dagster._core.storage.event_log import (
     SqlEventLogStorageTable,
     SqliteEventLogStorage,
 )
+from dagster._core.storage.event_log.schema import ConcurrencyLimitsTable, ConcurrencySlotsTable
 from dagster._core.storage.legacy_storage import LegacyEventLogStorage
 from dagster._core.storage.sql import create_engine
+from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.sqlite_storage import DagsterSqliteStorage
+from dagster._utils.test import ConcurrencyEnabledSqliteTestEventLogStorage
+from sqlalchemy.engine import Connection
 
 from .utils.event_log_storage import TestEventLogStorage
 
@@ -145,3 +152,97 @@ class TestLegacyStorage(TestEventLogStorage):
 
     def is_sqlite(self, storage):
         return True
+
+
+def _insert_slots(conn: Connection, concurrency_key: str, num: int, delete_num: int = 0):
+    rows = [
+        {
+            "concurrency_key": concurrency_key,
+            "run_id": None,
+            "step_key": None,
+            "deleted": False,
+        }
+        for _ in range(0, num)
+    ] + [
+        {
+            "concurrency_key": concurrency_key,
+            "run_id": None,
+            "step_key": None,
+            "deleted": True,
+        }
+        for _ in range(0, delete_num)
+    ]
+
+    conn.execute(ConcurrencySlotsTable.insert().values(rows))
+
+
+def _get_slot_count(conn: Connection, concurrency_key: str):
+    slot_row = conn.execute(
+        db_select([db.func.count(ConcurrencySlotsTable.c.id)]).where(
+            db.and_(
+                ConcurrencySlotsTable.c.concurrency_key == concurrency_key,
+                ConcurrencySlotsTable.c.deleted == False,  # noqa: E712
+            )
+        )
+    ).fetchone()
+    return slot_row[0] if slot_row else None
+
+
+def _get_limit_row_num(conn: Connection, concurrency_key: str):
+    limit_row = conn.execute(
+        db_select([ConcurrencyLimitsTable.c.limit]).where(
+            ConcurrencyLimitsTable.c.concurrency_key == concurrency_key
+        )
+    ).fetchone()
+    return limit_row[0] if limit_row else None
+
+
+def test_concurrency_limit_set():
+    """Test that the concurrency limit is set correctly.  This doesn't really belong in the event
+    log test suites, since it kind of pokes at the table internals, by querying the limit rows in
+    addition to the slot rows.
+    """
+    TOTAL_TIMEOUT_TIME = 30
+    with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmpdir_path:
+        storage = ConcurrencyEnabledSqliteTestEventLogStorage(base_dir=tmpdir_path)
+
+        def _allocate_slot():
+            storage.set_concurrency_slots("foo", 5)
+
+        start = time.time()
+        with ThreadPoolExecutor() as executor:
+            futures = [executor.submit(_allocate_slot) for i in range(100)]
+            while not all(f.done() for f in futures) and time.time() < start + TOTAL_TIMEOUT_TIME:
+                time.sleep(1)
+
+        # assert that the number of slots match the limit row
+        with storage.index_connection() as conn:
+            assert _get_slot_count(conn, "foo") == 5
+            assert _get_limit_row_num(conn, "foo") == 5
+
+
+def test_concurrency_reconcile():
+    """Test that the concurrency limit is set correctly.  This doesn't really belong in the event
+    log test suites, since it kind of pokes at the table internals, by querying the limit rows in
+    addition to the slot rows.
+    """
+    with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmpdir_path:
+        storage = ConcurrencyEnabledSqliteTestEventLogStorage(base_dir=tmpdir_path)
+
+        # first set up the rows based on slots
+        with storage.index_connection() as conn:
+            _insert_slots(conn, "foo", 5, 1)
+            _insert_slots(conn, "bar", 3, 2)
+
+            assert _get_slot_count(conn, "foo") == 5
+            assert _get_slot_count(conn, "bar") == 3
+            assert _get_limit_row_num(conn, "foo") is None
+            assert _get_limit_row_num(conn, "bar") is None
+
+        storage._reconcile_concurrency_limits_from_slots()  # noqa: SLF001
+
+        with storage.index_connection() as conn:
+            assert _get_slot_count(conn, "foo") == 5
+            assert _get_slot_count(conn, "bar") == 3
+            assert _get_limit_row_num(conn, "foo") == 5
+            assert _get_limit_row_num(conn, "bar") == 3


### PR DESCRIPTION
## Summary & Motivation
We want to start supporting default limits for global concurrency keys.  We also want to start supporting zero-limits for global concurrency.  Both of these features require a single limit configuration row per concurrency key, in addition to the row-per-slot limit we currently have (which limits the db contention for claiming rows).

This PR sets up the limit configuration in a transaction, on this new limit row.  It lazily reconciles the limit rows off of the slot rows.

## How I Tested These Changes
BK