### PR TITLE
[amp-refactor][1/n] Update context objects

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_automation_condition_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_automation_condition_context.py
@@ -1,0 +1,319 @@
+import datetime
+import functools
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, AbstractSet, Mapping, Optional
+
+from dagster._core.definitions.auto_materialize_rule_evaluation import RuleEvaluationResults
+from dagster._core.definitions.data_time import CachingDataTimeResolver
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.partition import PartitionsDefinition
+from dagster._core.definitions.partition_mapping import IdentityPartitionMapping
+from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
+from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
+
+from .asset_daemon_cursor import AssetDaemonAssetCursor
+from .asset_graph import AssetGraph
+from .asset_subset import AssetSubset
+
+if TYPE_CHECKING:
+    from .asset_automation_evaluator import AutomationCondition, ConditionEvaluation
+    from .asset_daemon_context import AssetDaemonContext
+
+
+@dataclass(frozen=True)
+class AssetAutomationEvaluationContext:
+    """Context object containing methods and properties used for evaluating the entire state of an
+    asset's automation rules.
+    """
+
+    asset_key: AssetKey
+    asset_cursor: Optional[AssetDaemonAssetCursor]
+    root_condition: "AutomationCondition"
+
+    instance_queryer: CachingInstanceQueryer
+    data_time_resolver: CachingDataTimeResolver
+    daemon_context: "AssetDaemonContext"
+
+    evaluation_results_by_key: Mapping[AssetKey, "ConditionEvaluation"]
+    expected_data_time_mapping: Mapping[AssetKey, Optional[datetime.datetime]]
+
+    @property
+    def asset_graph(self) -> AssetGraph:
+        return self.instance_queryer.asset_graph
+
+    @property
+    def partitions_def(self) -> Optional[PartitionsDefinition]:
+        return self.asset_graph.get_partitions_def(self.asset_key)
+
+    @property
+    def evaluation_time(self) -> datetime.datetime:
+        """Returns the time at which this rule is being evaluated."""
+        return self.instance_queryer.evaluation_time
+
+    @functools.cached_property
+    def latest_evaluation(self) -> Optional["ConditionEvaluation"]:
+        if not self.asset_cursor:
+            return None
+        return self.asset_cursor.latest_evaluation
+
+    @functools.cached_property
+    def parent_will_update_subset(self) -> AssetSubset:
+        """Returns the set of asset partitions whose parents will be updated on this tick, and which
+        can be materialized in the same run as this asset.
+        """
+        subset = self.empty_subset()
+        for parent_key in self.asset_graph.get_parents(self.asset_key):
+            if not self.materializable_in_same_run(self.asset_key, parent_key):
+                continue
+            parent_result = self.evaluation_results_by_key.get(parent_key)
+            if not parent_result:
+                continue
+            parent_subset = parent_result.true_subset
+            subset |= parent_subset._replace(asset_key=self.asset_key)
+        return subset
+
+    @property
+    def previous_tick_requested_subset(self) -> AssetSubset:
+        """Returns the set of asset partitions that were requested on the previous tick."""
+        if not self.latest_evaluation:
+            return self.empty_subset()
+        return self.latest_evaluation.true_subset
+
+    @functools.cached_property
+    def materialized_since_previous_tick_subset(self) -> AssetSubset:
+        """Returns the set of asset partitions that were materialized since the previous tick."""
+        return AssetSubset.from_asset_partitions_set(
+            self.asset_key,
+            self.partitions_def,
+            self.instance_queryer.get_asset_partitions_updated_after_cursor(
+                self.asset_key,
+                asset_partitions=None,
+                after_cursor=self.asset_cursor.latest_storage_id if self.asset_cursor else None,
+                respect_materialization_data_versions=False,
+            ),
+        )
+
+    @functools.cached_property
+    def materialized_requested_or_discarded_since_previous_tick_subset(self) -> AssetSubset:
+        """Returns the set of asset partitions that were materialized since the previous tick."""
+        if not self.latest_evaluation:
+            return self.materialized_since_previous_tick_subset
+        return (
+            self.materialized_since_previous_tick_subset
+            | self.latest_evaluation.true_subset
+            | (self.latest_evaluation.discard_subset or self.empty_subset())
+        )
+
+    @functools.cached_property
+    def never_materialized_requested_or_discarded_root_subset(self) -> AssetSubset:
+        if self.asset_key not in self.asset_graph.root_materializable_or_observable_asset_keys:
+            return self.empty_subset()
+
+        handled_subset = (
+            self.asset_cursor.materialized_requested_or_discarded_subset
+            if self.asset_cursor
+            else self.empty_subset()
+        )
+        unhandled_subset = handled_subset.inverse(
+            self.partitions_def,
+            dynamic_partitions_store=self.instance_queryer,
+            current_time=self.evaluation_time,
+        )
+        return unhandled_subset - self.materialized_since_previous_tick_subset
+
+    def materializable_in_same_run(self, child_key: AssetKey, parent_key: AssetKey) -> bool:
+        """Returns whether a child asset can be materialized in the same run as a parent asset."""
+        from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+
+        return (
+            # both assets must be materializable
+            child_key in self.asset_graph.materializable_asset_keys
+            and parent_key in self.asset_graph.materializable_asset_keys
+            # the parent must have the same partitioning
+            and self.asset_graph.have_same_partitioning(child_key, parent_key)
+            # the parent must have a simple partition mapping to the child
+            and (
+                not self.asset_graph.is_partitioned(parent_key)
+                or isinstance(
+                    self.asset_graph.get_partition_mapping(child_key, parent_key),
+                    (TimeWindowPartitionMapping, IdentityPartitionMapping),
+                )
+            )
+            # the parent must be in the same repository to be materialized alongside the candidate
+            and (
+                not isinstance(self.asset_graph, ExternalAssetGraph)
+                or self.asset_graph.get_repository_handle(child_key)
+                == self.asset_graph.get_repository_handle(parent_key)
+            )
+        )
+
+    def get_parents_that_will_not_be_materialized_on_current_tick(
+        self, *, asset_partition: AssetKeyPartitionKey
+    ) -> AbstractSet[AssetKeyPartitionKey]:
+        """Returns the set of parent asset partitions that will not be updated in the same run of
+        this asset partition if a run is launched for this asset partition on this tick.
+        """
+        return {
+            parent
+            for parent in self.asset_graph.get_parents_partitions(
+                dynamic_partitions_store=self.instance_queryer,
+                current_time=self.instance_queryer.evaluation_time,
+                asset_key=asset_partition.asset_key,
+                partition_key=asset_partition.partition_key,
+            ).parent_partitions
+            if not self.will_update_asset_partition(parent)
+            or not self.materializable_in_same_run(asset_partition.asset_key, parent.asset_key)
+        }
+
+    def will_update_asset_partition(self, asset_partition: AssetKeyPartitionKey) -> bool:
+        parent_evaluation = self.evaluation_results_by_key.get(asset_partition.asset_key)
+        if not parent_evaluation:
+            return False
+        return asset_partition in parent_evaluation.true_subset
+
+    def empty_subset(self) -> AssetSubset:
+        return AssetSubset.empty(self.asset_key, self.partitions_def)
+
+    def get_root_condition_context(self) -> "AssetAutomationConditionEvaluationContext":
+        return AssetAutomationConditionEvaluationContext(
+            asset_context=self,
+            condition=self.root_condition,
+            candidate_subset=AssetSubset.all(
+                asset_key=self.asset_key,
+                partitions_def=self.partitions_def,
+                dynamic_partitions_store=self.instance_queryer,
+                current_time=self.instance_queryer.evaluation_time,
+            ),
+            latest_evaluation=self.latest_evaluation,
+        )
+
+    def get_new_asset_cursor(self, evaluation: "ConditionEvaluation") -> AssetDaemonAssetCursor:
+        """Returns a new AssetDaemonAssetCursor based on the current cursor and the results of
+        this tick's evaluation.
+        """
+        previous_handled_subset = (
+            self.asset_cursor.materialized_requested_or_discarded_subset
+            if self.asset_cursor
+            else self.empty_subset()
+        )
+        new_handled_subset = (
+            previous_handled_subset
+            | self.materialized_requested_or_discarded_since_previous_tick_subset
+            | evaluation.true_subset
+            | (evaluation.discard_subset or self.empty_subset())
+        )
+        return AssetDaemonAssetCursor(
+            asset_key=self.asset_key,
+            latest_storage_id=self.daemon_context.get_new_latest_storage_id(),
+            latest_evaluation=evaluation,
+            latest_evaluation_timestamp=self.evaluation_time.timestamp(),
+            materialized_requested_or_discarded_subset=new_handled_subset,
+        )
+
+
+@dataclass(frozen=True)
+class AssetAutomationConditionEvaluationContext:
+    """Context object containing methods and properties used for evaluating a particular AutomationCondition."""
+
+    asset_context: AssetAutomationEvaluationContext
+    condition: "AutomationCondition"
+    candidate_subset: AssetSubset
+    latest_evaluation: Optional["ConditionEvaluation"]
+
+    @property
+    def asset_key(self) -> AssetKey:
+        return self.asset_context.asset_key
+
+    @property
+    def partitions_def(self) -> Optional[PartitionsDefinition]:
+        return self.asset_context.partitions_def
+
+    @property
+    def asset_cursor(self) -> Optional[AssetDaemonAssetCursor]:
+        return self.asset_context.asset_cursor
+
+    @property
+    def asset_graph(self) -> AssetGraph:
+        return self.asset_context.asset_graph
+
+    @property
+    def instance_queryer(self) -> CachingInstanceQueryer:
+        return self.asset_context.instance_queryer
+
+    @property
+    def max_storage_id(self) -> Optional[int]:
+        return self.asset_cursor.latest_storage_id if self.asset_cursor else None
+
+    @property
+    def latest_evaluation_timestamp(self) -> Optional[float]:
+        return self.asset_cursor.latest_evaluation_timestamp if self.asset_cursor else None
+
+    @property
+    def previous_tick_true_subset(self) -> AssetSubset:
+        """Returns the set of asset partitions that were true on the previous tick."""
+        if not self.latest_evaluation:
+            return self.empty_subset()
+        return self.latest_evaluation.true_subset
+
+    @property
+    def parent_has_updated_subset(self) -> AssetSubset:
+        """Returns the set of asset partitions whose parents have updated since the last time this
+        condition was evaluated.
+        """
+        return AssetSubset.from_asset_partitions_set(
+            self.asset_key,
+            self.partitions_def,
+            self.asset_context.instance_queryer.asset_partitions_with_newly_updated_parents(
+                latest_storage_id=self.max_storage_id,
+                child_asset_key=self.asset_context.asset_key,
+                map_old_time_partitions=False,
+            ),
+        )
+
+    @property
+    def candidate_parent_has_or_will_update_subset(self) -> AssetSubset:
+        """Returns the set of candidates for this tick which have parents that have updated since
+        the previous tick, or will update on this tick.
+        """
+        return self.candidate_subset & (
+            self.parent_has_updated_subset | self.asset_context.parent_will_update_subset
+        )
+
+    @property
+    def candidates_not_evaluated_on_previous_tick_subset(self) -> AssetSubset:
+        """Returns the set of candidates for this tick which were not candidates on the previous
+        tick.
+        """
+        if not self.latest_evaluation:
+            return self.candidate_subset
+        return self.candidate_subset - self.latest_evaluation.candidate_subset
+
+    @property
+    def materialized_since_previous_tick_subset(self) -> AssetSubset:
+        """Returns the set of asset partitions that were materialized since the previous tick."""
+        return self.asset_context.materialized_since_previous_tick_subset
+
+    @property
+    def materialized_requested_or_discarded_since_previous_tick_subset(self) -> AssetSubset:
+        """Returns the set of asset partitions that were materialized since the previous tick."""
+        return self.asset_context.materialized_requested_or_discarded_since_previous_tick_subset
+
+    @property
+    def previous_tick_results(self) -> RuleEvaluationResults:
+        """Returns the RuleEvaluationResults calculated on the previous tick for this condition."""
+        return self.latest_evaluation.results if self.latest_evaluation else []
+
+    def empty_subset(self) -> AssetSubset:
+        return self.asset_context.empty_subset()
+
+    def for_child(
+        self, condition: "AutomationCondition", candidate_subset: AssetSubset
+    ) -> "AssetAutomationConditionEvaluationContext":
+        return AssetAutomationConditionEvaluationContext(
+            asset_context=self.asset_context,
+            condition=condition,
+            candidate_subset=candidate_subset,
+            latest_evaluation=self.latest_evaluation.for_child(condition)
+            if self.latest_evaluation
+            else None,
+        )

