### PR TITLE
[asset backfill] Sleep after fetching max storage ID

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1250,10 +1250,11 @@ def execute_asset_backfill_iteration_inner(
         next_latest_storage_id = instance_queryer.instance.event_log_storage.get_maximum_record_id()
     else:
         next_latest_storage_id = instance_queryer.instance.event_log_storage.get_maximum_record_id()
-        cursor_delay_time = int(os.getenv("ASSET_BACKFILL_CURSOR_DELAY_TIME", "3"))
+        cursor_delay_time = int(os.getenv("ASSET_BACKFILL_CURSOR_DELAY_TIME", "0"))
         # Events are not guaranteed to be written to the event log in monotonic increasing order,
         # so we wait to ensure all events up until next_latest_storage_id have been written.
-        time.sleep(cursor_delay_time)
+        if cursor_delay_time:
+            time.sleep(cursor_delay_time)
 
         updated_materialized_subset = None
         for updated_materialized_subset in get_asset_backfill_iteration_materialized_partitions(

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1250,7 +1250,7 @@ def execute_asset_backfill_iteration_inner(
         next_latest_storage_id = instance_queryer.instance.event_log_storage.get_maximum_record_id()
     else:
         next_latest_storage_id = instance_queryer.instance.event_log_storage.get_maximum_record_id()
-        cursor_delay_time = int(os.getenv("ASSET_BACKFILL_CURSOR_DELAY_TIME", "0"))
+        cursor_delay_time = int(os.getenv("ASSET_BACKFILL_CURSOR_DELAY_TIME", "3"))
         # Events are not guaranteed to be written to the event log in monotonic increasing order,
         # so we wait to ensure all events up until next_latest_storage_id have been written.
         time.sleep(cursor_delay_time)


### PR DESCRIPTION
This PR makes the cursor "lag" behind the maximum event log ID.

We currently can't ensure that postgres stores events in order respecting the event ID, so this PR makes the cursor lag behind the "bleeding edge" where events are stored. By setting `next_latest_storage_id` to the max event ID and waiting 3 seconds, all events up until `next_latest_storage_id` should be stored. Then, we can safely cursor after `next_latest_storage_id` on the next backfill iteration.

Events that are added after `next_latest_storage_id` and before updating the materialized and requested subsets will be evaluated again on the next iteration. But this should be safe since the asset backfill iteration operation is idempotent.