### PR TITLE
[ui] Sensor page branching for AMP

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AssetDaemonTicksQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AssetDaemonTicksQuery.tsx
@@ -2,6 +2,32 @@ import {gql} from '@apollo/client';
 
 import {PYTHON_ERROR_FRAGMENT} from '../../app/PythonErrorFragment';
 
+export const ASSET_DAEMON_TICK_FRAGMENT = gql`
+  fragment AssetDaemonTickFragment on InstigationTick {
+    id
+    timestamp
+    endTimestamp
+    status
+    instigationType
+    error {
+      ...PythonErrorFragment
+    }
+    requestedAssetKeys {
+      path
+    }
+    requestedAssetMaterializationCount
+    autoMaterializeAssetEvaluationId
+    requestedMaterializationsForAssets {
+      assetKey {
+        path
+      }
+      partitionKeys
+    }
+  }
+
+  ${PYTHON_ERROR_FRAGMENT}
+`;
+
 export const ASSET_DAEMON_TICKS_QUERY = gql`
   query AssetDaemonTicksQuery(
     $dayRange: Int
@@ -26,26 +52,5 @@ export const ASSET_DAEMON_TICKS_QUERY = gql`
     }
   }
 
-  fragment AssetDaemonTickFragment on InstigationTick {
-    id
-    timestamp
-    endTimestamp
-    status
-    instigationType
-    error {
-      ...PythonErrorFragment
-    }
-    requestedAssetKeys {
-      path
-    }
-    requestedAssetMaterializationCount
-    autoMaterializeAssetEvaluationId
-    requestedMaterializationsForAssets {
-      assetKey {
-        path
-      }
-      partitionKeys
-    }
-  }
-  ${PYTHON_ERROR_FRAGMENT}
+  ${ASSET_DAEMON_TICK_FRAGMENT}
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializeRunHistoryTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializeRunHistoryTable.tsx
@@ -11,8 +11,10 @@ import {useCursorPaginatedQuery} from '../../runs/useCursorPaginatedQuery';
 const PAGE_SIZE = 15;
 
 export const AutomaterializeRunHistoryTable = ({
+  filterTags,
   setTableView,
 }: {
+  filterTags?: {key: string; value: string}[];
   setTableView: (view: 'evaluations' | 'runs') => void;
 }) => {
   const {queryResult, paginationProps} = useCursorPaginatedQuery<
@@ -33,7 +35,7 @@ export const AutomaterializeRunHistoryTable = ({
     },
     variables: {
       filter: {
-        tags: [{key: 'dagster/auto_materialize', value: 'true'}],
+        tags: [...(filterTags || []), {key: 'dagster/auto_materialize', value: 'true'}],
       },
     },
     query: RUNS_ROOT_QUERY,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/SensorAutomaterializationEvaluationHistoryTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/SensorAutomaterializationEvaluationHistoryTable.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+
+import {useQueryRefreshAtInterval} from '../../app/QueryRefresh';
+import {InstigationTickStatus} from '../../graphql/types';
+import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
+import {useCursorPaginatedQuery} from '../../runs/useCursorPaginatedQuery';
+import {ASSET_SENSOR_TICKS_QUERY} from '../../sensors/AssetSensorTicksQuery';
+import {
+  AssetSensorTicksQuery,
+  AssetSensorTicksQueryVariables,
+} from '../../sensors/types/AssetSensorTicksQuery.types';
+import {SensorFragment} from '../../sensors/types/SensorFragment.types';
+import {RepoAddress} from '../../workspace/types';
+
+import {AutomaterializationEvaluationHistoryTable} from './AutomaterializationEvaluationHistoryTable';
+import {AssetDaemonTickFragment} from './types/AssetDaemonTicksQuery.types';
+
+const PAGE_SIZE = 15;
+
+interface Props {
+  repoAddress: RepoAddress;
+  sensor: SensorFragment;
+  setSelectedTick: (tick: AssetDaemonTickFragment | null) => void;
+  setTableView: (view: 'evaluations' | 'runs') => void;
+  setTimerange: (range?: [number, number]) => void;
+  setParentStatuses: (statuses?: InstigationTickStatus[]) => void;
+}
+
+export const SensorAutomaterializationEvaluationHistoryTable = ({
+  repoAddress,
+  sensor,
+  setSelectedTick,
+  setTableView,
+  setTimerange,
+  setParentStatuses,
+}: Props) => {
+  const [statuses, setStatuses] = useQueryPersistedState<Set<InstigationTickStatus>>({
+    queryKey: 'statuses',
+    decode: React.useCallback(({statuses}: {statuses?: string}) => {
+      return new Set<InstigationTickStatus>(
+        statuses
+          ? JSON.parse(statuses)
+          : [
+              InstigationTickStatus.STARTED,
+              InstigationTickStatus.SUCCESS,
+              InstigationTickStatus.FAILURE,
+              InstigationTickStatus.SKIPPED,
+            ],
+      );
+    }, []),
+    encode: React.useCallback((raw: Set<InstigationTickStatus>) => {
+      return {statuses: JSON.stringify(Array.from(raw))};
+    }, []),
+  });
+
+  const {queryResult, paginationProps} = useCursorPaginatedQuery<
+    AssetSensorTicksQuery,
+    AssetSensorTicksQueryVariables
+  >({
+    query: ASSET_SENSOR_TICKS_QUERY,
+    variables: {
+      sensorSelector: {
+        sensorName: sensor.name,
+        repositoryName: repoAddress.name,
+        repositoryLocationName: repoAddress.location,
+      },
+      statuses: React.useMemo(() => Array.from(statuses), [statuses]),
+    },
+    nextCursorForResult: (data) => {
+      if (data?.sensorOrError.__typename === 'Sensor') {
+        const ticks = data.sensorOrError.sensorState.ticks;
+        if (ticks.length) {
+          return ticks[PAGE_SIZE - 1]?.id;
+        }
+      }
+      return undefined;
+    },
+    getResultArray: (data) => {
+      if (data?.sensorOrError.__typename === 'Sensor') {
+        return data.sensorOrError.sensorState.ticks;
+      }
+      return [];
+    },
+    pageSize: PAGE_SIZE,
+  });
+
+  // Only refresh if we're on the first page
+  useQueryRefreshAtInterval(queryResult, 10000, !paginationProps.hasPrevCursor);
+
+  const allTicks =
+    queryResult.data?.sensorOrError?.__typename === 'Sensor'
+      ? queryResult.data.sensorOrError.sensorState.ticks
+      : null;
+
+  React.useEffect(() => {
+    if (paginationProps.hasPrevCursor) {
+      if (allTicks && allTicks.length) {
+        const start = allTicks[allTicks.length - 1]?.timestamp;
+        const end = allTicks[0]?.endTimestamp;
+        if (start && end) {
+          setTimerange([start, end]);
+        }
+      }
+    } else {
+      setTimerange(undefined);
+    }
+  }, [allTicks, paginationProps.hasPrevCursor, setTimerange]);
+
+  React.useEffect(() => {
+    if (paginationProps.hasPrevCursor) {
+      setParentStatuses(Array.from(statuses));
+    } else {
+      setParentStatuses(undefined);
+    }
+  }, [paginationProps.hasPrevCursor, setParentStatuses, statuses]);
+
+  return (
+    <AutomaterializationEvaluationHistoryTable
+      loading={queryResult.loading}
+      ticks={allTicks || []}
+      paginationProps={paginationProps}
+      setSelectedTick={setSelectedTick}
+      setStatuses={setStatuses}
+      setTableView={setTableView}
+      statuses={statuses}
+    />
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/types/AssetDaemonTicksQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/types/AssetDaemonTicksQuery.types.ts
@@ -2,6 +2,33 @@
 
 import * as Types from '../../../graphql/types';
 
+export type AssetDaemonTickFragment = {
+  __typename: 'InstigationTick';
+  id: string;
+  timestamp: number;
+  endTimestamp: number | null;
+  status: Types.InstigationTickStatus;
+  instigationType: Types.InstigationType;
+  requestedAssetMaterializationCount: number;
+  autoMaterializeAssetEvaluationId: number | null;
+  error: {
+    __typename: 'PythonError';
+    message: string;
+    stack: Array<string>;
+    errorChain: Array<{
+      __typename: 'ErrorChainLink';
+      isExplicitLink: boolean;
+      error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+    }>;
+  } | null;
+  requestedAssetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}>;
+  requestedMaterializationsForAssets: Array<{
+    __typename: 'RequestedMaterializationsForAsset';
+    partitionKeys: Array<string>;
+    assetKey: {__typename: 'AssetKey'; path: Array<string>};
+  }>;
+};
+
 export type AssetDaemonTicksQueryVariables = Types.Exact<{
   dayRange?: Types.InputMaybe<Types.Scalars['Int']>;
   dayOffset?: Types.InputMaybe<Types.Scalars['Int']>;
@@ -39,32 +66,5 @@ export type AssetDaemonTicksQuery = {
       partitionKeys: Array<string>;
       assetKey: {__typename: 'AssetKey'; path: Array<string>};
     }>;
-  }>;
-};
-
-export type AssetDaemonTickFragment = {
-  __typename: 'InstigationTick';
-  id: string;
-  timestamp: number;
-  endTimestamp: number | null;
-  status: Types.InstigationTickStatus;
-  instigationType: Types.InstigationType;
-  requestedAssetMaterializationCount: number;
-  autoMaterializeAssetEvaluationId: number | null;
-  error: {
-    __typename: 'PythonError';
-    message: string;
-    stack: Array<string>;
-    errorChain: Array<{
-      __typename: 'ErrorChainLink';
-      isExplicitLink: boolean;
-      error: {__typename: 'PythonError'; message: string; stack: Array<string>};
-    }>;
-  } | null;
-  requestedAssetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}>;
-  requestedMaterializationsForAssets: Array<{
-    __typename: 'RequestedMaterializationsForAsset';
-    partitionKeys: Array<string>;
-    assetKey: {__typename: 'AssetKey'; path: Array<string>};
   }>;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/AssetSensorTicksQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/AssetSensorTicksQuery.tsx
@@ -1,0 +1,42 @@
+import {gql} from '@apollo/client';
+
+import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
+import {ASSET_DAEMON_TICK_FRAGMENT} from '../assets/auto-materialization/AssetDaemonTicksQuery';
+
+export const ASSET_SENSOR_TICKS_QUERY = gql`
+  query AssetSensorTicksQuery(
+    $sensorSelector: SensorSelector!
+    $dayRange: Int
+    $dayOffset: Int
+    $statuses: [InstigationTickStatus!]
+    $limit: Int
+    $cursor: String
+    $beforeTimestamp: Float
+    $afterTimestamp: Float
+  ) {
+    sensorOrError(sensorSelector: $sensorSelector) {
+      ... on Sensor {
+        id
+        sensorState {
+          id
+          ticks(
+            dayRange: $dayRange
+            dayOffset: $dayOffset
+            statuses: $statuses
+            limit: $limit
+            cursor: $cursor
+            beforeTimestamp: $beforeTimestamp
+            afterTimestamp: $afterTimestamp
+          ) {
+            id
+            ...AssetDaemonTickFragment
+          }
+        }
+      }
+      ...PythonErrorFragment
+    }
+  }
+
+  ${ASSET_DAEMON_TICK_FRAGMENT}
+  ${PYTHON_ERROR_FRAGMENT}
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
@@ -173,29 +173,31 @@ export const SensorDetails = ({
               </td>
             </tr>
           ) : null}
-          <tr>
-            <td>
-              <Box flex={{alignItems: 'center'}} style={{height: '32px'}}>
-                Cursor
-              </Box>
-            </td>
-            <td>
-              <Box flex={{direction: 'row', gap: 12, alignItems: 'center'}}>
-                <span style={{fontFamily: FontFamily.monospace, fontSize: '16px'}}>
-                  {cursor ? cursor : 'None'}
-                </span>
-                <Button icon={<Icon name="edit" />} onClick={() => setCursorEditing(true)}>
-                  Edit
-                </Button>
-              </Box>
-              <EditCursorDialog
-                isOpen={isCursorEditing}
-                sensorSelector={sensorSelector}
-                cursor={cursor ? cursor : ''}
-                onClose={() => setCursorEditing(false)}
-              />
-            </td>
-          </tr>
+          {sensor.sensorType !== SensorType.AUTOMATION_POLICY ? (
+            <tr>
+              <td>
+                <Box flex={{alignItems: 'center'}} style={{height: '32px'}}>
+                  Cursor
+                </Box>
+              </td>
+              <td>
+                <Box flex={{direction: 'row', gap: 12, alignItems: 'center'}}>
+                  <span style={{fontFamily: FontFamily.monospace, fontSize: '16px'}}>
+                    {cursor ? cursor : 'None'}
+                  </span>
+                  <Button icon={<Icon name="edit" />} onClick={() => setCursorEditing(true)}>
+                    Edit
+                  </Button>
+                </Box>
+                <EditCursorDialog
+                  isOpen={isCursorEditing}
+                  sensorSelector={sensorSelector}
+                  cursor={cursor ? cursor : ''}
+                  onClose={() => setCursorEditing(false)}
+                />
+              </td>
+            </tr>
+          ) : null}
         </tbody>
       </MetadataTableWIP>
     </>

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorInfo.tsx
@@ -1,48 +1,55 @@
 import {Alert, Box} from '@dagster-io/ui-components';
 import * as React from 'react';
 
-import {DaemonHealthFragment} from '../instance/types/DaemonList.types';
-
-type Props = React.ComponentPropsWithRef<typeof Box> & {
-  daemonHealth: DaemonHealthFragment | undefined;
+export type DaemonStatusForWarning = {
+  healthy: boolean | null;
+  required: boolean | null;
 };
 
-export const SensorInfo = ({daemonHealth, ...boxProps}: Props) => {
-  let healthy = undefined;
+type Props = React.ComponentPropsWithRef<typeof Box> & {
+  sensorDaemonStatus?: DaemonStatusForWarning;
+  assetDaemonStatus?: DaemonStatusForWarning;
+};
 
-  if (daemonHealth) {
-    const sensorHealths = daemonHealth.allDaemonStatuses.filter(
-      (daemon) => daemon.daemonType === 'SENSOR',
-    );
-    if (sensorHealths[0]) {
-      const sensorHealth = sensorHealths[0];
-      healthy = !!(sensorHealth.required && sensorHealth.healthy);
+export const SensorInfo = ({sensorDaemonStatus, assetDaemonStatus, ...boxProps}: Props) => {
+  const warnForSensor =
+    sensorDaemonStatus && sensorDaemonStatus.healthy === false && sensorDaemonStatus.required;
+  const warnForAssets =
+    assetDaemonStatus && !assetDaemonStatus.healthy === false && assetDaemonStatus.required;
+
+  if (!warnForAssets && !warnForSensor) {
+    return null;
+  }
+
+  const title = () => {
+    if (warnForSensor) {
+      if (warnForAssets) {
+        return 'The sensor and asset daemons are not running';
+      }
+      return 'The sensor daemon is not running';
     }
-  }
+    return 'The asset daemon is not running';
+  };
 
-  if (healthy === false) {
-    return (
-      <Box {...boxProps}>
-        <Alert
-          intent="warning"
-          title="The sensor daemon is not running."
-          description={
-            <div>
-              See the{' '}
-              <a
-                href="https://docs.dagster.io/deployment/dagster-daemon"
-                target="_blank"
-                rel="noreferrer"
-              >
-                dagster-daemon documentation
-              </a>{' '}
-              for more information on how to deploy the dagster-daemon process.
-            </div>
-          }
-        />
-      </Box>
-    );
-  }
-
-  return null;
+  return (
+    <Box {...boxProps}>
+      <Alert
+        intent="warning"
+        title={title()}
+        description={
+          <div>
+            See the{' '}
+            <a
+              href="https://docs.dagster.io/deployment/dagster-daemon"
+              target="_blank"
+              rel="noreferrer"
+            >
+              dagster-daemon documentation
+            </a>{' '}
+            for more information on how to deploy the dagster-daemon process.
+          </div>
+        }
+      />
+    </Box>
+  );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorRoot.tsx
@@ -1,24 +1,31 @@
 import {gql, useQuery} from '@apollo/client';
-import {Box, Page, NonIdealState, ButtonGroup} from '@dagster-io/ui-components';
+import {
+  Box,
+  Page,
+  NonIdealState,
+  ButtonGroup,
+  colorTextLight,
+  Spinner,
+} from '@dagster-io/ui-components';
 import * as React from 'react';
-import {useParams} from 'react-router-dom';
+import {Redirect, useParams} from 'react-router-dom';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
-import {InstigationTickStatus} from '../graphql/types';
+import {InstigationTickStatus, SensorType} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
 import {TicksTable, TickHistoryTimeline} from '../instigation/TickHistory';
-import {Loading} from '../ui/Loading';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
 import {SensorDetails} from './SensorDetails';
 import {SENSOR_FRAGMENT} from './SensorFragment';
 import {SensorInfo} from './SensorInfo';
+import {SensorPageAutomaterialize} from './SensorPageAutomaterialize';
 import {SensorPreviousRuns} from './SensorPreviousRuns';
 import {SensorRootQuery, SensorRootQueryVariables} from './types/SensorRoot.types';
 
@@ -58,12 +65,14 @@ export const SensorRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
       [],
     ),
   );
+
   const queryResult = useQuery<SensorRootQuery, SensorRootQueryVariables>(SENSOR_ROOT_QUERY, {
     variables: {sensorSelector},
     notifyOnNetworkStatusChange: true,
   });
 
   const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
+  const {data, loading} = queryResult;
 
   const tabs = (
     <ButtonGroup
@@ -77,61 +86,87 @@ export const SensorRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
       }}
     />
   );
-  return (
-    <Loading queryResult={queryResult} allowStaleData={true}>
-      {({sensorOrError, instance}) => {
-        if (sensorOrError.__typename === 'SensorNotFoundError') {
-          return (
-            <Box padding={{vertical: 32}} flex={{justifyContent: 'center'}}>
-              <NonIdealState
-                icon="error"
-                title={`Could not find sensor \`${sensorName}\` in definitions for \`${repoAddress.name}\``}
-              />
-            </Box>
-          );
-        } else if (sensorOrError.__typename === 'PythonError') {
-          return <PythonErrorInfo error={sensorOrError} />;
-        } else if (sensorOrError.__typename !== 'Sensor') {
-          return null;
-        }
-        const showDaemonWarning = !instance.daemonHealth.daemonStatus.healthy;
 
