### PR TITLE
[Asset graph sidebar] Repair smooth scrolling animation + fix gaps between gutter lines

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
@@ -77,7 +77,11 @@ export const AssetSidebarNode = ({
     <>
       <Box ref={elementRef} onClick={selectThisNode} padding={{left: 8}}>
         <BoxWrapper level={level}>
-          <Box padding={{right: 12}} flex={{direction: 'row', alignItems: 'center'}}>
+          <Box
+            padding={{right: 12}}
+            flex={{direction: 'row', alignItems: 'center'}}
+            style={{height: '32px'}}
+          >
             {showArrow ? (
               <UnstyledButton
                 $showFocusOutline

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -245,7 +245,7 @@ export const AssetGraphExplorerSidebar = React.memo(
       if (indexOfLastSelectedNode !== -1) {
         rowVirtualizer.scrollToIndex(indexOfLastSelectedNode, {
           align: 'center',
-          behavior: 'auto',
+          behavior: 'smooth',
         });
       }
       // Only scroll if the rootNodes changes or the selected node changes
@@ -253,12 +253,6 @@ export const AssetGraphExplorerSidebar = React.memo(
       // if we toggle a node above the selected node
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedNode, rootNodes, rowVirtualizer]);
-
-    React.useLayoutEffect(() => {
-      // Fix a weird issue where the sidebar doesn't measure the full height.
-      const id = setInterval(rowVirtualizer.measure, 1000);
-      return () => clearInterval(id);
-    }, [rowVirtualizer.measure]);
 
     return (
       <div style={{display: 'grid', gridTemplateRows: 'auto minmax(0, 1fr)', height: '100%'}}>
@@ -323,47 +317,38 @@ export const AssetGraphExplorerSidebar = React.memo(
                 const isGroupNode = 'groupName' in node;
                 const row = !isCodelocationNode && !isGroupNode ? graphData.nodes[node.id] : node;
                 return (
-                  <Row
-                    $height={size}
-                    $start={start}
-                    key={key}
-                    data-key={key}
-                    style={{overflow: 'visible'}}
-                    ref={rowVirtualizer.measureElement}
-                  >
-                    {row ? (
-                      <AssetSidebarNode
-                        isOpen={openNodes.has(nodePathKey(node))}
-                        fullAssetGraphData={fullAssetGraphData}
-                        node={row}
-                        level={node.level}
-                        isLastSelected={lastSelectedNode?.id === node.id}
-                        isSelected={
-                          selectedNode?.id === node.id || selectedNodes.includes(row as GraphNode)
-                        }
-                        toggleOpen={() => {
-                          setOpenNodes((nodes) => {
-                            const openNodes = new Set(nodes);
-                            const isOpen = openNodes.has(nodePathKey(node));
-                            if (isOpen) {
-                              openNodes.delete(nodePathKey(node));
-                            } else {
-                              openNodes.add(nodePathKey(node));
-                            }
-                            return openNodes;
-                          });
-                        }}
-                        selectNode={(e, id) => {
-                          selectNode(e, id);
-                        }}
-                        selectThisNode={(e) => {
-                          setSelectedNode(node);
-                          selectNode(e, node.id);
-                        }}
-                        explorerPath={explorerPath}
-                        onChangeExplorerPath={onChangeExplorerPath}
-                      />
-                    ) : null}
+                  <Row $height={size} $start={start} key={key} data-key={key}>
+                    <AssetSidebarNode
+                      isOpen={openNodes.has(nodePathKey(node))}
+                      fullAssetGraphData={fullAssetGraphData}
+                      node={row!}
+                      level={node.level}
+                      isLastSelected={lastSelectedNode?.id === node.id}
+                      isSelected={
+                        selectedNode?.id === node.id || selectedNodes.includes(row as GraphNode)
+                      }
+                      toggleOpen={() => {
+                        setOpenNodes((nodes) => {
+                          const openNodes = new Set(nodes);
+                          const isOpen = openNodes.has(nodePathKey(node));
+                          if (isOpen) {
+                            openNodes.delete(nodePathKey(node));
+                          } else {
+                            openNodes.add(nodePathKey(node));
+                          }
+                          return openNodes;
+                        });
+                      }}
+                      selectNode={(e, id) => {
+                        selectNode(e, id);
+                      }}
+                      selectThisNode={(e) => {
+                        setSelectedNode(node);
+                        selectNode(e, node.id);
+                      }}
+                      explorerPath={explorerPath}
+                      onChangeExplorerPath={onChangeExplorerPath}
+                    />
                   </Row>
                 );
               })}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
@@ -1,4 +1,5 @@
 import {Box} from '@dagster-io/ui-components';
+import {VirtualizerOptions, elementScroll} from '@tanstack/react-virtual';
 import * as React from 'react';
 import styled from 'styled-components';
 
@@ -75,7 +76,7 @@ export const Row = styled.div.attrs<RowProps>(({$height, $start}) => ({
   position: absolute;
   right: 0;
   top: 0;
-  overflow: hidden;
+  overflow: visible;
 `;
 
 type DynamicRowContainerProps = {$start: number};

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
@@ -1,5 +1,4 @@
 import {Box} from '@dagster-io/ui-components';
-import {VirtualizerOptions, elementScroll} from '@tanstack/react-virtual';
 import * as React from 'react';
 import styled from 'styled-components';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
@@ -75,7 +75,7 @@ export const Row = styled.div.attrs<RowProps>(({$height, $start}) => ({
   position: absolute;
   right: 0;
   top: 0;
-  overflow: visible;
+  overflow: hidden;
 `;
 
 type DynamicRowContainerProps = {$start: number};


### PR DESCRIPTION
## Summary & Motivation

1. Add back smooth scrolling
2. Remove the gutter line gaps



## How I Tested These Changes


Before:

![image](https://github.com/dagster-io/dagster/assets/2286579/15421e82-bcfe-4565-9278-4211b40d8930)

After:
<img width="323" alt="Screenshot 2023-12-21 at 10 30 08 AM" src="https://github.com/dagster-io/dagster/assets/2286579/8c9cee99-601f-49d2-aea4-3f9743893715">
