### PR TITLE
[ui] Clean up focus ring behavior

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Button.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Button.tsx
@@ -261,6 +261,11 @@ export const JoinedButtons = styled.div`
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
+
+  ${StyledButton}:focus-visible {
+    z-index: 1;
+    position: relative;
+  }
 `;
 
 export const ExternalAnchorButton = React.forwardRef(

--- a/js_modules/dagster-ui/packages/ui-components/src/components/ButtonLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/ButtonLink.tsx
@@ -36,13 +36,6 @@ const fontColor = (color: Color) => {
   `;
 };
 
-const outlineColor = (color: Color) => {
-  if (typeof color === 'string') {
-    return color;
-  }
-  return color.link;
-};
-
 const textDecoration = (underline: Underline) => {
   switch (underline) {
     case 'always':
@@ -74,19 +67,13 @@ export const ButtonLink = styled(({color, underline, ...rest}) => <button {...re
   margin: -8px;
   text-align: left;
 
-  &:active,
-  &:focus {
-    outline: none;
-  }
-
-  &:focus-visible {
-    outline: 1px auto ${({color}) => outlineColor(color)};
-    outline-offset: 2px;
-  }
-
   &:disabled {
     cursor: default;
     opacity: 0.7;
+  }
+
+  &:focus:not(:focus-visible) {
+    outline: none;
   }
 
   transition: 30ms color linear;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Menu.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Menu.tsx
@@ -20,7 +20,6 @@ import {
   colorPopoverBackground,
   colorPopoverBackgroundHover,
   colorBackgroundBlue,
-  colorFocusRing,
 } from '../theme/color';
 
 import {IconName, Icon, IconWrapper} from './Icon';
@@ -188,9 +187,7 @@ const StyledMenuItem = styled(BlueprintMenuItem)<StyledMenuItemProps>`
     color: ${({$textColor}) => $textColor};
   }
 
-  &:focus {
-    color: ${({$textColor}) => $textColor};
-    box-shadow: ${colorFocusRing()} 0 0 0 2px;
-    outline: none;
+  &:focus-visible {
+    z-index: 1;
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/StyledButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/StyledButton.tsx
@@ -49,7 +49,9 @@ export const StyledButton = styled.button<StyledButtonProps>`
     text-decoration: none;
   }
 
-  :focus {
+  :focus,
+  :focus-visible,
+  :focus:hover:not(:disabled) {
     box-shadow: ${colorFocusRing()} 0 0 0 2px;
     outline: none;
   }

--- a/js_modules/dagster-ui/packages/ui-components/src/components/UnstyledButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/UnstyledButton.tsx
@@ -1,10 +1,9 @@
 import styled, {css} from 'styled-components';
 
-import {colorTextDefault, colorFocusRing} from '../theme/color';
+import {colorTextDefault} from '../theme/color';
 
 interface Props {
   $expandedClickPx?: number;
-  $showFocusOutline?: boolean;
 }
 
 export const UnstyledButton = styled.button<Props>`
@@ -28,16 +27,6 @@ export const UnstyledButton = styled.button<Props>`
           margin: -${$expandedClickPx}px;
         `
       : null}
-
-  :focus,
-  :active {
-    outline: none;
-    ${({$showFocusOutline}) =>
-      $showFocusOutline
-        ? `box-shadow: ${colorFocusRing()} 0 0 0 2px;
-      `
-        : null}
-  }
 
   &:disabled {
     color: inherit;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/UnstyledButton.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/UnstyledButton.stories.tsx
@@ -44,11 +44,3 @@ export const UnstyledWithLargerClickArea = () => {
     </Box>
   );
 };
-
-export const UnstyledWithFocusOutline = () => {
-  return (
-    <UnstyledButton $showFocusOutline $expandedClickPx={4}>
-      Click me to see focus
-    </UnstyledButton>
-  );
-};

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -22,6 +22,7 @@ import {
   colorBackgroundDefault,
   colorTextDefault,
   browserColorScheme,
+  colorFocusRing,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
 import {BrowserRouter} from 'react-router-dom';
@@ -101,6 +102,19 @@ const GlobalStyle = createGlobalStyle`
   code, pre {
     font-family: ${FontFamily.monospace};
     font-size: 16px;
+  }
+
+  :focus-visible {
+    outline: ${colorFocusRing()} auto 1px;
+  }
+
+  :focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  :not(a):focus,
+  :not(a):focus-visible {
+    outline-offset: 1px;
   }
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -227,9 +227,9 @@ const Header = ({assetNode, repoAddress}: HeaderProps) => {
 };
 const AssetCatalogLink = styled(Link)`
   display: flex;
-  gap: 5px;
-  padding: 6px;
-  margin: -6px;
+  gap: 4px;
+  padding: 2px;
+  margin: -2px;
   align-items: center;
   white-space: nowrap;
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
@@ -75,16 +75,11 @@ export const AssetSidebarNode = ({
 
   return (
     <>
-      <Box ref={elementRef} onClick={selectThisNode} padding={{left: 8}}>
+      <Box ref={elementRef} padding={{left: 8}}>
         <BoxWrapper level={level}>
-          <Box
-            padding={{right: 12}}
-            flex={{direction: 'row', alignItems: 'center'}}
-            style={{height: '32px'}}
-          >
+          <ItemContainer padding={{right: 12}} flex={{direction: 'row', alignItems: 'center'}}>
             {showArrow ? (
               <UnstyledButton
-                $showFocusOutline
                 onClick={(e) => {
                   e.stopPropagation();
                   toggleOpen();
@@ -111,13 +106,13 @@ export const AssetSidebarNode = ({
               <div style={{width: 18}} />
             )}
             <GrayOnHoverBox
+              onClick={selectThisNode}
               onDoubleClick={toggleOpen}
               style={{
                 width: '100%',
                 borderRadius: '8px',
                 ...(isSelected ? {background: colorBackgroundBlue()} : {}),
               }}
-              $showFocusOutline={true}
               ref={ref}
             >
               <div
@@ -133,7 +128,9 @@ export const AssetSidebarNode = ({
                 {isLocationNode ? <Icon name="folder_open" /> : null}
                 <MiddleTruncate text={displayName} />
               </div>
-              {isAssetNode ? (
+            </GrayOnHoverBox>
+            {isAssetNode ? (
+              <ExpandMore>
                 <AssetNodePopoverMenu
                   graphData={fullAssetGraphData}
                   node={node}
@@ -141,9 +138,9 @@ export const AssetSidebarNode = ({
                   explorerPath={explorerPath}
                   onChangeExplorerPath={onChangeExplorerPath}
                 />
-              ) : null}
-            </GrayOnHoverBox>
-          </Box>
+              </ExpandMore>
+            ) : null}
+          </ItemContainer>
         </BoxWrapper>
       </Box>
     </>
@@ -153,32 +150,20 @@ export const AssetSidebarNode = ({
 const AssetNodePopoverMenu = (props: Parameters<typeof useAssetNodeMenu>[0]) => {
   const {menu, dialog} = useAssetNodeMenu(props);
   return (
-    <div
-      onClick={(e) => {
-        // stop propagation outside of the popover to prevent parent onClick from being selected
-        e.stopPropagation();
-      }}
-      onKeyDown={(e) => {
-        if (e.code === 'Space') {
-          // Prevent the default scrolling behavior
-          e.preventDefault();
-        }
-      }}
-    >
+    <>
       {dialog}
       <Popover
         content={menu}
-        hoverOpenDelay={100}
-        hoverCloseDelay={100}
         placement="right"
         shouldReturnFocusOnClose
         canEscapeKeyClose
+        modifiers={{offset: {enabled: true, options: {offset: [0, 12]}}}}
       >
-        <ExpandMore tabIndex={0} role="button">
+        <UnstyledButton>
           <Icon name="more_horiz" color={colorAccentGray()} />
-        </ExpandMore>
+        </UnstyledButton>
       </Popover>
-    </div>
+    </>
   );
 };
 
@@ -205,7 +190,12 @@ const BoxWrapper = ({level, children}: {level: number; children: React.ReactNode
   return <>{wrapper}</>;
 };
 
-const ExpandMore = styled.div``;
+const ExpandMore = styled.div`
+  position: absolute;
+  top: 8px;
+  right: 20px;
+  visibility: hidden;
+`;
 
 const GrayOnHoverBox = styled(UnstyledButton)`
   border-radius: 8px;
@@ -220,17 +210,22 @@ const GrayOnHoverBox = styled(UnstyledButton)`
   gap: 6;
   flex-grow: 1;
   flex-shrink: 1;
+  transition: background 100ms linear;
+`;
+
+const ItemContainer = styled(Box)`
+  height: 32px;
+  position: relative;
+
   &:hover,
   &:focus-within {
-    background: ${colorBackgroundLightHover()};
-    transition: background 100ms linear;
-    box-shadow: none;
+    ${GrayOnHoverBox} {
+      background: ${colorBackgroundLightHover()};
+    }
+
     ${ExpandMore} {
       visibility: visible;
     }
-  }
-  ${ExpandMore} {
-    visibility: hidden;
   }
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -275,6 +275,7 @@ const SearchTrigger = styled.button`
 
   :focus {
     border-color: ${colorNavText()};
+  }
 `;
 
 const Container = styled.div`

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/MenuLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/MenuLink.tsx
@@ -7,7 +7,6 @@ import {
   MenuItem,
   colorTextDefault,
   colorBackgroundLighter,
-  colorFocusRing,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link, LinkProps} from 'react-router-dom';
@@ -72,10 +71,5 @@ const StyledMenuLink = styled(Link)`
 
   &&&:hover {
     background: ${colorBackgroundLighter()};
-  }
-
-  &:focus {
-    box-shadow: ${colorFocusRing()} 0 0 0 2px;
-    outline: none;
   }
 `;


### PR DESCRIPTION
## Summary & Motivation

Clean up some of our focus ring rendering.

- Use the focus ring palette color globally on `:focus-visible`, instead of one-offing it in a bunch of places. This should improve consistency across all of our focusable elements.
- Remove the custom focus behavior on `ButtonLink` and `UnstyledButton`, they should just do what other controls do.
- Modify AssetSidebarNode so that it doesn't have nested interactive controls -- I noticed this while testing focus here, so I went ahead and made the change.

Before:

<img width="430" alt="Screenshot 2024-01-04 at 1 59 42 PM" src="https://github.com/dagster-io/dagster/assets/2823852/d56b6b39-adbb-4bec-adcb-c0c8facb2fa1">

After:

<img width="437" alt="Screenshot 2024-01-04 at 1 59 11 PM" src="https://github.com/dagster-io/dagster/assets/2823852/d19a8b75-d9e8-469b-ac6f-20873dc7604c">
<img width="147" alt="Screenshot 2024-01-04 at 1 59 07 PM" src="https://github.com/dagster-io/dagster/assets/2823852/f794a5c0-9092-4afb-909b-be5c7455b395">


## How I Tested These Changes

Tab through the app. Focus isn't perfect everywhere, but its hould at least look more consistent.

View global asset graph, verify that the left nav items work the same.
