### PR TITLE
Env var to mask user code errors

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
@@ -88,7 +88,7 @@ query {
 
 @pytest.fixture(scope="function")
 def enable_masking_user_code_errors() -> Any:
-    with environ({"DAGSTER_MASK_USER_CODE_ERRORS": "1"}):
+    with environ({"DAGSTER_REDACT_USER_CODE_ERRORS": "1"}):
         yield
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
@@ -278,7 +278,9 @@ class TestLoadWorkspace(BaseTestSuite):
 
             assert failure_node["name"] == "error_location"
             assert failure_node["loadStatus"] == "LOADED"
-            assert "No such file or directory" not in failure_node["locationOrLoadError"]["message"]
+            assert (
+                "No such file or directory" not in failure_node["locationOrLoadError"]["message"]
+            ), failure_node["locationOrLoadError"]["message"]
             assert (
                 "Search in logs for this error ID for more details"
                 in failure_node["locationOrLoadError"]["message"]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
@@ -43,6 +43,13 @@ query {
             }
             ... on PythonError {
               message
+              stack
+              errorChain {
+                error {
+                  message
+                  stack
+                }
+              }
             }
           }
           loadStatus
@@ -60,6 +67,12 @@ query {
       ... on PythonError {
           message
           stack
+          errorChain {
+            error {
+                message
+                stack
+            }
+          }
       }
     }
 }
@@ -155,7 +168,10 @@ class TestLoadWorkspace(BaseTestSuite):
 
             assert failure_node["name"] == "error_location"
             assert failure_node["loadStatus"] == "LOADED"
-            assert "No such file or directory" in failure_node["locationOrLoadError"]["message"]
+
+            assert "No such file or directory" in str(
+                failure_node["locationOrLoadError"]
+            ), failure_node
 
             for node in nodes:
                 assert node["loadStatus"] == "LOADED"
@@ -278,8 +294,8 @@ class TestLoadWorkspace(BaseTestSuite):
 
             assert failure_node["name"] == "error_location"
             assert failure_node["loadStatus"] == "LOADED"
