### PR TITLE
[ui] Don't show msec for elapsed time in most cases

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
@@ -82,30 +82,21 @@ const formatMsecMantissa = (msec: number) =>
     .slice(-4);
 
 /**
- * Opinionated elapsed time formatting:
- *
- * - Times between -10 and 10 seconds are shown as `X.XXXs`
- * - Otherwise times are rendered in a `X:XX:XX` format, without milliseconds
+ * Format the time without milliseconds, rounding to :01 for non-zero value within (-1, 1)
  */
-export const formatElapsedTime = (msec: number) => {
-  const {hours, minutes, seconds, milliseconds} = timeByParts(msec);
+export const formatElapsedTimeWithoutMsec = (msec: number) => {
+  const {hours, minutes, seconds} = timeByParts(msec);
   const negative = msec < 0;
-
-  if (msec < 10000 && msec > -10000) {
-    const formattedMsec = formatMsecMantissa(milliseconds);
-    return `${negative ? '-' : ''}${seconds}${formattedMsec}s`;
-  }
-
-  return `${negative ? '-' : ''}${hours}:${twoDigit(minutes)}:${twoDigit(seconds)}`;
+  const roundedSeconds = msec !== 0 && msec < 1000 && msec > -1000 ? 1 : seconds;
+  return `${negative ? '-' : ''}${hours}:${twoDigit(minutes)}:${twoDigit(roundedSeconds)}`;
 };
 
 export const formatElapsedTimeWithMsec = (msec: number) => {
   const {hours, minutes, seconds, milliseconds} = timeByParts(msec);
   const negative = msec < 0;
-  const positiveValue = `${hours}:${twoDigit(minutes)}:${twoDigit(seconds)}${formatMsecMantissa(
-    milliseconds,
-  )}`;
-  return `${negative ? '-' : ''}${positiveValue}`;
+  return `${negative ? '-' : ''}${hours}:${twoDigit(minutes)}:${twoDigit(
+    seconds,
+  )}${formatMsecMantissa(milliseconds)}`;
 };
 
 export function breakOnUnderscores(str: string) {

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/formatElapsedTime.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/formatElapsedTime.test.tsx
@@ -1,18 +1,24 @@
-import {formatElapsedTime, formatElapsedTimeWithMsec} from '../Util';
+import {formatElapsedTimeWithoutMsec, formatElapsedTimeWithMsec} from '../Util';
 
 describe('Elapsed time formatters', () => {
-  describe('formatElapsedTime', () => {
+  describe('formatElapsedTimeWithoutMsec', () => {
+    it('formats times between -1 and 1 seconds', () => {
+      expect(formatElapsedTimeWithoutMsec(0)).toBe('0:00:00');
+      expect(formatElapsedTimeWithoutMsec(1)).toBe('0:00:01');
+      expect(formatElapsedTimeWithoutMsec(500)).toBe('0:00:01');
+      expect(formatElapsedTimeWithoutMsec(-500)).toBe('-0:00:01');
+    });
+
     it('formats times under 10s', () => {
-      expect(formatElapsedTime(500)).toBe('0.500s');
-      expect(formatElapsedTime(5000)).toBe('5.000s');
-      expect(formatElapsedTime(-5250)).toBe('-5.250s');
+      expect(formatElapsedTimeWithoutMsec(5000)).toBe('0:00:05');
+      expect(formatElapsedTimeWithoutMsec(-5250)).toBe('-0:00:05');
     });
 
     it('formats times over 10s', () => {
-      expect(formatElapsedTime(50000)).toBe('0:00:50');
-      expect(formatElapsedTime(500000)).toBe('0:08:20');
-      expect(formatElapsedTime(-500000)).toBe('-0:08:20');
-      expect(formatElapsedTime(363599999)).toBe('100:59:59');
+      expect(formatElapsedTimeWithoutMsec(50000)).toBe('0:00:50');
+      expect(formatElapsedTimeWithoutMsec(500000)).toBe('0:08:20');
+      expect(formatElapsedTimeWithoutMsec(-500000)).toBe('-0:08:20');
+      expect(formatElapsedTimeWithoutMsec(363599999)).toBe('100:59:59');
     });
   });
 
@@ -39,9 +45,11 @@ describe('Elapsed time formatters', () => {
       jest.clearAllMocks();
     });
 
-    it('handles decimal correctly in `formatElapsedTime`', () => {
-      expect(formatElapsedTime(5000)).toBe('5,000s');
-      expect(formatElapsedTime(-5250)).toBe('-5,250s');
+    it('is unchanged in `formatElapsedTimeWithoutMsec`', () => {
+      expect(formatElapsedTimeWithoutMsec(0)).toBe('0:00:00');
+      expect(formatElapsedTimeWithoutMsec(1)).toBe('0:00:01');
+      expect(formatElapsedTimeWithoutMsec(500)).toBe('0:00:01');
+      expect(formatElapsedTimeWithoutMsec(-500)).toBe('-0:00:01');
     });
 
     it('handles decimal correctly in `formatElapsedTimeWithMsec`', () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/app/apolloLinks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/apolloLinks.tsx
@@ -1,6 +1,6 @@
 import {ApolloLink} from '@apollo/client';
 
-import {formatElapsedTime, debugLog} from './Util';
+import {debugLog, formatElapsedTimeWithMsec} from './Util';
 
 const getCalls = (response: any) => {
   try {
@@ -16,7 +16,7 @@ export const logLink = new ApolloLink((operation, forward) =>
     const elapsedTime = performance.now() - context.start;
     const calls = getCalls(context.response);
     operation.setContext({elapsedTime, calls});
-    debugLog(`${operation.operationName} took ${formatElapsedTime(elapsedTime)}`, {
+    debugLog(`${operation.operationName} took ${formatElapsedTimeWithMsec(elapsedTime)}`, {
       operation,
       data,
       calls,

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttChartTimescale.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttChartTimescale.tsx
@@ -11,7 +11,7 @@ import {
 import * as React from 'react';
 import styled from 'styled-components';
 
-import {formatElapsedTime} from '../app/Util';
+import {formatElapsedTimeWithoutMsec} from '../app/Util';
 
 import {CSS_DURATION, GanttViewport, LEFT_INSET} from './Constants';
 
@@ -21,11 +21,11 @@ const ONE_HOUR = 60 * 60 * 1000;
 // If we're zoomed in to second or minute resolution but showing large values,
 // switch to the "1:00:05" format used elsewhere in the Dagster UI.
 const subsecondResolutionLabel = (ms: number) =>
-  ms > 5 * ONE_MIN ? formatElapsedTime(ms) : `${(ms / 1000).toFixed(1)}s`;
+  ms > 5 * ONE_MIN ? formatElapsedTimeWithoutMsec(ms) : `${(ms / 1000).toFixed(1)}s`;
 const secondResolutionLabel = (ms: number) =>
-  ms > 5 * ONE_MIN ? formatElapsedTime(ms) : `${(ms / 1000).toFixed(0)}s`;
+  ms > 5 * ONE_MIN ? formatElapsedTimeWithoutMsec(ms) : `${(ms / 1000).toFixed(0)}s`;
 const minuteResolutionLabel = (ms: number) =>
-  ms > 59 * ONE_MIN ? formatElapsedTime(ms) : `${Math.round(ms / ONE_MIN)}m`;
+  ms > 59 * ONE_MIN ? formatElapsedTimeWithoutMsec(ms) : `${Math.round(ms / ONE_MIN)}m`;
 const hourResolutionLabel = (ms: number) => `${Math.round(ms / ONE_HOUR)}h`;
 
 // We want to gracefully transition the tick marks shown as you zoom, but it's
@@ -160,7 +160,7 @@ export const GanttChartTimescale = ({
               transform,
             }}
           >
-            {formatElapsedTime(highlightedMs[1]! - highlightedMs[0]!)}
+            {formatElapsedTimeWithoutMsec(highlightedMs[1]! - highlightedMs[0]!)}
           </div>
         )}
         {highlightedMs.map((ms, idx) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttStatusPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttStatusPanel.tsx
@@ -10,7 +10,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import {GraphQueryItem} from '../app/GraphQueryImpl';
-import {formatElapsedTime} from '../app/Util';
+import {formatElapsedTimeWithoutMsec} from '../app/Util';
 import {SidebarSection} from '../pipelines/SidebarComponents';
 import {IRunMetadataDict, IStepState} from '../runs/RunMetadataProvider';
 import {StepSelection} from '../runs/StepSelection';
@@ -197,7 +197,7 @@ const StepItem = ({
         />
       )}
       <StepLabel>{name}</StepLabel>
-      {step?.start && <Elapsed>{formatElapsedTime(end - step.start)}</Elapsed>}
+      {step?.start && <Elapsed>{formatElapsedTimeWithoutMsec(end - step.start)}</Elapsed>}
     </StepItemContainer>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
-import {formatElapsedTime} from '../app/Util';
+import {formatElapsedTimeWithoutMsec} from '../app/Util';
 import {Timestamp} from '../app/time/Timestamp';
 import {AssetDaemonTickFragment} from '../assets/auto-materialization/types/AssetDaemonTicksQuery.types';
 import {
@@ -194,7 +194,7 @@ export function TickDetailSummary({tick}: {tick: HistoryTickFragment | AssetDaem
           <Subtitle2>Duration</Subtitle2>
           <div>
             {tick?.endTimestamp
-              ? formatElapsedTime(tick.endTimestamp * 1000 - tick.timestamp * 1000)
+              ? formatElapsedTimeWithoutMsec(tick.endTimestamp * 1000 - tick.timestamp * 1000)
               : '\u2013'}
           </div>
         </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimingTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimingTags.tsx
@@ -1,7 +1,7 @@
 import {Box, Popover, Tag} from '@dagster-io/ui-components';
 import * as React from 'react';
 
-import {formatElapsedTime} from '../app/Util';
+import {formatElapsedTimeWithoutMsec} from '../app/Util';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 
 import {RunTimingDetails} from './RunTimingDetails';
@@ -48,7 +48,9 @@ export const RunTimingTags = ({loading, run}: {loading: boolean; run: RunTimingF
           <Tag icon="timer">
             <span style={{fontVariantNumeric: 'tabular-nums'}}>
               {run?.startTime
-                ? formatElapsedTime((run?.endTime * 1000 || Date.now()) - run?.startTime * 1000)
+                ? formatElapsedTimeWithoutMsec(
+                    (run?.endTime * 1000 || Date.now()) - run?.startTime * 1000,
+                  )
                 : '–'}
             </span>
           </Tag>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/TimeElapsed.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/TimeElapsed.tsx
@@ -1,7 +1,7 @@
 import {Group, Icon, colorTextLight} from '@dagster-io/ui-components';
 import * as React from 'react';
 
-import {formatElapsedTime} from '../app/Util';
+import {formatElapsedTimeWithoutMsec} from '../app/Util';
 
 export interface Props {
   startUnix: number | null;
@@ -44,7 +44,7 @@ export const TimeElapsed = (props: Props) => {
     <Group direction="row" spacing={4} alignItems="center">
       <Icon name="timer" color={colorTextLight()} />
       <span style={{fontVariantNumeric: 'tabular-nums'}}>
-        {startTime ? formatElapsedTime((endTime || Date.now()) - startTime) : '–'}
+        {startTime ? formatElapsedTimeWithoutMsec((endTime || Date.now()) - startTime) : '–'}
       </span>
     </Group>
   );


### PR DESCRIPTION
## Summary & Motivation

The <10s elapsed time display (x.xxxs) is inconsistent with other elapsed time displays (HH:MM:SS) and can lead to confusion.

- Remove the special ms rendering for <10s.
- Don't show msec at all in the majority of cases. If the value is between -1 and 1 and not zero, show `00:00:01`.
- Be clear about the purpose of the without-msec function.

## How I Tested These Changes

Jest
