### PR TITLE
Support kwargs inputs for graph_multi_asset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1289,6 +1289,7 @@ def graph_multi_asset(
             name=name or fn.__name__,
             out=combined_outs_by_output_name,
             config=config,
+            # ins={input_name: GraphIn() for _, (input_name, _) in asset_ins.items()},
         )(fn)
 
         # source metadata from the AssetOuts (if any)

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1289,7 +1289,7 @@ def graph_multi_asset(
             name=name or fn.__name__,
             out=combined_outs_by_output_name,
             config=config,
-            # ins={input_name: GraphIn() for _, (input_name, _) in asset_ins.items()},
+            ins={input_name: GraphIn() for _, (input_name, _) in asset_ins.items()},
         )(fn)
 
         # source metadata from the AssetOuts (if any)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -1159,7 +1159,7 @@ def test_graph_multi_asset_w_key_prefix():
     }
 
 
-def test_graph_asset_w_ins():
+def test_graph_asset_w_ins_and_param_args():
     @asset
     def upstream():
         return 1
@@ -1184,6 +1184,12 @@ def test_graph_asset_w_ins():
     result = materialize_to_memory([upstream, bar])
     assert result.success
     assert result.output_for_node("bar", "first_asset") == 2
+
+
+def test_graph_asset_w_ins_and_kwargs():
+    @asset
+    def upstream():
+        return 1
 
     @asset
     def another_upstream():


### PR DESCRIPTION
## Summary & Motivation
User reported a bug in https://github.com/dagster-io/dagster/issues/18632 where `graph_asset` and `graph_multi_asset` do not have the same behavior with `ins` that are accessed via `kwargs`. 

At definition time, `graph_asset` and `graph_multi_asset` each create an underlying `graph`. `graph_asset` passes its `ins`, but `graph_multi_asset` does not, which causes the underlying `graph` to interpret the function parameters as the `ins`. If the `graph_multi_asset` doesn't have parameters, and instead accesses inputs from `**kwargs` then the underlying graph thinks it has no inputs. This causes an issue later on when the `ins` of the `graph_multi_asset` do not align with the `ins` of the underlying `graph`.

This change will be most useful for factory functions that create `graph_multi_assets` with variable numbers of inputs

This PR aligns the behavior of `graph_multi_asset` with `graph_asset`

## How I Tested These Changes
