### PR TITLE
Make upstream asset materialization events available on the context

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1926,3 +1926,6 @@ def enter_execution_context(
 _current_asset_execution_context: ContextVar[Optional[AssetExecutionContext]] = ContextVar(
     "_current_asset_execution_context", default=None
 )
+
+
+# TODO - remove

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -38,6 +38,7 @@ from dagster._core.definitions.events import (
     AssetKey,
     AssetMaterialization,
     AssetObservation,
+    CoercibleToAssetKey,
     ExpectationResult,
     UserEvent,
 )
@@ -1478,6 +1479,14 @@ class AssetExecutionContext(OpExecutionContext):
         """
         return self.op_execution_context.job_def
 
+    @public
+    def latest_materialization_event(
+        self, key: CoercibleToAssetKey
+    ) -> Optional[AssetMaterialization]:
+        return self._step_execution_context.latest_materialization_event.get(
+            AssetKey.from_coercible(key)
+        )
+
     ######## Deprecated methods
 
     @deprecated(**_get_deprecation_kwargs("dagster_run"))
@@ -1926,6 +1935,3 @@ def enter_execution_context(
 _current_asset_execution_context: ContextVar[Optional[AssetExecutionContext]] = ContextVar(
     "_current_asset_execution_context", default=None
 )
-
-
-# TODO - remove

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1489,7 +1489,7 @@ class AssetExecutionContext(OpExecutionContext):
 
         Returns: Optional[AssetMaterialization]
         """
-        return self._step_execution_context.upstream_asset_materialization_events.get(
+        return self.op_execution_context._step_execution_context.upstream_asset_materialization_events.get(  # noqa: SLF001
             AssetKey.from_coercible(key)
         )
 

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1480,17 +1480,26 @@ class AssetExecutionContext(OpExecutionContext):
         return self.op_execution_context.job_def
 
     @public
-    def latest_materialization_event(
+    def latest_materialization_for_upstream_asset(
         self, key: CoercibleToAssetKey
     ) -> Optional[AssetMaterialization]:
-        """Get the most recent AssetMaterialization event for the key. Information like metadata and tags
-        can be found on the AssetMaterialization. If the key is not an upstream asset of the currently
-        materializing asset, None will be returned.
+        """Get the most recent AssetMaterialization event for the key. The key must be an upstream
+        asset for the currently materializing asset. Information like metadata and tags can be found
+        on the AssetMaterialization. If the key is not an upstream asset of the currently
+        materializing asset, an error will be raised. If no AssetMaterialization exists for key, None
+        will be returned.
 
         Returns: Optional[AssetMaterialization]
         """
-        return self.op_execution_context._step_execution_context.upstream_asset_materialization_events.get(  # noqa: SLF001
-            AssetKey.from_coercible(key)
+        materialization_events = (
+            self.op_execution_context._step_execution_context.upstream_asset_materialization_events  # noqa: SLF001
+        )
+        if AssetKey.from_coercible(key) in materialization_events.keys():
+            return materialization_events.get(AssetKey.from_coercible(key))
+
+        raise DagsterInvariantViolationError(
+            f"Cannot fetch AssetMaterialization for asset {key}. {key} must be an upstream dependency"
+            "in order to call latest_materialization_for_upstream_asset."
         )
 
     ######## Deprecated methods

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1483,7 +1483,13 @@ class AssetExecutionContext(OpExecutionContext):
     def latest_materialization_event(
         self, key: CoercibleToAssetKey
     ) -> Optional[AssetMaterialization]:
-        return self._step_execution_context.latest_materialization_event.get(
+        """Get the most recent AssetMaterialization event for the key. Information like metadata and tags
+        can be found on the AssetMaterialization. If the key is not an upstream asset of the currently
+        materializing asset, None will be returned.
+
+        Returns: Optional[AssetMaterialization]
+        """
+        return self._step_execution_context.upstream_asset_materialization_events.get(
             AssetKey.from_coercible(key)
         )
 

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -22,6 +22,7 @@ from dagster._core.definitions.dependency import Node, NodeHandle
 from dagster._core.definitions.events import (
     AssetMaterialization,
     AssetObservation,
+    CoercibleToAssetKey,
     ExpectationResult,
     UserEvent,
 )
@@ -832,6 +833,13 @@ class DirectAssetExecutionContext(AssetExecutionContext, BaseDirectExecutionCont
 
     def observe_output(self, output_name: str, mapping_key: Optional[str] = None) -> None:
         self.op_execution_context.observe_output(output_name=output_name, mapping_key=mapping_key)
+
+    def latest_materialization_for_upstream_asset(
+        self, key: CoercibleToAssetKey
+    ) -> Optional[AssetMaterialization]:
+        raise DagsterInvalidPropertyError(
+            _property_msg("latest_materialization_for_upstream_asset", "method")
+        )
 
 
 def _validate_resource_requirements(

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -30,7 +30,7 @@ from dagster._core.definitions.data_version import (
     extract_data_version_from_entry,
 )
 from dagster._core.definitions.dependency import OpNode
-from dagster._core.definitions.events import AssetKey, AssetLineageInfo
+from dagster._core.definitions.events import AssetKey, AssetLineageInfo, AssetMaterialization
 from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.job_base import IJob
 from dagster._core.definitions.job_definition import JobDefinition
@@ -571,6 +571,8 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         self._output_metadata: Dict[str, Any] = {}
         self._seen_outputs: Dict[str, Union[str, Set[str]]] = {}
 
+        self.latest_materialization_event: Dict[AssetKey, Optional[AssetMaterialization]] = {}
+
         self._input_asset_version_info: Dict[AssetKey, Optional["InputAssetVersionInfo"]] = {}
         self._is_external_input_asset_version_info_loaded = False
         self._data_version_cache: Dict[AssetKey, "DataVersion"] = {}
@@ -955,11 +957,16 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
     def get_input_asset_version_info(self, key: AssetKey) -> Optional["InputAssetVersionInfo"]:
         if key not in self._input_asset_version_info:
-            self._fetch_input_asset_version_info(key)
+            self._fetch_input_asset_materialization_and_version_info(key)
         return self._input_asset_version_info[key]
 
     # "external" refers to records for inputs generated outside of this step
-    def fetch_external_input_asset_version_info(self) -> None:
+    def fetch_external_input_asset_materialization_and_version_info(self) -> None:
+        """Fetches the latest observation or materialization for each upstream dependency
+        in order to determine the version info. As a side effect we create a dictionary
+        of the materialization events so that the AssetContext can access the latest materialization
+        event.
+        """
         output_keys = self.get_output_asset_keys()
 
         all_dep_keys: List[AssetKey] = []
@@ -973,10 +980,10 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
         self._input_asset_version_info = {}
         for key in all_dep_keys:
-            self._fetch_input_asset_version_info(key)
+            self._fetch_input_asset_materialization_and_version_info(key)
         self._is_external_input_asset_version_info_loaded = True
 
-    def _fetch_input_asset_version_info(self, key: AssetKey) -> None:
+    def _fetch_input_asset_materialization_and_version_info(self, key: AssetKey) -> None:
         from dagster._core.definitions.data_version import (
             extract_data_version_from_entry,
         )
@@ -984,7 +991,11 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         event = self._get_input_asset_event(key)
         if event is None:
             self._input_asset_version_info[key] = None
+            self.latest_materialization_event[key] = None
         else:
+            self.latest_materialization_event[key] = (
+                event.asset_materialization if event.asset_materialization else None
+            )
             storage_id = event.storage_id
             # Input name will be none if this is an internal dep
             input_name = self.job_def.asset_layer.input_for_asset_key(self.node_handle, key)

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -571,7 +571,9 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         self._output_metadata: Dict[str, Any] = {}
         self._seen_outputs: Dict[str, Union[str, Set[str]]] = {}
 
-        self.latest_materialization_event: Dict[AssetKey, Optional[AssetMaterialization]] = {}
+        self._upstream_asset_materialization_events: Dict[
+            AssetKey, Optional[AssetMaterialization]
+        ] = {}
 
         self._input_asset_version_info: Dict[AssetKey, Optional["InputAssetVersionInfo"]] = {}
         self._is_external_input_asset_version_info_loaded = False
@@ -952,6 +954,12 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         return self._input_asset_version_info
 
     @property
+    def upstream_asset_materialization_events(
+        self,
+    ) -> Dict[AssetKey, Optional[AssetMaterialization]]:
+        return self._upstream_asset_materialization_events
+
+    @property
     def is_external_input_asset_version_info_loaded(self) -> bool:
         return self._is_external_input_asset_version_info_loaded
 
@@ -991,9 +999,9 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         event = self._get_input_asset_event(key)
         if event is None:
             self._input_asset_version_info[key] = None
-            self.latest_materialization_event[key] = None
+            self._upstream_asset_materialization_events[key] = None
         else:
-            self.latest_materialization_event[key] = (
+            self._upstream_asset_materialization_events[key] = (
                 event.asset_materialization if event.asset_materialization else None
             )
             storage_id = event.storage_id

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -458,7 +458,7 @@ def core_dagster_event_sequence_for_step(
     inputs = {}
 
     if step_context.is_sda_step:
-        step_context.fetch_external_input_asset_version_info()
+        step_context.fetch_external_input_asset_materialization_and_version_info()
 
     for step_input in step_context.step.step_inputs:
         input_def = step_context.op_def.input_def_named(step_input.name)

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
@@ -437,7 +437,7 @@ def test_upstream_metadata():
 
     @asset
     def downstream(context: AssetExecutionContext, upstream):
-        mat = context.latest_materialization_event("upstream")
+        mat = context.latest_materialization_for_upstream_asset("upstream")
         assert mat is not None
         assert mat.metadata["foo"].value == "bar"
 
@@ -452,7 +452,7 @@ def test_upstream_metadata_materialize_result():
 
     @asset
     def downstream(context: AssetExecutionContext, upstream):
-        mat = context.latest_materialization_event("upstream")
+        mat = context.latest_materialization_for_upstream_asset("upstream")
         assert mat is not None
         assert mat.metadata["foo"].value == "bar"
 


### PR DESCRIPTION
## Summary & Motivation
The data provenance/versioning feature already fetches the latest `AssetMaterialization` for the upstream assets for an asset that is materializing. This PR saves those `AssetMaterialization`s and provides a context method to fetch the `AssetMaterialization` for an upstream asset. This will allow users to get the metadata attached to an upstream asset, among other properties.  


## How I Tested These Changes
