### PR TITLE
Add automationPolicySensor field to GrapheneAssetNode

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -691,6 +691,7 @@ type AssetNode {
   hasAssetChecks: Boolean!
   assetChecksOrError(limit: Int, pipeline: PipelineSelector): AssetChecksOrError!
   currentAutoMaterializeEvaluationId: Int
+  automationPolicySensor: Sensor
 }
 
 type MaterializationUpstreamDataVersion {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -338,6 +338,7 @@ export type AssetNode = {
   assetObservations: Array<ObservationEvent>;
   assetPartitionStatuses: AssetPartitionStatuses;
   autoMaterializePolicy: Maybe<AutoMaterializePolicy>;
+  automationPolicySensor: Maybe<Sensor>;
   backfillPolicy: Maybe<BackfillPolicy>;
   computeKind: Maybe<Scalars['String']>;
   configField: Maybe<ConfigTypeField>;
@@ -5177,6 +5178,12 @@ export const buildAssetNode = (
         : relationshipsToOmit.has('AutoMaterializePolicy')
         ? ({} as AutoMaterializePolicy)
         : buildAutoMaterializePolicy({}, relationshipsToOmit),
+    automationPolicySensor:
+      overrides && overrides.hasOwnProperty('automationPolicySensor')
+        ? overrides.automationPolicySensor!
+        : relationshipsToOmit.has('Sensor')
+        ? ({} as Sensor)
+        : buildSensor({}, relationshipsToOmit),
     backfillPolicy:
       overrides && overrides.hasOwnProperty('backfillPolicy')
         ? overrides.backfillPolicy!

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_sensors.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_sensors.ambr
@@ -182,6 +182,61 @@
     dict({
       'description': None,
       'minIntervalSeconds': 30,
+      'name': 'my_automation_policy_sensor',
+      'sensorState': dict({
+        'runs': list([
+        ]),
+        'runsCount': 0,
+        'status': 'STOPPED',
+        'ticks': list([
+        ]),
+      }),
+      'targets': list([
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_0',
+          'solidSelection': None,
+        }),
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_1',
+          'solidSelection': None,
+        }),
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_2',
+          'solidSelection': None,
+        }),
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_3',
+          'solidSelection': None,
+        }),
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_4',
+          'solidSelection': None,
+        }),
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_5',
+          'solidSelection': None,
+        }),
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_6',
+          'solidSelection': None,
+        }),
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_7',
+          'solidSelection': None,
+        }),
+      ]),
+    }),
+    dict({
+      'description': None,
+      'minIntervalSeconds': 30,
       'name': 'never_no_config_sensor',
       'sensorState': dict({
         'runs': list([

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -86,6 +86,9 @@ from dagster import (
     with_resources,
 )
 from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.automation_policy_sensor_definition import (
+    AutomationPolicySensorDefinition,
+)
 from dagster._core.definitions.decorators.sensor_decorator import sensor
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import Failure
@@ -1208,6 +1211,11 @@ def define_sensors():
     def the_failure_sensor():
         pass
 
+    automation_policy_sensor = AutomationPolicySensorDefinition(
+        "my_automation_policy_sensor",
+        asset_selection=AssetSelection.keys("fresh_diamond_bottom"),
+    )
+
     return [
         always_no_config_sensor,
         always_error_sensor,
@@ -1224,6 +1232,7 @@ def define_sensors():
         many_asset_sensor,
         fresh_sensor,
         the_failure_sensor,
+        automation_policy_sensor,
     ]
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -608,7 +608,11 @@ class TestSensors(NonLaunchableGraphQLContextTestMatrix):
         assert result.data["sensorsOrError"]
         assert result.data["sensorsOrError"]["__typename"] == "Sensors"
         results = result.data["sensorsOrError"]["results"]
-        snapshot.assert_match(results)
+
+        # Snapshot is different for test_dict_repo because it does not contain any asset jobs,
+        # so the sensor targets for sensors with asset selections differ
+        if selector["repositoryName"] != "test_dict_repo":
+            snapshot.assert_match(results)
 
     def test_get_sensors_filtered(self, graphql_context: WorkspaceRequestContext, snapshot):
         selector = infer_repository_selector(graphql_context)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -476,7 +476,7 @@ class AssetDaemonScenarioState(NamedTuple):
         """Additional assertions for daemon mode. Checks that the evaluation for the given asset
         contains the expected run ids.
         """
-        current_evaluation_id = check.not_none(get_current_evaluation_id(self.instance))
+        current_evaluation_id = check.not_none(get_current_evaluation_id(self.instance, None))
         new_run_ids_for_asset = {
             run.run_id
             for run in self.instance.get_runs(


### PR DESCRIPTION
Summary:
Provides a way to link from an asset to the automation policy sensor that created it (unlike with regular sensors, there can be at most one automation policy sensor thatis attached to a given asset).

Also update current evaluation ID to be automation policy sensor aware.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
