### PR TITLE
[docs] Fix button breakpoints

### DIFF
--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -310,7 +310,6 @@ const Warning = ({children}) => {
   return <Admonition style="warning">{children}</Admonition>;
 };
 
-
 //////////////////////
 //  CODE REF LINK   //
 //////////////////////
@@ -797,14 +796,14 @@ const Button = ({
     <a
       href={link}
       className={cx(
-        'py-2 px-4 rounded-full transition hover:no-underline cursor-pointer',
+        'text-sm lg:text-base select-none text-center py-2 px-4 rounded-xl transition hover:no-underline cursor-pointer',
         style === 'primary' && 'bg-gable-green text-white hover:bg-gable-green-darker',
         style === 'secondary' &&
           'border text-gable-green hover:text-gable-green-darker hover:border-gable-green',
         style === 'blurple' && 'bg-blurple text-white hover:bg-blurple-darker',
       )}
     >
-      {children}
+      <div className="h-full flex flex-1 flex-col justify-evenly align-center">{children}</div>
     </a>
   );
 };


### PR DESCRIPTION
## Summary & Motivation

Resolves https://github.com/dagster-io/dagster/issues/17777.

Button rendering is a bit broken in certain viewport sizes. Fix it by:

- Adjusting border-radius
- Vertically and horizontally centering text within the button
- Using a smaller font for the button in smaller viewports

I also removed user-select from the buttons, since it's not needed and it ends up looking weird when surrounding text is selected and includes the button text.

<img width="527" alt="Screenshot 2023-12-13 at 12 48 00 PM" src="https://github.com/dagster-io/dagster/assets/2823852/c9c297c1-904e-442a-ae01-a8308eb4af81">
<img width="696" alt="Screenshot 2023-12-13 at 12 47 51 PM" src="https://github.com/dagster-io/dagster/assets/2823852/f6d92430-24a3-4721-b285-68471f9da82f">
<img width="939" alt="Screenshot 2023-12-13 at 12 47 43 PM" src="https://github.com/dagster-io/dagster/assets/2823852/baafa92d-e279-4812-8743-b5288ed3835b">
<img width="1135" alt="Screenshot 2023-12-13 at 12 47 31 PM" src="https://github.com/dagster-io/dagster/assets/2823852/60778f96-fe77-49b7-b3b1-3ef5aa6401a0">
<img width="1528" alt="Screenshot 2023-12-13 at 12 47 19 PM" src="https://github.com/dagster-io/dagster/assets/2823852/d899c04c-adab-45f2-9f67-c2576ce9e0a9">


## How I Tested These Changes

See screenshots.
