### PR TITLE
[amp-refactor][11/n] Create AssetConditionEvaluationResult object, remove AssetConditionCursorExtras

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -209,20 +209,20 @@ class AssetDaemonContext:
             expected_data_time_mapping=expected_data_time_mapping,
         )
 
-        evaluation, extras = asset_condition.evaluate(context)
+        evaluation_result = asset_condition.evaluate(context)
 
         new_asset_cursor = AssetConditionCursor(
             asset_key=asset_key,
             previous_max_storage_id=context.new_max_storage_id,
             previous_evaluation_timestamp=context.evaluation_time.timestamp(),
-            previous_evaluation=evaluation,
-            extras=extras,
+            previous_evaluation=evaluation_result.evaluation,
+            extra_values_by_unique_id=evaluation_result.extra_values_by_unique_id,
         )
 
         expected_data_time = get_expected_data_time_for_asset_key(
-            context, will_materialize=evaluation.true_subset.size > 0
+            context, will_materialize=evaluation_result.true_subset.size > 0
         )
-        return evaluation, new_asset_cursor, expected_data_time
+        return evaluation_result.evaluation, new_asset_cursor, expected_data_time
 
     def get_asset_condition_evaluations(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -55,7 +55,7 @@ class AssetConditionCursor(NamedTuple):
     previous_max_storage_id: Optional[int]
     previous_evaluation_timestamp: Optional[float]
 
-    extras: Sequence[AssetConditionCursorExtras]
+    extra_values_by_unique_id: Mapping[str, PackableValue]
 
     @staticmethod
     def empty(asset_key: AssetKey) -> "AssetConditionCursor":
@@ -64,21 +64,16 @@ class AssetConditionCursor(NamedTuple):
             previous_evaluation=None,
             previous_max_storage_id=None,
             previous_evaluation_timestamp=None,
-            extras=[],
+            extra_values_by_unique_id={},
         )
 
-    def get_extras_value(
-        self, condition: "AssetCondition", key: str, as_type: Type[T]
-    ) -> Optional[T]:
-        """Returns a value from the extras dict for the given condition, if it exists and is of the
-        expected type. Otherwise, returns None.
+    def get_extras_value(self, condition: "AssetCondition", as_type: Type[T]) -> Optional[T]:
+        """Returns the value from the extras dict for the given condition, if it exists and is of
+        the expected type. Otherwise, returns None.
         """
-        for condition_extras in self.extras:
-            if condition_extras.condition_snapshot == condition.snapshot:
-                extras_value = condition_extras.extras.get(key)
-                if isinstance(extras_value, as_type):
-                    return extras_value
-                return None
+        extras_value = self.extra_values_by_unique_id.get(condition.unique_id)
+        if isinstance(extras_value, as_type):
+            return extras_value
         return None
 
     def get_previous_requested_or_discarded_subset(
@@ -193,18 +188,12 @@ def get_backcompat_asset_condition_cursor(
         previous_evaluation=latest_evaluation,
         previous_evaluation_timestamp=latest_timestamp,
         previous_max_storage_id=latest_storage_id,
-        extras=[
-            # the only information we need to preserve from the previous cursor is the handled
-            # subset
-            AssetConditionCursorExtras(
-                condition_snapshot=RuleCondition(MaterializeOnMissingRule()).snapshot,
-                extras={MaterializeOnMissingRule.HANDLED_SUBSET_KEY: handled_root_subset},
-            )
-        ]
-        # only include this information if it's non-empty (otherwise we can just rebuild it from
-        # the set of materialized partitions later on)
+        # the only information we need to preserve from the previous cursor is the handled subset
+        extra_values_by_unique_id={
+            RuleCondition(MaterializeOnMissingRule()).unique_id: handled_root_subset,
+        }
         if handled_root_subset and handled_root_subset.size > 0
-        else [],
+        else {},
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -602,8 +602,6 @@ class MaterializeOnParentUpdatedRule(
 
 @whitelist_for_serdes
 class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMissingRule", [])):
-    HANDLED_SUBSET_KEY: str = "handled_subset"
-
     @property
     def decision_type(self) -> AutoMaterializeDecisionType:
         return AutoMaterializeDecisionType.MATERIALIZE
@@ -616,9 +614,7 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
         """Returns the AssetSubset which has been handled (materialized, requested, or discarded).
         Accounts for cases in which the partitions definition may have changed between ticks.
         """
-        previous_handled_subset = context.cursor.get_extras_value(
-            context.condition, self.HANDLED_SUBSET_KEY, AssetSubset
-        )
+        previous_handled_subset = context.cursor.get_extras_value(context.condition, AssetSubset)
         if previous_handled_subset:
             # partitioned -> unpartitioned or vice versa
             if previous_handled_subset.is_partitioned != (context.partitions_def is not None):
@@ -654,7 +650,7 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
             if handled_subset.size > 0
             else context.candidate_subset
         )
-        return (unhandled_candidates, [], {self.HANDLED_SUBSET_KEY: handled_subset})
+        return (unhandled_candidates, [], handled_subset)
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
@@ -9,7 +9,6 @@ from typing import (
     AbstractSet,
     Dict,
     FrozenSet,
-    Mapping,
     NamedTuple,
     Optional,
     Sequence,
@@ -129,9 +128,7 @@ class WaitingOnAssetsRuleEvaluationData(
         }
 
 
-RuleEvaluationResults = Tuple[
-    AssetSubset, Sequence["AssetSubsetWithMetadata"], Mapping[str, PackableValue]
-]
+RuleEvaluationResults = Tuple[AssetSubset, Sequence["AssetSubsetWithMetadata"], PackableValue]
 
 
 @whitelist_for_serdes


### PR DESCRIPTION
## Summary & Motivation

This is a simple refactor intended to make it more ergonomic to pass around both an AssetConditionEvaluation object as well as some cursor-specific information throughout the system.

While changing this return type, we refactor the cursor structure to make it unnecessary to have this weird AssetConditionCursorExtras object, opting to instead just store a simple mapping from condition unique id to extra value


## How I Tested These Changes
