### PR TITLE
[ui] Clean up AppTopNav.test

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/AppTopNav.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/AppTopNav.test.tsx
@@ -1,12 +1,8 @@
-import {act, render, screen, within} from '@testing-library/react';
+import {MockedProvider} from '@apollo/client/testing';
+import {render, screen} from '@testing-library/react';
 import * as React from 'react';
+import {MemoryRouter} from 'react-router-dom';
 
-import {InstigationStatus} from '../../graphql/types';
-import {
-  DeploymentStatusProvider,
-  DeploymentStatusType,
-} from '../../instance/DeploymentStatusProvider';
-import {TestProvider} from '../../testing/TestProvider';
 import {AppTopNav} from '../AppTopNav';
 
 // We don't need to render the search input here.
@@ -15,185 +11,21 @@ jest.mock('../../search/SearchDialog', () => ({
 }));
 
 describe('AppTopNav', () => {
-  const defaultMocks = {
-    Repository: () => ({
-      name: () => 'my_repository',
-      pipelines: () => [...new Array(1)],
-    }),
-    RepositoryLocation: () => ({
-      environmentPath: () => 'what then',
-      id: () => 'my_location',
-      name: () => 'my_location',
-      repositories: () => [...new Array(1)],
-    }),
-    Workspace: () => ({
-      id: () => 'my_workspace',
-      locationEntries: () => [...new Array(1)],
-    }),
-    RepositoryOrigin: () => ({
-      repositoryName: () => 'my_repository',
-      repositoryLocationName: () => 'my_location',
-    }),
-    SolidDefinition: () => ({
-      configField: null,
-      description: null,
-      inputDefinitions: () => [...new Array(1)],
-      outputDefinitions: () => [...new Array(1)],
-      metadata: () => [],
-      name: 'foo_solid',
-      requiredResources: () => [],
-    }),
-    SolidInvocationSite: () => ({
-      solidHandle: () => ({
-        handleID: 'foo_handle',
-      }),
-    }),
-    DaemonHealth: () => ({
-      allDaemonStatuses: () => [],
-    }),
-    Instance: () => ({
-      autoMaterializePaused: () => false,
-    }),
-  };
-
-  const Test = ({
-    children,
-    statusPolling = new Set(['code-locations', 'daemons']),
-  }: {
-    statusPolling?: Set<DeploymentStatusType>;
-    children: React.ReactNode;
-  }) => {
-    return <DeploymentStatusProvider include={statusPolling}>{children}</DeploymentStatusProvider>;
-  };
-
-  it('renders top nav without error', async () => {
+  it('renders links and controls', async () => {
     render(
-      <TestProvider
-        apolloProps={{mocks: [defaultMocks]}}
-        routerProps={{initialEntries: ['/locations/my_repository@my_location']}}
-      >
-        <Test>
+      <MockedProvider>
+        <MemoryRouter>
           <AppTopNav searchPlaceholder="Test..." rightOfSearchBar={<div>RightOfSearchBar</div>} />
-        </Test>
-      </TestProvider>,
+        </MemoryRouter>
+      </MockedProvider>,
     );
 
-    const runsLink = await screen.findByRole('link', {name: /runs/i});
-    expect(runsLink.closest('a')).toHaveAttribute('href', '/runs');
+    await screen.findByRole('link', {name: /runs/i});
+
+    expect(screen.getByText('Overview').closest('a')).toHaveAttribute('href', '/overview');
+    expect(screen.getByText('Runs').closest('a')).toHaveAttribute('href', '/runs');
     expect(screen.getByText('Assets').closest('a')).toHaveAttribute('href', '/assets');
     expect(screen.getByText('Deployment').closest('a')).toHaveAttribute('href', '/locations');
     expect(screen.getByText('RightOfSearchBar')).toBeVisible();
-  });
-
-  describe('Repo location errors', () => {
-    it('does not show warning icon when no errors', async () => {
-      // Act immediately since we're asserting a post-query null state.
-      await act(async () => {
-        render(
-          <TestProvider apolloProps={{mocks: [defaultMocks]}}>
-            <Test>
-              <AppTopNav searchPlaceholder="Test..." />
-            </Test>
-          </TestProvider>,
-        );
-      });
-
-      expect(
-        screen.queryByRole('img', {
-          name: /warning/i,
-        }),
-      ).toBeNull();
-    });
-
-    it('shows the error message when repo location errors are found', async () => {
-      const mocks = {
-        RepositoryLocationOrLoadError: () => ({
-          __typename: 'PythonError',
-        }),
-      };
-
-      render(
-        <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
-          <Test>
-            <AppTopNav searchPlaceholder="Test..." />
-          </Test>
-        </TestProvider>,
-      );
-
-      expect(await screen.findByRole('img', {name: /warning/i})).toBeVisible();
-    });
-  });
-
-  describe('Daemon status errors', () => {
-    const mocksWithDaemonError = {
-      DaemonHealth: () => ({
-        allDaemonStatuses: () => [...new Array(1)],
-      }),
-      DaemonStatus: () => ({
-        id: 'SENSOR',
-        daemonType: 'SENSOR',
-        required: true,
-        healthy: false,
-      }),
-    };
-
-    const mocksWithSensor = {
-      Repository: () => ({
-        sensors: () => [...new Array(1)],
-      }),
-      InstigationState: () => ({
-        status: () => InstigationStatus.RUNNING,
-      }),
-    };
-
-    it('does not show status warning icon if there are sensor daemon errors but no sensors', async () => {
-      const mocksWithoutSensor = {
-        Repository: () => ({
-          sensors: () => [],
-        }),
-      };
-
-      render(
-        <TestProvider
-          apolloProps={{mocks: [defaultMocks, mocksWithDaemonError, mocksWithoutSensor]}}
-        >
-          <Test>
-            <AppTopNav searchPlaceholder="Test..." />
-          </Test>
-        </TestProvider>,
-      );
-
-      const link = await screen.findByRole('link', {name: /deployment/i});
-      expect(within(link).queryByText(/warning/i)).toBeNull();
-    });
-
-    it('shows deployment warning icon by default, if there are errors', async () => {
-      render(
-        <TestProvider apolloProps={{mocks: [defaultMocks, mocksWithDaemonError, mocksWithSensor]}}>
-          <Test>
-            <AppTopNav searchPlaceholder="Test..." />
-          </Test>
-        </TestProvider>,
-      );
-
-      const link = await screen.findByRole('link', {
-        name: /deployment warning/i,
-      });
-
-      expect(within(link).getByText(/deployment/i)).toBeVisible();
-    });
-
-    it('does not show deployment warning icon if `statusPolling` does not include `daemons`, even with errors', async () => {
-      render(
-        <TestProvider apolloProps={{mocks: [defaultMocks, mocksWithDaemonError, mocksWithSensor]}}>
-          <Test statusPolling={new Set(['code-locations'])}>
-            <AppTopNav searchPlaceholder="Test..." />
-          </Test>
-        </TestProvider>,
-      );
-
-      const link = await screen.findByRole('link', {name: /deployment/i});
-      expect(within(link).queryByText(/warning/i)).toBeNull();
-    });
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/DeploymentStatusProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/DeploymentStatusProvider.tsx
@@ -7,7 +7,7 @@ import {useDaemonStatus} from './useDaemonStatus';
 
 export type DeploymentStatusType = 'code-locations' | 'daemons';
 
-type DeploymentStatus = {
+export type DeploymentStatus = {
   codeLocations: StatusAndMessage | null;
   daemons: StatusAndMessage | null;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/DeploymentStatusIcon.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/DeploymentStatusIcon.tsx
@@ -46,5 +46,5 @@ const CombinedStatusIcon = React.memo(() => {
     );
   }
 
-  return null;
+  return <div style={{display: 'none'}}>No errors</div>;
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/DeploymentStatusIcon.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/DeploymentStatusIcon.test.tsx
@@ -1,0 +1,79 @@
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+
+import {DeploymentStatus, DeploymentStatusContext} from '../../instance/DeploymentStatusProvider';
+import {DeploymentStatusIcon} from '../DeploymentStatusIcon';
+
+describe('DeploymentStatusIcon', () => {
+  it('does not show warning icon when no loading state or warnings', async () => {
+    const value = {codeLocations: null, daemons: null};
+    render(
+      <DeploymentStatusContext.Provider value={value}>
+        <DeploymentStatusIcon />
+      </DeploymentStatusContext.Provider>,
+    );
+
+    expect(await screen.findByText(/no errors/i)).toBeInTheDocument();
+  });
+
+  it('shows the spinner when repo locations are loading', async () => {
+    const event = userEvent.setup();
+    const value: DeploymentStatus = {
+      codeLocations: {type: 'spinner', content: 'Wait patiently!'},
+      daemons: null,
+    };
+
+    render(
+      <DeploymentStatusContext.Provider value={value}>
+        <DeploymentStatusIcon />
+      </DeploymentStatusContext.Provider>,
+    );
+
+    const spinner = await screen.findByTitle(/loading/i);
+    expect(spinner).toBeVisible();
+
+    await event.hover(spinner);
+    expect(await screen.findByText(/wait patiently/i)).toBeVisible();
+  });
+
+  it('shows the error message when repo location warnings are found', async () => {
+    const event = userEvent.setup();
+    const value: DeploymentStatus = {
+      codeLocations: {type: 'warning', content: 'Oh no!'},
+      daemons: null,
+    };
+
+    render(
+      <DeploymentStatusContext.Provider value={value}>
+        <DeploymentStatusIcon />
+      </DeploymentStatusContext.Provider>,
+    );
+
+    const warningIcon = await screen.findByRole('img', {name: /warning/i});
+    expect(warningIcon).toBeVisible();
+
+    await event.hover(warningIcon);
+    expect(await screen.findByText(/oh no/i)).toBeVisible();
+  });
+
+  it('shows the error message when daemon warnings are found', async () => {
+    const event = userEvent.setup();
+    const value: DeploymentStatus = {
+      codeLocations: null,
+      daemons: {type: 'warning', content: 'Daemon problem!'},
+    };
+
+    render(
+      <DeploymentStatusContext.Provider value={value}>
+        <DeploymentStatusIcon />
+      </DeploymentStatusContext.Provider>,
+    );
+
+    const warningIcon = await screen.findByRole('img', {name: /warning/i});
+    expect(warningIcon).toBeVisible();
+
+    await event.hover(warningIcon);
+    expect(await screen.findByText(/daemon problem/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary & Motivation

Break apart AppTopNav.test, which is doing more work than necessary and is a remaining `TestProvider` callsite.

## How I Tested These Changes

yarn jest
