### PR TITLE
added retry policy param to dbt assets decorator

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -36,11 +36,7 @@ from .asset_utils import (
     get_deps,
     has_self_dependency,
 )
-from .dagster_dbt_translator import (
-    DagsterDbtTranslator,
-    DbtManifestWrapper,
-    validate_translator,
-)
+from .dagster_dbt_translator import DagsterDbtTranslator, DbtManifestWrapper, validate_translator
 from .dbt_manifest import DbtManifestParam, validate_manifest
 from .utils import (
     ASSET_RESOURCE_TYPES,
@@ -376,10 +372,7 @@ def get_dbt_multi_asset_args(
         for test_unique_id in test_unique_ids:
             test_resource_props = manifest["nodes"][test_unique_id]
             check_spec = default_asset_check_fn(
-                asset_key,
-                unique_id,
-                dagster_dbt_translator.settings,
-                test_resource_props,
+                asset_key, unique_id, dagster_dbt_translator.settings, test_resource_props
             )
 
             if check_spec:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -166,9 +166,7 @@ def test_manifest_argument(manifest: DbtManifestParam):
     ],
 )
 def test_selections(
-    select: Optional[str],
-    exclude: Optional[str],
-    expected_asset_names: AbstractSet[str],
+    select: Optional[str], exclude: Optional[str], expected_asset_names: AbstractSet[str]
 ) -> None:
     @dbt_assets(
         manifest=manifest,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -17,6 +17,7 @@ from dagster import (
     NodeInvocation,
     PartitionMapping,
     PartitionsDefinition,
+    RetryPolicy,
     TimeWindowPartitionMapping,
     asset,
 )
@@ -165,7 +166,9 @@ def test_manifest_argument(manifest: DbtManifestParam):
     ],
 )
 def test_selections(
-    select: Optional[str], exclude: Optional[str], expected_asset_names: AbstractSet[str]
+    select: Optional[str],
+    exclude: Optional[str],
+    expected_asset_names: AbstractSet[str],
 ) -> None:
     @dbt_assets(
         manifest=manifest,
@@ -229,6 +232,19 @@ def test_backfill_policy():
         ...
 
     assert my_dbt_assets.backfill_policy == backfill_policy
+
+
+def test_retry_policy():
+    retry_policy = RetryPolicy(max_retries=2)
+
+    @dbt_assets(
+        manifest=manifest,
+        retry_policy=retry_policy,
+    )
+    def my_dbt_assets():
+        ...
+
+    assert my_dbt_assets.op.retry_policy == retry_policy
 
 
 def test_op_tags():


### PR DESCRIPTION
## Summary & Motivation

Noticed the parameter for retry policies is currently missing from the dbt assets decorator.

## How I Tested These Changes

Test suite, added test for the new attribute.