### PR TITLE
Add assets with backfill policies to toys

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/partitioned_assets/__init__.py
+++ b/python_modules/dagster-test/dagster_test/toys/partitioned_assets/__init__.py
@@ -5,3 +5,4 @@ from .hourly_and_daily_and_unpartitioned import *  # noqa: F403
 from .hourly_partitions_to_daily import *  # noqa: F403
 from .partitioned_run_request_sensors import *  # noqa: F403
 from .single_partitions_to_multi import *  # noqa: F403
+from .with_backfill_policies import *  # noqa: F403

--- a/python_modules/dagster-test/dagster_test/toys/partitioned_assets/with_backfill_policies.py
+++ b/python_modules/dagster-test/dagster_test/toys/partitioned_assets/with_backfill_policies.py
@@ -1,0 +1,19 @@
+from dagster import BackfillPolicy, DailyPartitionsDefinition, MaterializeResult, asset
+
+
+@asset(
+    partitions_def=DailyPartitionsDefinition(start_date="2023-01-01"),
+    backfill_policy=BackfillPolicy.single_run(),
+    group_name="with_backfill_policy",
+)
+def successful_daily_asset() -> MaterializeResult:
+    return MaterializeResult()
+
+
+@asset(
+    partitions_def=DailyPartitionsDefinition(start_date="2023-01-01"),
+    backfill_policy=BackfillPolicy.single_run(),
+    group_name="with_backfill_policy",
+)
+def failing_daily_asset() -> None:
+    raise Exception("This asset failed")

--- a/python_modules/dagster-test/dagster_test/toys/partitioned_assets/with_backfill_policies.py
+++ b/python_modules/dagster-test/dagster_test/toys/partitioned_assets/with_backfill_policies.py
@@ -6,7 +6,7 @@ from dagster import BackfillPolicy, DailyPartitionsDefinition, MaterializeResult
     backfill_policy=BackfillPolicy.single_run(),
     group_name="with_backfill_policy",
 )
-def successful_daily_asset() -> MaterializeResult:
+def successful_single_run_backfill_policy() -> MaterializeResult:
     return MaterializeResult()
 
 
@@ -15,5 +15,5 @@ def successful_daily_asset() -> MaterializeResult:
     backfill_policy=BackfillPolicy.single_run(),
     group_name="with_backfill_policy",
 )
-def failing_daily_asset() -> None:
+def failure_single_run_backfill_policy() -> None:
     raise Exception("This asset failed")


### PR DESCRIPTION
As the title.

Adds to toys to make local testing / canary testing easier.