### PR TITLE
[asset backfill] [non-urgent] Terminate "canceling" backfill when all runs complete 

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -1093,7 +1093,9 @@ def test_asset_backfill_cancellation():
 
     assert isinstance(canceling_backfill_data, AssetBackfillData)
 
-    assert canceling_backfill_data.have_all_requested_runs_finished() is True
+    assert (
+        canceling_backfill_data.all_requested_partitions_marked_as_materialized_or_failed() is True
+    )
     assert (
         canceling_backfill_data.materialized_subset.get_partitions_subset(
             upstream_hourly_partitioned_asset.key, asset_graph

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -32,6 +32,7 @@ from dagster import (
 from dagster._core.definitions import (
     StaticPartitionsDefinition,
 )
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
@@ -1127,6 +1128,83 @@ def test_asset_backfill_mid_iteration_cancel(
 
     assert instance.get_runs_count() == RUN_CHUNK_SIZE
     assert instance.get_runs_count(RunsFilter(statuses=IN_PROGRESS_RUN_STATUSES)) == 0
+
+
+def test_fail_backfill_when_runs_completed_but_partitions_marked_as_in_progress(
+    instance: DagsterInstance, workspace_context: WorkspaceProcessContext
+):
+    asset_selection = [AssetKey("daily_1"), AssetKey("daily_2")]
+    asset_graph = ExternalAssetGraph.from_workspace(workspace_context.create_request_context())
+
+    target_partitions = ["2023-01-01"]
+    backfill_id = "backfill_with_hanging_partitions"
+    backfill = PartitionBackfill.from_asset_partitions(
+        asset_graph=asset_graph,
+        backfill_id=backfill_id,
+        tags={},
+        backfill_timestamp=pendulum.now().timestamp(),
+        asset_selection=asset_selection,
+        partition_names=target_partitions,
+        dynamic_partitions_store=instance,
+        all_partitions=False,
+    )
+    instance.add_backfill(backfill)
+    assert instance.get_runs_count() == 0
+    backfill = instance.get_backfill(backfill_id)
+    assert backfill
+    assert backfill.status == BulkActionStatus.REQUESTED
+
+    assert all(
+        not error
+        for error in list(
+            execute_backfill_iteration(
+                workspace_context, get_default_daemon_logger("BackfillDaemon")
+            )
+        )
+    )
+    assert instance.get_runs_count() == 1
+
+    updated_backfill = instance.get_backfill(backfill_id)
+    assert updated_backfill
+    assert updated_backfill.asset_backfill_data
+
+    assert all(
+        not error
+        for error in list(
+            execute_backfill_iteration(
+                workspace_context, get_default_daemon_logger("BackfillDaemon")
+            )
+        )
+    )
+
+    updated_backfill = instance.get_backfill(backfill_id)
+    assert updated_backfill
+    assert updated_backfill.asset_backfill_data
+    assert len(updated_backfill.asset_backfill_data.materialized_subset) == 2
+    # Replace materialized_subset with an empty subset to mock "hanging" partitions
+    # Mark the backfill as CANCELING
+    instance.update_backfill(
+        updated_backfill.with_asset_backfill_data(
+            updated_backfill.asset_backfill_data._replace(materialized_subset=AssetGraphSubset()),
+            dynamic_partitions_store=instance,
+            asset_graph=asset_graph,
+        ).with_status(BulkActionStatus.CANCELING)
+    )
+
+    errors = list(
+        filter(
+            lambda e: e is not None,
+            execute_backfill_iteration(
+                workspace_context, get_default_daemon_logger("BackfillDaemon")
+            ),
+        )
+    )
+
+    assert len(errors) == 1
+    error_msg = check.not_none(errors[0]).message
+    assert (
+        "All runs have completed, but not all requested partitions have been marked as materialized or failed"
+    ) in error_msg
 
 
 def test_asset_backfill_with_single_run_backfill_policy(


### PR DESCRIPTION
Certain asset backfills that hit recent race condition issues were stuck in a `CANCELING` state. In the cancellation iteration, we wait until all partitions are marked as materialized or failed in order to enter a canceled state. When partitions are hanging (i.e. truly materialized, but skipped in the iteration), this causes these backfills to hang forever.

This PR checks if all partitions are complete (materialized/failed), marking the backfill as failed if there are no in-progress runs.