### PR TITLE
@asset_check additional_deps and additional_ins

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -1,8 +1,7 @@
-from typing import Any, Callable, Mapping, Optional, Set, Tuple, Union, cast
+from typing import AbstractSet, Any, Callable, Iterable, Mapping, Optional, Set, Tuple, Union
 
 from dagster import _check as check
 from dagster._annotations import experimental
-from dagster._builtins import Nothing
 from dagster._config import UserConfigSchema
 from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
@@ -10,20 +9,22 @@ from dagster._core.definitions.asset_checks import (
     AssetChecksDefinition,
     AssetChecksDefinitionInputOutputProps,
 )
+from dagster._core.definitions.asset_dep import CoercibleToAssetDep
+from dagster._core.definitions.asset_in import AssetIn
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.output import Out
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.source_asset import SourceAsset
-from dagster._core.definitions.utils import NoValueSentinel
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.execution.build_resources import wrap_resources_for_execution
 
 from ..input import In
 from .asset_decorator import (
+    build_asset_ins,
     get_function_params_without_context_or_config_or_resources,
-    stringify_asset_key_to_input_name,
+    make_asset_deps,
 )
 from .op_decorator import _Op
 
@@ -32,35 +33,66 @@ AssetCheckFunction = Callable[..., AssetCheckFunctionReturn]
 
 
 def _build_asset_check_input(
-    name: str, asset_key: AssetKey, fn: Callable
+    name: str,
+    asset_key: AssetKey,
+    fn: Callable,
+    secondary_ins: Mapping[str, AssetIn],
+    secondary_deps: Optional[AbstractSet[AssetKey]],
 ) -> Mapping[AssetKey, Tuple[str, In]]:
-    asset_params = get_function_params_without_context_or_config_or_resources(fn)
+    fn_params = get_function_params_without_context_or_config_or_resources(fn)
 
-    if len(asset_params) == 0:
-        input_name = stringify_asset_key_to_input_name(asset_key)
-        in_def = In(cast(type, Nothing))
-    elif len(asset_params) == 1:
-        input_name = asset_params[0].name
-        in_def = In(metadata={}, input_manager_key=None, dagster_type=NoValueSentinel)
-    else:
+    if asset_key in (secondary_deps or []):
         raise DagsterInvalidDefinitionError(
-            f"When defining check '{name}', multiple target assets provided as parameters:"
-            f" {[param.name for param in asset_params]}. Only one"
-            " is allowed."
+            f"When defining check '{name}', asset '{asset_key.to_user_string()}' was passed to `asset` and `secondary_deps`."
+            " It can only be passed to one of these parameters."
+        )
+    if asset_key in [asset_in.key for asset_in in secondary_ins.values()]:
+        raise DagsterInvalidDefinitionError(
+            f"When defining check '{name}', asset '{asset_key.to_user_string()}' was passed to `asset` and `secondary_ins`."
+            " It can only be passed to one of these parameters."
         )
 
