### PR TITLE
[ui] Don’t reference jobNames for REQUIRES_MATERIALIZATION checks

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
@@ -44,10 +44,7 @@ export interface IExecutionSession {
   needsRefresh: boolean;
   assetSelection: {assetKey: AssetKeyInput; opNames: string[]}[] | null;
   // Nullable for backwards compatibility
-  assetChecksAvailable?: Pick<
-    AssetCheck,
-    'name' | 'canExecuteIndividually' | 'assetKey' | 'jobNames'
-  >[];
+  assetChecksAvailable?: Pick<AssetCheck, 'name' | 'canExecuteIndividually' | 'assetKey'>[];
   includeSeparatelyExecutableChecks: boolean;
   solidSelection: string[] | null;
   solidSelectionQuery: string | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
@@ -44,7 +44,10 @@ export interface IExecutionSession {
   needsRefresh: boolean;
   assetSelection: {assetKey: AssetKeyInput; opNames: string[]}[] | null;
   // Nullable for backwards compatibility
-  assetChecksAvailable?: Pick<AssetCheck, 'name' | 'canExecuteIndividually' | 'assetKey'>[];
+  assetChecksAvailable?: Pick<
+    AssetCheck,
+    'name' | 'canExecuteIndividually' | 'assetKey' | 'jobNames'
+  >[];
   includeSeparatelyExecutableChecks: boolean;
   solidSelection: string[] | null;
   solidSelectionQuery: string | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -37,7 +37,7 @@ import {MULTIPLE_DEFINITIONS_WARNING} from './AssetDefinedInMultipleReposNotice'
 import {CalculateChangedAndMissingDialog} from './CalculateChangedAndMissingDialog';
 import {LaunchAssetChoosePartitionsDialog} from './LaunchAssetChoosePartitionsDialog';
 import {partitionDefinitionsEqual} from './MultipartitioningSupport';
-import {asAssetKeyInput, getAssetCheckHandleInputs} from './asInput';
+import {asAssetKeyInput, getAssetCheckHandleInputs, inMaterializeFunctionOrInJob} from './asInput';
 import {AssetKey} from './types';
 import {
   LaunchAssetCheckUpstreamQuery,
@@ -538,7 +538,7 @@ async function stateForLaunchingAssets(
         assetChecksAvailable: assets.flatMap((a) =>
           a.assetChecksOrError.__typename === 'AssetChecks'
             ? a.assetChecksOrError.checks
-                .filter((check) => check.jobNames.includes(jobName))
+                .filter((check) => inMaterializeFunctionOrInJob(check, jobName))
                 .map((check) => ({...check, assetKey: a.assetKey}))
             : [],
         ),

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
@@ -4,6 +4,7 @@ import without from 'lodash/without';
 import {tokenForAssetKey} from '../../asset-graph/Utils';
 import {AssetNodeForGraphQueryFragment} from '../../asset-graph/types/useAssetGraphData.types';
 import {
+  AssetCheckCanExecuteIndividually,
   AssetKeyInput,
   LaunchBackfillParams,
   PartitionDefinitionType,
@@ -1021,9 +1022,16 @@ const CHECKED_ASSET_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
   assetChecksOrError: buildAssetChecks({
     checks: [
       buildAssetCheck({
-        name: 'CHECK_1',
+        name: 'check_can_execute',
         assetKey: CHECKED_ASSET.assetKey,
+        canExecuteIndividually: AssetCheckCanExecuteIndividually.CAN_EXECUTE,
         jobNames: ['checks_included_job', '__ASSET_JOB_0'],
+      }),
+      buildAssetCheck({
+        name: 'check_requires_materialization',
+        assetKey: CHECKED_ASSET.assetKey,
+        canExecuteIndividually: AssetCheckCanExecuteIndividually.REQUIRES_MATERIALIZATION,
+        jobNames: [], // may be populated, but should not matter
       }),
     ],
   }),

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -162,7 +162,7 @@ describe('LaunchAssetExecutionButton', () => {
     });
 
     describe('assets with checks', () => {
-      it('should not include checks if the job in context is marked without_checks', async () => {
+      it('should not include CAN_EXECUTE checks that do not specify the job name (checks_excluded_job)', async () => {
         const launchMock = buildExpectedLaunchSingleRunMutation({
           mode: 'default',
           executionMetadata: {tags: []},
@@ -172,7 +172,11 @@ describe('LaunchAssetExecutionButton', () => {
             repositoryName: 'repo',
             pipelineName: 'checks_excluded_job',
             assetSelection: [{path: ['checked_asset']}],
-            assetCheckSelection: [],
+            assetCheckSelection: [
+              // This check is not executed because it's jobNames does not incldue checks_excluded_job
+              // {name: 'check_can_execute', assetKey: {path: ['checked_asset']}},
+              {name: 'check_requires_materialization', assetKey: {path: ['checked_asset']}},
+            ],
           },
         });
         renderButton({
@@ -184,7 +188,7 @@ describe('LaunchAssetExecutionButton', () => {
         await waitFor(() => expect(launchMock.result).toHaveBeenCalled());
       });
 
-      it('should include checks if the job in context includes them', async () => {
+      it('should include checks if the job in context includes them, or they REQUIRE_MATERIALIZATION', async () => {
         const launchMock = buildExpectedLaunchSingleRunMutation({
           mode: 'default',
           executionMetadata: {tags: []},
@@ -194,7 +198,10 @@ describe('LaunchAssetExecutionButton', () => {
             repositoryName: 'repo',
             pipelineName: 'checks_included_job',
             assetSelection: [{path: ['checked_asset']}],
-            assetCheckSelection: [{name: 'CHECK_1', assetKey: {path: ['checked_asset']}}],
+            assetCheckSelection: [
+              {name: 'check_can_execute', assetKey: {path: ['checked_asset']}},
+              {name: 'check_requires_materialization', assetKey: {path: ['checked_asset']}},
+            ],
           },
         });
         renderButton({

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asInput.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asInput.ts
@@ -6,13 +6,17 @@ import {
 
 import {LaunchAssetExecutionAssetNodeFragment} from './types/LaunchAssetExecutionButton.types';
 
+// Checks that REQUIRES_MATERIALIZATION cannot be omitted and need to be executed
+// whenver the asset is executed. Checks with CAN_EXECUTE should be omitted if their
+// jobNames array does not include the requested job.
+//
 export function inMaterializeFunctionOrInJob(
   check: Pick<AssetCheck, 'jobNames' | 'canExecuteIndividually'>,
   jobName?: string,
 ) {
+  const inJob = !jobName || check.jobNames.includes(jobName);
   const inMaterialize =
     check.canExecuteIndividually === AssetCheckCanExecuteIndividually.REQUIRES_MATERIALIZATION;
-  const inJob = !jobName || check.jobNames.includes(jobName);
 
   return inMaterialize || inJob;
 }


### PR DESCRIPTION
## Summary & Motivation

We recently made a change so that asset checks are only passed to the materialize mutation if their `jobNames` include the job being launched. This includes hidden asset jobs, eg: visiting the asset page and clicking "Materialize".

The asset checks `jobNames` array is empty for checks that have `canExecuteIndividually = REQUIRES_MATERIALIZATION`, meaning the check is actually IN the asset.

This change adjusts the filtering that we do to exclude checks that are not in the selected job so that these `REQUIRES_MATERIALIZATION` checks are always included in the selection.

## How I Tested These Changes

I upgraded our launch tests so that the graph contains one check with CAN_MATERIALIZE=true and one of two jobNames, and one REQUIRES_MATERIALIZATION check with no jobNames. Verified that before the fix, the tests fail, and after the fix, the latter is launched all the time.