### PR TITLE
Populate asset selection field on ranged backfill

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -419,4 +419,5 @@ class PartitionBackfill(
             backfill_timestamp=backfill_timestamp,
             serialized_asset_backfill_data=None,
             asset_backfill_data=asset_backfill_data,
+            asset_selection=[selector.asset_key for selector in partitions_by_assets],
         )

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -1155,6 +1155,7 @@ def test_asset_backfill_with_single_run_backfill_policy(
     backfill = instance.get_backfill(backfill_id)
     assert backfill
     assert backfill.status == BulkActionStatus.REQUESTED
+    assert backfill.asset_selection == [asset_with_single_run_backfill_policy.key]
 
     assert all(
         not error


### PR DESCRIPTION
Previously, for ranged backfills requested via GraphQL, the backfill table would display an empty cell for "backfill target". 

This PR populates this value for ranged backfills, matching existing behavior for asset backfills launched in the UI:
<img width="1368" alt="image" src="https://github.com/dagster-io/dagster/assets/29110579/0a997d15-113f-4f86-accd-102d7b24fbbb">

Requested by a cloud customer.