### PR TITLE
Skip automation policy sensors in sensor daemon

### DIFF
--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -32,7 +32,10 @@ from dagster._core.definitions.run_request import (
     RunRequest,
 )
 from dagster._core.definitions.selector import JobSubsetSelector
-from dagster._core.definitions.sensor_definition import DefaultSensorStatus
+from dagster._core.definitions.sensor_definition import (
+    DefaultSensorStatus,
+    SensorType,
+)
 from dagster._core.definitions.utils import validate_tags
 from dagster._core.errors import DagsterError
 from dagster._core.host_representation.code_location import CodeLocation
@@ -349,6 +352,9 @@ def execute_sensor_iteration(
         if code_location:
             for repo in code_location.get_repositories().values():
                 for sensor in repo.get_external_sensors():
+                    if sensor.sensor_type == SensorType.AUTOMATION_POLICY:
+                        continue
+
                     selector_id = sensor.selector_id
                     if sensor.get_current_instigator_state(
                         all_sensor_states.get(selector_id)

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -14,6 +14,7 @@ from dagster import (
     AssetMaterialization,
     AssetObservation,
     AssetSelection,
+    AutoMaterializePolicy,
     CodeLocationSelector,
     DagsterRunStatus,
     DailyPartitionsDefinition,
@@ -37,6 +38,9 @@ from dagster import (
     run_failure_sensor,
 )
 from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.automation_policy_sensor_definition import (
+    AutomationPolicySensorDefinition,
+)
 from dagster._core.definitions.decorators import op
 from dagster._core.definitions.decorators.job_decorator import job
 from dagster._core.definitions.decorators.sensor_decorator import asset_sensor, sensor
@@ -62,6 +66,7 @@ from dagster._core.scheduler.instigation import (
     DynamicPartitionsRequestResult,
     InstigatorState,
     InstigatorStatus,
+    SensorInstigatorData,
     TickStatus,
 )
 from dagster._core.storage.captured_log_manager import CapturedLogManager
@@ -696,6 +701,17 @@ def partitioned_pipeline_success_sensor(_context):
     assert _context.partition_key == "2022-08-01"
 
 
+@asset(auto_materialize_policy=AutoMaterializePolicy.eager())
+def auto_materialize_asset():
+    pass
+
+
+automation_policy_sensor = AutomationPolicySensorDefinition(
+    "my_automation_policy_sensor",
+    asset_selection=[auto_materialize_asset],
+)
+
+
 @repository
 def the_repo():
     return [
@@ -759,6 +775,7 @@ def the_repo():
         success_on_multipartition_run_request_with_two_dynamic_dimensions_sensor,
         error_on_multipartition_run_request_with_two_dynamic_dimensions_sensor,
         multipartitions_with_static_time_dimensions_run_requests_sensor,
+        automation_policy_sensor,
     ]
 
 
@@ -984,6 +1001,33 @@ def wait_for_all_runs_to_finish(instance, timeout=10):
 
         if len(not_finished_runs) == 0:
             break
+
+
+def test_ignore_automation_policy_sensor(instance, workspace_context, external_repo, executor):
+    freeze_datetime = to_timezone(
+        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
+        "US/Central",
+    )
+
+    with pendulum.test(freeze_datetime):
+        external_sensor = external_repo.get_external_sensor("my_automation_policy_sensor")
+        assert external_sensor
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+                instigator_data=SensorInstigatorData(
+                    sensor_type=SensorType.AUTOMATION_POLICY,
+                ),
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+        # No ticks because of the sensor type
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 0
 
 
 def test_simple_sensor(instance, workspace_context, external_repo, executor):


### PR DESCRIPTION
Summary:
These will run in the asset daemon, in the short term at least - prevent them from executing alongside other sensor types.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
