### PR TITLE
Adjust toggle colors for disabled state

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Checkbox.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Checkbox.tsx
@@ -104,8 +104,6 @@ const SwitchIcon = ({checked, indeterminate, fillColor, disabled}: IconProps) =>
           ? disabled
             ? colorAccentBlueHover()
             : fillColor
-          : disabled
-          ? colorAccentGray()
           : colorAccentGray()
       }
       style={{

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Checkbox.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Checkbox.tsx
@@ -14,6 +14,10 @@ import {
   colorTextDisabled,
   colorTextLighter,
   colorFocusRing,
+  colorAccentBlueHover,
+  colorBackgroundLight,
+  colorAccentGrayHover,
+  colorTextLight,
 } from '../theme/color';
 
 type Format = 'check' | 'star' | 'switch';
@@ -98,10 +102,10 @@ const SwitchIcon = ({checked, indeterminate, fillColor, disabled}: IconProps) =>
       fill={
         checked && !indeterminate
           ? disabled
-            ? colorBorderDefault()
+            ? colorAccentBlueHover()
             : fillColor
           : disabled
-          ? colorBorderDefault()
+          ? colorAccentGray()
           : colorAccentGray()
       }
       style={{
@@ -113,7 +117,7 @@ const SwitchIcon = ({checked, indeterminate, fillColor, disabled}: IconProps) =>
     {!disabled && <rect x="0" y="0" width="36" height="22" rx="11" fill="url(#innerShadow)" />}
     <rect
       id="handle"
-      style={{transition: 'x 100ms linear'}}
+      style={{transition: 'x 100ms linear', opacity: disabled ? 0.6 : 1}}
       x={indeterminate ? '8' : checked ? '15' : '1'}
       y="1"
       width="20"

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Checkbox.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Checkbox.tsx
@@ -9,15 +9,11 @@ import {
   colorAccentReversed,
   colorBackgroundDefault,
   colorBackgroundGray,
-  colorBorderDefault,
   colorTextDefault,
   colorTextDisabled,
   colorTextLighter,
   colorFocusRing,
   colorAccentBlueHover,
-  colorBackgroundLight,
-  colorAccentGrayHover,
-  colorTextLight,
 } from '../theme/color';
 
 type Format = 'check' | 'star' | 'switch';


### PR DESCRIPTION
## Summary & Motivation
Fix the disabled, check states that broke last week

### Light mode:
**Unchecked, Enabled:**
<img width="285" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/c95fd61c-dc07-4c61-8dbc-9b887cb68b7f">
**Unchecked, Disabled:**
<img width="295" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/b9a39a0c-da0e-42b0-a88c-001408f58dc3">
**Checked, Enabled:**
<img width="281" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/a4d278cf-6d5e-4614-9764-75c178e5bb0a">
**Checked, Disabled:**
<img width="299" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/b8c005ba-0ed5-4a3b-a784-c6006d7dc4e1">
----------
### Light mode:
**Unchecked, Enabled:**
<img width="317" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/28dcea20-24f4-45fc-85a6-30e2868bfcff">
**Unchecked, Disabled:**
<img width="294" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/601df1b6-e21e-4c1a-a625-2f23aa8b449a">
**Checked, Enabled:**
<img width="322" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/12e3e97c-970b-470a-a368-09c671cf7f1c">
**Checked, Disabled:**
<img width="276" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/a74c7005-3ceb-4a4e-bfd5-416a0a4cb72f">

## How I Tested These Changes
Loaded up the UI