### PR TITLE
[asset-automation] Create ConditionSnapshot class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_automation_condition_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_automation_condition_context.py
@@ -307,13 +307,13 @@ class AssetAutomationConditionEvaluationContext:
         return self.asset_context.empty_subset()
 
     def for_child(
-        self, condition: "AutomationCondition", candidate_subset: AssetSubset
+        self, condition: "AutomationCondition", candidate_subset: AssetSubset, child_index: int
     ) -> "AssetAutomationConditionEvaluationContext":
         return AssetAutomationConditionEvaluationContext(
             asset_context=self.asset_context,
             condition=condition,
             candidate_subset=candidate_subset,
-            latest_evaluation=self.latest_evaluation.for_child(condition)
+            latest_evaluation=self.latest_evaluation.for_child(condition, child_index)
             if self.latest_evaluation
             else None,
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_automation_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_automation_evaluator.py
@@ -24,6 +24,12 @@ if TYPE_CHECKING:
     from .auto_materialize_rule import AutoMaterializeRule, RuleEvaluationResults
 
 
+class AutomationConditionSnapshot(NamedTuple):
+    class_name: str
+    description: str
+    children: Sequence["AutomationConditionSnapshot"]
+
+
 class ConditionEvaluation(NamedTuple):
     """Internal representation of the results of evaluating a node in the evaluation tree."""
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_automation_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_automation_evaluator.py
@@ -98,7 +98,7 @@ class ConditionEvaluation(NamedTuple):
             .condition
         )
         # backcompat way to calculate the set of skipped partitions for legacy policies
-        if len(self.child_evaluations) == 2:
+        if condition.is_legacy and len(self.child_evaluations) == 2:
             # the first child is the materialize condition, the second child is the negation of
             # the skip condition
             _, nor_skip_evaluation = self.child_evaluations


### PR DESCRIPTION
## Summary & Motivation

We want to make this ConditionEvaluation class serializable, and in order to do so, we'll want to serialize snapshots of our conditions rather than the objects themselves.

This brings up an interesting question: the ConditionEvaluation class has information that we want to call up from previous ticks, and it has a recursive structure. On the next tick, we need to be able to locate which part of the recursive structure we should explore next (this is the `for_child` call). However, there are three issues:

1. A given condition can have multiple identical sub-expressions, i.e. `(A & (B | C) & (B | C))` is technically valid, so we can't use a pure equality test to detect which sub-expression to go to next
2. If each node in the condition evaluation tree needs to have a snapshot class which contains all of IT'S children, then the NamedTuple will end up being size O(N^2) where N is the number of nodes in the tree, as each node will need to have some limited representation of all nodes below it.
3. A condition can change between ticks, meaning that the entire structure may be different on the current tick vs. what we have a snapshot of.

I solve all of these issues by not including any information about children on the snapshot itself, and instead letting that get encoded in the recursive structure of the ConditionEvaluation. Then, to retrieve a specific child, we just rely on the index of that child in the structure. Some examples of what would happen if the condition changed between ticks:

Serialized: `A | B | C`
Current: `A | B | D | C`
Result: A and B get mapped to their previous tick's condition evaluation, D gets no data (because it's of a different type than C), C gets no data (because it's in a new index)

Serialized: `A | B | C`
Current: `A | B`
Result: A and B get mapped to their previous tick's condition evaluation

Serialized: `(A | B) & (C | D | E)`
Current: `(A | B) & (C | D | E | F)`
Result: All things serialized on the previous tick get mapped correctly

Serialized: `(A | B) & (C | D | E)`
Current:  `X & (A | B) & (C | D | E)`
Result: Nothing serialized on the previous tick gets mapped correctly

The last case is definitely the most concerning one -- it's possible that we could create a fancier way of detecting that sort of situation in some cases (this would come in the form of fancier `for_child` logic), but it seems hard to do in a fully-general way.

## How I Tested These Changes
