### PR TITLE
[docs] - Remove missed experimental marker for GraphQL Python client

### DIFF
--- a/docs/content/concepts/webserver/graphql.mdx
+++ b/docs/content/concepts/webserver/graphql.mdx
@@ -56,10 +56,6 @@ height={2028}
 
 ## Python client
 
-<Note>
-  This feature is <strong>experimental</strong>.
-</Note>
-
 Dagster also provides a Python client to interface with Dagster's GraphQL API from Python. Refer to the <Link href="/concepts/webserver/graphql-client">GraphQL Python client docs</Link> for more info.
 
 ---


### PR DESCRIPTION
## Summary & Motivation

This PR removes an experimental flag from a mention of the GraphQL Python client. This feature was marked stable as of 1.5.3.

## How I Tested These Changes

👀 