### PR TITLE
Deltalake fixes

### DIFF
--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
@@ -197,8 +197,8 @@ class DeltaLakeDbClient(DbClient):
         client_options = client_options or {}
 
         storage_options = {
-            **{k: v for k, v in storage_options.items() if v is not None},
-            **{k: v for k, v in client_options.items() if v is not None},
+            **{k: str(v) for k, v in storage_options.items() if v is not None},
+            **{k: str(v) for k, v in client_options.items() if v is not None},
         }
         table_config = resource_config.get("table_config")
         table_uri = f"{root_uri}/{table_slice.schema}/{table_slice.table}"


### PR DESCRIPTION
## Summary & Motivation

This PR fixes and error when passing non-string valued options to the deltalake package.

We also extend the supported data types by the arrow type handler to support pyarrow datasets which allows for lazily loading delta tables as well as incremental processing. 

## How I Tested These Changes
