### PR TITLE
feat(logging): add json log format

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -152,6 +152,14 @@ DEFAULT_POOL_RECYCLE = 3600  # 1 hr
     envvar="DAGSTER_WEBSERVER_LOG_LEVEL",
 )
 @click.option(
+    "--log-format",
+    type=click.Choice(["colored", "json"], case_sensitive=False),
+    show_default=True,
+    required=False,
+    default="colored",
+    help="Format of the log output from the webserver",
+)
+@click.option(
     "--code-server-log-level",
     help="Set the log level for any code servers spun up by the webserver.",
     show_default=True,
@@ -183,6 +191,7 @@ def dagster_webserver(
     suppress_warnings: bool,
     uvicorn_log_level: str,
     dagster_log_level: str,
+    log_format: str,
     code_server_log_level: str,
     instance_ref: Optional[str],
     live_data_poll_rate: int,
@@ -191,7 +200,7 @@ def dagster_webserver(
     if suppress_warnings:
         os.environ["PYTHONWARNINGS"] = "ignore"
 
-    configure_loggers(log_level=dagster_log_level.upper())
+    configure_loggers(formatter=log_format, log_level=dagster_log_level.upper())
     logger = logging.getLogger(WEBSERVER_LOGGER_NAME)
 
     if sys.argv[0].endswith("dagit"):

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -550,6 +550,14 @@ def _execute_step_command_body(
     help="Level at which to log output from the code server process",
 )
 @click.option(
+    "--log-format",
+    type=click.Choice(["colored", "json"], case_sensitive=False),
+    show_default=True,
+    required=False,
+    default="colored",
+    help="Format of the log output from the code server process",
+)
+@click.option(
     "--container-image",
     type=click.STRING,
     required=False,
@@ -606,6 +614,7 @@ def grpc_command(
     lazy_load_user_code=False,
     fixed_server_id=None,
     log_level="INFO",
+    log_format="colored",
     use_python_environment_entry_point=False,
     container_image=None,
     container_context=None,
@@ -632,7 +641,7 @@ def grpc_command(
 
     setup_interrupt_handlers()
 
-    configure_loggers(log_level=log_level.upper())
+    configure_loggers(formatter=log_format, log_level=log_level.upper())
     logger = logging.getLogger("dagster.code_server")
 
     container_image = container_image or os.getenv("DAGSTER_CURRENT_IMAGE")

--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -96,6 +96,14 @@ def code_server_cli():
     help="Level at which to log output from the code server process",
 )
 @click.option(
+    "--log-format",
+    type=click.Choice(["colored", "json"], case_sensitive=False),
+    show_default=True,
+    required=False,
+    default="colored",
+    help="Format of the log output from the code server process",
+)
+@click.option(
     "--container-image",
     type=click.STRING,
     required=False,
@@ -149,6 +157,7 @@ def start_command(
     max_workers: Optional[int] = None,
     fixed_server_id: Optional[str] = None,
     log_level: str = "INFO",
+    log_format: str = "colored",
     use_python_environment_entry_point: bool = False,
     container_image: Optional[str] = None,
     container_context: Optional[str] = None,
@@ -170,7 +179,7 @@ def start_command(
 
     setup_interrupt_handlers()
 
-    configure_loggers(log_level=log_level.upper())
+    configure_loggers(formatter=log_format, log_level=log_level.upper())
     logger = logging.getLogger("dagster.code_server")
 
     container_image = container_image or os.getenv("DAGSTER_CURRENT_IMAGE")

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -90,6 +90,7 @@ def daemon_controller_from_instance(
     error_interval_seconds: int = DEFAULT_DAEMON_ERROR_INTERVAL_SECONDS,
     code_server_log_level: str = "info",
     log_level: str = "info",
+    log_format: str = "colored",
 ) -> Iterator["DagsterDaemonController"]:
     check.inst_param(instance, "instance", DagsterInstance)
     check.inst_param(workspace_load_target, "workspace_load_target", WorkspaceLoadTarget)
@@ -115,6 +116,7 @@ def daemon_controller_from_instance(
                 error_interval_seconds=error_interval_seconds,
                 grpc_server_registry=grpc_server_registry,
                 log_level=log_level,
+                log_format=log_format,
             )
         )
 
@@ -145,6 +147,7 @@ class DagsterDaemonController(AbstractContextManager):
         error_interval_seconds: int = DEFAULT_DAEMON_ERROR_INTERVAL_SECONDS,
         handler: str = "default",
         log_level: str = "info",
+        log_format: str = "colored",
     ):
         self._daemon_uuid = str(uuid.uuid4())
 
@@ -170,7 +173,7 @@ class DagsterDaemonController(AbstractContextManager):
 
         self._daemon_shutdown_event = threading.Event()
 
-        configure_loggers(handler=handler, log_level=log_level.upper())
+        configure_loggers(handler=handler, formatter=log_format, log_level=log_level.upper())
 
         self._logger = logging.getLogger("dagster.daemon")
         self._logger.info(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_dagster_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_dagster_daemon.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from click.testing import CliRunner
 from dagster._core.test_utils import instance_for_test
@@ -6,6 +8,7 @@ from dagster._daemon.cli import run_command
 from dagster._daemon.controller import daemon_controller_from_instance
 from dagster._daemon.daemon import SchedulerDaemon
 from dagster._daemon.run_coordinator.queued_run_coordinator_daemon import QueuedRunCoordinatorDaemon
+from dagster._utils.log import get_structlog_json_formatter
 
 
 def test_scheduler_instance():
@@ -51,3 +54,27 @@ def test_ephemeral_instance():
     runner = CliRunner()
     with pytest.raises(Exception, match="DAGSTER_HOME is not set"):
         runner.invoke(run_command, env={"DAGSTER_HOME": ""}, catch_exceptions=False)
+
+
+def test_daemon_json_logs(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # https://github.com/pytest-dev/pytest/issues/2987#issuecomment-1460509126
+    #
+    # pytest captures log records using their handler. However, as a side-effect, this prevents
+    # Dagster's log formatting from being applied in a unit test.
+    #
+    # To test the formatting, we monkeypatch the handler's formatter to use the same formatter as
+    # the one used by Dagster when enabling JSON log format.
+    monkeypatch.setattr(caplog.handler, "formatter", get_structlog_json_formatter())
+
+    with instance_for_test() as instance, daemon_controller_from_instance(
+        instance,
+        workspace_load_target=EmptyWorkspaceTarget(),
+        log_format="json",
+    ):
+        lines = [line for line in caplog.text.split("\n") if line]
+
+        assert lines
+        assert [json.loads(line) for line in lines]

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -97,6 +97,7 @@ setup(
         "tomli<3",
         "tqdm<5",
         "typing_extensions>=4.4.0,<5",
+        "structlog",
         "sqlalchemy>=1.0,<3",
         "toposort>=1.0",
         "watchdog>=0.8.3",


### PR DESCRIPTION
## Summary & Motivation

Adds a new CLI flag `--log-format` to control how Dagster webserver and daemon logs are formatted in stdout. Here, we allow users to format their logs as JSON logs.

By default, logs are still formatted using `coloredlogs`.

## How I Tested These Changes
- `dagster dev --log-format json`
- pytest
