### PR TITLE
[amp-refactor][5/n] Whitelist AssetConditionEvaluation

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -195,22 +195,13 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
         super().__init__(
             id=record.id,
             evaluationId=record.evaluation_id,
-            numRequested=record.evaluation.num_requested,
-            numSkipped=record.evaluation.num_skipped,
-            numDiscarded=record.evaluation.num_discarded,
-            rulesWithRuleEvaluations=create_graphene_auto_materialize_rules_with_rule_evaluations(
-                record.evaluation.partition_subsets_by_condition, partitions_def
-            ),
+            numRequested=record.evaluation.true_subset.size,
+            numSkipped=0,
+            numDiscarded=0,
+            rulesWithRuleEvaluations=[],
             timestamp=record.timestamp,
-            runIds=record.evaluation.run_ids,
-            rules=(
-                [
-                    GrapheneAutoMaterializeRule(snapshot)
-                    for snapshot in record.evaluation.rule_snapshots
-                ]
-                if record.evaluation.rule_snapshots is not None
-                else None  # Return None if no rules serialized in evaluation
-            ),
+            runIds=record.run_ids,
+            rules=[],
             assetKey=GrapheneAssetKey(path=record.asset_key.path),
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition_evaluation_context.py
@@ -15,7 +15,7 @@ from .asset_graph import AssetGraph
 from .asset_subset import AssetSubset
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.asset_condition import AssetSubsetWithMetdata
+    from dagster._core.definitions.asset_condition import AssetSubsetWithMetadata
 
     from .asset_condition import AssetCondition, AssetConditionEvaluation
     from .asset_daemon_context import AssetDaemonContext
@@ -287,7 +287,7 @@ class AssetConditionEvaluationContext:
         """Returns the set of candidates for this tick which were not candidates on the previous
         tick.
         """
-        if not self.latest_evaluation:
+        if not self.latest_evaluation or not self.latest_evaluation.candidate_subset:
             return self.candidate_subset
         return self.candidate_subset - self.latest_evaluation.candidate_subset
 
@@ -302,7 +302,7 @@ class AssetConditionEvaluationContext:
         return self.root_context.materialized_requested_or_discarded_since_previous_tick_subset
 
     @property
-    def previous_tick_subsets_with_metadata(self) -> Sequence["AssetSubsetWithMetdata"]:
+    def previous_tick_subsets_with_metadata(self) -> Sequence["AssetSubsetWithMetadata"]:
         """Returns the RuleEvaluationResults calculated on the previous tick for this condition."""
         return self.latest_evaluation.subsets_with_metadata if self.latest_evaluation else []
 

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -90,7 +90,7 @@ class AutoMaterializeRule(ABC):
             ignore_subset: An AssetSubset which represents information that we should *not* carry
                 forward from the previous tick.
         """
-        from .asset_condition import AssetSubsetWithMetdata
+        from .asset_condition import AssetSubsetWithMetadata
 
         mapping = defaultdict(lambda: context.empty_subset())
         for evaluation_data, asset_partitions in asset_partitions_by_evaluation_data.items():
@@ -119,7 +119,7 @@ class AutoMaterializeRule(ABC):
         return (
             true_subset,
             [
-                AssetSubsetWithMetdata(subset, dict(metadata))
+                AssetSubsetWithMetadata(subset, dict(metadata))
                 for metadata, subset in mapping.items()
             ],
         )

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, AbstractSet, Optional, Tuple
 
 import pendulum
 
-from dagster._core.definitions.asset_condition import AssetSubsetWithMetdata
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
@@ -161,6 +160,8 @@ def freshness_evaluation_results_for_asset_key(
 
     Attempts to minimize the total number of asset executions.
     """
+    from .asset_condition import AssetSubsetWithMetadata
+
     asset_key = context.asset_key
     current_time = context.evaluation_time
 
@@ -220,7 +221,7 @@ def freshness_evaluation_results_for_asset_key(
     ):
         all_subset = AssetSubset.all(asset_key, None)
         return AssetSubset.all(asset_key, None), [
-            AssetSubsetWithMetdata(all_subset, evaluation_data.metadata)
+            AssetSubsetWithMetadata(all_subset, evaluation_data.metadata)
         ]
     else:
         return context.empty_subset(), []

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -6,8 +6,9 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._core.definitions import RunRequest
-from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    AutoMaterializeAssetEvaluation,
+from dagster._core.definitions.asset_condition import (
+    AssetConditionEvaluation,
+    AssetConditionEvaluationWithRunIds,
 )
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 
@@ -725,19 +726,27 @@ def _validate_tick_args(
 
 class AutoMaterializeAssetEvaluationRecord(NamedTuple):
     id: int
-    evaluation: AutoMaterializeAssetEvaluation
+    evaluation_with_run_ids: AssetConditionEvaluationWithRunIds
     evaluation_id: int
     timestamp: float
     asset_key: AssetKey
 
     @classmethod
-    def from_db_row(cls, row):
+    def from_db_row(cls, row) -> "AutoMaterializeAssetEvaluationRecord":
         return cls(
             id=row["id"],
-            evaluation=deserialize_value(
-                row["asset_evaluation_body"], AutoMaterializeAssetEvaluation
+            evaluation_with_run_ids=deserialize_value(
+                row["asset_evaluation_body"], AssetConditionEvaluationWithRunIds
             ),
             evaluation_id=row["evaluation_id"],
             timestamp=datetime_as_float(row["create_timestamp"]),
-            asset_key=AssetKey.from_db_string(row["asset_key"]),
+            asset_key=check.not_none(AssetKey.from_db_string(row["asset_key"])),
         )
+
+    @property
+    def run_ids(self) -> AbstractSet[str]:
+        return self.evaluation_with_run_ids.run_ids
+
+    @property
+    def evaluation(self) -> AssetConditionEvaluation:
+        return self.evaluation_with_run_ids.evaluation

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -13,9 +13,7 @@ from dagster import (
     _check as check,
 )
 from dagster._config.config_schema import UserConfigSchema
-from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    AutoMaterializeAssetEvaluation,
-)
+from dagster._core.definitions.asset_condition import AssetConditionEvaluationWithRunIds
 from dagster._core.definitions.events import AssetKey
 from dagster._core.event_api import EventHandlerFn
 from dagster._core.storage.asset_check_execution_record import (
@@ -788,7 +786,7 @@ class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):
     def add_auto_materialize_asset_evaluations(
         self,
         evaluation_id: int,
-        asset_evaluations: Sequence[AutoMaterializeAssetEvaluation],
+        asset_evaluations: Sequence[AssetConditionEvaluationWithRunIds],
     ) -> None:
         return self._storage.schedule_storage.add_auto_materialize_asset_evaluations(
             evaluation_id, asset_evaluations

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -2,8 +2,8 @@ import abc
 from typing import Mapping, Optional, Sequence, Set
 
 from dagster import AssetKey
-from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    AutoMaterializeAssetEvaluation,
+from dagster._core.definitions.asset_condition import (
+    AssetConditionEvaluationWithRunIds,
 )
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
@@ -156,9 +156,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
 
     @abc.abstractmethod
     def add_auto_materialize_asset_evaluations(
-        self,
-        evaluation_id: int,
-        asset_evaluations: Sequence[AutoMaterializeAssetEvaluation],
+        self, evaluation_id: int, asset_evaluations: Sequence[AssetConditionEvaluationWithRunIds]
     ) -> None:
         """Add asset policy evaluations to storage."""
 

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -20,9 +20,7 @@ import sqlalchemy.exc as db_exc
 from sqlalchemy.engine import Connection
 
 import dagster._check as check
-from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    AutoMaterializeAssetEvaluation,
-)
+from dagster._core.definitions.asset_condition import AssetConditionEvaluationWithRunIds
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.errors import DagsterInvariantViolationError
@@ -485,7 +483,7 @@ class SqlScheduleStorage(ScheduleStorage):
     def add_auto_materialize_asset_evaluations(
         self,
         evaluation_id: int,
-        asset_evaluations: Sequence[AutoMaterializeAssetEvaluation],
+        asset_evaluations: Sequence[AssetConditionEvaluationWithRunIds],
     ):
         if not asset_evaluations:
             return
@@ -499,8 +497,6 @@ class SqlScheduleStorage(ScheduleStorage):
                             "asset_key": evaluation.asset_key.to_string(),
                             "asset_evaluation_body": serialize_value(evaluation),
                             "num_requested": evaluation.num_requested,
-                            "num_skipped": evaluation.num_skipped,
-                            "num_discarded": evaluation.num_discarded,
                         }
                     ]
                 )