-    return {
-        asset_key: (
-            input_name,
-            in_def,
+    fn_param_names = {param.name for param in fn_params}
+    for in_name in secondary_ins.keys():
+        if in_name not in fn_param_names:
+            raise DagsterInvalidDefinitionError(
+                f"'{in_name}' is specified in 'secondary_ins' but isn't a parameter."
+            )
+
+    # if all the fn_params are in secondary_ins, then we add the prmary asset as a dep
+    if len(fn_params) == len(secondary_ins):
+        all_deps = {*(secondary_deps if secondary_deps else set()), asset_key}
+        all_ins = secondary_ins
+    # otherwise there should be one extra fn_param, which is the primary asset. Add that as an input
+    elif len(fn_params) == len(secondary_ins) + 1:
+        primary_asset_param_name = next(
+            param.name for param in fn_params if param.name not in secondary_ins.keys()
         )
-    }
+        all_ins = {**secondary_ins, primary_asset_param_name: AssetIn(asset_key)}
+        all_deps = secondary_deps
+    else:
+        param_names_not_in_secondary_ins = sorted(
+            [f"'{name}'" for name in (fn_param_names - set(secondary_ins.keys()))]
+        )
+        raise DagsterInvalidDefinitionError(
+            f"When defining check '{name}', multiple assets provided as parameters:"
+            f" [{', '.join(param_names_not_in_secondary_ins)}]. These should either match"
+            " the target asset or be specified in 'secondary_ins'."
+        )
+
+    return build_asset_ins(
+        fn=fn,
+        asset_ins=all_ins,
+        deps=all_deps,
+    )
 
 
 @experimental
 def asset_check(
     *,
     asset: Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset],
+    secondary_ins: Optional[Mapping[str, AssetIn]] = None,
+    secondary_deps: Optional[Iterable[CoercibleToAssetDep]] = None,
     name: Optional[str] = None,
     description: Optional[str] = None,
     required_resource_keys: Optional[Set[str]] = None,
@@ -75,6 +107,14 @@ def asset_check(
     Args:
         asset (Union[AssetKey, Sequence[str], str, AssetsDefinition, SourceAsset]): The
             asset that the check applies to.
+        secondary_ins (Optional[Mapping[str, AssetIn]]): A mapping from input name to
+            information about the input. These inputs will apply to the underlying op that
+            executes the check. These should not include the `asset` parameter, which is
+            always included as a dependency.
+        secondary_deps (Optional[Iterable[CoercibleToAssetDep]]): Assets that are upstream
+            dependencies, but do not correspond to a parameter of the decorated function. These
+            dependencies will apply to the underlying op that executes the check. These should not
+            include the `asset` parameter, which is always included as a dependency.
         name (Optional[str]): The name of the check. If not specified, the name of the decorated
             function will be used. Checks for the same asset must have unique names.
         description (Optional[str]): The description of the check.
@@ -135,24 +175,18 @@ def asset_check(
         asset_key = AssetKey.from_coercible_or_definition(asset)
 
         out = Out(dagster_type=None)
-        input_tuples_by_asset_key = _build_asset_check_input(resolved_name, asset_key, fn)
-        if len(input_tuples_by_asset_key) == 0:
-            raise DagsterInvalidDefinitionError(
-                f"No target asset provided when defining check '{resolved_name}'"
-            )
+        input_tuples_by_asset_key = _build_asset_check_input(
+            resolved_name,
+            asset_key,
+            fn,
+            secondary_ins=secondary_ins or {},
+            secondary_deps={dep.asset_key for dep in make_asset_deps(secondary_deps) or set()},
+        )
 
-        if len(input_tuples_by_asset_key) > 1:
-            raise DagsterInvalidDefinitionError(
-                f"When defining check '{resolved_name}', Multiple target assets provided:"
-                f" {[key.to_user_string() for key in input_tuples_by_asset_key.keys()]}. Only one"
-                " is allowed."
-            )
-
-        resolved_asset_key = next(iter(input_tuples_by_asset_key.keys()))
         spec = AssetCheckSpec(
             name=resolved_name,
             description=description,
-            asset=resolved_asset_key,
+            asset=asset_key,
         )
 
         arg_resource_keys = {arg.name for arg in get_resource_args(fn)}
@@ -189,7 +223,8 @@ def asset_check(
             specs=[spec],
             input_output_props=AssetChecksDefinitionInputOutputProps(
                 asset_keys_by_input_name={
-                    input_tuples_by_asset_key[resolved_asset_key][0]: resolved_asset_key
+                    input_tuple[0]: asset_key
+                    for asset_key, input_tuple in input_tuples_by_asset_key.items()
                 },
                 asset_check_keys_by_output_name={op_def.output_defs[0].name: spec.key},
             ),

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1369,14 +1369,14 @@ def _deps_and_non_argument_deps_to_asset_deps(
         )
 
     if deps is not None:
-        return _make_asset_deps(deps)
+        return make_asset_deps(deps)
 
     if non_argument_deps is not None:
         check.set_param(non_argument_deps, "non_argument_deps", of_type=(AssetKey, str))
-        return _make_asset_deps(non_argument_deps)
+        return make_asset_deps(non_argument_deps)
 
 
-def _make_asset_deps(deps: Optional[Iterable[CoercibleToAssetDep]]) -> Optional[Iterable[AssetDep]]:
+def make_asset_deps(deps: Optional[Iterable[CoercibleToAssetDep]]) -> Optional[Iterable[AssetDep]]:
     if deps is None:
         return None
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
@@ -570,7 +570,7 @@ def test_multiple_managed_inputs():
         match=re.escape(
             "When defining check 'check1', multiple assets provided as parameters:"
             " ['asset1', 'asset2']. These should either match the target asset or be specified "
-            "in 'secondary_ins'."
+            "in 'additional_ins'."
         ),
     ):
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
@@ -26,7 +26,11 @@ from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariant
 
 
 def execute_assets_and_checks(
-    assets=None, asset_checks=None, raise_on_error: bool = True, resources=None, instance=None
+    assets=None,
+    asset_checks=None,
+    raise_on_error: bool = True,
+    resources=None,
+    instance=None,
 ) -> ExecuteInProcessResult:
     defs = Definitions(assets=assets, asset_checks=asset_checks, resources=resources)
     job_def = defs.get_implicit_global_asset_job_def()
@@ -564,8 +568,9 @@ def test_multiple_managed_inputs():
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=re.escape(
-            "When defining check 'check1', multiple target assets provided as parameters:"
-            " ['asset1', 'asset2']. Only one is allowed."
+            "When defining check 'check1', multiple assets provided as parameters:"
+            " ['asset1', 'asset2']. These should either match the target asset or be specified "
+            "in 'secondary_ins'."
         ),
     ):
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator_secondary_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator_secondary_assets.py
@@ -22,8 +22,8 @@ def asset2() -> int:
     return 5
 
 
-def test_secondary_deps():
-    @asset_check(asset=asset1, secondary_deps=[asset2])
+def test_additional_deps():
+    @asset_check(asset=asset1, additional_deps=[asset2])
     def check1():
         return AssetCheckResult(passed=True)
 
@@ -32,8 +32,8 @@ def test_secondary_deps():
     execute_assets_and_checks(assets=[asset1, asset2], asset_checks=[check1])
 
 
-def test_secondary_deps_with_managed_input():
-    @asset_check(asset=asset1, secondary_deps=[asset2])
+def test_additional_deps_with_managed_input():
+    @asset_check(asset=asset1, additional_deps=[asset2])
     def check1(asset_1):
         assert asset_1 == 4
         return AssetCheckResult(passed=True)
@@ -43,16 +43,16 @@ def test_secondary_deps_with_managed_input():
     execute_assets_and_checks(assets=[asset1, asset2], asset_checks=[check1])
 
 
-def test_secondary_deps_overlap():
+def test_additional_deps_overlap():
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=re.escape(
             "When defining check 'check1', asset 'asset1' was passed to `asset` and "
-            "`secondary_deps`. It can only be passed to one of these parameters."
+            "`additional_deps`. It can only be passed to one of these parameters."
         ),
     ):
 
-        @asset_check(asset=asset1, secondary_deps=[asset1])
+        @asset_check(asset=asset1, additional_deps=[asset1])
         def check1(asset_1):
             pass
 
@@ -60,52 +60,52 @@ def test_secondary_deps_overlap():
         DagsterInvalidDefinitionError,
         match=re.escape(
             "When defining check 'check2', asset 'asset1' was passed to `asset` and "
-            "`secondary_deps`. It can only be passed to one of these parameters."
+            "`additional_deps`. It can only be passed to one of these parameters."
         ),
     ):
 
