### PR TITLE
docs(instigator-tick-logs): remove experimental warning in logging docs

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -324,6 +324,21 @@ Once the schedule is started, the schedule will begin executing immediately if y
 
 ---
 
+## Logging in schedules
+
+Any schedule can emit log messages during its evaluation function:
+
+```python file=concepts/partitions_schedules_sensors/schedules/schedules.py startafter=start_schedule_logging endbefore=end_schedule_logging
+@schedule(job=my_job, cron_schedule="* * * * *")
+def logs_then_skips(context):
+    context.log.info("Logging from a schedule!")
+    return SkipReason("Nothing to do")
+```
+
+These logs can be viewed when inspecting a tick in the tick history view on the corresponding schedule page.
+
+---
+
 ## Testing schedules
 
 <TabGroup>

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -281,6 +281,21 @@ For more information on resources, refer to the [Resources documentation](/conce
 
 ---
 
+## Logging in sensors
+
+Any sensor can emit log messages during its evaluation function:
+
+```python file=concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_sensor_logging endbefore=end_sensor_logging
+@sensor(job=the_job)
+def logs_then_skips(context):
+    context.log.info("Logging from a sensor!")
+    return SkipReason("Nothing to do")
+```
+
+These logs can be viewed when inspecting a tick in the tick history view on the corresponding sensor page.
+
+---
+
 ## Testing sensors
 
 <TabGroup>
@@ -419,25 +434,6 @@ def test_process_new_users_sensor():
 
 </TabItem>
 </TabGroup>
-
----
-
-## Logging in sensors
-
-<Note>
-  This feature is <strong>experimental</strong>.
-</Note>
-
-Any sensor can emit log messages during its evaluation function:
-
-```python file=concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_sensor_logging endbefore=end_sensor_logging
-@sensor(job=the_job)
-def logs_then_skips(context):
-    context.log.info("Logging from a sensor!")
-    return SkipReason("Nothing to do")
-```
-
-These logs can be viewed in the UI on the corresponding sensor page, after first enabling the **Experimental schedule/sensor logging view** option in **User Settings**.
 
 ---
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
@@ -4,6 +4,7 @@ from dagster import (
     RunRequest,
     ScheduleDefinition,
     ScheduleEvaluationContext,
+    SkipReason,
     asset,
     job,
     op,
@@ -75,3 +76,13 @@ my_running_schedule = ScheduleDefinition(
 )
 
 # end_running_in_code
+
+
+# start_schedule_logging
+@schedule(job=my_job, cron_schedule="* * * * *")
+def logs_then_skips(context):
+    context.log.info("Logging from a schedule!")
+    return SkipReason("Nothing to do")
+
+
+# end_schedule_logging


### PR DESCRIPTION
## Summary & Motivation
- Remove experimental warning about sensor/schedule tick logs in the docs
- Add an equivalent section for logging in schedule decorated functions (a user was confused about this recently)

## How I Tested These Changes
eyes

