### PR TITLE
add base concurrency limit initialize method to event log storage

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -934,6 +934,10 @@ class DagsterInstance(DynamicPartitionsStore):
     def auto_materialize_use_automation_policy_sensors(self) -> int:
         return self.get_settings("auto_materialize").get("use_automation_policy_sensors", False)
 
+    @property
+    def global_op_concurrency_default_limit(self) -> Optional[int]:
+        return self.get_settings("concurrency").get("default_op_concurrency_limit")
+
     # python logs
 
     @property

--- a/python_modules/dagster/dagster/_core/instance/ref.py
+++ b/python_modules/dagster/dagster/_core/instance/ref.py
@@ -456,6 +456,7 @@ class InstanceRef(
             "schedules",
             "nux",
             "auto_materialize",
+            "concurrency",
         }
         settings = {key: config_value.get(key) for key in settings_keys if config_value.get(key)}
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -402,8 +402,10 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         return False
 
     @abstractmethod
-    def initialize_concurrency_limit(self, concurrency_key: str, num: int) -> None:
-        """Allocate concurrency slots for the given concurrency key."""
+    def initialize_concurrency_limit_to_default(self, concurrency_key: str) -> None:
+        """Initialize a concurrency limit to the instance default value.  Is a no-op for concurrency
+        keys that are already configured with a limit.
+        """
         raise NotImplementedError()
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -402,7 +402,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         return False
 
     @abstractmethod
-    def initialize_concurrency_limit_to_default(self, concurrency_key: str) -> None:
+    def initialize_concurrency_limit_to_default(self, concurrency_key: str) -> bool:
         """Initialize a concurrency limit to the instance default value.  Is a no-op for concurrency
         keys that are already configured with a limit.
         """

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -402,6 +402,11 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         return False
 
     @abstractmethod
+    def initialize_concurrency_limit(self, concurrency_key: str, num: int) -> None:
+        """Allocate concurrency slots for the given concurrency key."""
+        raise NotImplementedError()
+
+    @abstractmethod
     def set_concurrency_slots(self, concurrency_key: str, num: int) -> None:
         """Allocate concurrency slots for the given concurrency key."""
         raise NotImplementedError()

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2174,7 +2174,7 @@ class SqlEventLogStorage(EventLogStorage):
 
         # consider setting this in the instance config
         default_value = 1