-        @asset_check(asset=asset1, secondary_deps=[asset1])
+        @asset_check(asset=asset1, additional_deps=[asset1])
         def check2():
             pass
 
 
-def test_secondary_ins_overlap():
+def test_additional_ins_overlap():
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=re.escape(
             "When defining check 'check1', asset 'asset1' was passed to `asset` and "
-            "`secondary_ins`. It can only be passed to one of these parameters."
+            "`additional_ins`. It can only be passed to one of these parameters."
         ),
     ):
 
-        @asset_check(asset=asset1, secondary_ins={"asset_1": AssetIn("asset1")})
+        @asset_check(asset=asset1, additional_ins={"asset_1": AssetIn("asset1")})
         def check1(asset_1):
             pass
 
 
-def test_secondary_ins_and_deps_overlap():
+def test_additional_ins_and_deps_overlap():
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=re.escape("deps value AssetKey(['asset2']) also declared as input/AssetIn"),
     ):
 
         @asset_check(
-            asset=asset1, secondary_ins={"asset_2": AssetIn("asset2")}, secondary_deps=[asset2]
+            asset=asset1, additional_ins={"asset_2": AssetIn("asset2")}, additional_deps=[asset2]
         )
         def check1(asset_2):
             pass
 
 
-def test_secondary_ins_must_correspond_to_params():
+def test_additional_ins_must_correspond_to_params():
     with pytest.raises(DagsterInvalidDefinitionError):
 
