### PR TITLE
[asset-automation] Further separate AutoMaterializeAssetEvaluation from internal logic

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -20,11 +20,12 @@ from dagster._core.definitions.time_window_partitions import (
 )
 from dagster._serdes.serdes import deserialize_value, serialize_value
 
-if TYPE_CHECKING:
-    from .asset_automation_evaluator import ConditionEvaluation
 from .asset_graph import AssetGraph
 from .asset_subset import AssetSubset
 from .partition import PartitionsSubset
+
+if TYPE_CHECKING:
+    from .asset_automation_evaluator import ConditionEvaluation
 
 
 class AssetDaemonAssetCursor(NamedTuple):

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -262,6 +262,7 @@ class AutoMaterializePolicy(
             OrAutomationCondition,
             RuleCondition,
         )
+        from .auto_materialize_rule import DiscardOnMaxMaterializationsExceededRule
 
         materialize_condition = OrAutomationCondition(
             children=[RuleCondition(rule) for rule in self.materialize_rules]
@@ -269,12 +270,15 @@ class AutoMaterializePolicy(
         skip_condition = OrAutomationCondition(
             children=[RuleCondition(rule) for rule in self.skip_rules]
         )
+        children = [
+            materialize_condition,
+            NotAutomationCondition([skip_condition]),
+        ]
+        if self.max_materializations_per_minute:
+            discard_condition = RuleCondition(
+                DiscardOnMaxMaterializationsExceededRule(self.max_materializations_per_minute)
+            )
+            children.append(NotAutomationCondition([discard_condition]))
 
-        # results in an expression of the form (m1 | m2 | ... | mn) & ~(s1 | s2 | ... | sn)
-        condition = AndAutomationCondition(
-            children=[materialize_condition, NotAutomationCondition([skip_condition])]
-        )
-        return AssetAutomationEvaluator(
-            condition=condition,
-            max_materializations_per_minute=self.max_materializations_per_minute,
-        )
+        # results in an expression of the form (m1 | m2 | ... | mn) & ~(s1 | s2 | ... | sn) & ~d
+        return AssetAutomationEvaluator(condition=AndAutomationCondition(children))

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -265,10 +265,16 @@ class AutoMaterializePolicy(
         from .auto_materialize_rule import DiscardOnMaxMaterializationsExceededRule
 
         materialize_condition = OrAutomationCondition(
-            children=[RuleCondition(rule) for rule in self.materialize_rules]
+            children=[
+                RuleCondition(rule)
+                for rule in sorted(self.materialize_rules, key=lambda rule: rule.description)
+            ]
         )
         skip_condition = OrAutomationCondition(
-            children=[RuleCondition(rule) for rule in self.skip_rules]
+            children=[
+                RuleCondition(rule)
+                for rule in sorted(self.skip_rules, key=lambda rule: rule.description)
+            ]
         )
         children = [
             materialize_condition,

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -111,7 +111,8 @@ class AutoMaterializeRule(ABC):
 
         for elt in context.previous_tick_subsets_with_metadata:
             carry_forward_subset = elt.subset - ignore_subset
-            mapping[elt.frozen_metadata] |= carry_forward_subset
+            if carry_forward_subset.size > 0:
+                mapping[elt.frozen_metadata] |= carry_forward_subset
 
         # for now, an asset is in the "true" subset if and only if we have some metadata for it
         true_subset = reduce(operator.or_, mapping.values(), context.empty_subset())

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -1,9 +1,10 @@
 import datetime
+import operator
 from abc import ABC, abstractmethod, abstractproperty
 from collections import defaultdict
+from functools import reduce
 from typing import (
     AbstractSet,
-    Callable,
     Dict,
     Iterable,
     Mapping,
@@ -17,6 +18,7 @@ import pytz
 
 import dagster._check as check
 from dagster._annotations import experimental, public
+from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeDecisionType,
     AutoMaterializeRuleEvaluationData,
@@ -74,32 +76,52 @@ class AutoMaterializeRule(ABC):
         self,
         context: AssetAutomationConditionEvaluationContext,
         asset_partitions_by_evaluation_data: Mapping[
-            Optional[AutoMaterializeRuleEvaluationData], Set[AssetKeyPartitionKey]
+            AutoMaterializeRuleEvaluationData, Set[AssetKeyPartitionKey]
         ],
-        should_use_past_data_fn: Callable[[AssetKeyPartitionKey], bool],
-    ) -> "RuleEvaluationResults":
-        """Combines a given set of evaluation data with evaluation data from the previous tick. The
-        returned value will include the union of the evaluation data contained within
-        `asset_partitions_by_evaluation_data` and the evaluation data calculated for asset
-        partitions on the previous tick for which `should_use_past_data_fn` evaluates to `True`.
+        ignore_subset: AssetSubset,
+    ) -> RuleEvaluationResults:
+        """Combines evaluation data calculated on this tick with evaluation data calculated on the
+        previous tick.
 
         Args:
             context: The current RuleEvaluationContext.
             asset_partitions_by_evaluation_data: A mapping from evaluation data to the set of asset
                 partitions that the rule applies to.
-            should_use_past_data_fn: A function that returns whether a given asset partition from the
-                previous tick should be included in the results of this tick.
+            ignore_subset: An AssetSubset which represents information that we should *not* carry
+                forward from the previous tick.
         """
-        asset_partitions_by_evaluation_data = defaultdict(set, asset_partitions_by_evaluation_data)
-        evaluated_asset_partitions = set().union(*asset_partitions_by_evaluation_data.values())
-        for evaluation_data, asset_partitions in context.previous_tick_results:
-            for ap in asset_partitions:
-                # evaluated data from this tick takes precedence over data from the previous tick
-                if ap in evaluated_asset_partitions:
-                    continue
-                elif should_use_past_data_fn(ap):
-                    asset_partitions_by_evaluation_data[evaluation_data].add(ap)
-        return list(asset_partitions_by_evaluation_data.items())
+        from .asset_automation_evaluator import AssetSubsetWithMetdata
+
+        mapping = defaultdict(lambda: context.empty_subset())
+        for evaluation_data, asset_partitions in asset_partitions_by_evaluation_data.items():
+            mapping[
+                frozenset(evaluation_data.metadata.items())
+            ] = AssetSubset.from_asset_partitions_set(
+                context.asset_key, context.partitions_def, asset_partitions
+            )
+
+        # get the set of all things we have metadata for
+        has_metadata_subset = context.empty_subset()
+        for evaluation_data, subset in mapping.items():
+            has_metadata_subset |= subset
+
+        # don't use information from the previous tick if we have explicit metadata for it or
+        # we've explicitly said to ignore it
+        ignore_subset = has_metadata_subset | ignore_subset
+
+        for elt in context.previous_tick_subsets_with_metadata:
+            carry_forward_subset = elt.subset - ignore_subset
+            mapping[elt.frozen_metadata] |= carry_forward_subset
+
+        # for now, an asset is in the "true" subset if and only if we have some metadata for it
+        true_subset = reduce(operator.or_, mapping.values(), context.empty_subset())
+        return (
+            true_subset,
+            [
+                AssetSubsetWithMetdata(subset, dict(metadata))
+                for metadata, subset in mapping.items()
+            ],
+        )
 
     @abstractmethod
     def evaluate_for_asset(
@@ -309,7 +331,7 @@ class MaterializeOnCronRule(
             missed_ticks.append(dt)
         return missed_ticks
 
-    def get_asset_partitions_to_request(
+    def get_new_asset_partitions_to_request(
         self, context: AssetAutomationConditionEvaluationContext
     ) -> AbstractSet[AssetKeyPartitionKey]:
         missed_ticks = self.missed_cron_ticks(context)
@@ -375,17 +397,15 @@ class MaterializeOnCronRule(
     def evaluate_for_asset(
         self, context: AssetAutomationConditionEvaluationContext
     ) -> RuleEvaluationResults:
-        asset_partitions_to_request = self.get_asset_partitions_to_request(context)
-        asset_partitions_by_evaluation_data = defaultdict(set)
-        if asset_partitions_to_request:
-            asset_partitions_by_evaluation_data[None].update(asset_partitions_to_request)
-
-        return self.add_evaluation_data_from_previous_tick(
-            context,
-            asset_partitions_by_evaluation_data,
-            should_use_past_data_fn=lambda ap: ap
-            not in context.materialized_requested_or_discarded_since_previous_tick_subset,
+        new_asset_partitions_to_request = self.get_new_asset_partitions_to_request(context)
+        asset_subset_to_request = AssetSubset.from_asset_partitions_set(
+            context.asset_key, context.partitions_def, new_asset_partitions_to_request
+        ) | (
+            context.previous_tick_true_subset
+            - context.materialized_requested_or_discarded_since_previous_tick_subset
         )
+
+        return asset_subset_to_request, []
 
 
 @whitelist_for_serdes
@@ -579,8 +599,7 @@ class MaterializeOnParentUpdatedRule(
         return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            should_use_past_data_fn=lambda ap: ap
-            not in context.materialized_requested_or_discarded_since_previous_tick_subset,
+            ignore_subset=context.materialized_requested_or_discarded_since_previous_tick_subset,
         )
 
 
@@ -601,8 +620,6 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
         previously discarded. Currently only applies to root asset partitions and asset partitions
         with updated parents.
         """
-        asset_partitions_by_evaluation_data = defaultdict(set)
-
         missing_asset_partitions = set(
             context.asset_context.never_materialized_requested_or_discarded_root_subset.asset_partitions
         )
@@ -614,15 +631,14 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
             ):
                 missing_asset_partitions |= {candidate}
 
-        if missing_asset_partitions:
-            asset_partitions_by_evaluation_data[None] = missing_asset_partitions
-
-        return self.add_evaluation_data_from_previous_tick(
-            context,
-            asset_partitions_by_evaluation_data,
-            should_use_past_data_fn=lambda ap: ap not in missing_asset_partitions
-            and ap not in context.materialized_requested_or_discarded_since_previous_tick_subset,
+        newly_missing_subset = AssetSubset.from_asset_partitions_set(
+            context.asset_key, context.partitions_def, missing_asset_partitions
         )
+        missing_subset = newly_missing_subset | (
+            context.previous_tick_true_subset
+            - context.materialized_requested_or_discarded_since_previous_tick_subset
+        )
+        return missing_subset, []
 
 
 @whitelist_for_serdes
@@ -668,7 +684,7 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
         return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            should_use_past_data_fn=lambda ap: ap not in subset_to_evaluate,
+            ignore_subset=subset_to_evaluate,
         )
 
 
@@ -717,7 +733,7 @@ class SkipOnParentMissingRule(AutoMaterializeRule, NamedTuple("_SkipOnParentMiss
         return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            should_use_past_data_fn=lambda ap: ap not in subset_to_evaluate,
+            ignore_subset=subset_to_evaluate,
         )
 
 
@@ -803,7 +819,7 @@ class SkipOnNotAllParentsUpdatedRule(
         return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            should_use_past_data_fn=lambda ap: ap not in subset_to_evaluate,
+            ignore_subset=subset_to_evaluate,
         )
 
 
@@ -845,7 +861,7 @@ class SkipOnRequiredButNonexistentParentsRule(
         return self.add_evaluation_data_from_previous_tick(
             context,
             asset_partitions_by_evaluation_data,
-            should_use_past_data_fn=lambda ap: ap not in subset_to_evaluate,
+            ignore_subset=subset_to_evaluate,
         )
 
 
@@ -873,14 +889,14 @@ class SkipOnBackfillInProgressRule(
         ).get_asset_subset(context.asset_key, context.asset_context.asset_graph)
 
         if backfilling_subset.size == 0:
-            return []
+            return context.empty_subset(), []
 
         if self.all_partitions:
             true_subset = context.candidate_subset
         else:
             true_subset = context.candidate_subset & backfilling_subset
 
-        return [(None, true_subset.asset_partitions)]
+        return true_subset, []
 
 
 @whitelist_for_serdes
@@ -905,6 +921,7 @@ class DiscardOnMaxMaterializationsExceededRule(
                 key=lambda x: sort_key_for_asset_partition(context.asset_graph, x),
             )[self.limit :]
         )
-        if rate_limited_asset_partitions:
-            return [(None, rate_limited_asset_partitions)]
-        return []
+
+        return AssetSubset.from_asset_partitions_set(
+            context.asset_key, context.partitions_def, rate_limited_asset_partitions
+        ), []


### PR DESCRIPTION
## Summary & Motivation

This continues work from further down the stack to make `ConditionEvaluation` the definitive object for tracking state in the condition evaluation path. This PR's main goal is to remove dependence on the weird AutoMaterializeRuleEvaluationData objects.

Currently have a few specific types of "rule evaluation data" which the UI knows how to display, and are serialized inside the AutoMaterializeAssetEvaluation. We want to move to a system where we can just attach generic metadata to any subset of asset partitions. So the north star here is for the evaluation of a particular condition to return two things: the set of partitions for which we've evaluated to `True`, and then a sequence of subsets that have extra metadata attached to them. In the current world, we attach metadata to a subset if and only if they are in the True subset, but this will not be the case in the future.

To further this goal, I create an AssetSubsetWithMetadata namedtuple, as this adds a bit more structure than just storing unnamed tuples of (asset_subset, metadata_mapping). However, we are not making any serialization changes yet, so we need to add some slightly gross backcompat to allow the internal logic to work with metadata mappings, but then convert them to one of the acceptable RuleEvaluationData formats, 

## How I Tested These Changes
