### PR TITLE
Clarify that tag match uses the tag key and not the tag value

### DIFF
--- a/docs/content/deployment/guides/aws.mdx
+++ b/docs/content/deployment/guides/aws.mdx
@@ -182,7 +182,7 @@ run_launcher:
     secrets_tag: "my-tag-name"
 ```
 
-In this example, any secret tagged with `my-tag-name` will be included as an environment variable with the name and value as that secret.
+In this example, any secret tagged with a key `my-tag-name` will be included as an environment variable with the name and value as that secret. The value of the tag is ignored.
 
 Additionally, you can pass specific secrets using the [same structure as the ECS API](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Secret.html):
 


### PR DESCRIPTION
Based on this support question: https://github.com/dagster-io/dagster/discussions/18761