### PR TITLE
[cli] asset materialize non zero exit code on failure

### DIFF
--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -78,9 +78,11 @@ def execute_materialize_command(instance: DagsterInstance, kwargs: Mapping[str, 
     else:
         tags = {}
 
-    execute_job(
+    result = execute_job(
         job=reconstructable_job, asset_selection=list(asset_keys), instance=instance, tags=tags
     )
+    if not result.success:
+        raise click.ClickException("Materialization failed.")
 
 
 @asset_cli.command(name="list", help="List assets")

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/assets.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/assets.py
@@ -24,3 +24,8 @@ def partitioned_asset() -> None:
 @asset(partitions_def=StaticPartitionsDefinition(["apple", "banana", "pear"]))
 def differently_partitioned_asset() -> None:
     ...
+
+
+@asset
+def fail_asset() -> None:
+    raise Exception("failure")

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_asset_list_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_asset_list_command.py
@@ -30,6 +30,7 @@ def test_no_selection():
                 "asset1",
                 "differently_partitioned_asset",
                 "downstream_asset",
+                "fail_asset",
                 "partitioned_asset",
                 "some/key/prefix/asset_with_prefix",
             ]

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_materialize_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_materialize_command.py
@@ -38,6 +38,7 @@ def test_single_asset():
         result = invoke_materialize("asset1")
         assert "RUN_SUCCESS" in result.output
         assert instance.get_latest_materialization_event(AssetKey("asset1")) is not None
+        assert result.exit_code == 0
 
 
 def test_multi_segment_asset_key():
@@ -112,3 +113,8 @@ def test_conflicting_partitions():
             "All selected assets must share the same PartitionsDefinition or have no"
             " PartitionsDefinition" in str(result.exception)
         )
+
+
+def test_failure():
+    result = invoke_materialize("fail_asset")
+    assert result.exit_code == 1


### PR DESCRIPTION
follow the pattern we use for `job execute` 
https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/_cli/job.py#L348

resolves https://github.com/dagster-io/dagster/issues/19009

## How I Tested These Changes

need to add a test
