### PR TITLE
[ui] Global AMP: Modify components to support asset sensor page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationEvaluationHistoryTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationEvaluationHistoryTable.tsx
@@ -5,108 +5,39 @@ import {
   ButtonLink,
   Checkbox,
   CursorHistoryControls,
+  CursorPaginationProps,
   Spinner,
   Table,
 } from '@dagster-io/ui-components';
 import React from 'react';
 import styled from 'styled-components';
 
-import {useQueryRefreshAtInterval} from '../../app/QueryRefresh';
 import {Timestamp} from '../../app/time/Timestamp';
 import {InstigationTickStatus} from '../../graphql/types';
-import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
 import {TimeElapsed} from '../../runs/TimeElapsed';
-import {useCursorPaginatedQuery} from '../../runs/useCursorPaginatedQuery';
 import {TickStatusTag} from '../../ticks/TickStatusTag';
 
-import {ASSET_DAEMON_TICKS_QUERY} from './AssetDaemonTicksQuery';
-import {
-  AssetDaemonTicksQuery,
-  AssetDaemonTicksQueryVariables,
-  AssetDaemonTickFragment,
-} from './types/AssetDaemonTicksQuery.types';
+import {AssetDaemonTickFragment} from './types/AssetDaemonTicksQuery.types';
 
