### PR TITLE
[ui] Replace broken “Open in launchpad” links for asset jobs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.tsx
@@ -183,7 +183,7 @@ export const RunActionsMenu = React.memo(({run, onAddTag, additionalActionsForRu
                   <MenuLink
                     text={jobLink.label}
                     disabled={!infoReady || !!jobLink.disabledReason}
-                    icon="edit"
+                    icon={jobLink.icon}
                     to={jobLink.to}
                   />
                 </Tooltip>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.tsx
@@ -25,13 +25,12 @@ import {showSharedToaster} from '../app/DomUtils';
 import {DEFAULT_DISABLED_REASON} from '../app/Permissions';
 import {useCopyToClipboard} from '../app/browser';
 import {ReexecutionStrategy} from '../graphql/types';
-import {NO_LAUNCH_PERMISSION_MESSAGE} from '../launchpad/LaunchRootExecutionButton';
 import {getPipelineSnapshotLink} from '../pipelines/PipelinePathUtils';
 import {AnchorButton} from '../ui/AnchorButton';
 import {MenuLink} from '../ui/MenuLink';
 import {isThisThingAJob} from '../workspace/WorkspaceContext';
 import {useRepositoryForRunWithParentSnapshot} from '../workspace/useRepositoryForRun';
-import {workspacePathFromRunDetails} from '../workspace/workspacePath';
+import {workspacePipelineLinkForRun} from '../workspace/workspacePath';
 
 import {DeletionDialog} from './DeletionDialog';
 import {ReexecutionDialog} from './ReexecutionDialog';
@@ -118,6 +117,13 @@ export const RunActionsMenu = React.memo(({run, onAddTag, additionalActionsForRu
     return {disabled: false};
   }, [run.hasReExecutePermission, jobError, infoReady]);
 
+  const jobLink = workspacePipelineLinkForRun({
+    run,
+    repositoryName: repoMatch?.match.repository.name,
+    repositoryLocationName: repoMatch?.match.repositoryLocation.name,
+    isJob,
+  });
+
   return (
     <>
       <JoinedButtons>
@@ -169,26 +175,16 @@ export const RunActionsMenu = React.memo(({run, onAddTag, additionalActionsForRu
               <MenuDivider />
               <>
                 <Tooltip
-                  content={
-                    run.hasReExecutePermission
-                      ? OPEN_LAUNCHPAD_UNKNOWN
-                      : NO_LAUNCH_PERMISSION_MESSAGE
-                  }
+                  content={jobLink.disabledReason || OPEN_LAUNCHPAD_UNKNOWN}
                   position="left"
-                  disabled={infoReady && run.hasReExecutePermission}
+                  disabled={infoReady && !jobLink.disabledReason}
                   targetTagName="div"
                 >
                   <MenuLink
-                    text="Open in Launchpad..."
-                    disabled={!infoReady || !run.hasReExecutePermission}
+                    text={jobLink.label}
+                    disabled={!infoReady || !!jobLink.disabledReason}
                     icon="edit"
-                    to={workspacePathFromRunDetails({
-                      id: run.id,
-                      pipelineName: run.pipelineName,
-                      repositoryName: repoMatch?.match.repository.name,
-                      repositoryLocationName: repoMatch?.match.repositoryLocation.name,
-                      isJob,
-                    })}
+                    to={jobLink.to}
                   />
                 </Tooltip>
                 <Tooltip

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunHeaderActions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunHeaderActions.tsx
@@ -11,9 +11,8 @@ import {
   FreeConcurrencySlotsMutation,
   FreeConcurrencySlotsMutationVariables,
 } from '../instance/types/InstanceConcurrency.types';
-import {NO_LAUNCH_PERMISSION_MESSAGE} from '../launchpad/LaunchRootExecutionButton';
 import {AnchorButton} from '../ui/AnchorButton';
-import {workspacePathFromRunDetails, workspacePipelinePath} from '../workspace/workspacePath';
+import {workspacePipelineLinkForRun, workspacePipelinePath} from '../workspace/workspacePath';
 
 import {DeletionDialog} from './DeletionDialog';
 import {RunConfigDialog} from './RunConfigDialog';
@@ -59,27 +58,26 @@ export const RunHeaderActions = ({run, isJob}: {run: RunFragment; isJob: boolean
     }
   };
 
-  const jobPath = workspacePathFromRunDetails({
-    id: run.id,
+  const jobLink = workspacePipelineLinkForRun({
     repositoryName: run.repositoryOrigin?.repositoryName,
     repositoryLocationName: run.repositoryOrigin?.repositoryLocationName,
-    pipelineName: run.pipelineName,
+    run,
     isJob,
   });
 
   return (
     <div>
       <Group direction="row" spacing={8}>
-        {run.hasReExecutePermission ? (
-          <AnchorButton icon={<Icon name="edit" />} to={jobPath}>
-            Open in Launchpad
-          </AnchorButton>
-        ) : (
-          <Tooltip content={NO_LAUNCH_PERMISSION_MESSAGE} useDisabledButtonTooltipFix>
+        {jobLink.disabledReason ? (
+          <Tooltip content={jobLink.disabledReason} useDisabledButtonTooltipFix>
             <Button icon={<Icon name="edit" />} disabled>
-              Open in Launchpad
+              {jobLink.label}
             </Button>
           </Tooltip>
+        ) : (
+          <AnchorButton icon={<Icon name="edit" />} to={jobLink.to}>
+            {jobLink.label}
+          </AnchorButton>
         )}
         <Button icon={<Icon name="tag" />} onClick={() => setVisibleDialog('config')}>
           View tags and config

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunHeaderActions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunHeaderActions.tsx
@@ -70,12 +70,12 @@ export const RunHeaderActions = ({run, isJob}: {run: RunFragment; isJob: boolean
       <Group direction="row" spacing={8}>
         {jobLink.disabledReason ? (
           <Tooltip content={jobLink.disabledReason} useDisabledButtonTooltipFix>
-            <Button icon={<Icon name="edit" />} disabled>
+            <Button icon={<Icon name={jobLink.icon} />} disabled>
               {jobLink.label}
             </Button>
           </Tooltip>
         ) : (
-          <AnchorButton icon={<Icon name="edit" />} to={jobLink.to}>
+          <AnchorButton icon={<Icon name={jobLink.icon} />} to={jobLink.to}>
             {jobLink.label}
           </AnchorButton>
         )}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/workspacePath.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/workspacePath.ts
@@ -1,3 +1,5 @@
+import {IconName} from '@dagster-io/ui-components';
+
 import {isHiddenAssetGroupJob, tokenForAssetKey} from '../asset-graph/Utils';
 import {globalAssetGraphPathToString} from '../assets/globalAssetGraphPathToString';
 import {Run} from '../graphql/types';
@@ -68,6 +70,7 @@ export const workspacePipelineLinkForRun = ({
     return {
       disabledReason: null,
       label: `View asset graph`,
+      icon: 'schema' as IconName,
       to: globalAssetGraphPathToString({opsQuery, opNames: []}),
     };
   }
@@ -88,6 +91,7 @@ export const workspacePipelineLinkForRun = ({
   return {
     to,
     label: isAssetJob ? 'View job' : 'Open in Launchpad',
+    icon: isAssetJob ? ('job' as IconName) : ('edit' as IconName),
     disabledReason: isAssetJob || run.hasReExecutePermission ? null : NO_LAUNCH_PERMISSION_MESSAGE,
   };
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/workspacePath.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/workspacePath.ts
@@ -1,3 +1,8 @@
+import {isHiddenAssetGroupJob, tokenForAssetKey} from '../asset-graph/Utils';
+import {globalAssetGraphPathToString} from '../assets/globalAssetGraphPathToString';
+import {Run} from '../graphql/types';
+import {NO_LAUNCH_PERMISSION_MESSAGE} from '../launchpad/LaunchRootExecutionButton';
+
 import {buildRepoPathForURL} from './buildRepoAddress';
 import {RepoAddress} from './types';
 
@@ -38,31 +43,51 @@ export const workspacePathFromAddress = (repoAddress: RepoAddress, path = '') =>
 };
 
 type RunDetails = {
-  id: string;
-  pipelineName: string;
+  run: Pick<
+    Run,
+    'id' | 'pipelineName' | 'assetSelection' | 'assetCheckSelection' | 'hasReExecutePermission'
+  >;
   repositoryName?: string;
   repositoryLocationName?: string;
   isJob: boolean;
 };
 
-export const workspacePathFromRunDetails = ({
-  id,
-  pipelineName,
+/**
+ * Returns a link path, label, and disabled reason for linking to the run belonging to a job.
+ * For asset jobs, this may be a link to the asset graph if the job is hidden. For asset
+ * jobs, it will be a link to the job page, and for op jobs a link to the job launchpad.
+ */
+export const workspacePipelineLinkForRun = ({
+  run,
   repositoryName,
   repositoryLocationName,
   isJob,
 }: RunDetails) => {
-  const path = `/playground/setup-from-run/${id}`;
-
-  if (repositoryName != null && repositoryLocationName != null) {
-    return workspacePipelinePath({
-      repoName: repositoryName,
-      repoLocation: repositoryLocationName,
-      pipelineName,
-      isJob,
-      path,
-    });
+  if (isHiddenAssetGroupJob(run.pipelineName)) {
+    const opsQuery = (run.assetSelection || []).map(tokenForAssetKey).join(', ');
+    return {
+      disabledReason: null,
+      label: `View asset graph`,
+      to: globalAssetGraphPathToString({opsQuery, opNames: []}),
+    };
   }
 
-  return workspacePipelinePathGuessRepo(pipelineName, path);
+  const isAssetJob = run.assetCheckSelection?.length || run.assetSelection?.length;
+  const path = isAssetJob ? '/' : `/playground/setup-from-run/${run.id}`;
+  const to =
+    repositoryName != null && repositoryLocationName != null
+      ? workspacePipelinePath({
+          repoName: repositoryName,
+          repoLocation: repositoryLocationName,
+          pipelineName: run.pipelineName,
+          isJob,
+          path,
+        })
+      : workspacePipelinePathGuessRepo(run.pipelineName, path);
+
+  return {
+    to,
+    label: isAssetJob ? 'View job' : 'Open in Launchpad',
+    disabledReason: isAssetJob || run.hasReExecutePermission ? null : NO_LAUNCH_PERMISSION_MESSAGE,
+  };
 };


### PR DESCRIPTION
## Summary & Motivation

Fixes #16639 

The top right of the Run page has always shown an "Open in Launchpad" button. There are two big problems:

- The launchpad / playground page does not exist for asset jobs and this opens it anyway
- The launchpad for a hidden asset job launches the entire asset graph, not the asset selection of the run you're viewing

This PR replaces this button (and the corresponding RunActionsMenu item) with three different actions based on the job type:

- For op jobs, it remains "Open in Launchpad" (Launchpad is capitalized, which is a bit odd, but we do it consistently everywhere as if it were a proper noun, so I left it that way!)

- For hidden asset jobs, it is "View asset graph" and links to the global graph view of the subset of assets you launched

- For proper asset jobs, it is "View job" and links to the main graph page of the job (since asset jobs have no launchpad)
 

<img width="1422" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/8f68d133-c2f2-45bb-b2d2-5d689903d609">

## How I Tested These Changes

I tested the different disabled states (it is disabled for op jobs if you do not have re-execute permission) by manually inserting true/false values in the data to verify the logic was correct. Also tested with the three different kinds of jobs above and verified the tooltips + run actions menu work. There is also a jest test for this and I verified it still passes.