### PR TITLE
[amp-refactor][7/n] Refactor AssetDaemonAssetCursor -> AssetConditionCursor

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition.py
@@ -76,6 +76,10 @@ class AssetConditionEvaluation(NamedTuple):
         )
 
     def discarded_subset(self, condition: "AssetCondition") -> Optional[AssetSubset]:
+        """Returns the AssetSubset representing asset partitions that were discarded during this
+        evaluation. Note that 'discarding' is a deprecated concept that is only used for backwards
+        compatibility.
+        """
         not_discard_condition = condition.not_discard_condition
         if not not_discard_condition or len(self.child_evaluations) != 3:
             return None
@@ -88,7 +92,8 @@ class AssetConditionEvaluation(NamedTuple):
         discarded_subset = self.discarded_subset(condition)
         if discarded_subset is None:
             return self.true_subset
-        return self.true_subset | discarded_subset
+        else:
+            return self.true_subset | discarded_subset
 
     def for_child(self, child_condition: "AssetCondition") -> Optional["AssetConditionEvaluation"]:
         """Returns the evaluation of a given child condition by finding the child evaluation that

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -109,7 +109,7 @@ class AutoMaterializeRule(ABC):
         # we've explicitly said to ignore it
         ignore_subset = has_metadata_subset | ignore_subset
 
-        for elt in context.previous_tick_subsets_with_metadata:
+        for elt in context.previous_subsets_with_metadata or []:
             carry_forward_subset = elt.subset - ignore_subset
             if carry_forward_subset.size > 0:
                 mapping[elt.frozen_metadata] |= carry_forward_subset
@@ -396,7 +396,7 @@ class MaterializeOnCronRule(
         asset_subset_to_request = AssetSubset.from_asset_partitions_set(
             context.asset_key, context.partitions_def, new_asset_partitions_to_request
         ) | (
-            context.previous_tick_true_subset
+            context.previous_true_subset
             - context.materialized_requested_or_discarded_since_previous_tick_subset
         )
 
@@ -626,7 +626,7 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
             context.asset_key, context.partitions_def, missing_asset_partitions
         )
         missing_subset = newly_missing_subset | (
-            context.previous_tick_true_subset
+            context.previous_true_subset
             - context.materialized_requested_or_discarded_since_previous_tick_subset
         )
         return missing_subset, []

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -215,6 +215,7 @@ class AssetDaemonScenarioState(NamedTuple):
     serialized_cursor: str = AssetDaemonCursor.empty().serialize()
     evaluations: Sequence[AssetConditionEvaluation] = []
     logger: logging.Logger = logging.getLogger("dagster.amp")
+    tick_index: int = 1
     # this is set by the scenario runner
     scenario_instance: Optional[DagsterInstance] = None
     is_daemon: bool = False
@@ -511,6 +512,9 @@ class AssetDaemonScenarioState(NamedTuple):
             return new_run_requests, new_cursor, new_evaluations
 
     def evaluate_tick(self) -> "AssetDaemonScenarioState":
+        self.logger.critical("********************************")
+        self.logger.critical(f"EVALUATING TICK {self.tick_index}")
+        self.logger.critical("********************************")
         with pendulum.test(self.current_time):
             if self.is_daemon:
                 (
@@ -525,6 +529,7 @@ class AssetDaemonScenarioState(NamedTuple):
             run_requests=new_run_requests,
             serialized_cursor=new_cursor.serialize(),
             evaluations=new_evaluations,
+            tick_index=self.tick_index + 1,
         )
 
     def _log_assertion_error(self, expected: Sequence[Any], actual: Sequence[Any]) -> None:


### PR DESCRIPTION
## Summary & Motivation


This PR renames the AssetDaemonAssetCursor object to the more generic `AssetConditionCursor` (imagine a future world in which AssetConditions are possible to evaluate outside the context of the AssetDaemon). It also removes the highly-specific `materialized_requested_and_discarded_subset` and replaces it with the general purpose "extras" field, which allows each condition to optionally stash arbitrary serializable information in a dictionary.

This doesn't yet make changes to the serialized format, so we have to generate these things based off of what we do actually have stored in the cursor, namely the latest AssetConditionEvaluation object for the asset and the 'handled subset', which is used by the MaterializeOnMissing rule (hence the weird hard-coding stuff, which is removed in the next PR in this stack)

## How I Tested These Changes
