### PR TITLE
Automation policy sensor daemon tests

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -6,6 +6,7 @@ import os
 import sys
 import threading
 from collections import namedtuple
+from contextlib import contextmanager
 from typing import (
     Any,
     Callable,
@@ -16,6 +17,7 @@ from typing import (
     Tuple,
     Type,
     Union,
+    cast,
 )
 
 import dagster._check as check
@@ -47,10 +49,23 @@ from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeRuleEvaluation,
     AutoMaterializeRuleEvaluationData,
 )
+from dagster._core.definitions.automation_policy_sensor_definition import (
+    AutomationPolicySensorDefinition,
+)
 from dagster._core.definitions.events import AssetKeyPartitionKey, CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import in_process_executor
-from dagster._core.host_representation.origin import InProcessCodeLocationOrigin
-from dagster._core.scheduler.instigation import TickStatus
+from dagster._core.definitions.repository_definition.valid_definitions import (
+    SINGLETON_REPOSITORY_NAME,
+)
+from dagster._core.host_representation.origin import (
+    ExternalInstigatorOrigin,
+    ExternalRepositoryOrigin,
+    InProcessCodeLocationOrigin,
+)
+from dagster._core.scheduler.instigation import (
+    SensorInstigatorData,
+    TickStatus,
+)
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._core.test_utils import (
     InProcessTestWorkspaceLoadTarget,
@@ -64,6 +79,7 @@ from dagster._daemon.asset_daemon import (
     AssetDaemon,
     get_current_evaluation_id,
 )
+from dagster._daemon.controller import DEFAULT_DAEMON_INTERVAL_SECONDS
 
 from .base_scenario import FAIL_TAG, run_request
 
@@ -77,9 +93,13 @@ def get_code_location_origin(
     attribute_name = (
         f"_asset_daemon_target_{hashlib.md5(str(scenario_state.asset_specs).encode()).hexdigest()}"
     )
-    globals()[attribute_name] = Definitions(
-        assets=scenario_state.assets, executor=in_process_executor
-    )
+    if attribute_name not in globals():
+        globals()[attribute_name] = Definitions(
+            assets=scenario_state.assets,
+            executor=in_process_executor,
+            sensors=scenario_state.automation_policy_sensors,
+        )
+
     return InProcessCodeLocationOrigin(
         loadable_target_origin=LoadableTargetOrigin(
             executable_path=sys.executable,
@@ -179,7 +199,8 @@ class AssetDaemonScenarioState(NamedTuple):
     """
 
     asset_specs: Sequence[Union[AssetSpec, AssetSpecWithPartitionsDef]]
-    current_time: datetime.datetime = pendulum.now()
+    current_time: datetime.datetime = pendulum.now("UTC")
+    previous_tick_time: Optional[datetime.datetime] = None
     run_requests: Sequence[RunRequest] = []
     serialized_cursor: str = AssetDaemonCursor.empty().serialize()
     evaluations: Sequence[AutoMaterializeAssetEvaluation] = []
@@ -187,6 +208,8 @@ class AssetDaemonScenarioState(NamedTuple):
     # this is set by the scenario runner
     scenario_instance: Optional[DagsterInstance] = None
     is_daemon: bool = False
+    sensor_name: Optional[str] = None
+    automation_policy_sensors: Optional[Sequence[AutomationPolicySensorDefinition]] = None
 
     @property
     def instance(self) -> DagsterInstance:
@@ -223,7 +246,7 @@ class AssetDaemonScenarioState(NamedTuple):
 
     @property
     def defs(self) -> Definitions:
-        return Definitions(assets=self.assets)
+        return Definitions(assets=self.assets, sensors=self.automation_policy_sensors)
 
     @property
     def asset_graph(self) -> AssetGraph:
@@ -246,6 +269,12 @@ class AssetDaemonScenarioState(NamedTuple):
             else:
                 new_asset_specs.append(spec)
         return self._replace(asset_specs=new_asset_specs)
+
+    def with_automation_policy_sensors(
+        self,
+        sensors: Optional[Sequence[AutomationPolicySensorDefinition]],
+    ):
+        return self._replace(automation_policy_sensors=sensors)
 
     def with_all_eager(
         self, max_materializations_per_minute: int = 1
@@ -351,32 +380,115 @@ class AssetDaemonScenarioState(NamedTuple):
             )
         return new_run_requests, new_cursor, new_evaluations
 
-    def _evaluate_tick_daemon(
-        self,
-    ) -> Tuple[Sequence[RunRequest], AssetDaemonCursor, Sequence[AutoMaterializeAssetEvaluation]]:
+    @contextmanager
+    def _create_workspace_context(self):
         target = InProcessTestWorkspaceLoadTarget(get_code_location_origin(self))
-
         with create_test_daemon_workspace_context(
             workspace_load_target=target, instance=self.instance
         ) as workspace_context:
+            yield workspace_context
+
+    @contextmanager
+    def _get_external_sensor(self, sensor_name):
+        with self._create_workspace_context() as workspace_context:
+            workspace = workspace_context.create_request_context()
+            sensor = next(
+                iter(workspace.get_code_location("test_location").get_repositories().values())
+            ).get_external_sensor(sensor_name)
+            assert sensor
+            yield sensor
+
+    def start_sensor(self, sensor_name: str):
+        with self._get_external_sensor(sensor_name) as sensor:
+            self.instance.start_sensor(sensor)
+        return self
+
+    def stop_sensor(self, sensor_name: str):
+        with self._get_external_sensor(sensor_name) as sensor:
+            self.instance.stop_sensor(sensor.get_external_origin_id(), sensor.selector_id, sensor)
+        return self
+
+    def _evaluate_tick_daemon(
+        self,
+        advance_time_to_next_tick: bool,
+    ) -> Tuple[
+        Sequence[RunRequest],
+        AssetDaemonCursor,
+        Sequence[AutoMaterializeAssetEvaluation],
+        datetime.datetime,
+    ]:
+        new_current_time = self.current_time
+        with self._create_workspace_context() as workspace_context:
             workspace = workspace_context.create_request_context()
             assert (
                 workspace.get_code_location_error("test_location") is None
             ), workspace.get_code_location_error("test_location")
 
-            list(
-                AssetDaemon(pre_sensor_interval_seconds=42)._run_iteration_impl(  # noqa: SLF001
-                    workspace_context,
-                    debug_crash_flags={},
-                    sensor_state_lock=threading.Lock(),
-                )
+            sensor = (
+                next(
+                    iter(workspace.get_code_location("test_location").get_repositories().values())
+                ).get_external_sensor(self.sensor_name)
+                if self.sensor_name
+                else None
             )
-            new_cursor = AssetDaemonCursor.from_serialized(
-                self.instance.daemon_cursor_storage.get_cursor_values(
+
+            pre_sensor_interval_seconds = (
+                self.instance.auto_materialize_minimum_interval_seconds
+                or DEFAULT_DAEMON_INTERVAL_SECONDS
+            )
+
+            if sensor:
+                # start sensor if it hasn't started already
+                self.instance.start_sensor(sensor)
+                interval = sensor.min_interval_seconds
+            else:
+                interval = pre_sensor_interval_seconds
+
+            if advance_time_to_next_tick:
+                if self.previous_tick_time:
+                    time_to_advance = (
+                        self.previous_tick_time.timestamp() + interval
+                    ) - self.current_time.timestamp()
+
+                    if time_to_advance > 0:
+                        new_current_time = new_current_time + datetime.timedelta(
+                            seconds=time_to_advance
+                        )
+
+            with pendulum.test(new_current_time):
+                list(
+                    AssetDaemon(  # noqa: SLF001
+                        pre_sensor_interval_seconds=pre_sensor_interval_seconds
+                    )._run_iteration_impl(
+                        workspace_context,
+                        debug_crash_flags={},
+                        sensor_state_lock=threading.Lock(),
+                    )
+                )
+
+            if sensor:
+                auto_materialize_instigator_state = check.not_none(
+                    self.instance.get_instigator_state(
+                        sensor.get_external_origin_id(), sensor.selector_id
+                    )
+                )
+                raw_cursor = (
+                    cast(
+                        SensorInstigatorData,
+                        check.not_none(auto_materialize_instigator_state).instigator_data,
+                    ).cursor
+                    or AssetDaemonCursor.empty().serialize()
+                )
+            else:
+                raw_cursor = self.instance.daemon_cursor_storage.get_cursor_values(
                     {_PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY}
                 ).get(
-                    _PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY, AssetDaemonCursor.empty().serialize()
-                ),
+                    _PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY,
+                    AssetDaemonCursor.empty().serialize(),
+                )
+
+            new_cursor = AssetDaemonCursor.from_serialized(
+                raw_cursor,
                 self.asset_graph,
             )
             new_run_requests = [
@@ -396,19 +508,27 @@ class AssetDaemonScenarioState(NamedTuple):
                     self.instance.schedule_storage
                 ).get_auto_materialize_evaluations_for_evaluation_id(new_cursor.evaluation_id)
             ]
-        return new_run_requests, new_cursor, new_evaluations
+        return new_run_requests, new_cursor, new_evaluations, new_current_time
 
-    def evaluate_tick(self) -> "AssetDaemonScenarioState":
-        with pendulum.test(self.current_time):
-            if self.is_daemon:
-                new_run_requests, new_cursor, new_evaluations = self._evaluate_tick_daemon()
-            else:
+    def evaluate_tick(self, advance_time_to_next_tick: bool = True) -> "AssetDaemonScenarioState":
+        if self.is_daemon:
+            (
+                new_run_requests,
+                new_cursor,
+                new_evaluations,
+                new_current_time,
+            ) = self._evaluate_tick_daemon(advance_time_to_next_tick=advance_time_to_next_tick)
+        else:
+            with pendulum.test(self.current_time):
                 new_run_requests, new_cursor, new_evaluations = self._evaluate_tick_fast()
+                new_current_time = self.current_time
 
         return self._replace(
             run_requests=new_run_requests,
             serialized_cursor=new_cursor.serialize(),
             evaluations=new_evaluations,
+            current_time=new_current_time,
+            previous_tick_time=new_current_time,
         )
 
     def _log_assertion_error(self, expected: Sequence[Any], actual: Sequence[Any]) -> None:
@@ -417,14 +537,34 @@ class AssetDaemonScenarioState(NamedTuple):
         message = f"\nExpected: \n\n{expected_str}\n\nActual: \n\n{actual_str}\n"
         self.logger.error(message)
 
+    def get_sensor_origin(self):
+        if not self.sensor_name:
+            return None
+        code_location_origin = get_code_location_origin(self)
+        return ExternalInstigatorOrigin(
+            external_repository_origin=ExternalRepositoryOrigin(
+                code_location_origin=code_location_origin,
+                repository_name=SINGLETON_REPOSITORY_NAME,
+            ),
+            instigator_name=self.sensor_name,
+        )
+
     def _assert_requested_runs_daemon(self, expected_run_requests: Sequence[RunRequest]) -> None:
         """Additional assertions for daemon mode. Checks that the most recent tick matches the
         expected requested asset partitions.
         """
+        sensor_origin = self.get_sensor_origin()
+        if sensor_origin:
+            origin_id = sensor_origin.get_id()
+            selector_id = sensor_origin.get_selector().get_id()
+        else:
+            origin_id = _PRE_SENSOR_AUTO_MATERIALIZE_ORIGIN_ID
+            selector_id = _PRE_SENSOR_AUTO_MATERIALIZE_SELECTOR_ID
+
         latest_tick = sorted(
             self.instance.get_ticks(
-                origin_id=_PRE_SENSOR_AUTO_MATERIALIZE_ORIGIN_ID,
-                selector_id=_PRE_SENSOR_AUTO_MATERIALIZE_SELECTOR_ID,
+                origin_id=origin_id,
+                selector_id=selector_id,
             ),
             key=lambda tick: tick.tick_id,
         )[-1]
@@ -480,7 +620,10 @@ class AssetDaemonScenarioState(NamedTuple):
         """Additional assertions for daemon mode. Checks that the evaluation for the given asset
         contains the expected run ids.
         """
-        current_evaluation_id = check.not_none(get_current_evaluation_id(self.instance, None))
+        sensor_origin = self.get_sensor_origin()
+        current_evaluation_id = check.not_none(
+            get_current_evaluation_id(self.instance, sensor_origin)
+        )
         new_run_ids_for_asset = {
             run.run_id
             for run in self.instance.get_runs(
@@ -578,8 +721,12 @@ class AssetDaemonScenario(NamedTuple):
             self.initial_state._replace(scenario_instance=DagsterInstance.ephemeral())
         )
 
-    def evaluate_daemon(self, instance: DagsterInstance) -> "AssetDaemonScenarioState":
+    def evaluate_daemon(
+        self, instance: DagsterInstance, sensor_name: Optional[str] = None
+    ) -> "AssetDaemonScenarioState":
         self.initial_state.logger.setLevel(logging.DEBUG)
         return self.execution_fn(
-            self.initial_state._replace(scenario_instance=instance, is_daemon=True)
+            self.initial_state._replace(
+                scenario_instance=instance, is_daemon=True, sensor_name=sensor_name
+            )
         )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -4,7 +4,13 @@ from typing import Any, Generator, Mapping, Optional, Sequence
 
 import pendulum
 import pytest
-from dagster import DagsterInstance, instance_for_test
+from dagster import AssetSpec, DagsterInstance, instance_for_test
+from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
+from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.automation_policy_sensor_definition import (
+    AutomationPolicySensorDefinition,
+)
+from dagster._core.definitions.sensor_definition import DefaultSensorStatus
 from dagster._core.scheduler.instigation import (
     InstigatorTick,
     InstigatorType,
@@ -12,6 +18,7 @@ from dagster._core.scheduler.instigation import (
     TickStatus,
 )
 from dagster._daemon.asset_daemon import (
+    _PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY,
     _PRE_SENSOR_AUTO_MATERIALIZE_INSTIGATOR_NAME,
     _PRE_SENSOR_AUTO_MATERIALIZE_ORIGIN_ID,
     _PRE_SENSOR_AUTO_MATERIALIZE_SELECTOR_ID,
@@ -22,11 +29,14 @@ from dagster_tests.definitions_tests.auto_materialize_tests.asset_daemon_scenari
     AssetDaemonScenario,
 )
 
+from .asset_daemon_scenario import AssetDaemonScenarioState
+from .base_scenario import run_request
 from .updated_scenarios.asset_daemon_scenario_states import (
     two_assets_in_sequence,
     two_partitions_def,
 )
 from .updated_scenarios.basic_scenarios import basic_scenarios
+from .updated_scenarios.cron_scenarios import cron_scenarios
 from .updated_scenarios.partition_scenarios import partition_scenarios
 
 
@@ -52,12 +62,46 @@ def get_daemon_instance(
 daemon_scenarios = [*basic_scenarios, *partition_scenarios]
 
 
+automation_policy_sensor_scenarios = [
+    *cron_scenarios,
+    AssetDaemonScenario(
+        id="sensor_interval_respected",
+        initial_state=two_assets_in_sequence.with_all_eager(),
+        execution_fn=lambda state: state.with_runs(run_request(["A", "B"]))
+        .evaluate_tick(advance_time_to_next_tick=False)
+        .assert_requested_runs()  # No runs initially
+        .with_runs(run_request(["A"]))
+        .evaluate_tick(advance_time_to_next_tick=False)
+        .assert_requested_runs()  # Still no runs because no time has passed
+        .with_current_time_advanced(seconds=10)  # 5 seconds later, no new tick
+        .evaluate_tick(advance_time_to_next_tick=False)
+        .assert_requested_runs()
+        .with_current_time_advanced(seconds=20)  # Once 30 seconds have passed, runs are created
+        .evaluate_tick(advance_time_to_next_tick=False)
+        .assert_requested_runs(run_request(["B"])),
+    ),
+    *basic_scenarios,
+]
+
+
 @pytest.mark.parametrize(
     "scenario", daemon_scenarios, ids=[scenario.id for scenario in daemon_scenarios]
 )
-def test_asset_daemon(scenario: AssetDaemonScenario) -> None:
+def test_asset_daemon_without_sensor(scenario: AssetDaemonScenario) -> None:
     with get_daemon_instance() as instance:
         scenario.evaluate_daemon(instance)
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    automation_policy_sensor_scenarios,
+    ids=[scenario.id for scenario in automation_policy_sensor_scenarios],
+)
+def test_asset_daemon_with_sensor(scenario: AssetDaemonScenario) -> None:
+    with get_daemon_instance(
+        extra_overrides={"auto_materialize": {"use_automation_policy_sensors": True}}
+    ) as instance:
+        scenario.evaluate_daemon(instance, sensor_name="default_automation_policy_sensor")
 
 
 def _get_asset_daemon_ticks(instance: DagsterInstance) -> Sequence[InstigatorTick]:
@@ -128,6 +172,174 @@ def test_daemon_paused() -> None:
         assert ticks[-1].timestamp == state.current_time.timestamp()
         assert ticks[-1].tick_data.end_timestamp == state.current_time.timestamp()
         assert ticks[-1].tick_data.auto_materialize_evaluation_id == 2
+
+
+three_assets = AssetDaemonScenarioState(
+    asset_specs=[AssetSpec("A"), AssetSpec("B"), AssetSpec("C")]
+)
+
+daemon_sensor_scenario = AssetDaemonScenario(
+    id="simple_daemon_scenario",
+    initial_state=three_assets.with_automation_policy_sensors(
+        [
+            AutomationPolicySensorDefinition(
+                name="automation_policy_sensor_a",
+                asset_selection=AssetSelection.keys("A"),
+                default_status=DefaultSensorStatus.RUNNING,
+            ),
+            AutomationPolicySensorDefinition(
+                name="automation_policy_sensor_b",
+                asset_selection=AssetSelection.keys("B"),
+                default_status=DefaultSensorStatus.STOPPED,
+                minimum_interval_seconds=15,
+            ),
+            # default sensor picks up "C"
+        ]
+    ).with_all_eager(3),
+    execution_fn=lambda state: state.evaluate_tick(advance_time_to_next_tick=False),
+)
+
+
+def _assert_sensor_ran(instance, sensor_name: str, expected_num_ticks: int):
+    sensor_states = [
+        sensor_state
+        for sensor_state in instance.schedule_storage.all_instigator_state(
+            instigator_type=InstigatorType.SENSOR
+        )
+        if sensor_state.origin.instigator_name == sensor_name
+    ]
+    assert len(sensor_states) == 1
+    sensor_state = sensor_states[0]
+
+    ticks = instance.get_ticks(
+        sensor_state.instigator_origin_id,
+        sensor_state.selector_id,
+    )
+
+    assert len(ticks) == expected_num_ticks
+
+
+def test_automation_policy_sensor_ticks():
+    with get_daemon_instance(
+        paused=True, extra_overrides={"auto_materialize": {"use_automation_policy_sensors": True}}
+    ) as instance:
+        pre_sensor_evaluation_id = 12345
+
+        instance.daemon_cursor_storage.set_cursor_values(
+            {
+                _PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY: AssetDaemonCursor.empty()
+                ._replace(evaluation_id=pre_sensor_evaluation_id)
+                .serialize()
+            }
+        )
+
+        # Global pause setting ignored by sensors, but per-sensor status is not ignored
+        result = daemon_sensor_scenario.evaluate_daemon(instance)
+
+        sensor_states = instance.schedule_storage.all_instigator_state(
+            instigator_type=InstigatorType.SENSOR
+        )
+
+        assert len(sensor_states) == 1
+        # Only sensor that was set with default status RUNNING ran
+        _assert_sensor_ran(instance, "automation_policy_sensor_a", expected_num_ticks=1)
+
+        # Starting a sensor causes it to make ticks too
+        result = result.start_sensor("automation_policy_sensor_b")
+        result = result.with_current_time_advanced(seconds=15)
+        result = result.evaluate_tick(advance_time_to_next_tick=False)
+        sensor_states = instance.schedule_storage.all_instigator_state(
+            instigator_type=InstigatorType.SENSOR
+        )
+
+        # No new tick yet for A since only 15 seconds have passed
+        _assert_sensor_ran(instance, "automation_policy_sensor_a", expected_num_ticks=1)
+        _assert_sensor_ran(instance, "automation_policy_sensor_b", expected_num_ticks=1)
+
+        result = result.with_current_time_advanced(seconds=15)
+        result = result.evaluate_tick(advance_time_to_next_tick=False)
+
+        _assert_sensor_ran(instance, "automation_policy_sensor_a", expected_num_ticks=2)
+        _assert_sensor_ran(instance, "automation_policy_sensor_b", expected_num_ticks=2)
+
+        # Starting a default sensor causes it to make ticks too
+        result = result.start_sensor("default_automation_policy_sensor")
+        result = result.with_current_time_advanced(seconds=15)
+        result = result.evaluate_tick(advance_time_to_next_tick=False)
+
+        sensor_states = instance.schedule_storage.all_instigator_state(
+            instigator_type=InstigatorType.SENSOR
+        )
+
+        assert len(sensor_states) == 3
+        _assert_sensor_ran(instance, "automation_policy_sensor_a", expected_num_ticks=2)
+        _assert_sensor_ran(instance, "automation_policy_sensor_b", expected_num_ticks=3)
+        _assert_sensor_ran(instance, "default_automation_policy_sensor", expected_num_ticks=1)
+
+        result = result.with_current_time_advanced(seconds=15)
+        result = result.evaluate_tick(advance_time_to_next_tick=False)
+
+        _assert_sensor_ran(instance, "automation_policy_sensor_a", expected_num_ticks=3)
+        _assert_sensor_ran(instance, "automation_policy_sensor_b", expected_num_ticks=4)
+        _assert_sensor_ran(instance, "default_automation_policy_sensor", expected_num_ticks=1)
+
+        result = result.with_current_time_advanced(seconds=15)
+        result = result.evaluate_tick(advance_time_to_next_tick=False)
+
+        _assert_sensor_ran(instance, "automation_policy_sensor_a", expected_num_ticks=3)
+        _assert_sensor_ran(instance, "automation_policy_sensor_b", expected_num_ticks=5)
+        _assert_sensor_ran(instance, "default_automation_policy_sensor", expected_num_ticks=2)
+
+        # Stop each sensor, ticks stop too
+        result = result.stop_sensor("automation_policy_sensor_b")
+        result = result.with_current_time_advanced(seconds=30)
+        result = result.evaluate_tick(advance_time_to_next_tick=False)
+
+        _assert_sensor_ran(instance, "automation_policy_sensor_a", expected_num_ticks=4)
+        _assert_sensor_ran(instance, "automation_policy_sensor_b", expected_num_ticks=5)
+        _assert_sensor_ran(instance, "default_automation_policy_sensor", expected_num_ticks=3)
+
+        result = result.stop_sensor("automation_policy_sensor_a")
+        result = result.with_current_time_advanced(seconds=30)
+        result = result.evaluate_tick(advance_time_to_next_tick=False)
+
+        _assert_sensor_ran(instance, "automation_policy_sensor_a", expected_num_ticks=4)
+        _assert_sensor_ran(instance, "automation_policy_sensor_b", expected_num_ticks=5)
+        _assert_sensor_ran(instance, "default_automation_policy_sensor", expected_num_ticks=4)
+
+        result = result.stop_sensor("default_automation_policy_sensor")
+        result = result.with_current_time_advanced(seconds=30)
+        result = result.evaluate_tick(advance_time_to_next_tick=False)
+
+        _assert_sensor_ran(instance, "automation_policy_sensor_a", expected_num_ticks=4)
+        _assert_sensor_ran(instance, "automation_policy_sensor_b", expected_num_ticks=5)
+        _assert_sensor_ran(instance, "default_automation_policy_sensor", expected_num_ticks=4)
+
+        seen_evaluation_ids = set()
+
+        # Assert every tick has a unique evaluation ID, all are distinct, all are greater
+        # than the pre-sensor evaluation ID and they are increasing for each sensor
+        sensor_states = [
+            sensor_state
+            for sensor_state in instance.schedule_storage.all_instigator_state(
+                instigator_type=InstigatorType.SENSOR
+            )
+        ]
+
+        for sensor_state in sensor_states:
+            ticks = instance.get_ticks(
+                sensor_state.instigator_origin_id,
+                sensor_state.selector_id,
+            )
+
+            prev_evaluation_id = None
+            for tick in ticks:
+                evaluation_id = tick.tick_data.auto_materialize_evaluation_id
+                assert evaluation_id > pre_sensor_evaluation_id
+                assert evaluation_id not in seen_evaluation_ids
+                seen_evaluation_ids.add(evaluation_id)
+                assert prev_evaluation_id is None or prev_evaluation_id > evaluation_id
+                prev_evaluation_id = evaluation_id
 
 
 def test_default_purge() -> None:


### PR DESCRIPTION
Summary:
Split this out from the main PR that modified the daemon behavior (https://github.com/dagster-io/dagster/pull/18765) because it involved changes to the asset daemon scenarios which has a different owner/ subject matter experts. Tests that a subset of the existing asset scenarios are correctly handled when they are run through the sensor path of the daemon (including tests that depend on cursor state being correctly included between ticks). Also used the helpful scenario state abstraction to power some other

## Summary & Motivation

## How I Tested These Changes
