### PR TITLE
[ui] Remove explicit Node install in build step

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster_ui.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster_ui.py
@@ -30,10 +30,6 @@ def build_dagster_ui_steps() -> List[CommandStep]:
         CommandStepBuilder(":typescript: dagster-ui")
         .run(
             "cd js_modules/dagster-ui",
-            # Explicitly install Node 16.x because BK is otherwise running 12.x.
-            # Todo: Fix BK images to use newer Node versions, remove this.
-            "curl -sL https://deb.nodesource.com/setup_16.x | bash -",
-            "apt-get -yqq --no-install-recommends install nodejs",
             "tox -vv -e py310",
         )
         .on_test_image(AvailablePythonVersion.get_default())


### PR DESCRIPTION
## Summary & Motivation

Buildkite is already installing Node 20, so we don't need this step anymore.

## How I Tested These Changes

Put up a fake JS change to trigger dagster-ui build. Verify that it passes.