### PR TITLE
Allow automation policy sensors to select both vanilla and source assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -294,7 +294,9 @@ class AssetSelection(ABC):
         return SubtractAssetSelection(self, other)
 
     def resolve(
-        self, all_assets: Union[Iterable[Union[AssetsDefinition, SourceAsset]], AssetGraph]
+        self,
+        all_assets: Union[Iterable[Union[AssetsDefinition, SourceAsset]], AssetGraph],
+        allow_regular_and_source_assets: bool = False,
     ) -> AbstractSet[AssetKey]:
         if isinstance(all_assets, AssetGraph):
             asset_graph = all_assets
@@ -303,13 +305,14 @@ class AssetSelection(ABC):
             asset_graph = AssetGraph.from_assets(all_assets)
 
         resolved = self.resolve_inner(asset_graph)
-        resolved_source_assets = asset_graph.source_asset_keys & resolved
-        resolved_regular_assets = resolved - asset_graph.source_asset_keys
-        check.invariant(
-            not (len(resolved_source_assets) > 0 and len(resolved_regular_assets) > 0),
-            "Asset selection specified both regular assets and source assets. This is not"
-            " currently supported. Selections must be all regular assets or all source assets.",
-        )
+        if not allow_regular_and_source_assets:
+            resolved_source_assets = asset_graph.source_asset_keys & resolved
+            resolved_regular_assets = resolved - asset_graph.source_asset_keys
+            check.invariant(
+                not (len(resolved_source_assets) > 0 and len(resolved_regular_assets) > 0),
+                "Asset selection specified both regular assets and source assets. This is not"
+                " currently supported. Selections must be all regular assets or all source assets.",
+            )
         return resolved
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -430,7 +430,9 @@ def _validate_automation_policy_sensors(
     sensor_names_by_asset_key: Dict[AssetKey, str] = {}
     for sensor in sensors:
         if isinstance(sensor, AutomationPolicySensorDefinition):
-            asset_keys = sensor.asset_selection.resolve(asset_graph)
+            asset_keys = sensor.asset_selection.resolve(
+                asset_graph, allow_regular_and_source_assets=True
+            )
             for asset_key in asset_keys:
                 if asset_key in sensor_names_by_asset_key:
                     raise DagsterInvalidDefinitionError(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
@@ -23,6 +23,7 @@ from dagster import (
     io_manager,
     job,
     logger,
+    observable_source_asset,
     op,
     repository,
     resource,
@@ -1445,12 +1446,17 @@ def test_automation_policy_sensors_incomplete_cover():
     def asset2():
         ...
 
+    @observable_source_asset
+    def auto_observe_asset():
+        pass
+
     @repository
     def repo():
         return [
             asset1,
             asset2,
-            AutomationPolicySensorDefinition("a", asset_selection=[asset1]),
+            auto_observe_asset,
+            AutomationPolicySensorDefinition("a", asset_selection=[asset1, auto_observe_asset]),
         ]
 
 


### PR DESCRIPTION
Summary:
Even though these assets cannot yet be part of a single run, this new sensor type has the ability to target them. Open to alternative APIs besides the boolean - I suspect we will know the specific places where we need to be more open when resolve these types of asset selections though.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