@@ -519,8 +515,6 @@ class SqlScheduleStorage(ScheduleStorage):
                         .values(
                             asset_evaluation_body=serialize_value(evaluation),
                             num_requested=evaluation.num_requested,
-                            num_skipped=evaluation.num_skipped,
-                            num_discarded=evaluation.num_discarded,
                         )
                     )
 

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -690,7 +690,7 @@ class AssetDaemon(DagsterDaemon):
                         )
                     )
                     evaluations_by_asset_key = {
-                        evaluation_record.asset_key: evaluation_record.evaluation
+                        evaluation_record.asset_key: evaluation_record.evaluation_with_run_ids
                         for evaluation_record in evaluation_records
                     }
                 else:
@@ -719,13 +719,15 @@ class AssetDaemon(DagsterDaemon):
                 check_for_debug_crash(debug_crash_flags, "EVALUATIONS_FINISHED")
 
                 evaluations_by_asset_key = {
-                    evaluation.asset_key: evaluation for evaluation in evaluations
+                    evaluation.asset_key: evaluation.with_run_ids(set())
+                    for evaluation in evaluations
                 }
 
                 # Write the asset evaluations without run IDs first
                 if schedule_storage.supports_auto_materialize_asset_evaluations:
                     schedule_storage.add_auto_materialize_asset_evaluations(
-                        evaluation_id, list(evaluations_by_asset_key.values())
+                        evaluation_id,
+                        list(evaluations_by_asset_key.values()),
                     )
                     check_for_debug_crash(debug_crash_flags, "ASSET_EVALUATIONS_ADDED")
 

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -5,13 +5,14 @@ import pendulum
 import pytest
 
 from dagster import StaticPartitionsDefinition
-from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
-from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    AutoMaterializeAssetEvaluation,
-    AutoMaterializeRuleEvaluation,
+from dagster._core.definitions.asset_condition import (
+    AssetConditionEvaluation,
+    AssetConditionSnapshot,
+    AssetSubsetWithMetadata,
 )
