### PR TITLE
fix celery-docker tests with lazy k8s import in test repo

### DIFF
--- a/python_modules/dagster-test/dagster_test/test_project/test_jobs/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_jobs/repo.py
@@ -36,7 +36,6 @@ from dagster._utils.merger import merge_dicts
 from dagster._utils.yaml_utils import merge_yamls
 from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
 from dagster_gcp.gcs import gcs_pickle_io_manager, gcs_resource
-from dagster_k8s import execute_k8s_job
 
 IS_BUILDKITE = bool(os.getenv("BUILDKITE"))
 
@@ -388,6 +387,9 @@ def slow_graph():
 
 @op
 def slow_execute_k8s_op(context):
+    # lazily import, since this repo is used in docker-tests and we can avoid the k8s import
+    from dagster_k8s import execute_k8s_job
+
     execute_k8s_job(
         context,
         image="busybox",


### PR DESCRIPTION
[NO_SKIP][test-all]

## Summary & Motivation
Fix build.

The two options I considered:
1. Lazily import within the op (this PR)
2. Just add `dagster-k8s` to the celery docker tox.ini

One option that's a little more involved that we can follow-up with but I punted on because I want to fix the build ASAP:
3. Refactor the repo so that we inherit in each location, and can fork the repo in each test module.

## How I Tested These Changes
BK