### PR TITLE
[amp-refactor][10/n] Improve backcompat logic

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -192,15 +192,16 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
         record: AutoMaterializeAssetEvaluationRecord,
         partitions_def: Optional[PartitionsDefinition],
     ):
+        evaluation_with_run_ids = record.get_evaluation_with_run_ids(partitions_def=partitions_def)
         super().__init__(
             id=record.id,
             evaluationId=record.evaluation_id,
-            numRequested=record.evaluation.true_subset.size,
+            numRequested=evaluation_with_run_ids.evaluation.true_subset.size,
             numSkipped=0,
             numDiscarded=0,
             rulesWithRuleEvaluations=[],
             timestamp=record.timestamp,
-            runIds=record.run_ids,
+            runIds=evaluation_with_run_ids.run_ids,
             rules=[],
             assetKey=GrapheneAssetKey(path=record.asset_key.path),
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition_evaluation_context.py
@@ -227,11 +227,17 @@ class AssetConditionEvaluationContext:
         """Returns the set of candidates for this tick which were not candidates on the previous
         tick.
         """
+        from .asset_condition import HistoricalAllPartitionsSubsetSentinel
+
         if not self.previous_condition_evaluation:
             return self.candidate_subset
-        # when the candidate_subset is None, this indicates that the entire asset was evaluated
-        # for this condition on the previous tick
-        elif self.previous_condition_evaluation.candidate_subset is None:
+        # when the candidate_subset is HistoricalAllPartitionsSubsetSentinel, this indicates that the
+        # entire asset was evaluated for this condition on the previous tick, and so no candidates
+        # were *not* evaluated on the previous tick
+        elif isinstance(
+            self.previous_condition_evaluation.candidate_subset,
+            HistoricalAllPartitionsSubsetSentinel,
+        ):
             return self.empty_subset()
         return self.candidate_subset - self.previous_condition_evaluation.candidate_subset
 

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -7,10 +7,13 @@ from typing_extensions import TypeAlias
 import dagster._check as check
 from dagster._core.definitions import RunRequest
 from dagster._core.definitions.asset_condition import (
-    AssetConditionEvaluation,
     AssetConditionEvaluationWithRunIds,
 )
+from dagster._core.definitions.auto_materialize_rule_evaluation import (
+    deserialize_auto_materialize_asset_evaluation_to_asset_condition_evaluation_with_run_ids,
+)
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.partition import PartitionsDefinition
 
 # re-export
 from dagster._core.definitions.run_request import (
@@ -21,6 +24,7 @@ from dagster._core.definitions.selector import InstigatorSelector, RepositorySel
 from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.host_representation.origin import ExternalInstigatorOrigin
 from dagster._serdes import create_snapshot_id
+from dagster._serdes.errors import DeserializationError
 from dagster._serdes.serdes import (
     EnumSerializer,
     deserialize_value,
@@ -726,7 +730,7 @@ def _validate_tick_args(
 
 class AutoMaterializeAssetEvaluationRecord(NamedTuple):
     id: int
-    evaluation_with_run_ids: AssetConditionEvaluationWithRunIds
+    serialized_evaluation_body: str
     evaluation_id: int
     timestamp: float
     asset_key: AssetKey
@@ -735,18 +739,24 @@ class AutoMaterializeAssetEvaluationRecord(NamedTuple):
     def from_db_row(cls, row) -> "AutoMaterializeAssetEvaluationRecord":
         return cls(
             id=row["id"],
-            evaluation_with_run_ids=deserialize_value(
-                row["asset_evaluation_body"], AssetConditionEvaluationWithRunIds
-            ),
+            serialized_evaluation_body=row["asset_evaluation_body"],
             evaluation_id=row["evaluation_id"],
             timestamp=datetime_as_float(row["create_timestamp"]),
             asset_key=check.not_none(AssetKey.from_db_string(row["asset_key"])),
         )
 
-    @property
-    def run_ids(self) -> AbstractSet[str]:
-        return self.evaluation_with_run_ids.run_ids
-
-    @property
-    def evaluation(self) -> AssetConditionEvaluation:
-        return self.evaluation_with_run_ids.evaluation
+    def get_evaluation_with_run_ids(
+        self, partitions_def: Optional[PartitionsDefinition]
+    ) -> AssetConditionEvaluationWithRunIds:
+        try:
+            # If this was serialized as an AssetConditionEvaluationWithRunIds, we can deserialize
+            # this directly
+            return deserialize_value(
+                self.serialized_evaluation_body, AssetConditionEvaluationWithRunIds
+            )
+        except DeserializationError:
+            # If this is a legacy AutoMaterializeAssetEvaluation, we need to pass in the partitions
+            # definition in order to be able to deserialize the evaluation properly
+            return deserialize_auto_materialize_asset_evaluation_to_asset_condition_evaluation_with_run_ids(
+                self.serialized_evaluation_body, partitions_def
+            )

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -740,7 +740,11 @@ class AssetDaemon(DagsterDaemon):
                         )
                     )
                     evaluations_by_asset_key = {
-                        evaluation_record.asset_key: evaluation_record.evaluation_with_run_ids
+                        evaluation_record.asset_key: evaluation_record.get_evaluation_with_run_ids(
+                            partitions_def=asset_graph.get_partitions_def(
+                                evaluation_record.asset_key
+                            )
+                        )
                         for evaluation_record in evaluation_records
                     }
                 else:

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -499,7 +499,9 @@ class AssetDaemonScenarioState(NamedTuple):
                 )
             ]
             new_evaluations = [
-                e.evaluation
+                e.get_evaluation_with_run_ids(
+                    self.asset_graph.get_partitions_def(e.asset_key)
+                ).evaluation
                 for e in check.not_none(
                     self.instance.schedule_storage
                 ).get_auto_materialize_evaluations_for_evaluation_id(new_cursor.evaluation_id)
@@ -627,7 +629,7 @@ class AssetDaemonScenarioState(NamedTuple):
             )
             if key in (run.asset_selection or set())
         }
