### PR TITLE
feat(helm): daemon -> allow setting resources for check-db-ready initContainer

### DIFF
--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -52,6 +52,8 @@ spec:
           image: {{ include "dagster.externalImage.name" $.Values.postgresql.image | quote }}
           imagePullPolicy: "{{- $.Values.postgresql.image.pullPolicy -}}"
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" . | squote }}]
+          resources:
+            {{- toYaml .Values.dagsterDaemon.checkDBReady.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.dagsterDaemon.securityContext | nindent 12 }}
         {{- if (and $userDeployments.enabled $userDeployments.enableSubchart) }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -2833,6 +2833,10 @@
                 "schedules": {
                     "$ref": "#/definitions/Schedules"
                 },
+                "checkDBReady": {
+                    "title": "CheckDBReady",
+                    "type": "object"
+                },
                 "schedulerName": {
                     "title": "Schedulername",
                     "anyOf": [

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -1208,6 +1208,18 @@ dagsterDaemon:
   readinessProbe: {}
   startupProbe: {}
 
+  # initContainer checking the postgres connection
+  checkDBReady:
+    # Example:
+#    resources:
+#      limits:
+#        cpu: 100m
+#        memory: 128Mi
+#      requests:
+#        cpu: 100m
+#        memory: 128Mi
+    resources: {}
+
 ####################################################################################################
 # busybox: Configuration for the busybox image used to check connections
 ####################################################################################################


### PR DESCRIPTION
## Summary & Motivation

Applying namespace quotas with mandatory resources requests makes dagster daemon to fail due to resources being unset for `check-db-ready` init container.

This commit makes it possible to set the resources for this init container via a helm value.

If there's a better option to achieve this or more fundamental changes are required please let me know.

## How I Tested These Changes

set values:
```yaml
dagsterDaemon:
  checkDBReady:
    resources:
      limits:
        cpu: 100m
        memory: 128Mi
      requests:
        cpu: 100m
        memory: 128Mi
```

generated template:
```bash
helm template .
```

result:
```yaml
# ...
      initContainers:
        - name: check-db-ready
          image: "library/postgres:14.6"
          imagePullPolicy: "IfNotPresent"
          command: ['sh', '-c', 'until pg_isready -h release-name-postgresql -p 5432 -U test; do echo waiting for database; sleep 2; done;']
          resources:
            limits:
              cpu: 100m
              memory: 128Mi
            requests:
              cpu: 100m
              memory: 128Mi
# ...
```

