### PR TITLE
submit backfill run requests in partition key order

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -383,7 +383,12 @@ def build_run_requests(
                 )
             )
 
-    return run_requests
+    # We don't make public guarantees about sort order, but make an effort to provide a consistent
+    # ordering that puts earlier time partitions before later time partitions. Note that, with dates
+    # formatted like 12/7/2023, the run requests won't end up in time order. Sorting by converting
+    # to time windows seemed more risky from a perf perspective, so we didn't include it here, but
+    # it could make sense to actually benchmark that in the future.
+    return sorted(run_requests, key=lambda x: x.partition_key if x.partition_key else "")
 
 
 def build_run_requests_with_backfill_policies(

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
@@ -9,6 +9,7 @@ from dagster import (
     DagsterInstance,
     DailyPartitionsDefinition,
     DynamicPartitionsDefinition,
+    PartitionKeyRange,
     TimeWindowPartitionMapping,
     WeeklyPartitionsDefinition,
     asset,
@@ -889,3 +890,49 @@ def test_assets_backfill_with_partition_mapping_with_single_run_backfill_policy(
     assert set(result.run_requests[0].asset_selection) == {upstream_a.key, downstream_b.key}
     assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "2023-03-02"
     assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_END_TAG) == "2023-03-09"
+
+
+def test_run_request_partition_order():
+    @asset(
+        partitions_def=DailyPartitionsDefinition("2023-10-01"),
+        backfill_policy=BackfillPolicy.multi_run(2),
+    )
+    def foo():
+        pass
+
+    @asset(
+        partitions_def=DailyPartitionsDefinition("2023-10-01"),
+        backfill_policy=BackfillPolicy.multi_run(2),
+        deps={foo},
+    )
+    def foo_child():
+        pass
+
+    assets_by_repo_name = {"repo1": [foo], "repo2": [foo_child]}
+    asset_graph = get_asset_graph(assets_by_repo_name)
+
+    asset_backfill_data = AssetBackfillData.from_asset_partitions(
+        asset_graph=asset_graph,
+        partition_names=[
+            "2023-10-05",
+            "2023-10-06",
+            "2023-10-02",
+            "2023-10-01",
+            "2023-10-03",
+            "2023-10-04",
+        ],
+        asset_selection=[foo.key, foo_child.key],
+        dynamic_partitions_store=MagicMock(),
+        all_partitions=False,
+        backfill_start_time=pendulum.datetime(2023, 10, 7, 0, 0, 0),
+    )
+
+    result = execute_asset_backfill_iteration_consume_generator(
+        "apple", asset_backfill_data, asset_graph, DagsterInstance.ephemeral()
+    )
+
+    assert [run_request.partition_key_range for run_request in result.run_requests] == [
+        PartitionKeyRange("2023-10-01", "2023-10-02"),
+        PartitionKeyRange("2023-10-03", "2023-10-04"),
+        PartitionKeyRange("2023-10-05", "2023-10-06"),
+    ]


### PR DESCRIPTION
## Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/18563

This will also apply to auto-materialize run requests

## How I Tested These Changes
