### PR TITLE
feat(dbt): send `SIGINT` to dbt subprocess on exit

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -2,6 +2,7 @@ import atexit
 import contextlib
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import uuid
@@ -294,7 +295,7 @@ class DbtCliInvocation:
                     "The main process is being terminated, but the dbt command has not yet"
                     " completed. Terminating the execution of dbt command."
                 )
-                process.terminate()
+                process.send_signal(signal.SIGINT)
                 process.wait()
 
         atexit.register(cleanup_dbt_subprocess, process)


### PR DESCRIPTION
## Summary & Motivation

This essentially makes [the following behavior](https://medium.com/@brianepohl/terminating-dbt-in-dagster-kubernetes-job-c53c3bc26012) native to `dagster-dbt`.

## How I Tested These Changes
N/A
