### PR TITLE
Fix UnauthorizedError case in python graphql client

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -211,7 +211,7 @@ class DagsterGraphQLClient:
             raise DagsterGraphQLClientError(query_result_type, query_result["errors"])
         else:
             # query_result_type is a ConflictingExecutionParamsError, a PresetNotFoundError
-            # a PipelineNotFoundError, a RunConflict, or a PythonError
+            # a PipelineNotFoundError, a RunConflict, an UnauthorizedError or a PythonError
             raise DagsterGraphQLClientError(query_result_type, query_result["message"])
 
     @public

--- a/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
@@ -38,6 +38,9 @@ mutation($executionParams: ExecutionParams!) {
     ... on PythonError {
       message
     }
+    ... on UnauthorizedError {
+      message
+    }
   }
 }
 """

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_submit_pipeline_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_submit_pipeline_execution.py
@@ -318,6 +318,30 @@ def test_failure_with_python_error(mock_client: MockClient):
     assert exc_args[1] == message
 
 
+@python_client_test_suite
+def test_failure_with_unauthorized_error(mock_client: MockClient):
+    error_type, message = "UnauthorizedError", "permissions failure"
+    response = {
+        "launchPipelineExecution": {
+            "__typename": error_type,
+            "message": message,
+        }
+    }
+    mock_client.mock_gql_client.execute.return_value = response
+
+    with pytest.raises(DagsterGraphQLClientError) as exc_info:
+        mock_client.python_client.submit_job_execution(
+            "bar",
+            repository_location_name="baz",
+            repository_name="quux",
+            run_config={},
+        )
+    exc_args = exc_info.value.args
+
+    assert exc_args[0] == error_type
+    assert exc_args[1] == message
+
+
 def failure_with_job_run_conflict_mock_config(mock_client: MockClient):
     error_type, message = "RunConflict", "some conflict"
     response = {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/CLIENT_SUBMIT_PIPELINE_RUN_MUTATION/1!0+dev-2024_01_02.graphql
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/CLIENT_SUBMIT_PIPELINE_RUN_MUTATION/1!0+dev-2024_01_02.graphql
@@ -1,0 +1,43 @@
+mutation($executionParams: ExecutionParams!) {
+  launchPipelineExecution(executionParams: $executionParams) {
+    __typename
+    ... on InvalidStepError {
+      invalidStepKey
+    }
+    ... on InvalidOutputError {
+      stepKey
+      invalidOutputName
+    }
+    ... on LaunchPipelineRunSuccess {
+      run {
+        runId
+      }
+    }
+    ... on ConflictingExecutionParamsError {
+      message
+    }
+    ... on PresetNotFoundError {
+      message
+    }
+    ... on PipelineRunConflict {
+      message
+    }
+    ... on PipelineConfigValidationInvalid {
+      errors {
+        __typename
+        message
+        path
+        reason
+      }
+    }
+    ... on PipelineNotFoundError {
+      message
+    }
+    ... on PythonError {
+      message
+    }
+    ... on UnauthorizedError {
+      message
+    }
+  }
+}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/GET_PIPELINE_RUN_STATUS_QUERY/1!0+dev-2024_01_02.graphql
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/GET_PIPELINE_RUN_STATUS_QUERY/1!0+dev-2024_01_02.graphql
@@ -1,0 +1,14 @@
+query($runId: ID!) {
+  pipelineRunOrError(runId: $runId) {
+    __typename
+    ... on PipelineRun {
+        status
+    }
+    ... on PipelineRunNotFoundError {
+      message
+    }
+    ... on PythonError {
+      message
+    }
+  }
+}


### PR DESCRIPTION
Summary:
Handle the case wehre you launch a run against read-only dagit in open source, or as a viewer in Dagster Cloud.

Test Plan: new automated test case, manually use graphql client using a viewer user token and see a better error message

## Summary & Motivation

## How I Tested These Changes
