### PR TITLE
[Asset graph sidebar] Hide group/code location nodes when theres only 1 group

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
@@ -102,7 +102,12 @@ export const AssetSidebarNode = ({
                   style={{transform: isOpen ? 'rotate(0deg)' : 'rotate(-90deg)'}}
                 />
               </UnstyledButton>
+            ) : level === 1 && isAssetNode ? (
+              // Special case for when asset nodes are at the root (level = 1) due to their being only a single group.
+              // In this case we don't need the spacer div to align nodes because  none of the nodes will be collapsible/un-collapsible.
+              <div />
             ) : (
+              // Spacer div to align nodes with collapse/un-collapse arrows with nodes that don't have collapse/un-collapse arrows
               <div style={{width: 18}} />
             )}
             <GrayOnHoverBox


### PR DESCRIPTION
## Summary & Motivation

We want to hide the code location and group nodes in the case where theres only a single group/code location

## How I Tested These Changes


Before vs after:
<img width="362" alt="Screenshot 2023-12-21 at 11 26 33 AM" src="https://github.com/dagster-io/dagster/assets/2286579/b6d391f7-46fb-408a-bd23-d5156d4c8819">
<img width="353" alt="Screenshot 2023-12-21 at 11 26 52 AM" src="https://github.com/dagster-io/dagster/assets/2286579/2b48b365-648b-43ca-9525-ee82875fc0c6">

Verified that global asset graph is unaffected:
<img width="346" alt="Screenshot 2023-12-21 at 11 28 36 AM" src="https://github.com/dagster-io/dagster/assets/2286579/5c40b40c-5fdf-45a1-953c-b0070f92251b">

Although selecting a single group via the filters does result in this in the global asset graph too:

<img width="569" alt="Screenshot 2023-12-21 at 11 29 02 AM" src="https://github.com/dagster-io/dagster/assets/2286579/2d3f6d62-8168-4d5d-b040-f30a2a028543">