+from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.partition import SerializedPartitionsSubset
+from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.host_representation import (
     ExternalRepositoryOrigin,
     ManagedGrpcPythonEnvCodeLocationOrigin,
@@ -726,36 +727,32 @@ class TestScheduleStorage:
         assert ticks_by_origin["sensor_one"][0].tick_id == b.tick_id
         assert ticks_by_origin["sensor_two"][0].tick_id == d.tick_id
 
-    def test_auto_materialize_asset_evaluations(self, storage):
+    def test_auto_materialize_asset_evaluations(self, storage) -> None:
         if not self.can_store_auto_materialize_asset_evaluations():
             pytest.skip("Storage cannot store auto materialize asset evaluations")
+
+        condition_snapshot = AssetConditionSnapshot("foo", "bar", [])
 
         for _ in range(2):  # test idempotency
             storage.add_auto_materialize_asset_evaluations(
                 evaluation_id=10,
                 asset_evaluations=[
-                    AutoMaterializeAssetEvaluation(
-                        asset_key=AssetKey("asset_one"),
-                        partition_subsets_by_condition=[],
-                        num_requested=0,
-                        num_skipped=0,
-                        num_discarded=0,
-                    ),
-                    AutoMaterializeAssetEvaluation(
-                        asset_key=AssetKey("asset_two"),
-                        partition_subsets_by_condition=[
-                            (
-                                AutoMaterializeRuleEvaluation(
-                                    rule_snapshot=AutoMaterializeRule.materialize_on_missing().to_snapshot(),
-                                    evaluation_data=None,
-                                ),
-                                None,
+                    AssetConditionEvaluation(
+                        condition_snapshot=condition_snapshot,
+                        true_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=False),
+                        candidate_subset=None,
+                    ).with_run_ids(set()),
+                    AssetConditionEvaluation(
+                        condition_snapshot=condition_snapshot,
+                        true_subset=AssetSubset(asset_key=AssetKey("asset_two"), value=True),
+                        candidate_subset=None,
+                        subsets_with_metadata=[
+                            AssetSubsetWithMetadata(
+                                AssetSubset(asset_key=AssetKey("asset_two"), value=True),
+                                {"foo": MetadataValue.text("bar")},
                             )
                         ],
-                        num_requested=1,
-                        num_skipped=0,
-                        num_discarded=0,
-                    ),
+                    ).with_run_ids(set()),
                 ],
             )
 
@@ -765,7 +762,7 @@ class TestScheduleStorage:
             assert len(res) == 1
             assert res[0].evaluation.asset_key == AssetKey("asset_one")
             assert res[0].evaluation_id == 10
-            assert res[0].evaluation.num_requested == 0
+            assert res[0].evaluation.true_subset.size == 0
 
             res = storage.get_auto_materialize_asset_evaluations(
                 asset_key=AssetKey("asset_two"), limit=100
@@ -773,29 +770,27 @@ class TestScheduleStorage:
             assert len(res) == 1
             assert res[0].evaluation.asset_key == AssetKey("asset_two")
             assert res[0].evaluation_id == 10
-            assert res[0].evaluation.num_requested == 1
+            assert res[0].evaluation.true_subset.size == 1
 
             res = storage.get_auto_materialize_evaluations_for_evaluation_id(evaluation_id=10)
 
             assert len(res) == 2
             assert res[0].evaluation.asset_key == AssetKey("asset_one")
             assert res[0].evaluation_id == 10
-            assert res[0].evaluation.num_requested == 0
+            assert res[0].evaluation.true_subset.size == 0
 
             assert res[1].evaluation.asset_key == AssetKey("asset_two")
             assert res[1].evaluation_id == 10
-            assert res[1].evaluation.num_requested == 1
+            assert res[1].evaluation.true_subset.size == 1
 
         storage.add_auto_materialize_asset_evaluations(
             evaluation_id=11,
             asset_evaluations=[
-                AutoMaterializeAssetEvaluation(
-                    asset_key=AssetKey("asset_one"),
-                    partition_subsets_by_condition=[],
-                    num_requested=0,
-                    num_skipped=0,
-                    num_discarded=0,
-                ),
+                AssetConditionEvaluation(
+                    condition_snapshot=condition_snapshot,
+                    true_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=True),
+                    candidate_subset=None,
+                ).with_run_ids(set()),
             ],
         )
 
@@ -820,21 +815,17 @@ class TestScheduleStorage:
 
         # add a mix of keys - one that already is using the unique index and one that is not
 
-        eval_one = AutoMaterializeAssetEvaluation(
-            asset_key=AssetKey("asset_one"),
-            partition_subsets_by_condition=[],
-            num_requested=1,
-            num_skipped=2,
-            num_discarded=3,
-        )
+        eval_one = AssetConditionEvaluation(
+            condition_snapshot=AssetConditionSnapshot("foo", "bar", []),
+            true_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=True),
+            candidate_subset=None,
+        ).with_run_ids(set())
 
-        eval_asset_three = AutoMaterializeAssetEvaluation(
-            asset_key=AssetKey("asset_three"),
-            partition_subsets_by_condition=[],
-            num_requested=1,
-            num_skipped=2,
-            num_discarded=3,
-        )
+        eval_asset_three = AssetConditionEvaluation(
+            condition_snapshot=AssetConditionSnapshot("foo", "bar", []),
+            true_subset=AssetSubset(asset_key=AssetKey("asset_three"), value=True),
+            candidate_subset=None,
+        ).with_run_ids(set())
 
         storage.add_auto_materialize_asset_evaluations(
             evaluation_id=11,
@@ -849,7 +840,7 @@ class TestScheduleStorage:
         )
         assert len(res) == 2
         assert res[0].evaluation_id == 11
-        assert res[0].evaluation == eval_one
+        assert res[0].evaluation == eval_one.evaluation
 
         res = storage.get_auto_materialize_asset_evaluations(
             asset_key=AssetKey("asset_three"), limit=100
@@ -857,33 +848,29 @@ class TestScheduleStorage:
 
         assert len(res) == 1
         assert res[0].evaluation_id == 11
-        assert res[0].evaluation == eval_asset_three
+        assert res[0].evaluation == eval_asset_three.evaluation
 
-    def test_auto_materialize_asset_evaluations_with_partitions(self, storage):
+    def test_auto_materialize_asset_evaluations_with_partitions(self, storage) -> None:
         if not self.can_store_auto_materialize_asset_evaluations():
             pytest.skip("Storage cannot store auto materialize asset evaluations")
 
         partitions_def = StaticPartitionsDefinition(["a", "b"])
         subset = partitions_def.empty_subset().with_partition_keys(["a"])
+        asset_subset = AssetSubset(asset_key=AssetKey("asset_two"), value=subset)
+        asset_subset_with_metadata = AssetSubsetWithMetadata(
+            asset_subset,
+            {"foo": MetadataValue.text("bar"), "baz": MetadataValue.asset(AssetKey("asset_one"))},
+        )
 
         storage.add_auto_materialize_asset_evaluations(
             evaluation_id=10,
             asset_evaluations=[
-                AutoMaterializeAssetEvaluation(
-                    asset_key=AssetKey("asset_two"),
-                    partition_subsets_by_condition=[
-                        (
-                            AutoMaterializeRuleEvaluation(
-                                rule_snapshot=AutoMaterializeRule.materialize_on_missing().to_snapshot(),
-                                evaluation_data=None,
-                            ),
-                            SerializedPartitionsSubset.from_subset(subset, partitions_def, None),
-                        )
-                    ],
-                    num_requested=1,
-                    num_skipped=0,
-                    num_discarded=0,
-                ),
+                AssetConditionEvaluation(
+                    condition_snapshot=AssetConditionSnapshot("foo", "bar", []),
+                    true_subset=asset_subset,
+                    candidate_subset=None,
+                    subsets_with_metadata=[asset_subset_with_metadata],
+                ).with_run_ids(set()),
             ],
         )
 
@@ -893,38 +880,23 @@ class TestScheduleStorage:
         assert len(res) == 1
         assert res[0].evaluation.asset_key == AssetKey("asset_two")
         assert res[0].evaluation_id == 10
-        assert res[0].evaluation.num_requested == 1
+        assert res[0].evaluation.true_subset.size == 1
 
-        assert res[0].evaluation.partition_subsets_by_condition[0][
-            0
-        ] == AutoMaterializeRuleEvaluation(
-            rule_snapshot=AutoMaterializeRule.materialize_on_missing().to_snapshot(),
-            evaluation_data=None,
-        )
-        assert (
-            res[0].evaluation.partition_subsets_by_condition[0][1].can_deserialize(partitions_def)
-        )
-        assert (
-            partitions_def.deserialize_subset(
-                res[0].evaluation.partition_subsets_by_condition[0][1].serialized_subset
-            )
-            == subset
-        )
+        assert res[0].evaluation.subsets_with_metadata[0] == asset_subset_with_metadata
 
-    def test_purge_asset_evaluations(self, storage):
+    def test_purge_asset_evaluations(self, storage) -> None:
         if not self.can_purge():
             pytest.skip("Storage cannot purge")
 
         storage.add_auto_materialize_asset_evaluations(
             evaluation_id=11,
             asset_evaluations=[
-                AutoMaterializeAssetEvaluation(
-                    asset_key=AssetKey("asset_one"),
-                    partition_subsets_by_condition=[],
-                    num_requested=0,
-                    num_skipped=0,
-                    num_discarded=0,
-                ),
+                AssetConditionEvaluation(
+                    condition_snapshot=AssetConditionSnapshot("foo", "bar", []),
+                    true_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=True),
+                    candidate_subset=None,
+                    subsets_with_metadata=[],
+                ).with_run_ids(set()),
             ],
         )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -1,5 +1,6 @@
 import datetime
 import hashlib
+import itertools
 import json
 import logging
 import os
@@ -39,6 +40,10 @@ from dagster import (
     asset,
     materialize,
 )
+from dagster._core.definitions.asset_condition import (
+    AssetConditionEvaluation,
+    AssetSubsetWithMetadata,
+)
 from dagster._core.definitions.asset_daemon_context import (
     AssetDaemonContext,
 )
@@ -47,10 +52,9 @@ from dagster._core.definitions.asset_daemon_cursor import (
     LegacyAssetDaemonCursorWrapper,
 )
 from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    AutoMaterializeAssetEvaluation,
-    AutoMaterializeRuleEvaluation,
     AutoMaterializeRuleEvaluationData,
 )
 from dagster._core.definitions.automation_policy_sensor_definition import (
@@ -165,17 +169,20 @@ class AssetRuleEvaluationSpec(NamedTuple):
             rule_evaluation_data=data_type(**transformed_kwargs),
         )
 
-    def resolve(self) -> Tuple[AutoMaterializeRuleEvaluation, Optional[Sequence[str]]]:
+    def resolve(self, asset_key: AssetKey, asset_graph: AssetGraph) -> AssetSubsetWithMetadata:
         """Returns a tuple of the resolved AutoMaterializeRuleEvaluation for this spec and the
         partitions that it applies to.
         """
