### PR TITLE
Adjust sensor and AMP timeline tick colors

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/LiveTickTimeline2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/LiveTickTimeline2.tsx
@@ -1,9 +1,6 @@
 import {
   Caption,
   Tooltip,
-  colorAccentCyan,
-  colorAccentCyanHover,
-  colorAccentGray,
   colorAccentGrayHover,
   colorAccentGreen,
   colorAccentGreenHover,

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/LiveTickTimeline2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/LiveTickTimeline2.tsx
@@ -7,11 +7,14 @@ import {
   colorAccentGrayHover,
   colorAccentGreen,
   colorAccentGreenHover,
+  colorAccentLavender,
+  colorAccentLavenderHover,
   colorAccentPrimary,
   colorAccentRed,
   colorAccentRedHover,
   colorAccentReversed,
   colorBackgroundDefault,
+  colorBackgroundDisabled,
   colorKeylineDefault,
   colorTextLight,
   ifPlural,
@@ -36,14 +39,14 @@ dayjs.extend(relativeTime);
 const COLOR_MAP = {
   [InstigationTickStatus.SUCCESS]: colorAccentGreen(),
   [InstigationTickStatus.FAILURE]: colorAccentRed(),
-  [InstigationTickStatus.STARTED]: colorAccentCyan(),
-  [InstigationTickStatus.SKIPPED]: colorAccentGray(),
+  [InstigationTickStatus.STARTED]: colorAccentLavender(),
+  [InstigationTickStatus.SKIPPED]: colorBackgroundDisabled(),
 };
 
 const HoverColorMap = {
   [InstigationTickStatus.SUCCESS]: colorAccentGreenHover(),
   [InstigationTickStatus.FAILURE]: colorAccentRedHover(),
-  [InstigationTickStatus.STARTED]: colorAccentCyanHover(),
+  [InstigationTickStatus.STARTED]: colorAccentLavenderHover(),
   [InstigationTickStatus.SKIPPED]: colorAccentGrayHover(),
 };
 


### PR DESCRIPTION
## Summary & Motivation
Make the skipped tick color more subtle

CURRENT:
<img width="1591" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/c679e9fd-89df-45a7-8ad5-292207ecc739">

NEW:
<img width="1596" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/aaf8da59-a092-427f-a8d1-d69b10bcbf6b">


## How I Tested These Changes
