### PR TITLE
[ui] Sensors: Move logs into dialog, clean up flag

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -9,7 +9,6 @@ export const DAGSTER_FLAGS_KEY = 'DAGSTER_FLAGS';
 export const FeatureFlag = {
   flagDebugConsoleLogging: 'flagDebugConsoleLogging' as const,
   flagDisableWebsockets: 'flagDisableWebsockets' as const,
-  flagSensorScheduleLogging: 'flagSensorScheduleLogging' as const,
   flagSidebarResources: 'flagSidebarResources' as const,
   flagDisableAutoLoadDefaults: 'flagDisableAutoLoadDefaults' as const,
   flagDAGSidebar: 'flagDAGSidebar' as const,

--- a/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
@@ -26,10 +26,6 @@ export const getVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagDAGSidebar,
   },
   {
-    key: 'Experimental schedule/sensor logging view',
-    flagType: FeatureFlag.flagSensorScheduleLogging,
-  },
-  {
     key: 'Display resources in navigation sidebar',
     flagType: FeatureFlag.flagSidebarResources,
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/TickLogDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/TickLogDialog.tsx
@@ -75,16 +75,52 @@ export const TickLogDialog = ({
   );
 };
 
+interface TickLogTableProps {
+  tick: HistoryTickFragment;
+  instigationSelector: InstigationSelector;
+}
+
+export const QueryfulTickLogsTable = ({instigationSelector, tick}: TickLogTableProps) => {
+  const {data, loading} = useQuery<TickLogEventsQuery, TickLogEventsQueryVariables>(
+    TICK_LOG_EVENTS_QUERY,
+    {
+      variables: {instigationSelector, tickId: Number(tick.tickId)},
+    },
+  );
+
+  const events =
+    data?.instigationStateOrError.__typename === 'InstigationState' &&
+    data?.instigationStateOrError.tick
+      ? data?.instigationStateOrError.tick.logEvents.events
+      : undefined;
+
+  if (events && events.length) {
+    return <TickLogsTable events={events} />;
+  }
+
+  return (
+    <Box
+      style={{height: 500}}
+      flex={{justifyContent: 'center', alignItems: 'center'}}
+      padding={{vertical: 48}}
+    >
+      {loading ? 'Loading logs…' : 'No logs available'}
+    </Box>
+  );
+};
+
 const TickLogsTable = ({events}: {events: TickLogEventFragment[]}) => {
   return (
-    <div style={{overflow: 'hidden', borderBottom: '0.5px solid #ececec', flex: 1}}>
-      <ColumnWidthsProvider onWidthsChanged={() => {}}>
+    <ColumnWidthsProvider onWidthsChanged={() => {}}>
+      <div style={{height: 500, position: 'relative', zIndex: 0}}>
         <Headers />
-        {events.map((event, idx) => (
-          <TickLogRow event={event} key={idx} />
-        ))}
-      </ColumnWidthsProvider>
-    </div>
+        <div style={{height: 468, overflowY: 'auto'}}>
+          {events.map((event, idx) => (
+            <TickLogRow event={event} key={idx} />
+          ))}
+        </div>
+      </div>
+    </ColumnWidthsProvider>
   );
 };
 
@@ -112,7 +148,7 @@ const Headers = () => {
 
 const TickLogRow = ({event}: {event: TickLogEventFragment}) => {
   return (
-    <Row level={event.level} highlighted={false}>
+    <Row level={event.level} highlighted={false} style={{height: 'auto'}}>
       <EventTypeColumn>
         <span style={{marginLeft: 8}}>{event.level}</span>
       </EventTypeColumn>


### PR DESCRIPTION
## Summary & Motivation

- Remove the existing `flagSensorScheduleLogging` flag.
- Remove the "Logs" table column on sensor pages
- Expose "X runs requested" link that opens up the current tick details dialog
- Add a "Logs" tab to this dialog, with the relevant logs for the tick
- For error and skipped ticks, show the skip reason or error output

<img width="1203" alt="Screenshot 2023-12-29 at 2 32 08 PM" src="https://github.com/dagster-io/dagster/assets/2823852/e04297af-a7e9-464b-b14f-5fb04e18b203">

<img width="1207" alt="Screenshot 2023-12-29 at 2 32 13 PM" src="https://github.com/dagster-io/dagster/assets/2823852/55c9de0e-38db-402a-a4cf-81d72e63c2fc">

<img width="1206" alt="Screenshot 2023-12-29 at 2 32 21 PM" src="https://github.com/dagster-io/dagster/assets/2823852/80365e21-259f-4f3d-a0b9-53ac9a12e90f">

<img width="1217" alt="Screenshot 2023-12-29 at 2 31 48 PM" src="https://github.com/dagster-io/dagster/assets/2823852/bf153ae9-0811-41f0-ad25-74151daf7b8e">

<img width="1207" alt="Screenshot 2023-12-29 at 2 44 01 PM" src="https://github.com/dagster-io/dagster/assets/2823852/5f4c1f14-e482-4f01-99d7-6fe1ba3eecca">

<img width="1207" alt="Screenshot 2023-12-29 at 2 52 54 PM" src="https://github.com/dagster-io/dagster/assets/2823852/bcd867fa-2e55-43cc-89e5-acf12e6b9348">


## How I Tested These Changes

Use the new toy sensor to generate some ticks with logs. View the sensor, then click on different ticks to see the dialog.

Verify that skipped ticks show the skip reason, error ticks show the error info, and ticks that request runs show the list of runs (same as before). Click "Logs", verify that logs appear.

Modify the log output to be very long, verify that the log table can be scrolled successfully.