-            assert (
-                "No such file or directory" not in failure_node["locationOrLoadError"]["message"]
+            assert "No such file or directory" not in str(
+                failure_node["locationOrLoadError"]
             ), failure_node["locationOrLoadError"]["message"]
             assert (
                 "Search in logs for this error ID for more details"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
@@ -1,13 +1,16 @@
+import re
 import sys
 import time
 from typing import Any
 from unittest import mock
 
+import pytest
 from dagster import file_relative_path
 from dagster._core.host_representation import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.host_representation.feature_flags import (
     CodeLocationFeatureFlags,
 )
+from dagster._core.test_utils import environ
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.load import location_origins_from_yaml_paths
 from dagster.version import __version__ as dagster_version
@@ -15,6 +18,8 @@ from dagster_graphql.test.utils import execute_dagster_graphql
 from dagster_graphql.version import __version__ as dagster_graphql_version
 
 from .graphql_context_test_suite import GraphQLContextVariant, make_graphql_context_test_suite
+
+ERROR_ID_REGEX = r"Error occurred during user code execution, error ID ([a-z0-9\-]+)"
 
 WORKSPACE_QUERY = """
 query {
@@ -82,6 +87,13 @@ query {
     }
 }
 """
+
+
+@pytest.fixture(scope="function")
+def enable_masking_user_code_errors() -> Any:
+    with environ({"DAGSTER_MASK_USER_CODE_ERRORS": "1"}):
+        yield
+
 
 BaseTestSuite: Any = make_graphql_context_test_suite(
     context_variants=[GraphQLContextVariant.non_launchable_sqlite_instance_multi_location()]
@@ -213,3 +225,73 @@ class TestLoadWorkspace(BaseTestSuite):
             for node in nodes:
                 assert node["loadStatus"] == "LOADED"
                 assert float(node["updateTimestamp"]) > reload_timestamp
+
+    def test_load_workspace_masked(self, graphql_context, enable_masking_user_code_errors, capsys):
+        # Add an error origin
+        original_origins = location_origins_from_yaml_paths(
+            [file_relative_path(__file__, "multi_location.yaml")]
+        )
+        with mock.patch(
+            "dagster._core.workspace.load_target.location_origins_from_yaml_paths",
+        ) as origins_mock:
+            original_origins.append(
+                ManagedGrpcPythonEnvCodeLocationOrigin(
+                    location_name="error_location",
+                    loadable_target_origin=LoadableTargetOrigin(
+                        python_file="made_up_file.py", executable_path=sys.executable
+                    ),
+                )
+            )
+
+            origins_mock.return_value = original_origins
+
+            new_context = graphql_context.reload_workspace()
+
+            result = execute_dagster_graphql(new_context, WORKSPACE_QUERY)
+
+            assert result
+            assert result.data
+            assert result.data["workspaceOrError"]
+            assert result.data["workspaceOrError"]["__typename"] == "Workspace", str(result.data)
+
+            nodes = result.data["workspaceOrError"]["locationEntries"]
+
+            assert len(nodes) == 3
+
+            assert all([node["__typename"] == "WorkspaceLocationEntry" for node in nodes]), str(
+                nodes
+            )
+
+            success_nodes = [
+                node["locationOrLoadError"]
+                for node in nodes
+                if node["locationOrLoadError"]["__typename"] == "RepositoryLocation"
+            ]
+            assert len(success_nodes) == 2
+            assert success_nodes[0]["dagsterLibraryVersions"] == [
+                {"name": "dagster", "version": dagster_version},
+                {"name": "dagster-graphql", "version": dagster_graphql_version},
+            ]
+
+            failures = [
+                node for node in nodes if node["locationOrLoadError"]["__typename"] == "PythonError"
+            ]
+            assert len(failures) == 1
+            failure_node = failures[0]
+
+            assert failure_node["name"] == "error_location"
+            assert failure_node["loadStatus"] == "LOADED"
+            assert "No such file or directory" not in failure_node["locationOrLoadError"]["message"]
+            assert (
+                "Search in logs for this error ID for more details"
+                in failure_node["locationOrLoadError"]["message"]
+            )
+            error_id = re.search(
+                ERROR_ID_REGEX, str(failure_node["locationOrLoadError"]["message"])
+            ).group(1)
+
+            captured_stderr = capsys.readouterr().err
+            assert (
+                f"Error occurred during user code execution, error ID {error_id}" in captured_stderr
+            )
+            # assert "Search in logs for this error ID for more details" not in captured_stderr TODO: fix this

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
@@ -1,4 +1,3 @@
-import re
 import sys
 import time
 from typing import Any
@@ -18,8 +17,6 @@ from dagster_graphql.test.utils import execute_dagster_graphql
 from dagster_graphql.version import __version__ as dagster_graphql_version
 
 from .graphql_context_test_suite import GraphQLContextVariant, make_graphql_context_test_suite
-
-ERROR_ID_REGEX = r"Error occurred during user code execution, error ID ([a-z0-9\-]+)"
 
 WORKSPACE_QUERY = """
 query {
@@ -226,7 +223,7 @@ class TestLoadWorkspace(BaseTestSuite):
                 assert node["loadStatus"] == "LOADED"
                 assert float(node["updateTimestamp"]) > reload_timestamp
 
-    def test_load_workspace_masked(self, graphql_context, enable_masking_user_code_errors, capsys):
+    def test_load_workspace_masked(self, graphql_context, enable_masking_user_code_errors):
         # Add an error origin
         original_origins = location_origins_from_yaml_paths(
             [file_relative_path(__file__, "multi_location.yaml")]
@@ -286,12 +283,3 @@ class TestLoadWorkspace(BaseTestSuite):
                 "Search in logs for this error ID for more details"
                 in failure_node["locationOrLoadError"]["message"]
             )
-            error_id = re.search(
-                ERROR_ID_REGEX, str(failure_node["locationOrLoadError"]["message"])
-            ).group(1)
-
-            captured_stderr = capsys.readouterr().err
-            assert (
-                f"Error occurred during user code execution, error ID {error_id}" in captured_stderr
-            )
-            # assert "Search in logs for this error ID for more details" not in captured_stderr TODO: fix this

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -507,7 +507,7 @@ class DagsterCodeLocationNotFoundError(DagsterError):
     pass
 
 
-class DagsterMaskedUserCodeError(DagsterError):
+class DagsterRedactedUserCodeError(DagsterError):
     """Error used to mask user code errors to prevent leaking sensitive information. Contains an error ID that can be
     used to look up the original error in the user code error log.
     """

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -506,6 +506,16 @@ class DagsterCodeLocationNotFoundError(DagsterError):
     pass
 
 
+class DagsterMaskedUserCodeError(DagsterError):
+    """Error used to mask user code errors to prevent leaking sensitive information. Contains an error ID that can be
+    used to look up the original error in the user code error log.
+    """
+
+
+class DagsterUserCodeLoadError(DagsterUserCodeExecutionError):
+    """Errors raised in a user process during the loading of user code."""
+
+
 class DagsterCodeLocationLoadError(DagsterError):
     def __init__(self, *args, **kwargs):
         from dagster._utils.error import SerializableErrorInfo

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -291,9 +291,10 @@ def user_code_error_boundary(
         except Exception as e:
             # An exception has been thrown by user code and computation should cease
             # with the error reported further up the stack
-            raise error_cls(
+            new_error = error_cls(
                 msg_fn(), user_exception=e, original_exc_info=sys.exc_info(), **kwargs
-            ) from e
+            )
+            raise new_error from e
         finally:
             if log_manager:
                 log_manager.end_python_log_capture()

--- a/python_modules/dagster/dagster/_core/execution/plan/objects.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/objects.py
@@ -110,7 +110,7 @@ class StepFailureData(
         if self.error_source == ErrorSource.USER_CODE_ERROR:
             user_code_error = self.error.cause
             check.invariant(
-                self.error.cls_name == "DagsterMaskedUserCodeError" or user_code_error,
+                self.error.cls_name == "DagsterRedactedUserCodeError" or user_code_error,
                 "User code error is missing cause. User code errors are expected to have a"
                 " causes, which are the errors thrown from user code.",
             )

--- a/python_modules/dagster/dagster/_core/execution/plan/objects.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/objects.py
@@ -110,10 +110,12 @@ class StepFailureData(
         if self.error_source == ErrorSource.USER_CODE_ERROR:
             user_code_error = self.error.cause
             check.invariant(
-                user_code_error,
+                self.error.cls_name == "DagsterMaskedUserCodeError" or user_code_error,
                 "User code error is missing cause. User code errors are expected to have a"
                 " causes, which are the errors thrown from user code.",
             )
+            if not user_code_error:
+                return self.error.message.strip() + ":\n\n" + self.error.to_string()
             return self.error.message.strip() + ":\n\n" + user_code_error.to_string()
         else:
             return self.error.to_string()

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -202,7 +202,10 @@ class LoadedRepositories:
 
         with user_code_error_boundary(
             DagsterUserCodeLoadError,
-            lambda: "Error occurred assembling repositories to load",
+            lambda: "Error occurred during the loading of Dagster definitions in\n"
+            + ", ".join(
+                [f"{k}={v}" for k, v in loadable_target_origin._asdict().items() if v is not None]
+            ),
         ):
             loadable_targets = get_loadable_targets(
                 loadable_target_origin.python_file,
@@ -221,7 +224,8 @@ class LoadedRepositories:
             )
             with user_code_error_boundary(
                 DagsterUserCodeLoadError,
-                lambda: "Error occurred during the loading of repository " + pointer.describe(),
+                lambda: "Error occurred during the loading of Dagster definitions in "
+                + pointer.describe(),
             ):
                 repo_def = recon_repo.get_definition()
                 # force load of all lazy constructed code artifacts to prevent

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -372,7 +372,9 @@ class DagsterApiServer(DagsterApiServicer):
             if not lazy_load_user_code:
                 raise
             self._loaded_repositories = None
-            self._serializable_load_error = serializable_error_info_from_exc_info(sys.exc_info())
+            self._serializable_load_error = serializable_error_info_from_exc_info(
+                sys.exc_info(), hoist_user_code_execution_error=True
+            )
             self._logger.exception("Error while importing code")
 
         self.__last_heartbeat_time = time.time()

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -376,9 +376,7 @@ class DagsterApiServer(DagsterApiServicer):
             if not lazy_load_user_code:
                 raise
             self._loaded_repositories = None
-            self._serializable_load_error = serializable_error_info_from_exc_info(
-                sys.exc_info(),  # hoist_user_code_execution_error=True
-            )
+            self._serializable_load_error = serializable_error_info_from_exc_info(sys.exc_info())
             self._logger.exception("Error while importing code")
 
         self.__last_heartbeat_time = time.time()

--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -90,7 +90,7 @@ ExceptionInfo: TypeAlias = Union[
 
 
 def _should_redact_user_code_error() -> bool:
-    return os.getenv("DAGSTER_REDACT_USER_CODE_ERRORS") == "1"
+    return str(os.getenv("DAGSTER_REDACT_USER_CODE_ERRORS")).lower() in ("1", "true", "t")
 
 
 def _get_masked_traceback_exception(with_instruction: bool) -> traceback.TracebackException:
@@ -143,11 +143,10 @@ def serializable_error_info_from_exc_info(
 
     if isinstance(e, DagsterUserCodeExecutionError) and _should_redact_user_code_error():
         masked_tb_exc = _get_masked_traceback_exception(with_instruction=True)
-        print(  # noqa: T201
+        sys.stderr.write(
             _serializable_error_info_from_tb(
                 _get_masked_traceback_exception(with_instruction=False)
             ).to_string(),
-            file=sys.stderr,
         )
         return _serializable_error_info_from_tb(masked_tb_exc, no_cause=True)
 

--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -148,7 +148,8 @@ def serializable_error_info_from_exc_info(
     ):
         return e.user_code_process_error_infos[0]
     elif hoist_user_code_execution_error and isinstance(e, DagsterUserCodeExecutionError):
-        tb_exc = traceback.TracebackException(type(e.user_exception), e.user_exception, tb.tb_next)
+        inner_exc_type, inner_e, inner_tb = e.original_exc_info
+        tb_exc = traceback.TracebackException(inner_exc_type, inner_e, inner_tb)
         return _serializable_error_info_from_tb(tb_exc)
     else:
         tb_exc = traceback.TracebackException(exc_type, e, tb)

--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -120,6 +120,16 @@ def serializable_error_info_from_exc_info(
     hoist_user_code_error: Optional[bool] = True,
     hoist_user_code_execution_error: Optional[bool] = False,
 ) -> SerializableErrorInfo:
+    """This function is used to turn an exception into a serializable object that can be passed
+    across process boundaries or sent over GraphQL.
+
+    Args:
+        exc_info (ExceptionInfo): The exception info to serialize
+        hoist_user_code_error (Optional[bool]): Whether to extract the inner user code error if the raised exception
+            is a DagsterUserCodeProcessError. Defaults to True.
+        hoist_user_code_execution_error (Optional[bool]): Whether to extract the inner user code error if the raised
+            exception is a DagsterUserCodeExecutionError. Defaults to False.
+    """
     # `sys.exc_info() return Tuple[None, None, None] when there is no exception being processed. We accept this in
     # the type signature here since this function is meant to directly receive the return value of
     # `sys.exc_info`, but the function should never be called when there is no exception to process.

--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -118,7 +118,6 @@ def serializable_error_info_from_exc_info(
     exc_info: ExceptionInfo,
     # Whether to forward serialized errors thrown from subprocesses
     hoist_user_code_error: Optional[bool] = True,
-    hoist_user_code_execution_error: Optional[bool] = False,
 ) -> SerializableErrorInfo:
     """This function is used to turn an exception into a serializable object that can be passed
     across process boundaries or sent over GraphQL.
@@ -127,8 +126,6 @@ def serializable_error_info_from_exc_info(
         exc_info (ExceptionInfo): The exception info to serialize
         hoist_user_code_error (Optional[bool]): Whether to extract the inner user code error if the raised exception
             is a DagsterUserCodeProcessError. Defaults to True.
-        hoist_user_code_execution_error (Optional[bool]): Whether to extract the inner user code error if the raised
-            exception is a DagsterUserCodeExecutionError. Defaults to False.
     """
     # `sys.exc_info() return Tuple[None, None, None] when there is no exception being processed. We accept this in
     # the type signature here since this function is meant to directly receive the return value of
@@ -156,10 +153,6 @@ def serializable_error_info_from_exc_info(
         and len(e.user_code_process_error_infos) == 1
     ):
         return e.user_code_process_error_infos[0]
-    elif hoist_user_code_execution_error and isinstance(e, DagsterUserCodeExecutionError):
-        inner_exc_type, inner_e, inner_tb = e.original_exc_info
-        tb_exc = traceback.TracebackException(inner_exc_type, inner_e, inner_tb)
-        return _serializable_error_info_from_tb(tb_exc)
     else:
         tb_exc = traceback.TracebackException(exc_type, e, tb)
         return _serializable_error_info_from_tb(tb_exc)

--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -67,18 +67,14 @@ class SerializableErrorInfo(
         return SerializableErrorInfo(message=self.message, stack=[], cls_name=self.cls_name)
 
 
-def _serializable_error_info_from_tb(
-    tb: traceback.TracebackException, no_cause: bool = False
-) -> SerializableErrorInfo:
+def _serializable_error_info_from_tb(tb: traceback.TracebackException) -> SerializableErrorInfo:
     return SerializableErrorInfo(
         # usually one entry, multiple lines for SyntaxError
         "".join(list(tb.format_exception_only())),
         tb.stack.format(),
         tb.exc_type.__name__ if tb.exc_type is not None else None,
         _serializable_error_info_from_tb(tb.__cause__) if tb.__cause__ else None,
-        _serializable_error_info_from_tb(tb.__context__)
-        if tb.__context__ and not no_cause
-        else None,
+        _serializable_error_info_from_tb(tb.__context__) if tb.__context__ else None,
     )
 
 

--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -101,7 +101,8 @@ def _get_masked_traceback_exception(with_instruction: bool) -> traceback.Traceba
     error_id = str(uuid.uuid4())
     try:
         raise DagsterRedactedUserCodeError(
-            f"Error occurred during user code execution, error ID {error_id}"
+            f"Error occurred during user code execution, error ID {error_id}. "
+            "The error has been masked to prevent leaking sensitive information."
             + ("\nSearch in logs for this error ID for more details" if with_instruction else "")
         )
     except DagsterRedactedUserCodeError:

--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -8,7 +8,7 @@ from typing import Any, NamedTuple, Optional, Sequence, Tuple, Type, Union
 from typing_extensions import TypeAlias
 
 import dagster._check as check
-from dagster._core.errors import DagsterMaskedUserCodeError
+from dagster._core.errors import DagsterRedactedUserCodeError
 from dagster._serdes import whitelist_for_serdes
 
 
@@ -94,17 +94,17 @@ def _should_redact_user_code_error() -> bool:
 
 
 def _get_masked_traceback_exception(with_instruction: bool) -> traceback.TracebackException:
-    """Raises a DagsterMaskedUserCodeError and returns the traceback exception for it.
+    """Raises a DagsterRedactedUserCodeError and returns the traceback exception for it.
     Used to replace the traceback of a user code error with a generic message that they
     can search for in their own logs.
     """
     error_id = str(uuid.uuid4())
     try:
-        raise DagsterMaskedUserCodeError(
+        raise DagsterRedactedUserCodeError(
             f"Error occurred during user code execution, error ID {error_id}"
             + ("\nSearch in logs for this error ID for more details" if with_instruction else "")
         )
-    except DagsterMaskedUserCodeError:
+    except DagsterRedactedUserCodeError:
         # Get the stack trace from the masking exception we just raised, instead of
         # the underlying user code exception
         exc_type, e, tb = sys.exc_info()

--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -89,8 +89,8 @@ ExceptionInfo: TypeAlias = Union[
 ]
 
 
-def _should_mask_user_code_error() -> bool:
-    return os.getenv("DAGSTER_MASK_USER_CODE_ERRORS") == "1"
+def _should_redact_user_code_error() -> bool:
+    return os.getenv("DAGSTER_REDACT_USER_CODE_ERRORS") == "1"
 
 
 def _get_masked_traceback_exception(with_instruction: bool) -> traceback.TracebackException:
@@ -141,7 +141,7 @@ def serializable_error_info_from_exc_info(
 
     from dagster._core.errors import DagsterUserCodeExecutionError, DagsterUserCodeProcessError
 
-    if isinstance(e, DagsterUserCodeExecutionError) and _should_mask_user_code_error():
+    if isinstance(e, DagsterUserCodeExecutionError) and _should_redact_user_code_error():
         masked_tb_exc = _get_masked_traceback_exception(with_instruction=True)
         print(  # noqa: T201
             _serializable_error_info_from_tb(

--- a/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
+++ b/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
@@ -134,6 +134,11 @@ def schedule_times_out():
     time.sleep(2)
 
 
+@schedule(job_name="baz", cron_schedule="* * * * *")
+def schedule_error():
+    raise Exception("womp womp")
+
+
 def define_bar_schedules():
     return {
         "foo_schedule": ScheduleDefinition(
@@ -163,6 +168,7 @@ def define_bar_schedules():
         ),
         "partitioned_run_request_schedule": partitioned_run_request_schedule,
         "schedule_times_out": schedule_times_out,
+        "schedule_error": schedule_error,
     }
 
 

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_list_repositories.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_list_repositories.py
@@ -228,4 +228,4 @@ def test_sync_list_python_file_grpc_with_error():
             package_name=None,
         )
 
-    assert 'raise ValueError("User did something bad")' in e.value.args[0]
+    assert 'raise ValueError("User did something bad")' in str(e)

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_list_repositories.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_list_repositories.py
@@ -228,5 +228,4 @@ def test_sync_list_python_file_grpc_with_error():
             package_name=None,
         )
 
-    assert e.value.args[0].startswith("ValueError: User did something bad")
-    assert e.value.args[0].endswith('raise ValueError("User did something bad")\n')
+    assert 'raise ValueError("User did something bad")' in e.value.args[0]

--- a/python_modules/dagster/dagster_tests/core_tests/test_mask_user_code_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_mask_user_code_errors.py
@@ -27,7 +27,7 @@ class UserError(Exception):
 
 @pytest.fixture(scope="function")
 def enable_masking_user_code_errors() -> Any:
-    with environ({"DAGSTER_MASK_USER_CODE_ERRORS": "1"}):
+    with environ({"DAGSTER_REDACT_USER_CODE_ERRORS": "1"}):
         yield
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_mask_user_code_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_mask_user_code_errors.py
@@ -1,0 +1,79 @@
+from typing import Any
+
+import pytest
+from dagster import job, op
+from dagster._core.errors import DagsterUserCodeProcessError
+from dagster._core.test_utils import environ, instance_for_test
+from dagster._seven import get_current_datetime_in_utc
+
+from ..api_tests.utils import get_bar_repo_handle
+
+
+@pytest.fixture()
+def instance():
+    with instance_for_test() as instance:
+        yield instance
+
+
+class UserError(Exception):
+    def __init__(self):
+        super(UserError, self).__init__(
+            "This is an error which has some sensitive information! My password is hunter2"
+        )
+
+
+@pytest.fixture(scope="function")
+def enable_masking_user_code_errors() -> Any:
+    with environ({"DAGSTER_MASK_USER_CODE_ERRORS": "1"}):
+        yield
+
+
+def test_masking_op_execution(enable_masking_user_code_errors) -> Any:
+    @op
+    def throws_user_error(_):
+        raise UserError()
+
+    @job
+    def job_def():
+        throws_user_error()
+
+    result = job_def.execute_in_process(raise_on_error=False)
+    assert not result.success
+    assert not any("hunter2" in str(event) for event in result.all_events)
+    step_error = next(event for event in result.all_events if event.is_step_failure)
+    assert (
+        step_error.step_failure_data.error
+        and step_error.step_failure_data.error.cls_name == "DagsterMaskedUserCodeError"
+    )
+
+
+def test_masking_sensor_execution(instance, enable_masking_user_code_errors):
+    from dagster._api.snapshot_sensor import (
+        sync_get_external_sensor_execution_data_ephemeral_grpc,
+    )
+
+    with get_bar_repo_handle(instance) as repository_handle:
+        try:
+            sync_get_external_sensor_execution_data_ephemeral_grpc(
+                instance, repository_handle, "sensor_error", None, None, None
+            )
+            assert False, "Should have thrown an DagsterUserCodeProcessError!"
+        except DagsterUserCodeProcessError as e:
+            assert "womp womp" not in str(e)
+            assert "Search in logs for this error ID for more details" in str(e)
+
+
+def test_masking_schedule_execution(instance, enable_masking_user_code_errors):
+    from dagster._api.snapshot_schedule import (
+        sync_get_external_schedule_execution_data_ephemeral_grpc,
+    )
+
+    with get_bar_repo_handle(instance) as repository_handle:
+        try:
+            sync_get_external_schedule_execution_data_ephemeral_grpc(
+                instance, repository_handle, "schedule_error", get_current_datetime_in_utc()
+            )
+            assert False, "Should have thrown an DagsterUserCodeProcessError!"
+        except DagsterUserCodeProcessError as e:
+            assert "womp womp" not in str(e)
+            assert "Search in logs for this error ID for more details" in str(e)

--- a/python_modules/dagster/dagster_tests/core_tests/test_mask_user_code_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_mask_user_code_errors.py
@@ -46,7 +46,7 @@ def test_masking_op_execution(enable_masking_user_code_errors) -> Any:
     step_error = next(event for event in result.all_events if event.is_step_failure)
     assert (
         step_error.step_failure_data.error
-        and step_error.step_failure_data.error.cls_name == "DagsterMaskedUserCodeError"
+        and step_error.step_failure_data.error.cls_name == "DagsterRedactedUserCodeError"
     )
 
 
@@ -144,7 +144,7 @@ def test_config_mapping_error(enable_masking_user_code_errors, capsys) -> None:
         err_info = serializable_error_info_from_exc_info(sys.exc_info())
 
     assert err_info
-    assert err_info.cls_name == "DagsterMaskedUserCodeError"
+    assert err_info.cls_name == "DagsterRedactedUserCodeError"
     assert "hunter2" not in str(err_info.message)
     assert "Search in logs for this error ID for more details" in str(err_info.message)
 

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -667,7 +667,7 @@ def test_load_with_missing_env_var(entrypoint):
             list_repositories_response = deserialize_value(
                 client.list_repositories(), SerializableErrorInfo
             )
-            assert "Missing env var" in list_repositories_response.message
+            assert "Missing env var" in str(list_repositories_response)
         finally:
             client.shutdown_server()
             process.communicate(timeout=30)


### PR DESCRIPTION
## Summary

Implements functionality which strips user stacktraces from the values returned from the GRPC server / run. If the `DAGSTER_REDACT_USER_CODE_ERRORS` env var is set to `1`, any code errors raised in a `user_code_error_boundary` context will be replaced at serialization-time with a redacted error:

```python
serialized_error = None
try:
    with user_code_error_boundary(..., lambda: "..."):
        ...
except Exception as e:
    # will be a DagsterRedactedUserCodeError if DAGSTER_REDACT_USER_CODE_ERRORS=1
    serialized_error = serializable_error_info_from_exc_info(sys.exc_info())
```

These redacted errors contain a unique uuid error ID that they can use to find the actual stacktrace in their GRPC or run logs: 

```python
Error occurred during user code execution, error ID 5a8bd3b7-0095-4f46-945e-82bfbd496fcb
Search in logs for this error ID for more details

Stack Trace:
  File "/Users/ben/repos/dagster/python_modules/dagster/dagster/_utils/error.py", line 115, in serializable_error_info_from_exc_info
    raise DagsterRedactedUserCodeError(
```

This PR specifically handles the run, configmapping processing, code load, and schedule/sensor run cases.

## Screenshots
<img width="1123" alt="Screenshot 2024-01-05 at 11 42 39 AM" src="https://github.com/dagster-io/dagster/assets/10215173/2479dd1b-cf44-4f02-a465-bca1163f6223">
<img width="1123" alt="Screenshot 2024-01-05 at 11 42 57 AM" src="https://github.com/dagster-io/dagster/assets/10215173/7ad370a0-3a07-45a9-ad11-963894eeacf4">
<img width="1123" alt="Screenshot 2024-01-05 at 11 44 33 AM" src="https://github.com/dagster-io/dagster/assets/10215173/c44b1f70-2ec1-4af3-b298-5441da7532cd">



## Test Plan

New unit tests.