### PR TITLE
Fix legacy graph background

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGroupNode.tsx
@@ -3,7 +3,7 @@ import {
   FontFamily,
   Icon,
   Mono,
-  colorLineageGroupNodeBorder,
+  colorLineageGroupBackground,
   colorTextLight,
 } from '@dagster-io/ui-components';
 import React from 'react';
@@ -75,8 +75,8 @@ export const AssetGroupNode = ({group, scale}: Props) => {
           position: 'absolute',
           background:
             scale < GROUPS_ONLY_SCALE
-              ? colorLineageGroupNodeBorder()
-              : colorLineageGroupNodeBorder(),
+              ? colorLineageGroupBackground()
+              : colorLineageGroupBackground(),
         }}
       />
 


### PR DESCRIPTION
## Summary & Motivation
We broke the old asset graph with the new themes. This fixes the group background color.

Before:
<img width="601" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/a45feaf6-d99c-4295-baa7-ba8e96de59aa">


After:
<img width="692" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/27b4a258-3b7c-47e6-a527-3cda04c36698">


## How I Tested These Changes
Loaded the UI and clicked around