### PR TITLE
[auto-materialize] Update context objects

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_automation_condition_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_automation_condition_context.py
@@ -1,0 +1,319 @@
+import datetime
+import functools
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, AbstractSet, Mapping, Optional
+
+from dagster._core.definitions.auto_materialize_rule_evaluation import RuleEvaluationResults
+from dagster._core.definitions.data_time import CachingDataTimeResolver
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.partition import PartitionsDefinition
+from dagster._core.definitions.partition_mapping import IdentityPartitionMapping
+from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
+from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
+
+from .asset_daemon_cursor import AssetDaemonAssetCursor
+from .asset_graph import AssetGraph
+from .asset_subset import AssetSubset
+
+if TYPE_CHECKING:
+    from .asset_automation_evaluator import AutomationCondition, ConditionEvaluation
+    from .asset_daemon_context import AssetDaemonContext
+
+
+@dataclass(frozen=True)
+class AssetAutomationEvaluationContext:
+    """Context object containing methods and properties used for evaluating the entire state of an
+    asset's automation rules.
+    """
+
+    asset_key: AssetKey
+    asset_cursor: Optional[AssetDaemonAssetCursor]
+    root_condition: "AutomationCondition"
+
+    instance_queryer: CachingInstanceQueryer
+    data_time_resolver: CachingDataTimeResolver
+    daemon_context: "AssetDaemonContext"
+
+    evaluation_results_by_key: Mapping[AssetKey, "ConditionEvaluation"]
+    expected_data_time_mapping: Mapping[AssetKey, Optional[datetime.datetime]]
+
+    @property
+    def asset_graph(self) -> AssetGraph:
+        return self.instance_queryer.asset_graph
+
+    @property
+    def partitions_def(self) -> Optional[PartitionsDefinition]:
+        return self.asset_graph.get_partitions_def(self.asset_key)
+
+    @property
+    def evaluation_time(self) -> datetime.datetime:
+        """Returns the time at which this rule is being evaluated."""
+        return self.instance_queryer.evaluation_time
+
+    @functools.cached_property
+    def latest_evaluation(self) -> Optional["ConditionEvaluation"]:
+        if not self.asset_cursor:
+            return None
+        return self.asset_cursor.latest_evaluation
+
+    @functools.cached_property
+    def parent_will_update_subset(self) -> AssetSubset:
+        """Returns the set of asset partitions whose parents will be updated on this tick, and which
+        can be materialized in the same run as this asset.
+        """
+        subset = self.empty_subset()
+        for parent_key in self.asset_graph.get_parents(self.asset_key):
+            if not self.materializable_in_same_run(self.asset_key, parent_key):
+                continue
+            parent_result = self.evaluation_results_by_key.get(parent_key)
+            if not parent_result:
+                continue
+            parent_subset = parent_result.true_subset
+            subset |= parent_subset._replace(asset_key=self.asset_key)
+        return subset
+
+    @property
+    def previous_tick_requested_subset(self) -> AssetSubset:
+        """Returns the set of asset partitions that were requested on the previous tick."""
+        if not self.latest_evaluation:
+            return self.empty_subset()
+        return self.latest_evaluation.true_subset
+
+    @functools.cached_property
+    def materialized_since_previous_tick_subset(self) -> AssetSubset:
+        """Returns the set of asset partitions that were materialized since the previous tick."""
+        return AssetSubset.from_asset_partitions_set(
+            self.asset_key,
+            self.partitions_def,
+            self.instance_queryer.get_asset_partitions_updated_after_cursor(
+                self.asset_key,
+                asset_partitions=None,
+                after_cursor=self.asset_cursor.latest_storage_id if self.asset_cursor else None,
+                respect_materialization_data_versions=False,
+            ),
+        )
+
+    @functools.cached_property
+    def materialized_requested_or_discarded_since_previous_tick_subset(self) -> AssetSubset:
+        """Returns the set of asset partitions that were materialized since the previous tick."""
+        if not self.latest_evaluation:
+            return self.materialized_since_previous_tick_subset
+        return (
+            self.materialized_since_previous_tick_subset
+            | self.latest_evaluation.true_subset
+            | (self.latest_evaluation.discard_subset or self.empty_subset())
+        )
+
+    @functools.cached_property
+    def never_materialized_requested_or_discarded_root_subset(self) -> AssetSubset:
+        if self.asset_key not in self.asset_graph.root_materializable_or_observable_asset_keys:
+            return self.empty_subset()
+
+        handled_subset = (
+            self.asset_cursor.materialized_requested_or_discarded_subset
+            if self.asset_cursor
+            else self.empty_subset()
+        )
+        unhandled_subset = handled_subset.inverse(
+            self.partitions_def,
+            dynamic_partitions_store=self.instance_queryer,
+            current_time=self.evaluation_time,
+        )
+        return unhandled_subset - self.materialized_since_previous_tick_subset
+
+    def materializable_in_same_run(self, child_key: AssetKey, parent_key: AssetKey) -> bool:
+        """Returns whether a child asset can be materialized in the same run as a parent asset."""
+        from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+
+        return (
+            # both assets must be materializable
+            child_key in self.asset_graph.materializable_asset_keys
+            and parent_key in self.asset_graph.materializable_asset_keys
+            # the parent must have the same partitioning
+            and self.asset_graph.have_same_partitioning(child_key, parent_key)
+            # the parent must have a simple partition mapping to the child
+            and (
+                not self.asset_graph.is_partitioned(parent_key)
+                or isinstance(
+                    self.asset_graph.get_partition_mapping(child_key, parent_key),
+                    (TimeWindowPartitionMapping, IdentityPartitionMapping),
+                )
+            )
+            # the parent must be in the same repository to be materialized alongside the candidate
+            and (
+                not isinstance(self.asset_graph, ExternalAssetGraph)
+                or self.asset_graph.get_repository_handle(child_key)
+                == self.asset_graph.get_repository_handle(parent_key)
+            )
+        )
+
+    def get_parents_that_will_not_be_materialized_on_current_tick(
+        self, *, asset_partition: AssetKeyPartitionKey
+    ) -> AbstractSet[AssetKeyPartitionKey]:
+        """Returns the set of parent asset partitions that will not be updated in the same run of
+        this asset partition if a run is launched for this asset partition on this tick.
+        """
+        return {
+            parent
+            for parent in self.asset_graph.get_parents_partitions(
+                dynamic_partitions_store=self.instance_queryer,
+                current_time=self.instance_queryer.evaluation_time,
+                asset_key=asset_partition.asset_key,
+                partition_key=asset_partition.partition_key,
+            ).parent_partitions
+            if not self.will_udpate_asset_partition(parent)
+            or not self.materializable_in_same_run(asset_partition.asset_key, parent.asset_key)
+        }
+
+    def will_udpate_asset_partition(self, asset_partition: AssetKeyPartitionKey) -> bool:
+        parent_evaluation = self.evaluation_results_by_key.get(asset_partition.asset_key)
+        if not parent_evaluation:
+            return False
+        return asset_partition in parent_evaluation.true_subset
+
+    def empty_subset(self) -> AssetSubset:
+        return AssetSubset.empty(self.asset_key, self.partitions_def)
+
+    def get_root_condition_context(self) -> "AssetAutomationConditionEvaluationContext":
+        return AssetAutomationConditionEvaluationContext(
+            asset_context=self,
+            condition=self.root_condition,
+            candidate_subset=AssetSubset.all(
+                asset_key=self.asset_key,
+                partitions_def=self.partitions_def,
+                dynamic_partitions_store=self.instance_queryer,
+                current_time=self.instance_queryer.evaluation_time,
+            ),
+            latest_evaluation=self.latest_evaluation,
+        )
+
+    def get_new_asset_cursor(self, evaluation: "ConditionEvaluation") -> AssetDaemonAssetCursor:
+        """Returns a new AssetDaemonAssetCursor based on the current cursor and the results of
+        this tick's evaluation.
+        """
+        previous_handled_subset = (
+            self.asset_cursor.materialized_requested_or_discarded_subset
+            if self.asset_cursor
+            else self.empty_subset()
+        )
+        new_handled_subset = (
+            previous_handled_subset
+            | self.materialized_requested_or_discarded_since_previous_tick_subset
+            | evaluation.true_subset
+            | (evaluation.discard_subset or self.empty_subset())
+        )
+        return AssetDaemonAssetCursor(
+            asset_key=self.asset_key,
+            latest_storage_id=self.daemon_context.get_new_latest_storage_id(),
+            latest_evaluation=evaluation,
+            latest_evaluation_timestamp=self.evaluation_time.timestamp(),
+            materialized_requested_or_discarded_subset=new_handled_subset,
+        )
+
+
+@dataclass(frozen=True)
+class AssetAutomationConditionEvaluationContext:
+    """Context object containing methods and properties used for evaluating a particular AutomationCondition."""
+
+    asset_context: AssetAutomationEvaluationContext
+    condition: "AutomationCondition"
+    candidate_subset: AssetSubset
+    latest_evaluation: Optional["ConditionEvaluation"]
+
+    @property
+    def asset_key(self) -> AssetKey:
+        return self.asset_context.asset_key
+
+    @property
+    def partitions_def(self) -> Optional[PartitionsDefinition]:
+        return self.asset_context.partitions_def
+
+    @property
+    def asset_cursor(self) -> Optional[AssetDaemonAssetCursor]:
+        return self.asset_context.asset_cursor
+
+    @property
+    def asset_graph(self) -> AssetGraph:
+        return self.asset_context.asset_graph
+
+    @property
+    def instance_queryer(self) -> CachingInstanceQueryer:
+        return self.asset_context.instance_queryer
+
+    @property
+    def max_storage_id(self) -> Optional[int]:
+        return self.asset_cursor.latest_storage_id if self.asset_cursor else None
+
+    @property
+    def latest_evaluation_timestamp(self) -> Optional[float]:
+        return self.asset_cursor.latest_evaluation_timestamp if self.asset_cursor else None
+
+    @property
+    def previous_tick_true_subset(self) -> AssetSubset:
+        """Returns the set of asset partitions that were true on the previous tick."""
+        if not self.latest_evaluation:
+            return self.empty_subset()
+        return self.latest_evaluation.true_subset
+
+    @property
+    def parent_has_updated_subset(self) -> AssetSubset:
+        """Returns the set of asset partitions whose parents have updated since the last time this
+        condition was evaluated.
+        """
+        return AssetSubset.from_asset_partitions_set(
+            self.asset_key,
+            self.partitions_def,
+            self.asset_context.instance_queryer.asset_partitions_with_newly_updated_parents(
+                latest_storage_id=self.max_storage_id,
+                child_asset_key=self.asset_context.asset_key,
+                map_old_time_partitions=False,
+            ),
+        )
+
+    @property
+    def candidate_parent_has_or_will_update_subset(self) -> AssetSubset:
+        """Returns the set of candidates for this tick which have parents that have updated since
+        the previous tick, or will update on this tick.
+        """
+        return self.candidate_subset & (
+            self.parent_has_updated_subset | self.asset_context.parent_will_update_subset
+        )
+
+    @property
+    def candidates_not_evaluated_on_previous_tick_subset(self) -> AssetSubset:
+        """Returns the set of candidates for this tick which were not candidates on the previous
+        tick.
+        """
+        if not self.latest_evaluation:
+            return self.candidate_subset
+        return self.candidate_subset - self.latest_evaluation.candidate_subset
+
+    @property
+    def materialized_since_previous_tick_subset(self) -> AssetSubset:
+        """Returns the set of asset partitions that were materialized since the previous tick."""
+        return self.asset_context.materialized_since_previous_tick_subset
+
+    @property
+    def materialized_requested_or_discarded_since_previous_tick_subset(self) -> AssetSubset:
+        """Returns the set of asset partitions that were materialized since the previous tick."""
+        return self.asset_context.materialized_requested_or_discarded_since_previous_tick_subset
+
+    @property
+    def previous_tick_results(self) -> RuleEvaluationResults:
+        """Returns the RuleEvaluationResults calculated on the previous tick for this condition."""
+        return self.latest_evaluation.results if self.latest_evaluation else []
+
+    def empty_subset(self) -> AssetSubset:
+        return self.asset_context.empty_subset()
+
+    def for_child(
+        self, condition: "AutomationCondition", candidate_subset: AssetSubset
+    ) -> "AssetAutomationConditionEvaluationContext":
+        return AssetAutomationConditionEvaluationContext(
+            asset_context=self.asset_context,
+            condition=condition,
+            candidate_subset=candidate_subset,
+            latest_evaluation=self.latest_evaluation.for_child(condition)
+            if self.latest_evaluation
+            else None,
+        )

