### PR TITLE
[amp-refactor][13/n] Add start/end timestamps to evaluations

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition.py
@@ -15,6 +15,8 @@ from typing import (
     Union,
 )
 
+import pendulum
+
 import dagster._check as check
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataMapping, MetadataValue
@@ -112,6 +114,8 @@ class AssetConditionEvaluation(NamedTuple):
     condition_snapshot: AssetConditionSnapshot
     true_subset: AssetSubset
     candidate_subset: Union[AssetSubset, HistoricalAllPartitionsSubsetSentinel]
+    start_timestamp: Optional[float]
+    end_timestamp: Optional[float]
     subsets_with_metadata: Sequence[AssetSubsetWithMetadata] = []
     child_evaluations: Sequence["AssetConditionEvaluation"] = []
 
@@ -195,6 +199,8 @@ class AssetConditionEvaluationResult(NamedTuple):
                 context.condition.snapshot,
                 true_subset=true_subset,
                 candidate_subset=context.candidate_subset,
+                start_timestamp=context.start_timestamp,
+                end_timestamp=pendulum.now("UTC").timestamp(),
                 subsets_with_metadata=[],
                 child_evaluations=[child_result.evaluation for child_result in child_results],
             ),
@@ -218,6 +224,8 @@ class AssetConditionEvaluationResult(NamedTuple):
             evaluation=AssetConditionEvaluation(
                 context.condition.snapshot,
                 true_subset=true_subset,
+                start_timestamp=context.start_timestamp,
+                end_timestamp=pendulum.now("UTC").timestamp(),
                 candidate_subset=context.candidate_subset,
                 subsets_with_metadata=subsets_with_metadata,
             ),

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition_evaluation_context.py
@@ -16,6 +16,8 @@ from typing import (
     Tuple,
 )
 
+import pendulum
+
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.metadata import MetadataValue
@@ -63,6 +65,7 @@ class AssetConditionEvaluationContext:
     evaluation_results_by_key: Mapping[AssetKey, "AssetConditionEvaluation"]
     expected_data_time_mapping: Mapping[AssetKey, Optional[datetime.datetime]]
 
+    start_timestamp: float
     root_ref: Optional["AssetConditionEvaluationContext"] = None
 
     @staticmethod
@@ -94,6 +97,7 @@ class AssetConditionEvaluationContext:
             daemon_context=daemon_context,
             evaluation_results_by_key=evaluation_results_by_key,
             expected_data_time_mapping=expected_data_time_mapping,
+            start_timestamp=pendulum.now("UTC").timestamp(),
         )
 
     def for_child(
@@ -107,6 +111,7 @@ class AssetConditionEvaluationContext:
             else None,
             candidate_subset=candidate_subset,
             root_ref=self.root_context,
+            start_timestamp=pendulum.now("UTC").timestamp(),
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
@@ -275,6 +275,8 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
             candidate_subset=HistoricalAllPartitionsSubsetSentinel()
             if is_partitioned
             else AssetSubset.empty(asset_key, None),
+            start_timestamp=None,
+            end_timestamp=None,
             subsets_with_metadata=subsets_with_metadata,
         )
 
@@ -340,6 +342,8 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
                 else AssetSubset.all(asset_key, None),
                 subsets_with_metadata=[],
                 child_evaluations=child_evaluations,
+                start_timestamp=None,
+                end_timestamp=None,
             )
 
         if decision_type == AutoMaterializeDecisionType.MATERIALIZE:
@@ -365,6 +369,8 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
             else AssetSubset.all(asset_key, None),
             subsets_with_metadata=[],
             child_evaluations=[evaluation],
+            start_timestamp=None,
+            end_timestamp=None,
         )
 
     def unpack(
@@ -437,6 +443,8 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
             else AssetSubset.all(asset_key, None),
             subsets_with_metadata=[],
             child_evaluations=child_evaluations,
+            start_timestamp=None,
+            end_timestamp=None,
         ).with_run_ids(cast(AbstractSet[str], unpacked_dict.get("run_ids", set())))
 
 

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -741,11 +741,15 @@ class TestScheduleStorage:
                         condition_snapshot=condition_snapshot,
                         true_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=False),
                         candidate_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=False),
+                        start_timestamp=0,
+                        end_timestamp=1,
                     ).with_run_ids(set()),
                     AssetConditionEvaluation(
                         condition_snapshot=condition_snapshot,
                         true_subset=AssetSubset(asset_key=AssetKey("asset_two"), value=True),
                         candidate_subset=AssetSubset(asset_key=AssetKey("asset_two"), value=True),
+                        start_timestamp=0,
+                        end_timestamp=1,
                         subsets_with_metadata=[
                             AssetSubsetWithMetadata(
                                 AssetSubset(asset_key=AssetKey("asset_two"), value=True),
@@ -796,6 +800,8 @@ class TestScheduleStorage:
             asset_evaluations=[
                 AssetConditionEvaluation(
                     condition_snapshot=condition_snapshot,
+                    start_timestamp=0,
+                    end_timestamp=1,
                     true_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=True),
                     candidate_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=True),
                 ).with_run_ids(set()),
@@ -825,12 +831,16 @@ class TestScheduleStorage:
 
         eval_one = AssetConditionEvaluation(
             condition_snapshot=AssetConditionSnapshot("foo", "bar", ""),
+            start_timestamp=0,
+            end_timestamp=1,
             true_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=True),
             candidate_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=True),
         ).with_run_ids(set())
 
         eval_asset_three = AssetConditionEvaluation(
             condition_snapshot=AssetConditionSnapshot("foo", "bar", ""),
+            start_timestamp=0,
+            end_timestamp=1,
             true_subset=AssetSubset(asset_key=AssetKey("asset_three"), value=True),
             candidate_subset=AssetSubset(asset_key=AssetKey("asset_three"), value=True),
         ).with_run_ids(set())
@@ -875,6 +885,8 @@ class TestScheduleStorage:
             asset_evaluations=[
                 AssetConditionEvaluation(
                     condition_snapshot=AssetConditionSnapshot("foo", "bar", ""),
+                    start_timestamp=0,
+                    end_timestamp=1,
                     true_subset=asset_subset,
                     candidate_subset=asset_subset,
                     subsets_with_metadata=[asset_subset_with_metadata],
@@ -906,6 +918,8 @@ class TestScheduleStorage:
             asset_evaluations=[
                 AssetConditionEvaluation(
                     condition_snapshot=AssetConditionSnapshot("foo", "bar", ""),
+                    start_timestamp=0,
+                    end_timestamp=1,
                     true_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=True),
                     candidate_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=True),
                     subsets_with_metadata=[],


### PR DESCRIPTION
## Summary & Motivation

We want to be able to natively track how long each evaluation takes. This PR adds a start/end timestamp to the AssetConditionEvaluation object to enable this. The start timestamp, for now, is just the timestamp of whenever its context object was created. This isn't necessarily exactly when the condition starts processing, so we may want to update this in the future, I just did it this way so that we don't have to update all the individual evaluate() functions to track a start timestamp.

I chose to store explicit start/end timestamps rather than just the duration because it seems like very little downside and potentially some nice upsides. For example, you could imagine a future world in which we show a more gantt-style rendering of this information, or a world where we execute multiple conditions in parallel. In either of these cases, it'd be handy to know the start/end timestamps more precisely, even if for now we'll just use the difference.

## How I Tested These Changes
