### PR TITLE
Raise error on invalid partition range in get_partition_keys_in_range

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -742,7 +742,22 @@ class TimeWindowPartitionsDefinition(
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Sequence[str]:
         start_time = self.start_time_for_partition_key(partition_key_range.start)
+        check.invariant(
+            start_time.timestamp() >= self.start.timestamp(),
+            (
+                f"Partition key range start {partition_key_range.start} is before "
+                f"the partitions definition start time {self.start}"
+            ),
+        )
         end_time = self.end_time_for_partition_key(partition_key_range.end)
+        if self.end:
+            check.invariant(
+                end_time.timestamp() <= self.end.timestamp(),
+                (
+                    f"Partition key range end {partition_key_range.end} is after the "
+                    f"partitions definition end time {self.end}"
+                ),
+            )
 
         return self.get_partition_keys_in_time_window(TimeWindow(start_time, end_time))
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -726,6 +726,19 @@ def test_get_partition_keys_in_range(partitions_def, range_start, range_end, par
     )
 
 
+def test_invalid_get_partition_keys_in_range():
+    partitions_def = DailyPartitionsDefinition(start_date="2020-01-01", end_date="2020-01-05")
+    with pytest.raises(CheckError, match="before the partitions definition start time"):
+        partitions_def.get_partition_keys_in_range(PartitionKeyRange("2019-12-12", "2020-01-01"))
+
+    with pytest.raises(CheckError, match="after the partitions definition end time"):
+        partitions_def.get_partition_keys_in_range(PartitionKeyRange("2020-01-01", "2020-01-06"))
+
+    assert partitions_def.get_partition_keys_in_range(
+        PartitionKeyRange("2020-01-01", "2020-01-04")
+    ) == ["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04"]
+
+
 def test_twice_daily_partitions():
     partitions_def = TimeWindowPartitionsDefinition(
         start=pendulum.parse("2021-05-05"),


### PR DESCRIPTION
A user hit an unexpected error caused by [empty time window partitions subsets being created when providing an invalid range to `partitions_def.get_partition_keys_in_range`](https://github.com/dagster-io/dagster/blob/bf9820c54910da94d6e5d33b660e14fbd02ef690/python_modules/dagster/dagster/_core/execution/asset_backfill.py#L473-L484).

This PR updates `TimeWindowPartitionsDefinition.get_partition_keys_in_range` to raise an exception when an invalid range is provided.