### PR TITLE
[ui] Remove non-SDAs from global search

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/search/types/useGlobalSearch.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/types/useGlobalSearch.types.ts
@@ -71,6 +71,7 @@ export type SearchSecondaryQuery = {
           __typename: 'Asset';
           id: string;
           key: {__typename: 'AssetKey'; path: Array<string>};
+          definition: {__typename: 'AssetNode'; id: string} | null;
         }>;
       }
     | {__typename: 'PythonError'};

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -142,15 +142,17 @@ const secondaryDataToSearchResults = (input: {data?: SearchSecondaryQuery}) => {
   }
 
   const {nodes} = data.assetsOrError;
-  return nodes.map(({key}) => {
-    return {
-      label: displayNameForAssetKey(key),
-      href: assetDetailsPathForKey(key),
-      segments: key.path,
-      description: 'Asset',
-      type: SearchResultType.Asset,
-    };
-  });
+  return nodes
+    .filter(({definition}) => definition !== null)
+    .map(({key}) => {
+      return {
+        label: displayNameForAssetKey(key),
+        href: assetDetailsPathForKey(key),
+        segments: key.path,
+        description: 'Asset',
+        type: SearchResultType.Asset,
+      };
+    });
 };
 
 const fuseOptions = {
@@ -306,6 +308,9 @@ export const SEARCH_SECONDARY_QUERY = gql`
           id
           key {
             path
+          }
+          definition {
+            id
           }
         }
       }


### PR DESCRIPTION
## Summary & Motivation

Resolves #18669.

There is currently an issue where deleted SDAs are still appearing in search, because we can't currently know whether a deleted SDA is any different from a non-SDA.

To resolve this, just don't show non-SDA assets in global search. Thus, if the definition is deleted, it will no longer appear in search, though it will still appear in the asset catalog.

## How I Tested These Changes

Search for a non-SDA. Verify that it doesn't appear in global search.