-        return (
-            AutoMaterializeRuleEvaluation(
-                rule_snapshot=self.rule.to_snapshot(),
-                evaluation_data=self.rule_evaluation_data,
-            ),
-            sorted(self.partitions) if self.partitions else None,
+        subset = AssetSubset.from_asset_partitions_set(
+            asset_key,
+            asset_graph.get_partitions_def(asset_key),
+            {
+                AssetKeyPartitionKey(asset_key, partition_key)
+                for partition_key in self.partitions or [None]
+            },
         )
+        metadata = self.rule_evaluation_data.metadata if self.rule_evaluation_data else {}
+        return AssetSubsetWithMetadata(subset=subset, metadata=metadata)
 
 
 class AssetSpecWithPartitionsDef(
@@ -206,7 +213,7 @@ class AssetDaemonScenarioState(NamedTuple):
     current_time: datetime.datetime = pendulum.now("UTC")
     run_requests: Sequence[RunRequest] = []
     serialized_cursor: str = AssetDaemonCursor.empty().serialize()
-    evaluations: Sequence[AutoMaterializeAssetEvaluation] = []
+    evaluations: Sequence[AssetConditionEvaluation] = []
     logger: logging.Logger = logging.getLogger("dagster.amp")
     # this is set by the scenario runner
     scenario_instance: Optional[DagsterInstance] = None
@@ -349,7 +356,7 @@ class AssetDaemonScenarioState(NamedTuple):
 
     def _evaluate_tick_fast(
         self,
-    ) -> Tuple[Sequence[RunRequest], AssetDaemonCursor, Sequence[AutoMaterializeAssetEvaluation]]:
+    ) -> Tuple[Sequence[RunRequest], AssetDaemonCursor, Sequence[AssetConditionEvaluation]]:
         cursor = AssetDaemonCursor.from_serialized(self.serialized_cursor, self.asset_graph)
 
         new_run_requests, new_cursor, new_evaluations = AssetDaemonContext(
@@ -417,7 +424,7 @@ class AssetDaemonScenarioState(NamedTuple):
     ) -> Tuple[
         Sequence[RunRequest],
         AssetDaemonCursor,
-        Sequence[AutoMaterializeAssetEvaluation],
+        Sequence[AssetConditionEvaluation],
     ]:
         with self._create_workspace_context() as workspace_context:
             workspace = workspace_context.create_request_context()
@@ -604,7 +611,7 @@ class AssetDaemonScenarioState(NamedTuple):
         return self
 
     def _assert_evaluation_daemon(
-        self, key: AssetKey, actual_evaluation: AutoMaterializeAssetEvaluation
+        self, key: AssetKey, actual_evaluation: AssetConditionEvaluation
     ) -> None:
         """Additional assertions for daemon mode. Checks that the evaluation for the given asset
         contains the expected run ids.
@@ -620,15 +627,24 @@ class AssetDaemonScenarioState(NamedTuple):
             )
             if key in (run.asset_selection or set())
         }
-        assert new_run_ids_for_asset == actual_evaluation.run_ids
+        evaluation_with_run_ids = next(
+            iter(
+                [
+                    e
+                    for e in check.not_none(
+                        self.instance.schedule_storage
+                    ).get_auto_materialize_evaluations_for_evaluation_id(current_evaluation_id)
+                    if e.asset_key == key
+                ]
+            )
+        )
+        assert new_run_ids_for_asset == evaluation_with_run_ids.run_ids
 
     def assert_evaluation(
         self,
         key: CoercibleToAssetKey,
         expected_evaluation_specs: Sequence[AssetRuleEvaluationSpec],
         num_requested: Optional[int] = None,
-        num_skipped: Optional[int] = None,
-        num_discarded: Optional[int] = None,
     ) -> "AssetDaemonScenarioState":
         """Asserts that AutoMaterializeRuleEvaluations on the AutoMaterializeAssetEvaluation for the
         given asset key match the given expected_evaluation_specs.
@@ -642,7 +658,7 @@ class AssetDaemonScenarioState(NamedTuple):
         if actual_evaluation is None:
             try:
                 assert len(expected_evaluation_specs) == 0
-                assert all(n is None for n in (num_requested, num_skipped, num_discarded))
+                assert num_requested is None
             except:
                 self.logger.error(
                     "\nAll Evaluations: \n\n" + "\n\n".join("\t" + str(e) for e in self.evaluations)
@@ -650,41 +666,48 @@ class AssetDaemonScenarioState(NamedTuple):
                 raise
             return self
         if num_requested is not None:
-            assert actual_evaluation.num_requested == num_requested
-        if num_skipped is not None:
-            assert actual_evaluation.num_skipped == num_skipped
-        if num_discarded is not None:
-            assert actual_evaluation.num_discarded == num_discarded
+            assert actual_evaluation.true_subset.size == num_requested
 
-        # unpack the serialized partition subsets into an easier format
-        actual_rule_evaluations = [
-            (
-                rule_evaluation,
-                sorted(
-                    serialized_subset.deserialize(
-                        check.not_none(self.asset_graph.get_partitions_def(asset_key))
-                    ).get_partition_keys()
-                )
-                if serialized_subset is not None
-                else None,
+        def get_leaf_evaluations(e: AssetConditionEvaluation) -> Sequence[AssetConditionEvaluation]:
+            if len(e.child_evaluations) == 0:
+                return [e]
+            leaf_evals = []
+            for child_eval in e.child_evaluations:
+                leaf_evals.extend(get_leaf_evaluations(child_eval))
+            return leaf_evals
+
+        actual_subsets_with_metadata = list(
+            itertools.chain(
+                *[
+                    leaf_eval.subsets_with_metadata
+                    # backcompat as previously we stored None metadata for any true evaluation
+                    or (
+                        [AssetSubsetWithMetadata(leaf_eval.true_subset, {})]
+                        if leaf_eval.true_subset.size
+                        else []
+                    )
+                    for leaf_eval in get_leaf_evaluations(actual_evaluation)
+                ]
             )
-            for rule_evaluation, serialized_subset in actual_evaluation.partition_subsets_by_condition
+        )
+        expected_subsets_with_metadata = [
+            ees.resolve(asset_key, self.asset_graph) for ees in expected_evaluation_specs
         ]
-        expected_rule_evaluations = [ees.resolve() for ees in expected_evaluation_specs]
 
         try:
-            for (actual_data, actual_partitions), (expected_data, expected_partitions) in zip(
-                sorted(actual_rule_evaluations), sorted(expected_rule_evaluations)
+            for actual_sm, expected_sm in zip(
+                sorted(actual_subsets_with_metadata, key=lambda x: str(x)),
+                sorted(expected_subsets_with_metadata, key=lambda x: str(x)),
             ):
-                assert actual_data.rule_snapshot == expected_data.rule_snapshot
-                assert actual_partitions == expected_partitions
+                assert actual_sm.subset == expected_sm.subset
                 # only check evaluation data if it was set on the expected evaluation spec
-                if expected_data.evaluation_data is not None:
-                    assert actual_data.evaluation_data == expected_data.evaluation_data
+                if expected_sm.metadata:
+                    assert actual_sm.metadata == expected_sm.metadata
 
         except:
             self._log_assertion_error(
-                sorted(expected_rule_evaluations), sorted(actual_rule_evaluations)
+                sorted(expected_subsets_with_metadata, key=lambda x: str(x)),
+                sorted(actual_subsets_with_metadata, key=lambda x: str(x)),
             )
             raise
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -56,13 +56,12 @@ from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    AutoMaterializeAssetEvaluation,
     AutoMaterializeDecisionType,
     AutoMaterializeRuleEvaluation,
     AutoMaterializeRuleEvaluationData,
 )
 from dagster._core.definitions.data_version import DataVersionsByPartition
-from dagster._core.definitions.events import AssetKeyPartitionKey, CoercibleToAssetKey
+from dagster._core.definitions.events import CoercibleToAssetKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.observe import observe
@@ -127,33 +126,6 @@ class AssetEvaluationSpec(NamedTuple):
             num_requested=1 if rule.decision_type == AutoMaterializeDecisionType.MATERIALIZE else 0,
             num_skipped=1 if rule.decision_type == AutoMaterializeDecisionType.SKIP else 0,
             num_discarded=1 if rule.decision_type == AutoMaterializeDecisionType.DISCARD else 0,
-        )
-
-    def to_evaluation(
-        self, asset_graph: AssetGraph, instance: DagsterInstance
-    ) -> AutoMaterializeAssetEvaluation:
-        asset_key = AssetKey.from_coercible(self.asset_key)
-        return AutoMaterializeAssetEvaluation.from_rule_evaluation_results(
-            asset_graph=asset_graph,
-            asset_key=asset_key,
-            asset_partitions_by_rule_evaluation=[
-                (
-                    rule_evaluation,
-                    (
-                        {
-                            AssetKeyPartitionKey(asset_key, partition_key)
-                            for partition_key in partition_keys
-                        }
-                        if partition_keys
-                        else set()
-                    ),
-                )
-                for rule_evaluation, partition_keys in self.rule_evaluations
-            ],
-            num_requested=self.num_requested,
-            num_skipped=self.num_skipped,
-            num_discarded=self.num_discarded,
-            dynamic_partitions_store=instance,
         )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_failure_recovery.py
@@ -505,7 +505,7 @@ def test_asset_daemon_crash_recovery(daemon_not_paused_instance, crash_location)
     )
     assert len(evaluations) == 1
     assert evaluations[0].evaluation.asset_key == AssetKey("hourly")
-    assert evaluations[0].evaluation.run_ids == {run.run_id for run in sorted_runs}
+    assert evaluations[0].run_ids == {run.run_id for run in sorted_runs}
 
 
 @pytest.mark.parametrize(
@@ -612,7 +612,7 @@ def test_asset_daemon_exception_recovery(daemon_not_paused_instance, crash_locat
     )
     assert len(evaluations) == 1
     assert evaluations[0].evaluation.asset_key == AssetKey("hourly")
-    assert evaluations[0].evaluation.run_ids == {run.run_id for run in sorted_runs}
+    assert evaluations[0].run_ids == {run.run_id for run in sorted_runs}
 
     cursor = _get_pre_sensor_auto_materialize_serialized_cursor(instance)
     assert cursor

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
@@ -1,5 +1,3 @@
-from typing import Sequence
-
 import pytest
 from dagster import (
     AssetMaterialization,
@@ -7,10 +5,6 @@ from dagster import (
     DagsterInstance,
     job,
     op,
-)
-from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    AutoMaterializeAssetEvaluation,
 )
 from dagster._core.definitions.time_window_partitions import (
     HourlyPartitionsDefinition,
@@ -43,37 +37,6 @@ def test_reconciliation(scenario, respect_materialization_data_versions):
     run_requests, _, evaluations = scenario.do_sensor_scenario(
         instance, respect_materialization_data_versions=respect_materialization_data_versions
     )
-
-    def _sorted_evaluations(
-        evaluations: Sequence[AutoMaterializeAssetEvaluation],
-    ) -> Sequence[AutoMaterializeAssetEvaluation]:
-        """Allows a stable ordering for comparison."""
-        return sorted(
-            [
-                evaluation._replace(
-                    partition_subsets_by_condition=sorted(
-                        evaluation.partition_subsets_by_condition, key=repr
-                    )
-                )._replace(
-                    rule_snapshots=(
-                        sorted(evaluation.rule_snapshots, key=repr)
-                        if evaluation.rule_snapshots
-                        else None
-                    )
-                )
-                for evaluation in evaluations
-            ],
-            key=repr,
-        )
-
-    if scenario.expected_evaluations is not None:
-        asset_graph = AssetGraph.from_assets(scenario.assets)
-        assert _sorted_evaluations(
-            [
-                evaluation_spec.to_evaluation(asset_graph, instance)
-                for evaluation_spec in scenario.expected_evaluations
-            ]
-        ) == _sorted_evaluations(evaluations)
 
     assert len(run_requests) == len(scenario.expected_run_requests), evaluations
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_materialize_asset_evaluation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_materialize_asset_evaluation.py
@@ -1,124 +1,166 @@
-from dagster import AssetKey, AutoMaterializePolicy, StaticPartitionsDefinition, asset
-from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
-from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    AutoMaterializeAssetEvaluation,
-    AutoMaterializeRuleEvaluation,
-    ParentUpdatedRuleEvaluationData,
-    WaitingOnAssetsRuleEvaluationData,
+from dagster import MetadataValue
+from dagster._core.definitions.asset_condition import (
+    AssetConditionEvaluationWithRunIds,
+    AssetSubsetWithMetadata,
 )
-from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._serdes.serdes import deserialize_value, serialize_value
-
-partitions = StaticPartitionsDefinition(partition_keys=["a", "b", "c"])
-
-
-@asset(partitions_def=partitions, auto_materialize_policy=AutoMaterializePolicy.eager())
-def my_asset(_):
-    pass
+from dagster._core.definitions.asset_subset import AssetSubset
+from dagster._core.definitions.events import AssetKey
+from dagster._serdes.serdes import deserialize_value
 
 
-def test_backcompat():
+def test_backcompat_unpartitioned_skipped() -> None:
+    serialized_asset_evaluation = (
+        '{"__class__": "AutoMaterializeAssetEvaluation", "asset_key": {"__class__": "AssetKey", '
+        '"path": ["C"]}, "num_discarded": 0, "num_requested": 0, "num_skipped": 1, '
+        '"partition_subsets_by_condition": [[{"__class__": "AutoMaterializeRuleEvaluation", '
+        '"evaluation_data": null, "rule_snapshot": {"__class__": "AutoMaterializeRuleSnapshot", '
+        '"class_name": "MaterializeOnCronRule", "decision_type": {"__enum__": '
+        '"AutoMaterializeDecisionType.MATERIALIZE"}, "description": "not materialized since last '
+        'cron schedule tick of \'0 * * * *\' (timezone: UTC)"}}, null], [{"__class__": '
+        '"AutoMaterializeRuleEvaluation", "evaluation_data": {"__class__": '
+        '"WaitingOnAssetsRuleEvaluationData", "waiting_on_asset_keys": {"__frozenset__": '
+        '[{"__class__": "AssetKey", "path": ["A"]}, {"__class__": "AssetKey", "path": ["B"]}]}}, '
+        '"rule_snapshot": {"__class__": "AutoMaterializeRuleSnapshot", "class_name": '
+        '"SkipOnNotAllParentsUpdatedRule", "decision_type": {"__enum__": '
+        '"AutoMaterializeDecisionType.SKIP"}, "description": "waiting on upstream data to be '
+        'updated"}}, null]], "rule_snapshots": [{"__class__": "AutoMaterializeRuleSnapshot", '
+        '"class_name": "SkipOnNotAllParentsUpdatedRule", "decision_type": {"__enum__": '
+        '"AutoMaterializeDecisionType.SKIP"}, "description": "waiting on upstream data to be '
+        'updated"}, {"__class__": "AutoMaterializeRuleSnapshot", "class_name": '
+        '"MaterializeOnCronRule", "decision_type": {"__enum__": '
+        '"AutoMaterializeDecisionType.MATERIALIZE"}, "description": "not materialized since last '
+        'cron schedule tick of \'0 * * * *\' (timezone: UTC)"}], "run_ids": {"__set__": []}}'
+    )
+    deserialized_with_run_ids = deserialize_value(
+        serialized_asset_evaluation, AssetConditionEvaluationWithRunIds
+    )
+    deserialized = deserialized_with_run_ids.evaluation
+
+    assert deserialized.true_subset.size == 0
+    assert len(deserialized.child_evaluations) == 2
+    materialize_evaluation, not_skip_evaluation = deserialized.child_evaluations
+    assert materialize_evaluation.true_subset.size == 1
+    assert not_skip_evaluation.true_subset.size == 0
+    skip_evaluation = not_skip_evaluation.child_evaluations[0]
+    assert skip_evaluation.true_subset.size == 1
+    assert len(skip_evaluation.child_evaluations) == 1
+    assert skip_evaluation.child_evaluations[0].true_subset.size == 1
+    assert len(skip_evaluation.child_evaluations[0].subsets_with_metadata) == 1
+    skip_metadata = skip_evaluation.child_evaluations[0].subsets_with_metadata[0]
+    assert skip_metadata == AssetSubsetWithMetadata(
+        subset=AssetSubset(asset_key=AssetKey(["C"]), value=True),
+        metadata={
+            "waiting_on_ancestor_1": MetadataValue.asset(asset_key=AssetKey(["A"])),
+            "waiting_on_ancestor_2": MetadataValue.asset(asset_key=AssetKey(["B"])),
+        },
+    )
+
+
+def test_backcompat_unpartitioned_requested() -> None:
+    serialized_asset_evaluation = (
+        '{"__class__": "AutoMaterializeAssetEvaluation", "asset_key": {"__class__": "AssetKey", '
+        '"path": ["C"]}, "num_discarded": 0, "num_requested": 1, "num_skipped": 0, '
+        '"partition_subsets_by_condition": [[{"__class__": "AutoMaterializeRuleEvaluation", '
+        '"evaluation_data": null, "rule_snapshot": {"__class__": "AutoMaterializeRuleSnapshot", '
+        '"class_name": "MaterializeOnCronRule", "decision_type": {"__enum__": '
+        '"AutoMaterializeDecisionType.MATERIALIZE"}, "description": "not materialized since last '
+        'cron schedule tick of \'0 * * * *\' (timezone: UTC)"}}, null]], "rule_snapshots": '
+        '[{"__class__": "AutoMaterializeRuleSnapshot", "class_name": '
+        '"SkipOnNotAllParentsUpdatedRule", "decision_type": {"__enum__": '
+        '"AutoMaterializeDecisionType.SKIP"}, "description": "waiting on upstream data to be '
+        'updated"}, {"__class__": "AutoMaterializeRuleSnapshot", "class_name": '
+        '"MaterializeOnCronRule", "decision_type": {"__enum__": '
+        '"AutoMaterializeDecisionType.MATERIALIZE"}, "description": "not materialized since last '
+        'cron schedule tick of \'0 * * * *\' (timezone: UTC)"}], "run_ids": {"__set__": []}}'
+    )
+    deserialized_with_run_ids = deserialize_value(
+        serialized_asset_evaluation, AssetConditionEvaluationWithRunIds
+    )
+    deserialized = deserialized_with_run_ids.evaluation
+    assert len(deserialized.true_subset.asset_partitions) == 1
+    assert len(deserialized.child_evaluations) == 2
+    materialize_evaluation, not_skip_evaluation = deserialized.child_evaluations
+    assert len(materialize_evaluation.child_evaluations) == 1
+    cron_rule_evaluation = materialize_evaluation.child_evaluations[0]
+    assert len(cron_rule_evaluation.child_evaluations) == 0
+    assert cron_rule_evaluation.subsets_with_metadata == []
+    assert len(not_skip_evaluation.child_evaluations) == 1
+
+
+def test_backcompat_partitioned_asset() -> None:
     serialized_asset_evaluation = (
         '{"__class__": "AutoMaterializeAssetEvaluation", "asset_key": {"__class__": "AssetKey",'
-        ' "path": ["my_asset"]}, "num_discarded": 0, "num_requested": 0, "num_skipped": 2,'
-        ' "partition_subsets_by_condition": [[{"__class__": "MissingAutoMaterializeCondition",'
-        ' "decision_type": {"__enum__": "AutoMaterializeDecisionType.MATERIALIZE"}}, {"__class__":'
-        ' "SerializedPartitionsSubset", "serialized_partitions_def_class_name":'
-        ' "StaticPartitionsDefinition", "serialized_partitions_def_unique_id":'
-        ' "411905f695e47a51ceafc178e6cd4eb3680f4453", "serialized_subset": "{\\"version\\": 1,'
-        ' \\"subset\\": [\\"a\\", \\"b\\"]}"}], [{"__class__":'
-        ' "ParentOutdatedAutoMaterializeCondition", "decision_type": {"__enum__":'
-        ' "AutoMaterializeDecisionType.SKIP"}, "waiting_on_asset_keys": {"__frozenset__":'
-        ' [{"__class__": "AssetKey", "path": ["parent1"]}, {"__class__": "AssetKey", "path":'
-        ' ["parent2"]}]}}, {"__class__": "SerializedPartitionsSubset",'
-        ' "serialized_partitions_def_class_name": "StaticPartitionsDefinition",'
-        ' "serialized_partitions_def_unique_id": "411905f695e47a51ceafc178e6cd4eb3680f4453",'
-        ' "serialized_subset": "{\\"version\\": 1, \\"subset\\": [\\"a\\"]}"}], [{"__class__":'
-        ' "ParentMaterializedAutoMaterializeCondition", "decision_type": {"__enum__":'
-        ' "AutoMaterializeDecisionType.MATERIALIZE"}, "updated_asset_keys": {"__frozenset__":'
-        ' [{"__class__": "AssetKey", "path": ["parent1"]}, {"__class__": "AssetKey", "path":'
-        ' ["parent2"]}]}, "will_update_asset_keys": {"__frozenset__": [{"__class__": "AssetKey",'
-        ' "path": ["parent3"]}]}}, {"__class__": "SerializedPartitionsSubset",'
-        ' "serialized_partitions_def_class_name": "StaticPartitionsDefinition",'
-        ' "serialized_partitions_def_unique_id": "411905f695e47a51ceafc178e6cd4eb3680f4453",'
-        ' "serialized_subset": "{\\"version\\": 1, \\"subset\\": [\\"b\\"]}"}], [{"__class__":'
-        ' "ParentOutdatedAutoMaterializeCondition", "decision_type": {"__enum__":'
-        ' "AutoMaterializeDecisionType.SKIP"}, "waiting_on_asset_keys": {"__frozenset__":'
-        ' [{"__class__": "AssetKey", "path": ["parent1"]}]}}, {"__class__":'
-        ' "SerializedPartitionsSubset", "serialized_partitions_def_class_name":'
-        ' "StaticPartitionsDefinition", "serialized_partitions_def_unique_id":'
-        ' "411905f695e47a51ceafc178e6cd4eb3680f4453", "serialized_subset": "{\\"version\\": 1,'
-        ' \\"subset\\": [\\"b\\"]}"}]], "run_ids": {"__set__": []}}'
+        ' "path": ["B"]}, "num_discarded": 1, "num_requested": 1, "num_skipped": 1, '
+        '"partition_subsets_by_condition": [[{"__class__": "AutoMaterializeRuleEvaluation", '
+        '"evaluation_data": {"__class__": "ParentUpdatedRuleEvaluationData", "updated_asset_keys": '
+        '{"__frozenset__": [{"__class__": "AssetKey", "path": ["A"]}]}, "will_update_asset_keys": '
+        '{"__frozenset__": []}}, "rule_snapshot": {"__class__": "AutoMaterializeRuleSnapshot", '
+        '"class_name": "MaterializeOnParentUpdatedRule", "decision_type": {"__enum__": '
+        '"AutoMaterializeDecisionType.MATERIALIZE"}, "description": "upstream data has changed '
+        'since latest materialization"}}, {"__class__": "SerializedPartitionsSubset", '
+        '"serialized_partitions_def_class_name": "DailyPartitionsDefinition", '
+        '"serialized_partitions_def_unique_id": "809725ad60ffac0302d5c81f6e45865e21ec0b85", '
+        '"serialized_subset": "{\\"version\\": 1, \\"time_windows\\": [[1357344000.0, 1357603200.0]], '
+        '\\"num_partitions\\": 3}"}], [{"__class__": "AutoMaterializeRuleEvaluation", '
+        '"evaluation_data": null, "rule_snapshot": {"__class__": "AutoMaterializeRuleSnapshot", '
+        '"class_name": "MaterializeOnMissingRule", "decision_type": {"__enum__": '
+        '"AutoMaterializeDecisionType.MATERIALIZE"}, "description": "materialization is missing"}}, '
+        '{"__class__": "SerializedPartitionsSubset", "serialized_partitions_def_class_name": '
+        '"DailyPartitionsDefinition", "serialized_partitions_def_unique_id": '
+        '"809725ad60ffac0302d5c81f6e45865e21ec0b85", "serialized_subset": '
+        '"{\\"version\\": 1, \\"time_windows\\": [[1357344000.0, 1357603200.0]], \\"num_partitions\\": 3}"}], '
+        '[{"__class__": "AutoMaterializeRuleEvaluation", "evaluation_data": {"__class__": '
+        '"WaitingOnAssetsRuleEvaluationData", "waiting_on_asset_keys": {"__frozenset__": '
+        '[{"__class__": "AssetKey", "path": ["A"]}]}}, "rule_snapshot": {"__class__": '
+        '"AutoMaterializeRuleSnapshot", "class_name": "SkipOnParentMissingRule", "decision_type": '
+        '{"__enum__": "AutoMaterializeDecisionType.SKIP"}, "description": "waiting on upstream data '
+        'to be present"}}, {"__class__": "SerializedPartitionsSubset", '
+        '"serialized_partitions_def_class_name": "DailyPartitionsDefinition", '
+        '"serialized_partitions_def_unique_id": "809725ad60ffac0302d5c81f6e45865e21ec0b85", '
+        '"serialized_subset": "{\\"version\\": 1, \\"time_windows\\": [[1357516800.0, 1357603200.0]], '
+        '\\"num_partitions\\": 1}"}], [{"__class__": "AutoMaterializeRuleEvaluation", '
+        '"evaluation_data": null, "rule_snapshot": {"__class__": "AutoMaterializeRuleSnapshot", '
+        '"class_name": "DiscardOnMaxMaterializationsExceededRule", "decision_type": {"__enum__": '
+        '"AutoMaterializeDecisionType.DISCARD"}, "description": "exceeds 1 materialization(s) per '
+        'minute"}}, {"__class__": "SerializedPartitionsSubset", '
+        '"serialized_partitions_def_class_name": "DailyPartitionsDefinition", '
+        '"serialized_partitions_def_unique_id": "809725ad60ffac0302d5c81f6e45865e21ec0b85", '
+        '"serialized_subset": "{\\"version\\": 1, \\"time_windows\\": [[1357344000.0, 1357430400.0]], '
+        '\\"num_partitions\\": 1}"}]], "rule_snapshots": [{"__class__": "AutoMaterializeRuleSnapshot", '
+        '"class_name": "SkipOnBackfillInProgressRule", "decision_type": {"__enum__": '
+        '"AutoMaterializeDecisionType.SKIP"}, "description": "targeted by an in-progress backfill"'
+        '}, {"__class__": "AutoMaterializeRuleSnapshot", "class_name": "MaterializeOnMissingRule", '
+        '"decision_type": {"__enum__": "AutoMaterializeDecisionType.MATERIALIZE"}, "description": '
+        '"materialization is missing"}, {"__class__": "AutoMaterializeRuleSnapshot", '
+        '"class_name": "MaterializeOnRequiredForFreshnessRule", "decision_type": {"__enum__": '
+        '"AutoMaterializeDecisionType.MATERIALIZE"}, "description": "required to meet this or '
+        'downstream asset\'s freshness policy"}, {"__class__": "AutoMaterializeRuleSnapshot", '
+        '"class_name": "SkipOnParentOutdatedRule", "decision_type": {"__enum__": '
+        '"AutoMaterializeDecisionType.SKIP"}, "description": "waiting on upstream data to be up to '
+        'date"}, {"__class__": "AutoMaterializeRuleSnapshot", "class_name": '
+        '"SkipOnParentMissingRule", "decision_type": {"__enum__": '
+        '"AutoMaterializeDecisionType.SKIP"}, "description": "waiting on upstream data to be '
+        'present"}, {"__class__": "AutoMaterializeRuleSnapshot", "class_name": '
+        '"SkipOnRequiredButNonexistentParentsRule", "decision_type": {"__enum__": '
+        '"AutoMaterializeDecisionType.SKIP"}, "description": "required parent partitions do not '
+        'exist"}, {"__class__": "AutoMaterializeRuleSnapshot", "class_name": '
+        '"MaterializeOnParentUpdatedRule", "decision_type": {"__enum__": '
+        '"AutoMaterializeDecisionType.MATERIALIZE"}, "description": "upstream data has changed '
+        'since latest materialization"}], "run_ids": {"__set__": []}}'
     )
-    expected_asset_evaluation = AutoMaterializeAssetEvaluation.from_rule_evaluation_results(
-        asset_key=AssetKey(["my_asset"]),
-        asset_graph=AssetGraph.from_assets([my_asset]),
-        asset_partitions_by_rule_evaluation=[
-            (
-                AutoMaterializeRuleEvaluation(
-                    rule_snapshot=AutoMaterializeRule.materialize_on_missing().to_snapshot(),
-                    evaluation_data=None,
-                ),
-                {AssetKeyPartitionKey(AssetKey(["my_asset"]), p) for p in ("a", "b")},
-            ),
-            (
-                AutoMaterializeRuleEvaluation(
-                    rule_snapshot=AutoMaterializeRule.materialize_on_parent_updated().to_snapshot(),
-                    evaluation_data=ParentUpdatedRuleEvaluationData(
-                        updated_asset_keys=frozenset(
-                            {AssetKey(["parent1"]), AssetKey(["parent2"])}
-                        ),
-                        will_update_asset_keys=frozenset({AssetKey(["parent3"])}),
-                    ),
-                ),
-                {AssetKeyPartitionKey(AssetKey(["my_asset"]), "b")},
-            ),
-            (
-                AutoMaterializeRuleEvaluation(
-                    rule_snapshot=AutoMaterializeRule.skip_on_parent_outdated().to_snapshot(),
-                    evaluation_data=WaitingOnAssetsRuleEvaluationData(
-                        waiting_on_asset_keys=frozenset(
-                            {AssetKey(["parent1"]), AssetKey(["parent2"])}
-                        ),
-                    ),
-                ),
-                {AssetKeyPartitionKey(AssetKey(["my_asset"]), "a")},
-            ),
-            (
-                AutoMaterializeRuleEvaluation(
-                    rule_snapshot=AutoMaterializeRule.skip_on_parent_outdated().to_snapshot(),
-                    evaluation_data=WaitingOnAssetsRuleEvaluationData(
-                        waiting_on_asset_keys=frozenset({AssetKey(["parent1"])}),
-                    ),
-                ),
-                {AssetKeyPartitionKey(AssetKey(["my_asset"]), "a")},
-            ),
-        ],
-        num_requested=0,
-        num_skipped=2,
-        num_discarded=0,
-        dynamic_partitions_store=None,
+    deserialized_with_run_ids = deserialize_value(
+        serialized_asset_evaluation, AssetConditionEvaluationWithRunIds
     )
+    deserialized = deserialized_with_run_ids.evaluation
 
-    # Previously serialized asset evaluations do not contain rule snapshots, so
-    # we override to be None
-    expected_asset_evaluation = expected_asset_evaluation._replace(rule_snapshots=None)
+    # all subsets should have zero size
+    assert deserialized.true_subset.size == 0
+    assert len(deserialized.child_evaluations) == 2
+    (materialize_evaluation, not_skip_evaluation) = deserialized.child_evaluations
+    assert materialize_evaluation.true_subset.size == 0
+    assert not_skip_evaluation.true_subset.size == 0
 
-    # json doesn't handle tuples, so they get turned into lists
-    assert (
-        deserialize_value(serialized_asset_evaluation)._replace(
-            partition_subsets_by_condition=[
-                tuple(t) for t in expected_asset_evaluation.partition_subsets_by_condition
-            ]
-        )
-        == expected_asset_evaluation
-    )
-    assert (
-        deserialize_value(serialize_value(expected_asset_evaluation))._replace(
-            partition_subsets_by_condition=[
-                tuple(t) for t in expected_asset_evaluation.partition_subsets_by_condition
-            ]
-        )
-        == expected_asset_evaluation
-    )
+    skip_evaluation = not_skip_evaluation.child_evaluations[0]
+    assert skip_evaluation.true_subset.size == 0
+    assert len(skip_evaluation.child_evaluations) == 4
+    assert skip_evaluation.child_evaluations[0].true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
@@ -131,7 +131,6 @@ cron_scenarios = [
                 ),
             ],
             num_requested=0,
-            num_skipped=1,
         )
         .with_runs(run_request("A"))
         .with_current_time_advanced(seconds=30)
@@ -149,7 +148,6 @@ cron_scenarios = [
                 ),
             ],
             num_requested=0,
-            num_skipped=1,
         )
         .with_runs(run_request("B"))
         .with_current_time_advanced(seconds=30)
@@ -211,7 +209,6 @@ cron_scenarios = [
                 ),
             ],
             num_requested=0,
