### PR TITLE
Allow io manager keys to be str enums not just strs

### DIFF
--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -829,10 +829,13 @@ def _pack_value(
     if isinstance(val, Enum):
         klass_name = val.__class__.__name__
         if not whitelist_map.has_enum_entry(klass_name):
+            if isinstance(val, str): # serialize StrEnums in their string value
+                return val.value
             raise SerializationError(
                 "Can only serialize whitelisted Enums, received"
                 f" {klass_name}.\nDescent path: {descent_path}",
             )
+        
         enum_serializer = whitelist_map.get_enum_entry(klass_name)
         return {"__enum__": enum_serializer.pack(val, whitelist_map, descent_path)}
     if (

--- a/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
@@ -2,9 +2,9 @@ import dataclasses
 import re
 import string
 from collections import namedtuple
-from enum import Enum
+from enum import Enum, auto
 from typing import AbstractSet, Any, Dict, List, Mapping, NamedTuple, Optional, Sequence
-
+from strenum import LowercaseStrEnum
 import pydantic
 import pytest
 from dagster._check import ParameterCheckError, inst_param, set_param
@@ -180,6 +180,19 @@ def test_serdes_enum_backcompat():
     assert deserialized == Corge.FOO_FOO
 
 
+
+def test_str_enum_serialization_deserialisation():
+    """
+    Checks that (de)serializing an StrEnum from the strenum lib does not produces any error and returns the string value of the enum
+    """
+    class MyStrEnum(LowercaseStrEnum):
+        ONE_STR_ENUM = auto()
+    
+    enum_val = MyStrEnum.ONE_STR_ENUM 
+    serialized_value = serialize_value(val=enum_val) 
+    assert serialized_value == f'"{enum_val.value}"'
+    assert deserialize_value(serialized_value) == enum_val.value
+    
 def test_backward_compat_serdes():
     test_map = WhitelistMap.create()
 

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -129,6 +129,7 @@ setup(
             "syrupy<4",  # 3.7 compatible,
             "tox==3.25.0",
             "morefs[asynclocal]; python_version>='3.8'",
+            "strenum",
         ],
         "mypy": [
             "mypy==0.991",


### PR DESCRIPTION
## Summary & Motivation

More details in this issue  : https://github.com/dagster-io/dagster/issues/18623
Previously, Dagster didn't accept to serialize enums from the [StrEnum library](https://pypi.org/project/StrEnum/).
I modified the _pack_value() method so that if it receives an Enum that is also of type str, we return the value of this enum.

With this change, users will be able to define keys for IOManager, Jobs, Assets etc into a single file separate in scope through the name of the enum, just like this example : 

```python
from enum import  auto
from strenum import SnakeCaseStrEnum

class IOManagerKeysSTR(SnakeCaseStrEnum): # SnakeCaseStrEnum inherits from StrEnum to convert the name into snake case
    IO_MANAGER_STR_ENUM = auto()

class JobKeysEnum(SnakeCaseStrEnum):
    SIMPLE_JOB = auto()
```

```python
from dagster import AssetSelection, define_asset_job
from my_dagster_project.assets import upstream_asset, downstream_asset
from my_dagster_project.dagster_keys import JobKeysEnum

dummy_job = define_asset_job(
    name=JobKeysEnum.SIMPLE_JOB,
    selection=AssetSelection.assets(upstream_asset, downstream_asset),

)
```

## How I Tested These Changes

I tested that it was possible to serialize and de-serialize an StrEnum and that the resulting de-serialized object was the str value of the enum (which is an ok behaviour for me because I will never read back the StrEnum in my use cases). 
I also rerun all test from the `test_serdes.py` to check if it was okay
I also tested the test provided in the [issue](https://github.com/dagster-io/dagster/issues/18623) but I didn't added to the code because it was maybe a too big test

```python
def test_str_enum_serialization_deserialisation():
    """
    Checks that (de)serializing an StrEnum from the strenum lib does not produces any error and returns the string value of the enum
    """
    class MyStrEnum(LowercaseStrEnum):
        ONE_STR_ENUM = auto()
    
    enum_val = MyStrEnum.ONE_STR_ENUM 
    serialized_value = serialize_value(val=enum_val) 
    assert serialized_value == f'"{enum_val.value}"'
    assert deserialize_value(serialized_value) == enum_val.value
```
**To make the test I had to add strenum as extra-dependency for the tests, is it ok?**
