### PR TITLE
Only consider/resolve the specific job being executed in a run worker or step worker

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data.py
@@ -1,3 +1,4 @@
+import os
 from abc import ABC, abstractmethod
 from types import FunctionType
 from typing import (
@@ -343,12 +344,18 @@ class CachingRepositoryData(RepositoryData):
         """
         from .repository_data_builder import build_caching_repository_data_from_list
 
+        # Detect the case where a specific job is all that we care about (using an environment
+        # variable that is set in every run worker and step worker where definitions are loaded)
+        # and pass that through to optimize performance by not loading other jobs
+        specific_job_name = os.getenv("DAGSTER_RUN_JOB_NAME")
+
         return build_caching_repository_data_from_list(
             repository_definitions=repository_definitions,
             default_executor_def=default_executor_def,
             default_logger_defs=default_logger_defs,
             top_level_resources=top_level_resources,
             resource_key_mapping=resource_key_mapping,
+            specific_job_name=specific_job_name,
         )
 
     def get_env_vars_by_top_level_resource(self) -> Mapping[str, AbstractSet[str]]:

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -262,6 +262,7 @@ def _run_in_subprocess(
 def start_run_in_subprocess(
     serialized_execute_run_args, recon_pipeline, event_queue, termination_event
 ):
+    os.environ["DAGSTER_RUN_JOB_NAME"] = recon_pipeline.job_name
     with capture_interrupts():
         _run_in_subprocess(
             serialized_execute_run_args,


### PR DESCRIPTION
Summary:
Addresses a perf bottleneck identified using speedscope when there are a lot of define_asset_job jobs and resolving their assets or resource requirements takes a long time.

Test Plan: BK