### PR TITLE
[Asset graph] Hide left nav when viewing global asset graph

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -181,7 +181,7 @@ type WithDataProps = Props & {
 
   filterButton?: React.ReactNode;
   filterBar?: React.ReactNode;
-  isGlobalGraph: boolean;
+  isGlobalGraph?: boolean;
 };
 
 const AssetGraphExplorerWithData = ({

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -89,6 +89,7 @@ type Props = {
   explorerPath: ExplorerPath;
   onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
   onNavigateToSourceAssetNode: (node: AssetLocation) => void;
+  isGlobalGraph?: boolean;
 } & OptionalFilters;
 
 export const MINIMAL_SCALE = 0.6;
@@ -180,6 +181,7 @@ type WithDataProps = Props & {
 
   filterButton?: React.ReactNode;
   filterBar?: React.ReactNode;
+  isGlobalGraph: boolean;
 };
 
 const AssetGraphExplorerWithData = ({
@@ -197,6 +199,7 @@ const AssetGraphExplorerWithData = ({
   filterBar,
   filters,
   setFilters,
+  isGlobalGraph = false,
 }: WithDataProps) => {
   const findAssetLocation = useFindAssetLocation();
   const {flagDAGSidebar} = useFeatureFlags();
@@ -769,6 +772,7 @@ const AssetGraphExplorerWithData = ({
         first={
           showSidebar ? (
             <AssetGraphExplorerSidebar
+              isGlobalGraph={isGlobalGraph}
               allAssetKeys={allAssetKeys}
               assetGraphData={assetGraphData}
               fullAssetGraphData={fullAssetGraphData}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
@@ -102,7 +102,12 @@ export const AssetSidebarNode = ({
                   style={{transform: isOpen ? 'rotate(0deg)' : 'rotate(-90deg)'}}
                 />
               </UnstyledButton>
+            ) : level === 1 && isAssetNode ? (
+              // Special case for when asset nodes are at the root (level = 1) due to their being only a single group.
+              // In this case we don't need the spacer div to align nodes because  none of the nodes will be collapsible/un-collapsible.
+              <div />
             ) : (
+              // Spacer div to align nodes with collapse/un-collapse arrows with nodes that don't have collapse/un-collapse arrows
               <div style={{width: 18}} />
             )}
             <GrayOnHoverBox

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -2,6 +2,7 @@ import {Button, Icon, Tooltip, Box} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import React from 'react';
 
+import {LayoutContext} from '../../app/LayoutProvider';
 import {AssetKey} from '../../assets/types';
 import {ExplorerPath} from '../../pipelines/PipelinePathUtils';
 import {Container, Inner, Row} from '../../ui/VirtualizedTable';
@@ -101,7 +102,7 @@ export const AssetGraphExplorerSidebar = React.memo(
       [graphData],
     );
 
-    const renderedNodes = React.useMemo(() => {
+    const {folderNodes: renderedNodes, groupsCount} = React.useMemo(() => {
       const folderNodes: FolderNodeType[] = [];
 
       // Map of Code Locations -> Groups -> Assets
@@ -161,16 +162,30 @@ export const AssetGraphExplorerSidebar = React.memo(
       });
 
       if (groupsCount === 1) {
-        return folderNodes
-          .filter((node) => node.level === 3)
-          .map((node) => ({
-            ...node,
-            level: 1,
-          }));
+        return {
+          folderNodes: folderNodes
+            .filter((node) => node.level === 3)
+            .map((node) => ({
+              ...node,
+              level: 1,
+            })),
+          groupsCount,
+        };
       }
 
-      return folderNodes;
+      return {folderNodes, groupsCount};
     }, [graphData.nodes, openNodes]);
+
+    const {nav} = React.useContext(LayoutContext);
+
+    React.useEffect(() => {
+      if (groupsCount === 1) {
+        // Close the left sidebar if there's only 1 group and this is the first render
+        nav.close();
+      }
+      // Exclude groupsCount so that we don't close the left nav due to filtering changing
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [nav.close]);
 
     const containerRef = React.useRef<HTMLDivElement | null>(null);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -25,6 +25,7 @@ export const AssetGraphExplorerSidebar = React.memo(
     onChangeExplorerPath,
     allAssetKeys,
     hideSidebar,
+    isGlobalGraph,
   }: {
     assetGraphData: GraphData;
     fullAssetGraphData: GraphData;
@@ -36,6 +37,7 @@ export const AssetGraphExplorerSidebar = React.memo(
     expandedGroups: string[];
     setExpandedGroups: (a: string[]) => void;
     hideSidebar: () => void;
+    isGlobalGraph: boolean;
   }) => {
     const lastSelectedNode = selectedNodes[selectedNodes.length - 1];
     // In the empty stay when no query is typed use the full asset graph data to populate the sidebar
@@ -179,14 +181,14 @@ export const AssetGraphExplorerSidebar = React.memo(
     const {nav} = React.useContext(LayoutContext);
 
     React.useEffect(() => {
-      if (groupsCount > 1) {
+      if (isGlobalGraph) {
         // Close the left sidebar if there's more than 1 group (if viewing more than 1 group then this is the global asset graph)
         // to avoid duplication between the global left sidebar and the graph's left sidebar.
         nav.close();
       }
       // Exclude groupsCount so that we don't close the left nav due to filtering changing
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [nav.close]);
+    }, [isGlobalGraph]);
 
     const containerRef = React.useRef<HTMLDivElement | null>(null);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -179,11 +179,8 @@ export const AssetGraphExplorerSidebar = React.memo(
 
     React.useEffect(() => {
       if (isGlobalGraph) {
-        // Close the left sidebar if there's more than 1 group (if viewing more than 1 group then this is the global asset graph)
-        // to avoid duplication between the global left sidebar and the graph's left sidebar.
         nav.close();
       }
-      // Exclude groupsCount so that we don't close the left nav due to filtering changing
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isGlobalGraph]);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -102,11 +102,7 @@ export const AssetGraphExplorerSidebar = React.memo(
       [graphData],
     );
 
-<<<<<<< HEAD
     const {folderNodes: renderedNodes, groupsCount} = React.useMemo(() => {
-=======
-    const renderedNodes = React.useMemo(() => {
->>>>>>> 9d0ceeed5d179a50bd25a0a687495f6dc0a1002c
       const folderNodes: FolderNodeType[] = [];
 
       // Map of Code Locations -> Groups -> Assets

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -179,8 +179,9 @@ export const AssetGraphExplorerSidebar = React.memo(
     const {nav} = React.useContext(LayoutContext);
 
     React.useEffect(() => {
-      if (groupsCount === 1) {
-        // Close the left sidebar if there's only 1 group and this is the first render
+      if (groupsCount > 1) {
+        // Close the left sidebar if there's more than 1 group (if viewing more than 1 group then this is the global asset graph)
+        // to avoid duplication between the global left sidebar and the graph's left sidebar.
         nav.close();
       }
       // Exclude groupsCount so that we don't close the left nav due to filtering changing

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -104,7 +104,7 @@ export const AssetGraphExplorerSidebar = React.memo(
       [graphData],
     );
 
-    const {folderNodes: renderedNodes, groupsCount} = React.useMemo(() => {
+    const renderedNodes = React.useMemo(() => {
       const folderNodes: FolderNodeType[] = [];
 
       // Map of Code Locations -> Groups -> Assets
@@ -164,18 +164,15 @@ export const AssetGraphExplorerSidebar = React.memo(
       });
 
       if (groupsCount === 1) {
-        return {
-          folderNodes: folderNodes
-            .filter((node) => node.level === 3)
-            .map((node) => ({
-              ...node,
-              level: 1,
-            })),
-          groupsCount,
-        };
+        return folderNodes
+          .filter((node) => node.level === 3)
+          .map((node) => ({
+            ...node,
+            level: 1,
+          }));
       }
 
-      return {folderNodes, groupsCount};
+      return folderNodes;
     }, [graphData.nodes, openNodes]);
 
     const {nav} = React.useContext(LayoutContext);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
@@ -102,6 +102,7 @@ export const AssetsGroupsGlobalGraphRoot = () => {
         explorerPath={globalAssetGraphPathFromString(path)}
         onChangeExplorerPath={onChangeExplorerPath}
         onNavigateToSourceAssetNode={onNavigateToSourceAssetNode}
+        isGlobalGraph
       />
     </Page>
   );


### PR DESCRIPTION
## Summary & Motivation

If there's only a single group then we hide the left nav by default

## How I Tested These Changes

https://github.com/dagster-io/dagster/assets/2286579/3b198726-09ee-428c-8f16-785a0f56b91e