-const PAGE_SIZE = 15;
-
-export const AutomaterializationEvaluationHistoryTable = ({
-  setSelectedTick,
-  setTableView,
-  setTimerange,
-  setParentStatuses,
-}: {
+interface Props {
+  loading: boolean;
+  ticks: AssetDaemonTickFragment[];
+  statuses: Set<InstigationTickStatus>;
+  setStatuses: (statuses: Set<InstigationTickStatus>) => void;
   setSelectedTick: (tick: AssetDaemonTickFragment | null) => void;
   setTableView: (view: 'evaluations' | 'runs') => void;
-  setTimerange: (range?: [number, number]) => void;
-  setParentStatuses: (statuses?: InstigationTickStatus[]) => void;
-}) => {
-  const [statuses, setStatuses] = useQueryPersistedState<Set<InstigationTickStatus>>({
-    queryKey: 'statuses',
-    decode: React.useCallback(({statuses}: {statuses?: string}) => {
-      return new Set<InstigationTickStatus>(
-        statuses
-          ? JSON.parse(statuses)
-          : [
-              InstigationTickStatus.STARTED,
-              InstigationTickStatus.SUCCESS,
-              InstigationTickStatus.FAILURE,
-              InstigationTickStatus.SKIPPED,
-            ],
-      );
-    }, []),
-    encode: React.useCallback((raw: Set<InstigationTickStatus>) => {
-      return {statuses: JSON.stringify(Array.from(raw))};
-    }, []),
-  });
+  paginationProps: CursorPaginationProps;
+}
 
-  const {queryResult, paginationProps} = useCursorPaginatedQuery<
-    AssetDaemonTicksQuery,
-    AssetDaemonTicksQueryVariables
-  >({
-    query: ASSET_DAEMON_TICKS_QUERY,
-    variables: {
-      statuses: React.useMemo(() => Array.from(statuses), [statuses]),
-    },
-    nextCursorForResult: (data) => {
-      const ticks = data.autoMaterializeTicks;
-      if (!ticks.length) {
-        return undefined;
-      }
-      return ticks[PAGE_SIZE - 1]?.id;
-    },
-    getResultArray: (data) => {
-      if (!data?.autoMaterializeTicks) {
-        return [];
-      }
-      return data.autoMaterializeTicks;
-    },
-    pageSize: PAGE_SIZE,
-  });
-  // Only refresh if we're on the first page
-  useQueryRefreshAtInterval(queryResult, 10000, !paginationProps.hasPrevCursor);
-
-  React.useEffect(() => {
-    if (paginationProps.hasPrevCursor) {
-      const ticks = queryResult.data?.autoMaterializeTicks;
-      if (ticks && ticks.length) {
-        const start = ticks[ticks.length - 1]?.timestamp;
-        const end = ticks[0]?.endTimestamp;
-        if (start && end) {
-          setTimerange([start, end]);
-        }
-      }
-    } else {
-      setTimerange(undefined);
-    }
-  }, [paginationProps.hasPrevCursor, queryResult.data?.autoMaterializeTicks, setTimerange]);
-
-  React.useEffect(() => {
-    if (paginationProps.hasPrevCursor) {
-      setParentStatuses(Array.from(statuses));
-    } else {
-      setParentStatuses(undefined);
-    }
-  }, [paginationProps.hasPrevCursor, setParentStatuses, statuses]);
-
+export const AutomaterializationEvaluationHistoryTable = ({
+  loading,
+  ticks,
+  statuses,
+  setStatuses,
+  setSelectedTick,
+  setTableView,
+  paginationProps,
+}: Props) => {
   return (
     <Box>
       <Box
@@ -126,7 +57,7 @@ export const AutomaterializationEvaluationHistoryTable = ({
               setTableView(id);
             }}
           />
-          {!queryResult.data ? <Spinner purpose="body-text" /> : null}
+          {loading && !ticks?.length ? <Spinner purpose="body-text" /> : null}
         </Box>
         <Box flex={{direction: 'row', gap: 12, alignItems: 'center'}}>
           <StatusCheckbox
@@ -162,53 +93,48 @@ export const AutomaterializationEvaluationHistoryTable = ({
         </thead>
         <tbody>
           {/* Use previous data to stop page from jumping while new data loads */}
-          {(queryResult.data || queryResult.previousData)?.autoMaterializeTicks.map(
-            (tick, index) => {
-              // This is a hack for ticks that get stuck in started
-              const isTickStuckInStartedState =
-                index !== 0 &&
-                tick.status === InstigationTickStatus.STARTED &&
-                !paginationProps.hasPrevCursor;
+          {ticks.map((tick, index) => {
+            // This is a hack for ticks that get stuck in started
+            const isTickStuckInStartedState =
+              index !== 0 &&
+              tick.status === InstigationTickStatus.STARTED &&
+              !paginationProps.hasPrevCursor;
 
-              return (
-                <tr key={tick.id}>
-                  <td>
-                    <Timestamp
-                      timestamp={{unix: tick.timestamp}}
-                      timeFormat={{showTimezone: true}}
-                    />
-                  </td>
-                  <td>
-                    <TickStatusTag tick={tick} isStuckStarted={isTickStuckInStartedState} />
-                  </td>
-                  <td>
-                    {isTickStuckInStartedState ? (
-                      ' - '
-                    ) : (
-                      <TimeElapsed startUnix={tick.timestamp} endUnix={tick.endTimestamp} />
-                    )}
-                  </td>
-                  <td>
-                    {[InstigationTickStatus.SKIPPED, InstigationTickStatus.SUCCESS].includes(
-                      tick.status,
-                    ) ? (
-                      <ButtonLink
-                        onClick={() => {
-                          setSelectedTick(tick);
-                        }}
-                      >
-                        <Body2>
-                          {tick.requestedAssetMaterializationCount} materializations requested
-                        </Body2>
-                      </ButtonLink>
-                    ) : (
-                      ' - '
-                    )}
-                  </td>
-                </tr>
-              );
-            },
-          )}
+            return (
+              <tr key={tick.id}>
+                <td>
+                  <Timestamp timestamp={{unix: tick.timestamp}} timeFormat={{showTimezone: true}} />
+                </td>
+                <td>
+                  <TickStatusTag tick={tick} isStuckStarted={isTickStuckInStartedState} />
+                </td>
+                <td>
+                  {isTickStuckInStartedState ? (
+                    ' - '
+                  ) : (
+                    <TimeElapsed startUnix={tick.timestamp} endUnix={tick.endTimestamp} />
+                  )}
+                </td>
+                <td>
+                  {[InstigationTickStatus.SKIPPED, InstigationTickStatus.SUCCESS].includes(
+                    tick.status,
+                  ) ? (
+                    <ButtonLink
+                      onClick={() => {
+                        setSelectedTick(tick);
+                      }}
+                    >
+                      <Body2>
+                        {tick.requestedAssetMaterializationCount} materializations requested
+                      </Body2>
+                    </ButtonLink>
+                  ) : (
+                    ' - '
+                  )}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </TableWrapper>
       <div style={{paddingBottom: '16px'}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -9,6 +9,7 @@ import {
   Heading,
   PageHeader,
   Table,
+  colorTextLight,
 } from '@dagster-io/ui-components';
 import React, {useLayoutEffect} from 'react';
 import {Redirect} from 'react-router-dom';
@@ -27,9 +28,9 @@ import {useAutomaterializeDaemonStatus} from '../AutomaterializeDaemonStatusTag'
 import {useAutomationPolicySensorFlag} from '../AutomationPolicySensorFlag';
 
 import {ASSET_DAEMON_TICKS_QUERY} from './AssetDaemonTicksQuery';
-import {AutomaterializationEvaluationHistoryTable} from './AutomaterializationEvaluationHistoryTable';
 import {AutomaterializationTickDetailDialog} from './AutomaterializationTickDetailDialog';
 import {AutomaterializeRunHistoryTable} from './AutomaterializeRunHistoryTable';
+import {InstanceAutomaterializationEvaluationHistoryTable} from './InstanceAutomaterializationEvaluationHistoryTable';
 import {
   AssetDaemonTicksQuery,
   AssetDaemonTicksQueryVariables,
@@ -203,8 +204,12 @@ const GlobalAutomaterializationRoot = () => {
         <Subtitle2>Evaluation timeline</Subtitle2>
       </Box>
       {!data ? (
-        <Box padding={{vertical: 48}}>
-          <Spinner purpose="page" />
+        <Box
+          padding={{vertical: 48}}
+          flex={{direction: 'row', justifyContent: 'center', gap: 12, alignItems: 'center'}}
+        >
+          <Spinner purpose="body-text" />
+          <div style={{color: colorTextLight()}}>Loading evaluations…</div>
         </Box>
       ) : (
         <>
@@ -218,7 +223,6 @@ const GlobalAutomaterializationRoot = () => {
             timeAfter={THREE_MINUTES}
           />
           <AutomaterializationTickDetailDialog
-            key={selectedTick?.id}
             tick={selectedTick}
             isOpen={!!selectedTick}
             close={() => {
@@ -226,7 +230,7 @@ const GlobalAutomaterializationRoot = () => {
             }}
           />
           {tableView === 'evaluations' ? (
-            <AutomaterializationEvaluationHistoryTable
+            <InstanceAutomaterializationEvaluationHistoryTable
               setSelectedTick={setSelectedTick}
               setTableView={setTableView}
               setParentStatuses={setStatuses}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/InstanceAutomaterializationEvaluationHistoryTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/InstanceAutomaterializationEvaluationHistoryTable.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+
+import {useQueryRefreshAtInterval} from '../../app/QueryRefresh';
+import {InstigationTickStatus} from '../../graphql/types';
+import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
+import {useCursorPaginatedQuery} from '../../runs/useCursorPaginatedQuery';
+
+import {ASSET_DAEMON_TICKS_QUERY} from './AssetDaemonTicksQuery';
+import {AutomaterializationEvaluationHistoryTable} from './AutomaterializationEvaluationHistoryTable';
+import {
+  AssetDaemonTicksQuery,
+  AssetDaemonTicksQueryVariables,
+  AssetDaemonTickFragment,
+} from './types/AssetDaemonTicksQuery.types';
+
+const PAGE_SIZE = 15;
+
+interface Props {
+  setSelectedTick: (tick: AssetDaemonTickFragment | null) => void;
+  setTableView: (view: 'evaluations' | 'runs') => void;
+  setTimerange: (range?: [number, number]) => void;
+  setParentStatuses: (statuses?: InstigationTickStatus[]) => void;
+}
+
+export const InstanceAutomaterializationEvaluationHistoryTable = ({
+  setSelectedTick,
+  setTableView,
+  setTimerange,
+  setParentStatuses,
+}: Props) => {
+  const [statuses, setStatuses] = useQueryPersistedState<Set<InstigationTickStatus>>({
+    queryKey: 'statuses',
+    decode: React.useCallback(({statuses}: {statuses?: string}) => {
+      return new Set<InstigationTickStatus>(
+        statuses
+          ? JSON.parse(statuses)
+          : [
+              InstigationTickStatus.STARTED,
+              InstigationTickStatus.SUCCESS,
+              InstigationTickStatus.FAILURE,
+              InstigationTickStatus.SKIPPED,
+            ],
+      );
+    }, []),
+    encode: React.useCallback((raw: Set<InstigationTickStatus>) => {
+      return {statuses: JSON.stringify(Array.from(raw))};
+    }, []),
+  });
+
+  const {queryResult, paginationProps} = useCursorPaginatedQuery<
+    AssetDaemonTicksQuery,
+    AssetDaemonTicksQueryVariables
+  >({
+    query: ASSET_DAEMON_TICKS_QUERY,
+    variables: {
+      statuses: React.useMemo(() => Array.from(statuses), [statuses]),
+    },
+    nextCursorForResult: (data) => {
+      const ticks = data.autoMaterializeTicks;
+      if (!ticks.length) {
+        return undefined;
+      }
+      return ticks[PAGE_SIZE - 1]?.id;
+    },
+    getResultArray: (data) => {
+      if (!data?.autoMaterializeTicks) {
+        return [];
+      }
+      return data.autoMaterializeTicks;
+    },
+    pageSize: PAGE_SIZE,
+  });
+
+  // Only refresh if we're on the first page
+  useQueryRefreshAtInterval(queryResult, 10000, !paginationProps.hasPrevCursor);
+
+  React.useEffect(() => {
+    if (paginationProps.hasPrevCursor) {
+      const ticks = queryResult.data?.autoMaterializeTicks;
+      if (ticks && ticks.length) {
+        const start = ticks[ticks.length - 1]?.timestamp;
+        const end = ticks[0]?.endTimestamp;
+        if (start && end) {
+          setTimerange([start, end]);
+        }
+      }
+    } else {
+      setTimerange(undefined);
+    }
+  }, [paginationProps.hasPrevCursor, queryResult.data?.autoMaterializeTicks, setTimerange]);
+
+  React.useEffect(() => {
+    if (paginationProps.hasPrevCursor) {
+      setParentStatuses(Array.from(statuses));
+    } else {
+      setParentStatuses(undefined);
+    }
+  }, [paginationProps.hasPrevCursor, setParentStatuses, statuses]);
+
+  return (
+    <AutomaterializationEvaluationHistoryTable
+      loading={queryResult.loading}
+      ticks={queryResult.data?.autoMaterializeTicks || []}
+      paginationProps={paginationProps}
+      setSelectedTick={setSelectedTick}
+      setStatuses={setStatuses}
+      setTableView={setTableView}
+      statuses={statuses}
+    />
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
@@ -41,7 +41,11 @@ interface DialogProps extends InnerProps {
 
 export const TickDetailsDialog = ({tickId, isOpen, instigationSelector, onClose}: DialogProps) => {
   return (
-    <Dialog isOpen={isOpen} onClose={onClose} style={{width: '90vw'}}>
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      style={{width: '80vw', maxWidth: '1200px', minWidth: '600px'}}
+    >
       <TickDetailsDialogImpl tickId={tickId} instigationSelector={instigationSelector} />
       <DialogFooter>
         <Button onClick={onClose}>Close</Button>

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -349,7 +349,7 @@ export const TickHistoryTimeline = ({
   const {ticks = []} = data.instigationStateOrError;
 
   const onTickClick = (tick?: InstigationTick) => {
-    setSelectedTickId(tick ? Number(tick.id) : undefined);
+    setSelectedTickId(tick ? Number(tick.tickId) : undefined);
   };
 
   const onTickHover = (tick?: InstigationTick) => {


### PR DESCRIPTION
## Summary & Motivation

Extract out some pieces of existing global AMP components to make them reusable for sensor-based AMP.

## How I Tested These Changes

Set the sensor flag to false, loading the app. Verify that the AMP overview page is unchanged:

- I can toggle the daemon on/off, and it works as expected.
- When on, the timeline runs properly and the ticks can be clicked to open information about the resulting materializations, if any.
- The table of ticks also looks and behaves correctly, and I can paginate and filter them.