-        @asset_check(asset=asset1, secondary_ins={"foo": AssetIn("asset2")})
+        @asset_check(asset=asset1, additional_ins={"foo": AssetIn("asset2")})
         def check1():
             return AssetCheckResult(passed=True)
 
 
-def test_secondary_ins():
-    @asset_check(asset=asset1, secondary_ins={"foo": AssetIn("asset2")})
+def test_additional_ins():
+    @asset_check(asset=asset1, additional_ins={"foo": AssetIn("asset2")})
     def check1(asset1, foo):
         assert asset1 == 4
         assert foo == 5
@@ -116,8 +116,8 @@ def test_secondary_ins():
     execute_assets_and_checks(assets=[asset1, asset2], asset_checks=[check1])
 
 
-def test_secondary_ins_primary_asset_not_a_param():
-    @asset_check(asset=asset1, secondary_ins={"foo": AssetIn("asset2")})
+def test_additional_ins_primary_asset_not_a_param():
+    @asset_check(asset=asset1, additional_ins={"foo": AssetIn("asset2")})
     def check1(foo):
         assert foo == 5
         return AssetCheckResult(passed=True)
@@ -127,7 +127,7 @@ def test_secondary_ins_primary_asset_not_a_param():
     execute_assets_and_checks(assets=[asset1, asset2], asset_checks=[check1])
 
 
-def test_check_waits_for_secondary():
+def test_check_waits_for_additional_deps():
     @asset
     def my_asset():
         pass
@@ -136,7 +136,7 @@ def test_check_waits_for_secondary():
     def my_fail_asset():
         raise Exception("foobar")
 
