### PR TITLE
Update toggle style

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Checkbox.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Checkbox.tsx
@@ -101,8 +101,8 @@ const SwitchIcon = ({checked, indeterminate, fillColor, disabled}: IconProps) =>
             ? colorBorderDefault()
             : fillColor
           : disabled
-          ? colorAccentGray()
-          : colorBorderDefault()
+          ? colorBorderDefault()
+          : colorAccentGray()
       }
       style={{
         transition: 'fill 100ms linear',


### PR DESCRIPTION
## Summary & Motivation
Dark mode toggle style was hard to see. This adjusts the bg color to be a bit higher contrast.

**Before**:
<img width="149" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/aa039364-7c95-4663-ad5d-9eb9bb722b69">
**After**:
<img width="149" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/72f8b97a-1e13-4095-8765-0cb2346e7b31">


## How I Tested These Changes
Booted up the UI, checked all states in Storybook