### PR TITLE
[amp-refactor][4/n] AssetAutomationCondition -> AssetCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -27,7 +27,7 @@ from .asset_subset import AssetSubset
 from .partition import PartitionsSubset
 
 if TYPE_CHECKING:
-    from .asset_automation_evaluator import ConditionEvaluation
+    from .asset_condition import AssetConditionEvaluation
 
 
 class AssetDaemonAssetCursor(NamedTuple):
@@ -38,7 +38,7 @@ class AssetDaemonAssetCursor(NamedTuple):
     asset_key: AssetKey
     latest_storage_id: Optional[int]
     latest_evaluation_timestamp: Optional[float]
-    latest_evaluation: Optional["ConditionEvaluation"]
+    latest_evaluation: Optional["AssetConditionEvaluation"]
     materialized_requested_or_discarded_subset: AssetSubset
 
 
@@ -75,7 +75,7 @@ class AssetDaemonCursor(NamedTuple):
     def asset_cursor_for_key(
         self, asset_key: AssetKey, asset_graph: AssetGraph
     ) -> AssetDaemonAssetCursor:
-        from .asset_automation_evaluator import ConditionEvaluation
+        from .asset_condition import AssetConditionEvaluation
 
         partitions_def = asset_graph.get_partitions_def(asset_key)
         handled_partitions_subset = self.handled_root_partitions_by_asset_key.get(asset_key)
@@ -85,16 +85,14 @@ class AssetDaemonCursor(NamedTuple):
             handled_subset = AssetSubset(asset_key=asset_key, value=True)
         else:
             handled_subset = AssetSubset.empty(asset_key, partitions_def)
-        condition = (
-            check.not_none(asset_graph.get_auto_materialize_policy(asset_key))
-            .to_auto_materialize_policy_evaluator()
-            .condition
-        )
+        condition = check.not_none(
+            asset_graph.get_auto_materialize_policy(asset_key)
+        ).to_asset_condition()
         return AssetDaemonAssetCursor(
             asset_key=asset_key,
             latest_storage_id=self.latest_storage_id,
             latest_evaluation_timestamp=self.latest_evaluation_timestamp,
-            latest_evaluation=ConditionEvaluation.from_evaluation(
+            latest_evaluation=AssetConditionEvaluation.from_evaluation(
                 condition=condition,
                 evaluation=self.latest_evaluation_by_asset_key.get(asset_key),
                 asset_graph=asset_graph,

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
@@ -29,7 +29,7 @@ from .asset_graph import AssetGraph
 from .partition import SerializedPartitionsSubset
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.asset_automation_evaluator import AssetSubsetWithMetdata
+    from dagster._core.definitions.asset_condition import AssetSubsetWithMetdata
     from dagster._core.instance import DynamicPartitionsStore
 
 
@@ -272,7 +272,7 @@ class AutoMaterializeAssetEvaluation(NamedTuple):
         self, rule_snapshot: AutoMaterializeRuleSnapshot, asset_graph: AssetGraph
     ) -> RuleEvaluationResults:
         """For a given rule snapshot, returns the calculated evaluations for that rule."""
-        from dagster._core.definitions.asset_automation_evaluator import AssetSubsetWithMetdata
+        from dagster._core.definitions.asset_condition import AssetSubsetWithMetdata
 
         true_subset = AssetSubset.empty(
             self.asset_key, asset_graph.get_partitions_def(self.asset_key)

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -12,14 +12,14 @@ from typing import TYPE_CHECKING, AbstractSet, Optional, Tuple
 
 import pendulum
 
-from dagster._core.definitions.asset_automation_evaluator import AssetSubsetWithMetdata
+from dagster._core.definitions.asset_condition import AssetSubsetWithMetdata
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._utils.schedules import cron_string_iterator
 
 if TYPE_CHECKING:
-    from .asset_automation_condition_context import AssetAutomationEvaluationContext
+    from .asset_condition_evaluation_context import RootAssetConditionEvaluationContext
     from .auto_materialize_rule_evaluation import RuleEvaluationResults, TextRuleEvaluationData
 
 
@@ -111,7 +111,7 @@ def get_execution_period_and_evaluation_data_for_policies(
 
 
 def get_expected_data_time_for_asset_key(
-    context: "AssetAutomationEvaluationContext", will_materialize: bool
+    context: "RootAssetConditionEvaluationContext", will_materialize: bool
 ) -> Optional[datetime.datetime]:
     """Returns the data time that you would expect this asset to have if you were to execute it
     on this tick.
@@ -154,7 +154,7 @@ def get_expected_data_time_for_asset_key(
 
 
 def freshness_evaluation_results_for_asset_key(
-    context: "AssetAutomationEvaluationContext",
+    context: "RootAssetConditionEvaluationContext",
 ) -> "RuleEvaluationResults":
     """Returns a set of AssetKeyPartitionKeys to materialize in order to abide by the given
     FreshnessPolicies.


### PR DESCRIPTION
## Summary & Motivation

This PR renames some classes to get them closer to the final form. In this case, we rename AutomationCondition to AssetCondition, which has knock-on effects for things such as the context objects.

This also gets rid of the now-redundant AutomationPolicyEvaluator class

## How I Tested These Changes
