### PR TITLE
Add sensor_type to SensorInstigatorData

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -238,6 +238,7 @@ def set_sensor_cursor(
             last_run_key=instigator_data.last_run_key,
             min_interval=external_sensor.min_interval_seconds,
             cursor=cursor,
+            sensor_type=external_sensor.sensor_type,
         )
     )
     if not stored_state:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
@@ -19,6 +19,9 @@ from dagster._core.definitions.partition import (
 from dagster._core.definitions.run_request import (
     InstigatorType,
 )
+from dagster._core.definitions.sensor_definition import (
+    SensorType,
+)
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
 from dagster._core.host_representation.origin import (
     ExternalInstigatorOrigin,
@@ -344,7 +347,8 @@ class TestAutoMaterializeAssetEvaluations(ExecutingGraphQLContextTestMatrix):
                 InstigatorType.SENSOR,
                 status=InstigatorStatus.RUNNING,
                 instigator_data=SensorInstigatorData(
-                    cursor=AssetDaemonCursor.empty()._replace(evaluation_id=12345).serialize()
+                    cursor=AssetDaemonCursor.empty()._replace(evaluation_id=12345).serialize(),
+                    sensor_type=SensorType.AUTOMATION_POLICY,
                 ),
             )
         )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -4,6 +4,9 @@ import sys
 import pendulum
 import pytest
 from dagster._core.definitions.run_request import InstigatorType
+from dagster._core.definitions.sensor_definition import (
+    SensorType,
+)
 from dagster._core.host_representation import (
     ExternalRepositoryOrigin,
     InProcessCodeLocationOrigin,
@@ -1167,7 +1170,7 @@ def test_unloadable_sensor(graphql_context: WorkspaceRequestContext):
         running_origin,
         InstigatorType.SENSOR,
         InstigatorStatus.RUNNING,
-        SensorInstigatorData(min_interval=30, cursor=None),
+        SensorInstigatorData(min_interval=30, cursor=None, sensor_type=SensorType.STANDARD),
     )
 
     stopped_origin = _get_unloadable_sensor_origin("unloadable_stopped")
@@ -1179,7 +1182,7 @@ def test_unloadable_sensor(graphql_context: WorkspaceRequestContext):
             stopped_origin,
             InstigatorType.SENSOR,
             InstigatorStatus.STOPPED,
-            SensorInstigatorData(min_interval=30, cursor=None),
+            SensorInstigatorData(min_interval=30, cursor=None, sensor_type=SensorType.STANDARD),
         )
     )
 

--- a/python_modules/dagster/dagster/_cli/sensor.py
+++ b/python_modules/dagster/dagster/_cli/sensor.py
@@ -363,7 +363,9 @@ def execute_cursor_command(sensor_name, cli_args, print_fn):
                         InstigatorType.SENSOR,
                         InstigatorStatus.STOPPED,
                         SensorInstigatorData(
-                            min_interval=external_sensor.min_interval_seconds, cursor=cursor_value
+                            min_interval=external_sensor.min_interval_seconds,
+                            cursor=cursor_value,
+                            sensor_type=external_sensor.sensor_type,
                         ),
                     )
                 )
@@ -377,6 +379,7 @@ def execute_cursor_command(sensor_name, cli_args, print_fn):
                             cursor=cursor_value,
                             last_tick_start_timestamp=job_state.instigator_data.last_tick_start_timestamp,
                             last_sensor_start_timestamp=job_state.instigator_data.last_sensor_start_timestamp,
+                            sensor_type=external_sensor.sensor_type,
                         ),
                     )
                 )

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -911,7 +911,10 @@ class ExternalSensor:
                     self.get_external_origin(),
                     InstigatorType.SENSOR,
                     InstigatorStatus.AUTOMATICALLY_RUNNING,
-                    SensorInstigatorData(min_interval=self.min_interval_seconds),
+                    SensorInstigatorData(
+                        min_interval=self.min_interval_seconds,
+                        sensor_type=self.sensor_type,
+                    ),
                 )
             )
         else:
@@ -925,7 +928,10 @@ class ExternalSensor:
                 self.get_external_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.STOPPED,
