### PR TITLE
Handle K8s jobs on job termination and K8s errors

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_integration.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_integration.py
@@ -42,9 +42,7 @@ def _wait_k8s_job_to_start(
     return False
 
 
-def _wait_job_termination_availability(
-    webserver_url_for_k8s_run_launcher: str, run_id: str
-) -> None:
+def _wait_until_job_can_be_terminated(webserver_url_for_k8s_run_launcher: str, run_id: str) -> None:
     """Check if Dagster job could be terminated."""
     timeout = datetime.timedelta(0, 30)
     start_time = datetime.datetime.now()
@@ -194,7 +192,7 @@ def test_k8s_run_launcher_terminate(
         job_name="dagster-run-%s" % run_id, namespace=user_code_namespace_for_k8s_run_launcher
     )
 
-    _wait_job_termination_availability(webserver_url_for_k8s_run_launcher, run_id)
+    _wait_until_job_can_be_terminated(webserver_url_for_k8s_run_launcher, run_id)
     terminate_run_over_graphql(webserver_url_for_k8s_run_launcher, run_id=run_id)
 
     timeout = datetime.timedelta(0, 30)
@@ -239,7 +237,7 @@ def test_k8s_run_launcher_secret_from_deployment(
 
 @pytest.mark.integration
 def test_execute_k8s_job_terminate(namespace, cluster_provider, webserver_url_for_k8s_run_launcher):
-    job_name = "execute_k8s_job"
+    job_name = "slow_execute_k8s_op_job"
     k8s_job_name = "execute-k8s-job"
     run_config = {
         "ops": {
@@ -257,7 +255,7 @@ def test_execute_k8s_job_terminate(namespace, cluster_provider, webserver_url_fo
         webserver_url_for_k8s_run_launcher, run_config=run_config, job_name=job_name
     )
 
-    _wait_job_termination_availability(webserver_url_for_k8s_run_launcher, run_id)
+    _wait_until_job_can_be_terminated(webserver_url_for_k8s_run_launcher, run_id)
 
     kubernetes.config.load_kube_config(cluster_provider.kubeconfig_file)
     api_client = DagsterKubernetesClient.production_client()

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_integration.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_integration.py
@@ -2,6 +2,7 @@ import datetime
 import os
 import time
 
+import kubernetes
 import pytest
 from dagster import (
     DagsterEventType,
@@ -23,6 +24,35 @@ from dagster_test.test_project import (
     get_test_project_docker_image,
     get_test_project_environments_path,
 )
+
+from .utils import _wait_k8s_job_to_delete
+
+
+def _wait_k8s_job_to_start(
+    api_client: DagsterKubernetesClient, job_name: str, namespace: str
+) -> bool:
+    """Wait until Kubernetes job exists."""
+    for _ in range(5):
+        try:
+            api_client.batch_api.read_namespaced_job_status(job_name, namespace)
+            return True
+        except kubernetes.client.rest.ApiException:
+            time.sleep(5)
+
+    return False
+
+
+def _wait_job_termination_availability(
+    webserver_url_for_k8s_run_launcher: str, run_id: str
+) -> None:
+    """Check if Dagster job could be terminated."""
+    timeout = datetime.timedelta(0, 30)
+    start_time = datetime.datetime.now()
+    while True:
+        assert datetime.datetime.now() < start_time + timeout, "Timed out waiting for can_terminate"
+        if can_terminate_run_over_graphql(webserver_url_for_k8s_run_launcher, run_id):
+            break
+        time.sleep(5)
 
 
 @pytest.mark.integration
@@ -164,16 +194,10 @@ def test_k8s_run_launcher_terminate(
         job_name="dagster-run-%s" % run_id, namespace=user_code_namespace_for_k8s_run_launcher
     )
 
-    timeout = datetime.timedelta(0, 30)
-    start_time = datetime.datetime.now()
-    while True:
-        assert datetime.datetime.now() < start_time + timeout, "Timed out waiting for can_terminate"
-        if can_terminate_run_over_graphql(webserver_url_for_k8s_run_launcher, run_id):
-            break
-        time.sleep(5)
-
+    _wait_job_termination_availability(webserver_url_for_k8s_run_launcher, run_id)
     terminate_run_over_graphql(webserver_url_for_k8s_run_launcher, run_id=run_id)
 
+    timeout = datetime.timedelta(0, 30)
     start_time = datetime.datetime.now()
     dagster_run = None
     while True:
@@ -211,3 +235,39 @@ def test_k8s_run_launcher_secret_from_deployment(
     )
 
     assert "RUN_SUCCESS" in result, f"no match, result: {result}"
+
+
+@pytest.mark.integration
+def test_execute_k8s_job_terminate(namespace, cluster_provider, webserver_url_for_k8s_run_launcher):
+    job_name = "execute_k8s_job"
+    k8s_job_name = "execute-k8s-job"
+    run_config = {
+        "ops": {
+            "execute_k8s_op": {
+                "config": {
+                    "namespace": namespace,
+                    "kubeconfig_file": cluster_provider.kubeconfig_file,
+                    "k8s_job_name": k8s_job_name,
+                }
+            }
+        }
+    }
+
+    run_id = launch_run_over_graphql(
+        webserver_url_for_k8s_run_launcher, run_config=run_config, job_name=job_name
+    )
+
+    _wait_job_termination_availability(webserver_url_for_k8s_run_launcher, run_id)
+
+    kubernetes.config.load_kube_config(cluster_provider.kubeconfig_file)
+    api_client = DagsterKubernetesClient.production_client()
+    # make sure that K8s job is already created
+    _wait_k8s_job_to_start(api_client, k8s_job_name, namespace)
+
+    terminate_run_over_graphql(webserver_url_for_k8s_run_launcher, run_id=run_id)
+
+    # make sure that K8s job is deleted before assertion because it might not happen instantly
+    _wait_k8s_job_to_delete(api_client, k8s_job_name, namespace)
+
+    with pytest.raises(kubernetes.client.rest.ApiException, match=r"Reason: Not Found"):
+        api_client.batch_api.read_namespaced_job_status(k8s_job_name, namespace)

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
@@ -220,7 +220,7 @@ def test_k8s_job_op_with_failure(namespace, cluster_provider):
     def failure_job():
         failure_op()
 
-    with pytest.raises(DagsterK8sError, match=r"Timed out"):
+    with pytest.raises(DagsterK8sError, match=r"Pod did not exit successfully"):
         failure_job.execute_in_process()
 
     kubernetes.config.load_kube_config(cluster_provider.kubeconfig_file)

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
@@ -8,6 +8,8 @@ from dagster_k8s import execute_k8s_job, k8s_job_op
 from dagster_k8s.client import DagsterK8sError, DagsterKubernetesClient
 from dagster_k8s.job import get_k8s_job_name
 
+from .utils import _wait_k8s_job_to_delete
+
 
 def _get_pods_logs(cluster_provider, job_name, namespace, container_name=None):
     kubernetes.config.load_kube_config(cluster_provider.kubeconfig_file)
@@ -164,48 +166,71 @@ def test_k8s_job_op_with_timeout_success(namespace, cluster_provider):
 
 @pytest.mark.default
 def test_k8s_job_op_with_timeout_fail(namespace, cluster_provider):
-    timeout_op = k8s_job_op.configured(
-        {
-            "image": "busybox",
-            "command": ["/bin/sh", "-c"],
-            "args": ["sleep 15 && echo HI"],
-            "namespace": namespace,
-            "load_incluster_config": False,
-            "kubeconfig_file": cluster_provider.kubeconfig_file,
-            "timeout": 5,
-        },
-        name="timeout_op",
-    )
+    custom_k8s_job_name = str(uuid.uuid4())
+
+    @op
+    def timeout_op(context):
+        execute_k8s_job(
+            context,
+            image="busybox",
+            command=["/bin/sh", "-c"],
+            args=["sleep 15 && echo HI"],
+            namespace=namespace,
+            load_incluster_config=False,
+            kubeconfig_file=cluster_provider.kubeconfig_file,
+            timeout=5,
+            k8s_job_name=custom_k8s_job_name,
+        )
 
     @job
     def timeout_job():
         timeout_op()
 
-    with pytest.raises(DagsterK8sError, match=r"Timed out while waiting for pod to become ready"):
+    with pytest.raises(DagsterK8sError, match=r"Timed out"):
         timeout_job.execute_in_process()
+
+    kubernetes.config.load_kube_config(cluster_provider.kubeconfig_file)
+    api_client = DagsterKubernetesClient.production_client()
+
+    # make sure that K8s job is deleted before assertion because it might not happen instantly
+    _wait_k8s_job_to_delete(api_client, custom_k8s_job_name, namespace)
+
+    with pytest.raises(kubernetes.client.rest.ApiException, match=r"Reason: Not Found"):
+        api_client.batch_api.read_namespaced_job_status(custom_k8s_job_name, namespace)
 
 
 @pytest.mark.default
 def test_k8s_job_op_with_failure(namespace, cluster_provider):
-    failure_op = k8s_job_op.configured(
-        {
-            "image": "busybox",
-            "command": ["/bin/sh", "-c"],
-            "args": ["sleep 10 && exit 1"],
-            "namespace": namespace,
-            "load_incluster_config": False,
-            "kubeconfig_file": cluster_provider.kubeconfig_file,
-            "timeout": 5,
-        },
-        name="failure_op",
-    )
+    custom_k8s_job_name = str(uuid.uuid4())
+
+    @op
+    def failure_op(context):
+        execute_k8s_job(
+            context,
+            image="busybox",
+            command=["/bin/sh", "-c"],
+            args=["exit 1"],
+            namespace=namespace,
+            load_incluster_config=False,
+            kubeconfig_file=cluster_provider.kubeconfig_file,
+            k8s_job_name=custom_k8s_job_name,
+        )
 
     @job
     def failure_job():
         failure_op()
 
-    with pytest.raises(DagsterK8sError):
+    with pytest.raises(DagsterK8sError, match=r"Timed out"):
         failure_job.execute_in_process()
+
+    kubernetes.config.load_kube_config(cluster_provider.kubeconfig_file)
+    api_client = DagsterKubernetesClient.production_client()
+
+    # make sure that K8s job is deleted before assertion because it might not happen instantly
+    _wait_k8s_job_to_delete(api_client, custom_k8s_job_name, namespace)
+
+    with pytest.raises(kubernetes.client.rest.ApiException, match=r"Reason: Not Found"):
+        api_client.batch_api.read_namespaced_job_status(custom_k8s_job_name, namespace)
 
 
 @pytest.mark.default

--- a/integration_tests/test_suites/k8s-test-suite/tests/utils.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/utils.py
@@ -1,0 +1,16 @@
+import time
+
+import kubernetes
+from dagster_k8s.client import DagsterKubernetesClient
+
+
+def _wait_k8s_job_to_delete(
+    api_client: DagsterKubernetesClient, job_name: str, namespace: str
+) -> None:
+    """Wait until Kubernetes job is deleted."""
+    for _ in range(5):
+        try:
+            api_client.batch_api.read_namespaced_job_status(job_name, namespace)
+            time.sleep(5)
+        except kubernetes.client.rest.ApiException:
+            return

--- a/python_modules/dagster-test/dagster_test/test_project/test_jobs/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_jobs/repo.py
@@ -387,7 +387,7 @@ def slow_graph():
 
 
 @op
-def execute_k8s_op(context):
+def slow_execute_k8s_op(context):
     execute_k8s_job(
         context,
         image="busybox",
@@ -399,8 +399,8 @@ def execute_k8s_op(context):
 
 
 @graph
-def execute_k8s_graph():
-    execute_k8s_op()
+def slow_execute_k8s_op_graph():
+    slow_execute_k8s_op()
 
 
 @resource
@@ -577,7 +577,7 @@ def define_demo_execution_repo():
                 "retry_job_k8s": define_job(retry_graph, "k8s"),
                 "slow_job_celery_k8s": define_job(slow_graph, "celery_k8s"),
                 "slow_job_k8s": define_job(slow_graph, "k8s"),
-                "execute_k8s_job": define_job(execute_k8s_graph),
+                "slow_execute_k8s_op_job": define_job(slow_execute_k8s_op_graph),
                 "step_retries_job_docker": define_job(step_retries_graph, "docker"),
                 "volume_mount_job_celery_k8s": define_job(volume_mount_graph, "celery_k8s"),
             },

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -353,19 +353,12 @@ def execute_k8s_job(
             wait_timeout=timeout,
             start_time=start_time,
         )
-    except (DagsterExecutionInterruptedError, Exception) as e:
-        context.log.info(
-            f"Deleting Kubernetes job {job_name} in namespace {namespace} due to exception"
-        )
-        api_client.delete_job(job_name=job_name, namespace=namespace)
-        raise e
 
-    restart_policy = user_defined_k8s_config.pod_spec_config.get("restart_policy", "Never")
+        restart_policy = user_defined_k8s_config.pod_spec_config.get("restart_policy", "Never")
 
-    if restart_policy == "Never":
-        container_name = container_config.get("name", "dagster")
+        if restart_policy == "Never":
+            container_name = container_config.get("name", "dagster")
 
-        try:
             pods = api_client.wait_for_job_to_have_pods(
                 job_name,
                 namespace,
@@ -384,39 +377,32 @@ def execute_k8s_job(
             api_client.wait_for_pod(
                 pod_to_watch, namespace, wait_timeout=timeout, start_time=start_time
             )
-        except (DagsterExecutionInterruptedError, Exception) as e:
-            context.log.info(
-                f"Deleting Kubernetes job {job_name} in namespace {namespace} due to exception"
+
+            log_stream = watch.stream(
+                api_client.core_api.read_namespaced_pod_log,
+                name=pod_to_watch,
+                namespace=namespace,
+                container=container_name,
             )
-            api_client.delete_job(job_name=job_name, namespace=namespace)
-            raise e
 
-        log_stream = watch.stream(
-            api_client.core_api.read_namespaced_pod_log,
-            name=pod_to_watch,
-            namespace=namespace,
-            container=container_name,
-        )
+            while True:
+                if timeout and time.time() - start_time > timeout:
+                    watch.stop()
+                    raise Exception("Timed out waiting for pod to finish")
 
-        while True:
-            if timeout and time.time() - start_time > timeout:
-                watch.stop()
-                raise Exception("Timed out waiting for pod to finish")
+                try:
+                    log_entry = next(log_stream)
+                    print(log_entry)  # noqa: T201
+                except StopIteration:
+                    break
+        else:
+            context.log.info("Pod logs are disabled, because restart_policy is not Never")
 
-            try:
-                log_entry = next(log_stream)
-                print(log_entry)  # noqa: T201
-            except StopIteration:
-                break
-    else:
-        context.log.info("Pod logs are disabled, because restart_policy is not Never")
+        if job_spec_config and job_spec_config.get("parallelism"):
+            num_pods_to_wait_for = job_spec_config["parallelism"]
+        else:
+            num_pods_to_wait_for = DEFAULT_JOB_POD_COUNT
 
-    if job_spec_config and job_spec_config.get("parallelism"):
-        num_pods_to_wait_for = job_spec_config["parallelism"]
-    else:
-        num_pods_to_wait_for = DEFAULT_JOB_POD_COUNT
-
-    try:
         api_client.wait_for_running_job_to_succeed(
             job_name=job_name,
             namespace=namespace,


### PR DESCRIPTION
## Summary & Motivation

Before this change, Dagster would not handle K8s jobs created using `execute_k8s_job` if Dagster job is terminated. For example, there is a job called `launch-job` that consists of operation called `launch-op` which calls `execute_k8s_job` method. `execute_k8s_job` creates a Kubernetes job named `launch-k8s`. There are two main scenarios when Dagster job `launch-job` will be terminated but Kubernetes job `launch-k8s` will keep running:
- If exception related to the Kubernetes is raised (e.g. `launch-k8s` timeouts) it means that Dagster will mark `lauch-op` as failed and terminate `launch-job`. However, `launch-k8s` Kubernetes job will keep running
- If pipeline execution was interrupted during the execution process (e.g. pipeline was manually cancelled). It means that Dagster will terminate `launch-job` and all of its running operations. However, `launch-k8s` Kubernetes job will keep running

Main issues with this behavior are:
- Observability. This really hurts the observability of the pipelines because it's hard to tell if the job was fully terminated
- Kubernetes load. It also can increase load on the Kubernetes cluster because there will be running jobs that are not needed anymore. Basically, computing resources are wasted
- Unexpected behavior. It can cause some unexpected behavior if the same Dagster job is launched again, because there could be two Kubernetes job running at the same time and doing the same thing (e.g. consuming from the same queue)

With this change, Dagster will handle Kubernetes jobs created using `execute_k8s_job` on Dagster job termination and Kubernetes errors.

## How I Tested These Changes

- `test_k8s_job_op_with_timeout_fail` test was modified to check if Kubernetes job created through `execute_k8s_job` method is deleted after Kubernetes related exception (particularly timeout in this case) is raised. `Timed out while waiting for pod to become ready` was changed to the `Timed out` because timeout can be raised in different places, not only when waiting for pod to become ready (`wait_for_pod` method) but also when waiting for job to complete (`wait_for_job` method) and so on
- `test_k8s_job_op_with_failure` test was modified because of two reasons:

  - Basically, it was doing the same thing as `test_k8s_job_op_with_timeout_fail` test, because timeout was set to 5 seconds and Kubernetes job was set to sleep for 10 seconds and then exit with non-zero exit code. This means that Kubernetes job will always timeout and will never exit with non-zero exit code. So, I removed timeout from the Kubernetes job and set it to exit with non-zero exit code immediately

  - Check if Kubernetes job created through `execute_k8s_job` method is deleted after Kubernetes related exception (particularly failed job in this case) is raised.
- `test_execute_k8s_job_terminate` test was added to check if Kubernetes job
created through `execute_k8s_job` method is deleted after Dagster job is
manually terminated