### PR TITLE
[ui] More performant line numbers rendering in raw log content

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
@@ -79,18 +79,16 @@ export const LogsToolbar = (props: ILogsToolbarProps | WithExpandCollapseProps) 
   const activeItems = React.useMemo(() => new Set([logType]), [logType]);
 
   return (
-    <OptionsContainer>
-      <Box margin={{right: 12}}>
-        <ButtonGroup
-          activeItems={activeItems}
-          buttons={[
-            {id: LogType.structured, icon: 'view_list', label: 'Events'},
-            {id: LogType.stdout, icon: 'console', label: 'stdout'},
-            {id: LogType.stderr, icon: 'warning', label: 'stderr'},
-          ]}
-          onClick={(id) => onSetLogType(id)}
-        />
-      </Box>
+    <OptionsContainer style={{gap: 12}}>
+      <ButtonGroup
+        activeItems={activeItems}
+        buttons={[
+          {id: LogType.structured, icon: 'view_list', label: 'Events'},
+          {id: LogType.stdout, icon: 'console', label: 'stdout'},
+          {id: LogType.stderr, icon: 'warning', label: 'stderr'},
+        ]}
+        onClick={(id) => onSetLogType(id)}
+      />
       {logType === 'structured' ? (
         <StructuredLogToolbar
           counts={counts}


### PR DESCRIPTION
## Summary & Motivation

Fixes #13026


Investigation into #13026 turned this up -- we set a log limit at ~5MB, but a 5MB log can still have 200k+ lines if the user is logging short bits of text.

We were previously rendering 200k divs for 200k line numbers. It'd obviously be ideal to virtualize this whole thing, but since we use `anser` to render the raw text content and it does some interesting processing of line control characters, I'm not sure that we can just "cut" the text into lines and render the last N lines. Virtualization here might be more complicated.

In the meantime, I switched the implementation of the line numbers so it takes less time per render. Instead of re-processing 200k React children each render, I track the previous # of lines, and append a div with the new #s that are needed (and blow it all away if the line number count has gone down.) I think it's worth doing this outside React because we know there is exactly one case (appending new numbers) that covers 99.9% of the updates.

The remaining stutter on this page is caused by forced sync layout required by the `scrollToBottom` behavior, which sets scrollTop in a componentDidUpdate. I'm not sure how to avoid that, but it'd be nice if we could.

## How I Tested These Changes

I tested these changes manually and used the sample in the issue above to spam stdout + stderr.

![image](https://github.com/dagster-io/dagster/assets/1037212/e0d5017e-e6e3-47d3-a44a-76b676c6d01c)


![image](https://github.com/dagster-io/dagster/assets/1037212/040b2613-8c54-4430-827a-9b548ec2cce3)
