### PR TITLE
[docs] Fix missing images on PyPI page

### DIFF
--- a/python_modules/dagster/README.md
+++ b/python_modules/dagster/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <!-- Note: Do not try adding the dark mode version here with the `picture` element, it will break formatting in PyPI -->
   <a target="_blank" href="https://dagster.io" style="background:none">
-    <img alt="dagster logo" src=".github/dagster-readme-header.svg" width="auto" height="100%">
+    <img alt="dagster logo" src="https://raw.githubusercontent.com/dagster-io/dagster/master/.github/dagster-readme-header.svg" width="auto" height="100%">
   </a>
   <a target="_blank" href="https://github.com/dagster-io/dagster" style="background:none">
     <img src="https://img.shields.io/github/stars/dagster-io/dagster?labelColor=4F43DD&color=163B36&logo=github">
@@ -92,7 +92,7 @@ You can find the full Dagster documentation [here](https://docs.dagster.io), inc
 ## Key Features:
 
   <p align="center">
-    <img width="100%" alt="image" src=".github/key-features-cards.svg">
+    <img width="100%" alt="image" src="https://raw.githubusercontent.com/dagster-io/dagster/master/.github/key-features-cards.svg">
   </p>
 
 ### Dagster as a productivity platform
@@ -116,7 +116,7 @@ Dagster provides a growing library of integrations for today’s most popular da
 <br/>
 <p align="center">
     <a target="_blank" href="https://dagster.io/integrations" style="background:none">
-        <img width="100%" alt="image" src=".github/integrations-bar-for-readme.png">
+        <img width="100%" alt="image" src="https://raw.githubusercontent.com/dagster-io/dagster/master/.github/integrations-bar-for-readme.png">
     </a>
 </p>
 


### PR DESCRIPTION
## Summary & Motivation

Currently there are several images missing on our PyPI page:

![image](https://github.com/dagster-io/dagster/assets/1531373/183a6af0-30a7-4b7e-a22f-aae8a7bf195d)

The PyPI page is derived from the Dagster README, which gets copied into the `long_description` field of the PyPI package. `img` elements in the README with relative URLs then can't be resolved.

This PR replaces the all relative URLs in `img` tags with full URLs to github master.

## How I Tested These Changes

Not sure how to directly test PyPI without releasing, but:

- You can see the README still renders on this branch.
- These people had the same problem/solution: https://github.com/reflex-dev/reflex/issues/1558