### PR TITLE
[ui] Offer to materialize changed and missing on asset list views

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -743,7 +743,6 @@ const AssetGraphExplorerWithData = ({
                       ? {selected: selectedDefinitions}
                       : {all: allDefinitionsForMaterialize}
                   }
-                  showChangedAndMissingOption
                 />
               </Box>
               {filterBar}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineage.tsx
@@ -77,7 +77,6 @@ export const AssetNodeLineage = ({
           <LaunchAssetExecutionButton
             intent="none"
             scope={{all: Object.values(assetGraphData.nodes).map((n) => n.definition)}}
-            showChangedAndMissingOption
           />
         ) : (
           <Button icon={<Icon name="materialization" />} disabled>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
@@ -2,16 +2,16 @@ import {RefetchQueriesFunction} from '@apollo/client';
 import {
   Box,
   Button,
+  Checkbox,
   Icon,
-  MenuItem,
   Menu,
+  MenuItem,
+  NonIdealState,
   Popover,
   Tooltip,
-  Checkbox,
-  NonIdealState,
+  colorAccentRed,
   colorBackgroundDefault,
   colorTextDisabled,
-  colorAccentRed,
 } from '@dagster-io/ui-components';
 import groupBy from 'lodash/groupBy';
 import * as React from 'react';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -274,6 +274,7 @@ export const AssetView = ({assetKey, trace}: Props) => {
             ) : definition && definition.jobNames.length > 0 && upstream ? (
               <LaunchAssetExecutionButton
                 scope={{all: [definition]}}
+                scopeAlwaysSingleAsset
                 additionalDropdownOptions={reportEvents.dropdownOptions}
               />
             ) : undefined}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -274,7 +274,7 @@ export const AssetView = ({assetKey, trace}: Props) => {
             ) : definition && definition.jobNames.length > 0 && upstream ? (
               <LaunchAssetExecutionButton
                 scope={{all: [definition]}}
-                scopeAlwaysSingleAsset
+                showChangedAndMissingOption={false}
                 additionalDropdownOptions={reportEvents.dropdownOptions}
               />
             ) : undefined}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -163,10 +163,10 @@ export const LaunchAssetExecutionButton = ({
   preferredJobName,
   additionalDropdownOptions,
   intent = 'primary',
-  scopeAlwaysSingleAsset,
+  showChangedAndMissingOption = true,
 }: {
   scope: AssetsInScope;
-  scopeAlwaysSingleAsset?: boolean;
+  showChangedAndMissingOption?: boolean;
   intent?: 'primary' | 'none';
   preferredJobName?: string;
   additionalDropdownOptions?: {
@@ -256,7 +256,7 @@ export const LaunchAssetExecutionButton = ({
                   onClick={(e) => onClick(option.assetKeys, e)}
                 />
               ))}
-              {!scopeAlwaysSingleAsset ? (
+              {showChangedAndMissingOption ? (
                 <MenuItem
                   text="Materialize changed and missing"
                   icon="changes_present"

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -163,9 +163,10 @@ export const LaunchAssetExecutionButton = ({
   preferredJobName,
   additionalDropdownOptions,
   intent = 'primary',
-  showChangedAndMissingOption,
+  scopeAlwaysSingleAsset,
 }: {
   scope: AssetsInScope;
+  scopeAlwaysSingleAsset?: boolean;
   intent?: 'primary' | 'none';
   preferredJobName?: string;
   additionalDropdownOptions?: {
@@ -173,7 +174,6 @@ export const LaunchAssetExecutionButton = ({
     icon?: JSX.Element;
     onClick: () => void;
   }[];
-  showChangedAndMissingOption?: boolean;
 }) => {
   const {onClick, loading, launchpadElement} = useMaterializationAction(preferredJobName);
   const [isOpen, setIsOpen] = React.useState(false);
@@ -256,7 +256,7 @@ export const LaunchAssetExecutionButton = ({
                   onClick={(e) => onClick(option.assetKeys, e)}
                 />
               ))}
-              {showChangedAndMissingOption && 'all' in scope ? (
+              {!scopeAlwaysSingleAsset ? (
                 <MenuItem
                   text="Materialize changed and missing"
                   icon="changes_present"


### PR DESCRIPTION
When we revamped the data loading in the global asset graph, we limited the “materialize changed and missing” to specific contexts (#18198).

I think that it makes sense to show this option whenever more than one asset is in scope, whether you’re operating on an all assets in view or on a selection. This PR reverts a bit of #18198 so it appears here:

<img width="1727" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/5d1df552-dcd1-4d05-93d7-6d16f320637b">

Previously, we disabled this option when `scope=selection` because there was no confirmation modal and it was confusing whether it was "changed and missing and in your selection" or not. Now that we have a nice modal with checkboxes for revising + confirming the subset that will materialize, it’s no longer confusing and we should offer it in this case.

I audited all the callsites where we use the LaunchAssetExecutionButton, and I think the only place we don’t want to show this option is on the individual asset view. To make sure this doesn’t get left out again, I inverted the option from “showChangedAndMissingOption” (show option) to “scopeAlwaysSingleAsset” (hide option) and set it in just that one place.

## How I Tested These Changes

I verified the existing tests covering the launch button still pass, and tested these changes manually in the graph and list view.