-                SensorInstigatorData(min_interval=self.min_interval_seconds),
+                SensorInstigatorData(
+                    min_interval=self.min_interval_seconds,
+                    sensor_type=self.sensor_type,
+                ),
             )
 
     @property

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2689,6 +2689,7 @@ class DagsterInstance(DynamicPartitionsStore):
                     SensorInstigatorData(
                         min_interval=external_sensor.min_interval_seconds,
                         last_sensor_start_timestamp=pendulum.now("UTC").timestamp(),
+                        sensor_type=external_sensor.sensor_type,
                     ),
                 )
             )
@@ -2730,7 +2731,10 @@ class DagsterInstance(DynamicPartitionsStore):
                     external_sensor.get_external_origin(),
                     InstigatorType.SENSOR,
                     InstigatorStatus.STOPPED,
-                    SensorInstigatorData(min_interval=external_sensor.min_interval_seconds),
+                    SensorInstigatorData(
+                        min_interval=external_sensor.min_interval_seconds,
+                        sensor_type=external_sensor.sensor_type,
+                    ),
                 )
             )
         else:

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -17,6 +17,7 @@ from dagster._core.definitions.run_request import (
     SkipReason as SkipReason,
 )
 from dagster._core.definitions.selector import InstigatorSelector, RepositorySelector
+from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.host_representation.origin import ExternalInstigatorOrigin
 from dagster._serdes import create_snapshot_id
 from dagster._serdes.serdes import (
@@ -91,6 +92,7 @@ class SensorInstigatorData(
             ("last_tick_start_timestamp", Optional[float]),
             # the last time the sensor was started
             ("last_sensor_start_timestamp", Optional[float]),
+            ("sensor_type", Optional[SensorType]),
         ],
     )
 ):
@@ -102,6 +104,7 @@ class SensorInstigatorData(
         cursor: Optional[str] = None,
         last_tick_start_timestamp: Optional[float] = None,
         last_sensor_start_timestamp: Optional[float] = None,
+        sensor_type: Optional[SensorType] = None,
     ):
         return super(SensorInstigatorData, cls).__new__(
             cls,
@@ -111,6 +114,7 @@ class SensorInstigatorData(
             check.opt_str_param(cursor, "cursor"),
             check.opt_float_param(last_tick_start_timestamp, "last_tick_start_timestamp"),
             check.opt_float_param(last_sensor_start_timestamp, "last_sensor_start_timestamp"),
+            check.opt_inst_param(sensor_type, "sensor_type", SensorType),
         )
 
     def with_sensor_start_timestamp(self, start_timestamp: float) -> "SensorInstigatorData":
@@ -122,6 +126,7 @@ class SensorInstigatorData(
             self.cursor,
             self.last_tick_start_timestamp,
             start_timestamp,
+            self.sensor_type,
         )
 
 

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -207,6 +207,7 @@ class SensorLaunchContext(AbstractContextManager):
                         cursor=cursor,
                         last_tick_start_timestamp=marked_timestamp,
                         last_sensor_start_timestamp=last_sensor_start_timestamp,
+                        sensor_type=self._external_sensor.sensor_type,
                     )
                 )
             )
@@ -417,6 +418,7 @@ def execute_sensor_iteration(
                 SensorInstigatorData(
                     min_interval=external_sensor.min_interval_seconds,
                     last_sensor_start_timestamp=pendulum.now("UTC").timestamp(),
+                    sensor_type=external_sensor.sensor_type,
                 ),
             )
             instance.add_instigator_state(sensor_state)
@@ -578,6 +580,7 @@ def _mark_sensor_state_for_tick(
                 min_interval=external_sensor.min_interval_seconds,
                 cursor=instigator_data.cursor if instigator_data else None,
                 last_tick_start_timestamp=now.timestamp(),
+                sensor_type=external_sensor.sensor_type,
             )
         )
     )

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -47,6 +47,7 @@ from dagster._core.definitions.sensor_definition import (
     DefaultSensorStatus,
     RunRequest,
     SensorEvaluationContext,
+    SensorType,
     SkipReason,
 )
 from dagster._core.events import DagsterEventType
@@ -1224,6 +1225,7 @@ def test_error_sensor(caplog, executor, instance, workspace_context, external_re
         state = instance.get_instigator_state(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
         )
+        assert state.instigator_data.sensor_type == SensorType.STANDARD
         assert state.instigator_data.cursor is None
         assert state.instigator_data.last_tick_timestamp == freeze_datetime.timestamp()
 


### PR DESCRIPTION
Summary:
This is useful for the asset daemon to be able to specifically look at sensor states that were stored for specific types of assets.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