-        return (
-          <Page>
-            <SensorDetails
-              repoAddress={repoAddress}
-              sensor={sensorOrError}
-              daemonHealth={instance.daemonHealth.daemonStatus.healthy}
-              refreshState={refreshState}
-            />
-            {showDaemonWarning ? (
-              <SensorInfo
-                daemonHealth={instance.daemonHealth}
-                padding={{vertical: 16, horizontal: 24}}
-              />
-            ) : null}
-            <TickHistoryTimeline
-              repoAddress={repoAddress}
-              name={sensorOrError.name}
-              {...variables}
-            />
-            <Box margin={{top: 32}} border="top">
-              {selectedTab === 'evaluations' ? (
-                <TicksTable
-                  tabs={tabs}
-                  repoAddress={repoAddress}
-                  name={sensorOrError.name}
-                  setParentStatuses={setStatuses}
-                  setTimerange={setTimerange}
-                />
-              ) : (
-                <SensorPreviousRuns repoAddress={repoAddress} sensor={sensorOrError} tabs={tabs} />
-              )}
-            </Box>
-          </Page>
-        );
-      }}
-    </Loading>
+  if (!data && loading) {
+    return (
+      <Box margin={{top: 32}} flex={{direction: 'row', alignItems: 'center', gap: 16}}>
+        <Spinner purpose="body-text" />
+        <div style={{color: colorTextLight()}}>Loading sensor…</div>
+      </Box>
+    );
+  }
+
+  if (!data || data.sensorOrError.__typename === 'SensorNotFoundError') {
+    return (
+      <Box padding={{vertical: 32}}>
+        <NonIdealState
+          icon="error"
+          title={`Could not find sensor \`${sensorName}\` in definitions for \`${repoAddress.name}\``}
+        />
+      </Box>
+    );
+  }
+
+  const {sensorOrError} = data;
+  if (sensorOrError.__typename === 'PythonError') {
+    return <PythonErrorInfo error={sensorOrError} />;
+  }
+
+  if (sensorOrError.__typename === 'UnauthorizedError') {
+    return <Redirect to="/overview/sensors" />;
+  }
+
+  const {instance} = data;
+
+  if (sensorOrError.sensorType === SensorType.AUTOMATION_POLICY) {
+    const assetDaemonStatus = instance.daemonHealth.ampDaemonStatus;
+    return (
+      <Page>
+        <SensorDetails
+          repoAddress={repoAddress}
+          sensor={sensorOrError}
+          daemonHealth={assetDaemonStatus.healthy}
+          refreshState={refreshState}
+        />
+        <SensorPageAutomaterialize
+          repoAddress={repoAddress}
+          sensor={sensorOrError}
+          daemonStatus={assetDaemonStatus}
+          loading={loading}
+        />
+      </Page>
+    );
+  }
+
+  const sensorDaemonStatus = instance.daemonHealth.sensorDaemonStatus;
+
+  return (
+    <Page>
+      <SensorDetails
+        repoAddress={repoAddress}
+        sensor={sensorOrError}
+        daemonHealth={sensorDaemonStatus.healthy}
+        refreshState={refreshState}
+      />
+      <SensorInfo
+        sensorDaemonStatus={sensorDaemonStatus}
+        padding={{vertical: 16, horizontal: 24}}
+      />
+      <TickHistoryTimeline repoAddress={repoAddress} name={sensorOrError.name} {...variables} />
+      <Box margin={{top: 32}} border="top">
+        {selectedTab === 'evaluations' ? (
+          <TicksTable
+            tabs={tabs}
+            repoAddress={repoAddress}
+            name={sensorOrError.name}
+            setParentStatuses={setStatuses}
+            setTimerange={setTimerange}
+          />
+        ) : (
+          <SensorPreviousRuns repoAddress={repoAddress} sensor={sensorOrError} tabs={tabs} />
+        )}
+      </Box>
+    </Page>
   );
 };
 