--- a/python_modules/dagster/dagster/_core/definitions/asset_automation_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_automation_evaluator.py
@@ -1,4 +1,5 @@
-from abc import ABC, abstractmethod
+import dataclasses
+from abc import ABC, abstractmethod, abstractproperty
 from typing import TYPE_CHECKING, AbstractSet, List, NamedTuple, Optional, Sequence, Tuple
 
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonAssetCursor
@@ -6,14 +7,15 @@ from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 
-from .asset_subset import AssetSubset
-from .auto_materialize_rule import (
-    DiscardOnMaxMaterializationsExceededRule,
-    RuleEvaluationContext,
-    RuleEvaluationResults,
+from .asset_automation_condition_context import (
+    AssetAutomationConditionEvaluationContext,
+    AssetAutomationEvaluationContext,
 )
+from .asset_subset import AssetSubset
+from .auto_materialize_rule import DiscardOnMaxMaterializationsExceededRule, RuleEvaluationResults
 from .auto_materialize_rule_evaluation import (
     AutoMaterializeAssetEvaluation,
+    AutoMaterializeDecisionType,
     AutoMaterializeRuleEvaluation,
 )
 
@@ -26,8 +28,14 @@ class ConditionEvaluation(NamedTuple):
 
     condition: "AutomationCondition"
     true_subset: AssetSubset
+    candidate_subset: AssetSubset
+
+    # backcompat until we remove the discard concept
+    discard_subset: Optional[AssetSubset] = None
+    discard_results: RuleEvaluationResults = []
+
     results: RuleEvaluationResults = []
-    children: Sequence["ConditionEvaluation"] = []
+    child_evaluations: Sequence["ConditionEvaluation"] = []
 
     @property
     def all_results(
@@ -49,9 +57,16 @@ class ConditionEvaluation(NamedTuple):
             ]
         else:
             results = []
-        for child in self.children:
+        for child in self.child_evaluations:
             results = [*results, *child.all_results]
         return results
+
+    def for_child(self, child_condition: "AutomationCondition") -> Optional["ConditionEvaluation"]:
+        """Returns the evaluation of a given child condition."""
+        for child_evaluation in self.child_evaluations:
+            if child_evaluation.condition == child_condition:
+                return child_evaluation
+        return None
 
     def to_evaluation(
         self,
@@ -62,11 +77,20 @@ class ConditionEvaluation(NamedTuple):
         discard_results: Sequence[
             Tuple[AutoMaterializeRuleEvaluation, AbstractSet[AssetKeyPartitionKey]]
         ],
-        skipped_subset_size: int,
     ) -> AutoMaterializeAssetEvaluation:
         """This method is a placeholder to allow us to convert this into a shape that other parts
         of the system understand.
         """
+        # backcompat way to calculate the set of skipped partitions for legacy policies
+        if self.condition.is_legacy and len(self.child_evaluations) == 2:
+            # the first child is the materialize condition, the second child is the skip_condition
+            materialize_condition, skip_evaluation = self.child_evaluations
+            skipped_subset_size = (
+                materialize_condition.true_subset.size - skip_evaluation.true_subset.size
+            )
+        else:
+            skipped_subset_size = 0
+
         return AutoMaterializeAssetEvaluation.from_rule_evaluation_results(
             asset_key=asset_key,
             asset_graph=asset_graph,
@@ -77,6 +101,81 @@ class ConditionEvaluation(NamedTuple):
             dynamic_partitions_store=instance_queryer,
         )
 
+    @staticmethod
+    def from_evaluation_and_rule(
+        evaluation: AutoMaterializeAssetEvaluation,
+        asset_graph: AssetGraph,
+        rule: AutoMaterializeRule,
+    ) -> "ConditionEvaluation":
+        asset_key = evaluation.asset_key
+        partitions_def = asset_graph.get_partitions_def(asset_key)
+        empty_subset = AssetSubset.empty(asset_key, partitions_def)
+        return ConditionEvaluation(
+            condition=RuleCondition(rule=rule),
+            true_subset=empty_subset,
+            candidate_subset=empty_subset
+            if rule.decision_type == AutoMaterializeDecisionType.MATERIALIZE
+            else evaluation.get_evaluated_subset(asset_graph),
+            discard_subset=empty_subset,
+            results=evaluation.get_rule_evaluation_results(rule.to_snapshot(), asset_graph),
+        )
+
+    @staticmethod
+    def from_evaluation(
+        condition: "AutomationCondition",
+        evaluation: AutoMaterializeAssetEvaluation,
+        asset_graph: AssetGraph,
+    ) -> Optional["ConditionEvaluation"]:
+        """This method is a placeholder to allow us to convert the serialized objects the system
+        uses into a more-convenient internal representation.
+        """
+        if not condition.is_legacy:
+            return None
+
+        asset_key = evaluation.asset_key
+        partitions_def = asset_graph.get_partitions_def(asset_key)
+        empty_subset = AssetSubset.empty(asset_key, partitions_def)
+
+        materialize_condition, skip_condition = condition.children
+        materialize_rules = [
+            materialize_condition.rule
+            for materialize_condition in materialize_condition.children
+            if isinstance(materialize_condition, RuleCondition)
+            and materialize_condition.rule.to_snapshot() in (evaluation.rule_snapshots or set())
+        ]
+        skip_rules = [
+            skip_condition.rule
+            for skip_condition in skip_condition.children
+            if isinstance(skip_condition, RuleCondition)
+            and skip_condition.rule.to_snapshot() in (evaluation.rule_snapshots or set())
+        ]
+        children = [
+            ConditionEvaluation(
+                condition=materialize_condition,
+                true_subset=empty_subset,
+                candidate_subset=empty_subset,
+                child_evaluations=[
+                    ConditionEvaluation.from_evaluation_and_rule(evaluation, asset_graph, rule)
+                    for rule in materialize_rules
+                ],
+            ),
+            ConditionEvaluation(
+                condition=skip_condition,
+                true_subset=empty_subset,
+                candidate_subset=empty_subset,
+                child_evaluations=[
+                    ConditionEvaluation.from_evaluation_and_rule(evaluation, asset_graph, rule)
+                    for rule in skip_rules
+                ],
+            ),
+        ]
+        return ConditionEvaluation(
+            condition=condition,
+            true_subset=evaluation.get_evaluated_subset(asset_graph),
+            candidate_subset=empty_subset,
+            child_evaluations=children,
+        )
+
 
 class AutomationCondition(ABC):
     """An AutomationCondition represents some state of the world that can influence if an asset
@@ -84,8 +183,12 @@ class AutomationCondition(ABC):
     new conditions using the `&` (and), `|` (or), and `~` (not) operators.
     """
 
+    @abstractproperty
+    def children(self) -> Sequence["AutomationCondition"]:
+        raise NotImplementedError()
+
     @abstractmethod
-    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+    def evaluate(self, context: AssetAutomationConditionEvaluationContext) -> ConditionEvaluation:
         raise NotImplementedError()
 
     def __and__(self, other: "AutomationCondition") -> "AutomationCondition":
@@ -109,22 +212,43 @@ class AutomationCondition(ABC):
             return OrAutomationCondition(children=self.children)
         return NorAutomationCondition(children=[self])
 
+    @property
+    def is_legacy(self) -> bool:
+        """Returns if this condition is in the legacy format. This is used to determine if we can
+        do certain types of backwards-compatible operations on it.
+        """
+        return (
+            isinstance(self, AndAutomationCondition)
+            and len(self.children) == 2
+            and isinstance(self.children[0], OrAutomationCondition)
+            and isinstance(self.children[1], NorAutomationCondition)
+        )
+
 
 class RuleCondition(
     AutomationCondition, NamedTuple("_RuleCondition", [("rule", AutoMaterializeRule)])
 ):
     """This class represents the condition that a particular AutoMaterializeRule is satisfied."""
 
-    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
-        context.daemon_context._verbose_log_fn(f"Evaluating rule: {self.rule.to_snapshot()}")  # noqa
+    def evaluate(self, context: AssetAutomationConditionEvaluationContext) -> ConditionEvaluation:
+        context.asset_context.daemon_context._verbose_log_fn(  # noqa
+            f"Evaluating rule: {self.rule.to_snapshot()}"
+        )
         results = self.rule.evaluate_for_asset(context)
         true_subset = context.empty_subset()
         for _, asset_partitions in results:
             true_subset |= AssetSubset.from_asset_partitions_set(
                 context.asset_key, context.partitions_def, asset_partitions
             )
-        context.daemon_context._verbose_log_fn(f"Rule returned {true_subset.size} partitions")  # noqa
-        return ConditionEvaluation(condition=self, true_subset=true_subset, results=results)
+        context.asset_context.daemon_context._verbose_log_fn(  # noqa
+            f"Rule returned {true_subset.size} partitions"
+        )
+        return ConditionEvaluation(
+            condition=self,
+            true_subset=true_subset,
+            candidate_subset=context.candidate_subset,
+            results=results,
+        )
 
 
 class AndAutomationCondition(
@@ -133,16 +257,19 @@ class AndAutomationCondition(
 ):
     """This class represents the condition that all of its children evaluate to true."""
 
-    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+    def evaluate(self, context: AssetAutomationConditionEvaluationContext) -> ConditionEvaluation:
         child_evaluations: List[ConditionEvaluation] = []
         true_subset = context.candidate_subset
         for child in self.children:
-            context = context.with_candidate_subset(true_subset)
+            context = context.for_child(condition=child, candidate_subset=true_subset)
             result = child.evaluate(context)
             child_evaluations.append(result)
             true_subset &= result.true_subset
         return ConditionEvaluation(
-            condition=self, true_subset=true_subset, children=child_evaluations
+            condition=self,
+            true_subset=true_subset,
+            candidate_subset=context.candidate_subset,
+            child_evaluations=child_evaluations,
         )
 
 
@@ -152,7 +279,7 @@ class OrAutomationCondition(
 ):
     """This class represents the condition that any of its children evaluate to true."""
 
-    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+    def evaluate(self, context: AssetAutomationConditionEvaluationContext) -> ConditionEvaluation:
         child_evaluations: List[ConditionEvaluation] = []
         true_subset = context.empty_subset()
         for child in self.children:
@@ -160,7 +287,10 @@ class OrAutomationCondition(
             child_evaluations.append(result)
             true_subset |= result.true_subset
         return ConditionEvaluation(
-            condition=self, true_subset=true_subset, children=child_evaluations
+            condition=self,
+            true_subset=true_subset,
+            candidate_subset=context.candidate_subset,
+            child_evaluations=child_evaluations,
         )
 
 
@@ -170,7 +300,7 @@ class NorAutomationCondition(
 ):
     """This class represents the condition that none of its children evaluate to true."""
 
-    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+    def evaluate(self, context: AssetAutomationConditionEvaluationContext) -> ConditionEvaluation:
         child_evaluations: List[ConditionEvaluation] = []
         true_subset = context.candidate_subset
         for child in self.children:
@@ -179,7 +309,10 @@ class NorAutomationCondition(
             child_evaluations.append(result)
             true_subset -= result.true_subset
         return ConditionEvaluation(
-            condition=self, true_subset=true_subset, children=child_evaluations
+            condition=self,
+            true_subset=true_subset,
+            candidate_subset=context.candidate_subset,
+            child_evaluations=child_evaluations,
         )
 
 
@@ -192,67 +325,37 @@ class AssetAutomationEvaluator(NamedTuple):
     max_materializations_per_minute: Optional[int] = 1
 
     def evaluate(
-        self, context: RuleEvaluationContext, report_num_skipped: bool
-    ) -> Tuple[
-        AutoMaterializeAssetEvaluation,
-        AssetDaemonAssetCursor,
-        AbstractSet[AssetKeyPartitionKey],
-    ]:
+        self, context: AssetAutomationEvaluationContext
+    ) -> Tuple[ConditionEvaluation, AssetDaemonAssetCursor, AssetSubset]:
         """Evaluates the auto materialize policy of a given asset.
 
         Returns:
-        - An AutoMaterializeAssetEvaluation object representing serializable information about
-        this evaluation. If `report_num_skipped` is set to `True`, then this will attempt to
-        calculate the number of skipped partitions in a backwards-compatible way. This can only be
-        done for policies that are in the format `(a | b | ...) & ~(c | d | ...).
-        - The set of AssetKeyPartitionKeys that should be materialized.
-        - The set of AssetKeyPartitionKeys that should be discarded.
+        - A ConditionEvaluation object representing information about this evaluation. If
+        `report_num_skipped` is set to `True`, then this will attempt to calculate the number of
+        skipped partitions in a backwards-compatible way. This can only be done for policies that
+        are in the format `(a | b | ...) & ~(c | d | ...).
+        - A new AssetDaemonAssetCursor that represents the state of the world after this evaluation.
+        - The AssetSubset that should be discarded.
         """
-        condition_evaluation = self.condition.evaluate(context)
+        condition_context = context.get_root_condition_context()
+        condition_evaluation = self.condition.evaluate(condition_context)
 
         # this is treated separately from other rules, for now
-        to_discard, discard_results = context.empty_subset(), []
+        to_discard = context.empty_subset()
         if self.max_materializations_per_minute is not None:
-            discard_context = context.with_candidate_subset(condition_evaluation.true_subset)
+            discard_context = dataclasses.replace(
+                condition_context, candidate_subset=condition_evaluation.true_subset
+            )
             condition = RuleCondition(
                 DiscardOnMaxMaterializationsExceededRule(limit=self.max_materializations_per_minute)
             )
             discard_condition_evaluation = condition.evaluate(discard_context)
             to_discard = discard_condition_evaluation.true_subset
-            discard_results = discard_condition_evaluation.all_results
-
-        to_materialize = condition_evaluation.true_subset - to_discard
-
-        skipped_subset_size = 0
-        if (
-            report_num_skipped
-            # check shape of top-level condition
-            and isinstance(self.condition, AndAutomationCondition)
-            and len(self.condition.children) == 2
-            and isinstance(self.condition.children[1], NorAutomationCondition)
-            # confirm shape of evaluation
-            and len(condition_evaluation.children) == 2
-        ):
-            # the first child is the materialize condition, the second child is the skip_condition
-            materialize_condition, skip_evaluation = condition_evaluation.children
-            skipped_subset_size = (
-                materialize_condition.true_subset.size - skip_evaluation.true_subset.size
-            )
 
         return (
-            condition_evaluation.to_evaluation(
-                context.asset_key,
-                context.asset_graph,
-                context.instance_queryer,
-                to_discard,
-                discard_results,
-                skipped_subset_size=skipped_subset_size,
+            condition_evaluation._replace(discard_subset=to_discard),
+            context.get_new_asset_cursor(
+                to_materialize=condition_evaluation.true_subset, to_discard=to_discard
             ),
-            context.cursor.with_updates(
-                asset_graph=context.asset_graph,
-                newly_materialized_subset=context.newly_materialized_root_subset,
-                requested_asset_partitions=to_materialize.asset_partitions,
-                discarded_asset_partitions=to_discard.asset_partitions,
-            ),
-            to_materialize.asset_partitions,
+            to_discard,
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -265,17 +265,6 @@ class AssetDaemonContext:
 
         evaluation, cursor, to_discard = auto_materialize_policy_evaluator.evaluate(context, report_num_skipped=True)
 
-        if (
-            # check shape of top-level condition
-            auto_materialize_policy_evaluator.condition.is_legacy
-            # confirm shape of evaluation
-            and len(condition_evaluation.child_evaluations) == 2
-        ):
-            # the first child is the materialize condition, the second child is the skip_condition
-            materialize_condition, skip_evaluation = condition_evaluation.child_evaluations
-            skipped_subset_size = (
-                materialize_condition.true_subset.size - skip_evaluation.true_subset.size
-            )
 
 
     def get_auto_materialize_asset_evaluations(

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -314,12 +314,11 @@ class AssetDaemonContext:
                 else self._logger.debug
             )
 
+            to_request_asset_partitions = evaluation.true_subset.asset_partitions
             to_request_str = ",".join(
-                [
-                    (to_request.partition_key or "No partition")
-                    for to_request in evaluation.true_subset.asset_partitions
-                ]
+                [(ap.partition_key or "No partition") for ap in to_request_asset_partitions]
             )
+            to_request |= to_request_asset_partitions
 
             log_fn(
                 f"Asset {asset_key.to_user_string()} evaluation result: {legacy_evaluation.num_requested}"
@@ -343,12 +342,6 @@ class AssetDaemonContext:
                         for ap in evaluation.true_subset.asset_partitions
                     }
 
-        to_request = set().union(
-            *(
-                evaluation.true_subset.asset_partitions
-                for evaluation in evaluation_results_by_key.values()
-            )
-        )
         return (list(legacy_evaluation_results_by_key.values()), asset_cursors, to_request)
 
     def evaluate(

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -36,6 +36,7 @@ from dagster._utils.cached_method import cached_method
 from ... import PartitionKeyRange
 from ..storage.tags import ASSET_PARTITION_RANGE_END_TAG, ASSET_PARTITION_RANGE_START_TAG
 from .asset_automation_condition_context import AssetAutomationEvaluationContext
+from .asset_automation_evaluator import ConditionEvaluation
 from .asset_daemon_cursor import AssetDaemonAssetCursor, AssetDaemonCursor
 from .asset_graph import AssetGraph
 from .auto_materialize_rule import AutoMaterializeRule
@@ -43,7 +44,6 @@ from .auto_materialize_rule_evaluation import AutoMaterializeAssetEvaluation
 from .backfill_policy import BackfillPolicy, BackfillPolicyType
 from .freshness_based_auto_materialize import get_expected_data_time_for_asset_key
 from .partition import PartitionsDefinition, ScheduleType
-from .asset_automation_evaluator import ConditionEvaluation
 
 if TYPE_CHECKING:
     from dagster._core.instance import DagsterInstance
@@ -224,11 +224,7 @@ class AssetDaemonContext:
         asset_key: AssetKey,
         evaluation_results_by_key: Mapping[AssetKey, ConditionEvaluation],
         expected_data_time_mapping: Mapping[AssetKey, Optional[datetime.datetime]],
-    ) -> Tuple[
-        AutoMaterializeAssetEvaluation,
-        AssetDaemonAssetCursor,
-        AbstractSet[AssetKeyPartitionKey],
-    ]:
+    ) -> Tuple[ConditionEvaluation, AssetDaemonAssetCursor, Optional[datetime.datetime]]:
         """Evaluates the auto materialize policy of a given asset key.
 
         Params:
@@ -240,11 +236,6 @@ class AssetDaemonContext:
                 asset after this tick. As this function is called in topological order, this mapping
                 will contain the expected data times of all upstream assets.
 
-        Returns:
-            - An AutoMaterializeAssetEvaluation object representing serializable information about
-                this evaluation.
-            - The set of AssetKeyPartitionKeys that should be materialized.
-            - The set of AssetKeyPartitionKeys that should be discarded.
         """
         # convert the legacy AutoMaterializePolicy to an Evaluator
         auto_materialize_policy_evaluator = check.not_none(
@@ -254,7 +245,7 @@ class AssetDaemonContext:
         partitions_def = self.asset_graph.get_partitions_def(asset_key)
         context = AssetAutomationEvaluationContext(
             asset_key=asset_key,
-            asset_cursor=self.cursor.asset_cursor_for_key(asset_key, partitions_def),
+            asset_cursor=self.cursor.asset_cursor_for_key(asset_key, self.asset_graph),
             root_condition=auto_materialize_policy_evaluator.condition,
             instance_queryer=self.instance_queryer,
             data_time_resolver=self.data_time_resolver,
@@ -262,17 +253,18 @@ class AssetDaemonContext:
             evaluation_results_by_key=evaluation_results_by_key,
             expected_data_time_mapping=expected_data_time_mapping,
         )
-
-        evaluation, cursor, to_discard = auto_materialize_policy_evaluator.evaluate(context, report_num_skipped=True)
-
-
+        evaluation, asset_cursor = auto_materialize_policy_evaluator.evaluate(context)
+        expected_data_time = get_expected_data_time_for_asset_key(
+            context, will_materialize=evaluation.true_subset.size > 0
+        )
+        return evaluation, asset_cursor, expected_data_time
 
     def get_auto_materialize_asset_evaluations(
         self,
     ) -> Tuple[
         Sequence[AutoMaterializeAssetEvaluation],
         Sequence[AssetDaemonAssetCursor],
-        AbstractSet[AssetKeyPartitionKey]
+        AbstractSet[AssetKeyPartitionKey],
     ]:
         """Returns a mapping from asset key to the AutoMaterializeAssetEvaluation for that key, a
         sequence of new per-asset cursors, and the set of all asset partitions that should be
@@ -280,8 +272,10 @@ class AssetDaemonContext:
         """
         asset_cursors: List[AssetDaemonAssetCursor] = []
 
-        evaluations_results_by_key: Dict[AssetKey, ConditionEvaluation] = {}
+        evaluation_results_by_key: Dict[AssetKey, ConditionEvaluation] = {}
+        legacy_evaluation_results_by_key: Dict[AssetKey, AutoMaterializeAssetEvaluation] = {}
         expected_data_time_mapping: Dict[AssetKey, Optional[datetime.datetime]] = defaultdict()
+        to_request: Set[AssetKeyPartitionKey] = set()
 
         num_checked_assets = 0
         num_target_asset_keys = len(self.target_asset_keys)
@@ -302,70 +296,61 @@ class AssetDaemonContext:
                 self._verbose_log_fn(f"Asset {asset_key.to_user_string()} already visited")
                 continue
 
-            (
-                evaluation,
-                asset_cursor_for_asset,
-                to_materialize_for_asset,
-            ) = self.evaluate_asset(asset_key, evaluations_results_by_key, expected_data_time_mapping)
+            (evaluation, asset_cursor_for_asset, expected_data_time) = self.evaluate_asset(
+                asset_key, evaluation_results_by_key, expected_data_time_mapping
+            )
+
+            # convert the new-format evaluation to the legacy format
+            legacy_evaluation = evaluation.to_evaluation(
+                asset_key, self.asset_graph, self.instance_queryer
+            )
 
             log_fn = (
                 self._logger.info
-                if (evaluation.num_requested or evaluation.num_skipped or evaluation.num_discarded)
+                if (
+                    legacy_evaluation.num_requested
+                    or legacy_evaluation.num_skipped
+                    or legacy_evaluation.num_discarded
+                )
                 else self._logger.debug
             )
 
-            to_materialize_str = ",".join(
+            to_request_str = ",".join(
                 [
-                    (to_materialize.partition_key or "No partition")
-                    for to_materialize in to_materialize_for_asset
+                    (to_request.partition_key or "No partition")
+                    for to_request in evaluation.true_subset.asset_partitions
                 ]
             )
 
             log_fn(
-                f"Asset {asset_key.to_user_string()} evaluation result: {evaluation.num_requested}"
-                f" requested ({to_materialize_str}), {evaluation.num_skipped}"
-                f" skipped, {evaluation.num_discarded} discarded ({format(time.time()-start_time, '.3f')} seconds)"
+                f"Asset {asset_key.to_user_string()} evaluation result: {legacy_evaluation.num_requested}"
+                f" requested ({to_request_str}), {legacy_evaluation.num_skipped}"
+                f" skipped, {legacy_evaluation.num_discarded} discarded ({format(time.time()-start_time, '.3f')} seconds)"
             )
 
-            evaluations_by_key[asset_key] = evaluation
-            asset_cursors.append(asset_cursor_for_asset)
-            will_materialize_mapping[asset_key] = to_materialize_for_asset
-
-            expected_data_time = get_expected_data_time_for_asset_key(
-                self.asset_graph,
-                asset_key,
-                will_materialize_mapping=will_materialize_mapping,
-                expected_data_time_mapping=expected_data_time_mapping,
-                data_time_resolver=self.data_time_resolver,
-                current_time=self.instance_queryer.evaluation_time,
-                will_materialize=bool(to_materialize_for_asset),
-            )
+            evaluation_results_by_key[asset_key] = evaluation
+            legacy_evaluation_results_by_key[asset_key] = legacy_evaluation
             expected_data_time_mapping[asset_key] = expected_data_time
-            # if we need to materialize any partitions of a non-subsettable multi-asset, just copy
-            # over evaluation to any required neighbor key
-            if to_materialize_for_asset:
+            asset_cursors.append(asset_cursor_for_asset)
+
+            # if we need to materialize any partitions of a non-subsettable multi-asset, we need to
+            # materialize all of them
+            if legacy_evaluation.num_requested > 0:
                 for neighbor_key in self.asset_graph.get_required_multi_asset_keys(asset_key):
-                    auto_materialize_policy = self.asset_graph.auto_materialize_policies_by_key.get(
-                        neighbor_key
-                    )
-
-                    if auto_materialize_policy is None:
-                        check.failed(f"Expected auto materialize policy on asset {asset_key}")
-
-                    to_materialize_for_neighbor = {
-                        ap._replace(asset_key=neighbor_key) for ap in to_materialize_for_asset
-                    }
-
-                    evaluations_by_key[neighbor_key] = evaluation._replace(
-                        asset_key=neighbor_key,
-                        rule_snapshots=auto_materialize_policy.rule_snapshots,  # Neighbors can have different rule snapshots
-                    )
-
                     expected_data_time_mapping[neighbor_key] = expected_data_time
                     visited_multi_asset_keys.add(neighbor_key)
+                    to_request |= {
+                        ap._replace(asset_key=neighbor_key)
+                        for ap in evaluation.true_subset.asset_partitions
+                    }
 
-        to_materialize = set().union(*will_materialize_mapping.values())
-        return (evaluations_by_key, asset_cursors, to_materialize)
+        to_request = set().union(
+            *(
+                evaluation.true_subset.asset_partitions
+                for evaluation in evaluation_results_by_key.values()
+            )
+        )
+        return (list(legacy_evaluation_results_by_key.values()), asset_cursors, to_request)
 
     def evaluate(
         self,
@@ -382,11 +367,11 @@ class AssetDaemonContext:
             else []
         )
 
-        evaluations, asset_cursors, to_materialize = self.get_auto_materialize_asset_evaluations()
+        evaluations, asset_cursors, to_request = self.get_auto_materialize_asset_evaluations()
 
         run_requests = [
             *build_run_requests(
-                asset_partitions=to_materialize,
+                asset_partitions=to_request,
                 asset_graph=self.asset_graph,
                 run_tags=self.auto_materialize_run_tags,
             ),
@@ -411,7 +396,7 @@ class AssetDaemonContext:
             # only record evaluations where something changed
             [
                 evaluation
-                for evaluation in evaluations,
+                for evaluation in evaluations
                 if not evaluation.equivalent_to_stored_evaluation(
                     self.cursor.latest_evaluation_by_asset_key.get(evaluation.asset_key),
                     self.asset_graph,

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -242,7 +242,6 @@ class AssetDaemonContext:
             self.asset_graph.auto_materialize_policies_by_key.get(asset_key)
         ).to_auto_materialize_policy_evaluator()
 
-        partitions_def = self.asset_graph.get_partitions_def(asset_key)
         context = AssetAutomationEvaluationContext(
             asset_key=asset_key,
             asset_cursor=self.cursor.asset_cursor_for_key(asset_key, self.asset_graph),

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 from typing import (
+    TYPE_CHECKING,
     AbstractSet,
     Mapping,
     NamedTuple,
@@ -12,16 +13,18 @@ import dagster._check as check
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeAssetEvaluation,
 )
-from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,
 )
 from dagster._serdes.serdes import deserialize_value, serialize_value
 
+if TYPE_CHECKING:
+    from .asset_automation_evaluator import ConditionEvaluation
 from .asset_graph import AssetGraph
 from .asset_subset import AssetSubset
-from .partition import PartitionsDefinition, PartitionsSubset
+from .partition import PartitionsSubset
 
 
 class AssetDaemonAssetCursor(NamedTuple):
@@ -32,32 +35,8 @@ class AssetDaemonAssetCursor(NamedTuple):
     asset_key: AssetKey
     latest_storage_id: Optional[int]
     latest_evaluation_timestamp: Optional[float]
-    latest_evaluation: Optional[AutoMaterializeAssetEvaluation]
+    latest_evaluation: Optional["ConditionEvaluation"]
     materialized_requested_or_discarded_subset: AssetSubset
-
-    def with_updates(
-        self,
-        asset_graph: AssetGraph,
-        newly_materialized_subset: AssetSubset,
-        requested_asset_partitions: AbstractSet[AssetKeyPartitionKey],
-        discarded_asset_partitions: AbstractSet[AssetKeyPartitionKey],
-    ) -> "AssetDaemonAssetCursor":
-        if self.asset_key not in asset_graph.root_asset_keys:
-            return self
-        newly_materialized_requested_or_discarded_asset_partitions = (
-            newly_materialized_subset.asset_partitions
-            | requested_asset_partitions
-            | discarded_asset_partitions
-        )
-        newly_materialized_requested_or_discarded_subset = AssetSubset.from_asset_partitions_set(
-            self.asset_key,
-            asset_graph.get_partitions_def(self.asset_key),
-            newly_materialized_requested_or_discarded_asset_partitions,
-        )
-        return self._replace(
-            materialized_requested_or_discarded_subset=self.materialized_requested_or_discarded_subset
-            | newly_materialized_requested_or_discarded_subset
-        )
 
 
 class AssetDaemonCursor(NamedTuple):
@@ -91,8 +70,11 @@ class AssetDaemonCursor(NamedTuple):
         return asset_key in self.handled_root_asset_keys
 
     def asset_cursor_for_key(
-        self, asset_key: AssetKey, partitions_def: Optional[PartitionsDefinition]
+        self, asset_key: AssetKey, asset_graph: AssetGraph
     ) -> AssetDaemonAssetCursor:
+        from .asset_automation_evaluator import ConditionEvaluation
+
+        partitions_def = asset_graph.get_partitions_def(asset_key)
         handled_partitions_subset = self.handled_root_partitions_by_asset_key.get(asset_key)
         if handled_partitions_subset is not None:
             handled_subset = AssetSubset(asset_key=asset_key, value=handled_partitions_subset)
@@ -100,11 +82,20 @@ class AssetDaemonCursor(NamedTuple):
             handled_subset = AssetSubset(asset_key=asset_key, value=True)
         else:
             handled_subset = AssetSubset.empty(asset_key, partitions_def)
+        condition = (
+            check.not_none(asset_graph.get_auto_materialize_policy(asset_key))
+            .to_auto_materialize_policy_evaluator()
+            .condition
+        )
         return AssetDaemonAssetCursor(
             asset_key=asset_key,
             latest_storage_id=self.latest_storage_id,
             latest_evaluation_timestamp=self.latest_evaluation_timestamp,
-            latest_evaluation=self.latest_evaluation_by_asset_key.get(asset_key),
+            latest_evaluation=ConditionEvaluation.from_evaluation(
+                condition=condition,
+                evaluation=self.latest_evaluation_by_asset_key.get(asset_key),
+                asset_graph=asset_graph,
+            ),
             materialized_requested_or_discarded_subset=handled_subset,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -258,7 +258,7 @@ class AutoMaterializePolicy(
         from .asset_automation_evaluator import (
             AndAutomationCondition,
             AssetAutomationEvaluator,
-            NorAutomationCondition,
+            NotAutomationCondition,
             OrAutomationCondition,
             RuleCondition,
         )
@@ -266,12 +266,14 @@ class AutoMaterializePolicy(
         materialize_condition = OrAutomationCondition(
             children=[RuleCondition(rule) for rule in self.materialize_rules]
         )
-        not_skip_condition = NorAutomationCondition(
+        skip_condition = OrAutomationCondition(
             children=[RuleCondition(rule) for rule in self.skip_rules]
         )
 
         # results in an expression of the form (m1 | m2 | ... | mn) & ~(s1 | s2 | ... | sn)
-        condition = AndAutomationCondition(children=[materialize_condition, not_skip_condition])
+        condition = AndAutomationCondition(
+            children=[materialize_condition, NotAutomationCondition([skip_condition])]
+        )
         return AssetAutomationEvaluator(
             condition=condition,
             max_materializations_per_minute=self.max_materializations_per_minute,

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -1,6 +1,4 @@
-import operator
 from enum import Enum
-from functools import reduce
 from typing import TYPE_CHECKING, AbstractSet, Dict, FrozenSet, NamedTuple, Optional, Sequence
 
 import dagster._check as check
@@ -257,27 +255,23 @@ class AutoMaterializePolicy(
 
     def to_auto_materialize_policy_evaluator(self) -> "AssetAutomationEvaluator":
         """Converts a set of materialize / skip rules into a single binary expression."""
-        from .asset_automation_evaluator import AssetAutomationEvaluator, RuleCondition
+        from .asset_automation_evaluator import (
+            AndAutomationCondition,
+            AssetAutomationEvaluator,
+            NorAutomationCondition,
+            OrAutomationCondition,
+            RuleCondition,
+        )
 
-        materialize_condition = (
-            reduce(
-                operator.or_,
-                [RuleCondition(rule) for rule in self.materialize_rules],
-            )
-            if self.materialize_rules
-            else None
+        materialize_condition = OrAutomationCondition(
+            children=[RuleCondition(rule) for rule in self.materialize_rules]
         )
-        skip_condition = (
-            ~reduce(
-                operator.or_,
-                [RuleCondition(rule) for rule in self.skip_rules],
-            )
-            if self.skip_rules
-            else None
+        not_skip_condition = NorAutomationCondition(
+            children=[RuleCondition(rule) for rule in self.skip_rules]
         )
+
         # results in an expression of the form (m1 | m2 | ... | mn) & ~(s1 | s2 | ... | sn)
-        condition = reduce(operator.and_, filter(None, [materialize_condition, skip_condition]))
-        check.invariant(condition is not None, "must have at least one rule")
+        condition = AndAutomationCondition(children=[materialize_condition, not_skip_condition])
         return AssetAutomationEvaluator(
             condition=condition,
             max_materializations_per_minute=self.max_materializations_per_minute,

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -1,11 +1,7 @@
-import dataclasses
 import datetime
-import functools
 from abc import ABC, abstractmethod, abstractproperty
 from collections import defaultdict
-from dataclasses import dataclass
 from typing import (
-    TYPE_CHECKING,
     AbstractSet,
     Callable,
     Dict,
@@ -29,262 +25,25 @@ from dagster._core.definitions.auto_materialize_rule_evaluation import (
     RuleEvaluationResults,
     WaitingOnAssetsRuleEvaluationData,
 )
-from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.freshness_based_auto_materialize import (
     freshness_evaluation_results_for_asset_key,
 )
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
-from dagster._core.definitions.partition import PartitionsDefinition
-from dagster._core.definitions.partition_mapping import IdentityPartitionMapping
-from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
 from dagster._core.definitions.time_window_partitions import get_time_partitions_def
 from dagster._core.storage.dagster_run import RunsFilter
 from dagster._core.storage.tags import AUTO_MATERIALIZE_TAG
 from dagster._serdes.serdes import (
     whitelist_for_serdes,
 )
-from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 from dagster._utils.schedules import (
     cron_string_iterator,
     is_valid_cron_string,
     reverse_cron_string_iterator,
 )
 
-from .asset_graph import AssetGraph, sort_key_for_asset_partition
-from .asset_subset import AssetSubset
-
-if TYPE_CHECKING:
-    from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
-    from dagster._core.definitions.asset_daemon_cursor import AssetDaemonAssetCursor
-
-
-@dataclass(frozen=True)
-class RuleEvaluationContext:
-    asset_key: AssetKey
-    cursor: "AssetDaemonAssetCursor"
-    instance_queryer: CachingInstanceQueryer
-    data_time_resolver: CachingDataTimeResolver
-    # Tracks which asset partitions are already slated for materialization in this tick. The asset
-    # keys in the values match the asset key in the corresponding key.
-    will_materialize_mapping: Mapping[AssetKey, AbstractSet[AssetKeyPartitionKey]]
-    expected_data_time_mapping: Mapping[AssetKey, Optional[datetime.datetime]]
-    candidate_subset: AssetSubset
-    daemon_context: "AssetDaemonContext"
-
-    def with_candidate_subset(self, candidate_subset: AssetSubset) -> "RuleEvaluationContext":
-        return dataclasses.replace(self, candidate_subset=candidate_subset)
-
-    @property
-    def asset_graph(self) -> AssetGraph:
-        return self.instance_queryer.asset_graph
-
-    @property
-    def partitions_def(self) -> Optional[PartitionsDefinition]:
-        return self.asset_graph.get_partitions_def(self.asset_key)
-
-    @property
-    def evaluation_time(self) -> datetime.datetime:
-        """Returns the time at which this rule is being evaluated."""
-        return self.instance_queryer.evaluation_time
-
-    @property
-    def auto_materialize_run_tags(self) -> Mapping[str, str]:
-        return self.daemon_context.auto_materialize_run_tags
-
-    @functools.cached_property
-    def previous_tick_requested_or_discarded_subset(self) -> AssetSubset:
-        """Returns the set of asset partitions that were requested or discarded on the previous tick."""
-        if not self.cursor.latest_evaluation:
-            return self.empty_subset()
-        return self.cursor.latest_evaluation.get_requested_or_discarded_subset(
-            asset_graph=self.asset_graph
-        )
-
-    @functools.cached_property
-    def previous_tick_evaluated_subset(self) -> AssetSubset:
-        """Returns the set of asset partitions that were evaluated on the previous tick."""
-        if not self.cursor.latest_evaluation:
-            return self.empty_subset()
-        return self.cursor.latest_evaluation.get_evaluated_subset(asset_graph=self.asset_graph)
-
-    @functools.cached_property
-    def candidate_has_parents_that_have_or_will_update_subset(self) -> AssetSubset:
-        """Returns the set of candidate asset partitions whose parents have been updated since the
-        last tick or will be requested on this tick.
-
-        Many rules depend on the state of the asset's parents, so this function is useful for
-        finding asset partitions that should be re-evaluated.
-        """
-        subset_with_parents_which_will_update = AssetSubset.from_asset_partitions_set(
-            self.asset_key, self.partitions_def, set(self.get_will_update_parent_mapping().keys())
-        )
-        return self.candidate_subset & (
-            self.subset_with_updated_parents_since_previous_tick
-            | subset_with_parents_which_will_update
-        )
-
-    @functools.cached_property
-    def candidate_not_evaluated_on_previous_tick_subset(self) -> AssetSubset:
-        """Returns the set of candidates that were not evaluated by the rule that is currently being
-        evaluated on the previous tick.
-
-        Any asset partition that was evaluated by any rule on the previous tick must have been
-        evaluated by *all* skip rules.
-        """
-        return self.candidate_subset - self.previous_tick_evaluated_subset
-
-    @functools.cached_property
-    def newly_materialized_root_subset(self) -> AssetSubset:
-        if self.asset_key not in self.asset_graph.root_materializable_or_observable_asset_keys:
-            return self.empty_subset()
-        newly_materialized = set()
-        for asset_partition in self.cursor.materialized_requested_or_discarded_subset.inverse(
-            self.partitions_def,
-            dynamic_partitions_store=self.instance_queryer,
-            current_time=self.instance_queryer.evaluation_time,
-        ).asset_partitions:
-            if self.instance_queryer.asset_partition_has_materialization_or_observation(
-                asset_partition
-            ):
-                newly_materialized.add(asset_partition)
-
-        return AssetSubset.from_asset_partitions_set(
-            self.asset_key, self.partitions_def, newly_materialized
-        )
-
-    @functools.cached_property
-    def never_materialized_requested_or_discarded_root_subset(self) -> AssetSubset:
-        if self.asset_key not in self.asset_graph.root_materializable_or_observable_asset_keys:
-            return self.empty_subset()
-
-        never_materialized = self.cursor.materialized_requested_or_discarded_subset.inverse(
-            self.partitions_def,
-            dynamic_partitions_store=self.instance_queryer,
-            current_time=self.instance_queryer.evaluation_time,
-        ).asset_partitions
-        return (
-            AssetSubset.from_asset_partitions_set(
-                self.asset_key, self.partitions_def, never_materialized
-            )
-            - self.newly_materialized_root_subset
-        )
-
-    def empty_subset(self) -> AssetSubset:
-        return AssetSubset.empty(self.asset_key, self.partitions_def)
-
-    def get_previous_tick_results(self, rule: "AutoMaterializeRule") -> "RuleEvaluationResults":
-        """Returns the results that were calculated for a given rule on the previous tick."""
-        if not self.cursor.latest_evaluation:
-            return []
-        return self.cursor.latest_evaluation.get_rule_evaluation_results(
-            rule_snapshot=rule.to_snapshot(), asset_graph=self.asset_graph
-        )
-
-    def materialized_requested_or_discarded_since_previous_tick(
-        self, asset_partition: AssetKeyPartitionKey
-    ) -> bool:
-        """Returns whether an asset partition has been materialized, requested, or discarded since
-        the last tick.
-        """
-        if asset_partition in self.previous_tick_requested_or_discarded_subset:
-            return True
-        return self.instance_queryer.asset_partition_has_materialization_or_observation(
-            asset_partition, after_cursor=self.cursor.latest_storage_id
-        )
-
-    def materializable_in_same_run(self, child_key: AssetKey, parent_key: AssetKey) -> bool:
-        """Returns whether a child asset can be materialized in the same run as a parent asset."""
-        from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
-
-        return (
-            # both assets must be materializable
-            child_key in self.asset_graph.materializable_asset_keys
-            and parent_key in self.asset_graph.materializable_asset_keys
-            # the parent must have the same partitioning
-            and self.asset_graph.have_same_partitioning(child_key, parent_key)
-            # the parent must have a simple partition mapping to the child
-            and (
-                not self.asset_graph.is_partitioned(parent_key)
-                or isinstance(
-                    self.asset_graph.get_partition_mapping(child_key, parent_key),
-                    (TimeWindowPartitionMapping, IdentityPartitionMapping),
-                )
-            )
-            # the parent must be in the same repository to be materialized alongside the candidate
-            and (
-                not isinstance(self.asset_graph, ExternalAssetGraph)
-                or self.asset_graph.get_repository_handle(child_key)
-                == self.asset_graph.get_repository_handle(parent_key)
-            )
-        )
-
-    def get_parents_that_will_not_be_materialized_on_current_tick(
-        self, *, asset_partition: AssetKeyPartitionKey
-    ) -> AbstractSet[AssetKeyPartitionKey]:
-        """Returns the set of parent asset partitions that will not be updated in the same run of
-        this asset partition if a run is launched for this asset partition on this tick.
-        """
-        return {
-            parent
-            for parent in self.asset_graph.get_parents_partitions(
-                dynamic_partitions_store=self.instance_queryer,
-                current_time=self.instance_queryer.evaluation_time,
-                asset_key=asset_partition.asset_key,
-                partition_key=asset_partition.partition_key,
-            ).parent_partitions
-            if parent not in self.will_materialize_mapping.get(parent.asset_key, set())
-            or not self.materializable_in_same_run(asset_partition.asset_key, parent.asset_key)
-        }
-
-    @functools.cached_property
-    def subset_with_updated_parents_since_previous_tick(self) -> AssetSubset:
-        """Returns the set of asset partitions for the current key which have parents that updated
-        since the last tick.
-        """
-        return AssetSubset.from_asset_partitions_set(
-            self.asset_key,
-            self.partitions_def,
-            self.instance_queryer.asset_partitions_with_newly_updated_parents(
-                latest_storage_id=self.cursor.latest_storage_id,
-                child_asset_key=self.asset_key,
-                map_old_time_partitions=False,
-            ),
-        )
-
-    def get_will_update_parent_mapping(
-        self,
-    ) -> Mapping[AssetKeyPartitionKey, AbstractSet[AssetKey]]:
-        """Returns a mapping from asset partitions of the current asset to the set of parent keys
-        which will be requested this tick and can execute in the same run as the current asset.
-        """
-        will_update_parents_by_asset_partition = defaultdict(set)
-        # these are the set of parents that will be requested this tick and can be materialized in
-        # the same run as this asset
-        for parent_key in self.asset_graph.get_parents(self.asset_key):
-            if not self.materializable_in_same_run(self.asset_key, parent_key):
-                continue
-            for parent_partition in self.will_materialize_mapping.get(parent_key, set()):
-                asset_partition = AssetKeyPartitionKey(
-                    self.asset_key, parent_partition.partition_key
-                )
-                will_update_parents_by_asset_partition[asset_partition].add(parent_key)
-
-        return will_update_parents_by_asset_partition
-
-    def will_update_asset_partition(self, asset_partition: AssetKeyPartitionKey) -> bool:
-        return asset_partition in self.will_materialize_mapping.get(
-            asset_partition.asset_key, set()
-        )
-
-    def get_asset_partitions_by_asset_key(
-        self, asset_partitions: AbstractSet[AssetKeyPartitionKey]
-    ) -> Mapping[AssetKey, Set[AssetKeyPartitionKey]]:
-        asset_partitions_by_asset_key: Dict[AssetKey, Set[AssetKeyPartitionKey]] = defaultdict(set)
-        for parent in asset_partitions:
-            asset_partitions_by_asset_key[parent.asset_key].add(parent)
-
-        return asset_partitions_by_asset_key
+from .asset_automation_condition_context import AssetAutomationConditionEvaluationContext
+from .asset_graph import sort_key_for_asset_partition
 
 
 class AutoMaterializeRule(ABC):
@@ -313,7 +72,7 @@ class AutoMaterializeRule(ABC):
 
     def add_evaluation_data_from_previous_tick(
         self,
-        context: RuleEvaluationContext,
+        context: AssetAutomationConditionEvaluationContext,
         asset_partitions_by_evaluation_data: Mapping[
             Optional[AutoMaterializeRuleEvaluationData], Set[AssetKeyPartitionKey]
         ],
@@ -333,7 +92,7 @@ class AutoMaterializeRule(ABC):
         """
         asset_partitions_by_evaluation_data = defaultdict(set, asset_partitions_by_evaluation_data)
         evaluated_asset_partitions = set().union(*asset_partitions_by_evaluation_data.values())
-        for evaluation_data, asset_partitions in context.get_previous_tick_results(self):
+        for evaluation_data, asset_partitions in context.previous_tick_results:
             for ap in asset_partitions:
                 # evaluated data from this tick takes precedence over data from the previous tick
                 if ap in evaluated_asset_partitions:
@@ -344,7 +103,9 @@ class AutoMaterializeRule(ABC):
         return list(asset_partitions_by_evaluation_data.items())
 
     @abstractmethod
-    def evaluate_for_asset(self, context: RuleEvaluationContext) -> RuleEvaluationResults:
+    def evaluate_for_asset(
+        self, context: AssetAutomationConditionEvaluationContext
+    ) -> RuleEvaluationResults:
         """The core evaluation function for the rule. This function takes in a context object and
         returns a mapping from evaluated rules to the set of asset partitions that the rule applies
         to.
@@ -503,16 +264,10 @@ class MaterializeOnRequiredForFreshnessRule(
     def description(self) -> str:
         return "required to meet this or downstream asset's freshness policy"
 
-    def evaluate_for_asset(self, context: RuleEvaluationContext) -> RuleEvaluationResults:
-        freshness_conditions = freshness_evaluation_results_for_asset_key(
-            asset_key=context.asset_key,
-            data_time_resolver=context.data_time_resolver,
-            asset_graph=context.asset_graph,
-            current_time=context.instance_queryer.evaluation_time,
-            will_materialize_mapping=context.will_materialize_mapping,
-            expected_data_time_mapping=context.expected_data_time_mapping,
-        )
-        return freshness_conditions
+    def evaluate_for_asset(
+        self, context: AssetAutomationConditionEvaluationContext
+    ) -> RuleEvaluationResults:
+        return freshness_evaluation_results_for_asset_key(context.asset_context)
 
 
 @whitelist_for_serdes
@@ -531,12 +286,14 @@ class MaterializeOnCronRule(
     def description(self) -> str:
         return f"not materialized since last cron schedule tick of '{self.cron_schedule}' (timezone: {self.timezone})"
 
-    def missed_cron_ticks(self, context: RuleEvaluationContext) -> Sequence[datetime.datetime]:
+    def missed_cron_ticks(
+        self, context: AssetAutomationConditionEvaluationContext
+    ) -> Sequence[datetime.datetime]:
         """Returns the cron ticks which have been missed since the previous cursor was generated."""
-        if not context.cursor.latest_evaluation_timestamp:
+        if not context.latest_evaluation_timestamp:
             previous_dt = next(
                 reverse_cron_string_iterator(
-                    end_timestamp=context.evaluation_time.timestamp(),
+                    end_timestamp=context.asset_context.evaluation_time.timestamp(),
                     cron_string=self.cron_schedule,
                     execution_timezone=self.timezone,
                 )
@@ -544,24 +301,24 @@ class MaterializeOnCronRule(
             return [previous_dt]
         missed_ticks = []
         for dt in cron_string_iterator(
-            start_timestamp=context.cursor.latest_evaluation_timestamp,
+            start_timestamp=context.latest_evaluation_timestamp,
             cron_string=self.cron_schedule,
             execution_timezone=self.timezone,
         ):
-            if dt > context.evaluation_time:
+            if dt > context.asset_context.evaluation_time:
                 break
             missed_ticks.append(dt)
         return missed_ticks
 
     def get_asset_partitions_to_request(
-        self, context: RuleEvaluationContext
+        self, context: AssetAutomationConditionEvaluationContext
     ) -> AbstractSet[AssetKeyPartitionKey]:
         missed_ticks = self.missed_cron_ticks(context)
 
         if not missed_ticks:
             return set()
 
-        partitions_def = context.asset_graph.get_partitions_def(context.asset_key)
+        partitions_def = context.partitions_def
         if partitions_def is None:
             return {AssetKeyPartitionKey(context.asset_key)}
 
@@ -570,7 +327,7 @@ class MaterializeOnCronRule(
             return {
                 AssetKeyPartitionKey(context.asset_key, partition_key)
                 for partition_key in partitions_def.get_partition_keys(
-                    current_time=context.evaluation_time,
+                    current_time=context.asset_context.evaluation_time,
                     dynamic_partitions_store=context.instance_queryer,
                 )
             }
@@ -592,7 +349,8 @@ class MaterializeOnCronRule(
             None,
             [
                 time_partitions_def.get_last_partition_key(
-                    current_time=missed_tick, dynamic_partitions_store=context.instance_queryer
+                    current_time=missed_tick,
+                    dynamic_partitions_store=context.instance_queryer,
                 )
                 for missed_tick in missed_ticks
             ],
@@ -615,7 +373,9 @@ class MaterializeOnCronRule(
                 for time_partition_key in missed_time_partition_keys
             }
 
-    def evaluate_for_asset(self, context: RuleEvaluationContext) -> RuleEvaluationResults:
+    def evaluate_for_asset(
+        self, context: AssetAutomationConditionEvaluationContext
+    ) -> RuleEvaluationResults:
         asset_partitions_to_request = self.get_asset_partitions_to_request(context)
         asset_partitions_by_evaluation_data = defaultdict(set)
         if asset_partitions_to_request:
@@ -623,9 +383,8 @@ class MaterializeOnCronRule(
         return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            should_use_past_data_fn=lambda ap: not context.materialized_requested_or_discarded_since_previous_tick(
-                ap
-            ),
+            should_use_past_data_fn=lambda ap: ap
+            not in context.materialized_requested_or_discarded_since_previous_tick_subset,
         )
 
 
@@ -651,7 +410,9 @@ class AutoMaterializeAssetPartitionsFilter(
         return f"latest run includes required tags: {self.latest_run_required_tags}"
 
     def passes(
-        self, context: RuleEvaluationContext, asset_partitions: Iterable[AssetKeyPartitionKey]
+        self,
+        context: AssetAutomationConditionEvaluationContext,
+        asset_partitions: Iterable[AssetKeyPartitionKey],
     ) -> Iterable[AssetKeyPartitionKey]:
         if self.latest_run_required_tags is None:
             return asset_partitions
@@ -660,7 +421,7 @@ class AutoMaterializeAssetPartitionsFilter(
 
         asset_partitions_by_latest_run_id: Dict[str, Set[AssetKeyPartitionKey]] = defaultdict(set)
         for asset_partition in asset_partitions:
-            if context.will_update_asset_partition(asset_partition):
+            if asset_partition in context.candidate_parent_has_or_will_update_subset:
                 will_update_asset_partitions.add(asset_partition)
             else:
                 record = context.instance_queryer.get_latest_materialization_or_observation_record(
@@ -693,7 +454,10 @@ class AutoMaterializeAssetPartitionsFilter(
 
         if (
             self.latest_run_required_tags.items()
-            <= {AUTO_MATERIALIZE_TAG: "true", **context.auto_materialize_run_tags}.items()
+            <= {
+                AUTO_MATERIALIZE_TAG: "true",
+                **context.asset_context.daemon_context.auto_materialize_run_tags,
+            }.items()
         ):
             return will_update_asset_partitions | updated_partitions_with_required_tags
         else:
@@ -726,7 +490,9 @@ class MaterializeOnParentUpdatedRule(
         else:
             return base
 
-    def evaluate_for_asset(self, context: RuleEvaluationContext) -> RuleEvaluationResults:
+    def evaluate_for_asset(
+        self, context: AssetAutomationConditionEvaluationContext
+    ) -> RuleEvaluationResults:
         """Evaluates the set of asset partitions of this asset whose parents have been updated,
         or will update on this tick.
         """
@@ -737,7 +503,7 @@ class MaterializeOnParentUpdatedRule(
             AssetKeyPartitionKey, Set[AssetKeyPartitionKey]
         ] = defaultdict(set)
 
-        subset_to_evaluate = context.candidate_has_parents_that_have_or_will_update_subset
+        subset_to_evaluate = context.candidate_parent_has_or_will_update_subset
         for asset_partition in subset_to_evaluate.asset_partitions:
             parent_asset_partitions = context.asset_graph.get_parents_partitions(
                 dynamic_partitions_store=context.instance_queryer,
@@ -751,7 +517,7 @@ class MaterializeOnParentUpdatedRule(
                 parent_asset_partitions,
                 # do a precise check for updated parents, factoring in data versions, as long as
                 # we're within reasonable limits on the number of partitions to check
-                respect_materialization_data_versions=context.daemon_context.respect_materialization_data_versions
+                respect_materialization_data_versions=context.asset_context.daemon_context.respect_materialization_data_versions
                 and len(parent_asset_partitions) + subset_to_evaluate.size < 100,
                 # ignore self-dependencies when checking for updated parents, to avoid historical
                 # rematerializations from causing a chain of materializations to be kicked off
@@ -761,7 +527,7 @@ class MaterializeOnParentUpdatedRule(
                 asset_partitions_by_updated_parents[parent].add(asset_partition)
 
             for parent in parent_asset_partitions:
-                if context.will_update_asset_partition(parent):
+                if context.asset_context.will_udpate_asset_partition(parent):
                     asset_partitions_by_will_update_parents[parent].add(asset_partition)
 
         updated_and_will_update_parents = (
@@ -813,9 +579,8 @@ class MaterializeOnParentUpdatedRule(
         return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            should_use_past_data_fn=lambda ap: not context.materialized_requested_or_discarded_since_previous_tick(
-                ap
-            ),
+            should_use_past_data_fn=lambda ap: ap
+            not in context.materialized_requested_or_discarded_since_previous_tick_subset,
         )
 
 
@@ -829,7 +594,9 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
     def description(self) -> str:
         return "materialization is missing"
 
-    def evaluate_for_asset(self, context: RuleEvaluationContext) -> RuleEvaluationResults:
+    def evaluate_for_asset(
+        self, context: AssetAutomationConditionEvaluationContext
+    ) -> RuleEvaluationResults:
         """Evaluates the set of asset partitions for this asset which are missing and were not
         previously discarded. Currently only applies to root asset partitions and asset partitions
         with updated parents.
@@ -837,11 +604,11 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
         asset_partitions_by_evaluation_data = defaultdict(set)
 
         missing_asset_partitions = set(
-            context.never_materialized_requested_or_discarded_root_subset.asset_partitions
+            context.asset_context.never_materialized_requested_or_discarded_root_subset.asset_partitions
         )
         # in addition to missing root asset partitions, check any asset partitions with updated
         # parents to see if they're missing
-        for candidate in context.subset_with_updated_parents_since_previous_tick.asset_partitions:
+        for candidate in context.candidate_parent_has_or_will_update_subset.asset_partitions:
             if not context.instance_queryer.asset_partition_has_materialization_or_observation(
                 candidate
             ):
@@ -854,7 +621,7 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
             context,
             asset_partitions_by_evaluation_data,
             should_use_past_data_fn=lambda ap: ap not in missing_asset_partitions
-            and not context.materialized_requested_or_discarded_since_previous_tick(ap),
+            and ap not in context.materialized_requested_or_discarded_since_previous_tick_subset,
         )
 
 
@@ -868,18 +635,22 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
     def description(self) -> str:
         return "waiting on upstream data to be up to date"
 
-    def evaluate_for_asset(self, context: RuleEvaluationContext) -> RuleEvaluationResults:
+    def evaluate_for_asset(
+        self, context: AssetAutomationConditionEvaluationContext
+    ) -> RuleEvaluationResults:
         asset_partitions_by_evaluation_data = defaultdict(set)
 
         # only need to evaluate net-new candidates and candidates whose parents have changed
         subset_to_evaluate = (
-            context.candidate_not_evaluated_on_previous_tick_subset
-            | context.candidate_has_parents_that_have_or_will_update_subset
+            context.candidates_not_evaluated_on_previous_tick_subset
+            | context.candidate_parent_has_or_will_update_subset
         )
         for candidate in subset_to_evaluate.asset_partitions:
             outdated_ancestors = set()
             # find the root cause of why this asset partition's parents are outdated (if any)
-            for parent in context.get_parents_that_will_not_be_materialized_on_current_tick(
+            for (
+                parent
+            ) in context.asset_context.get_parents_that_will_not_be_materialized_on_current_tick(
                 asset_partition=candidate
             ):
                 if context.instance_queryer.have_ignorable_partition_mapping_for_outdated(
@@ -913,24 +684,26 @@ class SkipOnParentMissingRule(AutoMaterializeRule, NamedTuple("_SkipOnParentMiss
 
     def evaluate_for_asset(
         self,
-        context: RuleEvaluationContext,
+        context: AssetAutomationConditionEvaluationContext,
     ) -> RuleEvaluationResults:
         asset_partitions_by_evaluation_data = defaultdict(set)
 
         # only need to evaluate net-new candidates and candidates whose parents have changed
         subset_to_evaluate = (
-            context.candidate_not_evaluated_on_previous_tick_subset
-            | context.candidate_has_parents_that_have_or_will_update_subset
+            context.candidates_not_evaluated_on_previous_tick_subset
+            | context.candidate_parent_has_or_will_update_subset
         )
         for candidate in subset_to_evaluate.asset_partitions:
             missing_parent_asset_keys = set()
-            for parent in context.get_parents_that_will_not_be_materialized_on_current_tick(
+            for (
+                parent
+            ) in context.asset_context.get_parents_that_will_not_be_materialized_on_current_tick(
                 asset_partition=candidate
             ):
                 # ignore non-observable sources, which will never have a materialization or observation
-                if context.asset_graph.is_source(
+                if context.asset_context.asset_graph.is_source(
                     parent.asset_key
-                ) and not context.asset_graph.is_observable(parent.asset_key):
+                ) and not context.asset_context.asset_graph.is_observable(parent.asset_key):
                     continue
                 if not context.instance_queryer.asset_partition_has_materialization_or_observation(
                     parent
@@ -980,14 +753,14 @@ class SkipOnNotAllParentsUpdatedRule(
 
     def evaluate_for_asset(
         self,
-        context: RuleEvaluationContext,
+        context: AssetAutomationConditionEvaluationContext,
     ) -> RuleEvaluationResults:
         asset_partitions_by_evaluation_data = defaultdict(set)
 
         # only need to evaluate net-new candidates and candidates whose parents have changed
         subset_to_evaluate = (
-            context.candidate_not_evaluated_on_previous_tick_subset
-            | context.candidate_has_parents_that_have_or_will_update_subset
+            context.candidates_not_evaluated_on_previous_tick_subset
+            | context.candidate_parent_has_or_will_update_subset
         )
         for candidate in subset_to_evaluate.asset_partitions:
             parent_partitions = context.asset_graph.get_parents_partitions(
@@ -1001,15 +774,10 @@ class SkipOnNotAllParentsUpdatedRule(
                 context.instance_queryer.get_parent_asset_partitions_updated_after_child(
                     candidate,
                     parent_partitions,
-                    context.daemon_context.respect_materialization_data_versions,
+                    context.asset_context.daemon_context.respect_materialization_data_versions,
                     ignored_parent_keys=set(),
                 )
-                | set().union(
-                    *[
-                        context.will_materialize_mapping.get(parent, set())
-                        for parent in context.asset_graph.get_parents(context.asset_key)
-                    ]
-                )
+                | context.asset_context.parent_will_update_subset.asset_partitions
             )
 
             if self.require_update_for_all_parent_partitions:
@@ -1021,14 +789,8 @@ class SkipOnNotAllParentsUpdatedRule(
                 # At least one upstream partition in each upstream asset must be updated in order
                 # for the candidate to be updated
                 parent_asset_keys = context.asset_graph.get_parents(context.asset_key)
-                updated_parent_partitions_by_asset_key = context.get_asset_partitions_by_asset_key(
-                    updated_parent_partitions
-                )
-                non_updated_parent_keys = {
-                    parent
-                    for parent in parent_asset_keys
-                    if not updated_parent_partitions_by_asset_key.get(parent)
-                }
+                updated_parent_keys = {ap.asset_key for ap in updated_parent_partitions}
+                non_updated_parent_keys = parent_asset_keys - updated_parent_keys
 
             # do not require past partitions of this asset to be updated
             non_updated_parent_keys -= {context.asset_key}
@@ -1057,12 +819,14 @@ class SkipOnRequiredButNonexistentParentsRule(
     def description(self) -> str:
         return "required parent partitions do not exist"
 
-    def evaluate_for_asset(self, context: RuleEvaluationContext) -> RuleEvaluationResults:
+    def evaluate_for_asset(
+        self, context: AssetAutomationConditionEvaluationContext
+    ) -> RuleEvaluationResults:
         asset_partitions_by_evaluation_data = defaultdict(set)
 
         subset_to_evaluate = (
-            context.candidate_not_evaluated_on_previous_tick_subset
-            | context.candidate_has_parents_that_have_or_will_update_subset
+            context.candidates_not_evaluated_on_previous_tick_subset
+            | context.candidate_parent_has_or_will_update_subset
         )
         for candidate in subset_to_evaluate.asset_partitions:
             nonexistent_parent_partitions = context.asset_graph.get_parents_partitions(
@@ -1101,27 +865,22 @@ class SkipOnBackfillInProgressRule(
         else:
             return "targeted by an in-progress backfill"
 
-    def evaluate_for_asset(self, context: RuleEvaluationContext) -> RuleEvaluationResults:
-        backfill_in_progress_candidates: AbstractSet[AssetKeyPartitionKey] = set()
+    def evaluate_for_asset(
+        self, context: AssetAutomationConditionEvaluationContext
+    ) -> RuleEvaluationResults:
         backfilling_subset = (
             context.instance_queryer.get_active_backfill_target_asset_graph_subset()
-        )
+        ).get_asset_subset(context.asset_key, context.asset_context.asset_graph)
 
-        if self.all_partitions:
-            backfill_in_progress_candidates = {
-                candidate
-                for candidate in context.candidate_subset.asset_partitions
-                if candidate.asset_key in backfilling_subset.asset_keys
-            }
+        if backfilling_subset.size == 0:
+            true_subset = context.empty_subset()
+        elif self.all_partitions:
+            true_subset = context.candidate_subset
         else:
-            backfill_in_progress_candidates = {
-                candidate
-                for candidate in context.candidate_subset.asset_partitions
-                if candidate in backfilling_subset
-            }
+            true_subset = context.candidate_subset & backfilling_subset
 
-        if backfill_in_progress_candidates:
-            return [(None, backfill_in_progress_candidates)]
+        if true_subset:
+            return [(None, true_subset.asset_partitions)]
 
         return []
 
@@ -1138,7 +897,9 @@ class DiscardOnMaxMaterializationsExceededRule(
     def description(self) -> str:
         return f"exceeds {self.limit} materialization(s) per minute"
 
-    def evaluate_for_asset(self, context: RuleEvaluationContext) -> RuleEvaluationResults:
+    def evaluate_for_asset(
+        self, context: AssetAutomationConditionEvaluationContext
+    ) -> RuleEvaluationResults:
         # the set of asset partitions which exceed the limit
         rate_limited_asset_partitions = set(
             sorted(

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -152,7 +152,7 @@ def get_expected_data_time_for_asset_key(
 
 
 def freshness_evaluation_results_for_asset_key(
-    context: "AssetAutomationEvaluationContext"
+    context: "AssetAutomationEvaluationContext",
 ) -> "RuleEvaluationResults":
     """Returns a set of AssetKeyPartitionKeys to materialize in order to abide by the given
     FreshnessPolicies.

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -8,19 +8,17 @@
     maximum lag minutes.
 """
 import datetime
-from typing import TYPE_CHECKING, AbstractSet, Mapping, Optional, Tuple
+from typing import TYPE_CHECKING, AbstractSet, Optional, Tuple
 
 import pendulum
 
-from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._utils.schedules import cron_string_iterator
 
-from .asset_graph import AssetGraph
+from .asset_automation_condition_context import AssetAutomationEvaluationContext
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.data_time import CachingDataTimeResolver
-
     from .auto_materialize_rule_evaluation import RuleEvaluationResults, TextRuleEvaluationData
 
 
@@ -112,41 +110,38 @@ def get_execution_period_and_evaluation_data_for_policies(
 
 
 def get_expected_data_time_for_asset_key(
-    asset_graph: AssetGraph,
-    asset_key: AssetKey,
-    will_materialize_mapping: Mapping[AssetKey, AbstractSet[AssetKeyPartitionKey]],
-    expected_data_time_mapping: Mapping[AssetKey, Optional[datetime.datetime]],
-    data_time_resolver: "CachingDataTimeResolver",
-    current_time: datetime.datetime,
-    will_materialize: bool,
+    context: AssetAutomationEvaluationContext, will_materialize: bool
 ) -> Optional[datetime.datetime]:
     """Returns the data time that you would expect this asset to have if you were to execute it
     on this tick.
     """
     from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 
+    asset_key = context.asset_key
+    asset_graph = context.asset_graph
+    current_time = context.evaluation_time
+
     # don't bother calculating if no downstream assets have freshness policies
     if not asset_graph.get_downstream_freshness_policies(asset_key=asset_key):
         return None
     # if asset will not be materialized, just return the current time
     elif not will_materialize:
-        return data_time_resolver.get_current_data_time(asset_key, current_time)
+        return context.data_time_resolver.get_current_data_time(asset_key, current_time)
     elif asset_graph.has_non_source_parents(asset_key):
         expected_data_time = None
         for parent_key in asset_graph.get_parents(asset_key):
             # if the parent will be materialized on this tick, and it's not in the same repo, then
             # we must wait for this asset to be materialized
-            if (
-                isinstance(asset_graph, ExternalAssetGraph)
-                and AssetKeyPartitionKey(parent_key) in will_materialize_mapping[parent_key]
+            if isinstance(asset_graph, ExternalAssetGraph) and context.will_udpate_asset_partition(
+                AssetKeyPartitionKey(parent_key)
             ):
                 parent_repo = asset_graph.get_repository_handle(parent_key)
                 if parent_repo != asset_graph.get_repository_handle(asset_key):
-                    return data_time_resolver.get_current_data_time(asset_key, current_time)
+                    return context.data_time_resolver.get_current_data_time(asset_key, current_time)
             # find the minimum non-None data time of your parents
-            parent_expected_data_time = expected_data_time_mapping.get(
+            parent_expected_data_time = context.expected_data_time_mapping.get(
                 parent_key
-            ) or data_time_resolver.get_current_data_time(parent_key, current_time)
+            ) or context.data_time_resolver.get_current_data_time(parent_key, current_time)
             expected_data_time = min(
                 filter(None, [expected_data_time, parent_expected_data_time]),
                 default=None,
@@ -158,34 +153,27 @@ def get_expected_data_time_for_asset_key(
 
 
 def freshness_evaluation_results_for_asset_key(
-    asset_key: AssetKey,
-    data_time_resolver: "CachingDataTimeResolver",
-    asset_graph: AssetGraph,
-    current_time: datetime.datetime,
-    will_materialize_mapping: Mapping[AssetKey, AbstractSet[AssetKeyPartitionKey]],
-    expected_data_time_mapping: Mapping[AssetKey, Optional[datetime.datetime]],
+    context: AssetAutomationEvaluationContext
 ) -> "RuleEvaluationResults":
     """Returns a set of AssetKeyPartitionKeys to materialize in order to abide by the given
     FreshnessPolicies.
 
     Attempts to minimize the total number of asset executions.
     """
-    if not asset_graph.get_downstream_freshness_policies(
+    asset_key = context.asset_key
+    current_time = context.evaluation_time
+
+    if not context.asset_graph.get_downstream_freshness_policies(
         asset_key=asset_key
-    ) or asset_graph.is_partitioned(asset_key):
+    ) or context.asset_graph.is_partitioned(asset_key):
         return []
 
     # figure out the current contents of this asset
-    current_data_time = data_time_resolver.get_current_data_time(asset_key, current_time)
+    current_data_time = context.data_time_resolver.get_current_data_time(asset_key, current_time)
 
     # figure out the data time you would expect if you were to execute this asset on this tick
     expected_data_time = get_expected_data_time_for_asset_key(
-        asset_graph=asset_graph,
-        asset_key=asset_key,
-        will_materialize_mapping=will_materialize_mapping,
-        expected_data_time_mapping=expected_data_time_mapping,
-        data_time_resolver=data_time_resolver,
-        current_time=current_time,
+        context=context,
         will_materialize=True,
     )
 
@@ -195,10 +183,14 @@ def freshness_evaluation_results_for_asset_key(
 
     # calculate the data times you would expect after all currently-executing runs
     # were to successfully complete
-    in_progress_data_time = data_time_resolver.get_in_progress_data_time(asset_key, current_time)
+    in_progress_data_time = context.data_time_resolver.get_in_progress_data_time(
+        asset_key, current_time
+    )
 
     # calculate the data times you would have expected if the most recent run succeeded
-    failed_data_time = data_time_resolver.get_ignored_failure_data_time(asset_key, current_time)
+    failed_data_time = context.data_time_resolver.get_ignored_failure_data_time(
+        asset_key, current_time
+    )
 
     effective_data_time = max(
         filter(None, (current_data_time, in_progress_data_time, failed_data_time)),
@@ -211,8 +203,8 @@ def freshness_evaluation_results_for_asset_key(
         execution_period,
         evaluation_data,
     ) = get_execution_period_and_evaluation_data_for_policies(
-        local_policy=asset_graph.freshness_policies_by_key.get(asset_key),
-        policies=asset_graph.get_downstream_freshness_policies(asset_key=asset_key),
+        local_policy=context.asset_graph.freshness_policies_by_key.get(asset_key),
+        policies=context.asset_graph.get_downstream_freshness_policies(asset_key=asset_key),
         effective_data_time=effective_data_time,
         current_time=current_time,
     )

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -16,9 +16,8 @@ from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._utils.schedules import cron_string_iterator
 
-from .asset_automation_condition_context import AssetAutomationEvaluationContext
-
 if TYPE_CHECKING:
+    from .asset_automation_condition_context import AssetAutomationEvaluationContext
     from .auto_materialize_rule_evaluation import RuleEvaluationResults, TextRuleEvaluationData
 
 
@@ -110,7 +109,7 @@ def get_execution_period_and_evaluation_data_for_policies(
 
 
 def get_expected_data_time_for_asset_key(
-    context: AssetAutomationEvaluationContext, will_materialize: bool
+    context: "AssetAutomationEvaluationContext", will_materialize: bool
 ) -> Optional[datetime.datetime]:
     """Returns the data time that you would expect this asset to have if you were to execute it
     on this tick.
@@ -153,7 +152,7 @@ def get_expected_data_time_for_asset_key(
 
 
 def freshness_evaluation_results_for_asset_key(
-    context: AssetAutomationEvaluationContext
+    context: "AssetAutomationEvaluationContext"
 ) -> "RuleEvaluationResults":
     """Returns a set of AssetKeyPartitionKeys to materialize in order to abide by the given
     FreshnessPolicies.

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/basic_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/basic_scenarios.py
@@ -74,7 +74,7 @@ basic_scenarios = {
             unevaluated_runs=[run(["asset1", "asset2", "asset3", "asset4", "asset5", "asset6"])],
         ),
         # don't need to run asset4 for reconciliation but asset4 must run when asset3 does
-        expected_run_requests=[run_request(asset_keys=["asset3", "asset4", "asset5", "asset6"])],
+        expected_run_requests=[run_request(asset_keys=["asset3", "asset4", "asset5"])],
     ),
     "multi_asset_in_middle_single_parent_rematerialized_subsettable": AssetReconciliationScenario(
         assets=multi_asset_in_middle_subsettable,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/freshness_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/freshness_policy_scenarios.py
@@ -6,10 +6,8 @@ from dagster import (
 )
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    ParentUpdatedRuleEvaluationData,
     TextRuleEvaluationData,
 )
-from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 
 from ..base_scenario import (
@@ -72,33 +70,12 @@ freshness_policy_scenarios = {
         unevaluated_runs=[run([f"asset{i}" for i in range(1, 6)])],
         evaluation_delta=datetime.timedelta(minutes=35),
         # need to run assets 1, 2 and 3 as they're all part of the same non-subsettable multi asset
-        # need to run asset 4 as it eagerly updates after asset 1
-        expected_run_requests=[
-            run_request(asset_keys=["asset1", "asset2", "asset3", "asset4", "asset5"])
-        ],
+        expected_run_requests=[run_request(asset_keys=["asset1", "asset2", "asset3", "asset5"])],
         expected_evaluations=[
-            AssetEvaluationSpec.from_single_rule(
-                "asset1",
-                AutoMaterializeRule.materialize_on_required_for_freshness(),
-                TextRuleEvaluationData("Required by downstream asset's policy"),
-            ),
             AssetEvaluationSpec.from_single_rule(
                 "asset2",
                 AutoMaterializeRule.materialize_on_required_for_freshness(),
                 TextRuleEvaluationData("Required by downstream asset's policy"),
-            ),
-            AssetEvaluationSpec.from_single_rule(
-                "asset3",
-                AutoMaterializeRule.materialize_on_required_for_freshness(),
-                TextRuleEvaluationData("Required by downstream asset's policy"),
-            ),
-            AssetEvaluationSpec.from_single_rule(
-                "asset4",
-                AutoMaterializeRule.materialize_on_parent_updated(),
-                ParentUpdatedRuleEvaluationData(
-                    updated_asset_keys=frozenset(),
-                    will_update_asset_keys=frozenset([AssetKey("asset1")]),
-                ),
             ),
             AssetEvaluationSpec.from_single_rule(
                 "asset5",

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/basic_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/basic_scenarios.py
@@ -53,7 +53,8 @@ basic_scenarios = [
                     ParentUpdatedRuleEvaluationData,
                     updated_asset_keys=set(),
                     will_update_asset_keys={"A"},
-                )
+                ),
+                AssetRuleEvaluationSpec(rule=AutoMaterializeRule.materialize_on_missing()),
             ],
         ),
     ),

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
@@ -660,7 +660,8 @@ partition_scenarios = [
         .evaluate_tick()
         .assert_requested_runs(
             run_request(
-                ["C"], partition_key=day_partition_key(time_partitions_start_datetime, delta=1)
+                ["C"],
+                partition_key=day_partition_key(time_partitions_start_datetime, delta=1),
             )
         )
         # new day's partition is filled in, should still be able to materialize the new partition
@@ -669,7 +670,7 @@ partition_scenarios = [
         .with_runs(
             run_request(
                 ["A"], partition_key=day_partition_key(time_partitions_start_datetime, delta=3)
-            )
+            ),
         )
         .evaluate_tick()
         .assert_requested_runs(


### PR DESCRIPTION
## Summary & Motivation

This PR breaks up the original RuleEvaluationContext into two pieces:

- AssetAutomationEvaluationContext:
    - A context object that contains methods and properties which are static across all individual conditions
- AssetAutomationConditionEvaluationContext:
    - A context object that contains methods and properties which are specific to an individual condition

This also updates the `AssetDaemonAssetCursor` object to work purely in terms of the `ConditionEvaluation` object, rather than the (soon-to-be deprecated) `AutoMaterializeAssetEvaluation` object.

In order to do this without changing any serialized information, we have to add this somewhat nasty conversion logic to convert the serialized "latest evaluation" into a ConditionEvaluation, then convert the ConditionEvaluation back into an AutoMaterializeAssetEvaluation before it gets stored. 

## How I Tested These Changes
