### PR TITLE
Detect cross-code-location cycles in GQL service

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -649,6 +649,7 @@ type AssetNode {
   backfillPolicy: BackfillPolicy
   computeKind: String
   configField: ConfigTypeField
+  cycle: [AssetKey!]
   dataVersion(partition: String): String
   dataVersionByPartition(partitions: [String!]): [String]!
   dependedBy: [AssetDependency!]!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -374,6 +374,7 @@ export type AssetNode = {
   computeKind: Maybe<Scalars['String']>;
   configField: Maybe<ConfigTypeField>;
   currentAutoMaterializeEvaluationId: Maybe<Scalars['Int']>;
+  cycle: Maybe<Array<AssetKey>>;
   dataVersion: Maybe<Scalars['String']>;
   dataVersionByPartition: Array<Maybe<Scalars['String']>>;
   dependedBy: Array<AssetDependency>;
@@ -5290,26 +5291,13 @@ export const buildArrayConfigType = (
     ofType:
       overrides && overrides.hasOwnProperty('ofType')
         ? overrides.ofType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
     recursiveConfigTypes:
       overrides && overrides.hasOwnProperty('recursiveConfigTypes')
         ? overrides.recursiveConfigTypes!
@@ -5933,6 +5921,7 @@ export const buildAssetNode = (
       overrides && overrides.hasOwnProperty('currentAutoMaterializeEvaluationId')
         ? overrides.currentAutoMaterializeEvaluationId!
         : 6693,
+    cycle: overrides && overrides.hasOwnProperty('cycle') ? overrides.cycle! : [],
     dataVersion:
       overrides && overrides.hasOwnProperty('dataVersion') ? overrides.dataVersion! : 'a',
     dataVersionByPartition:
@@ -6052,15 +6041,7 @@ export const buildAssetNode = (
     type:
       overrides && overrides.hasOwnProperty('type')
         ? overrides.type!
-        : relationshipsToOmit.has('ListDagsterType')
-        ? ({} as ListDagsterType)
-        : buildListDagsterType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableDagsterType')
-        ? ({} as NullableDagsterType)
-        : buildNullableDagsterType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularDagsterType')
-        ? ({} as RegularDagsterType)
-        : buildRegularDagsterType({}, relationshipsToOmit),
+        : buildListDagsterType() || buildNullableDagsterType() || buildRegularDagsterType(),
   };
 };
 
@@ -6614,26 +6595,13 @@ export const buildConfigTypeField = (
     configType:
       overrides && overrides.hasOwnProperty('configType')
         ? overrides.configType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
     configTypeKey:
       overrides && overrides.hasOwnProperty('configTypeKey')
         ? overrides.configTypeKey!
@@ -6774,26 +6742,13 @@ export const buildDagsterType = (
     inputSchemaType:
       overrides && overrides.hasOwnProperty('inputSchemaType')
         ? overrides.inputSchemaType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
     isBuiltin: overrides && overrides.hasOwnProperty('isBuiltin') ? overrides.isBuiltin! : true,
     isList: overrides && overrides.hasOwnProperty('isList') ? overrides.isList! : true,
     isNothing: overrides && overrides.hasOwnProperty('isNothing') ? overrides.isNothing! : true,
@@ -6805,26 +6760,13 @@ export const buildDagsterType = (
     outputSchemaType:
       overrides && overrides.hasOwnProperty('outputSchemaType')
         ? overrides.outputSchemaType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
   };
 };
 
@@ -8071,15 +8013,7 @@ export const buildInputDefinition = (
     type:
       overrides && overrides.hasOwnProperty('type')
         ? overrides.type!
-        : relationshipsToOmit.has('ListDagsterType')
-        ? ({} as ListDagsterType)
-        : buildListDagsterType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableDagsterType')
-        ? ({} as NullableDagsterType)
-        : buildNullableDagsterType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularDagsterType')
-        ? ({} as RegularDagsterType)
-        : buildRegularDagsterType({}, relationshipsToOmit),
+        : buildListDagsterType() || buildNullableDagsterType() || buildRegularDagsterType(),
   };
 };
 
@@ -8771,26 +8705,13 @@ export const buildListDagsterType = (
     inputSchemaType:
       overrides && overrides.hasOwnProperty('inputSchemaType')
         ? overrides.inputSchemaType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
     isBuiltin: overrides && overrides.hasOwnProperty('isBuiltin') ? overrides.isBuiltin! : true,
     isList: overrides && overrides.hasOwnProperty('isList') ? overrides.isList! : true,
     isNothing: overrides && overrides.hasOwnProperty('isNothing') ? overrides.isNothing! : true,
@@ -8802,38 +8723,17 @@ export const buildListDagsterType = (
     ofType:
       overrides && overrides.hasOwnProperty('ofType')
         ? overrides.ofType!
-        : relationshipsToOmit.has('ListDagsterType')
-        ? ({} as ListDagsterType)
-        : buildListDagsterType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableDagsterType')
-        ? ({} as NullableDagsterType)
-        : buildNullableDagsterType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularDagsterType')
-        ? ({} as RegularDagsterType)
-        : buildRegularDagsterType({}, relationshipsToOmit),
+        : buildListDagsterType() || buildNullableDagsterType() || buildRegularDagsterType(),
     outputSchemaType:
       overrides && overrides.hasOwnProperty('outputSchemaType')
         ? overrides.outputSchemaType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
   };
 };
 
@@ -9023,26 +8923,13 @@ export const buildMapConfigType = (
     keyType:
       overrides && overrides.hasOwnProperty('keyType')
         ? overrides.keyType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
     recursiveConfigTypes:
       overrides && overrides.hasOwnProperty('recursiveConfigTypes')
         ? overrides.recursiveConfigTypes!
@@ -9052,26 +8939,13 @@ export const buildMapConfigType = (
     valueType:
       overrides && overrides.hasOwnProperty('valueType')
         ? overrides.valueType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
   };
 };
 
@@ -9702,26 +9576,13 @@ export const buildNullableConfigType = (
     ofType:
       overrides && overrides.hasOwnProperty('ofType')
         ? overrides.ofType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
     recursiveConfigTypes:
       overrides && overrides.hasOwnProperty('recursiveConfigTypes')
         ? overrides.recursiveConfigTypes!
@@ -9749,26 +9610,13 @@ export const buildNullableDagsterType = (
     inputSchemaType:
       overrides && overrides.hasOwnProperty('inputSchemaType')
         ? overrides.inputSchemaType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
     isBuiltin: overrides && overrides.hasOwnProperty('isBuiltin') ? overrides.isBuiltin! : false,
     isList: overrides && overrides.hasOwnProperty('isList') ? overrides.isList! : false,
     isNothing: overrides && overrides.hasOwnProperty('isNothing') ? overrides.isNothing! : true,
@@ -9780,38 +9628,17 @@ export const buildNullableDagsterType = (
     ofType:
       overrides && overrides.hasOwnProperty('ofType')
         ? overrides.ofType!
-        : relationshipsToOmit.has('ListDagsterType')
-        ? ({} as ListDagsterType)
-        : buildListDagsterType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableDagsterType')
-        ? ({} as NullableDagsterType)
-        : buildNullableDagsterType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularDagsterType')
-        ? ({} as RegularDagsterType)
-        : buildRegularDagsterType({}, relationshipsToOmit),
+        : buildListDagsterType() || buildNullableDagsterType() || buildRegularDagsterType(),
     outputSchemaType:
       overrides && overrides.hasOwnProperty('outputSchemaType')
         ? overrides.outputSchemaType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
   };
 };
 
@@ -9955,15 +9782,7 @@ export const buildOutputDefinition = (
     type:
       overrides && overrides.hasOwnProperty('type')
         ? overrides.type!
-        : relationshipsToOmit.has('ListDagsterType')
-        ? ({} as ListDagsterType)
-        : buildListDagsterType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableDagsterType')
-        ? ({} as NullableDagsterType)
-        : buildNullableDagsterType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularDagsterType')
-        ? ({} as RegularDagsterType)
-        : buildRegularDagsterType({}, relationshipsToOmit),
+        : buildListDagsterType() || buildNullableDagsterType() || buildRegularDagsterType(),
   };
 };
 
@@ -10751,12 +10570,7 @@ export const buildPipelineRun = (
     pipeline:
       overrides && overrides.hasOwnProperty('pipeline')
         ? overrides.pipeline!
-        : relationshipsToOmit.has('PipelineSnapshot')
-        ? ({} as PipelineSnapshot)
-        : buildPipelineSnapshot({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('UnknownPipeline')
-        ? ({} as UnknownPipeline)
-        : buildUnknownPipeline({}, relationshipsToOmit),
+        : buildPipelineSnapshot() || buildUnknownPipeline(),
     pipelineName:
       overrides && overrides.hasOwnProperty('pipelineName') ? overrides.pipelineName! : 'animi',
     pipelineSnapshotId:
@@ -11450,26 +11264,13 @@ export const buildRegularDagsterType = (
     inputSchemaType:
       overrides && overrides.hasOwnProperty('inputSchemaType')
         ? overrides.inputSchemaType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
     isBuiltin: overrides && overrides.hasOwnProperty('isBuiltin') ? overrides.isBuiltin! : true,
     isList: overrides && overrides.hasOwnProperty('isList') ? overrides.isList! : false,
     isNothing: overrides && overrides.hasOwnProperty('isNothing') ? overrides.isNothing! : false,
@@ -11481,26 +11282,13 @@ export const buildRegularDagsterType = (
     outputSchemaType:
       overrides && overrides.hasOwnProperty('outputSchemaType')
         ? overrides.outputSchemaType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
   };
 };
 
@@ -12119,12 +11907,7 @@ export const buildRun = (
     pipeline:
       overrides && overrides.hasOwnProperty('pipeline')
         ? overrides.pipeline!
-        : relationshipsToOmit.has('PipelineSnapshot')
-        ? ({} as PipelineSnapshot)
-        : buildPipelineSnapshot({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('UnknownPipeline')
-        ? ({} as UnknownPipeline)
-        : buildUnknownPipeline({}, relationshipsToOmit),
+        : buildPipelineSnapshot() || buildUnknownPipeline(),
     pipelineName:
       overrides && overrides.hasOwnProperty('pipelineName') ? overrides.pipelineName! : 'enim',
     pipelineSnapshotId:
@@ -12235,26 +12018,13 @@ export const buildRunConfigSchema = (
     rootConfigType:
       overrides && overrides.hasOwnProperty('rootConfigType')
         ? overrides.rootConfigType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
     rootDefaultYaml:
       overrides && overrides.hasOwnProperty('rootDefaultYaml') ? overrides.rootDefaultYaml! : 'cum',
   };
@@ -12739,26 +12509,13 @@ export const buildScalarUnionConfigType = (
     nonScalarType:
       overrides && overrides.hasOwnProperty('nonScalarType')
         ? overrides.nonScalarType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
     nonScalarTypeKey:
       overrides && overrides.hasOwnProperty('nonScalarTypeKey')
         ? overrides.nonScalarTypeKey!
@@ -12770,26 +12527,13 @@ export const buildScalarUnionConfigType = (
     scalarType:
       overrides && overrides.hasOwnProperty('scalarType')
         ? overrides.scalarType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
     scalarTypeKey:
       overrides && overrides.hasOwnProperty('scalarTypeKey') ? overrides.scalarTypeKey! : 'esse',
     typeParamKeys:
@@ -13229,12 +12973,7 @@ export const buildSolid = (
     definition:
       overrides && overrides.hasOwnProperty('definition')
         ? overrides.definition!
-        : relationshipsToOmit.has('CompositeSolidDefinition')
-        ? ({} as CompositeSolidDefinition)
-        : buildCompositeSolidDefinition({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('SolidDefinition')
-        ? ({} as SolidDefinition)
-        : buildSolidDefinition({}, relationshipsToOmit),
+        : buildCompositeSolidDefinition() || buildSolidDefinition(),
     inputs: overrides && overrides.hasOwnProperty('inputs') ? overrides.inputs! : [],
     isDynamicMapped:
       overrides && overrides.hasOwnProperty('isDynamicMapped') ? overrides.isDynamicMapped! : true,
@@ -14061,12 +13800,7 @@ export const buildUsedSolid = (
     definition:
       overrides && overrides.hasOwnProperty('definition')
         ? overrides.definition!
-        : relationshipsToOmit.has('CompositeSolidDefinition')
-        ? ({} as CompositeSolidDefinition)
-        : buildCompositeSolidDefinition({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('SolidDefinition')
-        ? ({} as SolidDefinition)
-        : buildSolidDefinition({}, relationshipsToOmit),
+        : buildCompositeSolidDefinition() || buildSolidDefinition(),
     invocations: overrides && overrides.hasOwnProperty('invocations') ? overrides.invocations! : [],
   };
 };
@@ -14180,26 +13914,13 @@ export const buildWrappingConfigType = (
     ofType:
       overrides && overrides.hasOwnProperty('ofType')
         ? overrides.ofType!
-        : relationshipsToOmit.has('ArrayConfigType')
-        ? ({} as ArrayConfigType)
-        : buildArrayConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('CompositeConfigType')
-        ? ({} as CompositeConfigType)
-        : buildCompositeConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('EnumConfigType')
-        ? ({} as EnumConfigType)
-        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
-        ? ({} as MapConfigType)
-        : buildMapConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableConfigType')
-        ? ({} as NullableConfigType)
-        : buildNullableConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularConfigType')
-        ? ({} as RegularConfigType)
-        : buildRegularConfigType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('ScalarUnionConfigType')
-        ? ({} as ScalarUnionConfigType)
-        : buildScalarUnionConfigType({}, relationshipsToOmit),
+        : buildArrayConfigType() ||
+          buildCompositeConfigType() ||
+          buildEnumConfigType() ||
+          buildMapConfigType() ||
+          buildNullableConfigType() ||
+          buildRegularConfigType() ||
+          buildScalarUnionConfigType(),
   };
 };
 
@@ -14214,14 +13935,6 @@ export const buildWrappingDagsterType = (
     ofType:
       overrides && overrides.hasOwnProperty('ofType')
         ? overrides.ofType!
-        : relationshipsToOmit.has('ListDagsterType')
-        ? ({} as ListDagsterType)
-        : buildListDagsterType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('NullableDagsterType')
-        ? ({} as NullableDagsterType)
-        : buildNullableDagsterType({}, relationshipsToOmit) ||
-          relationshipsToOmit.has('RegularDagsterType')
-        ? ({} as RegularDagsterType)
-        : buildRegularDagsterType({}, relationshipsToOmit),
+        : buildListDagsterType() || buildNullableDagsterType() || buildRegularDagsterType(),
   };
 };

--- a/python_modules/dagster/dagster/_core/utils.py
+++ b/python_modules/dagster/dagster/_core/utils.py
@@ -191,3 +191,56 @@ class InheritContextThreadPoolExecutor(FuturesAwareThreadPoolExecutor):
     def submit(self, fn, *args, **kwargs):
         ctx = copy_context()
         return super().submit(ctx.run, fn, *args, **kwargs)
+
+
+T = TypeVar("T")
+
+
+def find_strongly_connected_components(graph: Mapping[T, Iterable[T]]):
+    """This function implements Tarjan's algorithm to find strongly connected components ("sccs") in
+    a graph. Each strongly connected component contains at least one cycle.
+
+    Args:
+        graph: A dictionary where the key is a node and the value is a list of its neighbors.
+
+    Returns:
+        A list of strongly connected components found in the graph. Each scc is a list of nodes.
+    """
+    index = 0
+    ids = {}
+    lowlink = {}
+    on_stack = set()
+    stack = []
+    sccs = []
+
+    def dfs(node):
+        nonlocal index, ids, lowlink, on_stack, stack, sccs
+
+        index += 1
+        ids[node] = index
+        lowlink[node] = index
+        on_stack.add(node)
+        stack.append(node)
+
+        for neighbor in graph[node]:
+            if neighbor not in ids:
+                dfs(neighbor)
+                lowlink[node] = min(lowlink[node], lowlink[neighbor])
+            elif neighbor in on_stack:
+                lowlink[node] = min(lowlink[node], ids[neighbor])
+
+        head = None
+        if lowlink[node] == ids[node]:
+            scc = []
+            while head != node:
+                head = stack.pop()
+                on_stack.remove(head)
+                scc.append(head)
+            if len(scc) > 1:
+                sccs.append(scc)
+
+    for node in graph:
+        if node not in ids:
+            dfs(node)
+
+    return sccs

--- a/python_modules/dagster/dagster_tests/core_tests/test_utils.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_utils.py
@@ -11,6 +11,7 @@ from dagster._core.test_utils import environ
 from dagster._core.utils import (
     InheritContextThreadPoolExecutor,
     check_dagster_package_version,
+    find_strongly_connected_components,
     parse_env_var,
 )
 from dagster._utils import hash_collection, library_version_from_core_version
@@ -142,3 +143,27 @@ def test_inherit_context_threadpool_properties():
 
         assert executor.num_running_futures == 0
         assert executor.num_queued_futures == 0
+
+
+def test_find_strongly_connected_components():
+    graph = {
+        "a": ["b", "c"],
+        "b": ["c", "d"],
+        "c": ["d", "e"],
+        "d": ["e", "a"],
+        "e": ["f"],
+        "f": ["e"],
+    }
+    sccs = find_strongly_connected_components(graph)
+    assert len(sccs) == 2
+    assert ["d", "c", "b", "a"] in sccs
+    assert ["f", "e"] in sccs
+
+    graph = {
+        "a": ["b", "c"],
+        "b": ["a"],
+        "c": ["a"],
+    }
+    sccs = find_strongly_connected_components(graph)
+    assert len(sccs) == 1
+    assert ["c", "b", "a"] in sccs


### PR DESCRIPTION
## Summary & Motivation

This implements reliable cross-code-location cycle detection in the GQL server.

- Add an implementation of [Tarjan's algorithm](https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm) for finding strongly connected graph components (which contain all cycles) in utils. Tarjan's is O(V + E) where V is number of vertices and E is number of edges, so hopefully this scales to large asset graphs without major perf impact.
- Extend existing `CrossRepoAssetDependedByLoader` GQL to invoke Tarjan's for cycle detection. This allows cycles to be detected only once for a workspace in the scope of a GQL request.
- Add `cycle` field to GQL AssetNode type that is either null or a list of asset keys representing the strongly connected component that node is a member of.

A follow-up UI PR will need to query for cycles when loading the asset graph, and to handle the situation appropriately if at least one node contains a cycle.

Motivated by:

- https://dagsterlabs.slack.com/archives/C03F3HVV60G/p1701792714650219
- https://dagsterlabs.slack.com/archives/C03CCE471E0/p1701798216647879

## How I Tested These Changes

Extended GQL test utils to support easy multi-location test workspaces. New unit tests.