-        with self.index_connection() as conn:
+        with self.index_transaction() as conn:
             try:
                 conn.execute(
                     ConcurrencyLimitsTable.insert().values(

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2163,18 +2163,21 @@ class SqlEventLogStorage(EventLogStorage):
             row = conn.execute(db_select([True]).select_from(table).limit(1)).fetchone()
         return bool(row[0]) if row else False
 
-    def initialize_concurrency_limit(self, concurrency_key: str, num: int):
+    def initialize_concurrency_limit_to_default(self, concurrency_key: str):
         if not self.has_table(ConcurrencyLimitsTable.name):
             return None
+
+        # consider setting this in the instance config
+        default_value = 1
 
         with self.index_connection() as conn:
             try:
                 conn.execute(
                     ConcurrencyLimitsTable.insert().values(
-                        concurrency_key=concurrency_key, limit=num
+                        concurrency_key=concurrency_key, limit=default_value
                     )
                 )
-                self._allocate_concurrency_slots(conn, concurrency_key, num)
+                self._allocate_concurrency_slots(conn, concurrency_key, default_value)
             except db_exc.IntegrityError:
                 pass
 

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -620,6 +620,11 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
             run_id, cursor, of_type, limit, ascending
         )
 
+    def initialize_concurrency_limit_to_default(self, concurrency_key: str) -> bool:
+        return self._storage.event_log_storage.initialize_concurrency_limit_to_default(
+            concurrency_key
+        )
+
     def set_concurrency_slots(self, concurrency_key: str, num: int) -> None:
         return self._storage.event_log_storage.set_concurrency_slots(concurrency_key, num)
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/conftest.py
@@ -22,6 +22,22 @@ def concurrency_instance():
 
 
 @pytest.fixture()
+def concurrency_instance_with_default_one():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with instance_for_test(
+            overrides={
+                "event_log_storage": {
+                    "module": "dagster.utils.test",
+                    "class": "ConcurrencyEnabledSqliteTestEventLogStorage",
+                    "config": {"base_dir": temp_dir},
+                },
+                "concurrency": {"default_op_concurrency_limit": 1},
+            }
+        ) as instance:
+            yield instance
+
+
+@pytest.fixture()
 def concurrency_custom_sleep_instance():
     with tempfile.TemporaryDirectory() as temp_dir:
         with instance_for_test(

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_instance_concurrency_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_instance_concurrency_context.py
@@ -32,22 +32,6 @@ def test_global_concurrency(concurrency_instance):
     assert foo_info.pending_step_count == 0
 
 
-def test_limitless_context(concurrency_instance):
-    run_id = make_new_run_id()
-    assert concurrency_instance.event_log_storage.get_concurrency_info("foo").slot_count == 0
-
-    with InstanceConcurrencyContext(concurrency_instance, run_id) as context:
-        assert context.claim("foo", "a")
-        assert context.claim("foo", "b")
-        assert context.claim("foo", "d")
-        assert context.claim("foo", "e")
-        assert not context.has_pending_claims()
-
-        foo_info = concurrency_instance.event_log_storage.get_concurrency_info("foo")
-        assert foo_info.slot_count == 0
-        assert foo_info.active_slot_count == 0
-
-
 def test_context_error(concurrency_instance):
     run_id = make_new_run_id()
     concurrency_instance.event_log_storage.set_concurrency_slots("foo", 2)
@@ -138,3 +122,25 @@ def test_custom_interval(concurrency_custom_sleep_instance):
         time.sleep(interval_to_custom)
         context.claim("foo", "b")
         assert storage.get_check_calls("b") == call_count + 1
+
+
+def test_default_concurrency_key(concurrency_instance):
+    run_id = make_new_run_id()
+
+    assert concurrency_instance.event_log_storage.get_concurrency_keys() == set()
+
+    with InstanceConcurrencyContext(concurrency_instance, run_id) as context:
+        # by default, the concurrency key is set to 1
+        assert context.claim("foo", "a")
+        assert not context.claim("foo", "b")
+
+
+def test_zero_concurrency_key(concurrency_instance):
+    run_id = make_new_run_id()
+
+    concurrency_instance.event_log_storage.set_concurrency_slots("foo", 0)
+    assert concurrency_instance.event_log_storage.get_concurrency_keys() == set(["foo"])
+
+    with InstanceConcurrencyContext(concurrency_instance, run_id) as context:
+        assert not context.claim("foo", "a")
+        assert not context.claim("foo", "b")

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_instance_concurrency_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_instance_concurrency_context.py
@@ -32,6 +32,22 @@ def test_global_concurrency(concurrency_instance):
     assert foo_info.pending_step_count == 0
 
 
+def test_limitless_context(concurrency_instance):
+    run_id = make_new_run_id()
+    assert concurrency_instance.event_log_storage.get_concurrency_info("foo").slot_count == 0
+
+    with InstanceConcurrencyContext(concurrency_instance, run_id) as context:
+        assert context.claim("foo", "a")
+        assert context.claim("foo", "b")
+        assert context.claim("foo", "d")
+        assert context.claim("foo", "e")
+        assert not context.has_pending_claims()
+
+        foo_info = concurrency_instance.event_log_storage.get_concurrency_info("foo")
+        assert foo_info.slot_count == 0
+        assert foo_info.active_slot_count == 0
+
+
 def test_context_error(concurrency_instance):
     run_id = make_new_run_id()
     concurrency_instance.event_log_storage.set_concurrency_slots("foo", 2)
@@ -124,13 +140,23 @@ def test_custom_interval(concurrency_custom_sleep_instance):
         assert storage.get_check_calls("b") == call_count + 1
 
 
-def test_default_concurrency_key(concurrency_instance):
+def test_unset_concurrency_default(concurrency_instance):
     run_id = make_new_run_id()
 
     assert concurrency_instance.event_log_storage.get_concurrency_keys() == set()
 
     with InstanceConcurrencyContext(concurrency_instance, run_id) as context:
-        # by default, the concurrency key is set to 1
+        assert context.claim("foo", "a")
+        assert context.claim("foo", "b")
+
+
+def test_default_concurrency_key(concurrency_instance_with_default_one):
+    run_id = make_new_run_id()
+
+    assert concurrency_instance_with_default_one.event_log_storage.get_concurrency_keys() == set()
+    assert concurrency_instance_with_default_one.global_op_concurrency_default_limit == 1
+
+    with InstanceConcurrencyContext(concurrency_instance_with_default_one, run_id) as context:
         assert context.claim("foo", "a")
         assert not context.claim("foo", "b")
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -4354,6 +4354,24 @@ class TestEventLogStorage:
         assert info.pending_step_count == 1
         assert info.assigned_step_count == 0
 
+    def test_default_concurrency(self, storage):
+        assert storage
+        if not storage.supports_global_concurrency_limits:
+            pytest.skip("storage does not support global op concurrency")
+
+        if self.can_wipe():
+            storage.wipe()
+
+        # initially there are no concurrency limited keys
+        assert storage.get_concurrency_keys() == set()
+
+        # initialize with default concurrency
+        assert storage.initialize_concurrency_limit_to_default("foo")
+
+        # initially there are no concurrency limited keys
+        assert storage.get_concurrency_keys() == set(["foo"])
+        assert storage.get_concurrency_info("foo").slot_count == 1
+
     def test_asset_checks(self, storage):
         if self.can_wipe():
             storage.wipe()

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -4366,7 +4366,7 @@ class TestEventLogStorage:
         assert storage.get_concurrency_keys() == set()
 
         # initialize with default concurrency
-        assert storage.initialize_concurrency_limit_to_default("foo")
+        storage.initialize_concurrency_limit_to_default("foo")
 
         # initially there are no concurrency limited keys
         assert storage.get_concurrency_keys() == set(["foo"])


### PR DESCRIPTION
## Summary & Motivation
This changes the behavior for non-configured concurrency keys to default to a configurable concurrency limit default, if you have run `dagster instance migrate`.

The behavior in the unmigrated state is the same as the status quo, which is default open (e.g. not limited).

Right now, this default limit can be configured in the instance settings (`concurrency` > `default_op_concurrency_limit`) in `dagster.yaml` (or deployment settings in cloud).

I also considered storing this default in the DB, in the limits table, for a special hard-coded concurrency key (i.e. `DEFAULT_CONCURRENCY_KEY`), but opted for this instead.

Not included in this diff: figuring out how to coalesce some different concurrency related settings under this new settings key (e.g. the run monitoring setting `free_slots_after_run_end_seconds`).  This is mostly because reconciling the settings may be tricky if they don't have run monitoring enabled, etc..  Also, unclear if we should coalesce the run concurrency config into this concurrency section.


## How I Tested These Changes
BK