### PR TITLE
Include a default automation policy sensor for any AMP-eligible asset keys that are not already mapped to one

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -924,6 +924,10 @@ class DagsterInstance(DynamicPartitionsStore):
     def auto_materialize_max_tick_retries(self) -> int:
         return self.get_settings("auto_materialize").get("max_tick_retries", 3)
 
+    @property
+    def auto_materialize_use_automation_policy_sensors(self) -> int:
+        return self.get_settings("auto_materialize").get("use_automation_policy_sensors", False)
+
     # python logs
 
     @property

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -16,6 +16,7 @@ from dagster._config import (
     StringSource,
     validate_config,
 )
+from dagster._config.source import BoolSource
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.storage.config import mysql_config, pg_config
 from dagster._serdes import class_from_code_pointer
@@ -363,10 +364,10 @@ def dagster_instance_config_schema() -> Mapping[str, Field]:
         "schedules": schedules_daemon_config(),
         "auto_materialize": Field(
             {
-                "enabled": Field(Bool, is_required=False),
-                "minimum_interval_seconds": Field(int, is_required=False),
+                "enabled": Field(BoolSource, is_required=False),
+                "minimum_interval_seconds": Field(IntSource, is_required=False),
                 "run_tags": Field(dict, is_required=False),
-                "respect_materialization_data_versions": Field(Bool, is_required=False),
+                "respect_materialization_data_versions": Field(BoolSource, is_required=False),
                 "max_tick_retries": Field(
                     IntSource,
                     default_value=3,
@@ -375,6 +376,7 @@ def dagster_instance_config_schema() -> Mapping[str, Field]:
                         "For each auto-materialize tick that raises an error, how many times to retry that tick"
                     ),
                 ),
+                "use_automation_policy_sensors": Field(BoolSource, is_required=False),
             }
         ),
     }

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_asset_policy_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_asset_policy_sensors.py
@@ -1,0 +1,268 @@
+from unittest.mock import MagicMock
+
+import pytest
+from dagster import (
+    AssetKey,
+    AutoMaterializePolicy,
+    Definitions,
+    SkipReason,
+    asset,
+    observable_source_asset,
+    sensor,
+)
+from dagster._core.definitions.automation_policy_sensor_definition import (
+    AutomationPolicySensorDefinition,
+)
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.sensor_definition import (
+    SensorType,
+)
+from dagster._core.host_representation.external import ExternalRepository
+from dagster._core.host_representation.external_data import external_repository_data_from_def
+from dagster._core.host_representation.handle import RepositoryHandle
+from dagster._core.host_representation.origin import (
+    ExternalRepositoryOrigin,
+    RegisteredCodeLocationOrigin,
+)
+from dagster._core.test_utils import instance_for_test
+
+
+@asset(auto_materialize_policy=AutoMaterializePolicy.eager())
+def auto_materialize_asset():
+    pass
+
+
+@asset(auto_materialize_policy=AutoMaterializePolicy.eager())
+def other_auto_materialize_asset():
+    pass
+
+
+@observable_source_asset(auto_observe_interval_minutes=1)
+def auto_observe_asset():
+    pass
+
+
+@observable_source_asset(auto_observe_interval_minutes=1)
+def other_auto_observe_asset():
+    pass
+
+
+@asset
+def boring_asset():
+    pass
+
+
+@observable_source_asset
+def boring_observable_asset():
+    pass
+
+
+@sensor()
+def normal_sensor():
+    yield SkipReason("OOPS")
+
+
+defs = Definitions(
+    assets=[
+        auto_materialize_asset,
+        other_auto_materialize_asset,
+        auto_observe_asset,
+        other_auto_observe_asset,
+        boring_asset,
+        boring_observable_asset,
+    ],
+    sensors=[normal_sensor],
+)
+
+
+@pytest.fixture
+def instance_with_automation_policy_sensors():
+    with instance_for_test(
+        {"auto_materialize": {"use_automation_policy_sensors": True}}
+    ) as the_instance:
+        yield the_instance
+
+
+@pytest.fixture
+def instance_without_automation_policy_sensors():
+    with instance_for_test() as the_instance:
+        yield the_instance
+
+
+def test_default_automation_policy_sensors(instance_with_automation_policy_sensors):
+    instance = instance_with_automation_policy_sensors
+
+    repo_handle = MagicMock(spec=RepositoryHandle)
+    repo_handle.get_external_origin.return_value = ExternalRepositoryOrigin(
+        code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
+        repository_name="bar_repo",
+    )
+
+    external_repo = ExternalRepository(
+        external_repository_data_from_def(
+            defs.get_repository_def(),
+        ),
+        repository_handle=repo_handle,
+        instance=instance,
+    )
+
+    sensors = external_repo.get_external_sensors()
+
+    assert len(sensors) == 2
+
+    assert external_repo.has_external_sensor("normal_sensor")
+
+    automation_policy_sensors = [
+        sensor for sensor in sensors if sensor.sensor_type == SensorType.AUTOMATION_POLICY
+    ]
+    assert len(automation_policy_sensors) == 1
+
+    automation_policy_sensor = automation_policy_sensors[0]
+
+    assert automation_policy_sensor.name == "default_automation_policy_sensor"
+    assert external_repo.has_external_sensor(automation_policy_sensor.name)
+
+    asset_graph = ExternalAssetGraph.from_external_repository(external_repo)
+
+    assert automation_policy_sensor.asset_selection.resolve(asset_graph) == {
+        AssetKey(["auto_materialize_asset"]),
+        AssetKey(["auto_observe_asset"]),
+        AssetKey(["other_auto_materialize_asset"]),
+        AssetKey(["other_auto_observe_asset"]),
+    }
+
+
+def test_no_default_automation_policy_sensors(instance_without_automation_policy_sensors):
+    repo_handle = MagicMock(spec=RepositoryHandle)
+    repo_handle.get_external_origin.return_value = ExternalRepositoryOrigin(
+        code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
+        repository_name="bar_repo",
+    )
+
+    # If not opted in, no default sensors are created
+    external_repo = ExternalRepository(
+        external_repository_data_from_def(
+            defs.get_repository_def(),
+        ),
+        repository_handle=repo_handle,
+        instance=instance_without_automation_policy_sensors,
+    )
+    sensors = external_repo.get_external_sensors()
+    assert len(sensors) == 1
+    assert sensors[0].name == "normal_sensor"
+
+
+def test_combine_default_sensors_with_non_default_sensors(instance_with_automation_policy_sensors):
+    automation_policy_sensor = AutomationPolicySensorDefinition(
+        "my_custom_policy_sensor",
+        asset_selection=[auto_materialize_asset, auto_observe_asset],
+    )
+
+    defs_with_automation_policy_sensor = Definitions(
+        assets=[
+            auto_materialize_asset,
+            other_auto_materialize_asset,
+            auto_observe_asset,
+            other_auto_observe_asset,
+            boring_asset,
+            boring_observable_asset,
+        ],
+        sensors=[normal_sensor, automation_policy_sensor],
+    )
+
+    repo_handle = MagicMock(spec=RepositoryHandle)
+    repo_handle.get_external_origin.return_value = ExternalRepositoryOrigin(
+        code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
+        repository_name="bar_repo",
+    )
+
+    external_repo = ExternalRepository(
+        external_repository_data_from_def(
+            defs_with_automation_policy_sensor.get_repository_def(),
+        ),
+        repository_handle=repo_handle,
+        instance=instance_with_automation_policy_sensors,
+    )
+
+    sensors = external_repo.get_external_sensors()
+
+    assert len(sensors) == 3
+
+    assert external_repo.has_external_sensor("normal_sensor")
+    assert external_repo.has_external_sensor("default_automation_policy_sensor")
+    assert external_repo.has_external_sensor("my_custom_policy_sensor")
+
+    asset_graph = ExternalAssetGraph.from_external_repository(external_repo)
+
+    # default sensor includes the assets that weren't covered by the custom one
+
+    default_sensor = external_repo.get_external_sensor("default_automation_policy_sensor")
+
+    assert default_sensor.asset_selection.resolve(asset_graph) == {
+        AssetKey(["other_auto_materialize_asset"]),
+        AssetKey(["other_auto_observe_asset"]),
+    }
+
+    custom_sensor = external_repo.get_external_sensor("my_custom_policy_sensor")
+
+    assert custom_sensor.asset_selection.resolve(asset_graph) == {
+        AssetKey(["auto_materialize_asset"]),
+        AssetKey(["auto_observe_asset"]),
+    }
+
+
+def test_custom_sensors_cover_all(instance_with_automation_policy_sensors):
+    automation_policy_sensor = AutomationPolicySensorDefinition(
+        "my_custom_policy_sensor",
+        asset_selection=[
+            auto_materialize_asset,
+            auto_observe_asset,
+            other_auto_materialize_asset,
+            other_auto_observe_asset,
+        ],
+    )
+
+    defs_with_automation_policy_sensor = Definitions(
+        assets=[
+            auto_materialize_asset,
+            other_auto_materialize_asset,
+            auto_observe_asset,
+            other_auto_observe_asset,
+            boring_asset,
+            boring_observable_asset,
+        ],
+        sensors=[normal_sensor, automation_policy_sensor],
+    )
+
+    repo_handle = MagicMock(spec=RepositoryHandle)
+    repo_handle.get_external_origin.return_value = ExternalRepositoryOrigin(
+        code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
+        repository_name="bar_repo",
+    )
+
+    external_repo = ExternalRepository(
+        external_repository_data_from_def(
+            defs_with_automation_policy_sensor.get_repository_def(),
+        ),
+        repository_handle=repo_handle,
+        instance=instance_with_automation_policy_sensors,
+    )
+
+    sensors = external_repo.get_external_sensors()
+
+    assert len(sensors) == 2
+
+    assert external_repo.has_external_sensor("normal_sensor")
+    assert external_repo.has_external_sensor("my_custom_policy_sensor")
+
+    asset_graph = ExternalAssetGraph.from_external_repository(external_repo)
+
+    # Custom sensor covered all the valid assets
+    custom_sensor = external_repo.get_external_sensor("my_custom_policy_sensor")
+
+    assert custom_sensor.asset_selection.resolve(asset_graph) == {
+        AssetKey(["auto_materialize_asset"]),
+        AssetKey(["auto_observe_asset"]),
+        AssetKey(["other_auto_materialize_asset"]),
+        AssetKey(["other_auto_observe_asset"]),
+    }


### PR DESCRIPTION
Summary:
For users who are opted in to using automation policy sensors, create a default automation policy sensor for all assets in the repository that include either an auto-materialize policy or an auto-observe interval.

This requires making AssetSelection able to handle asset keys that are combinations of both asset keys and source asset keys.

Test Plan: BK
