### PR TITLE
[ui] Clean up timer types

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/ShortcutHandler.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ShortcutHandler.tsx
@@ -26,7 +26,7 @@ const SHORTCUT_VISIBLITY_DELAY = 800;
 // implemented inside a React component.
 //
 let shortcutsVisible = false;
-let shortcutsTimer: NodeJS.Timeout | null = null;
+let shortcutsTimer: ReturnType<typeof setTimeout> | null = null;
 
 function getShortcutsVisible() {
   return shortcutsVisible;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.tsx
@@ -26,7 +26,7 @@ export const AssetPageHeader = ({assetKey, ...extra}: Props) => {
   const copy = useCopyToClipboard();
   const copyableString = assetKey.path.join('/');
   const [didCopy, setDidCopy] = React.useState(false);
-  const iconTimeout = React.useRef<NodeJS.Timeout>();
+  const iconTimeout = React.useRef<ReturnType<typeof setTimeout>>();
 
   const performCopy = React.useCallback(async () => {
     if (iconTimeout.current) {

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttChart.tsx
@@ -83,7 +83,7 @@ export {GanttChartMode} from './Constants';
 
 const HIGHLIGHT_TIME_EVENT = 'gantt-highlight-time';
 
-let highlightTimer: NodeJS.Timeout;
+let highlightTimer: ReturnType<typeof setTimeout>;
 
 /**
  * Set or clear the highlighted time on the Gantt chart. Goal of this convenience

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
@@ -664,7 +664,7 @@ const ZoomSliderContainer = styled.div`
 const WheelInstructionTooltip = () => {
   const [usedMeta, setUsedMeta] = React.useState(false);
   const [wheeling, setWheeling] = React.useState(false);
-  const timeout = React.useRef<NodeJS.Timeout>();
+  const timeout = React.useRef<ReturnType<typeof setTimeout>>();
 
   React.useEffect(() => {
     const listener = (e: WheelEvent) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
@@ -129,7 +129,7 @@ export function usePartitionStepQuery({
       // Note: this timer is canceled when a subsequent invocation of the useEffect updates `version.current`,
       // because we don't want to create this interval until the initial load completes.
 
-      const timer: NodeJS.Timeout = setInterval(async () => {
+      const timer: ReturnType<typeof setInterval> = setInterval(async () => {
         if (version.current !== v) {
           return clearInterval(timer);
         }

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/TimeElapsed.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/TimeElapsed.tsx
@@ -12,8 +12,8 @@ export const TimeElapsed = (props: Props) => {
   const {startUnix, endUnix} = props;
 
   const [endTime, setEndTime] = React.useState(() => (endUnix ? endUnix * 1000 : null));
-  const interval = React.useRef<NodeJS.Timeout | null>(null);
-  const timeout = React.useRef<NodeJS.Timeout | null>(null);
+  const interval = React.useRef<ReturnType<typeof setInterval>>();
+  const timeout = React.useRef<ReturnType<typeof setTimeout>>();
 
   const clearTimers = React.useCallback(() => {
     interval.current && clearInterval(interval.current);


### PR DESCRIPTION
## Summary & Motivation

Use `ReturnType` for type annotations on `setTimeout` and `setInterval`, instead of the odd `NodeJS` annotations.

## How I Tested These Changes

yarn ts
