### PR TITLE
[amp-refactor][9/n] Keep an accurate per-asset cursor

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1378,10 +1378,10 @@ def execute_asset_backfill_iteration_inner(
 
         parent_materialized_asset_partitions = set().union(
             *(
-                instance_queryer.asset_partitions_with_newly_updated_parents(
+                instance_queryer.asset_partitions_with_newly_updated_parents_and_new_cursor(
                     latest_storage_id=asset_backfill_data.latest_storage_id,
                     child_asset_key=asset_key,
-                )
+                )[0]
                 for asset_key in asset_backfill_data.target_subset.asset_keys
             )
         )


### PR DESCRIPTION
## Summary & Motivation

As alluded to in the previous PR, we were using a very sketchy method of generating a new "latest storage id" value, which is known to cause issues with race conditions / dropped events. Here, we fix this issue, ensuring that the latest_storage_id value is always based off of the latest observed storage id of the asset / parent assets

## How I Tested These Changes
