### PR TITLE
[ui] Reuse RunConfigDialog for Runs list

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.tsx
@@ -13,7 +13,6 @@ import {
   JoinedButtons,
   DialogBody,
   Box,
-  StyledRawCodeMirror,
   colorBackgroundLight,
   colorTextLight,
 } from '@dagster-io/ui-components';
@@ -36,6 +35,7 @@ import {workspacePathFromRunDetails} from '../workspace/workspacePath';
 
 import {DeletionDialog} from './DeletionDialog';
 import {ReexecutionDialog} from './ReexecutionDialog';
+import {RunConfigDialog} from './RunConfigDialog';
 import {doneStatuses, failedStatuses} from './RunStatuses';
 import {RunTags} from './RunTags';
 import {RunsQueryRefetchContext} from './RunUtils';
@@ -64,6 +64,15 @@ export const RunActionsMenu = React.memo(({run, onAddTag, additionalActionsForRu
   const {rootServerURI} = React.useContext(AppContext);
 
   const copyConfig = useCopyToClipboard();
+  const onCopy = async () => {
+    copyConfig(runConfigYaml || '');
+    await showSharedToaster({
+      intent: 'success',
+      icon: 'copy_to_clipboard_done',
+      message: 'Copied!',
+    });
+  };
+
   const reexecute = useJobReexecution({onCompleted: refetch});
 
   const [loadEnv, {called, loading, data}] = useLazyQuery<
@@ -273,36 +282,14 @@ export const RunActionsMenu = React.memo(({run, onAddTag, additionalActionsForRu
           </Button>
         </DialogFooter>
       </Dialog>
-      <Dialog
+      <RunConfigDialog
         isOpen={visibleDialog === 'config'}
-        title="Config"
-        canOutsideClickClose
-        canEscapeKeyClose
         onClose={closeDialogs}
-      >
-        <StyledRawCodeMirror
-          value={runConfigYaml || ''}
-          options={{readOnly: true, lineNumbers: true, mode: 'yaml'}}
-        />
-        <DialogFooter topBorder>
-          <Button
-            intent="none"
-            onClick={async () => {
-              copyConfig(runConfigYaml || '');
-              await showSharedToaster({
-                intent: 'success',
-                icon: 'copy_to_clipboard_done',
-                message: 'Copied!',
-              });
-            }}
-          >
-            Copy config
-          </Button>
-          <Button intent="primary" onClick={closeDialogs}>
-            OK
-          </Button>
-        </DialogFooter>
-      </Dialog>
+        copyConfig={onCopy}
+        mode={run.mode}
+        runConfigYaml={runConfigYaml || ''}
+        isJob={isJob}
+      />
     </>
   );
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunConfigDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunConfigDialog.tsx
@@ -1,217 +1,84 @@
-import {useMutation} from '@apollo/client';
 import {
   Box,
   Button,
   Dialog,
   DialogFooter,
-  Group,
-  Icon,
-  Menu,
-  MenuItem,
-  Popover,
   StyledRawCodeMirror,
   Subheading,
-  Tooltip,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
-import {useHistory} from 'react-router-dom';
 import styled from 'styled-components';
 
-import {AppContext} from '../app/AppContext';
-import {showSharedToaster} from '../app/DomUtils';
-import {useCopyToClipboard} from '../app/browser';
-import {FREE_CONCURRENCY_SLOTS_MUTATION} from '../instance/InstanceConcurrency';
-import {
-  FreeConcurrencySlotsMutation,
-  FreeConcurrencySlotsMutationVariables,
-} from '../instance/types/InstanceConcurrency.types';
-import {NO_LAUNCH_PERMISSION_MESSAGE} from '../launchpad/LaunchRootExecutionButton';
-import {AnchorButton} from '../ui/AnchorButton';
-import {workspacePathFromRunDetails, workspacePipelinePath} from '../workspace/workspacePath';
-
-import {DeletionDialog} from './DeletionDialog';
-import {doneStatuses} from './RunStatuses';
 import {RunTags} from './RunTags';
-import {RunsQueryRefetchContext} from './RunUtils';
-import {TerminationDialog} from './TerminationDialog';
-import {RunFragment} from './types/RunFragments.types';
+import {RunTagsFragment} from './types/RunTable.types';
 
-type VisibleDialog = 'config' | 'delete' | 'terminate' | 'free_slots' | null;
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  copyConfig: () => void;
+  runConfigYaml: string;
+  mode: string | null;
+  isJob: boolean;
 
-export const RunConfigDialog = ({run, isJob}: {run: RunFragment; isJob: boolean}) => {
-  const {runConfigYaml} = run;
-  const [visibleDialog, setVisibleDialog] = React.useState<VisibleDialog>(null);
+  // Optionally provide tags to display them as well.
+  tags?: RunTagsFragment[];
+}
 
-  const {rootServerURI} = React.useContext(AppContext);
-  const {refetch} = React.useContext(RunsQueryRefetchContext);
-
-  const copy = useCopyToClipboard();
-  const history = useHistory();
-
-  const [freeSlots] = useMutation<
-    FreeConcurrencySlotsMutation,
-    FreeConcurrencySlotsMutationVariables
-  >(FREE_CONCURRENCY_SLOTS_MUTATION);
-
-  const copyConfig = async () => {
-    copy(runConfigYaml);
-    await showSharedToaster({
-      intent: 'success',
-      icon: 'copy_to_clipboard_done',
-      message: 'Copied!',
-    });
-  };
-
-  const freeConcurrencySlots = async () => {
-    const resp = await freeSlots({variables: {runId: run.id}});
-    if (resp.data?.freeConcurrencySlots) {
-      await showSharedToaster({
-        intent: 'success',
-        icon: 'check_circle',
-        message: 'Freed concurrency slots',
-      });
-    }
-  };
-
-  const jobPath = workspacePathFromRunDetails({
-    id: run.id,
-    repositoryName: run.repositoryOrigin?.repositoryName,
-    repositoryLocationName: run.repositoryOrigin?.repositoryLocationName,
-    pipelineName: run.pipelineName,
-    isJob,
-  });
+export const RunConfigDialog = (props: Props) => {
+  const {isOpen, onClose, copyConfig, runConfigYaml, tags, mode, isJob} = props;
+  const hasTags = !!tags && tags.length > 0;
 
   return (
-    <div>
-      <Group direction="row" spacing={8}>
-        {run.hasReExecutePermission ? (
-          <AnchorButton icon={<Icon name="edit" />} to={jobPath}>
-            Open in Launchpad
-          </AnchorButton>
-        ) : (
-          <Tooltip content={NO_LAUNCH_PERMISSION_MESSAGE} useDisabledButtonTooltipFix>
-            <Button icon={<Icon name="edit" />} disabled>
-              Open in Launchpad
-            </Button>
-          </Tooltip>
-        )}
-        <Button icon={<Icon name="tag" />} onClick={() => setVisibleDialog('config')}>
-          View tags and config
-        </Button>
-        <Popover
-          position="bottom-right"
-          content={
-            <Menu>
-              <Tooltip
-                content="Loadable in dagster-webserver-debug"
-                position="left"
-                targetTagName="div"
-              >
-                <MenuItem
-                  text="Download debug file"
-                  icon={<Icon name="download_for_offline" />}
-                  onClick={() => window.open(`${rootServerURI}/download_debug/${run.id}`)}
-                />
-              </Tooltip>
-              {run.hasConcurrencyKeySlots && doneStatuses.has(run.status) ? (
-                <MenuItem
-                  text="Free concurrency slots"
-                  icon={<Icon name="lock" />}
-                  onClick={freeConcurrencySlots}
-                />
-              ) : null}
-              {run.hasDeletePermission ? (
-                <MenuItem
-                  icon="delete"
-                  text="Delete"
-                  intent="danger"
-                  onClick={() => setVisibleDialog('delete')}
-                />
-              ) : null}
-            </Menu>
-          }
-        >
-          <Button icon={<Icon name="expand_more" />} />
-        </Popover>
-      </Group>
-      <Dialog
-        isOpen={visibleDialog === 'config'}
-        onClose={() => setVisibleDialog(null)}
-        style={{
-          width: '90vw',
-          maxWidth: '1000px',
-          minWidth: '600px',
-          height: '90vh',
-          maxHeight: '1000px',
-          minHeight: '600px',
-        }}
-        title="Run configuration"
-      >
-        <Box flex={{direction: 'column'}} style={{flex: 1, overflow: 'hidden'}}>
-          <Box flex={{direction: 'column', gap: 20}} style={{flex: 1, overflow: 'hidden'}}>
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      canOutsideClickClose
+      canEscapeKeyClose
+      style={{
+        width: '90vw',
+        maxWidth: '1000px',
+        minWidth: '600px',
+        height: '90vh',
+        maxHeight: '1000px',
+        minHeight: '600px',
+      }}
+      title="Run configuration"
+    >
+      <Box flex={{direction: 'column'}} style={{flex: 1, overflow: 'hidden'}}>
+        <Box flex={{direction: 'column', gap: 20}} style={{flex: 1, overflow: 'hidden'}}>
+          {hasTags ? (
             <Box flex={{direction: 'column', gap: 12}} padding={{top: 16, horizontal: 24}}>
               <Subheading>Tags</Subheading>
               <div>
-                <RunTags tags={run.tags} mode={isJob ? null : run.mode} />
+                <RunTags tags={tags} mode={isJob ? null : mode} />
               </div>
             </Box>
-            <Box flex={{direction: 'column'}} style={{flex: 1, overflow: 'hidden'}}>
+          ) : null}
+          <Box flex={{direction: 'column'}} style={{flex: 1, overflow: 'hidden'}}>
+            {hasTags ? (
               <Box border="bottom" padding={{left: 24, bottom: 16}}>
                 <Subheading>Config</Subheading>
               </Box>
-              <CodeMirrorContainer>
-                <StyledRawCodeMirror
-                  value={runConfigYaml}
-                  options={{readOnly: true, lineNumbers: true, mode: 'yaml'}}
-                  theme={['config-editor']}
-                />
-              </CodeMirrorContainer>
-            </Box>
+            ) : null}
+            <CodeMirrorContainer>
+              <StyledRawCodeMirror
+                value={runConfigYaml}
+                options={{readOnly: true, lineNumbers: true, mode: 'yaml'}}
+                theme={['config-editor']}
+              />
+            </CodeMirrorContainer>
           </Box>
-          <DialogFooter topBorder>
-            <Button onClick={() => copyConfig()} intent="none">
-              Copy config
-            </Button>
-            <Button onClick={() => setVisibleDialog(null)} intent="primary">
-              OK
-            </Button>
-          </DialogFooter>
         </Box>
-      </Dialog>
-      {run.hasDeletePermission ? (
-        <DeletionDialog
-          isOpen={visibleDialog === 'delete'}
-          onClose={() => setVisibleDialog(null)}
-          onComplete={() => {
-            if (run.repositoryOrigin) {
-              history.push(
-                workspacePipelinePath({
-                  repoName: run.repositoryOrigin.repositoryName,
-                  repoLocation: run.repositoryOrigin.repositoryLocationName,
-                  pipelineName: run.pipelineName,
-                  isJob,
-                  path: '/runs',
-                }),
-              );
-            } else {
-              setVisibleDialog(null);
-            }
-          }}
-          onTerminateInstead={() => setVisibleDialog('terminate')}
-          selectedRuns={{[run.id]: run.canTerminate}}
-        />
-      ) : null}
-      {run.hasTerminatePermission ? (
-        <TerminationDialog
-          isOpen={visibleDialog === 'terminate'}
-          onClose={() => setVisibleDialog(null)}
-          onComplete={() => {
-            refetch();
-          }}
-          selectedRuns={{[run.id]: run.canTerminate}}
-        />
-      ) : null}
-    </div>
+        <DialogFooter topBorder>
+          <Button onClick={() => copyConfig()} intent="none">
+            Copy config
+          </Button>
+          <Button onClick={onClose} intent="primary">
+            OK
+          </Button>
+        </DialogFooter>
+      </Box>
+    </Dialog>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunHeaderActions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunHeaderActions.tsx
@@ -1,0 +1,167 @@
+import {useMutation} from '@apollo/client';
+import {Button, Group, Icon, Menu, MenuItem, Popover, Tooltip} from '@dagster-io/ui-components';
+import * as React from 'react';
+import {useHistory} from 'react-router-dom';
+
+import {AppContext} from '../app/AppContext';
+import {showSharedToaster} from '../app/DomUtils';
+import {useCopyToClipboard} from '../app/browser';
+import {FREE_CONCURRENCY_SLOTS_MUTATION} from '../instance/InstanceConcurrency';
+import {
+  FreeConcurrencySlotsMutation,
+  FreeConcurrencySlotsMutationVariables,
+} from '../instance/types/InstanceConcurrency.types';
+import {NO_LAUNCH_PERMISSION_MESSAGE} from '../launchpad/LaunchRootExecutionButton';
+import {AnchorButton} from '../ui/AnchorButton';
+import {workspacePathFromRunDetails, workspacePipelinePath} from '../workspace/workspacePath';
+
+import {DeletionDialog} from './DeletionDialog';
+import {RunConfigDialog} from './RunConfigDialog';
+import {doneStatuses} from './RunStatuses';
+import {RunsQueryRefetchContext} from './RunUtils';
+import {TerminationDialog} from './TerminationDialog';
+import {RunFragment} from './types/RunFragments.types';
+
+type VisibleDialog = 'config' | 'delete' | 'terminate' | 'free_slots' | null;
+
+export const RunHeaderActions = ({run, isJob}: {run: RunFragment; isJob: boolean}) => {
+  const {runConfigYaml} = run;
+  const [visibleDialog, setVisibleDialog] = React.useState<VisibleDialog>(null);
+
+  const {rootServerURI} = React.useContext(AppContext);
+  const {refetch} = React.useContext(RunsQueryRefetchContext);
+
+  const copy = useCopyToClipboard();
+  const history = useHistory();
+
+  const [freeSlots] = useMutation<
+    FreeConcurrencySlotsMutation,
+    FreeConcurrencySlotsMutationVariables
+  >(FREE_CONCURRENCY_SLOTS_MUTATION);
+
+  const copyConfig = async () => {
+    copy(runConfigYaml);
+    await showSharedToaster({
+      intent: 'success',
+      icon: 'copy_to_clipboard_done',
+      message: 'Copied!',
+    });
+  };
+
+  const freeConcurrencySlots = async () => {
+    const resp = await freeSlots({variables: {runId: run.id}});
+    if (resp.data?.freeConcurrencySlots) {
+      await showSharedToaster({
+        intent: 'success',
+        icon: 'check_circle',
+        message: 'Freed concurrency slots',
+      });
+    }
+  };
+
+  const jobPath = workspacePathFromRunDetails({
+    id: run.id,
+    repositoryName: run.repositoryOrigin?.repositoryName,
+    repositoryLocationName: run.repositoryOrigin?.repositoryLocationName,
+    pipelineName: run.pipelineName,
+    isJob,
+  });
+
+  return (
+    <div>
+      <Group direction="row" spacing={8}>
+        {run.hasReExecutePermission ? (
+          <AnchorButton icon={<Icon name="edit" />} to={jobPath}>
+            Open in Launchpad
+          </AnchorButton>
+        ) : (
+          <Tooltip content={NO_LAUNCH_PERMISSION_MESSAGE} useDisabledButtonTooltipFix>
+            <Button icon={<Icon name="edit" />} disabled>
+              Open in Launchpad
+            </Button>
+          </Tooltip>
+        )}
+        <Button icon={<Icon name="tag" />} onClick={() => setVisibleDialog('config')}>
+          View tags and config
+        </Button>
+        <Popover
+          position="bottom-right"
+          content={
+            <Menu>
+              <Tooltip
+                content="Loadable in dagster-webserver-debug"
+                position="left"
+                targetTagName="div"
+              >
+                <MenuItem
+                  text="Download debug file"
+                  icon={<Icon name="download_for_offline" />}
+                  onClick={() => window.open(`${rootServerURI}/download_debug/${run.id}`)}
+                />
+              </Tooltip>
+              {run.hasConcurrencyKeySlots && doneStatuses.has(run.status) ? (
+                <MenuItem
+                  text="Free concurrency slots"
+                  icon={<Icon name="lock" />}
+                  onClick={freeConcurrencySlots}
+                />
+              ) : null}
+              {run.hasDeletePermission ? (
+                <MenuItem
+                  icon="delete"
+                  text="Delete"
+                  intent="danger"
+                  onClick={() => setVisibleDialog('delete')}
+                />
+              ) : null}
+            </Menu>
+          }
+        >
+          <Button icon={<Icon name="expand_more" />} />
+        </Popover>
+      </Group>
+      <RunConfigDialog
+        isOpen={visibleDialog === 'config'}
+        onClose={() => setVisibleDialog(null)}
+        copyConfig={() => copyConfig()}
+        mode={run.mode}
+        runConfigYaml={run.runConfigYaml}
+        tags={run.tags}
+        isJob={isJob}
+      />
+      {run.hasDeletePermission ? (
+        <DeletionDialog
+          isOpen={visibleDialog === 'delete'}
+          onClose={() => setVisibleDialog(null)}
+          onComplete={() => {
+            if (run.repositoryOrigin) {
+              history.push(
+                workspacePipelinePath({
+                  repoName: run.repositoryOrigin.repositoryName,
+                  repoLocation: run.repositoryOrigin.repositoryLocationName,
+                  pipelineName: run.pipelineName,
+                  isJob,
+                  path: '/runs',
+                }),
+              );
+            } else {
+              setVisibleDialog(null);
+            }
+          }}
+          onTerminateInstead={() => setVisibleDialog('terminate')}
+          selectedRuns={{[run.id]: run.canTerminate}}
+        />
+      ) : null}
+      {run.hasTerminatePermission ? (
+        <TerminationDialog
+          isOpen={visibleDialog === 'terminate'}
+          onClose={() => setVisibleDialog(null)}
+          onComplete={() => {
+            refetch();
+          }}
+          selectedRuns={{[run.id]: run.canTerminate}}
+        />
+      ) : null}
+    </div>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
@@ -15,8 +15,8 @@ import {useRepositoryForRunWithParentSnapshot} from '../workspace/useRepositoryF
 
 import {AssetKeyTagCollection, AssetCheckTagCollection} from './AssetTagCollections';
 import {Run} from './Run';
-import {RunConfigDialog} from './RunConfigDialog';
 import {RUN_PAGE_FRAGMENT} from './RunFragments';
+import {RunHeaderActions} from './RunHeaderActions';
 import {RunRootTrace, useRunRootTrace} from './RunRootTrace';
 import {RunStatusTag} from './RunStatusTag';
 import {DagsterTag} from './RunTag';
@@ -155,7 +155,7 @@ export const RunRoot = () => {
               </Box>
             ) : null
           }
-          right={run ? <RunConfigDialog run={run} isJob={isJob} /> : null}
+          right={run ? <RunHeaderActions run={run} isJob={isJob} /> : null}
         />
       </Box>
       <RunById data={data} runId={runId} trace={trace} />


### PR DESCRIPTION
## Summary & Motivation

Resolves #18855.

Use the run config dialog from the Run page on the Runs list. It occupies more of the viewport, which is better for runs with large config yaml content.

## How I Tested These Changes

View a run, click to view the tags/config. Verify success.

View Runs list, use action menu to view config. Verify that the large dialog appears properly.