-    @asset_check(asset=asset1, secondary_deps=[my_fail_asset])
+    @asset_check(asset=asset1, additional_deps=[my_fail_asset])
     def check_with_dep():
         return AssetCheckResult(passed=True)
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator_secondary_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator_secondary_assets.py
@@ -1,0 +1,155 @@
+import re
+
+import pytest
+from dagster import (
+    AssetCheckResult,
+    AssetIn,
+    DagsterInvalidDefinitionError,
+    asset,
+    asset_check,
+)
+
+from .test_asset_check_decorator import execute_assets_and_checks
+
+
+@asset
+def asset1() -> int:
+    return 4
+
+
+@asset
+def asset2() -> int:
+    return 5
+
+
+def test_secondary_deps():
+    @asset_check(asset=asset1, secondary_deps=[asset2])
+    def check1():
+        return AssetCheckResult(passed=True)
+
+    assert len(check1.node_def.input_defs) == 2
+
+    execute_assets_and_checks(assets=[asset1, asset2], asset_checks=[check1])
+
+
+def test_secondary_deps_with_managed_input():
+    @asset_check(asset=asset1, secondary_deps=[asset2])
+    def check1(asset_1):
+        assert asset_1 == 4
+        return AssetCheckResult(passed=True)
+
+    assert len(check1.node_def.input_defs) == 2
+
+    execute_assets_and_checks(assets=[asset1, asset2], asset_checks=[check1])
+
+
+def test_secondary_deps_overlap():
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=re.escape(
+            "When defining check 'check1', asset 'asset1' was passed to `asset` and "
+            "`secondary_deps`. It can only be passed to one of these parameters."
+        ),
+    ):
+
+        @asset_check(asset=asset1, secondary_deps=[asset1])
+        def check1(asset_1):
+            pass
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=re.escape(
+            "When defining check 'check2', asset 'asset1' was passed to `asset` and "
+            "`secondary_deps`. It can only be passed to one of these parameters."
+        ),
+    ):
+
+        @asset_check(asset=asset1, secondary_deps=[asset1])
+        def check2():
+            pass
+
+
+def test_secondary_ins_overlap():
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=re.escape(
+            "When defining check 'check1', asset 'asset1' was passed to `asset` and "
+            "`secondary_ins`. It can only be passed to one of these parameters."
+        ),
+    ):
+
+        @asset_check(asset=asset1, secondary_ins={"asset_1": AssetIn("asset1")})
+        def check1(asset_1):
+            pass
+
+
+def test_secondary_ins_and_deps_overlap():
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=re.escape("deps value AssetKey(['asset2']) also declared as input/AssetIn"),
+    ):
+
+        @asset_check(
+            asset=asset1, secondary_ins={"asset_2": AssetIn("asset2")}, secondary_deps=[asset2]
+        )
+        def check1(asset_2):
+            pass
+
+
+def test_secondary_ins_must_correspond_to_params():
+    with pytest.raises(DagsterInvalidDefinitionError):
+
+        @asset_check(asset=asset1, secondary_ins={"foo": AssetIn("asset2")})
+        def check1():
+            return AssetCheckResult(passed=True)
+
+
+def test_secondary_ins():
+    @asset_check(asset=asset1, secondary_ins={"foo": AssetIn("asset2")})
+    def check1(asset1, foo):
+        assert asset1 == 4
+        assert foo == 5
+        return AssetCheckResult(passed=True)
+
+    assert len(check1.node_def.input_defs) == 2
+
+    execute_assets_and_checks(assets=[asset1, asset2], asset_checks=[check1])
+
+
+def test_secondary_ins_primary_asset_not_a_param():
+    @asset_check(asset=asset1, secondary_ins={"foo": AssetIn("asset2")})
+    def check1(foo):
+        assert foo == 5
+        return AssetCheckResult(passed=True)
+
+    assert len(check1.node_def.input_defs) == 2
+
+    execute_assets_and_checks(assets=[asset1, asset2], asset_checks=[check1])
+
+
+def test_check_waits_for_secondary():
+    @asset
+    def my_asset():
+        pass
+
+    @asset
+    def my_fail_asset():
+        raise Exception("foobar")
+
+    @asset_check(asset=asset1, secondary_deps=[my_fail_asset])
+    def check_with_dep():
+        return AssetCheckResult(passed=True)
+
+    @asset_check(asset=asset1)
+    def check_without_dep():
+        return AssetCheckResult(passed=True)
+
+    result = execute_assets_and_checks(
+        assets=[my_asset, my_fail_asset],
+        asset_checks=[check_with_dep, check_without_dep],
+        raise_on_error=False,
+    )
+    assert not result.success
+    assert len(result.get_asset_materialization_events()) == 1
+    assert len(result.get_asset_check_evaluations()) == 1
+    assert result.get_asset_check_evaluations()[0].check_name == "check_without_dep"


### PR DESCRIPTION
Add two new parameters to @asset_check: `secondary_ins` and `secondary_deps`. These match the respective types of `ins` and `deps` on @asset.

Previously the check op could only depend on the op of the asset that it targets. These enable adding dependencies other than the target asset. This is useful for cases like 'joinability' tests that compare a dataset with another. A related behavior would be to allow checks to target multiple assets at once. We may end up doing that down the road, but we've heard from several users that they want to have dependencies on assets that the check doesn't apply to.

This diff ~~needs some attention to the error messages, but otherwise~~ is ready to go.

Followups:
- we'll want to surface dependencies in the UI (for now, the plan is to just list them as part of the check definition, not to show them in the asset graph).
- to do that, we'll add a `secondary_dependencies` field to ExternalAssetCheck
- with more complicated dependencies come more complicated staleness scenarios. I think at some stage we'll want to surface data versions/'upstream newer' info for checks now that they can have multiple deps.

**Update:** renamed to additional_deps and additional_ins