### PR TITLE
Make user preference selection look like dropdown menus instead of links

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Button,
-  ButtonLink,
   Checkbox,
   Dialog,
   DialogBody,
@@ -20,6 +19,7 @@ import {HourCycleSelect} from './time/HourCycleSelect';
 import {ThemeSelect} from './time/ThemeSelect';
 import {TimezoneSelect} from './time/TimezoneSelect';
 import {automaticLabel} from './time/browserTimezone';
+import {Icon} from '@dagster-io/ui-components';
 
 type OnCloseFn = (event: React.SyntheticEvent<HTMLElement>) => void;
 type VisibleFlag = {key: string; label?: React.ReactNode; flagType: FeatureFlagType};
@@ -87,7 +87,9 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
 
   const trigger = React.useCallback(
     (timezone: string) => (
-      <ButtonLink>{timezone === 'Automatic' ? automaticLabel() : timezone}</ButtonLink>
+      <Button rightIcon={<Icon name="arrow_drop_down"/>}>
+        {timezone === 'Automatic' ? automaticLabel() : timezone}
+      </Button>
     ),
     [],
   );
@@ -123,7 +125,7 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
               {
                 key: 'Timezone',
                 value: (
-                  <Box margin={{bottom: 4}}>
+                  <Box>
                     <TimezoneSelect trigger={trigger} />
                   </Box>
                 ),
@@ -131,7 +133,7 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
               {
                 key: 'Hour format',
                 value: (
-                  <Box margin={{bottom: 4}}>
+                  <Box>
                     <HourCycleSelect />
                   </Box>
                 ),
@@ -152,7 +154,7 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
                   </div>
                 ),
                 value: (
-                  <Box margin={{bottom: 4}}>
+                  <Box>
                     <ThemeSelect theme={theme} onChange={setTheme} />
                   </Box>
                 ),

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog.tsx
@@ -5,7 +5,6 @@ import {
   Dialog,
   DialogBody,
   DialogFooter,
-  MetadataTable,
   Subheading,
   Icon,
 } from '@dagster-io/ui-components';
@@ -123,31 +122,18 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
           <Box padding={{bottom: 8}}>
             <Subheading>Preferences</Subheading>
           </Box>
-          <Box
-            padding={{bottom: 4, right: 16}}
-            flex={{justifyContent: 'space-between', alignItems: 'center'}}
-          >
-            <Box style={{width: '100%'}}>Timezone</Box>
-            <Box style={{display: 'flex', justifyContent: 'flex-end', width: '100%'}}>
-              <TimezoneSelect trigger={trigger} />
-            </Box>
+          <Box padding={{bottom: 4}} flex={{justifyContent: 'space-between', alignItems: 'center'}}>
+            <div>Timezone</div>
+            <TimezoneSelect trigger={trigger} />
           </Box>
 
-          <Box
-            padding={{bottom: 4, right: 16}}
-            flex={{justifyContent: 'space-between', alignItems: 'center'}}
-          >
-            <Box style={{width: '100%'}}>Hour format</Box>
-            <Box style={{display: 'flex', justifyContent: 'flex-end', width: '100%'}}>
-              <HourCycleSelect />
-            </Box>
+          <Box padding={{bottom: 4}} flex={{justifyContent: 'space-between', alignItems: 'center'}}>
+            <div>Hour format</div>
+            <HourCycleSelect />
           </Box>
 
-          <Box
-            padding={{bottom: 4, right: 16}}
-            flex={{justifyContent: 'space-between', alignItems: 'center'}}
-          >
-            <Box style={{width: '100%'}}>
+          <Box padding={{bottom: 4}} flex={{justifyContent: 'space-between', alignItems: 'center'}}>
+            <div>
               <span>Theme (</span>
               <a
                 href="https://github.com/dagster-io/dagster/discussions/18439"
@@ -157,43 +143,41 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
                 Learn more
               </a>
               )
-            </Box>
-            <Box style={{display: 'flex', justifyContent: 'flex-end', width: '100%'}}>
-              <ThemeSelect theme={theme} onChange={setTheme} />
-            </Box>
+            </div>
+            <ThemeSelect theme={theme} onChange={setTheme} />
           </Box>
 
           <Box
-            padding={{vertical: 8, right: 16}}
+            padding={{vertical: 8}}
             flex={{justifyContent: 'space-between', alignItems: 'center'}}
           >
-            <Box style={{width: '100%'}}>Enable keyboard shortcuts</Box>
-            <Box style={{display: 'flex', justifyContent: 'flex-end', width: '100%'}}>
-              <Checkbox
-                checked={shortcutsEnabled}
-                format="switch"
-                onChange={toggleKeyboardShortcuts}
-              />
-            </Box>
+            <div>Enable keyboard shortcuts</div>
+            <Checkbox
+              checked={shortcutsEnabled}
+              format="switch"
+              onChange={toggleKeyboardShortcuts}
+            />
           </Box>
         </Box>
         <Box padding={{top: 16}} border="top">
           <Box padding={{bottom: 8}}>
             <Subheading>Experimental features</Subheading>
           </Box>
-          <MetadataTable
-            rows={visibleFlags.map(({key, label, flagType}) => ({
-              key,
-              label,
-              value: (
-                <Checkbox
-                  format="switch"
-                  checked={flags.includes(flagType)}
-                  onChange={() => toggleFlag(flagType)}
-                />
-              ),
-            }))}
-          />
+
+          {visibleFlags.map(({key, label, flagType}) => (
+            <Box
+              padding={{vertical: 8}}
+              flex={{justifyContent: 'space-between', alignItems: 'center'}}
+              key={key}
+            >
+              <div>{label || key}</div>
+              <Checkbox
+                format="switch"
+                checked={flags.includes(flagType)}
+                onChange={() => toggleFlag(flagType)}
+              />
+            </Box>
+          ))}
         </Box>
       </DialogBody>
       <DialogFooter topBorder>

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog.tsx
@@ -87,7 +87,10 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
 
   const trigger = React.useCallback(
     (timezone: string) => (
-      <Button rightIcon={<Icon name="arrow_drop_down" />}>
+      <Button
+        rightIcon={<Icon name="arrow_drop_down" />}
+        style={{minWidth: '200px', display: 'flex', justifyContent: 'space-between'}}
+      >
         {timezone === 'Automatic' ? automaticLabel() : timezone}
       </Button>
     ),
@@ -120,57 +123,59 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
           <Box padding={{bottom: 8}}>
             <Subheading>Preferences</Subheading>
           </Box>
-          <MetadataTable
-            rows={[
-              {
-                key: 'Timezone',
-                value: (
-                  <Box>
-                    <TimezoneSelect trigger={trigger} />
-                  </Box>
-                ),
-              },
-              {
-                key: 'Hour format',
-                value: (
-                  <Box>
-                    <HourCycleSelect />
-                  </Box>
-                ),
-              },
-              {
-                key: 'Theme',
-                label: (
-                  <div>
-                    Theme (
-                    <a
-                      href="https://github.com/dagster-io/dagster/discussions/18439"
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      Learn more
-                    </a>
-                    )
-                  </div>
-                ),
-                value: (
-                  <Box>
-                    <ThemeSelect theme={theme} onChange={setTheme} />
-                  </Box>
-                ),
-              },
-              {
-                key: 'Enable keyboard shortcuts',
-                value: (
-                  <Checkbox
-                    checked={shortcutsEnabled}
-                    format="switch"
-                    onChange={toggleKeyboardShortcuts}
-                  />
-                ),
-              },
-            ]}
-          />
+          <Box
+            padding={{bottom: 4, right: 16}}
+            flex={{justifyContent: 'space-between', alignItems: 'center'}}
+          >
+            <Box style={{width: '100%'}}>Timezone</Box>
+            <Box style={{display: 'flex', justifyContent: 'flex-end', width: '100%'}}>
+              <TimezoneSelect trigger={trigger} />
+            </Box>
+          </Box>
+
+          <Box
+            padding={{bottom: 4, right: 16}}
+            flex={{justifyContent: 'space-between', alignItems: 'center'}}
+          >
+            <Box style={{width: '100%'}}>Hour format</Box>
+            <Box style={{display: 'flex', justifyContent: 'flex-end', width: '100%'}}>
+              <HourCycleSelect />
+            </Box>
+          </Box>
+
+          <Box
+            padding={{bottom: 4, right: 16}}
+            flex={{justifyContent: 'space-between', alignItems: 'center'}}
+          >
+            <Box style={{width: '100%'}}>
+              <span>Theme (</span>
+              <a
+                href="https://github.com/dagster-io/dagster/discussions/18439"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Learn more
+              </a>
+              )
+            </Box>
+            <Box style={{display: 'flex', justifyContent: 'flex-end', width: '100%'}}>
+              <ThemeSelect theme={theme} onChange={setTheme} />
+            </Box>
+          </Box>
+
+          <Box
+            padding={{vertical: 8, right: 16}}
+            flex={{justifyContent: 'space-between', alignItems: 'center'}}
+          >
+            <Box style={{width: '100%'}}>Enable keyboard shortcuts</Box>
+            <Box style={{display: 'flex', justifyContent: 'flex-end', width: '100%'}}>
+              <Checkbox
+                checked={shortcutsEnabled}
+                format="switch"
+                onChange={toggleKeyboardShortcuts}
+              />
+            </Box>
+          </Box>
         </Box>
         <Box padding={{top: 16}} border="top">
           <Box padding={{bottom: 8}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogFooter,
   MetadataTable,
   Subheading,
+  Icon,
 } from '@dagster-io/ui-components';
 import {DAGSTER_THEME_KEY, DagsterTheme} from '@dagster-io/ui-components/src/theme/theme';
 import * as React from 'react';
@@ -19,7 +20,6 @@ import {HourCycleSelect} from './time/HourCycleSelect';
 import {ThemeSelect} from './time/ThemeSelect';
 import {TimezoneSelect} from './time/TimezoneSelect';
 import {automaticLabel} from './time/browserTimezone';
-import {Icon} from '@dagster-io/ui-components';
 
 type OnCloseFn = (event: React.SyntheticEvent<HTMLElement>) => void;
 type VisibleFlag = {key: string; label?: React.ReactNode; flagType: FeatureFlagType};
@@ -87,7 +87,7 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
 
   const trigger = React.useCallback(
     (timezone: string) => (
-      <Button rightIcon={<Icon name="arrow_drop_down"/>}>
+      <Button rightIcon={<Icon name="arrow_drop_down" />}>
         {timezone === 'Automatic' ? automaticLabel() : timezone}
       </Button>
     ),

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/HourCycleSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/HourCycleSelect.tsx
@@ -1,4 +1,4 @@
-import {MenuItem, Menu, Select, ButtonLink} from '@dagster-io/ui-components';
+import {MenuItem, Menu, Select, ButtonLink, Button, Icon} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {HourCycle} from './HourCycle';
@@ -99,9 +99,9 @@ export const HourCycleSelect = () => {
       }}
       onItemSelect={(item) => setHourCycle(item.key as HourCycle)}
     >
-      <ButtonLink>
+      <Button rightIcon={<Icon name="arrow_drop_down"/>}>
         {hourCycle === 'Automatic' || !hourCycle ? labels.automatic : labels[hourCycle]}
-      </ButtonLink>
+      </Button>
     </Select>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/HourCycleSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/HourCycleSelect.tsx
@@ -1,4 +1,4 @@
-import {MenuItem, Menu, Select, ButtonLink, Button, Icon} from '@dagster-io/ui-components';
+import {MenuItem, Menu, Select, Button, Icon} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {HourCycle} from './HourCycle';
@@ -99,7 +99,7 @@ export const HourCycleSelect = () => {
       }}
       onItemSelect={(item) => setHourCycle(item.key as HourCycle)}
     >
-      <Button rightIcon={<Icon name="arrow_drop_down"/>}>
+      <Button rightIcon={<Icon name="arrow_drop_down" />}>
         {hourCycle === 'Automatic' || !hourCycle ? labels.automatic : labels[hourCycle]}
       </Button>
     </Select>

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/HourCycleSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/HourCycleSelect.tsx
@@ -99,7 +99,10 @@ export const HourCycleSelect = () => {
       }}
       onItemSelect={(item) => setHourCycle(item.key as HourCycle)}
     >
