### PR TITLE
[dagster-snowflake] More specific error catching when tables don't exist

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -367,7 +367,7 @@ class SnowflakeDbClient(DbClient):
         try:
             connection.execute(_get_cleanup_statement(table_slice))
         except ProgrammingError as e:
-            if "does not exist" in e._message():  # noqa: SLF001
+            if "does not exist" in e._message():  # type: ignore # noqa: SLF001
                 # table doesn't exist yet, so ignore the error
                 return
             else:

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -366,9 +366,12 @@ class SnowflakeDbClient(DbClient):
     def delete_table_slice(context: OutputContext, table_slice: TableSlice, connection) -> None:
         try:
             connection.execute(_get_cleanup_statement(table_slice))
-        except ProgrammingError:
-            # table doesn't exist yet, so ignore the error
-            pass
+        except ProgrammingError as e:
+            if "does not exist" in e._message():  # noqa: SLF001
+                # table doesn't exist yet, so ignore the error
+                return
+            else:
+                raise
 
     @staticmethod
     def get_select_statement(table_slice: TableSlice) -> str:


### PR DESCRIPTION
## Summary & Motivation
When materializing an asset and using the snowflake I/O manager we delete the table/table slice before adding the new data to the table. If the table hasn't been created yet (when the asset is materialized for the first time) this delete statement will fail, so we catch the error and continue on. However, there are other errors that can occur as documented in https://github.com/dagster-io/dagster/discussions/18415 that we do want to raise. This PR does some additional checking on the raised error to see if it is because the table doesn't exist before continuing with execution.

And alternate approach would be to add a `SHOW TERSE TABLES LIKE 'table_name'` before running the delete, but a vaguely remember a reason we didn't do this to begin with. I'm going to think on this some more, but if we don't think there's a reason to avoid the `SHOW` query, then I think that would be a better approach. 

Some potential reasons:
* SHOW requires different permissions than write? Not sure if that's true
* SHOW ... LIKE does case insensitive matching, but the write/delete queries are case sensitive, so we could match on the wrong table? I think we could avoid that by doing our own case sensitive matching with the returned tables 

## How I Tested These Changes
