### PR TITLE
[pyright] Filter deleted files from pyright check

### DIFF
--- a/scripts/run-pyright.py
+++ b/scripts/run-pyright.py
@@ -203,7 +203,9 @@ def get_params(args: argparse.Namespace) -> Params:
     elif args.diff:
         mode = "path"
         targets = (
-            subprocess.check_output(["git", "diff", "--name-only", "origin/master"])
+            subprocess.check_output(
+                ["git", "diff", "--name-only", "origin/master", "--diff-filter=d"]
+            )
             .decode("utf-8")
             .splitlines()
         )


### PR DESCRIPTION
## Summary & Motivation

Previously, any file touched between commits would end up getting passed into the pyright command. This causes problems if you deleted a file, which would cause the pyright command to error out (no such file or directory).

This modifies the git diff command we run to exclude such files.

## How I Tested These Changes
