### PR TITLE
[ui] Memoize timestamp rendering

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/timestampToString.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/timestampToString.test.tsx
@@ -1,4 +1,5 @@
-import {timestampToString} from '../time/timestampToString';
+import {DEFAULT_TIME_FORMAT} from '../time/TimestampFormat';
+import {resolveTimestampKey, timestampToString} from '../time/timestampToString';
 
 const DEC_1_2020 = 1606824000; // Dec 1, 2020 00:00 UTC
 const JAN_1_2021 = 1609459200; // Jan 1, 2021 00:00 UTC
@@ -90,5 +91,45 @@ describe('timestampToString', () => {
         timeFormat: {showSeconds: true, showTimezone: true},
       }),
     ).toBe('Mar 14, 9:00:00 AM GMT+1');
+  });
+
+  it('resolves to the same memoization key for the same config', () => {
+    const expectedKey =
+      '1615708800000-en-US-America/Chicago-{"showTimezone":false,"showSeconds":false}-Automatic';
+
+    expect(
+      resolveTimestampKey({
+        timestamp: {unix: MAR_14_2021},
+        locale: 'en-US',
+        timezone: 'America/Chicago',
+      }),
+    ).toBe(expectedKey);
+
+    expect(
+      resolveTimestampKey({
+        timestamp: {ms: MAR_14_2021 * 1000},
+        locale: 'en-US',
+        timezone: 'America/Chicago',
+      }),
+    ).toBe(expectedKey);
+
+    expect(
+      resolveTimestampKey({
+        timestamp: {unix: MAR_14_2021},
+        locale: 'en-US',
+        timezone: 'America/Chicago',
+        timeFormat: DEFAULT_TIME_FORMAT,
+        hourCycle: 'Automatic',
+      }),
+    ).toBe(expectedKey);
+
+    // Now let's try a different config. It should *not* match the key above.
+    expect(
+      resolveTimestampKey({
+        timestamp: {unix: MAR_14_2021},
+        locale: 'de-DE',
+        timezone: 'America/Chicago',
+      }),
+    ).not.toBe(expectedKey);
   });
 });


### PR DESCRIPTION
## Summary & Motivation

While doing a bit of perf profiling on the Sensor page, I noticed that timestamp rendering in the evaluations table is one of the slowest parts of the table. This can add up when there are a lot of timestamps rendered on the page, and when the table is being re-rendered often as polled data comes in.

Date formatting can be a bit slow in general, and since these are static values with consistent configuration, we can be a bit more proactive about avoiding extra work.

This PR adds memoization for the formatted date/time string for a given timestamp and config.

## How I Tested These Changes

On a running automaterialization sensor, note that the `Timestamp` component is one of the slowest parts of the evaluation table. Then, with the change in place, verify that the `Timestamp` component re-render time is nearly eliminated.
