### PR TITLE
Revert "switch run status sensors to read from index shard (#18616)"

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -31,7 +31,6 @@ from dagster._core.errors import (
     RunStatusSensorExecutionError,
     user_code_error_boundary,
 )
-from dagster._core.event_api import RunStatusChangeEventType, RunStatusChangeRecordsFilter
 from dagster._core.events import PIPELINE_RUN_STATUS_TO_EVENT_TYPE, DagsterEvent, DagsterEventType
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
@@ -86,24 +85,14 @@ RunFailureSensorEvaluationFn: TypeAlias = Union[
 class RunStatusSensorCursor(
     NamedTuple(
         "_RunStatusSensorCursor",
-        [
-            ("record_id", int),
-            # deprecated arg, used as a record cursor for the run-sharded sqlite implementation to
-            # filter records based on the update timestamp of the run.  When populated, the record
-            # id is ignored (since it maybe run-scoped).
-            ("update_timestamp", Optional[str]),
-            # debug arg, used to quickly inspect the last processed timestamp from the run status
-            # sensor's serialized state
-            ("record_timestamp", Optional[str]),
-        ],
+        [("record_id", int), ("update_timestamp", str)],
     )
 ):
-    def __new__(cls, record_id, update_timestamp=None, record_timestamp=None):
+    def __new__(cls, record_id, update_timestamp):
         return super(RunStatusSensorCursor, cls).__new__(
             cls,
             record_id=check.int_param(record_id, "record_id"),
-            update_timestamp=check.opt_str_param(update_timestamp, "update_timestamp"),
-            record_timestamp=check.opt_str_param(record_timestamp, "record_timestamp"),
+            update_timestamp=check.str_param(update_timestamp, "update_timestamp"),
         )
 
     @staticmethod
@@ -595,6 +584,8 @@ class RunStatusSensorDefinition(SensorDefinition):
             JobSelector,
             RepositorySelector,
         )
+        from dagster._core.event_api import RunShardedEventsCursor
+        from dagster._core.storage.event_log.base import EventRecordsFilter
 
         check.str_param(name, "name")
         check.inst_param(run_status, "run_status", DagsterRunStatus)
@@ -657,67 +648,47 @@ class RunStatusSensorDefinition(SensorDefinition):
             # * it's the first time starting the sensor
             # * or, the cursor isn't in valid format (backcompt)
             if context.cursor is None or not RunStatusSensorCursor.is_valid(context.cursor):
-                most_recent_event_records = context.instance.fetch_run_status_changes(
-                    records_filter=event_type, limit=1
-                ).records
+                most_recent_event_records = list(
+                    context.instance.get_event_records(
+                        EventRecordsFilter(event_type=event_type), ascending=False, limit=1
+                    )
+                )
                 most_recent_event_id = (
                     most_recent_event_records[0].storage_id
                     if len(most_recent_event_records) == 1
                     else -1
                 )
-                record_timestamp = (
-                    utc_datetime_from_timestamp(most_recent_event_records[0].timestamp).isoformat()
-                    if len(most_recent_event_records) == 1
-                    else None
-                )
 
                 new_cursor = RunStatusSensorCursor(
-                    record_id=most_recent_event_id, record_timestamp=record_timestamp
+                    update_timestamp=pendulum.now("UTC").isoformat(),
+                    record_id=most_recent_event_id,
                 )
                 context.update_cursor(new_cursor.to_json())
                 yield SkipReason(f"Initiating {name}. Set cursor to {new_cursor}")
                 return
 
-            sensor_cursor = RunStatusSensorCursor.from_json(context.cursor)
+            record_id, update_timestamp = RunStatusSensorCursor.from_json(context.cursor)
 
             # Fetch events after the cursor id
             # * we move the cursor forward to the latest visited event's id to avoid revisits
             # * when the daemon is down, bc we persist the cursor info, we can go back to where we
             #   left and backfill alerts for the qualified events (up to 5 at a time) during the downtime
