### PR TITLE
moving to dagster 1.5 bc of pendulum 3 breakage

### DIFF
--- a/docs/dagster-university/pages/dagster-essentials/lesson-2/requirements-and-installation.md
+++ b/docs/dagster-university/pages/dagster-essentials/lesson-2/requirements-and-installation.md
@@ -31,5 +31,5 @@ pip --version
 To install Dagster into your current Python environment:
 
 ```shell
-pip install 'dagster~=1.4'
+pip install 'dagster~=1.5'
 ```


### PR DESCRIPTION
## Summary & Motivation

Because of the Pendulum 3 release, Dagster 1.4 has issues with the latest version of Pendulum and a vanilla install for of 1.4 will likely break on users.

Proposing we update to 1.5, but not update the content yet until we can carve cycles for it.

## How I Tested These Changes
