### PR TITLE
Switch dagster_webserver and dagster_gcp_pyspark to hyphens

### DIFF
--- a/python_modules/dagster-webserver/setup.py
+++ b/python_modules/dagster-webserver/setup.py
@@ -22,7 +22,7 @@ ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
 pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
-    name="dagster_webserver",
+    name="dagster-webserver",
     version=ver,
     author="Dagster Labs",
     author_email="hello@dagsterlabs.com",

--- a/python_modules/libraries/dagster-gcp-pyspark/setup.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/setup.py
@@ -16,7 +16,7 @@ ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
 pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
-    name="dagster_gcp_pyspark",
+    name="dagster-gcp-pyspark",
     version=get_version(),
     author="Dagster Labs",
     author_email="hello@dagsterlabs.com",


### PR DESCRIPTION
Open questions:

- ~~why did tests start failing this weekend? (best guess is setuptools 69.03 on Dec 23rd)~~
- ~~why does this fix the failures?~~
- would this be a breaking change? I'm hopeful that it's not, because the package is already published as dagster-webserver https://pypi.org/project/dagster-webserver/

Edit: the first two are answered by https://github.com/pypa/setuptools/issues/2522#issuecomment-1856091483: setuptools change how they handle hyphens vs underscores

This makes the two required changes to get the build green (these two are special because of the underscore packages, they're the ones that are relied on in tests). In general we should make it a pattern to make package names use hyphens and match their directory name to avoid confusion.