### PR TITLE
handle unserializable asset selections on external sensors

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -96,6 +96,7 @@ from dagster._core.snap import JobSnapshot
 from dagster._core.snap.mode import ResourceDefSnap, build_resource_def_snap
 from dagster._core.storage.io_manager import IOManagerDefinition
 from dagster._serdes import whitelist_for_serdes
+from dagster._serdes.serdes import is_whitelisted_for_serdes_namedtuple
 from dagster._utils.error import SerializableErrorInfo
 
 if TYPE_CHECKING:
@@ -552,6 +553,13 @@ class ExternalSensorData(
                     ),
                 )
             }
+
+        if asset_selection:
+            check.opt_inst_param(asset_selection, "asset_selection", AssetSelection)
+            check.invariant(
+                is_whitelisted_for_serdes_namedtuple(asset_selection),
+                "asset_selection must be serializable",
+            )
 
         return super(ExternalSensorData, cls).__new__(
             cls,
@@ -2036,6 +2044,14 @@ def external_sensor_data_from_def(
             )
             for base_asset_job_name in repository_def.get_implicit_asset_job_names()
         }
+
+        if is_whitelisted_for_serdes_namedtuple(sensor_def.asset_selection):
+            asset_selection = sensor_def.asset_selection
+        else:
+            asset_selection = AssetSelection.keys(
+                *sensor_def.asset_selection.resolve(repository_def.asset_graph)
+            )
+
     else:
         target_dict = {
             target.job_name: ExternalTargetData(
@@ -2057,7 +2073,7 @@ def external_sensor_data_from_def(
         metadata=ExternalSensorMetadata(asset_keys=asset_keys),
         default_status=sensor_def.default_status,
         sensor_type=sensor_def.sensor_type,
-        asset_selection=sensor_def.asset_selection,
+        asset_selection=asset_selection,
     )
 
 

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -96,7 +96,7 @@ from dagster._core.snap import JobSnapshot
 from dagster._core.snap.mode import ResourceDefSnap, build_resource_def_snap
 from dagster._core.storage.io_manager import IOManagerDefinition
 from dagster._serdes import whitelist_for_serdes
-from dagster._serdes.serdes import is_whitelisted_for_serdes_namedtuple
+from dagster._serdes.serdes import is_whitelisted_for_serdes_object
 from dagster._utils.error import SerializableErrorInfo
 
 if TYPE_CHECKING:
@@ -557,7 +557,7 @@ class ExternalSensorData(
         if asset_selection:
             check.opt_inst_param(asset_selection, "asset_selection", AssetSelection)
             check.invariant(
-                is_whitelisted_for_serdes_namedtuple(asset_selection),
+                is_whitelisted_for_serdes_object(asset_selection),
                 "asset_selection must be serializable",
             )
 
@@ -2045,13 +2045,9 @@ def external_sensor_data_from_def(
             for base_asset_job_name in repository_def.get_implicit_asset_job_names()
         }
 
-        if is_whitelisted_for_serdes_namedtuple(sensor_def.asset_selection):
-            asset_selection = sensor_def.asset_selection
-        else:
-            asset_selection = AssetSelection.keys(
-                *sensor_def.asset_selection.resolve(repository_def.asset_graph)
-            )
-
+        serializable_asset_selection = sensor_def.asset_selection.to_serializable_asset_selection(
+            repository_def.asset_graph
+        )
     else:
         target_dict = {
             target.job_name: ExternalTargetData(
@@ -2061,6 +2057,8 @@ def external_sensor_data_from_def(
             )
             for target in sensor_def.targets
         }
+
+        serializable_asset_selection = None
 
     return ExternalSensorData(
         name=sensor_def.name,
@@ -2073,7 +2071,7 @@ def external_sensor_data_from_def(
         metadata=ExternalSensorMetadata(asset_keys=asset_keys),
         default_status=sensor_def.default_status,
         sensor_type=sensor_def.sensor_type,
-        asset_selection=asset_selection,
+        asset_selection=serializable_asset_selection,
     )
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -15,9 +15,11 @@ from dagster import (
     SourceAsset,
     StaticPartitionsDefinition,
     TimeWindowPartitionMapping,
+    asset_check,
     multi_asset,
 )
 from dagster._core.definitions import AssetSelection, asset
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.events import AssetKey
 from dagster._serdes.serdes import _WHITELIST_MAP
@@ -392,3 +394,100 @@ def test_all_asset_selection_subclasses_serializable():
     for asset_selection_subclass in asset_selection_subclasses:
         if asset_selection_subclass != AssetSelection:
             assert _WHITELIST_MAP.has_object_serializer(asset_selection_subclass.__name__)
+
+
+def test_to_serializable_asset_selection():
+    class UnserializableAssetSelection(AssetSelection):
+        def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+            return asset_graph.materializable_asset_keys - {AssetKey("asset2")}
+
+    @asset
+    def asset1():
+        ...
+
+    @asset
+    def asset2():
+        ...
+
+    @asset_check(asset=asset1)
+    def check1():
+        ...
+
+    asset_graph = AssetGraph.from_assets([asset1, asset2], asset_checks=[check1])
+
+    def assert_serializable_same(asset_selection: AssetSelection) -> None:
+        assert asset_selection.to_serializable_asset_selection(asset_graph) == asset_selection
+
+    assert_serializable_same(AssetSelection.groups("a"))
+    assert_serializable_same(AssetSelection.key_prefixes(["foo", "bar"]))
+    assert_serializable_same(AssetSelection.all())
+    assert_serializable_same(AssetSelection.all_asset_checks())
+    assert_serializable_same(AssetSelection.keys("asset1"))
+    assert_serializable_same(AssetSelection.checks_for_assets(asset1))
+    assert_serializable_same(AssetSelection.checks(check1))
+
+    assert_serializable_same(AssetSelection.sinks(AssetSelection.groups("a")))
+    assert_serializable_same(AssetSelection.downstream(AssetSelection.groups("a"), depth=1))
+    assert_serializable_same(AssetSelection.upstream(AssetSelection.groups("a"), depth=1))
+    assert_serializable_same(
+        AssetSelection.required_multi_asset_neighbors(AssetSelection.groups("a"))
+    )
+    assert_serializable_same(AssetSelection.roots(AssetSelection.groups("a")))
+    assert_serializable_same(AssetSelection.sources(AssetSelection.groups("a")))
+    assert_serializable_same(AssetSelection.upstream_source_assets(AssetSelection.groups("a")))
+
+    assert_serializable_same(AssetSelection.groups("a") & AssetSelection.groups("b"))
+    assert_serializable_same(AssetSelection.groups("a") | AssetSelection.groups("b"))
+    assert_serializable_same(AssetSelection.groups("a") - AssetSelection.groups("b"))
+
+    asset1_selection = AssetSelection.keys("asset1")
+    assert (
+        UnserializableAssetSelection().to_serializable_asset_selection(asset_graph)
+        == asset1_selection
+    )
+
+    assert AssetSelection.sinks(UnserializableAssetSelection()).to_serializable_asset_selection(
+        asset_graph
+    ) == AssetSelection.sinks(asset1_selection)
+    assert AssetSelection.downstream(
+        UnserializableAssetSelection(), depth=1
+    ).to_serializable_asset_selection(asset_graph) == AssetSelection.downstream(
+        asset1_selection, depth=1
+    )
+    assert AssetSelection.upstream(
+        UnserializableAssetSelection(), depth=1
+    ).to_serializable_asset_selection(asset_graph) == AssetSelection.upstream(
+        asset1_selection, depth=1
+    )
+    assert AssetSelection.required_multi_asset_neighbors(
+        UnserializableAssetSelection()
+    ).to_serializable_asset_selection(asset_graph) == AssetSelection.required_multi_asset_neighbors(
+        asset1_selection
+    )
+    assert AssetSelection.roots(UnserializableAssetSelection()).to_serializable_asset_selection(
+        asset_graph
+    ) == AssetSelection.roots(asset1_selection)
+    assert AssetSelection.sources(UnserializableAssetSelection()).to_serializable_asset_selection(
+        asset_graph
+    ) == AssetSelection.sources(asset1_selection)
+    assert AssetSelection.upstream_source_assets(
+        UnserializableAssetSelection()
+    ).to_serializable_asset_selection(asset_graph) == AssetSelection.upstream_source_assets(
+        asset1_selection
+    )
+
+    assert (
+        UnserializableAssetSelection() & AssetSelection.groups("b")
+    ).to_serializable_asset_selection(asset_graph) == (
+        asset1_selection & AssetSelection.groups("b")
+    )
+    assert (
+        UnserializableAssetSelection() | AssetSelection.groups("b")
+    ).to_serializable_asset_selection(asset_graph) == (
+        asset1_selection | AssetSelection.groups("b")
+    )
+    assert (
+        UnserializableAssetSelection() - AssetSelection.groups("b")
+    ).to_serializable_asset_selection(asset_graph) == (
+        asset1_selection - AssetSelection.groups("b")
+    )

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_sensor_decorator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_sensor_decorator.py
@@ -1,6 +1,4 @@
 from dagster import AssetKey, asset, sensor
-from dagster._core.definitions.decorators.repository_decorator import repository
-from dagster._core.host_representation.external_data import external_sensor_data_from_def
 
 
 def test_coerce_to_asset_selection():
@@ -29,31 +27,3 @@ def test_coerce_to_asset_selection():
         ...
 
     assert sensor2.asset_selection.resolve(assets) == {AssetKey("asset1"), AssetKey("asset2")}
-
-
-def test_external_sensor_has_asset_selection():
-    @asset
-    def asset1():
-        ...
-
-    @asset
-    def asset2():
-        ...
-
-    @asset
-    def asset3():
-        ...
-
-    @sensor(asset_selection=["asset1", "asset2"])
-    def sensor1():
-        ...
-
-    @repository
-    def my_repo():
-        return [
-            sensor1,
-        ]
-
-    assert (
-        external_sensor_data_from_def(sensor1, my_repo).asset_selection == sensor1.asset_selection
-    )

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_sensor_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_sensor_data.py
@@ -1,0 +1,51 @@
+from typing import AbstractSet
+
+from dagster import AssetKey, AssetSelection, Definitions, asset, sensor
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.host_representation.external_data import external_sensor_data_from_def
+
+
+def make_three_assets():
+    @asset
+    def asset1():
+        ...
+
+    @asset
+    def asset2():
+        ...
+
+    @asset
+    def asset3():
+        ...
+
+    return asset1, asset2, asset3
+
+
+def test_external_sensor_has_asset_selection():
+    @sensor(asset_selection=["asset1", "asset2"])
+    def sensor1():
+        ...
+
+    defs = Definitions(sensors=[sensor1])
+
+    assert (
+        external_sensor_data_from_def(sensor1, defs.get_repository_def()).asset_selection
+        == sensor1.asset_selection
+    )
+
+
+def test_unserializable_asset_selection():
+    assets = make_three_assets()
+
+    class MySpecialAssetSelection(AssetSelection):
+        def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+            return asset_graph.materializable_asset_keys - {AssetKey("asset3")}
+
+    @sensor(asset_selection=MySpecialAssetSelection())
+    def sensor1():
+        ...
+
+    defs = Definitions(assets=assets)
+    assert external_sensor_data_from_def(
+        sensor1, defs.get_repository_def()
+    ).asset_selection == AssetSelection.keys("asset1", "asset2")

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_sensor_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_sensor_data.py
@@ -5,22 +5,6 @@ from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.host_representation.external_data import external_sensor_data_from_def
 
 
-def make_three_assets():
-    @asset
-    def asset1():
-        ...
-
-    @asset
-    def asset2():
-        ...
-
-    @asset
-    def asset3():
-        ...
-
-    return asset1, asset2, asset3
-
-
 def test_external_sensor_has_asset_selection():
     @sensor(asset_selection=["asset1", "asset2"])
     def sensor1():
@@ -35,17 +19,23 @@ def test_external_sensor_has_asset_selection():
 
 
 def test_unserializable_asset_selection():
-    assets = make_three_assets()
+    @asset
+    def asset1():
+        ...
+
+    @asset
+    def asset2():
+        ...
 
     class MySpecialAssetSelection(AssetSelection):
         def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
-            return asset_graph.materializable_asset_keys - {AssetKey("asset3")}
+            return asset_graph.materializable_asset_keys - {AssetKey("asset2")}
 
     @sensor(asset_selection=MySpecialAssetSelection())
     def sensor1():
         ...
 
-    defs = Definitions(assets=assets)
+    defs = Definitions(assets=[asset1, asset2])
     assert external_sensor_data_from_def(
         sensor1, defs.get_repository_def()
-    ).asset_selection == AssetSelection.keys("asset1", "asset2")
+    ).asset_selection == AssetSelection.keys("asset1")


### PR DESCRIPTION
## Summary & Motivation

Nothing prevents users from making their own asset selection subclasses. We offer one of our own with `DbtManifestAssetSelection`. This handles these by converting them to `KeysAssetSelection`, instead of erroring.

## How I Tested These Changes
