### PR TITLE
[amp-refactor][?/n] Add asset_condition argument to AssetsDefinition and friends

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_checks.py
@@ -252,7 +252,7 @@ def build_asset_with_blocking_check(
         resource_defs=asset_def.resource_defs,
         metadata=asset_def.metadata_by_key.get(asset_def.key),
         freshness_policy=asset_def.freshness_policies_by_key.get(asset_def.key),
-        auto_materialize_policy=asset_def.auto_materialize_policies_by_key.get(asset_def.key),
+        asset_condition=asset_def.asset_conditions_by_key.get(asset_def.key),
         backfill_policy=asset_def.backfill_policy,
         config=None,  # gets config from asset_def.op
     )

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -10,7 +10,6 @@ from typing import (
     Sequence,
 )
 
-from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.events import AssetKey
 from dagster._serdes.serdes import (
@@ -25,14 +24,15 @@ from dagster._serdes.serdes import (
     whitelist_for_serdes,
 )
 
-from .asset_graph import AssetGraph
-
 if TYPE_CHECKING:
     from .asset_condition import (
         AssetConditionEvaluation,
         AssetConditionEvaluationState,
         AssetConditionSnapshot,
     )
+    from .asset_graph import AssetGraph
+
+T = TypeVar("T")
 
 
 @whitelist_for_serdes
@@ -168,12 +168,16 @@ def get_backcompat_asset_condition_evaluation_state(
 
 
 def backcompat_deserialize_asset_daemon_cursor_str(
-    cursor_str: str, asset_graph: Optional[AssetGraph], default_evaluation_id: int
+    cursor_str: str, asset_graph: Optional["AssetGraph"], default_evaluation_id: int
 ) -> AssetDaemonCursor:
     """This serves as a backcompat layer for deserializing the old cursor format. Some information
     is impossible to fully recover, this will recover enough to continue operating as normal.
     """
-    from .asset_condition import AssetConditionEvaluation, AssetConditionSnapshot
+    from .asset_condition import (
+        AssetConditionEvaluation,
+        AssetConditionSnapshot,
+    )
+    from .asset_graph_subset import AssetGraphSubset
     from .auto_materialize_rule_evaluation import (
         deserialize_auto_materialize_asset_evaluation_to_asset_condition_evaluation_with_run_ids,
     )

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -209,8 +209,8 @@ class ExternalRepository:
 
             default_sensor_asset_keys = set()
 
-            for asset_key, policy in asset_graph.auto_materialize_policies_by_key.items():
-                if not policy:
+            for asset_key, asset_condition in asset_graph.asset_condtitions_by_key.items():
+                if not asset_condition:
                     continue
 
                 if asset_key not in covered_asset_keys:

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -48,6 +48,7 @@ from dagster._core.definitions import (
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
+from dagster._core.definitions.asset_condition import AssetCondition
 from dagster._core.definitions.asset_sensor_definition import AssetSensorDefinition
 from dagster._core.definitions.asset_spec import (
     SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE,
@@ -1195,6 +1196,7 @@ class ExternalAssetNode(
             ("atomic_execution_unit_id", Optional[str]),
             ("required_top_level_resources", Optional[Sequence[str]]),
             ("auto_materialize_policy", Optional[AutoMaterializePolicy]),
+            ("asset_condition", Optional[AssetCondition]),
             ("backfill_policy", Optional[BackfillPolicy]),
             ("auto_observe_interval_minutes", Optional[float]),
         ],
@@ -1229,6 +1231,7 @@ class ExternalAssetNode(
         atomic_execution_unit_id: Optional[str] = None,
         required_top_level_resources: Optional[Sequence[str]] = None,
         auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
+        asset_condition: Optional[AssetCondition] = None,
         backfill_policy: Optional[BackfillPolicy] = None,
         auto_observe_interval_minutes: Optional[float] = None,
     ):
@@ -1285,6 +1288,9 @@ class ExternalAssetNode(
                 auto_materialize_policy,
                 "auto_materialize_policy",
                 AutoMaterializePolicy,
+            ),
+            asset_condition=check.opt_inst_param(
+                asset_condition, "asset_condition", AssetCondition
             ),
             backfill_policy=check.opt_inst_param(
                 backfill_policy, "backfill_policy", BackfillPolicy
@@ -1535,7 +1541,7 @@ def external_asset_nodes_from_defs(
     asset_info_by_asset_key: Dict[AssetKey, AssetOutputInfo] = dict()
     freshness_policy_by_asset_key: Dict[AssetKey, FreshnessPolicy] = dict()
     metadata_by_asset_key: Dict[AssetKey, MetadataUserInput] = dict()
-    auto_materialize_policy_by_asset_key: Dict[AssetKey, AutoMaterializePolicy] = dict()
+    asset_conditions_by_asset_key: Dict[AssetKey, AssetCondition] = dict()
     backfill_policy_by_asset_key: Dict[AssetKey, Optional[BackfillPolicy]] = dict()
 
     deps: Dict[AssetKey, Dict[AssetKey, ExternalAssetDependency]] = defaultdict(dict)
@@ -1590,7 +1596,7 @@ def external_asset_nodes_from_defs(
         for assets_def in asset_layer.assets_defs_by_key.values():
             metadata_by_asset_key.update(assets_def.metadata_by_key)
             freshness_policy_by_asset_key.update(assets_def.freshness_policies_by_key)
-            auto_materialize_policy_by_asset_key.update(assets_def.auto_materialize_policies_by_key)
+            asset_conditions_by_asset_key.update(assets_def.asset_conditions_by_key)
             backfill_policy_by_asset_key.update(
                 {key: assets_def.backfill_policy for key in assets_def.keys}
             )
@@ -1722,7 +1728,7 @@ def external_asset_nodes_from_defs(
                 # such assets are part of the default group
                 group_name=group_name_by_asset_key.get(asset_key, DEFAULT_GROUP_NAME),
                 freshness_policy=freshness_policy_by_asset_key.get(asset_key),
-                auto_materialize_policy=auto_materialize_policy_by_asset_key.get(asset_key),
+                asset_condition=asset_conditions_by_asset_key.get(asset_key),
                 backfill_policy=backfill_policy_by_asset_key.get(asset_key),
                 atomic_execution_unit_id=atomic_execution_unit_ids_by_key.get(asset_key),
                 required_top_level_resources=required_top_level_resources,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -224,7 +224,7 @@ def test_retain_freshness_policy():
     )
 
 
-def test_graph_backed_retain_freshness_policy_and_auto_materialize_policy():
+def test_graph_backed_retain_freshness_policy_and_auto_materialize_policy() -> None:
     fpa = FreshnessPolicy(maximum_lag_minutes=24.5)
     fpb = FreshnessPolicy(
         maximum_lag_minutes=30.5, cron_schedule="0 0 * * *", cron_schedule_timezone="US/Eastern"
@@ -262,9 +262,9 @@ def test_graph_backed_retain_freshness_policy_and_auto_materialize_policy():
     assert replaced.freshness_policies_by_key[AssetKey("bb")] == fpb
     assert replaced.freshness_policies_by_key.get(AssetKey("cc")) is None
 
-    assert replaced.auto_materialize_policies_by_key[AssetKey("aa")] == ampa
-    assert replaced.auto_materialize_policies_by_key[AssetKey("bb")] == ampb
-    assert replaced.auto_materialize_policies_by_key.get(AssetKey("cc")) is None
+    assert replaced.asset_conditions_by_key[AssetKey("aa")] == ampa.to_asset_condition()
+    assert replaced.asset_conditions_by_key[AssetKey("bb")] == ampb.to_asset_condition()
+    assert replaced.asset_conditions_by_key.get(AssetKey("cc")) is None
 
 
 def test_retain_metadata_graph():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
@@ -46,7 +46,8 @@ def check_auto_materialize_policy(assets, auto_materialize_policy):
             asset_keys = a.keys
             for asset_key in asset_keys:
                 assert (
-                    a.auto_materialize_policies_by_key.get(asset_key) == auto_materialize_policy
+                    a.asset_conditions_by_key.get(asset_key)
+                    == auto_materialize_policy.to_asset_condition()
                 ), asset_key
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -922,8 +922,8 @@ def test_graph_asset_with_args():
         maximum_lag_minutes=5
     )
     assert (
-        my_asset.auto_materialize_policies_by_key[AssetKey("my_asset")]
-        == AutoMaterializePolicy.lazy()
+        my_asset.asset_conditions_by_key[AssetKey("my_asset")]
+        == AutoMaterializePolicy.lazy().to_asset_condition()
     )
     assert my_asset.resource_defs["foo"] == foo_resource
 
@@ -1098,10 +1098,10 @@ def test_graph_multi_asset_decorator():
     )
 
     assert (
-        two_assets.auto_materialize_policies_by_key[AssetKey("first_asset")]
-        == AutoMaterializePolicy.eager()
+        two_assets.asset_conditions_by_key[AssetKey("first_asset")]
+        == AutoMaterializePolicy.eager().to_asset_condition()
     )
-    assert two_assets.auto_materialize_policies_by_key.get(AssetKey("second_asset")) is None
+    assert two_assets.asset_conditions_by_key.get(AssetKey("second_asset")) is None
 
     assert two_assets.resource_defs["foo"] == foo_resource
 
@@ -1254,9 +1254,9 @@ def test_multi_asset_with_auto_materialize_policy():
     def my_asset():
         ...
 
-    assert my_asset.auto_materialize_policies_by_key == {
-        AssetKey("o2"): AutoMaterializePolicy.eager(),
-        AssetKey("o3"): AutoMaterializePolicy.lazy(),
+    assert my_asset.asset_conditions_by_key == {
+        AssetKey("o2"): AutoMaterializePolicy.eager().to_asset_condition(),
+        AssetKey("o3"): AutoMaterializePolicy.lazy().to_asset_condition(),
     }
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -404,8 +404,8 @@ class AssetDaemonScenarioState(NamedTuple):
             asset_graph=self.asset_graph,
             auto_materialize_asset_keys={
                 key
-                for key, policy in self.asset_graph.auto_materialize_policies_by_key.items()
-                if policy is not None
+                for key, condition in self.asset_graph.asset_condtitions_by_key.items()
+                if condition is not None
             },
             instance=self.instance,
             materialize_run_tags={},

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/multi_code_location_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/multi_code_location_scenarios.py
@@ -29,8 +29,9 @@ def with_auto_materialize_policy(
     ret = []
     for assets_def in assets_defs:
         new_assets_def = copy.copy(assets_def)
-        new_assets_def._auto_materialize_policies_by_key = {  # noqa: SLF001
-            asset_key: auto_materialize_policy for asset_key in new_assets_def.keys
+        new_assets_def._asset_conditions_by_key = {  # noqa: SLF001
+            asset_key: auto_materialize_policy.to_asset_condition()
+            for asset_key in new_assets_def.keys
         }
         ret.append(new_assets_def)
     return ret

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -241,10 +241,15 @@ def test_load_from_instance(
     expected_auto_materialize_policy = (
         AutoMaterializePolicy.lazy() if connection_to_auto_materialize_policy_fn else None
     )
-    auto_materialize_policies_by_key = ab_assets[0].auto_materialize_policies_by_key
+    asset_conditions_by_key = ab_assets[0].asset_conditions_by_key
     assert all(
-        auto_materialize_policies_by_key[key] == expected_auto_materialize_policy
-        for key in auto_materialize_policies_by_key
+        asset_conditions_by_key[key]
+        == (
+            expected_auto_materialize_policy.to_asset_condition()
+            if expected_auto_materialize_policy
+            else None
+        )
+        for key in asset_conditions_by_key
     )
 
     responses.add(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
@@ -529,8 +529,8 @@ def test_custom_auto_materialize_policy(dbt_cloud, dbt_cloud_service):
         dbt_assets_definition_cacheable_data
     )
 
-    assert dbt_cloud_assets[0].auto_materialize_policies_by_key == {
-        key: AutoMaterializePolicy.eager() for key in dbt_cloud_assets[0].keys
+    assert dbt_cloud_assets[0].asset_conditions_by_key == {
+        key: AutoMaterializePolicy.eager().to_asset_condition() for key in dbt_cloud_assets[0].keys
     }
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -530,8 +530,8 @@ def test_with_auto_materialize_policy_replacements() -> None:
     def my_dbt_assets():
         ...
 
-    for auto_materialize_policy in my_dbt_assets.auto_materialize_policies_by_key.values():
-        assert auto_materialize_policy == expected_auto_materialize_policy
+    for asset_condition in my_dbt_assets.asset_conditions_by_key.values():
+        assert asset_condition == expected_auto_materialize_policy.to_asset_condition()
 
 
 def test_dbt_meta_auto_materialize_policy() -> None:
@@ -539,11 +539,11 @@ def test_dbt_meta_auto_materialize_policy() -> None:
     def my_dbt_assets():
         ...
 
-    auto_materialize_policies = my_dbt_assets.auto_materialize_policies_by_key.values()
-    assert auto_materialize_policies
+    asset_conditions = my_dbt_assets.asset_conditions_by_key.values()
+    assert asset_conditions
 
-    for auto_materialize_policy in auto_materialize_policies:
-        assert auto_materialize_policy == AutoMaterializePolicy.eager()
+    for asset_condition in asset_conditions:
+        assert asset_condition == AutoMaterializePolicy.eager().to_asset_condition()
 
 
 def test_dbt_meta_freshness_policy() -> None:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -342,8 +342,8 @@ def test_custom_auto_materialize_policy():
         node_info_to_auto_materialize_policy_fn=lambda _: AutoMaterializePolicy.lazy(),
     )
 
-    assert dbt_assets[0].auto_materialize_policies_by_key == {
-        key: AutoMaterializePolicy.lazy() for key in dbt_assets[0].keys
+    assert dbt_assets[0].asset_conditions_by_key == {
+        key: AutoMaterializePolicy.lazy().to_asset_condition() for key in dbt_assets[0].keys
     }
 
 
@@ -624,8 +624,8 @@ def test_dagster_dbt_translator(
     for freshness_policy in dbt_assets[0].freshness_policies_by_key.values():
         assert freshness_policy == FreshnessPolicy(maximum_lag_minutes=1)
 
-    for auto_materialize_policy in dbt_assets[0].auto_materialize_policies_by_key.values():
-        assert auto_materialize_policy == AutoMaterializePolicy.lazy()
+    for asset_condition in dbt_assets[0].asset_conditions_by_key.values():
+        assert asset_condition == AutoMaterializePolicy.lazy().to_asset_condition()
 
     result = materialize_to_memory(
         dbt_assets,


### PR DESCRIPTION
## Summary & Motivation

The plan is to allow users to supply AssetCondition objects instead of AutoMaterializePolicies. This PR makes that happen by turning the AutoMaterializePolicy class into a shell whose only purpose is to generate AssetConditions.

This meant that it had to be removed at the storage layer as well, as we want external asset nodes to be able to store regular AssetConditions. Luckily, it's fairly easy to ensure that AutoMaterializePolicies get deserialized as AssetConditions, as we already had some customized serialization going on in that part of the world.

## How I Tested These Changes
