### PR TITLE
[ui] Runs page: swap tag order for checks and assets

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
@@ -136,7 +136,6 @@ export const RunRoot = () => {
                     tickId={tickDetails.tickId}
                   />
                 ) : null}
-                <AssetCheckTagCollection useTags assetChecks={run.assetCheckSelection} />
                 <AssetKeyTagCollection
                   useTags
                   assetKeys={
@@ -145,6 +144,7 @@ export const RunRoot = () => {
                       : run.assets.map((a) => a.key)
                   }
                 />
+                <AssetCheckTagCollection useTags assetChecks={run.assetCheckSelection} />
                 <RunTimingTags run={run} loading={loading} />
                 {automaterializeTag && run.assetSelection?.length ? (
                   <AutomaterializeTagWithEvaluation


### PR DESCRIPTION
## Summary & Motivation

Resolves #18892.

Swap the order of the asset check tag and the asset key tag in the Run header.

## How I Tested These Changes

I don't have any asset checks going locally, but the tags render correctly when I force them to do so.
