### PR TITLE
Add context method to get observable asset key

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -636,6 +636,13 @@ class AssetLayer(NamedTuple):
         check.invariant(len(matching_handles) == 1)
         return matching_handles[0]
 
+    def observable_asset_key_for_node(self, node_handle: NodeHandle) -> Optional[AssetKey]:
+        result = self.asset_info_by_node_output_handle.get(NodeOutputHandle(node_handle, "result"))
+        if not result:
+            return None
+
+        return result.key
+
     def assets_def_for_node(self, node_handle: NodeHandle) -> Optional["AssetsDefinition"]:
         return self.assets_defs_by_node_handle.get(node_handle)
 

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -557,6 +557,11 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
                 "Cannot call `context.asset_key` in a multi_asset with more than one asset. Use"
                 " `context.asset_key_for_output` instead."
             )
+        observable_asset_key = self.job_def.asset_layer.observable_asset_key_for_node(
+            self.node_handle
+        )
+        if observable_asset_key:
+            return observable_asset_key
         return next(iter(self.assets_def.keys_by_output_name.values()))
 
     @public

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -568,6 +568,19 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
 
     @public
     @property
+    def observable_asset_key(self) -> AssetKey:
+        """If the current step corresponds to an observable asset, returns the AssetKey for the
+        observable asset.
+        """
+        asset_key = self.job_def.asset_layer.observable_asset_key_for_node(self.node_handle)
+        if not asset_key:
+            raise DagsterInvariantViolationError(
+                "Cannot call `context.observable_asset_key` in a non-observable asset."
+            )
+        return asset_key
+
+    @public
+    @property
     def assets_def(self) -> AssetsDefinition:
         """The backing AssetsDefinition for what is currently executing, errors if not available."""
         assets_def = self.job_def.asset_layer.assets_def_for_node(self.node_handle)

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset_decorator.py
@@ -121,6 +121,7 @@ def test_get_observable_asset_key_from_context() -> None:
     )
     def foo_source_asset(context: OpExecutionContext) -> DataVersion:
         assert context.observable_asset_key == AssetKey(["delta", "alpha"])
+        assert context.asset_key == AssetKey(["delta", "alpha"])
         executed["yes"] = True
         return DataVersion("version-string")
 


### PR DESCRIPTION
## Summary

Addresses #18896. Adds a new property `observable_asset_key` on the `OpExecutionContext` which returns the asset key associated with the currently executing `@observable_source_asset`, if inside the body of such an asset.

Right now it's pretty cumbersome to access, users have to use the (pretty opaque) `context.asset_key_for_output("result")`. Not sure if this is better addressed elsewhere w/ the context reworks.

```python
@observable_source_asset(
    ...
)
def source_asset_with_observer(context: OpExecutionContext):
    context.log.info("Self key: %s", context.observable_asset_key)
```

Also tentatively updates `asset_key` prop to return the observable asset key.

## Test Plan

New unit test.