--- a/python_modules/dagster/dagster/_core/definitions/asset_automation_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_automation_evaluator.py
@@ -1,24 +1,27 @@
+import dataclasses
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, AbstractSet, List, NamedTuple, Optional, Sequence, Tuple
 
+import dagster._check as check
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonAssetCursor
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 
-from .asset_subset import AssetSubset
-from .auto_materialize_rule import (
-    DiscardOnMaxMaterializationsExceededRule,
-    RuleEvaluationContext,
-    RuleEvaluationResults,
+from .asset_automation_condition_context import (
+    AssetAutomationConditionEvaluationContext,
+    AssetAutomationEvaluationContext,
 )
+from .asset_subset import AssetSubset
 from .auto_materialize_rule_evaluation import (
     AutoMaterializeAssetEvaluation,
+    AutoMaterializeDecisionType,
     AutoMaterializeRuleEvaluation,
 )
 
 if TYPE_CHECKING:
     from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
+
+    from .auto_materialize_rule import AutoMaterializeRule, RuleEvaluationResults
 
 
 class ConditionEvaluation(NamedTuple):
@@ -26,8 +29,16 @@ class ConditionEvaluation(NamedTuple):
 
     condition: "AutomationCondition"
     true_subset: AssetSubset
-    results: RuleEvaluationResults = []
-    children: Sequence["ConditionEvaluation"] = []
+    candidate_subset: AssetSubset
+
+    results: "RuleEvaluationResults" = []
+    child_evaluations: Sequence["ConditionEvaluation"] = []
+
+    # backcompat until we remove the discard concept
+    discard_subset: Optional[AssetSubset] = None
+    discard_results: Sequence[
+        Tuple[AutoMaterializeRuleEvaluation, AbstractSet[AssetKeyPartitionKey]]
+    ] = []
 
     @property
     def all_results(
@@ -49,32 +60,124 @@ class ConditionEvaluation(NamedTuple):
             ]
         else:
             results = []
-        for child in self.children:
+        for child in self.child_evaluations:
             results = [*results, *child.all_results]
         return results
+
+    def for_child(self, child_condition: "AutomationCondition") -> Optional["ConditionEvaluation"]:
+        """Returns the evaluation of a given child condition."""
+        for child_evaluation in self.child_evaluations:
+            if child_evaluation.condition == child_condition:
+                return child_evaluation
+        return None
 
     def to_evaluation(
         self,
         asset_key: AssetKey,
         asset_graph: AssetGraph,
         instance_queryer: "CachingInstanceQueryer",
-        to_discard: AssetSubset,
-        discard_results: Sequence[
-            Tuple[AutoMaterializeRuleEvaluation, AbstractSet[AssetKeyPartitionKey]]
-        ],
-        skipped_subset_size: int,
     ) -> AutoMaterializeAssetEvaluation:
         """This method is a placeholder to allow us to convert this into a shape that other parts
         of the system understand.
         """
+        # backcompat way to calculate the set of skipped partitions for legacy policies
+        if self.condition.is_legacy and len(self.child_evaluations) == 2:
+            # the first child is the materialize condition, the second child is the negation of
+            # the skip condition
+            _, nor_skip_evaluation = self.child_evaluations
+            skip_evaluation = nor_skip_evaluation.child_evaluations[0]
+            skipped_subset_size = skip_evaluation.true_subset.size
+        else:
+            skipped_subset_size = 0
+
+        discard_subset = self.discard_subset or AssetSubset.empty(
+            asset_key, asset_graph.get_partitions_def(asset_key)
+        )
+
         return AutoMaterializeAssetEvaluation.from_rule_evaluation_results(
             asset_key=asset_key,
             asset_graph=asset_graph,
-            asset_partitions_by_rule_evaluation=[*self.all_results, *discard_results],
-            num_requested=(self.true_subset - to_discard).size,
+            asset_partitions_by_rule_evaluation=[*self.all_results, *self.discard_results],
+            num_requested=(self.true_subset - discard_subset).size,
             num_skipped=skipped_subset_size,
-            num_discarded=to_discard.size,
+            num_discarded=discard_subset.size,
             dynamic_partitions_store=instance_queryer,
+        )
+
+    @staticmethod
+    def from_evaluation_and_rule(
+        evaluation: AutoMaterializeAssetEvaluation,
+        asset_graph: AssetGraph,
+        rule: "AutoMaterializeRule",
+    ) -> "ConditionEvaluation":
+        asset_key = evaluation.asset_key
+        partitions_def = asset_graph.get_partitions_def(asset_key)
+        empty_subset = AssetSubset.empty(asset_key, partitions_def)
+        return ConditionEvaluation(
+            condition=RuleCondition(rule=rule),
+            true_subset=empty_subset,
+            candidate_subset=empty_subset
+            if rule.decision_type == AutoMaterializeDecisionType.MATERIALIZE
+            else evaluation.get_evaluated_subset(asset_graph),
+            discard_subset=empty_subset,
+            results=evaluation.get_rule_evaluation_results(rule.to_snapshot(), asset_graph),
+        )
+
+    @staticmethod
+    def from_evaluation(
+        condition: "AutomationCondition",
+        evaluation: Optional[AutoMaterializeAssetEvaluation],
+        asset_graph: AssetGraph,
+    ) -> Optional["ConditionEvaluation"]:
+        """This method is a placeholder to allow us to convert the serialized objects the system
+        uses into a more-convenient internal representation.
+        """
+        if not condition.is_legacy or not evaluation:
+            return None
+
+        asset_key = evaluation.asset_key
+        partitions_def = asset_graph.get_partitions_def(asset_key)
+        empty_subset = AssetSubset.empty(asset_key, partitions_def)
+
+        materialize_condition, skip_condition = condition.children
+        materialize_rules = [
+            materialize_condition.rule
+            for materialize_condition in materialize_condition.children
+            if isinstance(materialize_condition, RuleCondition)
+            and materialize_condition.rule.to_snapshot() in (evaluation.rule_snapshots or set())
+        ]
+        skip_rules = [
+            skip_condition.rule
+            for skip_condition in skip_condition.children
+            if isinstance(skip_condition, RuleCondition)
+            and skip_condition.rule.to_snapshot() in (evaluation.rule_snapshots or set())
+        ]
+        children = [
+            ConditionEvaluation(
+                condition=materialize_condition,
+                true_subset=empty_subset,
+                candidate_subset=empty_subset,
+                child_evaluations=[
+                    ConditionEvaluation.from_evaluation_and_rule(evaluation, asset_graph, rule)
+                    for rule in materialize_rules
+                ],
+            ),
+            ConditionEvaluation(
+                condition=skip_condition,
+                true_subset=empty_subset,
+                candidate_subset=empty_subset,
+                child_evaluations=[
+                    ConditionEvaluation.from_evaluation_and_rule(evaluation, asset_graph, rule)
+                    for rule in skip_rules
+                ],
+            ),
+        ]
+        return ConditionEvaluation(
+            condition=condition,
+            true_subset=evaluation.get_requested_subset(asset_graph),
+            discard_subset=evaluation.get_discarded_subset(asset_graph),
+            candidate_subset=empty_subset,
+            child_evaluations=children,
         )
 
 
@@ -84,8 +187,12 @@ class AutomationCondition(ABC):
     new conditions using the `&` (and), `|` (or), and `~` (not) operators.
     """
 
+    @property
+    def children(self) -> Sequence["AutomationCondition"]:
+        return []
+
     @abstractmethod
-    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+    def evaluate(self, context: AssetAutomationConditionEvaluationContext) -> ConditionEvaluation:
         raise NotImplementedError()
 
     def __and__(self, other: "AutomationCondition") -> "AutomationCondition":
@@ -101,85 +208,120 @@ class AutomationCondition(ABC):
         return OrAutomationCondition(children=[self, other])
 
     def __invert__(self) -> "AutomationCondition":
-        # convert a negated OrAutomationCondition into a NorAutomationCondition
-        if isinstance(self, OrAutomationCondition):
-            return NorAutomationCondition(children=self.children)
-        # convert a negated NorAutomationCondition into an OrAutomationCondition
-        elif isinstance(self, NorAutomationCondition):
-            return OrAutomationCondition(children=self.children)
-        return NorAutomationCondition(children=[self])
+        return NotAutomationCondition(children=[self])
+
+    @property
+    def is_legacy(self) -> bool:
+        """Returns if this condition is in the legacy format. This is used to determine if we can
+        do certain types of backwards-compatible operations on it.
+        """
+        return (
+            isinstance(self, AndAutomationCondition)
+            and len(self.children) == 2
+            and isinstance(self.children[0], OrAutomationCondition)
+            and isinstance(self.children[1], NotAutomationCondition)
+        )
 
 
 class RuleCondition(
-    AutomationCondition, NamedTuple("_RuleCondition", [("rule", AutoMaterializeRule)])
+    NamedTuple("_RuleCondition", [("rule", "AutoMaterializeRule")]),
+    AutomationCondition,
 ):
     """This class represents the condition that a particular AutoMaterializeRule is satisfied."""
 
-    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
-        context.daemon_context._verbose_log_fn(f"Evaluating rule: {self.rule.to_snapshot()}")  # noqa
+    def evaluate(self, context: AssetAutomationConditionEvaluationContext) -> ConditionEvaluation:
+        context.asset_context.daemon_context._verbose_log_fn(  # noqa
+            f"Evaluating rule: {self.rule.to_snapshot()}"
+        )
         results = self.rule.evaluate_for_asset(context)
         true_subset = context.empty_subset()
         for _, asset_partitions in results:
             true_subset |= AssetSubset.from_asset_partitions_set(
                 context.asset_key, context.partitions_def, asset_partitions
             )
-        context.daemon_context._verbose_log_fn(f"Rule returned {true_subset.size} partitions")  # noqa
-        return ConditionEvaluation(condition=self, true_subset=true_subset, results=results)
+        context.asset_context.daemon_context._verbose_log_fn(  # noqa
+            f"Rule returned {true_subset.size} partitions"
+        )
+        return ConditionEvaluation(
+            condition=self,
+            true_subset=true_subset,
+            candidate_subset=context.candidate_subset,
+            results=results,
+        )
 
 
 class AndAutomationCondition(
-    AutomationCondition,
     NamedTuple("_AndAutomationCondition", [("children", Sequence[AutomationCondition])]),
+    AutomationCondition,
 ):
     """This class represents the condition that all of its children evaluate to true."""
 
-    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+    def evaluate(self, context: AssetAutomationConditionEvaluationContext) -> ConditionEvaluation:
         child_evaluations: List[ConditionEvaluation] = []
         true_subset = context.candidate_subset
         for child in self.children:
-            context = context.with_candidate_subset(true_subset)
-            result = child.evaluate(context)
+            child_context = context.for_child(condition=child, candidate_subset=true_subset)
+            result = child.evaluate(child_context)
             child_evaluations.append(result)
             true_subset &= result.true_subset
         return ConditionEvaluation(
-            condition=self, true_subset=true_subset, children=child_evaluations
+            condition=self,
+            true_subset=true_subset,
+            candidate_subset=context.candidate_subset,
+            child_evaluations=child_evaluations,
         )
 
 
 class OrAutomationCondition(
-    AutomationCondition,
     NamedTuple("_OrAutomationCondition", [("children", Sequence[AutomationCondition])]),
+    AutomationCondition,
 ):
     """This class represents the condition that any of its children evaluate to true."""
 
-    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
+    def evaluate(self, context: AssetAutomationConditionEvaluationContext) -> ConditionEvaluation:
         child_evaluations: List[ConditionEvaluation] = []
         true_subset = context.empty_subset()
         for child in self.children:
-            result = child.evaluate(context)
+            child_context = context.for_child(
+                condition=child, candidate_subset=context.candidate_subset
+            )
+            result = child.evaluate(child_context)
             child_evaluations.append(result)
             true_subset |= result.true_subset
         return ConditionEvaluation(
-            condition=self, true_subset=true_subset, children=child_evaluations
+            condition=self,
+            true_subset=true_subset,
+            candidate_subset=context.candidate_subset,
+            child_evaluations=child_evaluations,
         )
 
 
-class NorAutomationCondition(
+class NotAutomationCondition(
+    NamedTuple("_NotAutomationCondition", [("children", Sequence[AutomationCondition])]),
     AutomationCondition,
-    NamedTuple("_NorAutomationCondition", [("children", Sequence[AutomationCondition])]),
 ):
     """This class represents the condition that none of its children evaluate to true."""
 
-    def evaluate(self, context: RuleEvaluationContext) -> ConditionEvaluation:
-        child_evaluations: List[ConditionEvaluation] = []
-        true_subset = context.candidate_subset
-        for child in self.children:
-            context = context.with_candidate_subset(true_subset)
-            result = child.evaluate(context)
-            child_evaluations.append(result)
-            true_subset -= result.true_subset
+    def __new__(cls, children: Sequence[AutomationCondition]):
+        check.invariant(len(children) == 1)
+        return super().__new__(cls, children)
+
+    @property
+    def child(self) -> AutomationCondition:
+        return self.children[0]
+
+    def evaluate(self, context: AssetAutomationConditionEvaluationContext) -> ConditionEvaluation:
+        child_context = context.for_child(
+            condition=self.child, candidate_subset=context.candidate_subset
+        )
+        result = self.child.evaluate(child_context)
+        true_subset = context.candidate_subset - result.true_subset
+
         return ConditionEvaluation(
-            condition=self, true_subset=true_subset, children=child_evaluations
+            condition=self,
+            true_subset=true_subset,
+            candidate_subset=context.candidate_subset,
+            child_evaluations=[result],
         )
 
 
@@ -192,67 +334,45 @@ class AssetAutomationEvaluator(NamedTuple):
     max_materializations_per_minute: Optional[int] = 1
 
     def evaluate(
-        self, context: RuleEvaluationContext, report_num_skipped: bool
-    ) -> Tuple[
-        AutoMaterializeAssetEvaluation,
-        AssetDaemonAssetCursor,
-        AbstractSet[AssetKeyPartitionKey],
-    ]:
+        self, context: AssetAutomationEvaluationContext
+    ) -> Tuple[ConditionEvaluation, AssetDaemonAssetCursor]:
         """Evaluates the auto materialize policy of a given asset.
 
         Returns:
-        - An AutoMaterializeAssetEvaluation object representing serializable information about
-        this evaluation. If `report_num_skipped` is set to `True`, then this will attempt to
-        calculate the number of skipped partitions in a backwards-compatible way. This can only be
-        done for policies that are in the format `(a | b | ...) & ~(c | d | ...).
-        - The set of AssetKeyPartitionKeys that should be materialized.
-        - The set of AssetKeyPartitionKeys that should be discarded.
+        - A ConditionEvaluation object representing information about this evaluation. If
+        `report_num_skipped` is set to `True`, then this will attempt to calculate the number of
+        skipped partitions in a backwards-compatible way. This can only be done for policies that
+        are in the format `(a | b | ...) & ~(c | d | ...).
+        - A new AssetDaemonAssetCursor that represents the state of the world after this evaluation.
         """
-        condition_evaluation = self.condition.evaluate(context)
+        from .auto_materialize_rule import DiscardOnMaxMaterializationsExceededRule
+
+        condition_context = context.get_root_condition_context()
+        condition_evaluation = self.condition.evaluate(condition_context)
 
         # this is treated separately from other rules, for now
-        to_discard, discard_results = context.empty_subset(), []
+        discard_subset = context.empty_subset()
+        discard_results = []
         if self.max_materializations_per_minute is not None:
-            discard_context = context.with_candidate_subset(condition_evaluation.true_subset)
-            condition = RuleCondition(
-                DiscardOnMaxMaterializationsExceededRule(limit=self.max_materializations_per_minute)
+            discard_context = dataclasses.replace(
+                condition_context, candidate_subset=condition_evaluation.true_subset
             )
+            discard_rule = DiscardOnMaxMaterializationsExceededRule(
+                limit=self.max_materializations_per_minute
+            )
+            condition = RuleCondition(discard_rule)
             discard_condition_evaluation = condition.evaluate(discard_context)
-            to_discard = discard_condition_evaluation.true_subset
-            discard_results = discard_condition_evaluation.all_results
-
-        to_materialize = condition_evaluation.true_subset - to_discard
-
-        skipped_subset_size = 0
-        if (
-            report_num_skipped
-            # check shape of top-level condition
-            and isinstance(self.condition, AndAutomationCondition)
-            and len(self.condition.children) == 2
-            and isinstance(self.condition.children[1], NorAutomationCondition)
-            # confirm shape of evaluation
-            and len(condition_evaluation.children) == 2
-        ):
-            # the first child is the materialize condition, the second child is the skip_condition
-            materialize_condition, skip_evaluation = condition_evaluation.children
-            skipped_subset_size = (
-                materialize_condition.true_subset.size - skip_evaluation.true_subset.size
-            )
+            discard_subset = discard_condition_evaluation.true_subset
+            discard_results = [
+                (AutoMaterializeRuleEvaluation(discard_rule.to_snapshot(), evaluation_data), aps)
+                for evaluation_data, aps in discard_condition_evaluation.results
+            ]
 
         return (
-            condition_evaluation.to_evaluation(
-                context.asset_key,
-                context.asset_graph,
-                context.instance_queryer,
-                to_discard,
-                discard_results,
-                skipped_subset_size=skipped_subset_size,
+            condition_evaluation._replace(
+                true_subset=condition_evaluation.true_subset - discard_subset,
+                discard_subset=discard_subset,
+                discard_results=discard_results,
             ),
-            context.cursor.with_updates(
-                asset_graph=context.asset_graph,
-                newly_materialized_subset=context.newly_materialized_root_subset,
-                requested_asset_partitions=to_materialize.asset_partitions,
-                discarded_asset_partitions=to_discard.asset_partitions,
-            ),
-            to_materialize.asset_partitions,
+            context.get_new_asset_cursor(evaluation=condition_evaluation),
         )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/basic_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/basic_scenarios.py
@@ -74,7 +74,7 @@ basic_scenarios = {
             unevaluated_runs=[run(["asset1", "asset2", "asset3", "asset4", "asset5", "asset6"])],
         ),
         # don't need to run asset4 for reconciliation but asset4 must run when asset3 does
-        expected_run_requests=[run_request(asset_keys=["asset3", "asset4", "asset5", "asset6"])],
+        expected_run_requests=[run_request(asset_keys=["asset3", "asset4", "asset5"])],
     ),
     "multi_asset_in_middle_single_parent_rematerialized_subsettable": AssetReconciliationScenario(
         assets=multi_asset_in_middle_subsettable,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/freshness_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/freshness_policy_scenarios.py
@@ -6,10 +6,8 @@ from dagster import (
 )
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    ParentUpdatedRuleEvaluationData,
     TextRuleEvaluationData,
 )
-from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 
 from ..base_scenario import (
@@ -72,33 +70,12 @@ freshness_policy_scenarios = {
         unevaluated_runs=[run([f"asset{i}" for i in range(1, 6)])],
         evaluation_delta=datetime.timedelta(minutes=35),
         # need to run assets 1, 2 and 3 as they're all part of the same non-subsettable multi asset
-        # need to run asset 4 as it eagerly updates after asset 1
-        expected_run_requests=[
-            run_request(asset_keys=["asset1", "asset2", "asset3", "asset4", "asset5"])
-        ],
+        expected_run_requests=[run_request(asset_keys=["asset1", "asset2", "asset3", "asset5"])],
         expected_evaluations=[
-            AssetEvaluationSpec.from_single_rule(
-                "asset1",
-                AutoMaterializeRule.materialize_on_required_for_freshness(),
-                TextRuleEvaluationData("Required by downstream asset's policy"),
-            ),
             AssetEvaluationSpec.from_single_rule(
                 "asset2",
                 AutoMaterializeRule.materialize_on_required_for_freshness(),
                 TextRuleEvaluationData("Required by downstream asset's policy"),
-            ),
-            AssetEvaluationSpec.from_single_rule(
-                "asset3",
-                AutoMaterializeRule.materialize_on_required_for_freshness(),
-                TextRuleEvaluationData("Required by downstream asset's policy"),
-            ),
-            AssetEvaluationSpec.from_single_rule(
-                "asset4",
-                AutoMaterializeRule.materialize_on_parent_updated(),
-                ParentUpdatedRuleEvaluationData(
-                    updated_asset_keys=frozenset(),
-                    will_update_asset_keys=frozenset([AssetKey("asset1")]),
-                ),
             ),
             AssetEvaluationSpec.from_single_rule(
                 "asset5",

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/basic_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/basic_scenarios.py
@@ -53,7 +53,8 @@ basic_scenarios = [
                     ParentUpdatedRuleEvaluationData,
                     updated_asset_keys=set(),
                     will_update_asset_keys={"A"},
-                )
+                ),
+                AssetRuleEvaluationSpec(rule=AutoMaterializeRule.materialize_on_missing()),
             ],
         ),
     ),

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
@@ -660,7 +660,8 @@ partition_scenarios = [
         .evaluate_tick()
         .assert_requested_runs(
             run_request(
-                ["C"], partition_key=day_partition_key(time_partitions_start_datetime, delta=1)
+                ["C"],
+                partition_key=day_partition_key(time_partitions_start_datetime, delta=1),
             )
         )
         # new day's partition is filled in, should still be able to materialize the new partition
@@ -669,7 +670,7 @@ partition_scenarios = [
         .with_runs(
             run_request(
                 ["A"], partition_key=day_partition_key(time_partitions_start_datetime, delta=3)
-            )
+            ),
         )
         .evaluate_tick()
         .assert_requested_runs(


### PR DESCRIPTION
## Summary & Motivation

This PR breaks up the original RuleEvaluationContext into two pieces:

- AssetAutomationEvaluationContext: A context object that contains methods and properties which are static across all individual conditions
- AssetAutomationConditionEvaluationContext: A context object that contains methods and properties which are specific to an individual condition

This also updates the AssetDaemonAssetCursor object to work purely in terms of the ConditionEvaluation object, rather than the (soon-to-be deprecated) AutoMaterializeAssetEvaluation object.

In order to do this without changing any serialized information, we have to add this somewhat nasty conversion logic to convert the serialized "latest evaluation" into a ConditionEvaluation, then convert the ConditionEvaluation back into an AutoMaterializeAssetEvaluation before it gets stored.

## How I Tested These Changes
