### PR TITLE
Direct invocation asset execution context

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -102,7 +102,7 @@ def _separate_args_and_kwargs(
 
 
 def _get_op_context(
-    context,  # TODO - type hint
+    context,
 ) -> "OpExecutionContext":
     from dagster._core.execution.context.compute import AssetExecutionContext
 

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -33,7 +33,7 @@ from .result import MaterializeResult
 
 if TYPE_CHECKING:
     from ..execution.context.compute import OpExecutionContext
-    from ..execution.context.invocation import BaseRunlessContext
+    from ..execution.context.invocation import BaseDirectExecutionContext
     from .assets import AssetsDefinition
     from .composition import PendingNodeInvocation
     from .decorators.op_decorator import DecoratedOpFunction
@@ -120,7 +120,7 @@ def direct_invocation_result(
 ) -> Any:
     from dagster._config.pythonic_config import Config
     from dagster._core.execution.context.invocation import (
-        BaseRunlessContext,
+        BaseDirectExecutionContext,
         build_op_context,
     )
 
@@ -160,7 +160,7 @@ def direct_invocation_result(
                 " no context was provided when invoking."
             )
         if len(args) > 0:
-            if args[0] is not None and not isinstance(args[0], BaseRunlessContext):
+            if args[0] is not None and not isinstance(args[0], BaseDirectExecutionContext):
                 raise DagsterInvalidInvocationError(
                     f"Decorated function '{compute_fn.name}' has context argument, "
                     "but no context was provided when invoking."
@@ -182,7 +182,7 @@ def direct_invocation_result(
                 kwarg: val for kwarg, val in kwargs.items() if not kwarg == context_param_name
             }
     # allow passing context, even if the function doesn't have an arg for it
-    elif len(args) > 0 and isinstance(args[0], BaseRunlessContext):
+    elif len(args) > 0 and isinstance(args[0], BaseDirectExecutionContext):
         context = args[0]
         args = args[1:]
 
@@ -241,7 +241,7 @@ def direct_invocation_result(
 
 
 def _resolve_inputs(
-    op_def: "OpDefinition", args, kwargs, context: "BaseRunlessContext"
+    op_def: "OpDefinition", args, kwargs, context: "BaseDirectExecutionContext"
 ) -> Mapping[str, Any]:
     from dagster._core.execution.plan.execute_step import do_type_check
 
@@ -344,7 +344,7 @@ def _resolve_inputs(
     return input_dict
 
 
-def _key_for_result(result: MaterializeResult, context: "BaseRunlessContext") -> AssetKey:
+def _key_for_result(result: MaterializeResult, context: "BaseDirectExecutionContext") -> AssetKey:
     if not context.per_invocation_properties.assets_def:
         raise DagsterInvariantViolationError(
             f"Op {context.per_invocation_properties.alias} does not have an assets definition."
@@ -366,7 +366,7 @@ def _key_for_result(result: MaterializeResult, context: "BaseRunlessContext") ->
 
 def _output_name_for_result_obj(
     event: MaterializeResult,
-    context: "BaseRunlessContext",
+    context: "BaseDirectExecutionContext",
 ):
     if not context.per_invocation_properties.assets_def:
         raise DagsterInvariantViolationError(
@@ -379,7 +379,7 @@ def _output_name_for_result_obj(
 def _handle_gen_event(
     event: T,
     op_def: "OpDefinition",
-    context: "BaseRunlessContext",
+    context: "BaseDirectExecutionContext",
     output_defs: Mapping[str, OutputDefinition],
     outputs_seen: Set[str],
 ) -> T:
@@ -413,7 +413,7 @@ def _handle_gen_event(
 
 
 def _type_check_output_wrapper(
-    op_def: "OpDefinition", result: Any, context: "BaseRunlessContext"
+    op_def: "OpDefinition", result: Any, context: "BaseDirectExecutionContext"
 ) -> Any:
     """Type checks and returns the result of a op.
 
@@ -507,7 +507,7 @@ def _type_check_output_wrapper(
 
 
 def _type_check_function_output(
-    op_def: "OpDefinition", result: T, context: "BaseRunlessContext"
+    op_def: "OpDefinition", result: T, context: "BaseDirectExecutionContext"
 ) -> T:
     from ..execution.plan.compute_generator import validate_and_coerce_op_result_to_iterator
 
@@ -527,14 +527,14 @@ def _type_check_function_output(
 def _type_check_output(
     output_def: "OutputDefinition",
     output: Union[Output, DynamicOutput],
-    context: "BaseRunlessContext",
+    context: "BaseDirectExecutionContext",
 ) -> None:
     """Validates and performs core type check on a provided output.
 
     Args:
         output_def (OutputDefinition): The output definition to validate against.
         output (Any): The output to validate.
-        context (BaseRunlessContext): Context containing resources to be used for type
+        context (BaseDirectExecutionContext): Context containing resources to be used for type
             check.
     """
     from ..execution.plan.execute_step import do_type_check

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -32,8 +32,7 @@ from .output import DynamicOutputDefinition, OutputDefinition
 from .result import MaterializeResult
 
 if TYPE_CHECKING:
-    from dagster._core.execution.context.compute import OpExecutionContext
-
+    from ..execution.context.compute import OpExecutionContext
     from ..execution.context.invocation import BaseRunlessContext
     from .assets import AssetsDefinition
     from .composition import PendingNodeInvocation

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -19,6 +19,7 @@ from dagster._core.errors import (
     DagsterInvariantViolationError,
     DagsterTypeCheckDidNotPass,
 )
+from dagster._core.execution.context.compute import AssetExecutionContext, OpExecutionContext
 
 from .events import (
     AssetKey,
@@ -32,7 +33,7 @@ from .output import DynamicOutputDefinition, OutputDefinition
 from .result import MaterializeResult
 
 if TYPE_CHECKING:
-    from ..execution.context.invocation import DirectOpExecutionContext
+    from ..execution.context.invocation import BaseRunlessContext
     from .assets import AssetsDefinition
     from .composition import PendingNodeInvocation
     from .decorators.op_decorator import DecoratedOpFunction
@@ -100,6 +101,14 @@ def _separate_args_and_kwargs(
     )
 
 
+def _get_op_context(
+    context: Union[OpExecutionContext, AssetExecutionContext]
+) -> OpExecutionContext:
+    if isinstance(context, AssetExecutionContext):
+        return context.op_execution_context
+    return context
+
+
 def direct_invocation_result(
     def_or_invocation: Union[
         "OpDefinition", "PendingNodeInvocation[OpDefinition]", "AssetsDefinition"
@@ -109,7 +118,7 @@ def direct_invocation_result(
 ) -> Any:
     from dagster._config.pythonic_config import Config
     from dagster._core.execution.context.invocation import (
-        DirectOpExecutionContext,
+        BaseRunlessContext,
         build_op_context,
     )
 
@@ -149,12 +158,12 @@ def direct_invocation_result(
                 " no context was provided when invoking."
             )
         if len(args) > 0:
-            if args[0] is not None and not isinstance(args[0], DirectOpExecutionContext):
+            if args[0] is not None and not isinstance(args[0], BaseRunlessContext):
                 raise DagsterInvalidInvocationError(
                     f"Decorated function '{compute_fn.name}' has context argument, "
                     "but no context was provided when invoking."
                 )
-            context = cast(DirectOpExecutionContext, args[0])
+            context = args[0]
             # update args to omit context
             args = args[1:]
         else:  # context argument is provided under kwargs
@@ -165,14 +174,14 @@ def direct_invocation_result(
                     f"'{context_param_name}', but no value for '{context_param_name}' was "
                     f"found when invoking. Provided kwargs: {kwargs}"
                 )
-            context = cast(DirectOpExecutionContext, kwargs[context_param_name])
+            context = kwargs[context_param_name]
             # update kwargs to remove context
             kwargs = {
                 kwarg: val for kwarg, val in kwargs.items() if not kwarg == context_param_name
             }
     # allow passing context, even if the function doesn't have an arg for it
-    elif len(args) > 0 and isinstance(args[0], DirectOpExecutionContext):
-        context = cast(DirectOpExecutionContext, args[0])
+    elif len(args) > 0 and isinstance(args[0], BaseRunlessContext):
+        context = args[0]
         args = args[1:]
 
     resource_arg_mapping = {arg.name: arg.name for arg in compute_fn.get_resource_args()}
@@ -230,7 +239,7 @@ def direct_invocation_result(
 
 
 def _resolve_inputs(
-    op_def: "OpDefinition", args, kwargs, context: "DirectOpExecutionContext"
+    op_def: "OpDefinition", args, kwargs, context: "BaseRunlessContext"
 ) -> Mapping[str, Any]:
     from dagster._core.execution.plan.execute_step import do_type_check
 
@@ -333,7 +342,7 @@ def _resolve_inputs(
     return input_dict
 
 
-def _key_for_result(result: MaterializeResult, context: "DirectOpExecutionContext") -> AssetKey:
+def _key_for_result(result: MaterializeResult, context: "BaseRunlessContext") -> AssetKey:
     if not context.per_invocation_properties.assets_def:
         raise DagsterInvariantViolationError(
             f"Op {context.per_invocation_properties.alias} does not have an assets definition."
@@ -355,7 +364,7 @@ def _key_for_result(result: MaterializeResult, context: "DirectOpExecutionContex
 
 def _output_name_for_result_obj(
     event: MaterializeResult,
-    context: "DirectOpExecutionContext",
+    context: "BaseRunlessContext",
 ):
     if not context.per_invocation_properties.assets_def:
         raise DagsterInvariantViolationError(
@@ -368,7 +377,7 @@ def _output_name_for_result_obj(
 def _handle_gen_event(
     event: T,
     op_def: "OpDefinition",
-    context: "DirectOpExecutionContext",
+    context: "BaseRunlessContext",
     output_defs: Mapping[str, OutputDefinition],
     outputs_seen: Set[str],
 ) -> T:
@@ -402,7 +411,7 @@ def _handle_gen_event(
 
 
 def _type_check_output_wrapper(
-    op_def: "OpDefinition", result: Any, context: "DirectOpExecutionContext"
+    op_def: "OpDefinition", result: Any, context: "BaseRunlessContext"
 ) -> Any:
     """Type checks and returns the result of a op.
 
@@ -496,12 +505,13 @@ def _type_check_output_wrapper(
 
 
 def _type_check_function_output(
-    op_def: "OpDefinition", result: T, context: "DirectOpExecutionContext"
+    op_def: "OpDefinition", result: T, context: "BaseRunlessContext"
 ) -> T:
     from ..execution.plan.compute_generator import validate_and_coerce_op_result_to_iterator
 
     output_defs_by_name = {output_def.name: output_def for output_def in op_def.output_defs}
-    for event in validate_and_coerce_op_result_to_iterator(result, context, op_def.output_defs):
+    op_context = _get_op_context(context)
+    for event in validate_and_coerce_op_result_to_iterator(result, op_context, op_def.output_defs):
         if isinstance(event, (Output, DynamicOutput)):
             _type_check_output(output_defs_by_name[event.output_name], event, context)
         elif isinstance(event, (MaterializeResult)):
@@ -515,14 +525,14 @@ def _type_check_function_output(
 def _type_check_output(
     output_def: "OutputDefinition",
     output: Union[Output, DynamicOutput],
-    context: "DirectOpExecutionContext",
+    context: "BaseRunlessContext",
 ) -> None:
     """Validates and performs core type check on a provided output.
 
     Args:
         output_def (OutputDefinition): The output definition to validate against.
         output (Any): The output to validate.
-        context (DirectOpExecutionContext): Context containing resources to be used for type
+        context (BaseRunlessContext): Context containing resources to be used for type
             check.
     """
     from ..execution.plan.execute_step import do_type_check

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -19,7 +19,6 @@ from dagster._core.errors import (
     DagsterInvariantViolationError,
     DagsterTypeCheckDidNotPass,
 )
-from dagster._core.execution.context.compute import AssetExecutionContext, OpExecutionContext
 
 from .events import (
     AssetKey,
@@ -33,6 +32,8 @@ from .output import DynamicOutputDefinition, OutputDefinition
 from .result import MaterializeResult
 
 if TYPE_CHECKING:
+    from dagster._core.execution.context.compute import OpExecutionContext
+
     from ..execution.context.invocation import BaseRunlessContext
     from .assets import AssetsDefinition
     from .composition import PendingNodeInvocation
@@ -102,8 +103,10 @@ def _separate_args_and_kwargs(
 
 
 def _get_op_context(
-    context: Union[OpExecutionContext, AssetExecutionContext]
-) -> OpExecutionContext:
+    context,  # TODO - type hint
+) -> "OpExecutionContext":
+    from dagster._core.execution.context.compute import AssetExecutionContext
+
     if isinstance(context, AssetExecutionContext):
         return context.op_execution_context
     return context

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -65,7 +65,7 @@ def _property_msg(prop_name: str, method_name: str) -> str:
     return f"The {prop_name} {method_name} is not set on the context when an asset or op is directly invoked."
 
 
-class BasDirectExecutionContext:
+class BaseDirectExecutionContext:
     @abstractmethod
     def bind(
         self,
@@ -75,21 +75,21 @@ class BasDirectExecutionContext:
         config_from_args: Optional[Mapping[str, Any]],
         resources_from_args: Optional[Mapping[str, Any]],
     ):
-        """Instances of BasDirectExecutionContext must implement bind."""
+        """Instances of BaseDirectExecutionContext must implement bind."""
 
     @abstractmethod
     def unbind(self):
-        """Instances of BasDirectExecutionContext must implement unbind."""
+        """Instances of BaseDirectExecutionContext must implement unbind."""
 
     @property
     @abstractmethod
     def bound_properties(self) -> "BoundProperties":
-        """Instances of BasDirectExecutionContext must contain a BoundProperties object."""
+        """Instances of BaseDirectExecutionContext must contain a BoundProperties object."""
 
     @property
     @abstractmethod
     def execution_properties(self) -> "DirectExecutionProperties":
-        """Instances of BasDirectExecutionContext must contain a DirectExecutionProperties object."""
+        """Instances of BaseDirectExecutionContext must contain a DirectExecutionProperties object."""
 
     @abstractmethod
     def for_type(self, dagster_type: DagsterType) -> TypeCheckContext:
@@ -157,7 +157,7 @@ class DirectExecutionProperties:
         self.typed_event_stream_error_message: Optional[str] = None
 
 
-class DirectOpExecutionContext(OpExecutionContext, BasDirectExecutionContext):
+class DirectOpExecutionContext(OpExecutionContext, BaseDirectExecutionContext):
     """The ``context`` object available as the first argument to an op's compute function when
     being invoked directly. Can also be used as a context manager.
     """
@@ -736,7 +736,7 @@ class DirectOpExecutionContext(OpExecutionContext, BasDirectExecutionContext):
         self._execution_properties.typed_event_stream_error_message = error_message
 
 
-class DirectAssetExecutionContext(AssetExecutionContext, BasDirectExecutionContext):
+class DirectAssetExecutionContext(AssetExecutionContext, BaseDirectExecutionContext):
     """The ``context`` object available as the first argument to an asset's compute function when
     being invoked directly. Can also be used as a context manager.
     """

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from contextlib import ExitStack
 from typing import (
     AbstractSet,
@@ -66,6 +67,36 @@ def _property_msg(prop_name: str, method_name: str) -> str:
         f"The {prop_name} {method_name} is not set on the context when an op is directly invoked."
     )
 
+class BaseRunlessContext:
+    @abstractmethod
+    def bind(
+        self,
+        op_def: OpDefinition,
+        pending_invocation: Optional[PendingNodeInvocation[OpDefinition]],
+        assets_def: Optional[AssetsDefinition],
+        config_from_args: Optional[Mapping[str, Any]],
+        resources_from_args: Optional[Mapping[str, Any]],
+    ):
+        """Instances of BsaeRunlessContest must implement bind."""
+
+    @abstractmethod
+    def unbind(self):
+        """Instances of BsaeRunlessContest must implement unbind."""
+
+    @property
+    @abstractmethod
+    def bound_properties(self) -> "BoundProperties":
+        """Instances of BaseRunlessContext must contain a BoundProperties object."""
+
+    @property
+    @abstractmethod
+    def execution_properties(self) -> "RunlessExecutionProperties":
+        """Instances of BaseRunlessContext must contain a RunlessExecutionProperties object."""
+
+    @abstractmethod
+    def for_type(self, dagster_type: DagsterType) -> TypeCheckContext:
+        pass
+
 
 class PerInvocationProperties(
     NamedTuple(
@@ -128,7 +159,7 @@ class DirectExecutionProperties:
         self.typed_event_stream_error_message: Optional[str] = None
 
 
-class DirectOpExecutionContext(OpExecutionContext):
+class DirectOpExecutionContext(OpExecutionContext, BaseRunlessContext):
     """The ``context`` object available as the first argument to an op's compute function when
     being invoked directly. Can also be used as a context manager.
     """
@@ -707,7 +738,7 @@ class DirectOpExecutionContext(OpExecutionContext):
         self._execution_properties.typed_event_stream_error_message = error_message
 
 
-class RunlessAssetExecutionContext(AssetExecutionContext):
+class RunlessAssetExecutionContext(AssetExecutionContext, BaseRunlessContext):
     """The ``context`` object available as the first argument to an asset's compute function when
     being invoked directly. Can also be used as a context manager.
     """
@@ -716,6 +747,16 @@ class RunlessAssetExecutionContext(AssetExecutionContext):
         self._op_execution_context = op_execution_context
 
         self._run_props = None
+
+    def __enter__(self):
+        self.op_execution_context._cm_scope_entered = True  # noqa: SLF001
+        return self
+
+    def __exit__(self, *exc):
+        self.op_execution_context._exit_stack.close()  # noqa: SLF001
+
+    def __del__(self):
+        self.op_execution_context._exit_stack.close()  # noqa: SLF001
 
     def _check_bound(self, fn_name: str, fn_type: str):
         if not self._op_execution_context._bound_properties:  # noqa: SLF001
@@ -752,6 +793,14 @@ class RunlessAssetExecutionContext(AssetExecutionContext):
 
     def unbind(self):
         self._op_execution_context = self._op_execution_context.unbind()
+
+    @property
+    def bound_properties(self) -> BoundProperties:
+        return self.op_execution_context.bound_properties
+
+    @property
+    def execution_properties(self) -> RunlessExecutionProperties:
+        return self.op_execution_context.execution_properties
 
     @property
     def op_execution_context(self) -> RunlessOpExecutionContext:

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -66,6 +66,17 @@ def _property_msg(prop_name: str, method_name: str) -> str:
 
 
 class BaseDirectExecutionContext:
+    """Base class for any direct invocation execution contexts. Each type of execution context
+    (ex. OpExecutionContext, AssetExecutionContext) needs to have a variant for direct invocation.
+    Those direct invocation contexts have some methods that are not available until the context
+    is bound to a particular op/asset. The "bound" properties are held in PerInvocationProperties.
+    There are also some properties that are specific to a particular execution of an op/asset, these
+    properties are held in DirectExecutionProperties. Direct invocation contexts must
+    be able to be bound and unbound from a particular op/asset. Additionally, there are some methods
+    that all direct invocation contexts must implement so that the will be usable in the execution
+    code path.
+    """
+
     @abstractmethod
     def bind(
         self,

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -635,6 +635,10 @@ class DirectOpExecutionContext(OpExecutionContext, BaseDirectExecutionContext):
             Union[MultiPartitionsDefinition, TimeWindowPartitionsDefinition], partitions_def
         ).time_window_for_partition_key(self.partition_key)
 
+    @property
+    def partition_time_window(self) -> TimeWindow:
+        return self.asset_partitions_time_window_for_output()
+
     def add_output_metadata(
         self,
         metadata: Mapping[str, Any],

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -83,8 +83,8 @@ class BaseDirectExecutionContext:
 
     @property
     @abstractmethod
-    def bound_properties(self) -> "BoundProperties":
-        """Subclasses of BaseDirectExecutionContext must contain a BoundProperties object."""
+    def per_invocation_properties(self) -> "PerInvocationProperties":
+        """Subclasses of BaseDirectExecutionContext must contain a PerInvocationProperties object."""
 
     @property
     @abstractmethod
@@ -754,8 +754,6 @@ class DirectAssetExecutionContext(AssetExecutionContext, BaseDirectExecutionCont
     def __init__(self, op_execution_context: DirectOpExecutionContext):
         self._op_execution_context = op_execution_context
 
-        self._run_props = None
-
     def __enter__(self):
         self.op_execution_context._cm_scope_entered = True  # noqa: SLF001
         return self
@@ -766,8 +764,8 @@ class DirectAssetExecutionContext(AssetExecutionContext, BaseDirectExecutionCont
     def __del__(self):
         self.op_execution_context._exit_stack.close()  # noqa: SLF001
 
-    def _check_bound(self, fn_name: str, fn_type: str):
-        if not self._op_execution_context._bound_properties:  # noqa: SLF001
+    def _check_bound_to_invocation(self, fn_name: str, fn_type: str):
+        if not self._op_execution_context._per_invocation_properties:  # noqa: SLF001
             raise DagsterInvalidPropertyError(_property_msg(fn_name, fn_type))
 
     def bind(
@@ -782,7 +780,7 @@ class DirectAssetExecutionContext(AssetExecutionContext, BaseDirectExecutionCont
             raise DagsterInvariantViolationError(
                 "DirectAssetExecutionContext can only being used to invoke an asset."
             )
-        if self._op_execution_context._bound_properties is not None:  # noqa: SLF001
+        if self._op_execution_context._per_invocation_properties is not None:  # noqa: SLF001
             raise DagsterInvalidInvocationError(
                 f"This context is currently being used to execute {self.op_execution_context.alias}."
                 " The context cannot be used to execute another asset until"
@@ -803,8 +801,8 @@ class DirectAssetExecutionContext(AssetExecutionContext, BaseDirectExecutionCont
         self._op_execution_context.unbind()
 
     @property
-    def bound_properties(self) -> BoundProperties:
-        return self.op_execution_context.bound_properties
+    def per_invocation_properties(self) -> PerInvocationProperties:
+        return self.op_execution_context.per_invocation_properties
 
     @property
     def is_bound(self) -> bool:

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -635,10 +635,6 @@ class DirectOpExecutionContext(OpExecutionContext, BaseDirectExecutionContext):
             Union[MultiPartitionsDefinition, TimeWindowPartitionsDefinition], partitions_def
         ).time_window_for_partition_key(self.partition_key)
 
-    @property
-    def partition_time_window(self) -> TimeWindow:
-        return self.asset_partitions_time_window_for_output()
-
     def add_output_metadata(
         self,
         metadata: Mapping[str, Any],

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -799,6 +799,10 @@ class RunlessAssetExecutionContext(AssetExecutionContext, BaseRunlessContext):
         return self.op_execution_context.bound_properties
 
     @property
+    def is_bound(self) -> bool:
+        return self.op_execution_context.is_bound
+
+    @property
     def execution_properties(self) -> RunlessExecutionProperties:
         return self.op_execution_context.execution_properties
 

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -75,24 +75,30 @@ class BaseDirectExecutionContext:
         config_from_args: Optional[Mapping[str, Any]],
         resources_from_args: Optional[Mapping[str, Any]],
     ):
-        """Instances of BaseDirectExecutionContext must implement bind."""
+        """Subclasses of BaseDirectExecutionContext must implement bind."""
 
     @abstractmethod
     def unbind(self):
-        """Instances of BaseDirectExecutionContext must implement unbind."""
+        """Subclasses of BaseDirectExecutionContext must implement unbind."""
 
     @property
     @abstractmethod
     def bound_properties(self) -> "BoundProperties":
-        """Instances of BaseDirectExecutionContext must contain a BoundProperties object."""
+        """Subclasses of BaseDirectExecutionContext must contain a BoundProperties object."""
 
     @property
     @abstractmethod
     def execution_properties(self) -> "DirectExecutionProperties":
-        """Instances of BaseDirectExecutionContext must contain a DirectExecutionProperties object."""
+        """Subclasses of BaseDirectExecutionContext must contain a DirectExecutionProperties object."""
 
     @abstractmethod
     def for_type(self, dagster_type: DagsterType) -> TypeCheckContext:
+        """Subclasses of BaseDirectExecutionContext must implement for_type."""
+        pass
+
+    @abstractmethod
+    def observe_output(self, output_name: str, mapping_key: Optional[str] = None) -> None:
+        """Subclasses of BaseDirectExecutionContext must implement observe_output."""
         pass
 
 

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -792,7 +792,7 @@ class RunlessAssetExecutionContext(AssetExecutionContext, BaseRunlessContext):
         return self
 
     def unbind(self):
-        self._op_execution_context = self._op_execution_context.unbind()
+        self._op_execution_context.unbind()
 
     @property
     def bound_properties(self) -> BoundProperties:

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -39,11 +39,7 @@ from dagster._core.definitions.time_window_partitions import (
 from dagster._core.errors import DagsterPipesExecutionError
 from dagster._core.events import EngineEventData
 from dagster._core.execution.context.compute import OpExecutionContext
-<<<<<<< HEAD
-from dagster._core.execution.context.invocation import DirectOpExecutionContext
-=======
-from dagster._core.execution.context.invocation import BaseRunlessContext
->>>>>>> c4d31671bc (pipes)
+from dagster._core.execution.context.invocation import BaseDirectExecutionContext
 from dagster._utils.error import (
     ExceptionInfo,
     SerializableErrorInfo,
@@ -410,8 +406,8 @@ def build_external_execution_context_data(
             _convert_time_window(partition_time_window) if partition_time_window else None
         ),
         run_id=context.run_id,
-        job_name=None if isinstance(context, BaseRunlessContext) else context.job_name,
-        retry_number=0 if isinstance(context, BaseRunlessContext) else context.retry_number,
+        job_name=None if isinstance(context, BaseDirectExecutionContext) else context.job_name,
+        retry_number=0 if isinstance(context, BaseDirectExecutionContext) else context.retry_number,
         extras=extras or {},
     )
 

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -39,7 +39,11 @@ from dagster._core.definitions.time_window_partitions import (
 from dagster._core.errors import DagsterPipesExecutionError
 from dagster._core.events import EngineEventData
 from dagster._core.execution.context.compute import OpExecutionContext
+<<<<<<< HEAD
 from dagster._core.execution.context.invocation import DirectOpExecutionContext
+=======
+from dagster._core.execution.context.invocation import BaseRunlessContext
+>>>>>>> c4d31671bc (pipes)
 from dagster._utils.error import (
     ExceptionInfo,
     SerializableErrorInfo,
@@ -406,8 +410,8 @@ def build_external_execution_context_data(
             _convert_time_window(partition_time_window) if partition_time_window else None
         ),
         run_id=context.run_id,
-        job_name=None if isinstance(context, DirectOpExecutionContext) else context.job_name,
-        retry_number=0 if isinstance(context, DirectOpExecutionContext) else context.retry_number,
+        job_name=None if isinstance(context, BaseRunlessContext) else context.job_name,
+        retry_number=0 if isinstance(context, BaseRunlessContext) else context.retry_number,
         extras=extras or {},
     )
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -1383,7 +1383,7 @@ def test_async_assets_with_shared_context():
     with pytest.raises(
         DagsterInvalidInvocationError,
         match=r"This context is currently being used to execute .* The context"
-        r" cannot be used to execute another op until .* has finished executing",
+        r" cannot be used to execute another asset until .* has finished executing",
     ):
         asyncio.run(main())
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -1589,17 +1589,3 @@ def test_context_bound_state_with_error_async_generator():
         asyncio.run(get_results())
 
     assert_context_unbound(ctx)
-
-
-def test_run_properties_access():
-    @asset
-    def access_run_properties(context: AssetExecutionContext):
-        assert context.run_properties.run_id == "EPHEMERAL"
-        assert context.run_properties.retry_number == 0
-
-        with pytest.raises(DagsterInvalidPropertyError):
-            context.run_properties.dagster_run  # noqa:B018
-
-    ctx = build_asset_context()
-
-    access_run_properties(ctx)

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -1589,3 +1589,17 @@ def test_context_bound_state_with_error_async_generator():
         asyncio.run(get_results())
 
     assert_context_unbound(ctx)
+
+
+def test_run_properties_access():
+    @asset
+    def access_run_properties(context: AssetExecutionContext):
+        assert context.run_properties.run_id == "EPHEMERAL"
+        assert context.run_properties.retry_number == 0
+
+        with pytest.raises(DagsterInvalidPropertyError):
+            context.run_properties.dagster_run  # noqa:B018
+
+    ctx = build_asset_context()
+
+    access_run_properties(ctx)


### PR DESCRIPTION
## Summary & Motivation
This PR introduces a direct invocation AssetExecutionContext. The underlying `op_execution_context` is a `DirectOpExecutionContext`. Methods on `AssetExecutionContext` that have their own implementations, rather than passing through to a method on the op execution context, and access values not available during direct invocation will need to be re-implemented on the `DirectAssetExecutionContext` (but there are none of those in this PR). The bound/unbound state of this context is maintained on the underlying op context 

Introduces a parent class for `DirectOpExecutionContext` and `DirectAssetExecutionContext` so we can do type checking in the direct invocation code path 

## How I Tested These Changes
