### PR TITLE
display zero value concurrency limits, configurable max

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2326,6 +2326,8 @@ type Instance {
   hasCapturedLogManager: Boolean!
   autoMaterializePaused: Boolean!
   supportsConcurrencyLimits: Boolean!
+  minConcurrencyLimitValue: Int!
+  maxConcurrencyLimitValue: Int!
   concurrencyLimits: [ConcurrencyKeyInfo!]!
   concurrencyLimit(concurrencyKey: String): ConcurrencyKeyInfo!
   useAutomationPolicySensors: Boolean!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -1505,6 +1505,8 @@ export type Instance = {
   hasInfo: Scalars['Boolean'];
   id: Scalars['String'];
   info: Maybe<Scalars['String']>;
+  maxConcurrencyLimitValue: Scalars['Int'];
+  minConcurrencyLimitValue: Scalars['Int'];
   runLauncher: Maybe<RunLauncher>;
   runQueueConfig: Maybe<RunQueueConfig>;
   runQueuingSupported: Scalars['Boolean'];
@@ -7343,6 +7345,14 @@ export const buildInstance = (
     hasInfo: overrides && overrides.hasOwnProperty('hasInfo') ? overrides.hasInfo! : true,
     id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'deleniti',
     info: overrides && overrides.hasOwnProperty('info') ? overrides.info! : 'qui',
+    maxConcurrencyLimitValue:
+      overrides && overrides.hasOwnProperty('maxConcurrencyLimitValue')
+        ? overrides.maxConcurrencyLimitValue!
+        : 8998,
+    minConcurrencyLimitValue:
+      overrides && overrides.hasOwnProperty('minConcurrencyLimitValue')
+        ? overrides.minConcurrencyLimitValue!
+        : 4538,
     runLauncher:
       overrides && overrides.hasOwnProperty('runLauncher')
         ? overrides.runLauncher!

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
@@ -377,8 +377,8 @@ export const ConcurrencyLimits = ({
         onClose={() => setAction(undefined)}
         onComplete={refetch}
         concurrencyKey={action?.actionType === 'edit' ? action.concurrencyKey : ''}
-        minValue={minValue || DEFAULT_MIN_VALUE}
-        maxValue={maxValue || DEFAULT_MAX_VALUE}
+        minValue={minValue ?? DEFAULT_MIN_VALUE}
+        maxValue={maxValue ?? DEFAULT_MAX_VALUE}
       />
       <ConcurrencyStepsDialog
         title={

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
@@ -59,6 +59,9 @@ import {
   SetConcurrencyLimitMutationVariables,
 } from './types/InstanceConcurrency.types';
 
+const DEFAULT_MIN_VALUE = 1;
+const DEFAULT_MAX_VALUE = 1000;
+
 const InstanceConcurrencyPage = React.memo(() => {
   useTrackPageView();
   useDocumentTitle('Concurrency');
@@ -92,6 +95,8 @@ const InstanceConcurrencyPage = React.memo(() => {
             limits={data.instance.concurrencyLimits}
             hasSupport={data.instance.supportsConcurrencyLimits}
             refetch={queryResult.refetch}
+            minValue={data.instance.minConcurrencyLimitValue}
+            maxValue={data.instance.maxConcurrencyLimitValue}
           />
         </>
       ) : (
@@ -225,11 +230,15 @@ export const ConcurrencyLimits = ({
   hasSupport,
   limits,
   refetch,
+  minValue,
+  maxValue,
 }: {
   limits: ConcurrencyLimitFragment[];
   refetch: () => void;
   instanceConfig?: string | null;
   hasSupport?: boolean;
+  maxValue?: number;
+  minValue?: number;
 }) => {
   const [action, setAction] = React.useState<DialogAction>();
   const [selectedKey, setSelectedKey] = React.useState<string | undefined>(undefined);
@@ -354,6 +363,8 @@ export const ConcurrencyLimits = ({
         open={action?.actionType === 'add'}
         onClose={() => setAction(undefined)}
         onComplete={refetch}
+        minValue={minValue ?? DEFAULT_MIN_VALUE}
+        maxValue={maxValue ?? DEFAULT_MAX_VALUE}
       />
       <DeleteConcurrencyLimitDialog
         concurrencyKey={action && action.actionType === 'delete' ? action.concurrencyKey : ''}
@@ -366,6 +377,8 @@ export const ConcurrencyLimits = ({
         onClose={() => setAction(undefined)}
         onComplete={refetch}
         concurrencyKey={action?.actionType === 'edit' ? action.concurrencyKey : ''}
+        minValue={minValue || DEFAULT_MIN_VALUE}
+        maxValue={maxValue || DEFAULT_MAX_VALUE}
       />
       <ConcurrencyStepsDialog
         title={
@@ -430,7 +443,11 @@ const ConcurrencyLimitActionMenu = ({
   );
 };
 
-const isValidLimit = (concurrencyLimit?: string) => {
+const isValidLimit = (
+  concurrencyLimit?: string,
+  minLimitValue: number = DEFAULT_MIN_VALUE,
+  maxLimitValue: number = DEFAULT_MAX_VALUE,
+) => {
   if (!concurrencyLimit) {
     return false;
   }
@@ -441,17 +458,21 @@ const isValidLimit = (concurrencyLimit?: string) => {
   if (String(value) !== concurrencyLimit.trim()) {
     return false;
   }
-  return value > 0 && value < 1000;
+  return value >= minLimitValue && value <= maxLimitValue;
 };
 
 const AddConcurrencyLimitDialog = ({
   open,
   onClose,
   onComplete,
+  maxValue,
+  minValue,
 }: {
   open: boolean;
   onClose: () => void;
   onComplete: () => void;
+  maxValue: number;
+  minValue: number;
 }) => {
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [limitInput, setLimitInput] = React.useState('');
@@ -488,12 +509,14 @@ const AddConcurrencyLimitDialog = ({
             placeholder="Concurrency key"
           />
         </Box>
-        <Box margin={{bottom: 4}}>Concurrency limit (1-1000):</Box>
+        <Box margin={{bottom: 4}}>
+          Concurrency limit ({minValue}-{maxValue}):
+        </Box>
         <Box>
           <TextInput
             value={limitInput || ''}
             onChange={(e) => setLimitInput(e.target.value)}
-            placeholder="1 - 1000"
+            placeholder={`${minValue} - ${maxValue}`}
           />
         </Box>
       </DialogBody>
@@ -504,7 +527,9 @@ const AddConcurrencyLimitDialog = ({
         <Button
           intent="primary"
           onClick={save}
-          disabled={!isValidLimit(limitInput.trim()) || !keyInput || isSubmitting}
+          disabled={
+            !isValidLimit(limitInput.trim(), minValue, maxValue) || !keyInput || isSubmitting
+          }
         >
           {isSubmitting ? 'Adding...' : 'Add limit'}
         </Button>
@@ -518,11 +543,15 @@ const EditConcurrencyLimitDialog = ({
   open,
   onClose,
   onComplete,
+  minValue,
+  maxValue,
 }: {
   concurrencyKey: string;
   open: boolean;
   onClose: () => void;
   onComplete: () => void;
+  minValue: number;
+  maxValue: number;
 }) => {
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [limitInput, setLimitInput] = React.useState('');
@@ -559,12 +588,14 @@ const EditConcurrencyLimitDialog = ({
         <Box margin={{bottom: 16}}>
           <strong>{concurrencyKey}</strong>
         </Box>
-        <Box margin={{bottom: 4}}>Concurrency limit (1-1000):</Box>
+        <Box margin={{bottom: 4}}>
+          Concurrency limit ({minValue}-{maxValue}):
+        </Box>
         <Box>
           <TextInput
             value={limitInput || ''}
             onChange={(e) => setLimitInput(e.target.value)}
-            placeholder="1 - 1000"
+            placeholder={`${minValue} - ${maxValue}`}
           />
         </Box>
       </DialogBody>
@@ -577,7 +608,11 @@ const EditConcurrencyLimitDialog = ({
             Updating...
           </Button>
         ) : (
-          <Button intent="primary" onClick={save} disabled={!isValidLimit(limitInput.trim())}>
+          <Button
+            intent="primary"
+            onClick={save}
+            disabled={!isValidLimit(limitInput.trim(), minValue, maxValue)}
+          >
             Update limit
           </Button>
         )}
@@ -963,6 +998,8 @@ export const INSTANCE_CONCURRENCY_LIMITS_QUERY = gql`
       runQueueConfig {
         ...RunQueueConfigFragment
       }
+      minConcurrencyLimitValue
+      maxConcurrencyLimitValue
       concurrencyLimits {
         ...ConcurrencyLimitFragment
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceConcurrency.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceConcurrency.types.ts
@@ -42,6 +42,8 @@ export type InstanceConcurrencyLimitsQuery = {
     info: string | null;
     supportsConcurrencyLimits: boolean;
     runQueuingSupported: boolean;
+    minConcurrencyLimitValue: number;
+    maxConcurrencyLimitValue: number;
     runQueueConfig: {
       __typename: 'RunQueueConfig';
       maxConcurrentRuns: number;

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -20,6 +20,7 @@ from dagster._config.source import BoolSource
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.storage.config import mysql_config, pg_config
 from dagster._serdes import class_from_code_pointer
+from dagster._utils.concurrency import get_max_concurrency_limit_value
 from dagster._utils.merger import merge_dicts
 from dagster._utils.yaml_utils import load_yaml_from_globs
 
@@ -122,10 +123,11 @@ def dagster_instance_config(
             "default_op_concurrency_limit"
         )
         if default_concurrency_limit is not None:
-            if default_concurrency_limit < 0 or default_concurrency_limit > 1000:
+            max_limit = get_max_concurrency_limit_value()
+            if default_concurrency_limit < 0 or default_concurrency_limit > max_limit:
                 raise DagsterInvalidConfigError(
                     f"Found value `{default_concurrency_limit}` for `default_op_concurrency_limit`, "
-                    "Expected value between 0-1000.",
+                    f"Expected value between 0-{max_limit}.",
                     [],
                     None,
                 )

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -84,6 +84,7 @@ from dagster._utils.concurrency import (
     ConcurrencyKeyInfo,
     ConcurrencySlotStatus,
     PendingStepInfo,
+    get_max_concurrency_limit_value,
 )
 
 from ..dagster_run import DagsterRunStatsSnapshot
@@ -113,7 +114,6 @@ from .schema import (
 if TYPE_CHECKING:
     from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
-MAX_CONCURRENCY_SLOTS = 1000
 MIN_ASSET_ROWS = 25
 DEFAULT_MAX_LIMIT_EVENT_RECORDS = 10000
 
@@ -2226,9 +2226,10 @@ class SqlEventLogStorage(EventLogStorage):
             concurrency_key (str): The key to allocate the slots for.
             num (int): The number of slots to allocate.
         """
-        if num > MAX_CONCURRENCY_SLOTS:
+        max_limit = get_max_concurrency_limit_value()
+        if num > max_limit:
             raise DagsterInvalidInvocationError(
-                f"Cannot have more than {MAX_CONCURRENCY_SLOTS} slots per concurrency key."
+                f"Cannot have more than {max_limit} slots per concurrency key."
             )
         if num < 0:
             raise DagsterInvalidInvocationError("Cannot have a negative number of slots.")

--- a/python_modules/dagster/dagster/_utils/concurrency.py
+++ b/python_modules/dagster/dagster/_utils/concurrency.py
@@ -1,8 +1,13 @@
+import os
 from datetime import datetime
 from enum import Enum
 from typing import List, NamedTuple, Optional, Set
 
 from dagster import _check as check
+
+
+def get_max_concurrency_limit_value() -> int:
+    return int(os.getenv("MAX_GLOBAL_OP_CONCURRENCY_LIMIT_VALUE", "1000"))
 
 
 class ConcurrencySlotStatus(Enum):

--- a/python_modules/dagster/dagster/_utils/concurrency.py
+++ b/python_modules/dagster/dagster/_utils/concurrency.py
@@ -7,7 +7,7 @@ from dagster import _check as check
 
 
 def get_max_concurrency_limit_value() -> int:
-    return int(os.getenv("MAX_GLOBAL_OP_CONCURRENCY_LIMIT_VALUE", "1000"))
+    return int(os.getenv("DAGSTER_MAX_GLOBAL_OP_CONCURRENCY_LIMIT", "1000"))
 
 
 class ConcurrencySlotStatus(Enum):


### PR DESCRIPTION
## Summary & Motivation
We want the concurrency limit value ranges to be customizable for instances that really want them to be.

This PR reads the max limit value from an environment variable and the min limit based on the storage schema state (either 0 or 1), and passes them onto the frontend as required.

## How I Tested These Changes
BK, tested by setting a zero-value limit in the UI and set the env var `MAX_GLOBAL_OP_CONCURRENCY_LIMIT_VALUE` and saw them reflected