### PR TITLE
Don't replace airflow log handlers

### DIFF
--- a/python_modules/libraries/dagster-airflow/dagster_airflow/airflow_dag_converter.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/airflow_dag_converter.py
@@ -20,7 +20,6 @@ from dagster._core.definitions.node_definition import NodeDefinition
 from dagster_airflow.utils import (
     is_airflow_2_loaded_in_environment,
     normalized_name,
-    replace_airflow_logger_handlers,
 )
 
 if TYPE_CHECKING:
@@ -115,10 +114,9 @@ def make_dagster_op_from_airflow_task(
             importlib.reload(airflow)
         context.log.info(f"Running Airflow task: {task.task_id}")
 
-        with replace_airflow_logger_handlers():
-            dagrun = context.resources.airflow_db.get_dagrun(dag=dag)
-            ti = dagrun.get_task_instance(task_id=task.task_id)
-            ti.task = dag.get_task(task_id=task.task_id)
-            ti.run(ignore_ti_state=True)
+        dagrun = context.resources.airflow_db.get_dagrun(dag=dag)
+        ti = dagrun.get_task_instance(task_id=task.task_id)
+        ti.task = dag.get_task(task_id=task.task_id)
+        ti.run(ignore_ti_state=True)
 
     return _op

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/utils.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/utils.py
@@ -1,12 +1,9 @@
 import logging
 import os
-import sys
-from contextlib import contextmanager
-from typing import Generator, List, Mapping, Optional
+from typing import List, Mapping, Optional
 
 from airflow import __version__ as airflow_version
 from airflow.models.connection import Connection
-from airflow.settings import LOG_FORMAT
 from dagster._core.definitions.utils import VALID_NAME_REGEX
 from packaging import version
 
@@ -52,21 +49,6 @@ def normalized_name(dag_name, task_name=None) -> str:
         base_name += "__"
         base_name += "".join(c if VALID_NAME_REGEX.match(c) else "_" for c in task_name)
     return base_name
-
-
-@contextmanager
-def replace_airflow_logger_handlers() -> Generator[None, None, None]:
-    prev_airflow_handlers = logging.getLogger("airflow.task").handlers
-    try:
-        # Redirect airflow handlers to stdout / compute logs
-        handler = logging.StreamHandler(sys.stdout)
-        handler.setFormatter(logging.Formatter(LOG_FORMAT))
-        root = logging.getLogger("airflow.task")
-        root.handlers = [handler]
-        yield
-    finally:
-        # Restore previous log handlers
-        logging.getLogger("airflow.task").handlers = prev_airflow_handlers
 
 
 def serialize_connections(connections: List[Connection] = []) -> List[Mapping[str, Optional[str]]]:


### PR DESCRIPTION
I'm not entirely sure why this was added as part of:

https://github.com/dagster-io/dagster/commit/8359e3acb54c423fcb7d9760dcacd29e3e7a3f5f

Our test assertions around logging broke wtih the release of airflow 2.8; now everything gets logged twice:

https://github.com/dagster-io/dagster/pull/18838

Removing this causes our tests assertions around logging to pass. Curiously, they also pass on 2.7.3, 2.5.2, etc. So I suspect this has maybe outlived its usefulness. If we do find any old versions of Airflow where this is still needed, we could add a version check like we have elsewhere.
