### PR TITLE
[amp-refactor][6/n] Simplify AssetConditionEvaluationContext

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -33,9 +33,9 @@ class AssetDaemonAssetCursor(NamedTuple):
     """
 
     asset_key: AssetKey
-    latest_storage_id: Optional[int]
-    latest_evaluation_timestamp: Optional[float]
-    latest_evaluation: Optional["AssetConditionEvaluation"]
+    previous_max_storage_id: Optional[int]
+    previous_evaluation_timestamp: Optional[float]
+    previous_evaluation: Optional["AssetConditionEvaluation"]
     materialized_requested_or_discarded_subset: AssetSubset
 
 
@@ -82,9 +82,9 @@ class AssetDaemonCursor(NamedTuple):
             handled_subset = AssetSubset.empty(asset_key, partitions_def)
         return AssetDaemonAssetCursor(
             asset_key=asset_key,
-            latest_storage_id=self.latest_storage_id,
-            latest_evaluation_timestamp=self.latest_evaluation_timestamp,
-            latest_evaluation=self.latest_evaluation_by_asset_key.get(asset_key),
+            previous_max_storage_id=self.latest_storage_id,
+            previous_evaluation_timestamp=self.latest_evaluation_timestamp,
+            previous_evaluation=self.latest_evaluation_by_asset_key.get(asset_key),
             materialized_requested_or_discarded_subset=handled_subset,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -18,7 +18,7 @@ from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._utils.schedules import cron_string_iterator
 
 if TYPE_CHECKING:
-    from .asset_condition_evaluation_context import RootAssetConditionEvaluationContext
+    from .asset_condition_evaluation_context import AssetConditionEvaluationContext
     from .auto_materialize_rule_evaluation import RuleEvaluationResults, TextRuleEvaluationData
 
 
@@ -110,7 +110,7 @@ def get_execution_period_and_evaluation_data_for_policies(
 
 
 def get_expected_data_time_for_asset_key(
-    context: "RootAssetConditionEvaluationContext", will_materialize: bool
+    context: "AssetConditionEvaluationContext", will_materialize: bool
 ) -> Optional[datetime.datetime]:
     """Returns the data time that you would expect this asset to have if you were to execute it
     on this tick.
@@ -153,7 +153,7 @@ def get_expected_data_time_for_asset_key(
 
 
 def freshness_evaluation_results_for_asset_key(
-    context: "RootAssetConditionEvaluationContext",
+    context: "AssetConditionEvaluationContext",
 ) -> "RuleEvaluationResults":
     """Returns a set of AssetKeyPartitionKeys to materialize in order to abide by the given
     FreshnessPolicies.

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -731,7 +731,7 @@ class TestScheduleStorage:
         if not self.can_store_auto_materialize_asset_evaluations():
             pytest.skip("Storage cannot store auto materialize asset evaluations")
 
-        condition_snapshot = AssetConditionSnapshot("foo", "bar", [])
+        condition_snapshot = AssetConditionSnapshot("foo", "bar", "")
 
         for _ in range(2):  # test idempotency
             storage.add_auto_materialize_asset_evaluations(
@@ -816,13 +816,13 @@ class TestScheduleStorage:
         # add a mix of keys - one that already is using the unique index and one that is not
 
         eval_one = AssetConditionEvaluation(
-            condition_snapshot=AssetConditionSnapshot("foo", "bar", []),
+            condition_snapshot=AssetConditionSnapshot("foo", "bar", ""),
             true_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=True),
             candidate_subset=None,
         ).with_run_ids(set())
 
         eval_asset_three = AssetConditionEvaluation(
-            condition_snapshot=AssetConditionSnapshot("foo", "bar", []),
+            condition_snapshot=AssetConditionSnapshot("foo", "bar", ""),
             true_subset=AssetSubset(asset_key=AssetKey("asset_three"), value=True),
             candidate_subset=None,
         ).with_run_ids(set())
@@ -866,7 +866,7 @@ class TestScheduleStorage:
             evaluation_id=10,
             asset_evaluations=[
                 AssetConditionEvaluation(
-                    condition_snapshot=AssetConditionSnapshot("foo", "bar", []),
+                    condition_snapshot=AssetConditionSnapshot("foo", "bar", ""),
                     true_subset=asset_subset,
                     candidate_subset=None,
                     subsets_with_metadata=[asset_subset_with_metadata],
@@ -892,7 +892,7 @@ class TestScheduleStorage:
             evaluation_id=11,
             asset_evaluations=[
                 AssetConditionEvaluation(
-                    condition_snapshot=AssetConditionSnapshot("foo", "bar", []),
+                    condition_snapshot=AssetConditionSnapshot("foo", "bar", ""),
                     true_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=True),
                     candidate_subset=None,
                     subsets_with_metadata=[],

--- a/scripts/run-pyright.py
+++ b/scripts/run-pyright.py
@@ -203,7 +203,9 @@ def get_params(args: argparse.Namespace) -> Params:
     elif args.diff:
         mode = "path"
         targets = (
-            subprocess.check_output(["git", "diff", "--name-only", "origin/master"])
+            subprocess.check_output(
+                ["git", "diff", "--name-only", "origin/master", "--diff-filter=d"]
+            )
             .decode("utf-8")
             .splitlines()
         )


### PR DESCRIPTION
## Summary & Motivation

This simplifies the AssetConditionEvaluationContext. Previously, it was broken up into two separate classes. One class was reserved for storing all of the cached properties, which child context objects could reference. This PR changes the scheme for maintaining references to cached properties by just keeping a reference to the root context object on all child context objects, and providing a convenience wrapper to designate properties that should only be referenced on the root context object.

## How I Tested These Changes