-            num_skipped=1,
         )
         .with_runs(run_request("A", hour_partition_key(state.current_time, delta=1)))
         .with_current_time_advanced(seconds=30)
@@ -232,7 +229,6 @@ cron_scenarios = [
                 ),
             ],
             num_requested=0,
-            num_skipped=1,
         )
         .with_runs(run_request("B", hour_partition_key(state.current_time, delta=1)))
         .with_current_time_advanced(seconds=30)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
@@ -192,7 +192,6 @@ partition_scenarios = [
                 ),
             ],
             num_requested=1,
-            num_discarded=29,
         ),
     ),
     AssetDaemonScenario(

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -6,8 +6,8 @@ import sqlalchemy as db
 import sqlalchemy.dialects as db_dialects
 import sqlalchemy.pool as db_pool
 from dagster._config.config_schema import UserConfigSchema
-from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    AutoMaterializeAssetEvaluation,
+from dagster._core.definitions.asset_condition import (
+    AssetConditionEvaluationWithRunIds,
 )
 from dagster._core.storage.config import MySqlStorageConfig, mysql_config
 from dagster._core.storage.schedules import ScheduleStorageSqlMetadata, SqlScheduleStorage
@@ -174,7 +174,7 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
     def add_auto_materialize_asset_evaluations(
         self,
         evaluation_id: int,
-        asset_evaluations: Sequence[AutoMaterializeAssetEvaluation],
+        asset_evaluations: Sequence[AssetConditionEvaluationWithRunIds],
     ):
         if not asset_evaluations:
             return
@@ -187,8 +187,6 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
                     "asset_key": evaluation.asset_key.to_string(),
                     "asset_evaluation_body": serialize_value(evaluation),
                     "num_requested": evaluation.num_requested,
-                    "num_skipped": evaluation.num_skipped,
-                    "num_discarded": evaluation.num_discarded,
                 }
                 for evaluation in asset_evaluations
             ]