@@ -148,9 +183,15 @@ const SENSOR_ROOT_QUERY = gql`
       id
       daemonHealth {
         id
-        daemonStatus(daemonType: "SENSOR") {
+        sensorDaemonStatus: daemonStatus(daemonType: "SENSOR") {
           id
           healthy
+          required
+        }
+        ampDaemonStatus: daemonStatus(daemonType: "ASSET") {
+          id
+          healthy
+          required
         }
       }
       ...InstanceHealthFragment

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/AssetSensorTicksQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/AssetSensorTicksQuery.types.ts
@@ -1,0 +1,65 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type AssetSensorTicksQueryVariables = Types.Exact<{
+  sensorSelector: Types.SensorSelector;
+  dayRange?: Types.InputMaybe<Types.Scalars['Int']>;
+  dayOffset?: Types.InputMaybe<Types.Scalars['Int']>;
+  statuses?: Types.InputMaybe<Array<Types.InstigationTickStatus> | Types.InstigationTickStatus>;
+  limit?: Types.InputMaybe<Types.Scalars['Int']>;
+  cursor?: Types.InputMaybe<Types.Scalars['String']>;
+  beforeTimestamp?: Types.InputMaybe<Types.Scalars['Float']>;
+  afterTimestamp?: Types.InputMaybe<Types.Scalars['Float']>;
+}>;
+
+export type AssetSensorTicksQuery = {
+  __typename: 'Query';
+  sensorOrError:
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      }
+    | {
+        __typename: 'Sensor';
+        id: string;
+        sensorState: {
+          __typename: 'InstigationState';
+          id: string;
+          ticks: Array<{
+            __typename: 'InstigationTick';
+            id: string;
+            timestamp: number;
+            endTimestamp: number | null;
+            status: Types.InstigationTickStatus;
+            instigationType: Types.InstigationType;
+            requestedAssetMaterializationCount: number;
+            autoMaterializeAssetEvaluationId: number | null;
+            error: {
+              __typename: 'PythonError';
+              message: string;
+              stack: Array<string>;
+              errorChain: Array<{
+                __typename: 'ErrorChainLink';
+                isExplicitLink: boolean;
+                error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+              }>;
+            } | null;
+            requestedAssetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}>;
+            requestedMaterializationsForAssets: Array<{
+              __typename: 'RequestedMaterializationsForAsset';
+              partitionKeys: Array<string>;
+              assetKey: {__typename: 'AssetKey'; path: Array<string>};
+            }>;
+          }>;
+        };
+      }
+    | {__typename: 'SensorNotFoundError'}
+    | {__typename: 'UnauthorizedError'};
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorRoot.types.ts
@@ -93,7 +93,18 @@ export type SensorRootQuery = {
     daemonHealth: {
       __typename: 'DaemonHealth';
       id: string;
-      daemonStatus: {__typename: 'DaemonStatus'; id: string; healthy: boolean | null};
+      sensorDaemonStatus: {
+        __typename: 'DaemonStatus';
+        id: string;
+        healthy: boolean | null;
+        required: boolean;
+      };
+      ampDaemonStatus: {
+        __typename: 'DaemonStatus';
+        id: string;
+        healthy: boolean | null;
+        required: boolean;
+      };
       allDaemonStatuses: Array<{
         __typename: 'DaemonStatus';
         id: string;


### PR DESCRIPTION
## Summary & Motivation

Split the rendering of the Sensor page to handle both asset auto-materialization sensors and standard sensors.

For auto-materialization sensors, repurpose the timeline and table components used in the current Overview auto-materialization page.

<img width="1220" alt="Screenshot 2023-12-15 at 4 48 19 PM" src="https://github.com/dagster-io/dagster/assets/2823852/20f73491-ee70-4981-861e-51724d31df89">

## How I Tested These Changes

With `use_automation_policy_sensors: true`, load app and navigate to Sensors overview.

View auto-materializing sensor, verify that the timeline and evaluations table load correctly. Click an evaluation in the timeline, verify that it is the auto-materialization tick dialog. Switch from evaluations to runs, verify that the query retrieves the correct list of runs for the sensor.

View a standard sensor, verify that behavior and rendering is unchanged from the current UI.
