### PR TITLE
Sensor daemon threadpool refactor

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
@@ -36,6 +36,7 @@ def _create_sensor_tick(graphql_context):
             graphql_context.process_context,
             logger,
             threadpool_executor=SingleThreadPoolExecutor(),
+            submit_threadpool_executor=None,
             sensor_tick_futures=futures,
         )
     )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -907,6 +907,7 @@ def _create_tick(graphql_context):
             graphql_context.process_context,
             logger,
             threadpool_executor=SingleThreadPoolExecutor(),
+            submit_threadpool_executor=None,
             sensor_tick_futures=futures,
         )
     )

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -337,7 +337,7 @@ def create_daemon_of_type(daemon_type: str, instance: DagsterInstance) -> Dagste
     if daemon_type == SchedulerDaemon.daemon_type():
         return SchedulerDaemon()
     elif daemon_type == SensorDaemon.daemon_type():
-        return SensorDaemon()
+        return SensorDaemon(settings=instance.get_sensor_settings())
     elif daemon_type == QueuedRunCoordinatorDaemon.daemon_type():
         return QueuedRunCoordinatorDaemon(
             interval_seconds=instance.run_coordinator.dequeue_interval_seconds  # type: ignore  # (??)
@@ -447,7 +447,7 @@ def get_daemon_statuses(
 
 
 def debug_daemon_heartbeats(instance: DagsterInstance) -> None:
-    daemon = SensorDaemon()
+    daemon = SensorDaemon(settings=instance.get_sensor_settings())
     timestamp = pendulum.now("UTC").float_timestamp
     instance.add_daemon_heartbeat(DaemonHeartbeat(timestamp, daemon.daemon_type(), None, None))
     returned_timestamp = instance.get_daemon_heartbeats()[daemon.daemon_type()].timestamp

--- a/python_modules/dagster/dagster/_daemon/daemon.py
+++ b/python_modules/dagster/dagster/_daemon/daemon.py
@@ -4,9 +4,9 @@ import time
 import uuid
 from abc import ABC, abstractmethod
 from collections import deque
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, ExitStack
 from threading import Event
-from typing import TYPE_CHECKING, Generator, Generic, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Generator, Generic, Mapping, Optional, TypeVar, Union
 
 import pendulum
 from typing_extensions import TypeAlias
@@ -17,6 +17,7 @@ from dagster import (
 )
 from dagster._core.scheduler.scheduler import DagsterDaemonScheduler
 from dagster._core.telemetry import DAEMON_ALIVE, log_action
+from dagster._core.utils import InheritContextThreadPoolExecutor
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._daemon.backfill import execute_backfill_iteration
 from dagster._daemon.monitoring import (
@@ -29,6 +30,8 @@ from dagster._scheduler.scheduler import execute_scheduler_iteration_loop
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
 if TYPE_CHECKING:
+    from concurrent.futures import ThreadPoolExecutor
+
     from pendulum.datetime import DateTime
 
 
@@ -260,9 +263,35 @@ class SchedulerDaemon(DagsterDaemon):
 
 
 class SensorDaemon(DagsterDaemon):
+    def __init__(self, settings: Mapping[str, Any]) -> None:
+        super().__init__()
+        self._exit_stack = ExitStack()
+        self._threadpool_executor: Optional[ThreadPoolExecutor] = None
+        self._submit_threadpool_executor: Optional[ThreadPoolExecutor] = None
+
+        if settings.get("use_threads"):
+            self._threadpool_executor = self._exit_stack.enter_context(
+                InheritContextThreadPoolExecutor(
+                    max_workers=settings.get("num_workers"),
+                    thread_name_prefix="sensor_daemon_worker",
+                )
+            )
+            num_submit_workers = settings.get("num_submit_workers")
+            if num_submit_workers:
+                self._submit_threadpool_executor = self._exit_stack.enter_context(
+                    InheritContextThreadPoolExecutor(
+                        max_workers=settings.get("num_submit_workers"),
+                        thread_name_prefix="sensor_submit_worker",
+                    )
+                )
+
     @classmethod
     def daemon_type(cls) -> str:
         return "SENSOR"
+
+    def __exit__(self, _exception_type, _exception_value, _traceback):
+        self._exit_stack.close()
+        super().__exit__(_exception_type, _exception_value, _traceback)
 
     def core_loop(
         self,
@@ -273,6 +302,8 @@ class SensorDaemon(DagsterDaemon):
             workspace_process_context,
             self._logger,
             shutdown_event,
+            threadpool_executor=self._threadpool_executor,
+            submit_threadpool_executor=self._submit_threadpool_executor,
         )
 
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_failure_recovery.py
@@ -39,6 +39,7 @@ def _test_launch_sensor_runs_in_subprocess(instance_ref, execution_datetime, deb
                             workspace_context,
                             logger,
                             threadpool_executor=executor,
+                            submit_threadpool_executor=None,
                             debug_crash_flags=debug_crash_flags,
                             sensor_tick_futures=futures,
                         )

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -3280,6 +3280,7 @@ def test_stale_request_context(instance, workspace_context, external_repo):
                 workspace_context,
                 get_default_daemon_logger("SensorDaemon"),
                 threadpool_executor=executor,
+                submit_threadpool_executor=None,
                 sensor_tick_futures=futures,
             )
         )


### PR DESCRIPTION
Retain a reference to the threadpools we use in the sensor daemon, on the daemon object itself. This allows us to introspect information about the threadpool when control is yielded from the core loop.

Also makes some changes to the threadpool subclass we use to gate retrieval of internals on the threadpool.