@@ -198,8 +196,6 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         upsert_stmt = insert_stmt.on_duplicate_key_update(
             asset_evaluation_body=insert_stmt.inserted.asset_evaluation_body,
             num_requested=insert_stmt.inserted.num_requested,
-            num_skipped=insert_stmt.inserted.num_skipped,
-            num_discarded=insert_stmt.inserted.num_discarded,
         )
 
         with self.connect() as conn:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -6,9 +6,7 @@ import sqlalchemy as db
 import sqlalchemy.dialects as db_dialects
 import sqlalchemy.pool as db_pool
 from dagster._config.config_schema import UserConfigSchema
-from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    AutoMaterializeAssetEvaluation,
-)
+from dagster._core.definitions.asset_condition import AssetConditionEvaluationWithRunIds
 from dagster._core.scheduler.instigation import InstigatorState
 from dagster._core.storage.config import PostgresStorageConfig, pg_config
 from dagster._core.storage.schedules import ScheduleStorageSqlMetadata, SqlScheduleStorage
@@ -181,7 +179,7 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
     def add_auto_materialize_asset_evaluations(
         self,
         evaluation_id: int,
-        asset_evaluations: Sequence[AutoMaterializeAssetEvaluation],
+        asset_evaluations: Sequence[AssetConditionEvaluationWithRunIds],
     ):
         if not asset_evaluations:
             return
