### PR TITLE
[ui] Link git repo when it's a valid non-github link

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/CodeLocationSource.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/CodeLocationSource.tsx
@@ -27,8 +27,12 @@ export const CodeLocationSource = ({metadata}: {metadata: Metadata[]}) => {
   const isGitlab = url.hostname.includes('gitlab.com');
 
   if (!isGithub && !isGitlab) {
-    // Unknown URL type. Just render the text.
-    return <div>{metadataWithURL.value}</div>;
+    // Unknown URL type. Use a basic link.
+    return (
+      <a href={url.href} target="_blank" rel="noreferrer">
+        {metadataWithURL.value}
+      </a>
+    );
   }
 
   const metadataWithCommit = metadata.find(({key}) => key === 'commit_hash');

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/__tests__/CodeLocationSource.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/__tests__/CodeLocationSource.test.tsx
@@ -47,7 +47,7 @@ describe('CodeLocationSource', () => {
 
   it('renders anchor link if the value is a URL but not GH/GL', () => {
     const url = 'https://google.com';
-    const cleaned_url = 'https://google.com/';
+    const cleanedUrl = 'https://google.com/';
     const metadata = [{key: 'url', value: url}];
 
     render(<CodeLocationSource metadata={metadata} />);
@@ -55,7 +55,7 @@ describe('CodeLocationSource', () => {
     // No links.
     const link = screen.getByRole('link', {name: /google/});
     expect(link).toBeVisible();
-    expect(link.getAttribute('href')).toBe(cleaned_url);
+    expect(link.getAttribute('href')).toBe(cleanedUrl);
 
     // Jest text.
     expect(screen.getByText(url)).toBeVisible();

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/__tests__/CodeLocationSource.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/__tests__/CodeLocationSource.test.tsx
@@ -45,16 +45,19 @@ describe('CodeLocationSource', () => {
     expect(screen.getByText('nowhere')).toBeVisible();
   });
 
-  it('renders plaintext if the value is a URL but not GH/GL', () => {
+  it('renders anchor link if the value is a URL but not GH/GL', () => {
     const url = 'https://google.com';
+    const cleaned_url = 'https://google.com/';
     const metadata = [{key: 'url', value: url}];
 
     render(<CodeLocationSource metadata={metadata} />);
 
     // No links.
-    expect(screen.queryByRole('link')).toBeNull();
+    const link = screen.getByRole('link', {name: /google/});
+    expect(link).toBeVisible();
+    expect(link.getAttribute('href')).toBe(cleaned_url);
 
     // Jest text.
-    expect(screen.getByText('https://google.com')).toBeVisible();
+    expect(screen.getByText(url)).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary & Motivation

Basic ergonomics -- users have expressed frustration at having to copy-paste this url when they want to click in.

<img width="1390" alt="image" src="https://github.com/dagster-io/dagster/assets/1099866/e9b75b5f-faaa-4457-bdd1-584e72d978e4">


## How I Tested These Changes

Ran locally and updated existing jest test.