### PR TITLE
[RFC] GRPC threadpool size env var

### DIFF
--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -477,6 +477,7 @@ def _execute_step_command_body(
     required=False,
     default=None,
     help="Maximum number of (threaded) workers to use in the GRPC server",
+    envvar="DAGSTER_GRPC_MAX_WORKERS",
 )
 @click.option(
     "--heartbeat",

--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -61,6 +61,7 @@ def code_server_cli():
     required=False,
     default=None,
     help="Maximum number of (threaded) workers to use in the code server",
+    envvar="DAGSTER_CODE_SERVER_MAX_WORKERS",
 )
 @python_origin_target_argument
 @click.option(


### PR DESCRIPTION
Adds an environment variable for setting threadpool size on grpc server. This approach has the advantage of being very lightweight from an implementation perspective, and potentially changeable on a per-location-basis. 

The assumption here is that our current environment variable injection method (via the UI) happens at an early enough stage that this will be completely configurable in serverless; but I haven't actually verified that yet. 
