### PR TITLE
[ruff] 0.1.1 -> 0.1.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.1.1
+  rev: v0.1.5
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.1.5
+  rev: v0.1.7
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/docs/content/concepts/assets/asset-checks.mdx
+++ b/docs/content/concepts/assets/asset-checks.mdx
@@ -192,7 +192,7 @@ def items():
 
 
 def make_checks(
-    check_blobs: Sequence[Mapping[str, str]]
+    check_blobs: Sequence[Mapping[str, str]],
 ) -> Sequence[AssetChecksDefinition]:
     checks = []
     for check_blob in check_blobs:

--- a/docs/content/integrations/deltalake/reference.mdx
+++ b/docs/content/integrations/deltalake/reference.mdx
@@ -191,7 +191,7 @@ from dagster import (
     metadata={"partition_expr": {"date": "time", "species": "species"}},
 )
 def iris_dataset_partitioned(context) -> pd.DataFrame:
-    partition = partition = context.partition_key.keys_by_dimension
+    partition = context.partition_key.keys_by_dimension
     species = partition["species"]
     date = partition["date"]
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/factory.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/factory.py
@@ -20,7 +20,7 @@ def items():
 
 
 def make_checks(
-    check_blobs: Sequence[Mapping[str, str]]
+    check_blobs: Sequence[Mapping[str, str]],
 ) -> Sequence[AssetChecksDefinition]:
     checks = []
     for check_blob in check_blobs:

--- a/examples/docs_snippets/docs_snippets/integrations/deltalake/multi_partition.py
+++ b/examples/docs_snippets/docs_snippets/integrations/deltalake/multi_partition.py
@@ -26,7 +26,7 @@ from dagster import (
     metadata={"partition_expr": {"date": "time", "species": "species"}},
 )
 def iris_dataset_partitioned(context) -> pd.DataFrame:
-    partition = partition = context.partition_key.keys_by_dimension
+    partition = context.partition_key.keys_by_dimension
     species = partition["species"]
     date = partition["date"]
 

