### PR TITLE
make AssetSelections serializable

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -2,7 +2,7 @@ import collections.abc
 import operator
 from abc import ABC, abstractmethod
 from functools import reduce
-from typing import AbstractSet, Iterable, Optional, Sequence, Union, cast
+from typing import AbstractSet, Iterable, NamedTuple, Optional, Sequence, Union, cast
 
 from typing_extensions import TypeAlias
 
@@ -16,6 +16,7 @@ from dagster._core.selector.subset_selector import (
     fetch_sources,
     parse_clause,
 )
+from dagster._serdes.serdes import whitelist_for_serdes
 
 from .asset_check_spec import AssetCheckKey
 from .asset_graph import AssetGraph, InternalAssetGraph
@@ -94,7 +95,7 @@ class AssetSelection(ABC):
     @staticmethod
     def assets(*assets_defs: AssetsDefinition) -> "KeysAssetSelection":
         """Returns a selection that includes all of the provided assets and asset checks that target them."""
-        return KeysAssetSelection(*(key for assets_def in assets_defs for key in assets_def.keys))
+        return KeysAssetSelection([key for assets_def in assets_defs for key in assets_def.keys])
 
     @public
     @staticmethod
@@ -160,17 +161,17 @@ class AssetSelection(ABC):
 
     @public
     @staticmethod
-    def checks_for_assets(*assets_defs: AssetsDefinition) -> "AssetChecksForAssetKeys":
+    def checks_for_assets(*assets_defs: AssetsDefinition) -> "AssetChecksForAssetKeysSelection":
         """Returns a selection with the asset checks that target the provided assets."""
