### PR TITLE
added missing get_dagster_logger in tutorial

### DIFF
--- a/docs/content/tutorial/saving-your-data.mdx
+++ b/docs/content/tutorial/saving-your-data.mdx
@@ -85,6 +85,7 @@ Modify `topstory_ids` to use an I/O manager:
 
 ```python file=/tutorial/saving/update_assets_to_use_io.py startafter=start_topstory_ids_asset endbefore=end_topstory_ids_asset
 from typing import Dict, List  # add imports to the top of `assets.py`
+from dagster import AssetExecutionContext, MetadataValue, asset, MaterializeResult, get_dagster_logger
 
 
 @asset

--- a/docs/content/tutorial/saving-your-data.mdx
+++ b/docs/content/tutorial/saving-your-data.mdx
@@ -85,7 +85,6 @@ Modify `topstory_ids` to use an I/O manager:
 
 ```python file=/tutorial/saving/update_assets_to_use_io.py startafter=start_topstory_ids_asset endbefore=end_topstory_ids_asset
 from typing import Dict, List  # add imports to the top of `assets.py`
-from dagster import AssetExecutionContext, MetadataValue, asset, MaterializeResult, get_dagster_logger
 
 
 @asset
@@ -101,6 +100,9 @@ def topstory_ids() -> List:  # modify return type signature
 Modify `topstories` to use an I/O manager:
 
 ```python file=/tutorial/saving/update_assets_to_use_io.py startafter=start_topstories_asset endbefore=end_topstories_asset
+from dagster import AssetExecutionContext, MetadataValue, asset, get_dagster_logger
+
+
 @asset  # remove deps parameter
 def topstories(
     context: AssetExecutionContext,

--- a/examples/docs_snippets/docs_snippets/tutorial/saving/update_assets_to_use_io.py
+++ b/examples/docs_snippets/docs_snippets/tutorial/saving/update_assets_to_use_io.py
@@ -5,11 +5,12 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import requests
 
-from dagster import AssetExecutionContext, MetadataValue, asset, get_dagster_logger
-
 
 # start_topstory_ids_asset
+
+
 from typing import Dict, List  # add imports to the top of `assets.py`
+from dagster import AssetExecutionContext, MetadataValue, asset, MaterializeResult, get_dagster_logger
 
 
 @asset

--- a/examples/docs_snippets/docs_snippets/tutorial/saving/update_assets_to_use_io.py
+++ b/examples/docs_snippets/docs_snippets/tutorial/saving/update_assets_to_use_io.py
@@ -1,4 +1,3 @@
-# ruff: noqa
 import base64  # noqa: I001
 from io import BytesIO
 
@@ -6,12 +5,12 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import requests
 
+from dagster import asset
 
 # start_topstory_ids_asset
 
 
 from typing import Dict, List  # add imports to the top of `assets.py`
-from dagster import AssetExecutionContext, MetadataValue, asset, MaterializeResult, get_dagster_logger
 
 
 @asset
@@ -27,6 +26,9 @@ def topstory_ids() -> List:  # modify return type signature
 # end_topstory_ids_asset
 
 # start_topstories_asset
+
+
+from dagster import AssetExecutionContext, MetadataValue, asset, get_dagster_logger
 
 
 @asset  # remove deps parameter

--- a/examples/docs_snippets/docs_snippets/tutorial/saving/update_assets_to_use_io.py
+++ b/examples/docs_snippets/docs_snippets/tutorial/saving/update_assets_to_use_io.py
@@ -1,3 +1,4 @@
+# ruff: noqa
 import base64  # noqa: I001
 from io import BytesIO
 


### PR DESCRIPTION
## Summary & Motivation

I ran into this error while following the starting tutorial:

<img width="1000" alt="error" src="https://github.com/dagster-io/dagster/assets/1642710/9f760df4-4f4d-441a-9df0-894c9c759901">

I noticed a missing import for `get_dagster_logger` here: https://docs.dagster.io/tutorial/saving-your-data
The line with the correct import was there but just outside the snippet marker. I tried to keep the changes minimal. 

## How I Tested These Changes

I made the necessary changes in docs_snippets and ran `make mdx-format` just as instructed. I did not directly change the `.mdx` file myself. Everything ran and compiled fine. 
