### PR TITLE
Add a "starting code server" log line to code servers

### DIFF
--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -656,6 +656,23 @@ def grpc_command(
             package_name=kwargs["package_name"],
         )
 
+    code_desc = " "
+    if loadable_target_origin:
+        if loadable_target_origin.python_file:
+            code_desc = f" for file {loadable_target_origin.python_file} "
+        elif loadable_target_origin.package_name:
+            code_desc = f" for package {loadable_target_origin.package_name} "
+        elif loadable_target_origin.module_name:
+            code_desc = f" for module {loadable_target_origin.module_name} "
+
+    server_desc = (
+        f"Dagster code server{code_desc}on port {port} in process {os.getpid()}"
+        if port
+        else f"Dagster code server{code_desc}in process {os.getpid()}"
+    )
+
+    logger.info("Starting %s", server_desc)
+
     server_termination_event = threading.Event()
     api_servicer = DagsterApiServer(
         server_termination_event=server_termination_event,
@@ -687,21 +704,6 @@ def grpc_command(
         host=host,
         max_workers=max_workers,
         logger=logger,
-    )
-
-    code_desc = " "
-    if loadable_target_origin:
-        if loadable_target_origin.python_file:
-            code_desc = f" for file {loadable_target_origin.python_file} "
-        elif loadable_target_origin.package_name:
-            code_desc = f" for package {loadable_target_origin.package_name} "
-        elif loadable_target_origin.module_name:
-            code_desc = f" for module {loadable_target_origin.module_name} "
-
-    server_desc = (
-        f"Dagster code server{code_desc}on port {port} in process {os.getpid()}"
-        if port
-        else f"Dagster code server{code_desc}in process {os.getpid()}"
     )
 
     logger.info("Started %s", server_desc)

--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -186,6 +186,23 @@ def start_command(
         python_file=python_file,
         package_name=kwargs["package_name"],
     )
+
+    code_desc = " "
+    if loadable_target_origin.python_file:
+        code_desc = f" for file {loadable_target_origin.python_file} "
+    elif loadable_target_origin.package_name:
+        code_desc = f" for package {loadable_target_origin.package_name} "
+    elif loadable_target_origin.module_name:
+        code_desc = f" for module {loadable_target_origin.module_name} "
+
+    server_desc = (
+        f"Dagster code proxy server{code_desc}on port {port} in process {os.getpid()}"
+        if port
+        else f"Dagster code proxy server{code_desc}in process {os.getpid()}"
+    )
+
+    logger.info("Starting %s", server_desc)
+
     server_termination_event = threading.Event()
 
     api_servicer = DagsterProxyApiServicer(
@@ -211,20 +228,6 @@ def start_command(
         host=host,
         max_workers=max_workers,
         logger=logger,
-    )
-
-    code_desc = " "
-    if loadable_target_origin.python_file:
-        code_desc = f" for file {loadable_target_origin.python_file} "
-    elif loadable_target_origin.package_name:
-        code_desc = f" for package {loadable_target_origin.package_name} "
-    elif loadable_target_origin.module_name:
-        code_desc = f" for module {loadable_target_origin.module_name} "
-
-    server_desc = (
-        f"Dagster code proxy server{code_desc}on port {port} in process {os.getpid()}"
-        if port
-        else f"Dagster code proxy server{code_desc}in process {os.getpid()}"
     )
 
     logger.info("Started %s", server_desc)


### PR DESCRIPTION
Summary:
This makes it easier to measure the amount of time it takes to start up a code server from process/task/pod logs.

Test Plan: Run "dagster api grpc" and "dagster code-server start" locally, view log output

## Summary & Motivation

## How I Tested These Changes
