### PR TITLE
enable requesting backfills from sensors

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -334,6 +334,7 @@ from dagster._core.definitions.result import MaterializeResult as MaterializeRes
 from dagster._core.definitions.run_config import RunConfig as RunConfig
 from dagster._core.definitions.run_request import (
     AddDynamicPartitionsRequest as AddDynamicPartitionsRequest,
+    BackfillRequest as BackfillRequest,
     DeleteDynamicPartitionsRequest as DeleteDynamicPartitionsRequest,
     RunRequest as RunRequest,
     SensorResult as SensorResult,

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -6,6 +6,7 @@ import pendulum
 from dagster import _check as check
 from dagster._core.definitions import AssetKey
 from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.errors import DagsterDefinitionChangedDeserializationError
@@ -419,4 +420,27 @@ class PartitionBackfill(
             backfill_timestamp=backfill_timestamp,
             serialized_asset_backfill_data=None,
             asset_backfill_data=asset_backfill_data,
+        )
+
+    @classmethod
+    def from_asset_graph_subset(
+        cls,
+        backfill_id: str,
+        asset_graph_subset: AssetGraphSubset,
+        backfill_timestamp: float,
+        tags: Mapping[str, str],
+        dynamic_partitions_store: DynamicPartitionsStore,
+    ) -> "PartitionBackfill":
+        return cls(
+            backfill_id=backfill_id,
+            status=BulkActionStatus.REQUESTED,
+            from_failure=False,
+            tags=tags,
+            backfill_timestamp=backfill_timestamp,
+            serialized_asset_backfill_data=None,
+            asset_backfill_data=AssetBackfillData.empty(
+                target_subset=asset_graph_subset,
+                backfill_start_time=pendulum.from_timestamp(backfill_timestamp, tz="UTC"),
+                dynamic_partitions_store=dynamic_partitions_store,
+            ),
         )

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -41,6 +41,7 @@ from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.node_definition import NodeDefinition
 from dagster._core.errors import DagsterUserCodeUnreachableError
 from dagster._core.events import DagsterEvent
+from dagster._core.host_representation.external import ExternalRepository
 from dagster._core.host_representation.origin import (
     ExternalJobOrigin,
     InProcessCodeLocationOrigin,
@@ -520,6 +521,16 @@ def create_test_daemon_workspace_context(
             grpc_server_registry=grpc_server_registry,
         ) as workspace_process_context:
             yield workspace_process_context
+
+
+def load_external_repo(
+    workspace_context: WorkspaceProcessContext, repo_name: str
+) -> ExternalRepository:
+    code_location = next(
+        iter(workspace_context.create_request_context().get_workspace_snapshot().values())
+    ).code_location
+    assert code_location
+    return code_location.get_repository(repo_name)
 
 
 def remove_none_recursively(obj: T) -> T:

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
@@ -9,6 +9,7 @@ from dagster._core.test_utils import (
     SingleThreadPoolExecutor,
     create_test_daemon_workspace_context,
     instance_for_test,
+    load_external_repo,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceProcessContext
@@ -50,9 +51,12 @@ def instance_fixture(instance_module_scoped: DagsterInstance) -> Iterator[Dagste
     yield instance_module_scoped
 
 
-def create_workspace_load_target(attribute: Optional[str] = "the_repo") -> ModuleTarget:
+def create_workspace_load_target(
+    module_name: str = "dagster_tests.daemon_sensor_tests.test_sensor_run",
+    attribute: Optional[str] = "the_repo",
+) -> ModuleTarget:
     return ModuleTarget(
-        module_name="dagster_tests.daemon_sensor_tests.test_sensor_run",
+        module_name=module_name,
         attribute=attribute,
         working_directory=os.path.dirname(__file__),
         location_name="test_location",
@@ -70,11 +74,7 @@ def workspace_fixture(instance_module_scoped: DagsterInstance) -> Iterator[Works
 
 @pytest.fixture(name="external_repo", scope="module")
 def external_repo_fixture(workspace_context: WorkspaceProcessContext) -> ExternalRepository:
-    code_location = next(
-        iter(workspace_context.create_request_context().get_workspace_snapshot().values())
-    ).code_location
-    assert code_location
-    return code_location.get_repository("the_repo")
+    return load_external_repo(workspace_context, "the_repo")
 
 
 def loadable_target_origin() -> LoadableTargetOrigin:

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -103,7 +103,7 @@ def instance_with_multiple_code_locations(
 ) -> Iterator[Dict[str, CodeLocationInfoForSensorTest]]:
     with instance_for_test(overrides) as instance:
         with create_test_daemon_workspace_context(
-            workspace_load_target or create_workspace_load_target(None), instance=instance
+            workspace_load_target or create_workspace_load_target(attribute=None), instance=instance
         ) as workspace_context:
             location_infos: Dict[str, CodeLocationInfoForSensorTest] = {}
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -4,7 +4,7 @@ import string
 import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack
-from typing import Any
+from typing import Any, Optional, Sequence
 from unittest import mock
 
 import pendulum
@@ -922,11 +922,12 @@ def evaluate_sensors(workspace_context, executor, submit_executor=None, timeout=
 def validate_tick(
     tick,
     external_sensor,
-    expected_datetime,
-    expected_status,
+    expected_datetime=None,
+    expected_status=None,
     expected_run_ids=None,
     expected_error=None,
-):
+    expected_backfill_ids: Optional[Sequence[str]] = None,
+) -> None:
     tick_data = tick.tick_data
     assert tick_data.instigator_origin_id == external_sensor.get_external_origin_id()
     assert tick_data.instigator_name == external_sensor.name
@@ -938,6 +939,8 @@ def validate_tick(
         assert set(tick_data.run_ids) == set(expected_run_ids)
     if expected_error:
         assert expected_error in str(tick_data.error)
+    if expected_backfill_ids:
+        assert set(tick_data.backfill_ids) == set(expected_backfill_ids)
 
 
 def validate_run_started(run, expected_success=True):

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_request.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_request.py
@@ -1,0 +1,219 @@
+import os
+
+import pytest
+from dagster import (
+    BackfillRequest,
+    DagsterInstance,
+    Definitions,
+    DynamicPartitionsDefinition,
+    SensorResult,
+    StaticPartitionsDefinition,
+    asset,
+    load_assets_from_current_module,
+    sensor,
+)
+from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.run_request import InstigatorType
+from dagster._core.scheduler.instigation import (
+    InstigatorState,
+    InstigatorStatus,
+    TickStatus,
+)
+from dagster._core.test_utils import (
+    create_test_daemon_workspace_context,
+    load_external_repo,
+)
+from dagster._core.workspace.load_target import ModuleTarget
+
+from .test_sensor_run import evaluate_sensors, validate_tick
+
+dynamic_partitions_def = DynamicPartitionsDefinition(name="abc")
+
+
+@asset(partitions_def=dynamic_partitions_def)
+def asset1() -> None:
+    ...
+
+
+@asset(deps=[asset1])
+def unpartitioned_child():
+    ...
+
+
+def make_backfill_request(context) -> BackfillRequest:
+    return BackfillRequest.from_asset_selection_and_partitions(
+        asset_selection=[asset1.key, unpartitioned_child.key],
+        partition_keys=["foo", "bar"],
+        asset_graph=context.repository_def.asset_graph,
+        tags={"tagkey": "tagvalue"},
+    )
+
+
+@sensor(asset_selection=[asset1, unpartitioned_child])
+def sensor_result_backfill_request_sensor(context):
+    return SensorResult(
+        dynamic_partitions_requests=[dynamic_partitions_def.build_add_request(["foo", "bar"])],
+        backfill_requests=[make_backfill_request(context)],
+    )
+
+
+@sensor(asset_selection=[asset1, unpartitioned_child])
+def return_backfill_request_sensor(context):
+    context.instance.add_dynamic_partitions(dynamic_partitions_def.name, ["foo", "bar"])
+    return make_backfill_request(context)
+
+
+@sensor(asset_selection=[asset1, unpartitioned_child])
+def yield_backfill_request_sensor(context):
+    context.instance.add_dynamic_partitions(dynamic_partitions_def.name, ["foo", "bar"])
+    yield make_backfill_request(context)
+
+
+@asset(partitions_def=StaticPartitionsDefinition(["a", "b"]))
+def static_partitioned_asset():
+    ...
+
+
+@sensor(asset_selection=[asset1, unpartitioned_child])
+def asset_outside_of_selection_backfill_request_sensor(context):
+    return BackfillRequest.from_asset_selection_and_partitions(
+        asset_selection=[static_partitioned_asset.key],
+        partition_keys=["a", "b"],
+        asset_graph=context.repository_def.asset_graph,
+    )
+
+
+@sensor(asset_selection=[static_partitioned_asset])
+def invalid_partition_backfill_request_sensor(context):
+    return BackfillRequest.from_asset_selection_and_partitions(
+        asset_selection=[static_partitioned_asset.key],
+        partition_keys=["c"],
+        asset_graph=context.repository_def.asset_graph,
+    )
+
+
+defs = Definitions(
+    assets=load_assets_from_current_module(),
+    sensors=[
+        sensor_result_backfill_request_sensor,
+        return_backfill_request_sensor,
+        yield_backfill_request_sensor,
+        asset_outside_of_selection_backfill_request_sensor,
+        invalid_partition_backfill_request_sensor,
+    ],
+)
+
+module_target = ModuleTarget(
+    module_name="dagster_tests.daemon_sensor_tests.test_sensor_run_backfill_request",
+    attribute=None,
+    working_directory=os.path.dirname(__file__),
+    location_name="test_location",
+)
+
+
+@pytest.mark.parametrize(
+    "sensor_name",
+    [
+        "sensor_result_backfill_request_sensor",
+        "return_backfill_request_sensor",
+        "yield_backfill_request_sensor",
+    ],
+)
+def test_backfill_request_sensor(instance: DagsterInstance, executor, sensor_name: str):
+    with create_test_daemon_workspace_context(
+        workspace_load_target=module_target, instance=instance
+    ) as workspace_context:
+        external_repo = load_external_repo(workspace_context, "__repository__")
+        external_sensor = external_repo.get_external_sensor(sensor_name)
+
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 1
+
+        backfills = instance.get_backfills()
+        assert len(backfills) == 1
+        backfill = backfills[0]
+        assert backfill.tags == {"tagkey": "tagvalue"}
+        assert backfill.is_asset_backfill
+        asset_backfill_data = backfill.asset_backfill_data
+        assert asset_backfill_data
+        assert set(asset_backfill_data.target_subset.iterate_asset_partitions()) == {
+            AssetKeyPartitionKey(asset1.key, "foo"),
+            AssetKeyPartitionKey(asset1.key, "bar"),
+            AssetKeyPartitionKey(unpartitioned_child.key, None),
+        }
+
+        validate_tick(
+            ticks[0],
+            external_sensor,
+            None,
+            TickStatus.SUCCESS,
+            expected_backfill_ids=[backfill.backfill_id],
+        )
+
+
+def test_asset_selection_outside_of_range(instance, executor):
+    with create_test_daemon_workspace_context(
+        workspace_load_target=module_target, instance=instance
+    ) as workspace_context:
+        external_repo = load_external_repo(workspace_context, "__repository__")
+        external_sensor = external_repo.get_external_sensor(
+            asset_outside_of_selection_backfill_request_sensor.name
+        )
+
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+
+        validate_tick(
+            ticks[0],
+            external_sensor=external_sensor,
+            expected_status=TickStatus.FAILURE,
+            expected_error="BackfillRequest includes asset keys that are not part of sensor's "
+            "asset_selection: {AssetKey(['static_partitioned_asset'])}",
+        )
+
+
+def test_invalid_partition(instance, executor):
+    with create_test_daemon_workspace_context(
+        workspace_load_target=module_target, instance=instance
+    ) as workspace_context:
+        external_repo = load_external_repo(workspace_context, "__repository__")
+        external_sensor = external_repo.get_external_sensor(
+            invalid_partition_backfill_request_sensor.name
+        )
+
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+
+        # allow creating a backfill with an invalid partition. it will get caught in the daemon
+        # and show up as an error there.
+        validate_tick(ticks[0], external_sensor, None, TickStatus.SUCCESS)


### PR DESCRIPTION
## Summary & Motivation
Allows sensors to emit `BackfillRequest`s, which result in Dagster launching backfills.

We have a large user currently hacking this by invoking private APIs, and recently had to recommend this pattern to another user as well.  Additionally, we've seen questions like these:

- https://github.com/dagster-io/dagster/discussions/18168
- https://github.com/dagster-io/dagster/discussions/15532

## Details

Usage example:
```python
@sensor(asset_selection=[asset1, unpartitioned_child])
def sensor_result_backfill_request_sensor(context):
    return BackfillRequest.from_asset_selection_and_partitions(
        asset_selection=[asset1.key, unpartitioned_child.key],
        partition_keys=["foo", "bar"],
        asset_graph=context.repository_def.asset_graph,
        tags={"tagkey": "tagvalue"},
    )
```

Design choices worthy of review:
1. The asset partitions in a `BackfillRequest` are represented internally by an `AssetGraphSubset`. This class isn't currently a top-level import, but I imagine we eventually will make it one.
2. `BackfillRequest`s can only only target assets that are covered by the sensor's `asset_selection` argument.
3. You need to spell out the asset partitions that you want to target. I.e. an empty `BackfillRequest` doesn't automatically target all the assets covered by the sensor's `asset_selection` argument.
4. Relatedly to (2), `BackfillRequest`s can only be used to launch pure asset backfills, not job backfills. In the future, we could extend this by doing something like making the `asset_partitions` field on `BackfillRequest` optional and adding a `job_partitions` field and `job_name` field.
5. Previously, a tick ended up in the SUCCESS state only if it returned one or more run requests. Now, it also ends up in the SUCCESS state if it returns one or more backfill requests.

## How I Tested These Changes