-        evaluation_with_run_ids = next(
+        evaluation_record = next(
             iter(
                 [
                     e
@@ -638,7 +640,12 @@ class AssetDaemonScenarioState(NamedTuple):
                 ]
             )
         )
-        assert new_run_ids_for_asset == evaluation_with_run_ids.run_ids
+        assert (
+            new_run_ids_for_asset
+            == evaluation_record.get_evaluation_with_run_ids(
+                self.asset_graph.get_partitions_def(key)
+            ).run_ids
+        )
 
     def assert_evaluation(
         self,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_failure_recovery.py
@@ -504,8 +504,12 @@ def test_asset_daemon_crash_recovery(daemon_not_paused_instance, crash_location)
         asset_key=AssetKey("hourly"), limit=100
     )
     assert len(evaluations) == 1
-    assert evaluations[0].evaluation.asset_key == AssetKey("hourly")
-    assert evaluations[0].run_ids == {run.run_id for run in sorted_runs}
+    assert evaluations[0].get_evaluation_with_run_ids(None).evaluation.asset_key == AssetKey(
+        "hourly"
+    )
+    assert evaluations[0].get_evaluation_with_run_ids(None).run_ids == {
+        run.run_id for run in sorted_runs
+    }
 
 
 @pytest.mark.parametrize(
@@ -611,8 +615,12 @@ def test_asset_daemon_exception_recovery(daemon_not_paused_instance, crash_locat
         asset_key=AssetKey("hourly"), limit=100
     )
     assert len(evaluations) == 1
-    assert evaluations[0].evaluation.asset_key == AssetKey("hourly")
-    assert evaluations[0].run_ids == {run.run_id for run in sorted_runs}
+    assert evaluations[0].get_evaluation_with_run_ids(None).evaluation.asset_key == AssetKey(
+        "hourly"
+    )
+    assert evaluations[0].get_evaluation_with_run_ids(None).run_ids == {
+        run.run_id for run in sorted_runs
+    }
 
     cursor = _get_pre_sensor_auto_materialize_serialized_cursor(instance)
     assert cursor

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cursor_migration_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cursor_migration_scenarios.py
@@ -1,19 +1,25 @@
-from dagster import (
-    AutoMaterializeRule,
-)
+from dagster import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_rule import DiscardOnMaxMaterializationsExceededRule
+
+from dagster_tests.definitions_tests.auto_materialize_tests.updated_scenarios.cron_scenarios import (
+    basic_hourly_cron_rule,
+    get_cron_policy,
+)
 
 from ..asset_daemon_scenario import (
     AssetDaemonScenario,
     AssetRuleEvaluationSpec,
     day_partition_key,
+    hour_partition_key,
 )
 from ..base_scenario import (
     run_request,
 )
 from .asset_daemon_scenario_states import (
     daily_partitions_def,
+    hourly_partitions_def,
     one_asset,
+    three_assets_in_sequence,
     time_partitions_start_str,
 )
 
@@ -50,5 +56,121 @@ cursor_migration_scenarios = [
         .evaluate_tick("a")
         # the new cursor "remembers" that a bunch of partitions were discarded
         .assert_requested_runs(),
+    ),
+    AssetDaemonScenario(
+        id="one_asset_daily_partitions_two_years_never_materialized_migrate_after_run_requested",
+        initial_state=one_asset.with_asset_properties(partitions_def=daily_partitions_def)
+        .with_current_time(time_partitions_start_str)
+        .with_current_time_advanced(years=2, hours=4)
+        .with_all_eager(),
+        execution_fn=lambda state: state.evaluate_tick()
+        .assert_requested_runs(
+            run_request(asset_keys=["A"], partition_key=day_partition_key(state.current_time))
+        )
+        .with_serialized_cursor(
+            # this cursor was generate by running the above scenario before the cursor changes
+            """
+{"latest_storage_id": null, "handled_root_asset_keys": [], "handled_root_partitions_by_asset_key": {"A": "{\\"version\\": 1, \\"time_windows\\": [[1357344000.0, 1420416000.0]], \\"num_partitions\\": 730}"}, "evaluation_id": 1, "last_observe_request_timestamp_by_asset_key": {}, "latest_evaluation_by_asset_key": {"A": "{\\"__class__\\": \\"AutoMaterializeAssetEvaluation\\", \\"asset_key\\": {\\"__class__\\": \\"AssetKey\\", \\"path\\": [\\"A\\"]}, \\"num_discarded\\": 729, \\"num_requested\\": 1, \\"num_skipped\\": 0, \\"partition_subsets_by_condition\\": [[{\\"__class__\\": \\"AutoMaterializeRuleEvaluation\\", \\"evaluation_data\\": null, \\"rule_snapshot\\": {\\"__class__\\": \\"AutoMaterializeRuleSnapshot\\", \\"class_name\\": \\"MaterializeOnMissingRule\\", \\"decision_type\\": {\\"__enum__\\": \\"AutoMaterializeDecisionType.MATERIALIZE\\"}, \\"description\\": \\"materialization is missing\\"}}, {\\"__class__\\": \\"SerializedPartitionsSubset\\", \\"serialized_partitions_def_class_name\\": \\"DailyPartitionsDefinition\\", \\"serialized_partitions_def_unique_id\\": \\"809725ad60ffac0302d5c81f6e45865e21ec0b85\\", \\"serialized_subset\\": \\"{\\\\\\"version\\\\\\": 1, \\\\\\"time_windows\\\\\\": [[1357344000.0, 1420416000.0]], \\\\\\"num_partitions\\\\\\": 730}\\"}], [{\\"__class__\\": \\"AutoMaterializeRuleEvaluation\\", \\"evaluation_data\\": null, \\"rule_snapshot\\": {\\"__class__\\": \\"AutoMaterializeRuleSnapshot\\", \\"class_name\\": \\"DiscardOnMaxMaterializationsExceededRule\\", \\"decision_type\\": {\\"__enum__\\": \\"AutoMaterializeDecisionType.DISCARD\\"}, \\"description\\": \\"exceeds 1 materialization(s) per minute\\"}}, {\\"__class__\\": \\"SerializedPartitionsSubset\\", \\"serialized_partitions_def_class_name\\": \\"DailyPartitionsDefinition\\", \\"serialized_partitions_def_unique_id\\": \\"809725ad60ffac0302d5c81f6e45865e21ec0b85\\", \\"serialized_subset\\": \\"{\\\\\\"version\\\\\\": 1, \\\\\\"time_windows\\\\\\": [[1357344000.0, 1420329600.0]], \\\\\\"num_partitions\\\\\\": 729}\\"}]], \\"rule_snapshots\\": [{\\"__class__\\": \\"AutoMaterializeRuleSnapshot\\", \\"class_name\\": \\"SkipOnParentMissingRule\\", \\"decision_type\\": {\\"__enum__\\": \\"AutoMaterializeDecisionType.SKIP\\"}, \\"description\\": \\"waiting on upstream data to be present\\"}, {\\"__class__\\": \\"AutoMaterializeRuleSnapshot\\", \\"class_name\\": \\"MaterializeOnRequiredForFreshnessRule\\", \\"decision_type\\": {\\"__enum__\\": \\"AutoMaterializeDecisionType.MATERIALIZE\\"}, \\"description\\": \\"required to meet this or downstream asset's freshness policy\\"}, {\\"__class__\\": \\"AutoMaterializeRuleSnapshot\\", \\"class_name\\": \\"MaterializeOnParentUpdatedRule\\", \\"decision_type\\": {\\"__enum__\\": \\"AutoMaterializeDecisionType.MATERIALIZE\\"}, \\"description\\": \\"upstream data has changed since latest materialization\\"}, {\\"__class__\\": \\"AutoMaterializeRuleSnapshot\\", \\"class_name\\": \\"SkipOnBackfillInProgressRule\\", \\"decision_type\\": {\\"__enum__\\": \\"AutoMaterializeDecisionType.SKIP\\"}, \\"description\\": \\"targeted by an in-progress backfill\\"}, {\\"__class__\\": \\"AutoMaterializeRuleSnapshot\\", \\"class_name\\": \\"SkipOnParentOutdatedRule\\", \\"decision_type\\": {\\"__enum__\\": \\"AutoMaterializeDecisionType.SKIP\\"}, \\"description\\": \\"waiting on upstream data to be up to date\\"}, {\\"__class__\\": \\"AutoMaterializeRuleSnapshot\\", \\"class_name\\": \\"MaterializeOnMissingRule\\", \\"decision_type\\": {\\"__enum__\\": \\"AutoMaterializeDecisionType.MATERIALIZE\\"}, \\"description\\": \\"materialization is missing\\"}, {\\"__class__\\": \\"AutoMaterializeRuleSnapshot\\", \\"class_name\\": \\"SkipOnRequiredButNonexistentParentsRule\\", \\"decision_type\\": {\\"__enum__\\": \\"AutoMaterializeDecisionType.SKIP\\"}, \\"description\\": \\"required parent partitions do not exist\\"}], \\"run_ids\\": {\\"__set__\\": []}}"}, "latest_evaluation_timestamp": 1420430400.0}
+"""
+        )
+        .evaluate_tick()
+        # the new cursor should not kick off a new run because the previous tick already requested one
+        .assert_requested_runs(),
+    ),
+    AssetDaemonScenario(
+        id="partitioned_non_root_asset_missing_after_migrate",
+        initial_state=three_assets_in_sequence.with_asset_properties(
+            partitions_def=daily_partitions_def
+        )
+        .with_current_time(time_partitions_start_str)
+        .with_current_time_advanced(days=10, hours=4)
+        .with_all_eager(),
+        execution_fn=lambda state: state.evaluate_tick()
+        .assert_requested_runs(
+            run_request(
+                asset_keys=["A", "B", "C"], partition_key=day_partition_key(state.current_time)
+            )
+        )
+        # materialize the previous day's partitions manually
+        .with_runs(
+            run_request(
+                asset_keys=["A", "B", "C"],
+                partition_key=day_partition_key(state.current_time, delta=-1),
+            )
+        )
+        .evaluate_tick()
+        .assert_requested_runs()
+        # now update the cursor -- this serialized cursor does not contain any information about
+        # the missing partitions for B or C, because we used to only track this information for
+        # root assets. B or C also has not been materialized since the previous tick
+        .with_serialized_cursor(
+            """{"latest_storage_id": 24, "handled_root_asset_keys": [], "handled_root_partitions_by_asset_key": {"A": "{\\"version\\": 1, \\"time_windows\\": [[1357344000.0, 1358208000.0]], \\"num_partitions\\": 10}", "B": "{\\"version\\": 1, \\"time_windows\\": [], \\"num_partitions\\": 0}", "C": "{\\"version\\": 1, \\"time_windows\\": [], \\"num_partitions\\": 0}"}, "evaluation_id": 2, "last_observe_request_timestamp_by_asset_key": {}, "latest_evaluation_by_asset_key": {}, "latest_evaluation_timestamp": 1358222400.164996}"""
+        )
+        .evaluate_tick()
+        # when getting the new cursor, we should realize that B and C are not missing any partitions
+        # that can be materialized
+        .assert_requested_runs(),
+    ),
+    AssetDaemonScenario(
+        id="basic_hourly_cron_unpartitioned_migrate",
+        initial_state=one_asset.with_asset_properties(
+            auto_materialize_policy=get_cron_policy(basic_hourly_cron_rule)
+        ).with_current_time("2020-01-01T00:05"),
+        execution_fn=lambda state: state.evaluate_tick()
+        .assert_requested_runs(run_request(["A"]))
+        .assert_evaluation("A", [AssetRuleEvaluationSpec(basic_hourly_cron_rule)])
+        # next tick should not request any more runs
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs()
+        # still no runs should be requested
+        .with_current_time_advanced(minutes=50)
+        .evaluate_tick()
+        .assert_requested_runs()
+        # moved to a new cron schedule tick, request another run
+        .with_current_time_advanced(minutes=10)
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["A"]))
+        .assert_evaluation("A", [AssetRuleEvaluationSpec(basic_hourly_cron_rule)])
+        # next tick should not request any more runs
+        .with_serialized_cursor(
+            """{"latest_storage_id": null, "handled_root_asset_keys": ["A"], "handled_root_partitions_by_asset_key": {}, "evaluation_id": 4, "last_observe_request_timestamp_by_asset_key": {}, "latest_evaluation_by_asset_key": {"A": "{\\"__class__\\": \\"AutoMaterializeAssetEvaluation\\", \\"asset_key\\": {\\"__class__\\": \\"AssetKey\\", \\"path\\": [\\"A\\"]}, \\"num_discarded\\": 0, \\"num_requested\\": 1, \\"num_skipped\\": 0, \\"partition_subsets_by_condition\\": [[{\\"__class__\\": \\"AutoMaterializeRuleEvaluation\\", \\"evaluation_data\\": null, \\"rule_snapshot\\": {\\"__class__\\": \\"AutoMaterializeRuleSnapshot\\", \\"class_name\\": \\"MaterializeOnCronRule\\", \\"decision_type\\": {\\"__enum__\\": \\"AutoMaterializeDecisionType.MATERIALIZE\\"}, \\"description\\": \\"not materialized since last cron schedule tick of '0 * * * *' (timezone: UTC)\\"}}, null]], \\"rule_snapshots\\": [{\\"__class__\\": \\"AutoMaterializeRuleSnapshot\\", \\"class_name\\": \\"MaterializeOnCronRule\\", \\"decision_type\\": {\\"__enum__\\": \\"AutoMaterializeDecisionType.MATERIALIZE\\"}, \\"description\\": \\"not materialized since last cron schedule tick of '0 * * * *' (timezone: UTC)\\"}, {\\"__class__\\": \\"AutoMaterializeRuleSnapshot\\", \\"class_name\\": \\"SkipOnNotAllParentsUpdatedRule\\", \\"decision_type\\": {\\"__enum__\\": \\"AutoMaterializeDecisionType.SKIP\\"}, \\"description\\": \\"waiting on upstream data to be updated\\"}], \\"run_ids\\": {\\"__set__\\": []}}"}, "latest_evaluation_timestamp": 1577840730.0}"""
+        )
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs(),
+    ),
+    AssetDaemonScenario(
+        id="basic_hourly_cron_partitioned_migrate",
+        initial_state=one_asset.with_asset_properties(
+            partitions_def=hourly_partitions_def,
+            auto_materialize_policy=get_cron_policy(basic_hourly_cron_rule),
+        )
+        .with_current_time(time_partitions_start_str)
+        .with_current_time_advanced(days=1, minutes=5),
+        execution_fn=lambda state: state.evaluate_tick()
+        .assert_requested_runs(run_request(["A"], hour_partition_key(state.current_time)))
+        .assert_evaluation(
+            "A",
+            [
+                AssetRuleEvaluationSpec(
+                    basic_hourly_cron_rule, [hour_partition_key(state.current_time)]
+                )
+            ],
+        )
+        # next tick should not request any more runs
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs()
+        # still no runs should be requested
+        .with_current_time_advanced(minutes=50)
+        .evaluate_tick()
+        .assert_requested_runs()
+        # moved to a new cron schedule tick, request another run for the new partition
+        .with_current_time_advanced(minutes=10)
+        .evaluate_tick(
+            """{"latest_storage_id": null, "handled_root_asset_keys": [], "handled_root_partitions_by_asset_key": {"A": "{\"version\": 1, \"time_windows\": [[1357426800.0, 1357430400.0]], \"num_partitions\": 1}"}, "evaluation_id": 2, "last_observe_request_timestamp_by_asset_key": {}, "latest_evaluation_by_asset_key": {}, "latest_evaluation_timestamp": 1357430730.0}"""
+        )
+        .assert_requested_runs(run_request(["A"], hour_partition_key(state.current_time, 1))),
     ),
 ]

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
@@ -510,25 +510,23 @@ partition_scenarios = [
         )
         .evaluate_tick("FOO")
         .assert_requested_runs()
