### PR TITLE
refactor(instigator-tick-logs): standardize on `log_key`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -420,14 +420,16 @@ def build_schedule_context(
     )
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(
+    storage_field_names={"log_key": "captured_log_key"},
+)
 class ScheduleExecutionData(
     NamedTuple(
         "_ScheduleExecutionData",
         [
             ("run_requests", Optional[Sequence[RunRequest]]),
             ("skip_message", Optional[str]),
-            ("captured_log_key", Optional[Sequence[str]]),
+            ("log_key", Optional[Sequence[str]]),
         ],
     )
 ):
@@ -435,11 +437,11 @@ class ScheduleExecutionData(
         cls,
         run_requests: Optional[Sequence[RunRequest]] = None,
         skip_message: Optional[str] = None,
-        captured_log_key: Optional[Sequence[str]] = None,
+        log_key: Optional[Sequence[str]] = None,
     ):
         check.opt_sequence_param(run_requests, "run_requests", RunRequest)
         check.opt_str_param(skip_message, "skip_message")
-        check.opt_list_param(captured_log_key, "captured_log_key", str)
+        check.opt_list_param(log_key, "log_key", str)
         check.invariant(
             not (run_requests and skip_message), "Found both skip data and run request data"
         )
@@ -447,7 +449,7 @@ class ScheduleExecutionData(
             cls,
             run_requests=run_requests,
             skip_message=skip_message,
-            captured_log_key=captured_log_key,
+            log_key=log_key,
         )
 
 
@@ -914,7 +916,7 @@ class ScheduleDefinition(IHasInternalInit):
         return ScheduleExecutionData(
             run_requests=resolved_run_requests,
             skip_message=skip_message,
-            captured_log_key=context.log_key if context.has_captured_logs() else None,
+            log_key=context.log_key if context.has_captured_logs() else None,
         )
 
     def has_loadable_target(self):

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -856,7 +856,7 @@ class SensorDefinition(IHasInternalInit):
             skip_message,
             updated_cursor,
             dagster_run_reactions,
-            captured_log_key=context.log_key if context.has_captured_logs() else None,
+            log_key=context.log_key if context.has_captured_logs() else None,
             dynamic_partitions_requests=dynamic_partitions_requests,
             asset_events=asset_events,
         )
@@ -982,7 +982,10 @@ class SensorDefinition(IHasInternalInit):
 
 
 @whitelist_for_serdes(
-    storage_field_names={"dagster_run_reactions": "pipeline_run_reactions"},
+    storage_field_names={
+        "dagster_run_reactions": "pipeline_run_reactions",
+        "log_key": "captured_log_key",
+    },
 )
 class SensorExecutionData(
     NamedTuple(
@@ -992,7 +995,7 @@ class SensorExecutionData(
             ("skip_message", Optional[str]),
             ("cursor", Optional[str]),
             ("dagster_run_reactions", Optional[Sequence[DagsterRunReaction]]),
-            ("captured_log_key", Optional[Sequence[str]]),
+            ("log_key", Optional[Sequence[str]]),
             (
                 "dynamic_partitions_requests",
                 Optional[
@@ -1014,7 +1017,7 @@ class SensorExecutionData(
         skip_message: Optional[str] = None,
         cursor: Optional[str] = None,
         dagster_run_reactions: Optional[Sequence[DagsterRunReaction]] = None,
-        captured_log_key: Optional[Sequence[str]] = None,
+        log_key: Optional[Sequence[str]] = None,
         dynamic_partitions_requests: Optional[
             Sequence[Union[AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest]]
         ] = None,
@@ -1026,7 +1029,7 @@ class SensorExecutionData(
         check.opt_str_param(skip_message, "skip_message")
         check.opt_str_param(cursor, "cursor")
         check.opt_sequence_param(dagster_run_reactions, "dagster_run_reactions", DagsterRunReaction)
-        check.opt_list_param(captured_log_key, "captured_log_key", str)
+        check.opt_list_param(log_key, "log_key", str)
         check.opt_sequence_param(
             dynamic_partitions_requests,
             "dynamic_partitions_requests",
@@ -1046,7 +1049,7 @@ class SensorExecutionData(
             skip_message=skip_message,
             cursor=cursor,
             dagster_run_reactions=dagster_run_reactions,
-            captured_log_key=captured_log_key,
+            log_key=log_key,
             dynamic_partitions_requests=dynamic_partitions_requests,
             asset_events=asset_events or [],
         )

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -670,8 +670,8 @@ def _evaluate_sensor(
 
     yield
 
-    if sensor_runtime_data.captured_log_key:
-        context.add_log_info(sensor_runtime_data.captured_log_key)
+    if sensor_runtime_data.log_key:
+        context.add_log_info(sensor_runtime_data.log_key)
 
     assert isinstance(sensor_runtime_data, SensorExecutionData)
 

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -717,8 +717,8 @@ def _schedule_runs_at_time(
     )
     yield None
 
-    if schedule_execution_data.captured_log_key:
-        tick_context.add_log_key(schedule_execution_data.captured_log_key)
+    if schedule_execution_data.log_key:
+        tick_context.add_log_key(schedule_execution_data.log_key)
 
     if not schedule_execution_data.run_requests:
         if schedule_execution_data.skip_message:


### PR DESCRIPTION
## Summary & Motivation
Going forward, the log key shouldn't be captured. Instead, it's computed beforehand. Also, for simplicity, just standardize on `log_key`.

## How I Tested These Changes
bk
