### PR TITLE
Add some additional pyspark zip exclude rules

### DIFF
--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark/utils.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark/utils.py
@@ -8,6 +8,9 @@ DEFAULT_EXCLUDE = [
     r".*pytest.*",
     r".*__pycache__.*",
     r".*pyc$",
+    r".*\/venv\/.*",
+    r".*\.egg-info$",
+    r".*\/logs\/.*",
 ]
 
 


### PR DESCRIPTION
## Summary & Motivation
I needed to add the following exclude rules to prevent my virtual environment folder and dbt log files from being included in the pyspark zip archive.

## How I Tested These Changes
Tested locally against my project.
