### PR TITLE
[ui] Repair scroll behavior on dynamic virtualized lists

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/package.json
+++ b/js_modules/dagster-ui/packages/ui-core/package.json
@@ -32,7 +32,7 @@
     "styled-components": "^5.3.3"
   },
   "dependencies": {
-    "@tanstack/react-virtual": "3.0.0-beta.18",
+    "@tanstack/react-virtual": "^3.0.1",
     "@testing-library/react-hooks": "^7.0.2",
     "@vx/shape": "^0.0.192",
     "amator": "^1.1.0",

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -245,7 +245,7 @@ export const AssetGraphExplorerSidebar = React.memo(
       if (indexOfLastSelectedNode !== -1) {
         rowVirtualizer.scrollToIndex(indexOfLastSelectedNode, {
           align: 'center',
-          smoothScroll: true,
+          behavior: 'auto',
         });
       }
       // Only scroll if the rootNodes changes or the selected node changes
@@ -317,7 +317,7 @@ export const AssetGraphExplorerSidebar = React.memo(
             }}
           >
             <Inner $totalHeight={totalHeight}>
-              {items.map(({index, key, size, start, measureElement}) => {
+              {items.map(({index, key, size, start}) => {
                 const node = renderedNodes[index]!;
                 const isCodelocationNode = 'locationName' in node;
                 const isGroupNode = 'groupName' in node;
@@ -327,8 +327,9 @@ export const AssetGraphExplorerSidebar = React.memo(
                     $height={size}
                     $start={start}
                     key={key}
+                    data-key={key}
                     style={{overflow: 'visible'}}
-                    ref={measureElement}
+                    ref={rowVirtualizer.measureElement}
                   >
                     {row ? (
                       <AssetSidebarNode

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionList.tsx
@@ -40,7 +40,7 @@ export const AssetPartitionList = ({
   React.useEffect(() => {
     if (focusedDimensionKey) {
       rowVirtualizer.scrollToIndex(partitions.indexOf(focusedDimensionKey), {
-        smoothScroll: false,
+        behavior: 'auto',
         align: 'auto',
       });
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/CalculateChangedAndMissingDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/CalculateChangedAndMissingDialog.tsx
@@ -121,10 +121,16 @@ export const CalculateChangedAndMissingDialog = React.memo(
             </RowGrid>
             <Container ref={containerRef} style={{maxHeight: '400px'}}>
               <Inner $totalHeight={totalHeight}>
-                {items.map(({index, key, size, start, measureElement}) => {
+                {items.map(({index, key, size, start}) => {
                   const item = staleOrMissing[index]!;
                   return (
-                    <Row $height={size} $start={start} key={key} ref={measureElement}>
+                    <Row
+                      $height={size}
+                      $start={start}
+                      data-key={key}
+                      key={key}
+                      ref={virtualizer.measureElement}
+                    >
                       <RowGrid border="bottom">
                         <Checkbox
                           id={`checkbox-${key}`}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetTables.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetTables.test.tsx
@@ -27,6 +27,19 @@ const MOCKS = [
 jest.mock('../../graph/asyncGraphLayout', () => ({}));
 
 describe('AssetTable', () => {
+  let nativeGBRC: any;
+
+  beforeAll(() => {
+    nativeGBRC = window.Element.prototype.getBoundingClientRect;
+    window.Element.prototype.getBoundingClientRect = jest
+      .fn()
+      .mockReturnValue({height: 400, width: 400});
+  });
+
+  afterAll(() => {
+    window.Element.prototype.getBoundingClientRect = nativeGBRC;
+  });
+
   describe('Materialize button', () => {
     it('is enabled when rows are selected', async () => {
       const Test = () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/LeftNavRepositorySection.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/LeftNavRepositorySection.test.tsx
@@ -26,6 +26,19 @@ describe('Repository options', () => {
   const locationOne = 'ipsum';
   const repoOne = 'lorem';
 
+  let nativeGBRC: any;
+
+  beforeAll(() => {
+    nativeGBRC = window.Element.prototype.getBoundingClientRect;
+    window.Element.prototype.getBoundingClientRect = jest
+      .fn()
+      .mockReturnValue({height: 400, width: 400});
+  });
+
+  afterAll(() => {
+    window.Element.prototype.getBoundingClientRect = nativeGBRC;
+  });
+
   afterEach(() => {
     window.localStorage.clear();
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/RunFilterInput.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/RunFilterInput.test.tsx
@@ -49,6 +49,19 @@ const backfillRunTagsValuesMock = buildRunTagValuesQueryMockedResponse(DagsterTa
   'value2',
 ]);
 
+let nativeGBRC: any;
+
+beforeAll(() => {
+  nativeGBRC = window.Element.prototype.getBoundingClientRect;
+  window.Element.prototype.getBoundingClientRect = jest
+    .fn()
+    .mockReturnValue({height: 400, width: 400});
+});
+
+afterAll(() => {
+  window.Element.prototype.getBoundingClientRect = nativeGBRC;
+});
+
 describe('useTagDataFilterValues', () => {
   it('should return the correct filter values based on the tag data', async () => {
     // Render the hook and pass the mockTagData as an argument

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/FilterDropdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/FilterDropdown.tsx
@@ -208,7 +208,7 @@ export const FilterDropdown = ({filters, setIsOpen, setPortaledElements}: Filter
   const rowVirtualizer = useVirtualizer({
     count: allResultsJsx.length,
     getScrollElement: () => parentRef.current,
-    estimateSize: (_: number) => 32,
+    estimateSize: () => 32,
     overscan: 10,
   });
 
@@ -259,9 +259,9 @@ export const FilterDropdown = ({filters, setIsOpen, setPortaledElements}: Filter
               }}
             >
               <Inner $totalHeight={totalHeight}>
-                {items.map(({index, end, start}) => {
+                {items.map(({index, size, start}) => {
                   return (
-                    <Row $height={end - start} $start={start} key={index}>
+                    <Row $height={size} $start={start} key={index}>
                       {allResultsJsx[index]}
                     </Row>
                   );

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/__tests__/FilterDropdown.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/__tests__/FilterDropdown.test.tsx
@@ -37,6 +37,19 @@ beforeEach(() => {
   ] as any;
 });
 
+let nativeGBRC: any;
+
+beforeAll(() => {
+  nativeGBRC = window.Element.prototype.getBoundingClientRect;
+  window.Element.prototype.getBoundingClientRect = jest
+    .fn()
+    .mockReturnValue({height: 400, width: 400});
+});
+
+afterAll(() => {
+  window.Element.prototype.getBoundingClientRect = nativeGBRC;
+});
+
 describe('FilterDropdown', () => {
   test('displays filter categories initially', () => {
     render(

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryLocationsList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryLocationsList.tsx
@@ -18,28 +18,28 @@ interface Props {
 }
 
 export const RepositoryLocationsList = ({loading, codeLocations, searchValue}: Props) => {
-  const parentRef = React.useRef<HTMLDivElement | null>(null);
+  const parentRef = React.useRef<HTMLDivElement>(null);
 
-  const rowVirtualizer = useVirtualizer({
+  const virtualizer = useVirtualizer({
     count: codeLocations.length,
     getScrollElement: () => parentRef.current,
     estimateSize: () => 64,
     overscan: 10,
   });
 
-  const totalHeight = rowVirtualizer.getTotalSize();
-  const items = rowVirtualizer.getVirtualItems();
+  const totalHeight = virtualizer.getTotalSize();
+  const items = virtualizer.getVirtualItems();
 
-  if (loading && !items.length) {
+  if (loading && !codeLocations.length) {
     return (
       <Box flex={{gap: 8, alignItems: 'center'}} padding={{horizontal: 24}}>
         <Spinner purpose="body-text" />
-        <div>Loading...</div>
+        <div>Loading…</div>
       </Box>
     );
   }
 
-  if (!items.length) {
+  if (!codeLocations.length) {
     if (searchValue) {
       return (
         <Box padding={{vertical: 32}}>
@@ -70,35 +70,35 @@ export const RepositoryLocationsList = ({loading, codeLocations, searchValue}: P
   return (
     <>
       <VirtualizedCodeLocationHeader />
-      <div style={{overflow: 'hidden'}}>
-        <Container ref={parentRef}>
-          <Inner $totalHeight={totalHeight}>
-            <DynamicRowContainer $start={items[0]?.start ?? 0}>
-              {items.map(({index, key, measureElement}) => {
-                const row: CodeLocationRowType = codeLocations[index]!;
-                if (row.type === 'error') {
-                  return (
-                    <VirtualizedCodeLocationErrorRow
-                      key={key}
-                      locationNode={row.node}
-                      measure={measureElement}
-                    />
-                  );
-                }
-
+      <Container ref={parentRef}>
+        <Inner $totalHeight={totalHeight}>
+          <DynamicRowContainer $start={items[0]?.start ?? 0}>
+            {items.map(({index, key}) => {
+              const row: CodeLocationRowType = codeLocations[index]!;
+              if (row.type === 'error') {
                 return (
-                  <VirtualizedCodeLocationRow
+                  <VirtualizedCodeLocationErrorRow
                     key={key}
-                    codeLocation={row.codeLocation}
-                    repository={row.repository}
-                    measure={measureElement}
+                    index={index}
+                    locationNode={row.node}
+                    ref={virtualizer.measureElement}
                   />
                 );
-              })}
-            </DynamicRowContainer>
-          </Inner>
-        </Container>
-      </div>
+              }
+
+              return (
+                <VirtualizedCodeLocationRow
+                  key={key}
+                  index={index}
+                  codeLocation={row.codeLocation}
+                  repository={row.repository}
+                  ref={virtualizer.measureElement}
+                />
+              );
+            })}
+          </DynamicRowContainer>
+        </Inner>
+      </Container>
     </>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedCodeLocationRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedCodeLocationRow.tsx
@@ -30,89 +30,94 @@ const TEMPLATE_COLUMNS = '3fr 1fr 1fr 240px 160px';
 
 interface ErrorRowProps {
   locationNode: WorkspaceRepositoryLocationNode;
-  measure: (node: Element | null) => void;
+  index: number;
 }
 
-export const VirtualizedCodeLocationErrorRow = (props: ErrorRowProps) => {
-  const {locationNode, measure} = props;
-  const {name} = locationNode;
-  return (
-    <div ref={measure}>
-      <RowGrid border="bottom">
-        <RowCell>
-          <MiddleTruncate text={name} />
-        </RowCell>
-        <RowCell>
-          <div>
-            <LocationStatus location={name} locationOrError={locationNode} />
-          </div>
-        </RowCell>
-        <RowCell>
-          <div style={{whiteSpace: 'nowrap'}}>
-            <TimeFromNow unixTimestamp={locationNode.updatedTimestamp} />
-          </div>
-        </RowCell>
-        <RowCell>{'\u2013'}</RowCell>
-        <RowCell>
-          <JoinedButtons>
-            <ReloadButton location={name} />
-            <CodeLocationMenu locationNode={locationNode} />
-          </JoinedButtons>
-        </RowCell>
-      </RowGrid>
-    </div>
-  );
-};
+export const VirtualizedCodeLocationErrorRow = React.forwardRef(
+  (props: ErrorRowProps, ref: React.ForwardedRef<HTMLDivElement>) => {
+    const {locationNode, index} = props;
+    const {name} = locationNode;
+    return (
+      <div ref={ref} data-index={index}>
+        <RowGrid border="bottom">
+          <RowCell>
+            <MiddleTruncate text={name} />
+          </RowCell>
+          <RowCell>
+            <div>
+              <LocationStatus location={name} locationOrError={locationNode} />
+            </div>
+          </RowCell>
+          <RowCell>
+            <div style={{whiteSpace: 'nowrap'}}>
+              <TimeFromNow unixTimestamp={locationNode.updatedTimestamp} />
+            </div>
+          </RowCell>
+          <RowCell>{'\u2013'}</RowCell>
+          <RowCell>
+            <JoinedButtons>
+              <ReloadButton location={name} />
+              <CodeLocationMenu locationNode={locationNode} />
+            </JoinedButtons>
+          </RowCell>
+        </RowGrid>
+      </div>
+    );
+  },
+);
 
 interface Props {
   codeLocation: WorkspaceRepositoryLocationNode;
   repository: WorkspaceRepositoryFragment;
-  measure: (node: Element | null) => void;
+  index: number;
+  // measure: (node: Element | null) => void;
 }
 
-export const VirtualizedCodeLocationRow = (props: Props) => {
-  const {codeLocation, repository, measure} = props;
-  const repoAddress = buildRepoAddress(repository.name, repository.location.name);
+export const VirtualizedCodeLocationRow = React.forwardRef(
+  (props: Props, ref: React.ForwardedRef<HTMLDivElement>) => {
+    const {codeLocation, repository, index} = props;
+    const repoAddress = buildRepoAddress(repository.name, repository.location.name);
 
-  const allMetadata = [...codeLocation.displayMetadata, ...repository.displayMetadata];
+    const allMetadata = [...codeLocation.displayMetadata, ...repository.displayMetadata];
 
-  return (
-    <div ref={measure}>
-      <RowGrid border="bottom">
-        <RowCell>
-          <Box flex={{direction: 'column', gap: 4}}>
-            <div style={{fontWeight: 500}}>
-              <Link to={workspacePathFromAddress(repoAddress)}>
-                <MiddleTruncate text={repoAddressAsHumanString(repoAddress)} />
-              </Link>
+    return (
+      <div ref={ref} data-index={index}>
+        <RowGrid border="bottom">
+          <RowCell>
+            <Box flex={{direction: 'column', gap: 4}}>
+              <div style={{fontWeight: 500}}>
+                <Link to={workspacePathFromAddress(repoAddress)}>
+                  <MiddleTruncate text={repoAddressAsHumanString(repoAddress)} />
+                </Link>
+              </div>
+              <ImageName metadata={allMetadata} />
+              <ModuleOrPackageOrFile metadata={allMetadata} />
+            </Box>
+          </RowCell>
+          <RowCell>
+            <div>
+              <LocationStatus location={repository.name} locationOrError={codeLocation} />
             </div>
-            <ImageName metadata={allMetadata} />
-            <ModuleOrPackageOrFile metadata={allMetadata} />
-          </Box>
-        </RowCell>
-        <RowCell>
-          <div>
-            <LocationStatus location={repository.name} locationOrError={codeLocation} />
-          </div>
-        </RowCell>
-        <RowCell>
-          <div style={{whiteSpace: 'nowrap'}}>
-            <TimeFromNow unixTimestamp={codeLocation.updatedTimestamp} />
-          </div>
-        </RowCell>
-        <RowCell>
-          <RepositoryCountTags repo={repository} repoAddress={repoAddress} />
-        </RowCell>
-        <RowCell style={{alignItems: 'flex-end'}}>
-          <JoinedButtons>
-            <ReloadButton location={codeLocation.name} />
-            <CodeLocationMenu locationNode={codeLocation} />
-          </JoinedButtons>
-        </RowCell>
-      </RowGrid>
-    </div>
-  );
-};
+          </RowCell>
+          <RowCell>
+            <div style={{whiteSpace: 'nowrap'}}>
+              <TimeFromNow unixTimestamp={codeLocation.updatedTimestamp} />
+            </div>
+          </RowCell>
+          <RowCell>
+            <RepositoryCountTags repo={repository} repoAddress={repoAddress} />
+          </RowCell>
+          <RowCell style={{alignItems: 'flex-end'}}>
+            <JoinedButtons>
+              <ReloadButton location={codeLocation.name} />
+              <CodeLocationMenu locationNode={codeLocation} />
+            </JoinedButtons>
+          </RowCell>
+        </RowGrid>
+      </div>
+    );
+  },
+);
 
 export const VirtualizedCodeLocationHeader = () => {
   return (

--- a/js_modules/dagster-ui/yarn.lock
+++ b/js_modules/dagster-ui/yarn.lock
@@ -2416,7 +2416,7 @@ __metadata:
     "@storybook/addon-mdx-gfm": ^7.4.5
     "@storybook/nextjs": ^7.4.5
     "@storybook/react": ^7.4.5
-    "@tanstack/react-virtual": 3.0.0-beta.18
+    "@tanstack/react-virtual": ^3.0.1
     "@testing-library/dom": ^9.3.0
     "@testing-library/jest-dom": ^6.1.5
     "@testing-library/react": ^14.0.0
@@ -6408,21 +6408,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-virtual@npm:3.0.0-beta.18":
-  version: 3.0.0-beta.18
-  resolution: "@tanstack/react-virtual@npm:3.0.0-beta.18"
+"@tanstack/react-virtual@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@tanstack/react-virtual@npm:3.0.1"
   dependencies:
-    "@tanstack/virtual-core": 3.0.0-beta.18
+    "@tanstack/virtual-core": 3.0.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: e6d948b54179069776051434f021297d717d8cc911d8a9f71a6deac6ea9cb5f6438964049a5552265f0d97d2be584be4a68f95e60bcd859eb8c7ed07d277a155
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 11534a23100de14a7e0a95da667381181e60a24e29a71246aeed174f8d5f6e176216de6639e6e1f403722ae30d8b92b21ed75ea131529b1417fb81f433468ef0
   languageName: node
   linkType: hard
 
-"@tanstack/virtual-core@npm:3.0.0-beta.18":
-  version: 3.0.0-beta.18
-  resolution: "@tanstack/virtual-core@npm:3.0.0-beta.18"
-  checksum: fbf73de3c9cc296a14b262258e6c8da4826c744fc7ce98669b1c2692341313ffa4e34a13d20c3980f23b340720d7c771136b7f2673aa91d14558ddc086b92d1c
+"@tanstack/virtual-core@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@tanstack/virtual-core@npm:3.0.0"
+  checksum: 7283d50fc7b7a56608c37a8e94a93b85890ff7e39c6281633a19c4d6f6f4fbf25f8418f1eec302a008a8746a0d1d0cd00630137b55e6cf019818d68af8ed16b6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary & Motivation

Resolves #17892.

Repair a bug in virtualized dynamic-height lists in which the subpixel row height is causing an extra scrollbar to appear, specifically in the code locations list. The row heights are rounded for the summed container height, which can lead to the container being just a bit shorter than the total rendered row height, leading to an unwanted scrollbar.

Worse, the scrollbar sometimes broke the grid layout, causing the header column display and row column displays to become misaligned.

In this case, most notably, I needed to remove the `overflow: hidden` wrapper div. This way, even though the container may have a height that is less than the actual rendered row height sum, no scrollbar appears.

While working on this, I upgraded to v3.0.1 of the tanstack virtualizer lib, which required an update to the API usage. Specifically, `measureElement` is now on the `virtualizer` object, and the individual rows need a `data-key` prop.

## How I Tested These Changes

View code locations list, with the `count` value restricted to a smaller number. Verify that the unwanted scrollbar does not appear, even though the container height is less than the dynamically rendered row height sum.

View the side nav in the global asset graph, verify that it still renders and behaves correctly.