-        return AssetChecksForAssetKeys(
+        return AssetChecksForAssetKeysSelection(
             [key for assets_def in assets_defs for key in assets_def.keys]
         )
 
     @public
     @staticmethod
-    def checks(*asset_checks: AssetChecksDefinition) -> "AssetChecksForHandles":
+    def checks(*asset_checks: AssetChecksDefinition) -> "AssetCheckKeysSelection":
         """Returns a selection that includes all of the provided asset checks."""
-        return AssetChecksForHandles(
+        return AssetCheckKeysSelection(
             [
                 AssetCheckKey(asset_key=AssetKey.from_coercible(spec.asset_key), name=spec.name)
                 for checks_def in asset_checks
@@ -221,14 +222,14 @@ class AssetSelection(ABC):
         return UpstreamAssetSelection(self, depth=depth, include_self=include_self)
 
     @public
-    def sinks(self) -> "SinkAssetSelection":
+    def sinks(self) -> "SinksAssetSelection":
         """Given an asset selection, returns a new asset selection that contains all of the sink
         assets within the original asset selection. Includes the asset checks targeting the returned assets.
 
         A sink asset is an asset that has no downstream dependencies within the asset selection.
         The sink asset can have downstream dependencies outside of the asset selection.
         """
-        return SinkAssetSelection(self)
+        return SinksAssetSelection(self)
 
     @public
     def required_multi_asset_neighbors(self) -> "RequiredNeighborsAssetSelection":
@@ -239,7 +240,7 @@ class AssetSelection(ABC):
         return RequiredNeighborsAssetSelection(self)
 
     @public
-    def roots(self) -> "RootAssetSelection":
+    def roots(self) -> "RootsAssetSelection":
         """Given an asset selection, returns a new asset selection that contains all of the root
         assets within the original asset selection. Includes the asset checks targeting the returned assets.
 
@@ -250,11 +251,11 @@ class AssetSelection(ABC):
         keys corresponding to `SourceAssets` will not be included as roots. To select source assets,
         use the `upstream_source_assets` method.
         """
-        return RootAssetSelection(self)
+        return RootsAssetSelection(self)
 
     @public
     @deprecated(breaking_version="2.0", additional_warn_text="Use AssetSelection.roots instead.")
-    def sources(self) -> "RootAssetSelection":
+    def sources(self) -> "RootsAssetSelection":
         """Given an asset selection, returns a new asset selection that contains all of the root
         assets within the original asset selection. Includes the asset checks targeting the returned assets.
 
@@ -268,11 +269,11 @@ class AssetSelection(ABC):
         return self.roots()
 
     @public
-    def upstream_source_assets(self) -> "SourceAssetSelection":
+    def upstream_source_assets(self) -> "SourcesAssetSelection":
         """Given an asset selection, returns a new asset selection that contains all of the source
         assets upstream of assets in the original selection. Includes the asset checks targeting the returned assets.
         """
-        return SourceAssetSelection(self)
+        return SourcesAssetSelection(self)
 
     @public
     def without_checks(self) -> "AssetSelection":
@@ -287,9 +288,9 @@ class AssetSelection(ABC):
         check.inst_param(other, "other", AssetSelection)
         return AndAssetSelection(self, other)
 
-    def __sub__(self, other: "AssetSelection") -> "SubAssetSelection":
+    def __sub__(self, other: "AssetSelection") -> "SubtractAssetSelection":
         check.inst_param(other, "other", AssetSelection)
-        return SubAssetSelection(self, other)
+        return SubtractAssetSelection(self, other)
 
     def resolve(
         self, all_assets: Union[Iterable[Union[AssetsDefinition, SourceAsset]], AssetGraph]
@@ -380,12 +381,14 @@ class AssetSelection(ABC):
             )
 
 
-class AllSelection(AssetSelection):
+@whitelist_for_serdes
+class AllSelection(AssetSelection, NamedTuple("_AllSelection", [])):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
         return asset_graph.materializable_asset_keys
 
 
-class AllAssetCheckSelection(AssetSelection):
+@whitelist_for_serdes
+class AllAssetCheckSelection(AssetSelection, NamedTuple("_AllAssetChecksSelection", [])):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
         return set()
 
@@ -393,10 +396,11 @@ class AllAssetCheckSelection(AssetSelection):
         return asset_graph.asset_check_keys
 
 
-class AssetChecksForAssetKeys(AssetSelection):
-    def __init__(self, keys: Sequence[AssetKey]):
-        self._keys = keys
-
+@whitelist_for_serdes
+class AssetChecksForAssetKeysSelection(
+    AssetSelection,
+    NamedTuple("_AssetChecksForAssetKeysSelection", [("keys", Sequence[AssetKey])]),
+):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
         return set()
 
@@ -404,91 +408,97 @@ class AssetChecksForAssetKeys(AssetSelection):
         return {handle for handle in asset_graph.asset_check_keys if handle.asset_key in self._keys}
 
 
-class AssetChecksForHandles(AssetSelection):
-    def __init__(self, asset_check_keys: Sequence[AssetCheckKey]):
-        self._asset_check_keys = asset_check_keys
-
+@whitelist_for_serdes
+class AssetCheckKeysSelection(
+    AssetSelection,
+    NamedTuple(
+        "_AssetChecksForAssetKeysSelection", [("asset_check_keys", Sequence[AssetCheckKey])]
+    ),
+):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
         return set()
 
     def resolve_checks_inner(self, asset_graph: InternalAssetGraph) -> AbstractSet[AssetCheckKey]:
         return {
-            handle for handle in asset_graph.asset_check_keys if handle in self._asset_check_keys
+            handle for handle in asset_graph.asset_check_keys if handle in self.asset_check_keys
         }
 
 
-class AndAssetSelection(AssetSelection):
-    def __init__(self, left: AssetSelection, right: AssetSelection):
-        self._left = left
-        self._right = right
-
+@whitelist_for_serdes
+class AndAssetSelection(
+    AssetSelection,
+    NamedTuple("_AndAssetSelection", [("left", AssetSelection), ("right", AssetSelection)]),
+):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
-        return self._left.resolve_inner(asset_graph) & self._right.resolve_inner(asset_graph)
+        return self.left.resolve_inner(asset_graph) & self.right.resolve_inner(asset_graph)
 
     def resolve_checks_inner(self, asset_graph: InternalAssetGraph) -> AbstractSet[AssetCheckKey]:
-        return self._left.resolve_checks_inner(asset_graph) & self._right.resolve_checks_inner(
+        return self.left.resolve_checks_inner(asset_graph) & self.right.resolve_checks_inner(
             asset_graph
         )
 
 
-class SubAssetSelection(AssetSelection):
-    def __init__(self, left: AssetSelection, right: AssetSelection):
-        self._left = left
-        self._right = right
-
+@whitelist_for_serdes
+class SubtractAssetSelection(
+    AssetSelection,
+    NamedTuple("_AndAssetSelection", [("left", AssetSelection), ("right", AssetSelection)]),
+):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
-        return self._left.resolve_inner(asset_graph) - self._right.resolve_inner(asset_graph)
+        return self.left.resolve_inner(asset_graph) - self.right.resolve_inner(asset_graph)
 
     def resolve_checks_inner(self, asset_graph: InternalAssetGraph) -> AbstractSet[AssetCheckKey]:
-        return self._left.resolve_checks_inner(asset_graph) - self._right.resolve_checks_inner(
+        return self.left.resolve_checks_inner(asset_graph) - self.right.resolve_checks_inner(
             asset_graph
         )
 
 
-class SinkAssetSelection(AssetSelection):
-    def __init__(self, child: AssetSelection):
-        self._child = child
-
+@whitelist_for_serdes
+class SinksAssetSelection(
+    AssetSelection,
+    NamedTuple("_SinksAssetSelection", [("child", AssetSelection)]),
+):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
-        selection = self._child.resolve_inner(asset_graph)
+        selection = self.child.resolve_inner(asset_graph)
         return fetch_sinks(asset_graph.asset_dep_graph, selection)
 
 
-class RequiredNeighborsAssetSelection(AssetSelection):
-    def __init__(self, child: AssetSelection):
-        self._child = child
-
+@whitelist_for_serdes
+class RequiredNeighborsAssetSelection(
+    AssetSelection,
+    NamedTuple("_RequiredNeighborsAssetSelection", [("child", AssetSelection)]),
+):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
-        selection = self._child.resolve_inner(asset_graph)
+        selection = self.child.resolve_inner(asset_graph)
         output = set(selection)
         for asset_key in selection:
             output.update(asset_graph.get_required_multi_asset_keys(asset_key))
         return output
 
 
-class RootAssetSelection(AssetSelection):
-    def __init__(self, child: AssetSelection):
-        self._child = child
-
+@whitelist_for_serdes
+class RootsAssetSelection(
+    AssetSelection,
+    NamedTuple("_RootsAssetSelection", [("child", AssetSelection)]),
+):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
-        selection = self._child.resolve_inner(asset_graph)
+        selection = self.child.resolve_inner(asset_graph)
         return fetch_sources(asset_graph.asset_dep_graph, selection)
 
 
-class DownstreamAssetSelection(AssetSelection):
-    def __init__(
-        self,
-        child: AssetSelection,
-        *,
-        depth: Optional[int] = None,
-        include_self: Optional[bool] = True,
-    ):
-        self._child = child
-        self.depth = depth
-        self.include_self = include_self
-
+@whitelist_for_serdes
+class DownstreamAssetSelection(
+    AssetSelection,
+    NamedTuple(
+        "_DownstreamAssetSelection",
+        [
+            ("child", AssetSelection),
+            ("depth", Optional[int]),
+            ("include_self", bool),
+        ],
+    ),
+):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
-        selection = self._child.resolve_inner(asset_graph)
+        selection = self.child.resolve_inner(asset_graph)
         return operator.sub(
             reduce(
                 operator.or_,
@@ -507,30 +517,36 @@ class DownstreamAssetSelection(AssetSelection):
         )
 
 
-class GroupsAssetSelection(AssetSelection):
-    def __init__(self, *groups: str, include_sources: bool):
-        self._groups = groups
-        self._include_sources = include_sources
-
+@whitelist_for_serdes
+class GroupsAssetSelection(
+    AssetSelection,
+    NamedTuple(
+        "_GroupsAssetSelection",
+        [
+            ("groups", Sequence[str]),
+            ("include_sources", bool),
+        ],
+    ),
+):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.all_asset_keys
-            if self._include_sources
+            if self.include_sources
             else asset_graph.materializable_asset_keys
         )
         return {
             asset_key
             for asset_key, group in asset_graph.group_names_by_key.items()
-            if group in self._groups and asset_key in base_set
+            if group in self.groups and asset_key in base_set
         }
 
 
-class KeysAssetSelection(AssetSelection):
-    def __init__(self, *keys: AssetKey):
-        self._keys = keys
-
+@whitelist_for_serdes
+class KeysAssetSelection(
+    AssetSelection, NamedTuple("_KeysAssetSelection", [("keys", Sequence[AssetKey])])
+):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
-        specified_keys = set(self._keys)
+        specified_keys = set(self.keys)
         invalid_keys = {key for key in specified_keys if key not in asset_graph.all_asset_keys}
         if invalid_keys:
             raise DagsterInvalidSubsetError(
@@ -541,6 +557,7 @@ class KeysAssetSelection(AssetSelection):
         return specified_keys
 
 
+@whitelist_for_serdes
 class KeyPrefixesAssetSelection(AssetSelection):
     def __init__(self, *key_prefixes: Sequence[str], include_sources: bool):
         self._key_prefixes = key_prefixes
@@ -557,16 +574,16 @@ class KeyPrefixesAssetSelection(AssetSelection):
         }
 
 
-class OrAssetSelection(AssetSelection):
-    def __init__(self, left: AssetSelection, right: AssetSelection):
-        self._left = left
-        self._right = right
-
+@whitelist_for_serdes
+class OrAssetSelection(
+    AssetSelection,
+    NamedTuple("_OrAssetSelection", [("left", AssetSelection), ("right", AssetSelection)]),
+):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
-        return self._left.resolve_inner(asset_graph) | self._right.resolve_inner(asset_graph)
+        return self.left.resolve_inner(asset_graph) | self.right.resolve_inner(asset_graph)
 
     def resolve_checks_inner(self, asset_graph: InternalAssetGraph) -> AbstractSet[AssetCheckKey]:
-        return self._left.resolve_checks_inner(asset_graph) | self._right.resolve_checks_inner(
+        return self.left.resolve_checks_inner(asset_graph) | self.right.resolve_checks_inner(
             asset_graph
         )
 
@@ -596,32 +613,33 @@ def _fetch_all_upstream(
     )
 
 
-class UpstreamAssetSelection(AssetSelection):
-    def __init__(
-        self,
-        child: AssetSelection,
-        *,
-        depth: Optional[int] = None,
-        include_self: bool = True,
-    ):
-        self._child = child
-        self.depth = depth
-        self.include_self = include_self
-
+@whitelist_for_serdes
+class UpstreamAssetSelection(
+    AssetSelection,
+    NamedTuple(
+        "_UpstreamAssetSelection",
+        [
+            ("child", AssetSelection),
+            ("depth", Optional[int]),
+            ("include_self", bool),
+        ],
+    ),
+):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
-        selection = self._child.resolve_inner(asset_graph)
+        selection = self.child.resolve_inner(asset_graph)
         if len(selection) == 0:
             return selection
         all_upstream = _fetch_all_upstream(selection, asset_graph, self.depth, self.include_self)
         return {key for key in all_upstream if key not in asset_graph.source_asset_keys}
 
 
-class SourceAssetSelection(AssetSelection):
-    def __init__(self, child: AssetSelection):
-        self._child = child
-
+@whitelist_for_serdes
+class SourcesAssetSelection(
+    AssetSelection,
+    NamedTuple("_SourcesAssetSelection", [("child", AssetSelection)]),
+):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
-        selection = self._child.resolve_inner(asset_graph)
+        selection = self.child.resolve_inner(asset_graph)
         if len(selection) == 0:
             return selection
         all_upstream = _fetch_all_upstream(selection, asset_graph)

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -144,7 +144,7 @@ class AssetSelection(ABC):
               AssetSelection.key_prefixes(["a", "b"], ["a", "c"])
         """
         _asset_key_prefixes = [key_prefix_from_coercible(key_prefix) for key_prefix in key_prefixes]
-        return KeyPrefixesAssetSelection(*_asset_key_prefixes, include_sources=include_sources)
+        return KeyPrefixesAssetSelection(_asset_key_prefixes, include_sources=include_sources)
 
     @public
     @staticmethod
@@ -558,19 +558,20 @@ class KeysAssetSelection(
 
 
 @whitelist_for_serdes
-class KeyPrefixesAssetSelection(AssetSelection):
-    def __init__(self, *key_prefixes: Sequence[str], include_sources: bool):
-        self._key_prefixes = key_prefixes
-        self._include_sources = include_sources
-
+class KeyPrefixesAssetSelection(
+    AssetSelection,
+    NamedTuple(
+        "_KeysAssetSelection", [("key_prefixes", Sequence[AssetKey]), ("include_sources", bool)]
+    ),
+):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.all_asset_keys
-            if self._include_sources
+            if self.include_sources
             else asset_graph.materializable_asset_keys
         )
         return {
-            key for key in base_set if any(key.has_prefix(prefix) for prefix in self._key_prefixes)
+            key for key in base_set if any(key.has_prefix(prefix) for prefix in self.key_prefixes)
         }
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -20,6 +20,7 @@ from dagster import (
 from dagster._core.definitions import AssetSelection, asset
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.events import AssetKey
+from dagster._serdes.serdes import _WHITELIST_MAP
 from typing_extensions import TypeAlias
 
 earth = SourceAsset(["celestial", "earth"], group_name="planets")
@@ -387,3 +388,6 @@ def test_all_asset_selection_subclasses_serializable():
             asset_selection_subclasses.append(value)
 
     assert len(asset_selection_subclasses) > 5
+
+    for asset_selection_subclass in asset_selection_subclasses:
+        _WHITELIST_MAP.has_tuple_serializer(asset_selection_subclass.__class__.__name__)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -1,5 +1,6 @@
 import operator
 from functools import reduce
+from inspect import isclass
 from typing import AbstractSet, Iterable, Tuple, Union
 
 import pytest
@@ -374,3 +375,15 @@ def test_from_coercible_tuple():
         AssetKey("foo"),
         AssetKey("bar"),
     }
+
+
+def test_all_asset_selection_subclasses_serializable():
+    from dagster._core.definitions import asset_selection as asset_selection_module
+
+    asset_selection_subclasses = []
+    for attr in dir(asset_selection_module):
+        value = getattr(asset_selection_module, attr)
+        if isclass(value) and issubclass(value, AssetSelection):
+            asset_selection_subclasses.append(value)
+
+    assert len(asset_selection_subclasses) > 5

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -390,4 +390,5 @@ def test_all_asset_selection_subclasses_serializable():
     assert len(asset_selection_subclasses) > 5
 
     for asset_selection_subclass in asset_selection_subclasses:
-        _WHITELIST_MAP.has_tuple_serializer(asset_selection_subclass.__class__.__name__)
+        if asset_selection_subclass != AssetSelection:
+            assert _WHITELIST_MAP.has_tuple_serializer(asset_selection_subclass.__name__)

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
@@ -21,7 +21,7 @@ from dagster import (
     op,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
-from dagster._core.definitions.asset_selection import AssetChecksForHandles, AssetSelection
+from dagster._core.definitions.asset_selection import AssetCheckKeysSelection, AssetSelection
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
@@ -674,7 +674,7 @@ def test_can_subset_select_only_check() -> None:
 
     result = materialize(
         [foo],
-        selection=AssetChecksForHandles(
+        selection=AssetCheckKeysSelection(
             [AssetCheckKey(asset_key=AssetKey("asset1"), name="check1")]
         ),
     )


### PR DESCRIPTION
## Summary & Motivation

This will allow us to serialize the asset selections that are on automation policy sensors, as part of the repository snapshot.

A tricky followup will be to find a way to deal with `DbtManifestAssetSelection`, which isn't part of the core framework so can't be rehydrated in a host process.  We'll probably need to find some way to convert it to a core asset selection type before serializing it.

## How I Tested These Changes
