### PR TITLE
Add cpu/mem retrieval to grpc server

### DIFF
--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -9,7 +9,6 @@ import threading
 import time
 import uuid
 import warnings
-import pendulum
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack
@@ -62,6 +61,7 @@ from dagster._utils import (
     get_run_crash_explanation,
     safe_tempfile_path_unmanaged,
 )
+from dagster._utils.container import retrieve_containerized_utilization_metrics
 from dagster._utils.error import serializable_error_info_from_exc_info
 
 from .__generated__ import api_pb2
@@ -106,7 +106,6 @@ from .utils import (
     max_rx_bytes,
     max_send_bytes,
 )
-from dagster._utils.container import retrieve_containerized_cpu_time, retrieve_containerized_memory_limit, retrieve_containerized_memory_usage, retrieve_containerized_num_allocated_cores
 
 if TYPE_CHECKING:
     from multiprocessing.synchronize import Event as MPEvent
@@ -129,26 +128,18 @@ def _record_max_workers(max_workers: Optional[int]) -> None:
             max_workers if max_workers is not None else -1
         )
 
-def _record_cpu_utilization(logger: logging.Logger) -> None:
-    with _METRICS_LOCK:
-        last_cpu_measurement_time = _UTILIZATION_METRICS["general_info"].get("last_cpu_measurement_time")
-        last_cpu_measurement = _UTILIZATION_METRICS["general_info"].get("last_cpu_measurement")
-        cur_time = pendulum.now("UTC").timestamp()
-        cur_cpu_time_measurement = retrieve_containerized_cpu_time(logger)
-        num_cores = retrieve_containerized_num_allocated_cores(logger)
-        _UTILIZATION_METRICS["general_info"]["num_cores"] = num_cores
-        if last_cpu_measurement_time is not None and last_cpu_measurement is not None and num_cores is not None:
-            cpu_utilization = (cur_cpu_time_measurement - last_cpu_measurement) / (cur_time - last_cpu_measurement_time) / num_cores
-            _UTILIZATION_METRICS["general_info"]["cpu_utilization"] = cpu_utilization
-            _UTILIZATION_METRICS["general_info"]["last_cpu_measurement_time"] = cur_time
-            _UTILIZATION_METRICS["general_info"]["last_cpu_measurement"] = cur_cpu_time_measurement
 
-def _record_memory_utilization(logger: logging.Logger) -> None:
+def _record_utilization_metrics(logger: logging.Logger) -> None:
     with _METRICS_LOCK:
-        cur_memory_usage = retrieve_containerized_memory_usage(logger)
-        cur_memory_limit = retrieve_containerized_memory_limit(logger)
-        _UTILIZATION_METRICS["general_info"]["memory_usage"] = cur_memory_usage
-        _UTILIZATION_METRICS["general_info"]["memory_limit"] = cur_memory_limit
+        last_cpu_measurement_time = _UTILIZATION_METRICS["general_info"].get(
+            "measurement_timestamp"
+        )
+        last_cpu_measurement = _UTILIZATION_METRICS["general_info"].get("cpu_time")
+        utilization_metrics = retrieve_containerized_utilization_metrics(
+            logger, last_cpu_measurement_time, last_cpu_measurement
+        )
+        for key, val in utilization_metrics.items():
+            _UTILIZATION_METRICS["general_info"][key] = val
 
 
 class CouldNotBindGrpcServerToAddress(Exception):
@@ -478,8 +469,7 @@ class DagsterApiServer(DagsterApiServicer):
     def Ping(self, request, _context: grpc.ServicerContext) -> api_pb2.PingReply:
         echo = request.echo
         if self._enable_metrics:
-            _record_cpu_utilization(self._logger)
-            _record_memory_utilization(self._logger)
+            _record_utilization_metrics(self._logger)
         return api_pb2.PingReply(
             echo=echo, serialized_server_health_metadata=json.dumps(_UTILIZATION_METRICS)
         )

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_metrics.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_metrics.py
@@ -102,12 +102,11 @@ def test_ping_metrics_retrieval(provide_flag: bool):
             res = client.ping("blah")
             metadata = json.loads(res["serialized_server_health_metadata"])
             if provide_flag:
-                assert metadata == {
-                    "general_info": {
-                        "max_workers": -1  # Since max workers is not set.
-                    },
-                    "SyncExternalSensorExecution": {"current_count": 1},
-                }
+                assert "general_info" in metadata
+                assert "max_workers" in metadata["general_info"]
+                assert metadata["general_info"]["max_workers"] == -1
+                assert "SyncExternalSensorExecution" in metadata
+                assert metadata["SyncExternalSensorExecution"] == {"current_count": 1}
             else:
                 assert metadata == {}
     finally:


### PR DESCRIPTION
This PR builds upon the metrics retrieval APIs established in https://github.com/dagster-io/dagster/pull/18721 to also include CPU and memory utilization. Assuming that we're in agreement that this method of cpu/mem retrieval is reasonable, then I think this PR is quite straightforward.

I didn't add any new test for this functionality. It's a bit hard to put under test since the grpc server runs in another process (unless this doesn't need to be the case? But pretty sure it does since we're calling a terminal command), and mocks won't carry over. Open to suggestions for testing here.