### PR TITLE
[ui] Add tick detail dialog to Run page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
@@ -6,6 +6,7 @@ import {useParams} from 'react-router-dom';
 import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {AutomaterializeTagWithEvaluation} from '../assets/AutomaterializeTagWithEvaluation';
+import {InstigationSelector} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {isThisThingAJob} from '../workspace/WorkspaceContext';
@@ -20,6 +21,7 @@ import {RunStatusTag} from './RunStatusTag';
 import {DagsterTag} from './RunTag';
 import {RunTimingTags} from './RunTimingTags';
 import {assetKeysForRun} from './RunUtils';
+import {TickTagForRun} from './TickTagForRun';
 import {RunRootQuery, RunRootQueryVariables} from './types/RunRoot.types';
 
 export const RunRoot = () => {
@@ -49,6 +51,35 @@ export const RunRoot = () => {
     () => run?.tags.find((tag) => tag.key === DagsterTag.AssetEvaluationID) || null,
     [run],
   );
+
+  const tickDetails = React.useMemo(() => {
+    if (repoAddress) {
+      const tags = run?.tags || [];
+      const tickTag = tags.find((tag) => tag.key === DagsterTag.TickId);
+
+      if (tickTag) {
+        const scheduleOrSensor = tags.find(
+          (tag) => tag.key === DagsterTag.ScheduleName || tag.key === DagsterTag.SensorName,
+        );
+        if (scheduleOrSensor) {
+          const instigationSelector: InstigationSelector = {
+            name: scheduleOrSensor.value,
+            repositoryName: repoAddress.name,
+            repositoryLocationName: repoAddress.location,
+          };
+          return {
+            tickId: tickTag.value,
+            instigationType: scheduleOrSensor.key as
+              | DagsterTag.ScheduleName
+              | DagsterTag.SensorName,
+            instigationSelector,
+          };
+        }
+      }
+    }
+
+    return null;
+  }, [run, repoAddress]);
 
   return (
     <div
@@ -89,6 +120,13 @@ export const RunRoot = () => {
                       isJob={isJob}
                     />
                   </Tag>
+                ) : null}
+                {tickDetails ? (
+                  <TickTagForRun
+                    instigationSelector={tickDetails.instigationSelector}
+                    instigationType={tickDetails.instigationType}
+                    tickId={tickDetails.tickId}
+                  />
                 ) : null}
                 <AssetCheckTagCollection useTags assetChecks={run.assetCheckSelection} />
                 <AssetKeyTagCollection

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTag.tsx
@@ -21,6 +21,7 @@ export enum DagsterTag {
   RootRunId = 'dagster/root_run_id',
   ScheduleName = 'dagster/schedule_name',
   SensorName = 'dagster/sensor_name',
+  TickId = 'dagster/tick',
   AssetPartitionRangeStart = 'dagster/asset_partition_range_start',
   AssetPartitionRangeEnd = 'dagster/asset_partition_range_end',
   AssetEventDataVersion = 'dagster/data_version',

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/TickTagForRun.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/TickTagForRun.tsx
@@ -1,0 +1,40 @@
+import {ButtonLink, MiddleTruncate, Tag} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {InstigationSelector} from '../graphql/types';
+import {TickDetailsDialog} from '../instigation/TickDetailsDialog';
+
+import {DagsterTag} from './RunTag';
+
+interface Props {
+  instigationSelector: InstigationSelector;
+  instigationType: DagsterTag.SensorName | DagsterTag.ScheduleName;
+  tickId: string;
+}
+
+export const TickTagForRun = ({instigationSelector, instigationType, tickId}: Props) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const icon = instigationType === DagsterTag.ScheduleName ? 'schedule' : 'sensors';
+  const {name} = instigationSelector;
+
+  return (
+    <>
+      <Tag icon={icon}>
+        <span>
+          Launched by{' '}
+          <ButtonLink onClick={() => setIsOpen(true)}>
+            <div style={{maxWidth: '140px'}}>
+              <MiddleTruncate text={name} />
+            </div>
+          </ButtonLink>
+        </span>
+      </Tag>
+      <TickDetailsDialog
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        instigationSelector={instigationSelector}
+        tickId={Number(tickId)}
+      />
+    </>
+  );
+};


### PR DESCRIPTION
## Summary & Motivation

For runs launched by schedules and sensors, use the tick ID (from the run tag) to populate a Run page header tag that opens the tick detail dialog.

<img width="1165" alt="Screenshot 2023-12-07 at 2 41 22 PM" src="https://github.com/dagster-io/dagster/assets/2823852/5225b397-5295-4a24-8a84-2e8147dbb971">

https://github.com/dagster-io/dagster/assets/2823852/c7582db9-83f5-4369-bb56-89f6b85ffcdd


## How I Tested These Changes

View runs launched by schedules and sensors. Verify that the tag appears, and that its link opens the tick dialog.
