### PR TITLE
Add an env-var-controlled offset to the cursor used by asset backfills

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1220,6 +1220,20 @@ def _get_failed_and_downstream_asset_partitions(
     return failed_and_downstream_subset
 
 
+def _get_next_latest_storage_id(instance_queryer: CachingInstanceQueryer) -> int:
+    # Events are not always guaranteed to be written to the event log in monotonically increasing
+    # order, so add a configurable offset to ensure that any stragglers will still be included in
+    # the next iteration.
+    # This may result in the same event being considered within multiple iterations, but
+    # idempotence checks later ensure that the materialization isn't incorrectly
+    # double-counted.
+    cursor_offset = int(os.getenv("ASSET_BACKFILL_CURSOR_OFFSET", "0"))
+    next_latest_storage_id = (
+        instance_queryer.instance.event_log_storage.get_maximum_record_id() or 0
+    )
+    return max(next_latest_storage_id - cursor_offset, 0)
+
+
 def execute_asset_backfill_iteration_inner(
     backfill_id: str,
     asset_backfill_data: AssetBackfillData,
@@ -1247,9 +1261,10 @@ def execute_asset_backfill_iteration_inner(
 
         updated_materialized_subset = AssetGraphSubset()
         failed_and_downstream_subset = AssetGraphSubset()
-        next_latest_storage_id = instance_queryer.instance.event_log_storage.get_maximum_record_id()
+        next_latest_storage_id = _get_next_latest_storage_id(instance_queryer)
     else:
-        next_latest_storage_id = instance_queryer.instance.event_log_storage.get_maximum_record_id()
+        next_latest_storage_id = _get_next_latest_storage_id(instance_queryer)
+
         cursor_delay_time = int(os.getenv("ASSET_BACKFILL_CURSOR_DELAY_TIME", "0"))
         # Events are not guaranteed to be written to the event log in monotonic increasing order,
         # so we wait to ensure all events up until next_latest_storage_id have been written.


### PR DESCRIPTION
Summary:
This is another potential workaround for out-of-order race conditions with event insertions into postgres. We can take advantage of the fact that asset backfills can process the same events more than once without issue to add a fixed offset to the queries that. That should ensure that even if an event slips through the cracks on the first iteration, subsequent iterations will still pick it up via the offset.

## Summary & Motivation

## How I Tested These Changes