-      <Button rightIcon={<Icon name="arrow_drop_down" />}>
+      <Button
+        rightIcon={<Icon name="arrow_drop_down" />}
+        style={{minWidth: '200px', display: 'flex', justifyContent: 'space-between'}}
+      >
         {hourCycle === 'Automatic' || !hourCycle ? labels.automatic : labels[hourCycle]}
       </Button>
     </Select>

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/HourCycleSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/HourCycleSelect.tsx
@@ -75,8 +75,7 @@ export const HourCycleSelect = () => {
   return (
     <Select<(typeof items)[0]>
       popoverProps={{
-        position: 'bottom-left',
-        modifiers: {offset: {enabled: true, offset: '-12px, 8px'}},
+        position: 'bottom-right',
       }}
       filterable={false}
       activeItem={items.find((item) => item.key === hourCycle)}

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/ThemeSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/ThemeSelect.tsx
@@ -32,8 +32,7 @@ export const ThemeSelect = ({theme, onChange}: Props) => {
   return (
     <Select<(typeof items)[0]>
       popoverProps={{
-        position: 'bottom-left',
-        modifiers: {offset: {enabled: true, offset: '-12px, 8px'}},
+        position: 'bottom-right',
       }}
       filterable={false}
       activeItem={activeItem}

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/ThemeSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/ThemeSelect.tsx
@@ -1,4 +1,4 @@
-import {ButtonLink, Menu, MenuItem, Select} from '@dagster-io/ui-components';
+import {Icon, Menu, MenuItem, Select, Button} from '@dagster-io/ui-components';
 import {DagsterTheme} from '@dagster-io/ui-components/src/theme/theme';
 import * as React from 'react';
 
@@ -55,7 +55,9 @@ export const ThemeSelect = ({theme, onChange}: Props) => {
       }}
       onItemSelect={(item) => onChange(item.key)}
     >
-      <ButtonLink>{activeItem?.label}</ButtonLink>
+      <Button rightIcon={<Icon name="arrow_drop_down"/>}>
+        {activeItem?.label}
+      </Button>
     </Select>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/ThemeSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/ThemeSelect.tsx
@@ -55,7 +55,12 @@ export const ThemeSelect = ({theme, onChange}: Props) => {
       }}
       onItemSelect={(item) => onChange(item.key)}
     >
-      <Button rightIcon={<Icon name="arrow_drop_down" />}>{activeItem?.label}</Button>
+      <Button
+        rightIcon={<Icon name="arrow_drop_down" />}
+        style={{minWidth: '200px', display: 'flex', justifyContent: 'space-between'}}
+      >
+        {activeItem?.label}
+      </Button>
     </Select>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/ThemeSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/ThemeSelect.tsx
@@ -55,9 +55,7 @@ export const ThemeSelect = ({theme, onChange}: Props) => {
       }}
       onItemSelect={(item) => onChange(item.key)}
     >
-      <Button rightIcon={<Icon name="arrow_drop_down"/>}>
-        {activeItem?.label}
-      </Button>
+      <Button rightIcon={<Icon name="arrow_drop_down" />}>{activeItem?.label}</Button>
     </Select>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/TimezoneSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/TimezoneSelect.tsx
@@ -1,4 +1,4 @@
-import {MenuDivider, MenuItem, Menu, Select, Button} from '@dagster-io/ui-components';
+import {MenuDivider, MenuItem, Menu, Select} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {TimeContext} from './TimeContext';

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/TimezoneSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/TimezoneSelect.tsx
@@ -1,4 +1,4 @@
-import {MenuDivider, MenuItem, Menu, Select} from '@dagster-io/ui-components';
+import {MenuDivider, MenuItem, Menu, Select, Button} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {TimeContext} from './TimeContext';

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/TimezoneSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/TimezoneSelect.tsx
@@ -141,8 +141,7 @@ export const TimezoneSelect = ({trigger}: Props) => {
   return (
     <Select<(typeof allTimezoneItems)[0]>
       popoverProps={{
-        position: 'bottom-left',
-        modifiers: {offset: {enabled: true, offset: '-12px, 8px'}},
+        position: 'bottom-right',
       }}
       activeItem={allTimezoneItems.find((tz) => tz.key === timezone)}
       inputProps={{style: {width: '300px'}}}


### PR DESCRIPTION
## Summary & Motivation
Right now these preference selectiosn look like links and it's not obvious that I can click them to make a different selection.

### Old:
<img width="852" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/1aa47e78-4918-4db2-8625-1d4465f7348e">

### New:
<img width="799" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/3c860042-b032-4c3c-91b5-68fa5ca47fd3">

## How I Tested These Changes
Loaded up the UI