### PR TITLE
Add instance to ExternalRepository

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -87,11 +87,14 @@ class ExternalRepository:
         self,
         external_repository_data: ExternalRepositoryData,
         repository_handle: RepositoryHandle,
+        instance: DagsterInstance,
         ref_to_data_fn: Optional[Callable[[ExternalJobRef], ExternalJobData]] = None,
     ):
         self.external_repository_data = check.inst_param(
             external_repository_data, "external_repository_data", ExternalRepositoryData
         )
+
+        self._instance = instance
 
         if external_repository_data.external_job_datas is not None:
             self._job_map: Dict[str, Union[ExternalJobData, ExternalJobRef]] = {

--- a/python_modules/dagster/dagster/_core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/host_representation/origin.py
@@ -104,7 +104,7 @@ class CodeLocationOrigin(ABC):
         pass
 
     @abstractmethod
-    def create_location(self) -> "CodeLocation":
+    def create_location(self, instance: "DagsterInstance") -> "CodeLocation":
         pass
 
     @abstractmethod
@@ -129,7 +129,7 @@ class RegisteredCodeLocationOrigin(
     def get_display_metadata(self) -> Mapping[str, Any]:
         return {}
 
-    def create_location(self) -> NoReturn:
+    def create_location(self, instance: "DagsterInstance") -> NoReturn:
         raise DagsterInvariantViolationError(
             "A RegisteredCodeLocationOrigin does not have enough information to create its "
             "code location on its own."
@@ -194,12 +194,12 @@ class InProcessCodeLocationOrigin(
     def get_display_metadata(self) -> Mapping[str, Any]:
         return {}
 
-    def create_location(self) -> "InProcessCodeLocation":
+    def create_location(self, instance: "DagsterInstance") -> "InProcessCodeLocation":
         from dagster._core.host_representation.code_location import (
             InProcessCodeLocation,
         )
 
-        return InProcessCodeLocation(self)
+        return InProcessCodeLocation(self, instance=instance)
 
     def reload_location(self, instance: "DagsterInstance") -> "InProcessCodeLocation":
         raise NotImplementedError
@@ -244,7 +244,7 @@ class ManagedGrpcPythonEnvCodeLocationOrigin(
         }
         return {key: value for key, value in metadata.items() if value is not None}
 
-    def create_location(self) -> NoReturn:
+    def create_location(self, instance: "DagsterInstance") -> NoReturn:
         raise DagsterInvariantViolationError(
             "A ManagedGrpcPythonEnvCodeLocationOrigin needs a GrpcServerRegistry"
             " in order to create a code location."
@@ -287,6 +287,7 @@ class ManagedGrpcPythonEnvCodeLocationOrigin(
                 heartbeat=True,
                 watch_server=False,
                 grpc_server_registry=grpc_server_registry,
+                instance=instance,
             ) as location:
                 yield location
 
@@ -358,14 +359,14 @@ class GrpcServerCodeLocationOrigin(
             else:
                 raise
 
-        return GrpcServerCodeLocation(self)
+        return GrpcServerCodeLocation(self, instance=instance)
 
-    def create_location(self) -> "GrpcServerCodeLocation":
+    def create_location(self, instance: "DagsterInstance") -> "GrpcServerCodeLocation":
         from dagster._core.host_representation.code_location import (
             GrpcServerCodeLocation,
         )
 
-        return GrpcServerCodeLocation(self)
+        return GrpcServerCodeLocation(self, instance=instance)
 
     def create_client(self) -> "DagsterGrpcClient":
         from dagster._grpc.client import DagsterGrpcClient

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -605,10 +605,13 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
                     heartbeat=True,
                     watch_server=False,
                     grpc_server_registry=self._grpc_server_registry,
+                    instance=self._instance,
                 )
             else:
                 location = (
-                    origin.reload_location(self.instance) if reload else origin.create_location()
+                    origin.reload_location(self.instance)
+                    if reload
+                    else origin.create_location(self.instance)
                 )
 
         except Exception:

--- a/python_modules/dagster/dagster/_daemon/workspace.py
+++ b/python_modules/dagster/dagster/_daemon/workspace.py
@@ -1,25 +1,16 @@
-import sys
-import time
 from abc import abstractmethod
 from typing import Mapping, Sequence
 
-import dagster._check as check
 from dagster._core.errors import DagsterCodeLocationLoadError
 from dagster._core.host_representation.code_location import (
     CodeLocation,
-    GrpcServerCodeLocation,
 )
-from dagster._core.host_representation.grpc_server_registry import GrpcServerRegistry
-from dagster._core.host_representation.origin import CodeLocationOrigin
-from dagster._core.workspace.load_target import WorkspaceLoadTarget
 from dagster._core.workspace.workspace import (
     CodeLocationEntry,
-    CodeLocationLoadStatus,
     CodeLocationStatusEntry,
     IWorkspace,
     location_status_from_location_entry,
 )
-from dagster._utils.error import serializable_error_info_from_exc_info
 
 
 class BaseDaemonWorkspace(IWorkspace):
@@ -112,62 +103,3 @@ class DaemonIterationWorkspace(BaseDaemonWorkspace):
 
     def _load_workspace(self) -> Mapping[str, CodeLocationEntry]:
         return self._location_entries_copy
-
-
-class DaemonWorkspace(BaseDaemonWorkspace):
-    def __init__(
-        self, grpc_server_registry: GrpcServerRegistry, workspace_load_target: WorkspaceLoadTarget
-    ):
-        self._grpc_server_registry = check.inst_param(
-            grpc_server_registry, "grpc_server_registry", GrpcServerRegistry
-        )
-
-        self._workspace_load_target = check.inst_param(
-            workspace_load_target, "workspace_load_target", WorkspaceLoadTarget
-        )
-
-        super().__init__()
-
-    def _load_workspace(self) -> Mapping[str, CodeLocationEntry]:
-        entries = {}
-        origins = self._workspace_load_target.create_origins()
-        for origin in origins:
-            entries[origin.location_name] = self._load_location(origin)
-        return entries
-
-    def _load_location(self, origin) -> CodeLocationEntry:
-        location = None
-        error = None
-        try:
-            location = self._create_location_from_origin(origin)
-        except Exception:
-            error = serializable_error_info_from_exc_info(sys.exc_info())
-
-        return CodeLocationEntry(
-            origin=origin,
-            code_location=location,
-            load_error=error,
-            load_status=CodeLocationLoadStatus.LOADED,
-            display_metadata=(
-                location.get_display_metadata() if location else origin.get_display_metadata()
-            ),
-            update_timestamp=time.time(),
-        )
-
-    def _create_location_from_origin(self, origin) -> CodeLocation:
-        check.inst_param(origin, "origin", CodeLocationOrigin)
-
-        if not self._grpc_server_registry.supports_origin(origin):
-            return origin.create_location()
-        else:
-            endpoint = self._grpc_server_registry.get_grpc_endpoint(origin)
-            return GrpcServerCodeLocation(
-                origin=origin,
-                server_id=endpoint.server_id,
-                port=endpoint.port,
-                socket=endpoint.socket,
-                host=endpoint.host,
-                heartbeat=True,
-                watch_server=False,
-                grpc_server_registry=self._grpc_server_registry,
-            )

--- a/python_modules/dagster/dagster/_utils/hosted_user_process.py
+++ b/python_modules/dagster/dagster/_utils/hosted_user_process.py
@@ -8,20 +8,14 @@ These should only be invoked from contexts where we know this
 to be the case.
 """
 
-from typing import TYPE_CHECKING
 
 import dagster._check as check
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
-from dagster._core.host_representation import ExternalJob, ExternalRepository
+from dagster._core.host_representation import ExternalJob
 from dagster._core.host_representation.external_data import (
     external_job_data_from_def,
-    external_repository_data_from_def,
 )
 from dagster._core.origin import JobPythonOrigin, RepositoryPythonOrigin
-
-if TYPE_CHECKING:
-    from dagster._core.definitions.repository_definition import RepositoryDefinition
-    from dagster._core.host_representation.handle import RepositoryHandle
 
 
 def recon_job_from_origin(origin: JobPythonOrigin) -> ReconstructableJob:
@@ -39,12 +33,6 @@ def recon_repository_from_origin(origin: RepositoryPythonOrigin) -> "Reconstruct
         origin.entry_point,
         origin.container_context,
     )
-
-
-def external_repo_from_def(
-    repository_def: "RepositoryDefinition", repository_handle: "RepositoryHandle"
-) -> ExternalRepository:
-    return ExternalRepository(external_repository_data_from_def(repository_def), repository_handle)
 
 
 def external_job_from_recon_job(recon_job, op_selection, repository_handle, asset_selection=None):

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -137,6 +137,7 @@ def test_defer_snapshots(instance: DagsterInstance):
         repo = ExternalRepository(
             external_repository_data,
             RepositoryHandle(repository_name="bar_repo", code_location=code_location),
+            instance=instance,
             ref_to_data_fn=_ref_to_data,
         )
         jobs = repo.get_all_external_jobs()

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -3,6 +3,7 @@ import sys
 import time
 from unittest import mock
 
+import pytest
 from dagster import (
     AssetIn,
     AssetKey,
@@ -21,6 +22,7 @@ from dagster._core.definitions.data_version import CachingStaleStatusResolver
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.host_representation import InProcessCodeLocationOrigin
+from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceRequestContext
 from dagster._core.workspace.workspace import (
@@ -101,6 +103,12 @@ partitioned_defs = Definitions(
 static_partition = partitions_def = StaticPartitionsDefinition(["foo", "bar"])
 
 
+@pytest.fixture
+def instance():
+    with instance_for_test() as the_instance:
+        yield the_instance
+
+
 @asset(
     partitions_def=static_partition,
 )
@@ -125,7 +133,7 @@ different_partitions_defs = Definitions(
 )
 
 
-def make_location_entry(defs_attr: str):
+def _make_location_entry(defs_attr: str, instance: DagsterInstance):
     origin = InProcessCodeLocationOrigin(
         loadable_target_origin=LoadableTargetOrigin(
             executable_path=sys.executable,
@@ -139,7 +147,7 @@ def make_location_entry(defs_attr: str):
         location_name=None,
     )
 
-    code_location = origin.create_location()
+    code_location = origin.create_location(instance)
 
     return CodeLocationEntry(
         origin=origin,
@@ -151,10 +159,12 @@ def make_location_entry(defs_attr: str):
     )
 
 
-def make_context(defs_attrs):
+def _make_context(instance: DagsterInstance, defs_attrs):
     return WorkspaceRequestContext(
         instance=mock.MagicMock(),
-        workspace_snapshot={defs_attr: make_location_entry(defs_attr) for defs_attr in defs_attrs},
+        workspace_snapshot={
+            defs_attr: _make_location_entry(defs_attr, instance) for defs_attr in defs_attrs
+        },
         process_context=mock.MagicMock(),
         version=None,
         source=None,
@@ -162,8 +172,8 @@ def make_context(defs_attrs):
     )
 
 
-def test_get_repository_handle():
-    asset_graph = ExternalAssetGraph.from_workspace(make_context(["defs1", "defs2"]))
+def test_get_repository_handle(instance):
+    asset_graph = ExternalAssetGraph.from_workspace(_make_context(instance, ["defs1", "defs2"]))
 
     assert asset_graph.get_materialization_job_names(asset1.key) == ["__ASSET_JOB"]
     repo_handle1 = asset_graph.get_repository_handle(asset1.key)
@@ -176,8 +186,10 @@ def test_get_repository_handle():
     assert repo_handle2.repository_python_origin.code_pointer.fn_name == "defs2"
 
 
-def test_cross_repo_dep_with_source_asset():
-    asset_graph = ExternalAssetGraph.from_workspace(make_context(["defs1", "downstream_defs"]))
+def test_cross_repo_dep_with_source_asset(instance):
+    asset_graph = ExternalAssetGraph.from_workspace(
+        _make_context(instance, ["defs1", "downstream_defs"])
+    )
     assert len(asset_graph.source_asset_keys) == 0
     assert asset_graph.get_parents(AssetKey("downstream")) == {AssetKey("asset1")}
     assert asset_graph.get_children(AssetKey("asset1")) == {AssetKey("downstream")}
@@ -197,9 +209,9 @@ def test_cross_repo_dep_with_source_asset():
     assert asset_graph.get_materialization_job_names(AssetKey("downstream")) == ["__ASSET_JOB"]
 
 
-def test_cross_repo_dep_no_source_asset():
+def test_cross_repo_dep_no_source_asset(instance):
     asset_graph = ExternalAssetGraph.from_workspace(
-        make_context(["defs1", "downstream_defs_no_source"])
+        _make_context(instance, ["defs1", "downstream_defs_no_source"])
     )
     assert len(asset_graph.source_asset_keys) == 0
     assert asset_graph.get_parents(AssetKey("downstream_non_arg_dep")) == {AssetKey("asset1")}
@@ -222,15 +234,15 @@ def test_cross_repo_dep_no_source_asset():
     ]
 
 
-def test_partitioned_source_asset():
-    asset_graph = ExternalAssetGraph.from_workspace(make_context(["partitioned_defs"]))
+def test_partitioned_source_asset(instance):
+    asset_graph = ExternalAssetGraph.from_workspace(_make_context(instance, ["partitioned_defs"]))
 
     assert asset_graph.is_partitioned(AssetKey("partitioned_source"))
     assert asset_graph.is_partitioned(AssetKey("downstream_of_partitioned_source"))
 
 
-def test_get_implicit_job_name_for_assets():
-    asset_graph = ExternalAssetGraph.from_workspace(make_context(["defs1", "defs2"]))
+def test_get_implicit_job_name_for_assets(instance):
+    asset_graph = ExternalAssetGraph.from_workspace(_make_context(instance, ["defs1", "defs2"]))
     assert (
         asset_graph.get_implicit_job_name_for_assets([asset1.key], external_repo=None)
         == "__ASSET_JOB"
@@ -244,7 +256,7 @@ def test_get_implicit_job_name_for_assets():
         == "__ASSET_JOB"
     )
 
-    partitioned_defs_workspace = make_context(["partitioned_defs"])
+    partitioned_defs_workspace = _make_context(instance, ["partitioned_defs"])
     asset_graph = ExternalAssetGraph.from_workspace(partitioned_defs_workspace)
     external_repo = next(
         iter(partitioned_defs_workspace.code_locations[0].get_repositories().values())
@@ -269,7 +281,9 @@ def test_get_implicit_job_name_for_assets():
         == "__ASSET_JOB_0"
     )
 
-    asset_graph = ExternalAssetGraph.from_workspace(make_context(["different_partitions_defs"]))
+    asset_graph = ExternalAssetGraph.from_workspace(
+        _make_context(instance, ["different_partitions_defs"])
+    )
     assert (
         asset_graph.get_implicit_job_name_for_assets(
             [static_partitioned_asset.key], external_repo=None
@@ -309,8 +323,8 @@ def test_get_implicit_job_name_for_assets():
     )
 
 
-def test_auto_materialize_policy():
-    asset_graph = ExternalAssetGraph.from_workspace(make_context(["partitioned_defs"]))
+def test_auto_materialize_policy(instance):
+    asset_graph = ExternalAssetGraph.from_workspace(_make_context(instance, ["partitioned_defs"]))
 
     assert asset_graph.get_auto_materialize_policy(
         AssetKey("downstream_of_partitioned_source")
@@ -334,8 +348,10 @@ def partition_mapping_asset(static_partitioned_asset):
 partition_mapping_defs = Definitions(assets=[static_partitioned_asset, partition_mapping_asset])
 
 
-def test_partition_mapping():
-    asset_graph = ExternalAssetGraph.from_workspace(make_context(["partition_mapping_defs"]))
+def test_partition_mapping(instance):
+    asset_graph = ExternalAssetGraph.from_workspace(
+        _make_context(instance, ["partition_mapping_defs"])
+    )
     assert isinstance(
         asset_graph.get_partition_mapping(
             AssetKey("partition_mapping_asset"), AssetKey("static_partitioned_asset")
@@ -383,8 +399,10 @@ backfill_assets_defs = Definitions(
 )
 
 
-def test_assets_with_backfill_policies():
-    asset_graph = ExternalAssetGraph.from_workspace(make_context(["backfill_assets_defs"]))
+def test_assets_with_backfill_policies(instance):
+    asset_graph = ExternalAssetGraph.from_workspace(
+        _make_context(instance, ["backfill_assets_defs"])
+    )
     assert (
         asset_graph.get_backfill_policy(AssetKey("static_partitioned_single_run_backfill_asset"))
         == BackfillPolicy.single_run()
@@ -412,8 +430,10 @@ cycle_defs_a = Definitions(assets=[a])
 cycle_defs_b = Definitions(assets=[b])
 
 
-def test_cycle_status():
-    asset_graph = ExternalAssetGraph.from_workspace(make_context(["cycle_defs_a", "cycle_defs_b"]))
+def test_cycle_status(instance):
+    asset_graph = ExternalAssetGraph.from_workspace(
+        _make_context(instance, ["cycle_defs_a", "cycle_defs_b"])
+    )
     resolver = CachingStaleStatusResolver(DagsterInstance.ephemeral(), asset_graph)
     for key in asset_graph.all_asset_keys:
         resolver.get_status(key)

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_grpc_server_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_grpc_server_workspace.py
@@ -48,7 +48,7 @@ load_from:
 
             with ExitStack() as stack:
                 code_locations = {
-                    name: stack.enter_context(origin.create_location())
+                    name: stack.enter_context(origin.create_location(instance))
                     for name, origin in origins.items()
                 }
                 assert len(code_locations) == 2
@@ -141,7 +141,7 @@ load_from:
         # Actually connecting to the server will fail since it's expecting SSL
         # and we didn't set up the server with SSL
         try:
-            with origin.create_location():
+            with origin.create_location(instance):
                 assert False
         except DagsterUserCodeUnreachableError:
             pass
@@ -176,7 +176,7 @@ load_from:
 
             with ExitStack() as stack:
                 code_locations = {
-                    name: stack.enter_context(origin.create_location())
+                    name: stack.enter_context(origin.create_location(instance))
                     for name, origin in origins.items()
                 }
                 assert len(code_locations) == 2

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -672,7 +672,9 @@ def _grpc_server_external_repo(port: int, scheduler_instance: DagsterInstance):
         location_origin: GrpcServerCodeLocationOrigin = GrpcServerCodeLocationOrigin(
             host="localhost", port=port, location_name="test_location"
         )
-        with GrpcServerCodeLocation(origin=location_origin) as location:
+        with GrpcServerCodeLocation(
+            origin=location_origin, instance=scheduler_instance
+        ) as location:
             yield location.get_repository("the_repo")
     finally:
         DagsterGrpcClient(port=port, socket=None).shutdown_server()


### PR DESCRIPTION
Summary:
The plan of record is to create a default AssetPolicyAutomationSensor if you opt in to the new isolated mode of AMP. That flag will be controlled by the instance. In order to selectively create those default sensors based on the instance, we need ExternalRepository to have access to a DagsterInstance, which we have not historically done but is not a huge lift to add (and it is generally safe to assume that in hosted Dagster land you have access to a DagsterInstance)

## Summary & Motivation

## How I Tested These Changes
