### PR TITLE
Manually instrument workspace jobs root

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/performance.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/performance.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-type Trace = {
+type TraceData = {
   name: string;
   startTime: number;
   endTime: number | null;
 };
 
 class PointToPointInstrumentation {
-  private traces: {[traceId: string]: Trace} = {};
+  private traces: {[traceId: string]: TraceData} = {};
 
   startTrace(traceId: string, name: string): void {
     if (!traceId) {
@@ -62,3 +62,5 @@ export function useStartTrace(name: string) {
     [traceId],
   );
 }
+
+export type Trace = ReturnType<typeof useStartTrace>;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/Run.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/Run.tsx
@@ -31,7 +31,7 @@ import {LogsToolbar, LogType} from './LogsToolbar';
 import {RunActionButtons} from './RunActionButtons';
 import {RunContext} from './RunContext';
 import {IRunMetadataDict, RunMetadataProvider} from './RunMetadataProvider';
-import {useRunRootTrace} from './RunRootTrace';
+import {RunRootTrace} from './RunRootTrace';
 import {RunDagsterRunEventFragment, RunPageFragment} from './types/RunFragments.types';
 import {
   useComputeLogFileKeyForSelection,
@@ -42,7 +42,7 @@ import {useQueryPersistedLogFilter} from './useQueryPersistedLogFilter';
 interface RunProps {
   runId: string;
   run?: RunPageFragment;
-  trace: ReturnType<typeof useRunRootTrace>;
+  trace: RunRootTrace;
 }
 
 const runStatusFavicon = (status: RunStatus) => {
@@ -126,7 +126,7 @@ export const Run = (props: RunProps) => {
   );
 };
 
-const OnLogsLoaded = ({trace}: {trace: ReturnType<typeof useRunRootTrace>}) => {
+const OnLogsLoaded = ({trace}: {trace: RunRootTrace}) => {
   React.useLayoutEffect(() => {
     trace.onLogsLoaded();
   }, [trace]);

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
@@ -17,7 +17,7 @@ import {AssetKeyTagCollection, AssetCheckTagCollection} from './AssetTagCollecti
 import {Run} from './Run';
 import {RunConfigDialog} from './RunConfigDialog';
 import {RUN_PAGE_FRAGMENT} from './RunFragments';
-import {useRunRootTrace} from './RunRootTrace';
+import {RunRootTrace, useRunRootTrace} from './RunRootTrace';
 import {RunStatusTag} from './RunStatusTag';
 import {DagsterTag} from './RunTag';
 import {RunTimingTags} from './RunTimingTags';
@@ -88,7 +88,6 @@ export const RunRoot = () => {
 
     return null;
   }, [run, repoAddress]);
-
 
   return (
     <div
@@ -168,11 +167,7 @@ export const RunRoot = () => {
 // eslint-disable-next-line import/no-default-export
 export default RunRoot;
 
-const RunById = (props: {
-  data: RunRootQuery | undefined;
-  runId: string;
-  trace: ReturnType<typeof useRunRootTrace>;
-}) => {
+const RunById = (props: {data: RunRootQuery | undefined; runId: string; trace: RunRootTrace}) => {
   const {data, runId, trace} = props;
 
   if (!data || !data.pipelineRunOrError) {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRootTrace.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRootTrace.tsx
@@ -24,3 +24,5 @@ export const useRunRootTrace = () => {
     };
   }, [trace]);
 };
+
+export type RunRootTrace = ReturnType<typeof useRunRootTrace>;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceJobsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceJobsRoot.tsx
@@ -8,6 +8,7 @@ import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
+import {useStartTrace} from '../performance';
 
 import {VirtualizedJobTable} from './VirtualizedJobTable';
 import {WorkspaceHeader} from './WorkspaceHeader';
@@ -17,6 +18,7 @@ import {RepoAddress} from './types';
 import {WorkspaceJobsQuery, WorkspaceJobsQueryVariables} from './types/WorkspaceJobsRoot.types';
 
 export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
+  const trace = useStartTrace('WorkspaceJobsRoot');
   useTrackPageView();
 
   const repoName = repoAddressAsHumanString(repoAddress);
@@ -37,6 +39,13 @@ export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => 
     },
   );
   const {data, loading} = queryResultOverview;
+
+  React.useLayoutEffect(() => {
+    if (!loading) {
+      trace.endTrace();
+    }
+  }, [loading, trace]);
+
   const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();


### PR DESCRIPTION
## Summary & Motivation
As titled, we create a trace for the WorkspaceJobsRoot component. I might revisit some of the semantics here in the future, maybe instead of calling this a trace I might rename the API to call it a segment since really the trace this is going to be part of is a page load trace which will encapsulate this segment.

## How I Tested These Changes

console.log'd the "trace" finished when the data loaded.