### PR TITLE
[ui] Lazy-import markdown and react-dates

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/DateRangePickerWrapper.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/DateRangePickerWrapper.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import {DateRangePicker} from 'react-dates';
+
+import 'react-dates/initialize';
+import 'react-dates/lib/css/_datepicker.css';
+
+export const DateRangePickerWrapper = (props: React.ComponentProps<typeof DateRangePicker>) => {
+  return <DateRangePicker {...props} />;
+};
+
+// eslint-disable-next-line import/no-default-export
+export default DateRangePicker;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useTimeRangeFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useTimeRangeFilter.tsx
@@ -16,7 +16,6 @@ import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import isEqual from 'lodash/isEqual';
 import React from 'react';
-import {DateRangePicker} from 'react-dates';
 import styled from 'styled-components';
 
 import {TimeContext} from '../../app/time/TimeContext';
@@ -25,11 +24,10 @@ import {useUpdatingRef} from '../../hooks/useUpdatingRef';
 
 import {FilterObject, FilterTag, FilterTagHighlightedText} from './useFilter';
 
+const DateRangePicker = React.lazy(() => import('./DateRangePickerWrapper'));
+
 dayjs.extend(utc);
 dayjs.extend(timezone);
-
-import 'react-dates/initialize';
-import 'react-dates/lib/css/_datepicker.css';
 
 export type TimeRangeState = [number | null, number | null];
 
