### PR TITLE
fix docs links

### DIFF
--- a/docs/content/guides/dagster-pipes/aws-lambda.mdx
+++ b/docs/content/guides/dagster-pipes/aws-lambda.mdx
@@ -8,7 +8,7 @@ description: "Learn to integrate Dagster Pipes with AWS Lambda to launch externa
 <Note>
   <strong>Heads up!</strong> This guide focuses on using an out-of-the-box
   Amazon Web Services (AWS) Lambda resource. For further customization, use the{" "}
-  <a href="/guides/dagster-pipes/git@github.com:geoHeil/dagster.git">
+  <a href="/guides/dagster-pipes/dagster-pipes-details-and-customization">
     <code>open_pipes_session</code> approach
   </a>{" "}
   instead.

--- a/docs/content/guides/dagster-pipes/aws-lambda.mdx
+++ b/docs/content/guides/dagster-pipes/aws-lambda.mdx
@@ -8,7 +8,7 @@ description: "Learn to integrate Dagster Pipes with AWS Lambda to launch externa
 <Note>
   <strong>Heads up!</strong> This guide focuses on using an out-of-the-box
   Amazon Web Services (AWS) Lambda resource. For further customization, use the{" "}
-  <a href="/guides/dagster-pipes/customizing-dagster-pipes-protocols">
+  <a href="/guides/dagster-pipes/git@github.com:geoHeil/dagster.git">
     <code>open_pipes_session</code> approach
   </a>{" "}
   instead.

--- a/docs/content/guides/dagster-pipes/kubernetes.mdx
+++ b/docs/content/guides/dagster-pipes/kubernetes.mdx
@@ -8,7 +8,7 @@ description: "Learn to integrate Dagster Pipes with Kubernetes to launch externa
 <Note>
   <strong>Heads up!</strong> This guide focuses on using an out-of-the-box
   Kubernetes resource. For further customization, use the{" "}
-  <a href="/guides/dagster-pipes/customizing-dagster-pipes-protocols">
+  <a href="/guides/dagster-pipes/git@github.com:geoHeil/dagster.git">
     <code>open_pipes_session</code> approach
   </a>{" "}
   instead.

--- a/docs/content/guides/dagster-pipes/kubernetes.mdx
+++ b/docs/content/guides/dagster-pipes/kubernetes.mdx
@@ -8,7 +8,7 @@ description: "Learn to integrate Dagster Pipes with Kubernetes to launch externa
 <Note>
   <strong>Heads up!</strong> This guide focuses on using an out-of-the-box
   Kubernetes resource. For further customization, use the{" "}
-  <a href="/guides/dagster-pipes/git@github.com:geoHeil/dagster.git">
+  <a href="/guides/dagster-pipes/dagster-pipes-details-and-customization">
     <code>open_pipes_session</code> approach
   </a>{" "}
   instead.

--- a/docs/content/guides/dagster-pipes/subprocess.mdx
+++ b/docs/content/guides/dagster-pipes/subprocess.mdx
@@ -19,7 +19,7 @@ This guide focuses on using an out-of-the-box `PipesSubprocessClient` resource. 
 
 <!-- Uncomment when the page is ready -->
 
-<!-- Refer to [Customizing Dagster Pipes protocols](/guides/dagster-pipes/git@github.com:geoHeil/dagster.git) for more info. -->
+<!-- Refer to [Customizing Dagster Pipes protocols](/guides/dagster-pipes/dagster-pipes-details-and-customization) for more info. -->
 
 </Note>
 

--- a/docs/content/guides/dagster-pipes/subprocess.mdx
+++ b/docs/content/guides/dagster-pipes/subprocess.mdx
@@ -19,7 +19,7 @@ This guide focuses on using an out-of-the-box `PipesSubprocessClient` resource. 
 
 <!-- Uncomment when the page is ready -->
 
-<!-- Refer to [Customizing Dagster Pipes protocols](/guides/dagster-pipes/customizing-dagster-pipes-protocols) for more info. -->
+<!-- Refer to [Customizing Dagster Pipes protocols](/guides/dagster-pipes/git@github.com:geoHeil/dagster.git) for more info. -->
 
 </Note>
 


### PR DESCRIPTION
Fix broken links in the documentation

https://docs.dagster.io/guides/dagster-pipes/aws-lambda

https://docs.dagster.io/guides/dagster-pipes/customizing-dagster-pipes-protocols is not valid anymore