### PR TITLE
Add transaction storage method for event log

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -606,6 +606,10 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     PackageSpec(
         "python_modules/libraries/dagster-mysql",
         pytest_extra_cmds=mysql_extra_cmds,
+        pytest_tox_factors=[
+            "storage_tests",
+            "storage_tests_sqlalchemy_1_3",
+        ],
         unsupported_python_versions=[
             # mysql-connector-python not supported on 3.11
             AvailablePythonVersion.V3_11,
@@ -623,7 +627,14 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             AvailablePythonVersion.V3_11,
         ],
     ),
-    PackageSpec("python_modules/libraries/dagster-postgres", pytest_extra_cmds=postgres_extra_cmds),
+    PackageSpec(
+        "python_modules/libraries/dagster-postgres",
+        pytest_extra_cmds=postgres_extra_cmds,
+        pytest_tox_factors=[
+            "storage_tests",
+            "storage_tests_sqlalchemy_1_3",
+        ],
+    ),
     PackageSpec(
         "python_modules/libraries/dagster-twilio",
         env_vars=["TWILIO_TEST_ACCOUNT_SID", "TWILIO_TEST_AUTH_TOKEN"],

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
@@ -173,13 +173,7 @@ def mysql_alembic_config(dunder_file: str) -> Config:
 
 
 def mysql_isolation_level():
-    if db.__version__.startswith("2.") or db.__version__.startswith("1.4"):
-        # Starting with 1.4, the ability to emulate autocommit was deprecated, so we need to
-        # explicitly call commit on the connection for MySQL where the AUTOCOMMIT isolation
-        # level is not supported.  We should then set the isolation level to the MySQL default
-        return "REPEATABLE READ"
-
-    return "AUTOCOMMIT"
+    return "REPEATABLE READ"
 
 
 @contextmanager

--- a/python_modules/libraries/dagster-mysql/tox.ini
+++ b/python_modules/libraries/dagster-mysql/tox.ini
@@ -5,6 +5,7 @@ skipsdist = true
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN MYSQL_TEST_* BUILDKITE*
 deps =
+  storage_tests_sqlalchemy_1_3: sqlalchemy<1.4
   -e ../../dagster[test]
   -e ../../dagster-pipes
   -e .
@@ -12,4 +13,6 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-    pytest -c ../../../pyproject.toml -vv {posargs}
+
+  storage_tests: pytest -c ../../../pyproject.toml -vv {posargs}
+  storage_tests_sqlalchemy_1_3: pytest -c ../../../pyproject.toml -vv {posargs}

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -1,4 +1,5 @@
-from typing import Any, ContextManager, Mapping, Optional, Sequence
+from contextlib import contextmanager
+from typing import Any, ContextManager, Iterator, Mapping, Optional, Sequence
 
 import dagster._check as check
 import sqlalchemy as db
@@ -286,6 +287,17 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
     def index_connection(self) -> ContextManager[Connection]:
         return self._connect()
+
+    @contextmanager
+    def index_transaction(self) -> Iterator[Connection]:
+        """Context manager yielding a connection to the index shard that has begun a transaction."""
+        with self.index_connection() as conn:
+            if conn.in_transaction():
+                yield conn
+            else:
+                conn = conn.execution_options(isolation_level="READ COMMITTED")  # noqa: PLW2901
+                with conn.begin():
+                    yield conn
 
     def has_table(self, table_name: str) -> bool:
         return bool(self._engine.dialect.has_table(self._engine.connect(), table_name))

--- a/python_modules/libraries/dagster-postgres/tox.ini
+++ b/python_modules/libraries/dagster-postgres/tox.ini
@@ -5,6 +5,7 @@ skipsdist = true
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN POSTGRES_TEST_* BUILDKITE*
 deps =
+  storage_tests_sqlalchemy_1_3: sqlalchemy<1.4
   -e ../../dagster[test]
   -e ../../dagster-pipes
   -e .
@@ -12,4 +13,5 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-    pytest -c ../../../pyproject.toml -vv {posargs}
+  storage_tests: pytest -c ../../../pyproject.toml -vv {posargs}
+  storage_tests_sqlalchemy_1_3: pytest -c ../../../pyproject.toml -vv {posargs}


### PR DESCRIPTION
## Summary & Motivation
We need some way to specify that certain event log interactions happen within an explicit transaction.  For now, rather than enforcing this at the connection level see (https://github.com/dagster-io/dagster/pull/18584, reverted in https://github.com/dagster-io/dagster/pull/18706), we have a specific method on the event log storage.  This allows to override the behavior on a per-sql-backend basis (including Cloud).

[NO_SKIP][test-all]

## How I Tested These Changes
BK