### PR TITLE
only error on materializable+source asset selections in execution sit…

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -760,6 +760,14 @@ class InternalAssetGraph(AssetGraph):
     def asset_checks(self) -> Sequence[AssetChecksDefinition]:
         return self._asset_checks
 
+    def includes_materializable_and_source_assets(self, asset_keys: AbstractSet[AssetKey]) -> bool:
+        """Returns true if the given asset keys contains at least one materializable asset and
+        at least one source asset.
+        """
+        selected_source_assets = self.source_asset_keys & asset_keys
+        selected_regular_assets = asset_keys - self.source_asset_keys
+        return len(selected_source_assets) > 0 and len(selected_regular_assets) > 0
+
 
 def sort_key_for_asset_partition(
     asset_graph: AssetGraph, asset_partition: AssetKeyPartitionKey

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -302,15 +302,7 @@ class AssetSelection(ABC):
             check.iterable_param(all_assets, "all_assets", (AssetsDefinition, SourceAsset))
             asset_graph = AssetGraph.from_assets(all_assets)
 
-        resolved = self.resolve_inner(asset_graph)
-        resolved_source_assets = asset_graph.source_asset_keys & resolved
-        resolved_regular_assets = resolved - asset_graph.source_asset_keys
-        check.invariant(
-            not (len(resolved_source_assets) > 0 and len(resolved_regular_assets) > 0),
-            "Asset selection specified both regular assets and source assets. This is not"
-            " currently supported. Selections must be all regular assets or all source assets.",
-        )
-        return resolved
+        return self.resolve_inner(asset_graph)
 
     @abstractmethod
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -184,6 +184,13 @@ class UnresolvedAssetJobDefinition(
         assets = asset_graph.assets
         source_assets = asset_graph.source_assets
         selected_asset_keys = self.selection.resolve(asset_graph)
+        if asset_graph.includes_materializable_and_source_assets(selected_asset_keys):
+            raise DagsterInvalidDefinitionError(
+                f"Asset selection for job '{self.name}' specified both regular assets and source "
+                "assets. This is not currently supported. Selections must be all regular "
+                "assets or all source assets.",
+            )
+
         selected_asset_checks = self.selection.resolve_checks(asset_graph)
 
         asset_keys_by_partitions_def = defaultdict(set)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 import pytest
-from dagster._check import CheckError
 from dagster._config.pythonic_config import ConfigurableResource
 from dagster._core.definitions.data_version import (
     DataVersion,
@@ -103,7 +102,7 @@ def test_mixed_source_asset_observation_job():
         return 1
 
     with pytest.raises(
-        CheckError, match=r"Asset selection specified both regular assets and source assets"
+        DagsterInvalidDefinitionError, match=r"specified both regular assets and source assets"
     ):
         Definitions(
             assets=[foo, bar],


### PR DESCRIPTION
…uations

## Summary & Motivation

Currently, we raise an error any time an `AssetSelection` is resolved and the resolved asset keys include both materializable and source assets assets. We do this because the current execution machinery doesn't support the ability to include both of these in a single run.

However, there are contexts where it's fine to resolve this kind of asset selection, because we won't be targeting the resolved asset keys in a run.

This PR makes us only raise errors in the case where the resolved asset keys would be used in a run.

## How I Tested These Changes
