### PR TITLE
[ui] Fix partition status dots wrapping to next line on Asset > Partitions

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionList.tsx
@@ -91,17 +91,14 @@ export const AssetPartitionList = ({
                 flex={{direction: 'column', justifyContent: 'center', gap: 8}}
                 border="bottom"
               >
-                <div
-                  style={{
-                    gap: 4,
-                    display: 'grid',
-                    gridTemplateColumns: 'minmax(0, 1fr) auto',
-                    alignItems: 'center',
-                  }}
-                  data-tooltip={dimensionKey}
-                  data-tooltip-style={PartitionTooltipStyle}
-                >
-                  <MiddleTruncate text={dimensionKey} />
+                <Box flex={{gap: 4, direction: 'row', alignItems: 'center'}}>
+                  <div
+                    style={{flex: 1, minWidth: 0}}
+                    data-tooltip={dimensionKey}
+                    data-tooltip-style={PartitionTooltipStyle}
+                  >
+                    <MiddleTruncate text={dimensionKey} />
+                  </div>
                   {/* Note: we could just state.map, but we want these in a particular order*/}
                   {state.includes(AssetPartitionStatus.MISSING) && (
                     <AssetPartitionStatusDot status={[AssetPartitionStatus.MISSING]} />
@@ -115,7 +112,7 @@ export const AssetPartitionList = ({
                   {state.includes(AssetPartitionStatus.MATERIALIZED) && (
                     <AssetPartitionStatusDot status={[AssetPartitionStatus.MATERIALIZED]} />
                   )}
-                </div>
+                </Box>
               </Box>
             </AssetListRow>
           );


### PR DESCRIPTION
Using a grid here is a bit tricky because more than one of the statuses can apply to a partition in a multi-dimensional asset. I think our options are to wrap the dots in a `<Box flex gap={4}>` or convert this parent back to a flexbox, opted for the latter.

## How I Tested These Changes

I simulated a long title and made sure it truncates still and that the tooltip still works correctly. Also went through all the other `display: 'grid'` occurrences in the project and verified there aren't any others with a varying # of children!

<img width="364" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/6fddae9b-6a6f-4b46-9d7c-41890b345362">



