### PR TITLE
[amp-refactor][14/n] Fix non-subsettable multi-asset handling

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -59,8 +59,10 @@ from dagster._core.definitions.auto_materialize_rule_evaluation import (
 from dagster._core.definitions.automation_policy_sensor_definition import (
     AutomationPolicySensorDefinition,
 )
+from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.events import AssetKeyPartitionKey, CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import in_process_executor
+from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
 )
@@ -197,6 +199,12 @@ class AssetSpecWithPartitionsDef(
     ...
 
 
+class MultiAssetSpec(NamedTuple):
+    specs: Sequence[AssetSpec]
+    partitions_def: Optional[PartitionsDefinition] = None
+    can_subset: bool = False
+
+
 class AssetDaemonScenarioState(NamedTuple):
     """Specifies the state of a given AssetDaemonScenario. This state can be modified by changing
     the set of asset definitions it contains, executing runs, updating the time, evaluating ticks, etc.
@@ -211,7 +219,7 @@ class AssetDaemonScenarioState(NamedTuple):
         current_time (datetime): The current time of the scenario.
     """
 
-    asset_specs: Sequence[Union[AssetSpec, AssetSpecWithPartitionsDef]]
+    asset_specs: Sequence[Union[AssetSpec, AssetSpecWithPartitionsDef, MultiAssetSpec]]
     current_time: datetime.datetime = pendulum.now("UTC")
     run_requests: Sequence[RunRequest] = []
     serialized_cursor: str = serialize_value(AssetDaemonCursor.empty(0))
@@ -236,26 +244,35 @@ class AssetDaemonScenarioState(NamedTuple):
                 AssetKey.from_coercible(s)
                 for s in json.loads(context.run.tags.get(FAIL_TAG) or "[]")
             }
-            if context.asset_key in fail_keys:
-                raise Exception("Asset failed")
+            for asset_key in context.selected_asset_keys:
+                if asset_key in fail_keys:
+                    raise Exception("Asset failed")
 
         assets = []
-        params = {
-            "key",
-            "deps",
-            "group_name",
-            "code_version",
-            "auto_materialize_policy",
-            "freshness_policy",
-            "partitions_def",
-        }
         for spec in self.asset_specs:
-            assets.append(
-                asset(
-                    compute_fn=compute_fn,
-                    **{k: v for k, v in spec._asdict().items() if k in params},
+            if isinstance(spec, MultiAssetSpec):
+
+                @multi_asset(**spec._asdict())
+                def _multi_asset(context: AssetExecutionContext):
+                    return compute_fn(context)
+
+                assets.append(_multi_asset)
+            else:
+                params = {
+                    "key",
+                    "deps",
+                    "group_name",
+                    "code_version",
+                    "auto_materialize_policy",
+                    "freshness_policy",
+                    "partitions_def",
+                }
+                assets.append(
+                    asset(
+                        compute_fn=compute_fn,
+                        **{k: v for k, v in spec._asdict().items() if k in params},
+                    )
                 )
-            )
         return assets
 
     @property
@@ -272,16 +289,28 @@ class AssetDaemonScenarioState(NamedTuple):
         """Convenience method to update the properties of one or more assets in the scenario state."""
         new_asset_specs = []
         for spec in self.asset_specs:
-            if keys is None or spec.key in {AssetKey.from_coercible(key) for key in keys}:
-                if "partitions_def" in kwargs:
-                    # partitions_def is not a field on AssetSpec, so we need to do this hack
-                    new_asset_specs.append(
-                        AssetSpecWithPartitionsDef(**{**spec._asdict(), **kwargs})
-                    )
-                else:
-                    new_asset_specs.append(spec._replace(**kwargs))
+            if isinstance(spec, MultiAssetSpec):
+                partitions_def = kwargs.get("partitions_def", spec.partitions_def)
+                new_multi_specs = [
+                    s._replace(**{k: v for k, v in kwargs.items() if k != "partitions_def"})
+                    if keys is None or s.key in keys
+                    else s
+                    for s in spec.specs
+                ]
+                new_asset_specs.append(
+                    spec._replace(partitions_def=partitions_def, specs=new_multi_specs)
+                )
             else:
-                new_asset_specs.append(spec)
+                if keys is None or spec.key in {AssetKey.from_coercible(key) for key in keys}:
+                    if "partitions_def" in kwargs:
+                        # partitions_def is not a field on AssetSpec, so we need to do this hack
+                        new_asset_specs.append(
+                            AssetSpecWithPartitionsDef(**{**spec._asdict(), **kwargs})
+                        )
+                    else:
+                        new_asset_specs.append(spec._replace(**kwargs))
+                else:
+                    new_asset_specs.append(spec)
         return self._replace(asset_specs=new_asset_specs)
 
     def with_automation_policy_sensors(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario_states.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario_states.py
@@ -10,7 +10,7 @@ from dagster._core.definitions.time_window_partitions import (
     HourlyPartitionsDefinition,
 )
 
-from ..asset_daemon_scenario import AssetDaemonScenarioState
+from ..asset_daemon_scenario import AssetDaemonScenarioState, MultiAssetSpec
 
 ############
 # PARTITIONS
@@ -60,6 +60,14 @@ diamond = AssetDaemonScenarioState(
         AssetSpec(key="B", deps=["A"]),
         AssetSpec(key="C", deps=["A"]),
         AssetSpec(key="D", deps=["B", "C"]),
+    ]
+)
+
+three_assets_not_subsettable = AssetDaemonScenarioState(
+    asset_specs=[
+        MultiAssetSpec(
+            specs=[AssetSpec("A"), AssetSpec("B"), AssetSpec("C")],
+        )
     ]
 )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
@@ -11,6 +11,7 @@ from .asset_daemon_scenario_states import (
     hourly_partitions_def,
     one_asset,
     one_asset_depends_on_two,
+    three_assets_not_subsettable,
     time_partitions_start_str,
 )
 
@@ -52,6 +53,23 @@ cron_scenarios = [
         .assert_requested_runs(run_request(["A"]))
         .assert_evaluation("A", [AssetRuleEvaluationSpec(basic_hourly_cron_rule)])
         # next tick should not request any more runs
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs(),
+    ),
+    AssetDaemonScenario(
+        id="basic_hourly_cron_unpartitioned_multi_asset",
+        initial_state=three_assets_not_subsettable.with_asset_properties(
+            auto_materialize_policy=get_cron_policy(basic_hourly_cron_rule)
+        ).with_current_time("2020-01-01T00:05"),
+        execution_fn=lambda state: state.evaluate_tick()
+        .assert_requested_runs(run_request(["A", "B", "C"]))
+        .with_current_time_advanced(seconds=30)
+        .evaluate_tick()
+        .assert_requested_runs()
+        .with_current_time_advanced(hours=1)
+        .evaluate_tick()
+        .assert_requested_runs(run_request(["A", "B", "C"]))
         .with_current_time_advanced(seconds=30)
         .evaluate_tick()
         .assert_requested_runs(),


### PR DESCRIPTION
## Summary & Motivation

Lower in the stack, the way we handled non-subsettable multi-assets changed. Previously, when we hit the first of the neighbors in the group, we would do the calculation as normal, then copy the evaluation information over to all the neighbors (just swapping out the asset key where necessary). This was changed such that we would not actually copy the evaluation information over, and instead just add the neighbors to the set of asset partitions to request.

The issue here is that this means that on the next tick, when the unevaluated neighbor assets look at their previous evaluation info, they would not find anything, even though they were technically evaluated by proxy. For rules such as "materialize_on_cron", this would mean that the non-evaluated assets would then think they would need to be materialized again on the next tick, as they wouldn't be aware that they were requested on the previous one.

## How I Tested These Changes
