### PR TITLE
[ui] Allow horizontal scroll on asset metadata in right panel

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMetadata.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMetadata.tsx
@@ -31,7 +31,7 @@ export const AssetMetadataTable = ({
     };
   });
   return (
-    <Box padding={{vertical: 16, horizontal: 24}}>
+    <Box padding={{vertical: 16, horizontal: 24}} style={{overflowX: 'auto'}}>
       <MetadataTable rows={rows} />
     </Box>
   );


### PR DESCRIPTION
## Summary & Motivation

Resolves ##18496.

When the metadata for an asset overflows the container horizontally in the right panel, the entire page scrolls with it. Just make the container allow horizontal scrolling instead.

## How I Tested These Changes

Force the Metadata container to render a table with very long strings. Verify that the container h-scrolls, and the page does not.
