### PR TITLE
Feature/enhance dynamic partitions example for dynamically loading asset partitions

### DIFF
--- a/examples/assets_dynamic_partitions/assets_dynamic_partitions/__init__.py
+++ b/examples/assets_dynamic_partitions/assets_dynamic_partitions/__init__.py
@@ -1,4 +1,13 @@
-from dagster import Definitions, load_assets_from_modules
+from typing import Any
+
+from dagster import (
+    AssetKey,
+    Definitions,
+    OpExecutionContext,
+    job,
+    load_assets_from_modules,
+    op,
+)
 from dagster_duckdb import build_duckdb_io_manager
 from dagster_duckdb_pandas import DuckDBPandasTypeHandler
 
@@ -7,8 +16,39 @@ from .release_sensor import release_sensor
 
 duckdb_io_manager = build_duckdb_io_manager([DuckDBPandasTypeHandler()])
 
+
+@op
+def dynamic_partition_loader(
+    context: OpExecutionContext, asset_key: str, partition_key: str
+) -> Any:
+    """Dynamically fetches a previous value of asset_key at partition_id.
+
+    Args:
+        context (OpExecutionContext): standard op context
+        asset_key (str): unique identifier of the asset to load partition from
+        partition_key (str): unique identifier of the partition
+
+    Returns:
+        Any: the previously stored value of the dynamic partition ww
+    """
+    with defs.get_asset_value_loader(instance=context.instance) as loader:
+        partition_value = loader.load_asset_value(
+            AssetKey(asset_key),
+            partition_key=partition_key,
+        )
+
+        return partition_value
+
+
+@job
+def adhoc_partition_load():
+    """Job wrapper of dynamic_partition_loader."""
+    dynamic_partition_loader()
+
+
 defs = Definitions(
     assets=load_assets_from_modules([assets]),
     sensors=[release_sensor],
+    jobs=[adhoc_partition_load],
     resources={"warehouse": duckdb_io_manager.configured({"database": "releases.duckdb"})},
 )

--- a/examples/assets_dynamic_partitions/assets_dynamic_partitions_tests/test_defs.py
+++ b/examples/assets_dynamic_partitions/assets_dynamic_partitions_tests/test_defs.py
@@ -74,6 +74,7 @@ def test_adhoc_partition_load():
                     }
                 },
             )
+            assert res.success
 
     finally:
         os.environ.clear()

--- a/examples/assets_dynamic_partitions/assets_dynamic_partitions_tests/test_defs.py
+++ b/examples/assets_dynamic_partitions/assets_dynamic_partitions_tests/test_defs.py
@@ -1,0 +1,80 @@
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pendulum
+import pytest
+from dagster import DagsterInstance, materialize
+from dagster._check import CheckError
+
+from assets_dynamic_partitions import adhoc_partition_load, duckdb_io_manager
+from assets_dynamic_partitions.assets import releases_metadata, releases_partitions_def
+
+
+def test_adhoc_partition_load_no_partition():
+    with pytest.raises(CheckError):
+        adhoc_partition_load.execute_in_process(
+            run_config={
+                "ops": {
+                    "dynamic_partition_loader": {
+                        "inputs": {
+                            "asset_key": {
+                                "value": "test_asset_key",
+                            },
+                            "partition_key": {"value": "test_partition_id"},
+                        }
+                    }
+                }
+            }
+        )
+
+
+def test_adhoc_partition_load():
+    old_environ = dict(os.environ)
+    os.environ.update({"GITHUB_USER_NAME": "username", "GITHUB_ACCESS_TOKEN": "token"})
+    try:
+        instance = DagsterInstance.ephemeral()
+        with patch("requests.get") as mock:
+            mock.return_value = MagicMock(
+                ok=True,
+                content=json.dumps(
+                    {
+                        "tarball_url": "test_tarball_url",
+                        "zipball_url": "test_zipball_url",
+                        "id": "test_id",
+                        "author": {"login": "test_author_login"},
+                        "published_at": str(pendulum.now()),
+                    }
+                ),
+            )
+            instance.add_dynamic_partitions(releases_partitions_def.name, ["1.1.0"])
+            assert materialize(
+                [releases_metadata],
+                instance=instance,
+                partition_key="1.1.0",
+                resources={
+                    "warehouse": duckdb_io_manager.configured({"database": "releases.duckdb"})
+                },
+            ).success
+
+            assert instance.has_dynamic_partition(releases_partitions_def.name, "1.1.0")
+
+            res = adhoc_partition_load.execute_in_process(
+                instance=instance,
+                run_config={
+                    "ops": {
+                        "dynamic_partition_loader": {
+                            "inputs": {
+                                "asset_key": {
+                                    "value": "releases_metadata",
+                                },
+                                "partition_key": {"value": "1.1.0"},
+                            }
+                        }
+                    }
+                },
+            )
+
+    finally:
+        os.environ.clear()
+        os.environ.update(old_environ)


### PR DESCRIPTION
## Summary & Motivation
Motivation:
- From reading the dagster docs, it is not clear how one can dynamically referenced assets
- Issues/discussions in support of this change: #16524 #15119 #15946 #14417 #14805 
- After going through these discussions, and the docs, one can see that there are no examples on: "how do I dynamically load a partition value through a job on a given asset"
- As described in #16524 especially in Machine Learning use cases, it's very handy to load multiple asset's partitions dynamically, as often we work with a very large combination of models, datasets, and features. This example, allows users to see how to accomplish that

Changes:
- added a job in the `examples/assets_dynamic_partitions` which takes two parameters `asset_key` and `partition_key` which can be used to dynamically, at run time load partitions from a dynamic asset

## How I Tested These Changes
- Extended the unit cases: (1) asserting an exception is raised when the partition or asset key do not exists (2) added a test case that adds a partition to the release metadata, materializes it, and then runs the job to dynamically fetch the value of that partition

## Docs
I am also open to adding to the docs, if guided on which section, because, I think it would be awesome if the `load_asset_value` [reference](https://docs.dagster.io/concepts/assets/software-defined-assets#loading-asset-values-outside-of-dagster-runs), had further examples of how to use it  in difference circumstances

Another good addition to the docs could potentially be a section how how to fetch partitions through a job with config driven. Doing a job like proposed in the example allows the user to not have to define many combinations of assets