### PR TITLE
Update default checked statuses for sensors and auto-materialize to include Skipped by default

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationEvaluationHistoryTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationEvaluationHistoryTable.tsx
@@ -49,6 +49,7 @@ export const AutomaterializationEvaluationHistoryTable = ({
               InstigationTickStatus.STARTED,
               InstigationTickStatus.SUCCESS,
               InstigationTickStatus.FAILURE,
+              InstigationTickStatus.SKIPPED,
             ],
       );
     }, []),

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -69,7 +69,7 @@ const DEFAULT_SHOWN_STATUS_STATE = {
   [InstigationTickStatus.SUCCESS]: true,
   [InstigationTickStatus.FAILURE]: true,
   [InstigationTickStatus.STARTED]: true,
-  [InstigationTickStatus.SKIPPED]: false,
+  [InstigationTickStatus.SKIPPED]: true,
 };
 const STATUS_TEXT_MAP = {
   [InstigationTickStatus.SUCCESS]: 'Requested',


### PR DESCRIPTION
Summary:
Fixes an issues where sensors that have a lot of skips and only a few errors look broken, when in fact they are running just fine.

Test Plan:
View a sensor and AMP tick page with ticks of all types - default view now includes skip ticks as well as the other kinds
Changing checkboxes works as before

## Summary & Motivation

## How I Tested These Changes
