### PR TITLE
remove lambda in ConfigTypeSnap.__new__

### DIFF
--- a/python_modules/dagster/dagster/_config/snap.py
+++ b/python_modules/dagster/dagster/_config/snap.py
@@ -52,6 +52,10 @@ class ConfigSchemaSnapshot(
         return key in self.all_config_snaps_by_key
 
 
+def _ct_name(ct):
+    return ct.name
+
+
 @whitelist_for_serdes(skip_when_empty_fields={"field_aliases"})
 class ConfigTypeSnap(
     NamedTuple(
@@ -105,7 +109,7 @@ class ConfigTypeSnap(
                 if fields is None
                 else sorted(
                     check.list_param(fields, "field", of_type=ConfigFieldSnap),
-                    key=lambda ct: ct.name,
+                    key=_ct_name,
                 )
             ),
             description=check.opt_str_param(description, "description"),


### PR DESCRIPTION
bumped across this doing some memory profiling, its very negligible but figured it was worth committing 


## How I Tested These Changes
using a serdes benchmark that deserializes workspaces snapshots which end up instantiating lots of these ConfigTypeSnap

before
```
Target 4 size 1.8MiB:
deserialize_value (25 samples): mean 43.448, stdev 8.718, min 36.408

Target 5 size 23.8MiB:
deserialize_value (25 samples): mean 524.681, stdev 24.847, min 426.663
```

after
```
Target 4 size 1.8MiB:
deserialize_value (25 samples): mean 35.568, stdev 0.177, min 34.932

Target 5 size 23.8MiB:
deserialize_value (25 samples): mean 517.091, stdev 19.958, min 422.876
```