### PR TITLE
Use the repository label tag when filtering runs for a given schedule or sensor

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
@@ -12,6 +12,7 @@ import {TicksTable} from '../instigation/TickHistory';
 import {RunTable, RUN_TABLE_RUN_FRAGMENT} from '../runs/RunTable';
 import {DagsterTag} from '../runs/RunTag';
 import {Loading} from '../ui/Loading';
+import {repoAddressAsTag} from '../workspace/repoAddressAsString';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
@@ -100,6 +101,7 @@ export const ScheduleRoot = (props: Props) => {
 };
 
 const SchedulePreviousRuns = ({
+  repoAddress,
   schedule,
   highlightedIds,
   tabs,
@@ -115,8 +117,10 @@ const SchedulePreviousRuns = ({
       variables: {
         limit: 20,
         filter: {
-          pipelineName: schedule.pipelineName,
-          tags: [{key: DagsterTag.ScheduleName, value: schedule.name}],
+          tags: [
+            {key: DagsterTag.ScheduleName, value: schedule.name},
+            {key: DagsterTag.RepositoryLabelTag, value: repoAddressAsTag(repoAddress)},
+          ],
         },
       },
       notifyOnNetworkStatusChange: true,

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPreviousRuns.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPreviousRuns.tsx
@@ -6,6 +6,7 @@ import {useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {RunTable, RUN_TABLE_RUN_FRAGMENT} from '../runs/RunTable';
 import {DagsterTag} from '../runs/RunTag';
 import {useCursorPaginatedQuery} from '../runs/useCursorPaginatedQuery';
+import {repoAddressAsTag} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {SensorFragment} from './types/SensorFragment.types';
@@ -18,6 +19,7 @@ const RUNS_LIMIT = 20;
 
 export const SensorPreviousRuns = ({
   sensor,
+  repoAddress,
   highlightedIds,
   tabs,
 }: {
@@ -33,8 +35,10 @@ export const SensorPreviousRuns = ({
     query: PREVIOUS_RUNS_FOR_SENSOR_QUERY,
     variables: {
       filter: {
-        pipelineName: sensor.targets?.length === 1 ? sensor.targets[0]!.pipelineName : undefined,
-        tags: [{key: DagsterTag.SensorName, value: sensor.name}],
+        tags: [
+          {key: DagsterTag.SensorName, value: sensor.name},
+          {key: DagsterTag.RepositoryLabelTag, value: repoAddressAsTag(repoAddress)},
+        ],
       },
     },
     nextCursorForResult: (data) => {


### PR DESCRIPTION
Summary:
This fixes an issue where if you have two schedules or sensors in different repositories or code locations that target a job with the same and have the same name (or don't target a single job and have the same name) the runs tab returns

Test Plan: Create a repo that reproduces the above, create a run from each sensor, load the runs page for each one, see a single run from each sensor now

## Summary & Motivation

## How I Tested These Changes