@@ -300,23 +298,25 @@ export function CustomTimeRangeFilterDialog({
     >
       <Container>
         <Box flex={{direction: 'row', gap: 8}} padding={16}>
-          <DateRangePicker
-            onDatesChange={({startDate, endDate}) => {
-              setStartDate(startDate);
-              setEndDate(endDate);
-            }}
-            onFocusChange={(focusedInput) => {
-              focusedInput && setFocusedInput(focusedInput);
-            }}
-            startDate={startDate}
-            endDate={endDate}
-            startDateId="start"
-            endDateId="end"
-            focusedInput={focusedInput}
-            withPortal={false}
-            keepOpenOnDateSelect
-            isOutsideRange={() => false}
-          />
+          <React.Suspense fallback={<div />}>
+            <DateRangePicker
+              onDatesChange={({startDate, endDate}) => {
+                setStartDate(startDate);
+                setEndDate(endDate);
+              }}
+              onFocusChange={(focusedInput) => {
+                focusedInput && setFocusedInput(focusedInput);
+              }}
+              startDate={startDate}
+              endDate={endDate}
+              startDateId="start"
+              endDateId="end"
+              focusedInput={focusedInput}
+              withPortal={false}
+              keepOpenOnDateSelect
+              isOutsideRange={() => false}
+            />
+          </React.Suspense>
         </Box>
       </Container>
       <DialogFooter topBorder>

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Markdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Markdown.tsx
@@ -1,69 +1,8 @@
 import {FontFamily, colorTextLight} from '@dagster-io/ui-components';
 import * as React from 'react';
-import ReactMarkdown from 'react-markdown';
-import rehypeHighlight from 'rehype-highlight';
-import rehypeSanitize, {defaultSchema} from 'rehype-sanitize';
-import gfm from 'remark-gfm';
 import styled from 'styled-components';
 
-import 'highlight.js/styles/github.css';
-
-const sanitizeConfig = {
-  ...defaultSchema,
-  protocols: {
-    src: [...(defaultSchema.protocols?.src ?? []), 'data'],
-  },
-  attributes: {
-    ...defaultSchema.attributes,
-    span: [
-      ...(defaultSchema.attributes?.span || []),
-      // List of all allowed tokens:
-      [
-        'className',
-        'hljs-addition',
-        'hljs-attr',
-        'hljs-attribute',
-        'hljs-built_in',
-        'hljs-bullet',
-        'hljs-char',
-        'hljs-code',
-        'hljs-comment',
-        'hljs-deletion',
-        'hljs-doctag',
-        'hljs-emphasis',
-        'hljs-formula',
-        'hljs-keyword',
-        'hljs-link',
-        'hljs-literal',
-        'hljs-meta',
-        'hljs-name',
-        'hljs-number',
-        'hljs-operator',
-        'hljs-params',
-        'hljs-property',
-        'hljs-punctuation',
-        'hljs-quote',
-        'hljs-regexp',
-        'hljs-section',
-        'hljs-selector-attr',
-        'hljs-selector-class',
-        'hljs-selector-id',
-        'hljs-selector-pseudo',
-        'hljs-selector-tag',
-        'hljs-string',
-        'hljs-strong',
-        'hljs-subst',
-        'hljs-symbol',
-        'hljs-tag',
-        'hljs-template-tag',
-        'hljs-template-variable',
-        'hljs-title',
-        'hljs-type',
-        'hljs-variable',
-      ],
-    ],
-  },
-};
+const MarkdownWithPlugins = React.lazy(() => import('./MarkdownWithPlugins'));
 
 interface Props {
   children: string;
@@ -72,11 +11,9 @@ interface Props {
 export const Markdown = (props: Props) => {
   return (
     <Container>
-      <ReactMarkdown
-        {...props}
-        remarkPlugins={[gfm]}
-        rehypePlugins={[rehypeHighlight, [rehypeSanitize, sanitizeConfig]]}
-      />
+      <React.Suspense fallback={<div />}>
+        <MarkdownWithPlugins {...props} />
+      </React.Suspense>
     </Container>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/MarkdownWithPlugins.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/MarkdownWithPlugins.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import ReactMarkdown from 'react-markdown';
+import rehypeHighlight from 'rehype-highlight';
+import rehypeSanitize, {defaultSchema} from 'rehype-sanitize';
+import gfm from 'remark-gfm';
+
+import 'highlight.js/styles/github.css';
+
+const sanitizeConfig = {
+  ...defaultSchema,
+  protocols: {
+    src: [...(defaultSchema.protocols?.src ?? []), 'data'],
+  },
+  attributes: {
+    ...defaultSchema.attributes,
+    span: [
+      ...(defaultSchema.attributes?.span || []),
+      // List of all allowed tokens:
+      [
+        'className',
+        'hljs-addition',
+        'hljs-attr',
+        'hljs-attribute',
+        'hljs-built_in',
+        'hljs-bullet',
+        'hljs-char',
+        'hljs-code',
+        'hljs-comment',
+        'hljs-deletion',
+        'hljs-doctag',
+        'hljs-emphasis',
+        'hljs-formula',
+        'hljs-keyword',
+        'hljs-link',
+        'hljs-literal',
+        'hljs-meta',
+        'hljs-name',
+        'hljs-number',
+        'hljs-operator',
+        'hljs-params',
+        'hljs-property',
+        'hljs-punctuation',
+        'hljs-quote',
+        'hljs-regexp',
+        'hljs-section',
+        'hljs-selector-attr',
+        'hljs-selector-class',
+        'hljs-selector-id',
+        'hljs-selector-pseudo',
+        'hljs-selector-tag',
+        'hljs-string',
+        'hljs-strong',
+        'hljs-subst',
+        'hljs-symbol',
+        'hljs-tag',
+        'hljs-template-tag',
+        'hljs-template-variable',
+        'hljs-title',
+        'hljs-type',
+        'hljs-variable',
+      ],
+    ],
+  },
+};
+
+interface Props {
+  children: string;
+}
+
+export const MarkdownWithPlugins = (props: Props) => {
+  return (
+    <ReactMarkdown
+      {...props}
+      remarkPlugins={[gfm]}
+      rehypePlugins={[rehypeHighlight, [rehypeSanitize, sanitizeConfig]]}
+    />
+  );
+};
+
+// eslint-disable-next-line import/no-default-export
+export default MarkdownWithPlugins;


### PR DESCRIPTION
## Summary & Motivation

Trim 115kb gzipped off our largest bundle by lazy-loading `react-dates` and some markdown plugins.

Before:

<img width="1508" alt="Screenshot 2024-01-03 at 12 16 28 PM" src="https://github.com/dagster-io/dagster/assets/2823852/9ab38d63-7936-4602-ad2e-33ac72925392">

After:

<img width="1395" alt="Screenshot 2024-01-03 at 12 14 35 PM" src="https://github.com/dagster-io/dagster/assets/2823852/dda70a17-52d6-40b9-a31e-fea0b3ff4e07">


## How I Tested These Changes

See analysis images. Loaded the app, verified that datepicker renders properly in the date filter, and that markdown renders properly.
