### PR TITLE
performance improvement for querying runs in sql run storage

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -327,7 +327,10 @@ class SqlRunStorage(RunStorage):
             expressions = []
             for key, value in tags.items():
                 expression = RunTagsTable.c.key == key
-                expression &= RunTagsTable.c.value == value
+                if isinstance(value, str):
+                    expression &= RunTagsTable.c.value == value
+                else:
+                    expression &= RunTagsTable.c.value.in_(value)
                 expressions.append(expression)
             subquery = subquery.where(db.or_(*expressions))
             subquery = subquery.group_by(RunTagsTable.c.run_id)

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -477,6 +477,13 @@ class TestRunStorage:
         assert runs_with_multiple_tag_values[1].run_id == two
         assert runs_with_multiple_tag_values[2].run_id == one
 
+        multiple_tags_values_filter = RunsFilter(
+            tags={"tag": ["hello", "goodbye", "farewell"], "tag2": "world"},
+        )
+        runs_with_multiple_tags_values = storage.get_runs(multiple_tags_values_filter)
+        assert len(runs_with_multiple_tags_values) == 1
+        assert runs_with_multiple_tags_values[0].run_id == one
+
         count_with_multiple_tag_values = storage.get_runs_count(multiple_tag_values_filter)
         assert count_with_multiple_tag_values == 3
 


### PR DESCRIPTION
## Summary & Motivation

When working with a database with many runs and many tags per run, querying for runs could be very slow. In our production setting, (~70k runs, ~670k run tags) we would consistently get timeouts in the UI (where only a single row is being fetched). 

<img width="1849" alt="dagster_timeout" src="https://github.com/dagster-io/dagster/assets/61978823/6909f8eb-986e-4e09-95a1-11b7089f18b2">

In order to work around these, we had to increase the timeout in the Postgres config. This will reduce the rate of those error messages at the expense of a really slow UI. 

## How I Tested These Changes

I found this new query structure by building equivalent queries and experimenting with the query plan. I used the query that was timing out as my main test. This query looks for the latest run in a given job that has tags matching a schedule and a repository. 

In my database, the new query took ~380ms compared to ~17780ms in the old. The new query has a much more efficient single nested loop and processes less rows. 

I compared the results of this query and the results of other queries to ensure that the queries were doing the same work. 

I ran 

```python python -m pytest python_modules/libraries/dagster-postgres/dagster_postgres_tests```

which completed with no failures.

### New Query Plan

| QUERY PLAN                                                                                                                                                                                                                         |
|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Limit  (cost=13251.31..13251.32 rows=1 width=1206) (actual time=378.315..378.318 rows=1 loops=1)                                                                                                                                   |
|   ->  Sort  (cost=13251.31..13251.32 rows=1 width=1206) (actual time=378.314..378.316 rows=1 loops=1)                                                                                                                              |
|         Sort Key: r.id DESC                                                                                                                                                                                                        |
|         Sort Method: top-N heapsort  Memory: 29kB                                                                                                                                                                                  |
|         ->  Nested Loop  (cost=12776.27..13251.30 rows=1 width=1206) (actual time=257.464..378.014 rows=435 loops=1)                                                                                                               |
|               ->  GroupAggregate  (cost=12775.85..12930.26 rows=38 width=37) (actual time=257.429..374.589 rows=435 loops=1)                                                                                                       |
|                     Group Key: rt.run_id                                                                                                                                                                                           |
|                     Filter: (count(DISTINCT rt.key) = 2)                                                                                                                                                                           |
|                     Rows Removed by Filter: 72629                                                                                                                                                                                  |
|                     ->  Sort  (cost=12775.85..12795.79 rows=7976 width=54) (actual time=256.988..300.174 rows=73499 loops=1)                                                                                                       |
|                           Sort Key: rt.run_id                                                                                                                                                                                      |
|                           Sort Method: external merge  Disk: 4840kB                                                                                                                                                                |
|                           ->  Bitmap Heap Scan on run_tags rt  (cost=708.85..12258.95 rows=7976 width=54) (actual time=6.046..47.182 rows=73499 loops=1)                                                                           |
|                                 Recheck Cond: (((key = 'dagster/schedule_name'::text) AND (value = '{schedule_name}'::text)) OR ((key = '.dagster/repository'::text) AND (value = '__repository__@{repo_name}'::text))) |
|                                 Heap Blocks: exact=12136                                                                                                                                                                           |
|                                 ->  BitmapOr  (cost=708.85..708.85 rows=7976 width=0) (actual time=4.028..4.030 rows=0 loops=1)                                                                                                    |
|                                       ->  Bitmap Index Scan on idx_run_tags  (cost=0.00..4.56 rows=1 width=0) (actual time=0.070..0.070 rows=456 loops=1)                                                                          |
|                                             Index Cond: ((key = 'dagster/schedule_name'::text) AND (value = '{schedule_name}'::text))                                                                                     |
|                                       ->  Bitmap Index Scan on idx_run_tags  (cost=0.00..700.30 rows=7975 width=0) (actual time=3.957..3.957 rows=80063 loops=1)                                                                   |
|                                             Index Cond: ((key = '.dagster/repository'::text) AND (value = '__repository__@{repo_name}'::text))                                                                                   |
|               ->  Index Scan using runs_run_id_key on runs r  (cost=0.42..8.44 rows=1 width=1243) (actual time=0.007..0.007 rows=1 loops=435)                                                                                      |
|                     Index Cond: ((run_id)::text = (rt.run_id)::text)                                                                                                                                                               |
|                     Filter: (pipeline_name = '{job_name}'::text)                                                                                                                                                          |
| Planning Time: 0.312 ms                                                                                                                                                                                                            |
| Execution Time: 379.591 ms                                                                                                                                                                                                         |

