### PR TITLE
temp fix for airflow tests on 2.8

### DIFF
--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -43,7 +43,7 @@ setup(
     extras_require={
         "kubernetes": ["kubernetes>=3.0.0", "cryptography>=2.0.0"],
         "test_airflow_2": [
-            "apache-airflow>=2.0.0",
+            "apache-airflow>=2.0.0,<2.8",
             "boto3>=1.26.7",
             "kubernetes>=10.0.1",
             "apache-airflow-providers-docker>=3.2.0,<4",


### PR DESCRIPTION
## Summary & Motivation

This is a temp fix that changes the expected count of certain log messages in some tests (broken for airflow 2.8).

## How I Tested These Changes

BK