@@ -193,8 +191,6 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
                     "asset_key": evaluation.asset_key.to_string(),
                     "asset_evaluation_body": serialize_value(evaluation),
                     "num_requested": evaluation.num_requested,
-                    "num_skipped": evaluation.num_skipped,
-                    "num_discarded": evaluation.num_discarded,
                 }
                 for evaluation in asset_evaluations
             ]
@@ -207,8 +203,6 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             set_={
                 "asset_evaluation_body": insert_stmt.excluded.asset_evaluation_body,
                 "num_requested": insert_stmt.excluded.num_requested,
-                "num_skipped": insert_stmt.excluded.num_skipped,
-                "num_discarded": insert_stmt.excluded.num_discarded,
             },
         )
 


### PR DESCRIPTION
## Summary & Motivation

This PR makes AssetConditionEvaluation the serialized object that we work with throughout the storage layer. This allows us to remove a lot of code whose responsibility was to translate between AutoMaterializeAssetEvaluation and AssetConditionEvaluation, and retains one callsite where we deserialize AutoMaterializeAssetEvaluation objects automatically into AssetConditionEvaluations.

This deserialization process is not 100% accurate, as the old objects work with SerializedPartitionSubsets, which require access to the asset graph in order to deserialize, whereas the new objects work with regular serialized PartitionSubsets, which do not. So any partition-specific information gets unfortunately lost in this process.

One other structural change here is that previously, we crammed a set of `run_ids` onto the AutoMaterializeAssetEvaluation object, but that makes a bit less sense in this context. It was always on somewhat shaky theoretical grounds (as the internals of the AMP logic create the original evaluation objects, but they have no idea what run ids will be created, so those need to get stacked on afterwards), but the recursive nature of AssetConditionEvaluations make this even more distasteful (as every node in the tree would need this run_ids field, but only the top-level one would ever have it set). To get around this, I created another class, AssetConditionEvaluationWithRunIds, to store the run ids.

## How I Tested These Changes
