### PR TITLE
[io managers] remove special casing for Nothing outputs in io managers

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -122,8 +122,9 @@ class DbIOManager(IOManager):
             self._default_load_type = default_load_type
 
     def handle_output(self, context: OutputContext, obj: object) -> None:
-        # Nones cannot be stored by DB I/O managers. If the output type is set to None/Nothing,
-        # the handle_output will not be called
+        # If the output type is set to Nothing, handle_output will not be
+        # called. We still need to raise an error when the return value
+        # is None, but the typing type is not Nothing
         if obj is None:
             raise DagsterInvariantViolationError(
                 "Unexpected 'None' output value. If a 'None' value is intentional, set the output type to None.",

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -127,7 +127,8 @@ class DbIOManager(IOManager):
         # is None, but the typing type is not Nothing
         if obj is None:
             raise DagsterInvariantViolationError(
-                "Unexpected 'None' output value. If a 'None' value is intentional, set the output type to None by adding return type annotation '-> None'.",
+                "Unexpected 'None' output value. If a 'None' value is intentional, set the output"
+                " type to None by adding return type annotation '-> None'.",
             )
 
         obj_type = type(obj)

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -26,7 +26,7 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
     TimeWindowPartitionsDefinition,
 )
-from dagster._core.errors import DagsterExecutionHandleOutputError
+from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
 from dagster._core.storage.io_manager import IOManager
@@ -125,9 +125,8 @@ class DbIOManager(IOManager):
         # Nones cannot be stored by DB I/O managers. If the output type is set to None/Nothing,
         # the handle_output will not be called
         if obj is None:
-            raise DagsterExecutionHandleOutputError(
-                "Unexpected 'None' output value. If a 'None' value is intentional, set the"
-                " output type to None.",
+            raise DagsterInvariantViolationError(
+                "Unexpected 'None' output value. If a 'None' value is intentional, set the output type to None.",
             )
 
         table_slice = self._get_table_slice(context, context)

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -127,7 +127,7 @@ class DbIOManager(IOManager):
         # is None, but the typing type is not Nothing
         if obj is None:
             raise DagsterInvariantViolationError(
-                "Unexpected 'None' output value. If a 'None' value is intentional, set the output type to None.",
+                "Unexpected 'None' output value. If a 'None' value is intentional, set the output type to None by adding return type annotation '-> None'.",
             )
 
         obj_type = type(obj)

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -426,14 +426,6 @@ class UPathIOManager(MemoizableIOManager):
                 return self._load_multiple_inputs(context)
 
     def handle_output(self, context: OutputContext, obj: Any):
-        if context.dagster_type.typing_type == type(None):
-            check.invariant(
-                obj is None,
-                "Output had Nothing type or 'None' annotation, but handle_output received"
-                f" value that was not None and was of type {type(obj)}.",
-            )
-            return None
-
         if context.has_asset_partitions:
             paths = self._get_paths_for_partitions(context)
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
@@ -5,6 +5,7 @@ from dagster import AssetKey, InputContext, OutputContext, asset, build_output_c
 from dagster._check import CheckError
 from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition, TimeWindow
+from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.storage.db_io_manager import (
     DbClient,
     DbIOManager,
@@ -483,15 +484,17 @@ def test_handle_none_output():
     handler = IntHandler()
     db_client = MagicMock(spec=DbClient, get_select_statement=MagicMock(return_value=""))
     manager = build_db_io_manager(type_handlers=[handler], db_client=db_client)
+
     asset_key = AssetKey(["schema1", "table1"])
     output_context = build_output_context(
         asset_key=asset_key,
         resource_config=resource_config,
         dagster_type=resolve_dagster_type(type(None)),
+        name="result",
     )
-    manager.handle_output(output_context, None)
 
-    assert len(handler.handle_output_calls) == 0
+    with pytest.raises(DagsterInvariantViolationError):
+        manager.handle_output(output_context, None)
 
 
 def test_non_supported_type():


### PR DESCRIPTION
## Summary & Motivation
Our custom I/O managers have special cases written in that raise exceptions when an output is typed as `Nothing`. #18448 moves this logic of skipping the I/O manager so the main execution code path, so we can remove these special cases for the I/O managers. For DB I/O managers, we still need to raise an error when the return is `None` but doesn't have a `Nothing` typing type for consistency across versions.

## How I Tested These Changes