-            if sensor_cursor.update_timestamp and context.instance.event_log_storage.is_run_sharded:
-                # The run status sensor cursor has the timestamp set... and the event log storage
-                # is run sharded.  We need to query the index shard by timestamp instead of by
-                # record id (which is reindexed relative to some run sharded query).  When we update
-                # the cursor, we should omit the timestamp, since this API only queries the global
-                # index shard instead of the run shard.
-                event_records = context.instance.fetch_run_status_changes(
-                    records_filter=RunStatusChangeRecordsFilter(
-                        event_type=cast(RunStatusChangeEventType, event_type),
-                        after_timestamp=cast(
-                            datetime, pendulum.parse(sensor_cursor.update_timestamp)
-                        ).timestamp(),
+            # Note: this is a cross-run query which requires extra handling in sqlite, see details in SqliteEventLogStorage.
+            event_records = context.instance.get_event_records(
+                EventRecordsFilter(
+                    after_cursor=RunShardedEventsCursor(
+                        id=record_id,
+                        run_updated_after=cast(datetime, pendulum.parse(update_timestamp)),
                     ),
-                    ascending=True,
-                    limit=5,
-                ).records
-            else:
-                # the cursor storage id is globally unique, either because the event log storage is
-                # not run sharded or because the cursor was set from an event returned from the
-                # index shard. When we update the cursor, we should omit the timestamp, since this
-                # API only queries the global index shard instead of the run shard.
-                event_records = context.instance.fetch_run_status_changes(
-                    records_filter=RunStatusChangeRecordsFilter(
-                        event_type=cast(RunStatusChangeEventType, event_type),
-                        after_storage_id=sensor_cursor.record_id,
-                    ),
-                    ascending=True,
-                    limit=5,
-                ).records
+                    event_type=event_type,
+                ),
+                ascending=True,
+                limit=5,
+            )
 
             for event_record in event_records:
                 event_log_entry = event_record.event_log_entry
                 storage_id = event_record.storage_id
-                record_timestamp = utc_datetime_from_timestamp(event_record.timestamp).isoformat()
 
                 # get run info
                 run_records = context.instance.get_run_records(
@@ -726,14 +697,22 @@ class RunStatusSensorDefinition(SensorDefinition):
 
                 # skip if we couldn't find the right run
                 if len(run_records) != 1:
+                    # bc we couldn't find the run, we use the event timestamp as the approximate
+                    # run update timestamp
+                    approximate_update_timestamp = utc_datetime_from_timestamp(
+                        event_log_entry.timestamp
+                    )
                     context.update_cursor(
                         RunStatusSensorCursor(
-                            record_id=storage_id, record_timestamp=record_timestamp
+                            record_id=storage_id,
+                            update_timestamp=approximate_update_timestamp.isoformat(),
                         ).to_json()
                     )
                     continue
 
                 dagster_run = run_records[0].dagster_run
+                update_timestamp = run_records[0].update_timestamp
+
                 job_match = False
 
                 # if monitor_all_repositories is provided, then we want to run the sensor for all jobs in all repositories
@@ -783,7 +762,7 @@ class RunStatusSensorDefinition(SensorDefinition):
                     # the run in question doesn't match any of the criteria for we advance the cursor and move on
                     context.update_cursor(
                         RunStatusSensorCursor(
-                            record_id=storage_id, record_timestamp=record_timestamp
+                            record_id=storage_id, update_timestamp=update_timestamp.isoformat()
                         ).to_json()
                     )
                     continue
@@ -820,7 +799,8 @@ class RunStatusSensorDefinition(SensorDefinition):
                         if sensor_return is not None:
                             context.update_cursor(
                                 RunStatusSensorCursor(
-                                    record_id=storage_id, record_timestamp=record_timestamp
+                                    record_id=storage_id,
+                                    update_timestamp=update_timestamp.isoformat(),
                                 ).to_json()
                             )
 
@@ -848,7 +828,7 @@ class RunStatusSensorDefinition(SensorDefinition):
 
                 context.update_cursor(
                     RunStatusSensorCursor(
-                        record_id=storage_id, record_timestamp=record_timestamp
+                        record_id=storage_id, update_timestamp=update_timestamp.isoformat()
                     ).to_json()
                 )
 


### PR DESCRIPTION
## Summary & Motivation
This reverts commit 40e69f538ae9586001ebae01b4a3dae5b2571c1f.

This is a minor breaking change, but for optics, will defer to the `1.6` release, since it's so close.

## How I Tested These Changes
BK