### PR TITLE
Expose trace data via global for cypress 

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/performance.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/performance.tsx
@@ -6,6 +6,8 @@ type TraceData = {
   endTime: number | null;
 };
 
+// @ts-expect-error - exposing a global for cypress test to access traces
+window.__traceBuffer = [];
 class PointToPointInstrumentation {
   private traces: {[traceId: string]: TraceData} = {};
 
@@ -39,11 +41,8 @@ class PointToPointInstrumentation {
     }
 
     trace.endTime = performance.now();
-    document.dispatchEvent(
-      new CustomEvent('PerformanceTrace', {
-        detail: trace,
-      }),
-    );
+    // @ts-expect-error - exposing global for cypress
+    window.__traceBuffer.push(trace);
     if (process.env.NODE_ENV === 'development') {
       console.log(`Finished trace ${traceId}`);
     }


### PR DESCRIPTION
## Summary & Motivation

Currently Cypress isn't receiving the custom performance events we're emitting because cypress tests only run after the page is fully loaded which means our listener for the event doesn't get setup until after the event fires. To allow cypress to get the traces we added them to a global buffer. I don't expect the memory of this buffer to be an issue for now but down the line I can add some gating to make it so we only store this data if we're running cypress.

## How I Tested These Changes

dogfood