### PR TITLE
Add feature flag for automation policy sensors

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2327,6 +2327,7 @@ type Instance {
   supportsConcurrencyLimits: Boolean!
   concurrencyLimits: [ConcurrencyKeyInfo!]!
   concurrencyLimit(concurrencyKey: String): ConcurrencyKeyInfo!
+  useAutomationPolicySensors: Boolean!
 }
 
 type RunQueueConfig {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -1508,6 +1508,7 @@ export type Instance = {
   runQueueConfig: Maybe<RunQueueConfig>;
   runQueuingSupported: Scalars['Boolean'];
   supportsConcurrencyLimits: Scalars['Boolean'];
+  useAutomationPolicySensors: Scalars['Boolean'];
 };
 
 export type InstanceConcurrencyLimitArgs = {
@@ -7355,6 +7356,10 @@ export const buildInstance = (
       overrides && overrides.hasOwnProperty('supportsConcurrencyLimits')
         ? overrides.supportsConcurrencyLimits!
         : false,
+    useAutomationPolicySensors:
+      overrides && overrides.hasOwnProperty('useAutomationPolicySensors')
+        ? overrides.useAutomationPolicySensors!
+        : true,
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
@@ -208,6 +208,10 @@ class GrapheneInstance(graphene.ObjectType):
         graphene.NonNull(GrapheneConcurrencyKeyInfo),
         concurrencyKey=graphene.Argument(graphene.String),
     )
+    useAutomationPolicySensors = graphene.Field(
+        graphene.NonNull(graphene.Boolean),
+        description="Whether or not the deployment is using automation policy sensors to materialize assets",
+    )
 
     class Meta:
         name = "Instance"
@@ -221,6 +225,9 @@ class GrapheneInstance(graphene.ObjectType):
 
     def resolve_hasInfo(self, graphene_info: ResolveInfo) -> bool:
         return graphene_info.context.show_instance_config
+
+    def resolve_useAutomationPolicySensors(self, _graphene_info: ResolveInfo):
+        return self._instance.auto_materialize_use_automation_policy_sensors
 
     def resolve_info(self, graphene_info: ResolveInfo):
         return self._instance.info_str() if graphene_info.context.show_instance_config else None

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instance.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instance.py
@@ -9,6 +9,7 @@ query InstanceDetailSummaryQuery {
     instance {
         runQueuingSupported
         hasInfo
+        useAutomationPolicySensors
     }
 }
 """
@@ -69,6 +70,7 @@ class TestInstanceSettings(BaseTestSuite):
             "instance": {
                 "runQueuingSupported": True,
                 "hasInfo": graphql_context.show_instance_config,
+                "useAutomationPolicySensors": graphql_context.instance.auto_materialize_use_automation_policy_sensors,
             }
         }
 


### PR DESCRIPTION
Summary:
Give the frontend a way to gate new functionality around how we display the AMP page / break it up into multiple sensors. The daemon will be checking this same flag, so we can keep execution and UI in sync.

Test Plan: Bk

## Summary & Motivation

## How I Tested These Changes
