### PR TITLE
assetSelection on GrapheneSensor

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2872,6 +2872,7 @@ type Sensor {
   nextTick: DryRunInstigationTick
   metadata: SensorMetadata!
   sensorType: SensorType!
+  assetSelection: AssetSelection
 }
 
 type Target {
@@ -2892,6 +2893,10 @@ enum SensorType {
   FRESHNESS_POLICY
   AUTOMATION_POLICY
   UNKNOWN
+}
+
+type AssetSelection {
+  assetSelectionString: String
 }
 
 union SensorOrError = Sensor | SensorNotFoundError | UnauthorizedError | PythonError

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -476,6 +476,11 @@ export type AssetPartitionsStatusCounts = {
   numPartitionsTargeted: Scalars['Int'];
 };
 
+export type AssetSelection = {
+  __typename: 'AssetSelection';
+  assetSelectionString: Maybe<Scalars['String']>;
+};
+
 export type AssetWipeMutationResult =
   | AssetNotFoundError
   | AssetWipeSuccess
@@ -3950,6 +3955,7 @@ export type SelectorTypeConfigError = PipelineConfigValidationError & {
 
 export type Sensor = {
   __typename: 'Sensor';
+  assetSelection: Maybe<AssetSelection>;
   description: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   jobOriginId: Scalars['String'];
@@ -5410,6 +5416,21 @@ export const buildAssetPartitionsStatusCounts = (
       overrides && overrides.hasOwnProperty('numPartitionsTargeted')
         ? overrides.numPartitionsTargeted!
         : 5211,
+  };
+};
+
+export const buildAssetSelection = (
+  overrides?: Partial<AssetSelection>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'AssetSelection'} & AssetSelection => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('AssetSelection');
+  return {
+    __typename: 'AssetSelection',
+    assetSelectionString:
+      overrides && overrides.hasOwnProperty('assetSelectionString')
+        ? overrides.assetSelectionString!
+        : 'dolores',
   };
 };
 
@@ -11965,6 +11986,12 @@ export const buildSensor = (
   relationshipsToOmit.add('Sensor');
   return {
     __typename: 'Sensor',
+    assetSelection:
+      overrides && overrides.hasOwnProperty('assetSelection')
+        ? overrides.assetSelection!
+        : relationshipsToOmit.has('AssetSelection')
+        ? ({} as AssetSelection)
+        : buildAssetSelection({}, relationshipsToOmit),
     description:
       overrides && overrides.hasOwnProperty('description') ? overrides.description! : 'sapiente',
     id:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_selections.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_selections.py
@@ -1,0 +1,8 @@
+import graphene
+
+
+class GrapheneAssetSelection(graphene.ObjectType):
+    assetSelectionString = graphene.String()
+
+    class Meta:
+        name = "AssetSelection"

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -22,6 +22,7 @@ from ..implementation.fetch_sensors import (
     stop_sensor,
 )
 from .asset_key import GrapheneAssetKey
+from .asset_selections import GrapheneAssetSelection
 from .errors import (
     GraphenePythonError,
     GrapheneRepositoryNotFoundError,
@@ -73,6 +74,7 @@ class GrapheneSensor(graphene.ObjectType):
     nextTick = graphene.Field(GrapheneDryRunInstigationTick)
     metadata = graphene.NonNull(GrapheneSensorMetadata)
     sensorType = graphene.NonNull(GrapheneSensorType)
+    assetSelection = graphene.Field(GrapheneAssetSelection)
 
     class Meta:
         name = "Sensor"
@@ -97,6 +99,9 @@ class GrapheneSensor(graphene.ObjectType):
                 assetKeys=external_sensor.metadata.asset_keys if external_sensor.metadata else None
             ),
             sensorType=external_sensor.sensor_type.value,
+            assetSelection=GrapheneAssetSelection(str(external_sensor.asset_selection))
+            if external_sensor.asset_selection
+            else None,
         )
 
     def resolve_id(self, _):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_sensors.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_sensors.ambr
@@ -1,6 +1,7 @@
 # name: TestSensors.test_get_sensor[0]
   dict({
     '__typename': 'Sensor',
+    'assetSelection': None,
     'minIntervalSeconds': 30,
     'name': 'always_no_config_sensor',
     'nextTick': None,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -149,6 +149,9 @@ query SensorQuery($sensorSelector: SensorSelector!) {
         }
       }
       sensorType
+      assetSelection {
+        assetSelectionString
+      }
     }
   }
 }
@@ -1280,3 +1283,19 @@ def test_sensor_dynamic_partitions_request_results(graphql_context: WorkspaceReq
     assert results[1]["type"] == "DELETE_PARTITIONS"
     assert results[1]["partitionKeys"] == ["old_key"]
     assert results[1]["skippedPartitionKeys"] == ["nonexistent_key"]
+
+
+def test_asset_selection(graphql_context):
+    sensor_name = "my_automation_policy_sensor"
+    sensor_selector = infer_sensor_selector(graphql_context, sensor_name)
+
+    result = execute_dagster_graphql(
+        graphql_context, GET_SENSOR_QUERY, variables={"sensorSelector": sensor_selector}
+    )
+
+    assert result.data
+    assert result.data["sensorOrError"]["__typename"] == "Sensor"
+    assert (
+        result.data["sensorOrError"]["assetSelection"]["assetSelectionString"]
+        == "fresh_diamond_bottom"
+    )


### PR DESCRIPTION
## Summary & Motivation

For sensors that target asset selections (like automation policy sensors), this will allow displaying their asset selection on their sensor page.

## How I Tested These Changes
