### PR TITLE
[tests] fix container leaks

### DIFF
--- a/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
@@ -89,11 +89,9 @@ def docker_compose_down(docker_compose_yml, context, service, env_file):
         compose_command += ["--env-file", env_file]
 
     if service:
-        compose_command += ["--file", str(docker_compose_yml), "rm", "--volumes"]
-
-        compose_command.append(service)
-
+        compose_command += ["--file", str(docker_compose_yml), "down", "--volumes", service]
         subprocess.check_call(compose_command)
+
     else:
         compose_command += [
             "--file",
@@ -102,7 +100,6 @@ def docker_compose_down(docker_compose_yml, context, service, env_file):
             "--volumes",
             "--remove-orphans",
         ]
-
         subprocess.check_call(compose_command)
 
 

--- a/python_modules/dagster/dagster/_utils/test/postgres_instance.py
+++ b/python_modules/dagster/dagster/_utils/test/postgres_instance.py
@@ -157,15 +157,10 @@ class TestPostgresInstance:
             )  # buildkite docker is handled in pipeline setup
             return
 
-        try:
-            subprocess.check_output(
-                ["docker-compose", "-f", docker_compose_file, "stop", service_name]
-            )
-            subprocess.check_output(
-                ["docker-compose", "-f", docker_compose_file, "rm", "-f", service_name]
-            )
-        except subprocess.CalledProcessError:
-            pass
+        subprocess.run(
+            ["docker-compose", "-f", docker_compose_file, "down", service_name],
+            check=False,
+        )
 
         try:
             subprocess.check_output(
@@ -181,17 +176,13 @@ class TestPostgresInstance:
 
         conn_str = TestPostgresInstance.conn_string(**conn_args)
         wait_for_connection(conn_str, retry_limit=10, retry_wait=3)
-        yield conn_str
-
         try:
-            subprocess.check_output(
-                ["docker-compose", "-f", docker_compose_file, "stop", service_name]
+            yield conn_str
+        finally:
+            subprocess.run(
+                ["docker-compose", "-f", docker_compose_file, "down", service_name],
+                check=False,
             )
-            subprocess.check_output(
-                ["docker-compose", "-f", docker_compose_file, "rm", "-f", service_name]
-            )
-        except subprocess.CalledProcessError:
-            pass
 
     @staticmethod
     @contextmanager


### PR DESCRIPTION
These docker compose test fixutres utilities were not spinning down things correctly
* on exception for postgres
* at all for specific services within a compose

## How I Tested These Changes

using an internal test that excercises both of these, ensure that no container remain running after running successfuling or with exception
