### PR TITLE
Pass in desired observable source asset keys to AssetDaemonContext instead of a boolean

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -321,12 +321,20 @@ class AssetDaemonScenarioState(NamedTuple):
         new_run_requests, new_cursor, new_evaluations = AssetDaemonContext(
             evaluation_id=cursor.evaluation_id + 1,
             asset_graph=self.asset_graph,
-            target_asset_keys=None,
+            auto_materialize_asset_keys={
+                key
+                for key, policy in self.asset_graph.auto_materialize_policies_by_key.items()
+                if policy is not None
+            },
             instance=self.instance,
             materialize_run_tags={},
             observe_run_tags={},
             cursor=cursor,
-            auto_observe=True,
+            auto_observe_asset_keys={
+                key
+                for key in self.asset_graph.source_asset_keys
+                if self.asset_graph.get_auto_observe_interval_minutes(key) is not None
+            },
             respect_materialization_data_versions=False,
             logger=self.logger,
         ).evaluate()

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_observe.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_observe.py
@@ -24,6 +24,7 @@ def test_single_observable_source_asset_no_auto_observe():
                 current_timestamp=1000,
                 last_observe_request_timestamp_by_asset_key={},
                 run_tags={},
+                auto_observe_asset_keys=asset_graph.source_asset_keys,
             )
         )
         == 0
@@ -36,6 +37,7 @@ def test_single_observable_source_asset_no_auto_observe():
                 current_timestamp=1000,
                 last_observe_request_timestamp_by_asset_key={AssetKey("asset1"): 1},
                 run_tags={},
+                auto_observe_asset_keys=asset_graph.source_asset_keys,
             )
         )
         == 0
@@ -60,6 +62,7 @@ def test_single_observable_source_asset_no_prior_observe_requests(
         current_timestamp=1000,
         last_observe_request_timestamp_by_asset_key={},
         run_tags={},
+        auto_observe_asset_keys=single_auto_observe_source_asset_graph.source_asset_keys,
     )
     assert len(run_requests) == 1
     run_request = run_requests[0]
@@ -76,6 +79,7 @@ def test_single_observable_source_asset_prior_observe_requests(
         current_timestamp=last_timestamp + 30 * 60 + 5,
         last_observe_request_timestamp_by_asset_key={AssetKey("asset1"): last_timestamp},
         run_tags={},
+        auto_observe_asset_keys=single_auto_observe_source_asset_graph.source_asset_keys,
     )
     assert len(run_requests) == 1
     run_request = run_requests[0]
@@ -92,6 +96,7 @@ def test_single_observable_source_asset_prior_recent_observe_requests(
         current_timestamp=last_timestamp + 30 * 60 - 5,
         last_observe_request_timestamp_by_asset_key={AssetKey("asset1"): last_timestamp},
         run_tags={},
+        auto_observe_asset_keys=single_auto_observe_source_asset_graph.source_asset_keys,
     )
     assert len(run_requests) == 0
 
@@ -106,9 +111,9 @@ def test_reconcile():
 
     run_requests, cursor, _ = AssetDaemonContext(
         evaluation_id=1,
-        auto_observe=True,
+        auto_observe_asset_keys={AssetKey(["asset1"])},
         asset_graph=asset_graph,
-        target_asset_keys=set(),
+        auto_materialize_asset_keys=set(),
         instance=instance,
         cursor=AssetDaemonCursor.empty(),
         materialize_run_tags=None,


### PR DESCRIPTION
Right now auto-observe is all or nothing and controlled by a boolean. With sensor-based AMP on the horizon, we need the ability to pass in the specific keys that are covered by the sensor.

Test Plan: BK
