### PR TITLE
Fixing bug #18746.  Adding a new kwargs parameter to DbClient

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -96,7 +96,7 @@ class DbIOManager(IOManager):
         schema: Optional[str] = None,
         io_manager_name: Optional[str] = None,
         default_load_type: Optional[Type] = None,
-        connect_kwargs: Callable[[Union[OutputContext, InputContext]], Dict[str, Any]]
+        connect_kwargs: Optional[Callable[[Union[OutputContext, InputContext]], Dict[str, Any]]] = None
     ):
         self._handlers_by_type: Dict[Optional[Type], DbTypeHandler] = {}
         self._io_manager_name = io_manager_name or self.__class__.__name__


### PR DESCRIPTION
## Summary & Motivation
Fixing issue #18746.

DuckDb can only have one write connection at a time, but multiple read_only connection.  Right now we always open duckdb in write mode which can cause exceptions when multiple ops try to access the file at the same time (specially on a slow server).

The goal is to be able to open duckdb in read_only whenever possible and only open it in write mode when we need to.

I added a new kwargs parameter to DbClient connect method and a new way to pass a lambda to DbIOManager to calculate this kwargs dynamically based in the context (either reading or writing data).

## How I Tested These Changes
This is my first PR to dagster and the contributing guidelines does not seems to be made for a windows dev, so unfortunately I did not test the code.  Sorry in advance.
