### PR TITLE
don't filter out checks if jobNames=[]

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -538,7 +538,8 @@ async function stateForLaunchingAssets(
         assetChecksAvailable: assets.flatMap((a) =>
           a.assetChecksOrError.__typename === 'AssetChecks'
             ? a.assetChecksOrError.checks
-                .filter((check) => check.jobNames.includes(jobName))
+                // For user code prior to 1.5.10 jobNames isn't populated, so don't filter on it
+                .filter((check) => !check.jobNames || check.jobNames.includes(jobName))
                 .map((check) => ({...check, assetKey: a.assetKey}))
             : [],
         ),

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asInput.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asInput.ts
@@ -9,7 +9,8 @@ export function getAssetCheckHandleInputs(
   return assets.flatMap((a) =>
     a.assetChecksOrError.__typename === 'AssetChecks'
       ? a.assetChecksOrError.checks
-          .filter((check) => !jobName || check.jobNames.includes(jobName))
+          // For user code prior to 1.5.10 jobNames isn't populated, so don't filter on it
+          .filter((check) => !jobName || !check.jobNames || check.jobNames.includes(jobName))
           .map((check) => ({
             name: check.name,
             assetKey: {path: a.assetKey.path},


### PR DESCRIPTION
WIth user code prior to 1.5.10, jobNames isn't set and defaults to []. In that case we should default to including the checks, otherwise we'll never execute checks during materializations for old code versions.

jobNames will never be empty when using 1.5.10 or newer, since it's always at least in a default job. Ideally I should have made jobNames nullable instead of defaulting to [], but changing that now could result in a deserialization error if 1.5.10 code tried to load a newer serialized ExternalAssetCheck.

Additional context https://dagsterlabs.slack.com/archives/C05KFG9TETB/p1701907669697279?thread_ts=1701887385.184599&cid=C05KFG9TETB

---

test plan: manual, and will double check when I roll to canary