### PR TITLE
[ui] Handle tabs and routes for new asset sensor flag

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutomationPolicySensorFlag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutomationPolicySensorFlag.tsx
@@ -1,0 +1,28 @@
+import {gql, useQuery} from '@apollo/client';
+
+import {
+  AutomationPolicySensorFlagQuery,
+  AutomationPolicySensorFlagQueryVariables,
+} from './types/AutomationPolicySensorFlag.types';
+
+type FlagState = 'unknown' | 'has-sensor-amp' | 'has-global-amp';
+
+export const useAutomationPolicySensorFlag = (): FlagState => {
+  const {data} = useQuery<
+    AutomationPolicySensorFlagQuery,
+    AutomationPolicySensorFlagQueryVariables
+  >(AUTOMATION_POLICY_SENSOR_FLAG);
+  if (!data) {
+    return 'unknown';
+  }
+  return data?.instance.useAutomationPolicySensors ? 'has-sensor-amp' : 'has-global-amp';
+};
+
+const AUTOMATION_POLICY_SENSOR_FLAG = gql`
+  query AutomationPolicySensorFlag {
+    instance {
+      id
+      useAutomationPolicySensors
+    }
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AutomationPolicySensorFlag.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AutomationPolicySensorFlag.types.ts
@@ -1,0 +1,10 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type AutomationPolicySensorFlagQueryVariables = Types.Exact<{[key: string]: never}>;
+
+export type AutomationPolicySensorFlagQuery = {
+  __typename: 'Query';
+  instance: {__typename: 'Instance'; id: string; useAutomationPolicySensors: boolean};
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/__tests__/DaemonList.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/__tests__/DaemonList.test.tsx
@@ -18,6 +18,10 @@ jest.mock('../../app/Permissions', () => ({
   },
 }));
 
+jest.mock('../../assets/AutomationPolicySensorFlag', () => ({
+  useAutomationPolicySensorFlag: jest.fn().mockReturnValue('has-global-amp'),
+}));
+
 const mockDaemons = [
   buildDaemonStatus({
     id: '1',
@@ -91,7 +95,13 @@ describe('DaemonList', () => {
     };
 
     render(
-      <MockedProvider mocks={[autoMaterializePausedMock(false), setAutoMaterializePausedMock]}>
+      <MockedProvider
+        mocks={[
+          autoMaterializePausedMock(false),
+          setAutoMaterializePausedMock,
+          autoMaterializePausedMock(true),
+        ]}
+      >
         <CustomConfirmationProvider>
           <DaemonList daemonStatuses={mockDaemons} />
         </CustomConfirmationProvider>
@@ -123,7 +133,13 @@ describe('DaemonList', () => {
     };
 
     render(
-      <MockedProvider mocks={[autoMaterializePausedMock(true), setAutoMaterializePausedMock]}>
+      <MockedProvider
+        mocks={[
+          autoMaterializePausedMock(true),
+          setAutoMaterializePausedMock,
+          autoMaterializePausedMock(false),
+        ]}
+      >
         <CustomConfirmationProvider>
           <DaemonList daemonStatuses={mockDaemons} />
         </CustomConfirmationProvider>

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {useAutomaterializeDaemonStatus} from '../assets/AutomaterializeDaemonStatusTag';
+import {useAutomationPolicySensorFlag} from '../assets/AutomationPolicySensorFlag';
 import {TabLink} from '../ui/TabLink';
 
 interface Props<TData> {
@@ -16,6 +17,7 @@ export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TDa
   const {refreshState, tab} = props;
 
   const automaterialize = useAutomaterializeDaemonStatus();
+  const automaterializeSensorsFlagState = useAutomationPolicySensorFlag();
 
   return (
     <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
@@ -24,28 +26,30 @@ export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TDa
         <TabLink id="jobs" title="Jobs" to="/overview/jobs" />
         <TabLink id="schedules" title="Schedules" to="/overview/schedules" />
         <TabLink id="sensors" title="Sensors" to="/overview/sensors" />
-        <TabLink
-          id="amp"
-          title={
-            <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-              <div>Auto-materialize</div>
-              {automaterialize.loading ? (
-                <Spinner purpose="body-text" />
-              ) : (
-                <div
-                  style={{
-                    width: '10px',
-                    height: '10px',
-                    borderRadius: '50%',
-                    backgroundColor:
-                      automaterialize.paused === false ? colorAccentBlue() : colorAccentGray(),
-                  }}
-                />
-              )}
-            </Box>
-          }
-          to="/overview/automaterialize"
-        />
+        {automaterializeSensorsFlagState === 'has-global-amp' ? (
+          <TabLink
+            id="amp"
+            title={
+              <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+                <div>Auto-materialize</div>
+                {automaterialize.loading ? (
+                  <Spinner purpose="body-text" />
+                ) : (
+                  <div
+                    style={{
+                      width: '10px',
+                      height: '10px',
+                      borderRadius: '50%',
+                      backgroundColor:
+                        automaterialize.paused === false ? colorAccentBlue() : colorAccentGray(),
+                    }}
+                  />
+                )}
+              </Box>
+            }
+            to="/overview/automaterialize"
+          />
+        ) : null}
         <TabLink id="resources" title="Resources" to="/overview/resources" />
         <TabLink id="backfills" title="Backfills" to="/overview/backfills" />
       </Tabs>


### PR DESCRIPTION
## Summary & Motivation

Use the newly added `useAutomationPolicySensors` flag on the `Instance` type to determine what to render for AMP. This is a fairly simple PR to start things, since subsequent changes are more complex as I move more pieces around.

- If the flag is enabled (`has-sensor-amp`):
  - Do not show the Auto-materialization tab on Overview
  - Navigation to Auto-materialization overview should redirect to Sensors overview
  - Do not show the Auto-materialization daemon in the daemon list
- If the flag is disabled (`has-global-amp`):
  - Show the Auto-materialization tab on Overview
  - Allow navigation to that tab
  - Show the Auto-materialization daemon
- If the flag state is not available, e.g. loading (`unknown`):
  - Do not show the tab
  - Wait until the flag state resolves before rendering or redirecting on Auto-materialization overview
  - Do not show the daemon

## How I Tested These Changes

Add values to dagster.yaml, with the boolean true and false. Verify behavior described above.

```
auto_materialize:
  use_automation_policy_sensors: true
```
