### PR TITLE
Relax context annotation constraint on op/asset fn params

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -555,6 +555,7 @@ def _resolve_output_defs_from_outs(
 def _validate_context_type_hint(fn):
     from inspect import _empty as EmptyAnnotation
 
+    from dagster._config.pythonic_config.typing_utils import safe_is_subclass
     from dagster._core.decorator_utils import get_function_params
     from dagster._core.definitions.decorators.op_decorator import is_context_provided
     from dagster._core.execution.context.compute import AssetExecutionContext, OpExecutionContext
@@ -562,8 +563,8 @@ def _validate_context_type_hint(fn):
     params = get_function_params(fn)
     if is_context_provided(params):
         if (
-            params[0].annotation is not AssetExecutionContext
-            and params[0].annotation is not OpExecutionContext
+            not safe_is_subclass(params[0].annotation, AssetExecutionContext)
+            and not safe_is_subclass(params[0].annotation, OpExecutionContext)
             and params[0].annotation is not EmptyAnnotation
         ):
             raise DagsterInvalidDefinitionError(

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
@@ -407,6 +407,22 @@ def test_error_on_invalid_context_annotation():
             pass
 
 
+def test_no_error_on_subclass_context_annotation() -> None:
+    class MyOpExecutionContext(OpExecutionContext):
+        ...
+
+    @op
+    def the_op(context: MyOpExecutionContext):
+        pass
+
+    class MyAssetExecutionContext(AssetExecutionContext):
+        ...
+
+    @asset
+    def the_asset(context: MyAssetExecutionContext):
+        pass
+
+
 def test_get_context():
     with pytest.raises(DagsterInvariantViolationError):
         OpExecutionContext.get()


### PR DESCRIPTION
## Summary

Motivated by https://github.com/dagster-io/dagster/issues/18924.

Relaxes the annotation constraints on `context` to accept subclasses of `OpExecutionContext`, `AssetExecutionContext`.

## Test Plan

New unit test.
