### PR TITLE
feat(logging): add `rich` log format

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -153,7 +153,7 @@ DEFAULT_POOL_RECYCLE = 3600  # 1 hr
 )
 @click.option(
     "--log-format",
-    type=click.Choice(["colored", "json"], case_sensitive=False),
+    type=click.Choice(["colored", "json", "rich"], case_sensitive=False),
     show_default=True,
     required=False,
     default="colored",

--- a/python_modules/dagster-webserver/dagster_webserver_tests/test_app.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/test_app.py
@@ -355,13 +355,21 @@ def test_dagster_webserver_json_logs(
     # the one used by Dagster when enabling JSON log format.
     monkeypatch.setattr(caplog.handler, "formatter", get_structlog_json_formatter())
 
-    with instance_for_test():
-        runner = CliRunner()
-        result = runner.invoke(dagster_webserver, ["--log-format=json", "--empty-workspace"])
+    runner = CliRunner()
+    result = runner.invoke(dagster_webserver, ["--log-format", "json", "--empty-workspace"])
 
-        assert result.exit_code == 0, str(result.exception)
+    assert result.exit_code == 0, str(result.exception)
 
-        lines = [line for line in caplog.text.split("\n") if line]
+    lines = [line for line in caplog.text.split("\n") if line]
 
-        assert lines
-        assert [json.loads(line) for line in lines]
+    assert lines
+    assert [json.loads(line) for line in lines]
+
+
+@mock.patch("uvicorn.run")
+def test_dagster_webserver_rich_logs(_: mock.Mock) -> None:
+    runner = CliRunner()
+    result = runner.invoke(dagster_webserver, ["--log-format", "rich", "--empty-workspace"])
+
+    # Test that the webserver can be started with rich formatting.
+    assert result.exit_code == 0, str(result.exception)

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -551,7 +551,7 @@ def _execute_step_command_body(
 )
 @click.option(
     "--log-format",
-    type=click.Choice(["colored", "json"], case_sensitive=False),
+    type=click.Choice(["colored", "json", "rich"], case_sensitive=False),
     show_default=True,
     required=False,
     default="colored",

--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -97,7 +97,7 @@ def code_server_cli():
 )
 @click.option(
     "--log-format",
-    type=click.Choice(["colored", "json"], case_sensitive=False),
+    type=click.Choice(["colored", "json", "rich"], case_sensitive=False),
     show_default=True,
     required=False,
     default="colored",

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -69,7 +69,7 @@ def dev_command_options(f):
 )
 @click.option(
     "--log-format",
-    type=click.Choice(["colored", "json"], case_sensitive=False),
+    type=click.Choice(["colored", "json", "rich"], case_sensitive=False),
     show_default=True,
     required=False,
     default="colored",

--- a/python_modules/dagster/dagster/_daemon/cli/__init__.py
+++ b/python_modules/dagster/dagster/_daemon/cli/__init__.py
@@ -55,7 +55,7 @@ def _get_heartbeat_tolerance():
 )
 @click.option(
     "--log-format",
-    type=click.Choice(["colored", "json"], case_sensitive=False),
+    type=click.Choice(["colored", "json", "rich"], case_sensitive=False),
     show_default=True,
     required=False,
     default="colored",

--- a/python_modules/dagster/dagster/_utils/log.py
+++ b/python_modules/dagster/dagster/_utils/log.py
@@ -269,6 +269,14 @@ def configure_loggers(handler="default", formatter="colored", log_level="INFO"):
                 "foreign_pre_chain": json_formatter.foreign_pre_chain,
                 "processors": json_formatter.processors,
             },
+            "rich": {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "foreign_pre_chain": get_structlog_shared_processors(),
+                "processors": [
+                    structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                    structlog.dev.ConsoleRenderer(),
+                ],
+            },
         },
         "handlers": {
             "default": {

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_dagster_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_dagster_daemon.py
@@ -78,3 +78,13 @@ def test_daemon_json_logs(
 
         assert lines
         assert [json.loads(line) for line in lines]
+
+
+def test_daemon_rich_logs() -> None:
+    # Test that the daemon can be started with rich formatting.
+    with instance_for_test() as instance:
+        daemon_controller_from_instance(
+            instance,
+            workspace_load_target=EmptyWorkspaceTarget(),
+            log_format="rich",
+        )

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -108,6 +108,7 @@ setup(
         "universal_pathlib",
         # https://github.com/pydantic/pydantic/issues/5821
         "pydantic>1.10.0,!= 1.10.7,<3",
+        "rich",
         f"dagster-pipes{pin}",
     ],
     extras_require={


### PR DESCRIPTION
## Summary & Motivation

Allow users to log using `rich`. See https://www.structlog.org/en/stable/console-output.html for more details.

These server-side (Dagster webserver + daemon) tracebacks are less useful for users, as they are not working on framework system code. The main benefit comes from introducing this traceback logging in local user code execution. Regardless, we introduce this formatting in the server-side components for consistency.

## How I Tested These Changes
- `dagster dev --log-format=rich`
- pytest

### `rich` vs `coloredlogs`
<img width="933" alt="Screenshot 2024-01-04 at 5 10 46 PM" src="https://github.com/dagster-io/dagster/assets/16431325/146f3807-2a50-4dcc-a16f-63902fb5df16">

### `rich` shows full traceback on exception

**`rich`**
<img width="932" alt="Screenshot 2024-01-04 at 5 21 24 PM" src="https://github.com/dagster-io/dagster/assets/16431325/42215a00-1f13-4ac6-980b-c74b83a1306a">

**`coloredlogs`**
<img width="912" alt="Screenshot 2024-01-04 at 5 20 44 PM" src="https://github.com/dagster-io/dagster/assets/16431325/04ae4c6d-e7e4-4117-970f-c14e593d5ab2">

