### PR TITLE
flatten & and | asset selections

### DIFF
--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -20,6 +20,7 @@ from dagster import (
 )
 from dagster._core.definitions import AssetSelection, asset
 from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_selection import AndAssetSelection, OrAssetSelection
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.events import AssetKey
 from dagster._serdes.serdes import _WHITELIST_MAP
@@ -378,6 +379,24 @@ def test_from_coercible_tuple():
         AssetKey("foo"),
         AssetKey("bar"),
     }
+
+
+def test_multi_operand_selection():
+    foo = AssetSelection.keys("foo")
+    bar = AssetSelection.keys("bar")
+    baz = AssetSelection.keys("baz")
+
+    assert foo & bar & baz == AndAssetSelection([foo, bar, baz])
+    assert (foo & bar) & baz == AndAssetSelection([foo, bar, baz])
+    assert foo & (bar & baz) == AndAssetSelection([foo, bar, baz])
+    assert foo | bar | baz == OrAssetSelection([foo, bar, baz])
+    assert (foo | bar) | baz == OrAssetSelection([foo, bar, baz])
+    assert foo | (bar | baz) == OrAssetSelection([foo, bar, baz])
+
+    assert (foo & bar) | baz == OrAssetSelection([AndAssetSelection([foo, bar]), baz])
+    assert foo & (bar | baz) == AndAssetSelection([foo, OrAssetSelection([bar, baz])])
+    assert (foo | bar) & baz == AndAssetSelection([OrAssetSelection([foo, bar]), baz])
+    assert foo | (bar & baz) == OrAssetSelection([foo, AndAssetSelection([bar, baz])])
 
 
 def test_all_asset_selection_subclasses_serializable():


### PR DESCRIPTION
## Summary & Motivation

Prior to this PR, `&`-ing asset selections a, b, and c via `a & b & c` would result in `AndAssetSelection(AndAssetSelection(a, b), c)`.

With this PR, it results in `AndAssetSelection([a, b, c])`.

Advantages:
- The serialized representation takes up less space
- Its easier to generate a legible string representation, to display in the UI

Note that this breaks compatibility with previously serialized AndAssetSelection and OrAssetSelections. But we haven't released since we whitelisted those for serdes. So we need to merge this before we release.

## How I Tested These Changes
