### PR TITLE
Add asset_selection to ExternalSensorData

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -39,6 +39,7 @@ from dagster._config.pythonic_config import (
 )
 from dagster._config.snap import ConfigFieldSnap, ConfigSchemaSnapshot, snap_from_config_type
 from dagster._core.definitions import (
+    AssetSelection,
     JobDefinition,
     PartitionsDefinition,
     RepositoryDefinition,
@@ -521,6 +522,7 @@ class ExternalSensorData(
             ("metadata", Optional[ExternalSensorMetadata]),
             ("default_status", Optional[DefaultSensorStatus]),
             ("sensor_type", Optional[SensorType]),
+            ("asset_selection", Optional[AssetSelection]),
         ],
     )
 ):
@@ -536,6 +538,7 @@ class ExternalSensorData(
         metadata: Optional[ExternalSensorMetadata] = None,
         default_status: Optional[DefaultSensorStatus] = None,
         sensor_type: Optional[SensorType] = None,
+        asset_selection: Optional[AssetSelection] = None,
     ):
         if job_name and not target_dict:
             # handle the legacy case where the ExternalSensorData was constructed from an earlier
@@ -570,6 +573,7 @@ class ExternalSensorData(
                 else None
             ),
             sensor_type=sensor_type,
+            asset_selection=asset_selection,
         )
 
 
@@ -2053,6 +2057,7 @@ def external_sensor_data_from_def(
         metadata=ExternalSensorMetadata(asset_keys=asset_keys),
         default_status=sensor_def.default_status,
         sensor_type=sensor_def.sensor_type,
+        asset_selection=sensor_def.asset_selection,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_sensor_decorator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_sensor_decorator.py
@@ -1,4 +1,6 @@
 from dagster import AssetKey, asset, sensor
+from dagster._core.definitions.decorators.repository_decorator import repository
+from dagster._core.host_representation.external_data import external_sensor_data_from_def
 
 
 def test_coerce_to_asset_selection():
@@ -27,3 +29,31 @@ def test_coerce_to_asset_selection():
         ...
 
     assert sensor2.asset_selection.resolve(assets) == {AssetKey("asset1"), AssetKey("asset2")}
+
+
+def test_external_sensor_has_asset_selection():
+    @asset
+    def asset1():
+        ...
+
+    @asset
+    def asset2():
+        ...
+
+    @asset
+    def asset3():
+        ...
+
+    @sensor(asset_selection=["asset1", "asset2"])
+    def sensor1():
+        ...
+
+    @repository
+    def my_repo():
+        return [
+            sensor1,
+        ]
+
+    assert (
+        external_sensor_data_from_def(sensor1, my_repo).asset_selection == sensor1.asset_selection
+    )


### PR DESCRIPTION
Summary:
Builds on https://github.com/dagster-io/dagster/pull/18588. Use the new serdes field to make the AssetSelection object available outside of user code.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