-        .with_not_started_runs(),
-        # TEMPORARILY DISABLED: this test will be re-enabled upstack. It is currently broken because
-        # we do not handle the case where partitions defs change in the MaterializeOnMissingRule
+        .with_not_started_runs()
         # now the start date is updated, request the new first partition key
-        # .with_current_time_advanced(days=5)
-        # .with_asset_properties(
-        #    partitions_def=hourly_partitions_def._replace(
-        #        start=time_partitions_start_datetime + datetime.timedelta(days=5)
-        #    )
-        # )
-        # .evaluate_tick("BAR")
-        # .assert_requested_runs(
-        #    run_request(
-        #        ["A"],
-        #        partition_key=hour_partition_key(
-        #            time_partitions_start_datetime + datetime.timedelta(days=5), delta=1
-        #        ),
-        #    )
-        # ),
+        .with_current_time_advanced(days=5)
+        .with_asset_properties(
+            partitions_def=hourly_partitions_def._replace(
+                start=time_partitions_start_datetime + datetime.timedelta(days=5)
+            )
+        )
+        .evaluate_tick("BAR")
+        .assert_requested_runs(
+            run_request(
+                ["A"],
+                partition_key=hour_partition_key(
+                    time_partitions_start_datetime + datetime.timedelta(days=5), delta=1
+                ),
+            )
+        ),
     ),
     AssetDaemonScenario(
         id="one_asset_self_dependency_multi_partitions_def",


### PR DESCRIPTION
## Summary & Motivation

This patches up a few flaws with the backcompat logic, and adds some tests that would have failed prior to these changes.

The three big things are:

1. The logic for fetching the latest_evaluation_timestamp from the legacy cursor was incorrect (wrong key oops), meaning that cron schedule rules would always fire the first tick after migration (as to them, the previous time they had been evaluated was `None`).
2. Previously, we'd only ever check the root assets for the "missing" condition. However, in the new world, there's no good reason for this distinction, so we keep track of the missing status of all assets. The issue was the logic in transferring over the old data into the new format. We'd first build a big AssetGraphSubset, then subselect from that subset for each asset. However, we know that we don't expect to have any data for non-root assets, but the 'no data stored' was being treated as 'this entire asset is unhandled'. Now, if we have no data stored, we just keep that as a null value in the extras dictionary, and the missing rule will go out and query for the true materialized subset if it hits that null value.
3. We no longer serialize the candidates subset if it's an AllPartitionsSubset. This is just wasteful and adds significant overhead to each tick.

This means that on the first tick after the migration, we do have a small (but manageable) extra cost as we have to do this lookup for all non-root assets.

## How I Tested These Changes

Dry runs, new tests.
