### PR TITLE
Make all postgres connection CMs transactional

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -606,6 +606,10 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     PackageSpec(
         "python_modules/libraries/dagster-mysql",
         pytest_extra_cmds=mysql_extra_cmds,
+        pytest_tox_factors=[
+            "storage_tests",
+            "storage_tests_sqlalchemy_1_3",
+        ],
         unsupported_python_versions=[
             # mysql-connector-python not supported on 3.11
             AvailablePythonVersion.V3_11,
@@ -623,7 +627,14 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             AvailablePythonVersion.V3_11,
         ],
     ),
-    PackageSpec("python_modules/libraries/dagster-postgres", pytest_extra_cmds=postgres_extra_cmds),
+    PackageSpec(
+        "python_modules/libraries/dagster-postgres",
+        pytest_extra_cmds=postgres_extra_cmds,
+        pytest_tox_factors=[
+            "storage_tests",
+            "storage_tests_sqlalchemy_1_3",
+        ],
+    ),
     PackageSpec(
         "python_modules/libraries/dagster-twilio",
         env_vars=["TWILIO_TEST_ACCOUNT_SID", "TWILIO_TEST_AUTH_TOKEN"],

--- a/python_modules/libraries/dagster-mysql/tox.ini
+++ b/python_modules/libraries/dagster-mysql/tox.ini
@@ -5,6 +5,7 @@ skipsdist = true
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN MYSQL_TEST_* BUILDKITE*
 deps =
+  storage_tests_sqlalchemy_1_3: sqlalchemy<1.4
   -e ../../dagster[test]
   -e ../../dagster-pipes
   -e .
@@ -12,4 +13,6 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-    pytest -c ../../../pyproject.toml -vv {posargs}
+
+  storage_tests: pytest -c ../../../pyproject.toml -vv {posargs}
+  storage_tests_sqlalchemy_1_3: pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -108,9 +108,8 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
     def _init_db(self) -> None:
         with self._connect() as conn:
-            with conn.begin():
-                SqlEventLogStorageMetadata.create_all(conn)
-                stamp_alembic_rev(pg_alembic_config(__file__), conn)
+            SqlEventLogStorageMetadata.create_all(conn)
+            stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
     def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagster-webserver, hold an open connection and set statement_timeout

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -101,10 +101,9 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
 
     def _init_db(self) -> None:
         with self.connect() as conn:
-            with conn.begin():
-                RunStorageSqlMetadata.create_all(conn)
-                # This revision may be shared by any other dagster storage classes using the same DB
-                stamp_alembic_rev(pg_alembic_config(__file__), conn)
+            RunStorageSqlMetadata.create_all(conn)
+            # This revision may be shared by any other dagster storage classes using the same DB
+            stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
     def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagster-webserver, hold 1 open connection and set statement_timeout

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -93,9 +93,8 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
 
     def _init_db(self) -> None:
         with self.connect() as conn:
-            with conn.begin():
-                ScheduleStorageSqlMetadata.create_all(conn)
-                stamp_alembic_rev(pg_alembic_config(__file__), conn)
+            ScheduleStorageSqlMetadata.create_all(conn)
+            stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
         # mark all the data migrations as applied
         self.migrate()

--- a/python_modules/libraries/dagster-postgres/tox.ini
+++ b/python_modules/libraries/dagster-postgres/tox.ini
@@ -5,6 +5,7 @@ skipsdist = true
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN POSTGRES_TEST_* BUILDKITE*
 deps =
+  storage_tests_sqlalchemy_1_3: sqlalchemy<1.4
   -e ../../dagster[test]
   -e ../../dagster-pipes
   -e .
@@ -12,4 +13,5 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-    pytest -c ../../../pyproject.toml -vv {posargs}
+  storage_tests: pytest -c ../../../pyproject.toml -vv {posargs}
+  storage_tests_sqlalchemy_1_3: pytest -c ../../../pyproject.toml -vv {posargs}


### PR DESCRIPTION
## Summary & Motivation
We probably want all of these to happen in an explicit transaction.

Ran into this when implementing some of the concurrency changes which we explicitly want to happen in a transaction.  We're currently in a weird state where we have explicit transactions in MySQL / sqlite, but autocommit behavior in Postgres, so the generic sql-based implementations are ambiguous.

Depending on the version of sqlalchemy, we either allow or error on nested transactions.  Cloud is on sqlalchemy 1.4 for various reasons (which allows nested transactions), but if we ever upgrade to 2.0, we'll want to get rid of the nested transactions.

## How I Tested These Changes
BK