### PR TITLE
[docs] - Add Dagster Nomad community integration

### DIFF
--- a/docs/content/integrations.mdx
+++ b/docs/content/integrations.mdx
@@ -261,6 +261,10 @@ Explore integration libraries that are maintained by the Dagster community.
     href="https://github.com/silentsokolov/dagster-hashicorp"
   ></ArticleListItem>
   <ArticleListItem
+    title="Hashicorp Nomad"
+    href="https://github.com/PayLead/dagster-nomad"
+  ></ArticleListItem>
+  <ArticleListItem
     title="Noteable"
     href="https://papermill-origami.readthedocs.io/en/latest/reference/noteable_dagstermill/assets/"
   ></ArticleListItem>


### PR DESCRIPTION
## Summary & Motivation

Add to documentation the mention of our integration dagster with Hashicorp Nomad
