### PR TITLE
[ui] Asset partitions: Fix invalid filter state scrollToIndex

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionList.tsx
@@ -38,7 +38,7 @@ export const AssetPartitionList = ({
   const items = rowVirtualizer.getVirtualItems();
 
   React.useEffect(() => {
-    if (focusedDimensionKey) {
+    if (focusedDimensionKey && partitions.indexOf(focusedDimensionKey) !== -1) {
       rowVirtualizer.scrollToIndex(partitions.indexOf(focusedDimensionKey), {
         behavior: 'auto',
         align: 'auto',


### PR DESCRIPTION
## Summary & Motivation

There is currently a JS error being thrown on a partitioned asset view when attempting to view a specific partition with filters selected that do not match the partition. We try to scroll to that partition but fail because it doesn't exist.

Check for the existing of the partition key before trying to scroll to it.

## How I Tested These Changes

View a partitioned asset, select a partition, then unselect the filters that match its status. Verify that the page doesn't error. Reload the page with those params, verify that the page shows the selected partition and the partition list, but does not error.