--- a/helm/dagster/schema/schema/charts/utils/utils.py
+++ b/helm/dagster/schema/schema/charts/utils/utils.py
@@ -54,7 +54,7 @@ def create_definition_ref(definition: str, version: str = SupportedKubernetes.V1
 
 
 def create_json_schema_conditionals(
-    enum_type_to_config_name_mapping: Dict[Enum, str]
+    enum_type_to_config_name_mapping: Dict[Enum, str],
 ) -> List[dict]:
     return [
         {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,7 +231,7 @@ select = [
 ]
 
 # Fail if Ruff is not running this version.
-required-version = "0.1.1"
+required-version = "0.1.5"
 
 [tool.ruff.flake8-builtins]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,7 +231,7 @@ select = [
 ]
 
 # Fail if Ruff is not running this version.
-required-version = "0.1.5"
+required-version = "0.1.7"
 
 [tool.ruff.flake8-builtins]
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 
 def asset_checks_iter(
-    context: WorkspaceRequestContext
+    context: WorkspaceRequestContext,
 ) -> Iterator[Tuple[CodeLocation, ExternalRepository, ExternalAssetCheck]]:
     for location, repository in repository_iter(context):
         for external_check in repository.external_repository_data.external_asset_checks or []:
@@ -59,7 +59,7 @@ def get_asset_check_execution_statuses_by_id(
         planned_execution_runs_by_run_id = {}
 
     def _status_for_execution(
-        execution: AssetCheckExecutionRecord
+        execution: AssetCheckExecutionRecord,
     ) -> AssetCheckExecutionResolvedStatus:
         record_status = execution.status
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -92,7 +92,7 @@ def _noop(_) -> None:
 class ErrorCapture:
     @staticmethod
     def default_on_exception(
-        exc_info: Tuple[Type[BaseException], BaseException, TracebackType]
+        exc_info: Tuple[Type[BaseException], BaseException, TracebackType],
     ) -> "GraphenePythonError":
         from dagster_graphql.schema.errors import GraphenePythonError
 
@@ -118,7 +118,7 @@ class ErrorCapture:
 
 
 def capture_error(
-    fn: Callable[P, T]
+    fn: Callable[P, T],
 ) -> Callable[P, Union[T, "GrapheneError", "GraphenePythonError"]]:
     def _fn(*args: P.args, **kwargs: P.kwargs) -> T:
         try:

--- a/python_modules/dagster/dagster/_core/container_context/config.py
+++ b/python_modules/dagster/dagster/_core/container_context/config.py
@@ -21,7 +21,7 @@ SHARED_CONTAINER_CONTEXT_SCHEMA = Permissive(
 
 # Process fields shared by container contexts in all environments (docker / k8s / ecs etc.)
 def process_shared_container_context_config(
-    container_context_config: Optional[Mapping[str, Any]]
+    container_context_config: Optional[Mapping[str, Any]],
 ) -> Mapping[str, Any]:
     shared_container_context = process_config(
         SHARED_CONTAINER_CONTEXT_SCHEMA, container_context_config or {}

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -399,7 +399,7 @@ class AutoMaterializeRule(ABC):
     @public
     @staticmethod
     def materialize_on_parent_updated(
-        updated_parent_filter: Optional["AutoMaterializeAssetPartitionsFilter"] = None
+        updated_parent_filter: Optional["AutoMaterializeAssetPartitionsFilter"] = None,
     ) -> "MaterializeOnParentUpdatedRule":
         """Materialize an asset partition if one of its parents has been updated more recently
         than it has.

--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -189,7 +189,7 @@ def enter_composition(name: str, source: str) -> None:
 
 
 def exit_composition(
-    output: Optional[Mapping[str, OutputMapping]] = None
+    output: Optional[Mapping[str, OutputMapping]] = None,
 ) -> "CompleteCompositionContext":
     return _composition_stack.pop().complete(output)
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1410,7 +1410,7 @@ def _make_asset_deps(deps: Optional[Iterable[CoercibleToAssetDep]]) -> Optional[
 
 
 def _assign_output_names_to_check_specs(
-    check_specs: Optional[Sequence[AssetCheckSpec]]
+    check_specs: Optional[Sequence[AssetCheckSpec]],
 ) -> Mapping[str, AssetCheckSpec]:
     checks_by_output_name = {spec.get_python_identifier(): spec for spec in check_specs or []}
     if check_specs and len(checks_by_output_name) != len(check_specs):

--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -227,7 +227,7 @@ def repository(
 
 @overload
 def repository(
-    definitions_fn: Callable[..., Sequence[PendingRepositoryListDefinition]]
+    definitions_fn: Callable[..., Sequence[PendingRepositoryListDefinition]],
 ) -> PendingRepositoryDefinition:
     ...
 

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -177,7 +177,7 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
 
     @staticmethod
     def from_coercible_or_definition(
-        arg: Union["CoercibleToAssetKey", "AssetsDefinition", "SourceAsset"]
+        arg: Union["CoercibleToAssetKey", "AssetsDefinition", "SourceAsset"],
     ) -> "AssetKey":
         from dagster._core.definitions.assets import AssetsDefinition
         from dagster._core.definitions.source_asset import SourceAsset

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
@@ -62,7 +62,7 @@ class FreshnessPolicySensorCursor(
 
     @staticmethod
     def from_dict(
-        minutes_late_by_key: Mapping[AssetKey, Optional[float]]
+        minutes_late_by_key: Mapping[AssetKey, Optional[float]],
     ) -> "FreshnessPolicySensorCursor":
         return FreshnessPolicySensorCursor(
             minutes_late_by_key_str={k.to_user_string(): v for k, v in minutes_late_by_key.items()}

--- a/python_modules/dagster/dagster/_core/definitions/load_asset_checks_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_asset_checks_from_modules.py
@@ -60,7 +60,7 @@ def load_asset_checks_from_modules(
 
 
 def load_asset_checks_from_current_module(
-    asset_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None
+    asset_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
 ) -> Sequence[AssetChecksDefinition]:
     """Constructs a list of asset checks from the module where this function is called. This is most
     often used in conjunction with a call to `load_assets_from_current_module`.

--- a/python_modules/dagster/dagster/_core/definitions/materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/materialize.py
@@ -203,7 +203,7 @@ def materialize_to_memory(
 
 
 def _get_required_io_manager_keys(
-    assets: Sequence[Union[AssetsDefinition, SourceAsset]]
+    assets: Sequence[Union[AssetsDefinition, SourceAsset]],
 ) -> Set[str]:
     io_manager_keys = set()
     for asset in assets:

--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -136,7 +136,7 @@ ALLOWED_PARTITION_DIMENSION_TYPES = (
 
 
 def _check_valid_partitions_dimensions(
-    partitions_dimensions: Mapping[str, PartitionsDefinition]
+    partitions_dimensions: Mapping[str, PartitionsDefinition],
 ) -> None:
     for dim_name, partitions_def in partitions_dimensions.items():
         if not any(isinstance(partitions_def, t) for t in ALLOWED_PARTITION_DIMENSION_TYPES):

--- a/python_modules/dagster/dagster/_core/definitions/node_container.py
+++ b/python_modules/dagster/dagster/_core/definitions/node_container.py
@@ -35,7 +35,7 @@ T_DependencyKey = TypeVar("T_DependencyKey", str, "NodeInvocation")
 
 
 def normalize_dependency_dict(
-    dependencies: Optional[Union[DependencyMapping[str], DependencyMapping[NodeInvocation]]]
+    dependencies: Optional[Union[DependencyMapping[str], DependencyMapping[NodeInvocation]]],
 ) -> DependencyMapping[NodeInvocation]:
     prelude = (
         'The expected type for "dependencies" is Union[Mapping[str, Mapping[str, '

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -812,7 +812,7 @@ def static_partitioned_config(
     )
 
     def inner(
-        fn: Callable[[str], Mapping[str, Any]]
+        fn: Callable[[str], Mapping[str, Any]],
     ) -> PartitionedConfig[StaticPartitionsDefinition]:
         return PartitionedConfig(
             partitions_def=StaticPartitionsDefinition(partition_keys),

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -296,7 +296,7 @@ def build_caching_repository_data_from_list(
 
 
 def build_caching_repository_data_from_dict(
-    repository_definitions: Dict[str, Dict[str, Any]]
+    repository_definitions: Dict[str, Dict[str, Any]],
 ) -> "CachingRepositoryData":
     check.dict_param(repository_definitions, "repository_definitions", key_type=str)
     check.invariant(

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1142,7 +1142,7 @@ def daily_partitioned_config(
     """
 
     def inner(
-        fn: Callable[[datetime, datetime], Mapping[str, Any]]
+        fn: Callable[[datetime, datetime], Mapping[str, Any]],
     ) -> PartitionedConfig[DailyPartitionsDefinition]:
         check.callable_param(fn, "fn")
 
@@ -1278,7 +1278,7 @@ def hourly_partitioned_config(
     """
 
     def inner(
-        fn: Callable[[datetime, datetime], Mapping[str, Any]]
+        fn: Callable[[datetime, datetime], Mapping[str, Any]],
     ) -> PartitionedConfig[HourlyPartitionsDefinition]:
         check.callable_param(fn, "fn")
 
@@ -1422,7 +1422,7 @@ def monthly_partitioned_config(
     """
 
     def inner(
-        fn: Callable[[datetime, datetime], Mapping[str, Any]]
+        fn: Callable[[datetime, datetime], Mapping[str, Any]],
     ) -> PartitionedConfig[MonthlyPartitionsDefinition]:
         check.callable_param(fn, "fn")
 
@@ -1571,7 +1571,7 @@ def weekly_partitioned_config(
     """
 
     def inner(
-        fn: Callable[[datetime, datetime], Mapping[str, Any]]
+        fn: Callable[[datetime, datetime], Mapping[str, Any]],
     ) -> PartitionedConfig[WeeklyPartitionsDefinition]:
         check.callable_param(fn, "fn")
 
@@ -2281,7 +2281,7 @@ def _flatten(
 
 
 def fetch_flattened_time_window_ranges(
-    subsets: Mapping[PartitionRangeStatus, BaseTimeWindowPartitionsSubset]
+    subsets: Mapping[PartitionRangeStatus, BaseTimeWindowPartitionsSubset],
 ) -> Sequence[PartitionTimeWindowStatus]:
     """Given potentially overlapping subsets, return a flattened list of timewindows where the highest priority status wins
     on overlaps.

--- a/python_modules/dagster/dagster/_core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/build_resources.py
@@ -113,7 +113,7 @@ def build_resources(
 
 
 def wrap_resources_for_execution(
-    resources: Optional[Mapping[str, Any]] = None
+    resources: Optional[Mapping[str, Any]] = None,
 ) -> Dict[str, ResourceDefinition]:
     return (
         {

--- a/python_modules/dagster/dagster/_core/execution/job_execution_result.py
+++ b/python_modules/dagster/dagster/_core/execution/job_execution_result.py
@@ -126,9 +126,7 @@ class JobExecutionResult(ExecutionResult):
                     if result is None:
                         result = {mapping_key: value}
                     else:
-                        result[mapping_key] = (
-                            value  # pylint:disable=unsupported-assignment-operation
-                        )
+                        result[mapping_key] = value  # pylint:disable=unsupported-assignment-operation
                 else:
                     result = value
 

--- a/python_modules/dagster/dagster/_core/execution/plan/state.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/state.py
@@ -36,7 +36,7 @@ class StepOutputVersionData(NamedTuple):
 
     @staticmethod
     def get_version_list_from_dict(
-        step_output_versions: Mapping[StepOutputHandle, str]
+        step_output_versions: Mapping[StepOutputHandle, str],
     ) -> Sequence["StepOutputVersionData"]:
         return [
             StepOutputVersionData(step_output_handle=step_output_handle, version=version)

--- a/python_modules/dagster/dagster/_core/execution/plan/step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/step.py
@@ -45,7 +45,7 @@ class StepKind(Enum):
 
 
 def is_executable_step(
-    step: Union["ExecutionStep", "UnresolvedMappedExecutionStep"]
+    step: Union["ExecutionStep", "UnresolvedMappedExecutionStep"],
 ) -> TypeGuard["ExecutionStep"]:
     # This function is set up defensively to ensure new step types handled properly
     if isinstance(step, ExecutionStep):

--- a/python_modules/dagster/dagster/_core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/_core/execution/resources_init.py
@@ -72,7 +72,7 @@ def resource_initialization_manager(
 
 
 def resolve_resource_dependencies(
-    resource_defs: Mapping[str, ResourceDefinition]
+    resource_defs: Mapping[str, ResourceDefinition],
 ) -> Mapping[str, AbstractSet[str]]:
     """Generates a dictionary that maps resource key to resource keys it requires for initialization."""
     resource_dependencies = {
@@ -434,7 +434,7 @@ def get_required_resource_keys_for_step(
 
 
 def _wrapped_resource_iterator(
-    resource_or_gen: Union[Any, Generator[Any, None, None]]
+    resource_or_gen: Union[Any, Generator[Any, None, None]],
 ) -> Generator[Any, None, None]:
     """Returns an iterator which yields a single item, which is the resource.
 

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -112,7 +112,8 @@ def telemetry_wrapper(target_fn: T_Callable) -> T_Callable:
 
 @overload
 def telemetry_wrapper(
-    *, metadata: Optional[Mapping[str, str]]
+    *,
+    metadata: Optional[Mapping[str, str]],
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
     ...
 

--- a/python_modules/dagster/dagster/_core/workspace/config_schema.py
+++ b/python_modules/dagster/dagster/_core/workspace/config_schema.py
@@ -16,7 +16,7 @@ from dagster._utils.merger import merge_dicts
 
 
 def process_workspace_config(
-    workspace_config: Mapping[str, object]
+    workspace_config: Mapping[str, object],
 ) -> EvaluateValueResult[Mapping[str, object]]:
     workspace_config = check.mapping_param(workspace_config, "workspace_config")
 

--- a/python_modules/dagster/dagster/_core/workspace/load.py
+++ b/python_modules/dagster/dagster/_core/workspace/load.py
@@ -71,7 +71,7 @@ def location_origins_from_config(
 
 
 def _location_origin_from_module_config(
-    python_module_config: Union[str, Mapping[str, str]]
+    python_module_config: Union[str, Mapping[str, str]],
 ) -> ManagedGrpcPythonEnvCodeLocationOrigin:
     (
         module_name,
@@ -86,7 +86,7 @@ def _location_origin_from_module_config(
 
 
 def _get_module_config_data(
-    python_module_config: Union[str, Mapping[str, str]]
+    python_module_config: Union[str, Mapping[str, str]],
 ) -> Tuple[str, Optional[str], Optional[str], Optional[str], Optional[str]]:
     return (
         (python_module_config, None, None, None, None)
@@ -132,7 +132,7 @@ def location_origin_from_module_name(
 
 
 def _location_origin_from_package_config(
-    python_package_config: Union[str, Mapping[str, str]]
+    python_package_config: Union[str, Mapping[str, str]],
 ) -> ManagedGrpcPythonEnvCodeLocationOrigin:
     (
         module_name,
@@ -147,7 +147,7 @@ def _location_origin_from_package_config(
 
 
 def _get_package_config_data(
-    python_package_config: Union[str, Mapping[str, str]]
+    python_package_config: Union[str, Mapping[str, str]],
 ) -> Tuple[str, Optional[str], Optional[str], Optional[str], Optional[str]]:
     return (
         (python_package_config, None, None, None, None)

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -385,7 +385,7 @@ def ensure_gen(thing_or_gen: T) -> Generator[T, Any, Any]:
 
 
 def ensure_gen(
-    thing_or_gen: Union[T, Iterator[T], Generator[T, Any, Any]]
+    thing_or_gen: Union[T, Iterator[T], Generator[T, Any, Any]],
 ) -> Generator[T, Any, Any]:
     if not inspect.isgenerator(thing_or_gen):
         thing_or_gen = cast(T, thing_or_gen)

--- a/python_modules/dagster/dagster/_utils/test/__init__.py
+++ b/python_modules/dagster/dagster/_utils/test/__init__.py
@@ -58,7 +58,7 @@ from ..temp_file import (
 
 
 def create_test_pipeline_execution_context(
-    logger_defs: Optional[Mapping[str, LoggerDefinition]] = None
+    logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
 ) -> PlanExecutionContext:
     loggers = check.opt_mapping_param(
         logger_defs, "logger_defs", key_type=str, value_type=LoggerDefinition

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -493,7 +493,7 @@ def make_subset_from_partition_keys(
 
 
 def get_asset_graph(
-    assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]]
+    assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
 ) -> ExternalAssetGraph:
     assets_defs_by_key = {
         assets_def.key: assets_def

--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -118,7 +118,7 @@ def partitions_def_changes_workspace_1_load_target(attribute=None):
 
 @pytest.fixture(name="partitions_defs_changes_location_1_workspace_context", scope="module")
 def partitions_defs_changes_location_1_fixture(
-    instance_module_scoped
+    instance_module_scoped,
 ) -> Iterator[WorkspaceProcessContext]:
     with create_test_daemon_workspace_context(
         workspace_load_target=partitions_def_changes_workspace_1_load_target(),
@@ -143,7 +143,7 @@ def partitions_def_changes_workspace_2_load_target(attribute=None):
 
 @pytest.fixture(name="partitions_defs_changes_location_2_workspace_context", scope="module")
 def partitions_defs_changes_location_2_fixture(
-    instance_module_scoped
+    instance_module_scoped,
 ) -> Iterator[WorkspaceProcessContext]:
     with create_test_daemon_workspace_context(
         workspace_load_target=partitions_def_changes_workspace_2_load_target(),

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -314,7 +314,7 @@ class AssetDaemonScenarioState(NamedTuple):
         return self
 
     def _evaluate_tick_fast(
-        self
+        self,
     ) -> Tuple[Sequence[RunRequest], AssetDaemonCursor, Sequence[AutoMaterializeAssetEvaluation]]:
         cursor = AssetDaemonCursor.from_serialized(self.serialized_cursor, self.asset_graph)
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
@@ -23,7 +23,7 @@ from dagster._core.test_utils import instance_for_test
     ],
 )
 def test_dynamic_partitions_partitions(
-    partition_fn: Callable[[Optional[datetime]], Sequence[Partition]]
+    partition_fn: Callable[[Optional[datetime]], Sequence[Partition]],
 ):
     partitions = DynamicPartitionsDefinition(partition_fn)
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
@@ -380,7 +380,7 @@ def test_asset_schema_defaults():
     assert table_slice.schema == "public"
 
     asset_key = AssetKey(["schema1", "table1"])
-    output_context = output_context = build_output_context(
+    output_context = build_output_context(
         asset_key=asset_key, metadata={"schema": "schema2"}, resource_config=resource_config
     )
     table_slice = manager._get_table_slice(output_context, output_context)  # noqa: SLF001
@@ -388,7 +388,7 @@ def test_asset_schema_defaults():
     assert table_slice.schema == "schema2"
 
     asset_key = AssetKey(["table1"])
-    output_context = output_context = build_output_context(
+    output_context = build_output_context(
         asset_key=asset_key, metadata={"schema": "schema1"}, resource_config=resource_config
     )
     table_slice = manager._get_table_slice(output_context, output_context)  # noqa: SLF001

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -158,7 +158,7 @@ setup(
             "types-toml",  # version will be resolved against toml
         ],
         "ruff": [
-            "ruff==0.1.5",
+            "ruff==0.1.7",
         ],
     },
     entry_points={

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -158,7 +158,7 @@ setup(
             "types-toml",  # version will be resolved against toml
         ],
         "ruff": [
-            "ruff==0.1.1",
+            "ruff==0.1.5",
         ],
     },
     entry_points={

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -496,7 +496,7 @@ class AirbyteConnectionMetadata(
 
 
 def _get_schema_by_table_name(
-    stream_table_metadata: Mapping[str, AirbyteTableMetadata]
+    stream_table_metadata: Mapping[str, AirbyteTableMetadata],
 ) -> Mapping[str, TableSchema]:
     schema_by_base_table_name = [(k, v.schema) for k, v in stream_table_metadata.items()]
     schema_by_normalization_table_name = list(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
@@ -26,7 +26,7 @@ def airbyte_instance_constructor_fixture(request) -> Callable[[Dict[str, Any]], 
 
 @responses.activate
 def test_trigger_connection(
-    airbyte_instance_constructor: Callable[[Dict[str, Any]], AirbyteResource]
+    airbyte_instance_constructor: Callable[[Dict[str, Any]], AirbyteResource],
 ) -> None:
     ab_resource = airbyte_instance_constructor(
         {
@@ -46,7 +46,7 @@ def test_trigger_connection(
 
 
 def test_trigger_connection_fail(
-    airbyte_instance_constructor: Callable[[Dict[str, Any]], AirbyteResource]
+    airbyte_instance_constructor: Callable[[Dict[str, Any]], AirbyteResource],
 ) -> None:
     ab_resource = airbyte_instance_constructor({"host": "some_host", "port": "8000"})
     with pytest.raises(
@@ -131,7 +131,7 @@ def test_sync_and_poll(
 
 @responses.activate
 def test_start_sync_bad_out_fail(
-    airbyte_instance_constructor: Callable[[Dict[str, Any]], AirbyteResource]
+    airbyte_instance_constructor: Callable[[Dict[str, Any]], AirbyteResource],
 ) -> None:
     ab_resource = airbyte_instance_constructor(
         {
@@ -152,7 +152,7 @@ def test_start_sync_bad_out_fail(
 
 @responses.activate
 def test_get_connection_details_bad_out_fail(
-    airbyte_instance_constructor: Callable[[Dict[str, Any]], AirbyteResource]
+    airbyte_instance_constructor: Callable[[Dict[str, Any]], AirbyteResource],
 ) -> None:
     ab_resource = airbyte_instance_constructor(
         {

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -154,7 +154,7 @@ def instance_cm(stub_aws, stub_ecs_metadata) -> Callable[..., ContextManager[Dag
 
 @pytest.fixture
 def instance(
-    instance_cm: Callable[..., ContextManager[DagsterInstance]]
+    instance_cm: Callable[..., ContextManager[DagsterInstance]],
 ) -> Iterator[DagsterInstance]:
     with instance_cm(
         {
@@ -177,7 +177,7 @@ def instance_with_log_group(
 
 @pytest.fixture
 def instance_with_resources(
-    instance_cm: Callable[..., ContextManager[DagsterInstance]]
+    instance_cm: Callable[..., ContextManager[DagsterInstance]],
 ) -> Iterator[DagsterInstance]:
     with instance_cm(
         config={
@@ -216,7 +216,7 @@ def instance_dont_use_current_task(
 
 @pytest.fixture
 def instance_fargate_spot(
-    instance_cm: Callable[..., ContextManager[DagsterInstance]]
+    instance_cm: Callable[..., ContextManager[DagsterInstance]],
 ) -> Iterator[DagsterInstance]:
     with instance_cm(
         config={
@@ -331,7 +331,7 @@ def custom_instance_cm(stub_aws, stub_ecs_metadata):
 
 @pytest.fixture
 def custom_instance(
-    custom_instance_cm: Callable[..., ContextManager[DagsterInstance]]
+    custom_instance_cm: Callable[..., ContextManager[DagsterInstance]],
 ) -> Iterator[DagsterInstance]:
     with custom_instance_cm() as dagster_instance:
         yield dagster_instance

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -358,7 +358,7 @@ def default_asset_key_fn(dbt_resource_props: Mapping[str, Any]) -> AssetKey:
 
 
 def default_metadata_from_dbt_resource_props(
-    dbt_resource_props: Mapping[str, Any]
+    dbt_resource_props: Mapping[str, Any],
 ) -> Mapping[str, Any]:
     metadata: Dict[str, Any] = {}
     columns = dbt_resource_props.get("columns", {})
@@ -399,7 +399,7 @@ def default_group_from_dbt_resource_props(dbt_resource_props: Mapping[str, Any])
 
 
 def group_from_dbt_resource_props_fallback_to_directory(
-    dbt_resource_props: Mapping[str, Any]
+    dbt_resource_props: Mapping[str, Any],
 ) -> Optional[str]:
     """Get the group name for a dbt node.
 
@@ -456,7 +456,7 @@ def default_freshness_policy_fn(dbt_resource_props: Mapping[str, Any]) -> Option
 
 
 def _legacy_freshness_policy_fn(
-    freshness_policy_config: Mapping[str, Any]
+    freshness_policy_config: Mapping[str, Any],
 ) -> Optional[FreshnessPolicy]:
     if freshness_policy_config:
         return FreshnessPolicy(
@@ -468,7 +468,7 @@ def _legacy_freshness_policy_fn(
 
 
 def default_auto_materialize_policy_fn(
-    dbt_resource_props: Mapping[str, Any]
+    dbt_resource_props: Mapping[str, Any],
 ) -> Optional[AutoMaterializePolicy]:
     dagster_metadata = dbt_resource_props.get("meta", {}).get("dagster", {})
     auto_materialize_policy_config = dagster_metadata.get("auto_materialize_policy", {})
@@ -496,7 +496,7 @@ def default_auto_materialize_policy_fn(
 
 
 def _auto_materialize_policy_fn(
-    auto_materialize_policy_config: Mapping[str, Any]
+    auto_materialize_policy_config: Mapping[str, Any],
 ) -> Optional[AutoMaterializePolicy]:
     if auto_materialize_policy_config.get("type") == "eager":
         return AutoMaterializePolicy.eager()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -352,7 +352,7 @@ class DbtCliInvocation:
 
     @public
     def stream(
-        self
+        self,
     ) -> Iterator[
         Union[
             Output,
@@ -1027,7 +1027,7 @@ def get_subset_selection_for_context(
 
 
 def get_dbt_resource_props_by_output_name(
-    manifest: Mapping[str, Any]
+    manifest: Mapping[str, Any],
 ) -> Mapping[str, Mapping[str, Any]]:
     node_info_by_dbt_unique_id = get_dbt_resource_props_by_dbt_unique_id_from_manifest(manifest)
 
@@ -1039,7 +1039,7 @@ def get_dbt_resource_props_by_output_name(
 
 
 def get_dbt_resource_props_by_test_name(
-    manifest: Mapping[str, Any]
+    manifest: Mapping[str, Any],
 ) -> Mapping[str, Mapping[str, Any]]:
     return {
         dbt_resource_props["name"]: dbt_resource_props

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -297,7 +297,7 @@ def select_unique_ids_from_manifest(
 
 
 def get_dbt_resource_props_by_dbt_unique_id_from_manifest(
-    manifest: Mapping[str, Any]
+    manifest: Mapping[str, Any],
 ) -> Mapping[str, Mapping[str, Any]]:
     """A mapping of a dbt node's unique id to the node's dictionary representation in the manifest."""
     return {

--- a/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
@@ -202,7 +202,7 @@ def _pandera_schema_to_table_schema(schema: pa.DataFrameSchema) -> TableSchema:
 
 
 def _pandera_schema_wide_checks_to_table_constraints(
-    checks: Sequence[Union[pa.Check, pa.Hypothesis]]
+    checks: Sequence[Union[pa.Check, pa.Hypothesis]],
 ) -> TableConstraints:
     return TableConstraints(other=[_pandera_check_to_table_constraint(check) for check in checks])
 


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/7638

Bump ruff from 0.1.1 to 0.1.7. This fixes bugs, has a few performance improvements, and takes the formatter out of alpha.

The vast majority of changes are from a change to the formatter that adds a trailing comma in multiline parameter specifications.

## How I Tested These Changes

`make ruff`