### Old Query Plan

| QUERY PLAN                                                                                                                                             |
|--------------------------------------------------------------------------------------------------------------------------------------------------------|
| Limit  (cost=12325.68..12325.69 rows=1 width=1206) (actual time=17779.260..17779.261 rows=1 loops=1)                                                   |
|   ->  Sort  (cost=12325.68..12325.69 rows=1 width=1206) (actual time=17779.258..17779.260 rows=1 loops=1)                                              |
|         Sort Key: r.id DESC                                                                                                                            |
|         Sort Method: top-N heapsort  Memory: 27kB                                                                                                      |
|         ->  Nested Loop  (cost=703.26..12325.67 rows=1 width=1206) (actual time=5.395..17777.870 rows=434 loops=1)                                     |
|               Join Filter: ((rt1.run_id)::text = (r.run_id)::text)                                                                                     |
|               ->  Nested Loop  (cost=702.84..12320.75 rows=1 width=74) (actual time=5.372..17767.183 rows=434 loops=1)                                 |
|                     Join Filter: ((rt1.run_id)::text = (rt2.run_id)::text)                                                                             |
|                     Rows Removed by Join Filter: 31656828                                                                                              |
|                     ->  Index Scan using idx_run_tags on run_tags rt1  (cost=0.55..8.57 rows=1 width=37) (actual time=0.028..1.278 rows=434 loops=1)   |
|                           Index Cond: ((key = 'dagster/schedule_name'::text) AND (value = '{schedule_name}'::text))                           |
|                     ->  Bitmap Heap Scan on run_tags rt2  (cost=702.29..12212.50 rows=7975 width=37) (actual time=5.066..31.480 rows=72943 loops=434)  |
|                           Recheck Cond: ((key = '.dagster/repository'::text) AND (value = '__repository__@{repo_name}'::text))                       |
|                           Heap Blocks: exact=5266590                                                                                                   |
|                           ->  Bitmap Index Scan on idx_run_tags  (cost=0.00..700.30 rows=7975 width=0) (actual time=3.396..3.396 rows=79932 loops=434) |
|                                 Index Cond: ((key = '.dagster/repository'::text) AND (value = '__repository__@{repo_name}'::text))                   |
|               ->  Index Scan using runs_run_id_key on runs r  (cost=0.42..4.90 rows=1 width=1243) (actual time=0.018..0.018 rows=1 loops=434)          |
|                     Index Cond: ((run_id)::text = (rt2.run_id)::text)                                                                                  |
|                     Filter: (pipeline_name = '{job_name}'::text)                                                                              |
| Planning Time: 0.558 ms                                                                                                                                |
| Execution Time: 17779.309 ms                                                                                                                           |