### PR TITLE
[ui] Popover for partition segments

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/.storybook/preview.js
+++ b/js_modules/dagster-ui/packages/ui-core/.storybook/preview.js
@@ -7,6 +7,7 @@ import {
   GlobalSuggestStyle,
   GlobalToasterStyle,
   GlobalTooltipStyle,
+  browserColorScheme,
   colorBackgroundDefault,
   colorTextDefault,
   colorLinkDefault,
@@ -25,6 +26,7 @@ const GlobalStyle = createGlobalStyle`
   }
 
   html, body {
+    color-scheme: ${browserColorScheme()};
     background-color: ${colorBackgroundDefault()};
     color: ${colorTextDefault()};
     -webkit-font-smoothing: antialiased;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PartitionSegmentWithPopover.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PartitionSegmentWithPopover.tsx
@@ -1,0 +1,202 @@
+import {
+  Box,
+  MiddleTruncate,
+  Popover,
+  TextInput,
+  TextInputContainer,
+  colorAccentGray,
+  colorAccentGrayHover,
+  colorAccentGreen,
+  colorAccentGreenHover,
+  colorAccentYellow,
+  colorAccentYellowHover,
+} from '@dagster-io/ui-components';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import * as React from 'react';
+import styled from 'styled-components';
+
+import {assertUnreachable} from '../../app/Util';
+import {Container, Inner, Row} from '../../ui/VirtualizedTable';
+
+import {PolicyEvaluationStatusTag} from './PolicyEvaluationStatusTag';
+import {AssetConditionEvaluationStatus, AssetSubset} from './types';
+
+const statusToColors = (status: AssetConditionEvaluationStatus) => {
+  switch (status) {
+    case AssetConditionEvaluationStatus.TRUE:
+      return {color: colorAccentGreen(), hoverColor: colorAccentGreenHover()};
+    case AssetConditionEvaluationStatus.FALSE:
+      return {color: colorAccentYellow(), hoverColor: colorAccentYellowHover()};
+    case AssetConditionEvaluationStatus.SKIPPED:
+      return {color: colorAccentGray(), hoverColor: colorAccentGrayHover()};
+    default:
+      return assertUnreachable(status);
+  }
+};
+
+interface Props {
+  description: string;
+  status: AssetConditionEvaluationStatus;
+  subset: AssetSubset | null;
+  width: number;
+}
+
+export const PartitionSegmentWithPopover = ({description, width, status, subset}: Props) => {
+  const {color, hoverColor} = React.useMemo(() => statusToColors(status), [status]);
+  const segment = <PartitionSegment $color={color} $hoverColor={hoverColor} $width={width} />;
+  if (!subset) {
+    return segment;
+  }
+
+  return (
+    <SegmentContainer $width={width}>
+      <Popover
+        interactionKind="hover"
+        placement="bottom"
+        hoverOpenDelay={50}
+        hoverCloseDelay={50}
+        content={<PartitionSubsetList description={description} status={status} subset={subset} />}
+      >
+        {segment}
+      </Popover>
+    </SegmentContainer>
+  );
+};
+
+interface ListProps {
+  description: string;
+  status: AssetConditionEvaluationStatus;
+  subset: AssetSubset;
+}
+
+const ITEM_HEIGHT = 32;
+const MAX_ITEMS_BEFORE_TRUNCATION = 4;
+
+const PartitionSubsetList = ({description, status, subset}: ListProps) => {
+  const container = React.useRef<HTMLDivElement | null>(null);
+  const [searchValue, setSearchValue] = React.useState('');
+
+  const {color, hoverColor} = React.useMemo(() => statusToColors(status), [status]);
+
+  const partitionKeys = React.useMemo(() => subset.subsetValue.partitionKeys || [], [subset]);
+
+  const filteredKeys = React.useMemo(() => {
+    const searchLower = searchValue.toLocaleLowerCase();
+    return partitionKeys.filter((key) => key.toLocaleLowerCase().includes(searchLower));
+  }, [partitionKeys, searchValue]);
+
+  const count = filteredKeys.length;
+
+  const rowVirtualizer = useVirtualizer({
+    count: filteredKeys.length,
+    getScrollElement: () => container.current,
+    estimateSize: () => ITEM_HEIGHT,
+    overscan: 10,
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const virtualItems = rowVirtualizer.getVirtualItems();
+
+  return (
+    <div style={{width: '292px'}}>
+      <Box
+        padding={{vertical: 8, left: 12, right: 8}}
+        border="bottom"
+        flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
+      >
+        <strong>
+          <MiddleTruncate text={description} />
+        </strong>
+        <PolicyEvaluationStatusTag status={status} />
+      </Box>
+      {partitionKeys.length > MAX_ITEMS_BEFORE_TRUNCATION ? (
+        <SearchContainer padding={{vertical: 4, horizontal: 8}}>
+          <TextInput
+            icon="search"
+            placeholder="Filter partitions…"
+            value={searchValue}
+            onChange={(e) => setSearchValue(e.target.value)}
+          />
+        </SearchContainer>
+      ) : null}
+      <div
+        style={{
+          height: count > MAX_ITEMS_BEFORE_TRUNCATION ? '150px' : count * ITEM_HEIGHT,
+          overflow: 'hidden',
+        }}
+      >
+        <Container ref={container}>
+          <Inner $totalHeight={totalHeight}>
+            {virtualItems.map(({index, key, size, start}) => {
+              const partitionKey = filteredKeys[index]!;
+              return (
+                <Row $height={size} $start={start} key={key}>
+                  <Box
+                    style={{height: '100%'}}
+                    padding={{vertical: 8, horizontal: 16}}
+                    flex={{direction: 'row', alignItems: 'center', gap: 8}}
+                  >
+                    <PartitionStatusDot $color={color} $hoverColor={hoverColor} />
+                    <div>
+                      <MiddleTruncate text={partitionKey} />
+                    </div>
+                  </Box>
+                </Row>
+              );
+            })}
+          </Inner>
+        </Container>
+      </div>
+    </div>
+  );
+};
+
+const SegmentContainer = styled.div.attrs<{$width: number}>(({$width}) => ({
+  style: {
+    flexBasis: `${$width}px`,
+  },
+}))<{$width: number}>`
+  .bp4-popover2-target {
+    display: block;
+  }
+`;
+
+const SearchContainer = styled(Box)`
+  display: flex;
+  ${TextInputContainer} {
+    flex: 1;
+  }
+`;
+
+interface PartitionSegmentProps {
+  $color: string;
+  $hoverColor: string;
+  $width: number;
+}
+
+const PartitionSegment = styled.div.attrs<PartitionSegmentProps>(({$width}) => ({
+  style: {
+    flexBasis: `${$width}px`,
+  },
+}))<PartitionSegmentProps>`
+  background-color: ${({$color}) => $color};
+  border-radius: 2px;
+  height: 20px;
+  transition: background-color 100ms linear;
+
+  :hover {
+    background-color: ${({$hoverColor}) => $hoverColor};
+  }
+`;
+
+const PartitionStatusDot = styled.div<{$color: string; $hoverColor: string}>`
+  background-color: ${({$color}) => $color};
+  height: 8px;
+  width: 8px;
+  border-radius: 50%;
+  transition: background-color 100ms linear;
+
+  :hover {
+    background-color: ${({$hoverColor}) => $hoverColor};
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PolicyEvaluationStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PolicyEvaluationStatusTag.tsx
@@ -1,0 +1,27 @@
+import {Tag} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {assertUnreachable} from '../../app/Util';
+
+import {AssetConditionEvaluationStatus} from './types';
+
+export const PolicyEvaluationStatusTag = ({status}: {status: AssetConditionEvaluationStatus}) => {
+  switch (status) {
+    case AssetConditionEvaluationStatus.FALSE:
+      return (
+        <Tag intent="warning" icon="cancel">
+          False
+        </Tag>
+      );
+    case AssetConditionEvaluationStatus.TRUE:
+      return (
+        <Tag intent="success" icon="check_circle">
+          True
+        </Tag>
+      );
+    case AssetConditionEvaluationStatus.SKIPPED:
+      return <Tag intent="none">Skipped</Tag>;
+    default:
+      return assertUnreachable(status);
+  }
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/PartitionSegmentWithPopover.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/PartitionSegmentWithPopover.stories.tsx
@@ -1,0 +1,126 @@
+import {Box} from '@dagster-io/ui-components';
+import faker from 'faker';
+import * as React from 'react';
+
+import {PartitionSegmentWithPopover} from '../PartitionSegmentWithPopover';
+import {AssetConditionEvaluationStatus, AssetSubset} from '../types';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Asset Details/Automaterialize/PartitionSegmentWithPopover',
+  component: PartitionSegmentWithPopover,
+};
+
+const PARTITION_COUNT = 300;
+
+export const TruePartitions = () => {
+  const subset: AssetSubset = React.useMemo(() => {
+    const partitionKeys = new Array(PARTITION_COUNT)
+      .fill(null)
+      .map(() => faker.random.words(2).toLowerCase().replace(/ /g, '-'));
+    return {
+      assetKey: {path: ['foo', 'bar']},
+      subsetValue: {
+        boolValue: true,
+        partitionKeys,
+        partitionKeyRanges: null,
+        isPartitioned: true,
+      },
+    };
+  }, []);
+
+  return (
+    <Box flex={{direction: 'row'}}>
+      <PartitionSegmentWithPopover
+        description="is_missing"
+        status={AssetConditionEvaluationStatus.TRUE}
+        width={200}
+        subset={subset}
+      />
+    </Box>
+  );
+};
+
+export const FalsePartitions = () => {
+  const subset: AssetSubset = React.useMemo(() => {
+    const partitionKeys = new Array(PARTITION_COUNT)
+      .fill(null)
+      .map(() => faker.random.words(2).toLowerCase().replace(/ /g, '-'));
+    return {
+      assetKey: {path: ['foo', 'bar']},
+      subsetValue: {
+        boolValue: false,
+        partitionKeys,
+        partitionKeyRanges: null,
+        isPartitioned: true,
+      },
+    };
+  }, []);
+
+  return (
+    <Box flex={{direction: 'row'}}>
+      <PartitionSegmentWithPopover
+        description="is_missing"
+        status={AssetConditionEvaluationStatus.FALSE}
+        width={200}
+        subset={subset}
+      />
+    </Box>
+  );
+};
+
+export const SkippedPartitions = () => {
+  const subset: AssetSubset = React.useMemo(() => {
+    const partitionKeys = new Array(PARTITION_COUNT)
+      .fill(null)
+      .map(() => faker.random.words(2).toLowerCase().replace(/ /g, '-'));
+    return {
+      assetKey: {path: ['foo', 'bar']},
+      subsetValue: {
+        boolValue: null,
+        partitionKeys,
+        partitionKeyRanges: null,
+        isPartitioned: true,
+      },
+    };
+  }, []);
+
+  return (
+    <Box flex={{direction: 'row'}}>
+      <PartitionSegmentWithPopover
+        description="is_missing"
+        status={AssetConditionEvaluationStatus.SKIPPED}
+        width={200}
+        subset={subset}
+      />
+    </Box>
+  );
+};
+
+export const FewPartitions = () => {
+  const subset: AssetSubset = React.useMemo(() => {
+    const partitionKeys = new Array(2)
+      .fill(null)
+      .map(() => faker.random.words(2).toLowerCase().replace(/ /g, '-'));
+    return {
+      assetKey: {path: ['foo', 'bar']},
+      subsetValue: {
+        boolValue: true,
+        partitionKeys,
+        partitionKeyRanges: null,
+        isPartitioned: true,
+      },
+    };
+  }, []);
+
+  return (
+    <Box flex={{direction: 'row'}}>
+      <PartitionSegmentWithPopover
+        description="is_missing"
+        status={AssetConditionEvaluationStatus.TRUE}
+        width={200}
+        subset={subset}
+      />
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/PolicyEvaluationTable.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/PolicyEvaluationTable.stories.tsx
@@ -97,6 +97,25 @@ export const Partitioned = () => {
     numTrue: 0,
     numFalse: 100,
     numSkipped: 0,
+    trueSubset: {
+      assetKey: {path: ['foo']},
+      subsetValue: {
+        boolValue: true,
+        partitionKeys: [],
+        partitionKeyRanges: null,
+        isPartitioned: true,
+      },
+    },
+    falseSubset: {
+      assetKey: {path: ['foo']},
+      subsetValue: {
+        boolValue: false,
+        partitionKeys: new Array(100).fill(null).map((_, ii) => `false-${ii}`),
+        partitionKeyRanges: null,
+        isPartitioned: true,
+      },
+    },
+    candidateSubset: null,
     childEvaluations: [
       {
         __typename: 'PartitionedAssetConditionEvaluation' as const,
@@ -106,6 +125,25 @@ export const Partitioned = () => {
         numTrue: 30,
         numFalse: 70,
         numSkipped: 0,
+        trueSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: true,
+            partitionKeys: new Array(30).fill(null).map((_, ii) => `true-${ii}`),
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        falseSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: false,
+            partitionKeys: new Array(70).fill(null).map((_, ii) => `false-${ii}`),
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        candidateSubset: null,
         childEvaluations: [
           {
             __typename: 'PartitionedAssetConditionEvaluation' as const,
@@ -116,6 +154,33 @@ export const Partitioned = () => {
             numTrue: 30,
             numFalse: 20,
             numSkipped: 50,
+            trueSubset: {
+              assetKey: {path: ['foo']},
+              subsetValue: {
+                boolValue: true,
+                partitionKeys: new Array(30).fill(null).map((_, ii) => `true-${ii}`),
+                partitionKeyRanges: null,
+                isPartitioned: true,
+              },
+            },
+            falseSubset: {
+              assetKey: {path: ['foo']},
+              subsetValue: {
+                boolValue: false,
+                partitionKeys: new Array(20).fill(null).map((_, ii) => `false-${ii}`),
+                partitionKeyRanges: null,
+                isPartitioned: true,
+              },
+            },
+            candidateSubset: {
+              assetKey: {path: ['foo']},
+              subsetValue: {
+                boolValue: null,
+                partitionKeys: new Array(50).fill(null).map((_, ii) => `true-${ii}`),
+                partitionKeyRanges: null,
+                isPartitioned: true,
+              },
+            },
             childEvaluations: null,
           },
           {
@@ -127,6 +192,33 @@ export const Partitioned = () => {
             numTrue: 0,
             numFalse: 30,
             numSkipped: 70,
+            trueSubset: {
+              assetKey: {path: ['foo']},
+              subsetValue: {
+                boolValue: true,
+                partitionKeys: new Array(30).fill(null).map((_, ii) => `true-${ii}`),
+                partitionKeyRanges: null,
+                isPartitioned: true,
+              },
+            },
+            falseSubset: {
+              assetKey: {path: ['foo']},
+              subsetValue: {
+                boolValue: false,
+                partitionKeys: new Array(30).fill(null).map((_, ii) => `false-${ii}`),
+                partitionKeyRanges: null,
+                isPartitioned: true,
+              },
+            },
+            candidateSubset: {
+              assetKey: {path: ['foo']},
+              subsetValue: {
+                boolValue: null,
+                partitionKeys: new Array(70).fill(null).map((_, ii) => `true-${ii}`),
+                partitionKeyRanges: null,
+                isPartitioned: true,
+              },
+            },
             childEvaluations: null,
           },
         ],
@@ -139,6 +231,25 @@ export const Partitioned = () => {
         numTrue: 30,
         numFalse: 70,
         numSkipped: 0,
+        trueSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: true,
+            partitionKeys: new Array(30).fill(null).map((_, ii) => `true-${ii}`),
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        falseSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: false,
+            partitionKeys: new Array(70).fill(null).map((_, ii) => `false-${ii}`),
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        candidateSubset: null,
         childEvaluations: [
           {
             __typename: 'PartitionedAssetConditionEvaluation' as const,
@@ -149,6 +260,25 @@ export const Partitioned = () => {
             numTrue: 80,
             numFalse: 20,
             numSkipped: 0,
+            trueSubset: {
+              assetKey: {path: ['foo']},
+              subsetValue: {
+                boolValue: true,
+                partitionKeys: new Array(80).fill(null).map((_, ii) => `true-${ii}`),
+                partitionKeyRanges: null,
+                isPartitioned: true,
+              },
+            },
+            falseSubset: {
+              assetKey: {path: ['foo']},
+              subsetValue: {
+                boolValue: false,
+                partitionKeys: new Array(20).fill(null).map((_, ii) => `false-${ii}`),
+                partitionKeyRanges: null,
+                isPartitioned: true,
+              },
+            },
+            candidateSubset: null,
             childEvaluations: null,
           },
         ],
@@ -161,6 +291,25 @@ export const Partitioned = () => {
         numTrue: 0,
         numFalse: 100,
         numSkipped: 0,
+        trueSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: true,
+            partitionKeys: [],
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        falseSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: false,
+            partitionKeys: new Array(100).fill(null).map((_, ii) => `false-${ii}`),
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        candidateSubset: null,
         childEvaluations: null,
       },
       {
@@ -171,6 +320,33 @@ export const Partitioned = () => {
         numTrue: 0,
         numFalse: 0,
         numSkipped: 100,
+        trueSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: true,
+            partitionKeys: [],
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        falseSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: false,
+            partitionKeys: [],
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        candidateSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: null,
+            partitionKeys: new Array(100).fill(null).map((_, ii) => `true-${ii}`),
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
         childEvaluations: null,
       },
     ],

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types.tsx
@@ -1,3 +1,6 @@
+import {PartitionKeyRange} from '../../graphql/types';
+import {AssetKey} from '../types';
+
 import {AutoMaterializeEvaluationRecordItemFragment} from './types/GetEvaluationsQuery.types';
 
 export type NoConditionsMetEvaluation = {
@@ -29,6 +32,18 @@ export type AssetConditionEvaluation =
   | UnpartitionedAssetConditionEvaluation
   | PartitionedAssetConditionEvaluation;
 
+export type AssetSubset = {
+  assetKey: AssetKey;
+  subsetValue: AssetSubsetValue;
+};
+
+export type AssetSubsetValue = {
+  boolValue: boolean | null;
+  partitionKeys: string[] | null;
+  partitionKeyRanges: PartitionKeyRange[] | null;
+  isPartitioned: boolean;
+};
+
 export type UnpartitionedAssetConditionEvaluation = {
   __typename: 'UnpartitionedAssetConditionEvaluation';
   description: string;
@@ -48,4 +63,9 @@ export type PartitionedAssetConditionEvaluation = {
   numFalse: number;
   numSkipped: number;
   childEvaluations: PartitionedAssetConditionEvaluation[] | null;
+
+  // We may want to query for these separately
+  trueSubset: AssetSubset;
+  falseSubset: AssetSubset;
+  candidateSubset: AssetSubset | null;
 };


### PR DESCRIPTION
## Summary & Motivation

Implement a popover to display the list of partitions that are true/false/skipped for a given evaluation policy condition.

https://github.com/dagster-io/dagster/assets/2823852/be235d50-98d6-471f-be74-9eca7d2fa8c2

## How I Tested These Changes

Storybook
