### PR TITLE
[prototype] AssetExecutionContext partition methods given as named tuple

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -12,7 +12,6 @@ from typing import (
     Iterator,
     List,
     Mapping,
-    NamedTuple,
     Optional,
     Sequence,
     Set,
@@ -1417,12 +1416,45 @@ def _get_deprecation_kwargs(attr: str):
     return deprecation_kwargs
 
 
-class PartitionInfo(NamedTuple):  # TODO - this is a bad name, figure out something else
-    key: Optional[str]
-    keys: Sequence[str]
-    key_range: PartitionKeyRange
-    time_window: Optional[TimeWindow]
-    definition: PartitionsDefinition
+class PartitionInfo:  # TODO - this is a bad name, figure out something else
+    def __init__(
+        self,
+        key: Optional[str],
+        keys: Sequence[str],
+        key_range: PartitionKeyRange,
+        time_window: Optional[TimeWindow],
+        definition: PartitionsDefinition,
+    ):
+        self._key = key
+        self._keys = keys
+        self._key_range = key_range
+        self._time_window = time_window
+        self._definition = definition
+
+    @property
+    def key(self) -> str:
+        if self._key is None:
+            raise DagsterInvariantViolationError(
+                "Cannot access partition key for a partitioned run with a range of partitions."
+                " Call key_range instead."
+            )
+        return self._key
+
+    @property
+    def keys(self) -> Sequence[str]:
+        return self._keys
+
+    @property
+    def key_range(self) -> PartitionKeyRange:
+        return self._key_range
+
+    @property
+    def time_window(self) -> TimeWindow:
+        if self._time_window is None:
+            raise ValueError(
+                "Tried to get partition time window for an asset that is not time-partitioned."
+            )
+        return self._time_window
 
 
 class AssetExecutionContext(OpExecutionContext):

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1380,6 +1380,17 @@ ALTERNATE_METHODS = {
     "run_config": "run.run_config",
     "run_tags": "run.tags",
     "get_op_execution_context": "op_execution_context",
+    "asset_partition_key_for_output": "partition_info.key",
+    "asset_partitions_time_window_for_output": "partition_info.time_window",
+    "asset_partition_key_range_for_output": "partition_info.key_range",
+    "asset_partition_key_range_for_input": "upstream_partition_info(asset_key).key_range",
+    "asset_partition_key_for_input": "upstream_partition_info(asset_key).key",
+    "asset_partitions_def_for_output": "partition_info.definition",
+    "asset_partitions_def_for_input": "upstream_partition_info(asset_key).definition",
+    "asset_partition_keys_for_output": "partition_info.keys",
+    "asset_partition_keys_for_input": "upstream_partition_info(asset_key).keys",
+    "asset_partitions_time_window_for_input": "upstream_partition_info(asset_key).time_window",
+    "has_partition_key": "is_partitioned_materialization",
 }
 
 ALTERNATE_EXPRESSIONS = {
@@ -1508,11 +1519,16 @@ class AssetExecutionContext(OpExecutionContext):
             "in order to call latest_materialization_for_upstream_asset."
         )
 
+    @public
+    @property
+    def is_partitioned_materialization(self) -> bool:
+        return self.op_execution_context.has_partition_key
+
     @cached_property
     def partition_info(self) -> PartitionInfo:
         """Returns a filled out PartitionInfo for the currently materializing asset."""
         partitions_def = self.assets_def.partitions_def
-        if self.op_execution_context.has_partition_key and partitions_def:
+        if self.is_partitioned_materialization and partitions_def:
             key_range = self.op_execution_context.partition_key_range
             return PartitionInfo(
                 key=self.op_execution_context.partition_key
@@ -1540,7 +1556,7 @@ class AssetExecutionContext(OpExecutionContext):
         partitions_def = self._step_execution_context.job_def.asset_layer.partitions_def_for_asset(
             asset_key
         )
-        if self.op_execution_context.has_partition_key and partitions_def:
+        if self.is_partitioned_materialization and partitions_def:
             key_range = self._step_execution_context.asset_partition_key_range_for_upstream(
                 asset_key
             )
@@ -1608,18 +1624,22 @@ class AssetExecutionContext(OpExecutionContext):
     @deprecated(**_get_deprecation_kwargs("get_op_execution_context"))
     def get_op_execution_context(self) -> "OpExecutionContext":
         return self.op_execution_context
+    
+    @deprecated(**_get_deprecation_kwargs("has_partition_key"))
     @public
     @property
     @_copy_docs_from_op_execution_context
     def has_partition_key(self) -> bool:
         return self.op_execution_context.has_partition_key
 
+    @deprecated(**_get_deprecation_kwargs("partition_key"))
     @public
     @property
     @_copy_docs_from_op_execution_context
     def partition_key(self) -> str:
         return self.op_execution_context.partition_key
 
+    @deprecated(**_get_deprecation_kwargs("partition_keys"))
     @public
     @property
     @_copy_docs_from_op_execution_context
@@ -1633,28 +1653,33 @@ class AssetExecutionContext(OpExecutionContext):
     def asset_partition_key_range(self) -> PartitionKeyRange:
         return self.op_execution_context.asset_partition_key_range
 
+    @deprecated(**_get_deprecation_kwargs("partition_key_range"))
     @public
     @property
     @_copy_docs_from_op_execution_context
     def partition_key_range(self) -> PartitionKeyRange:
         return self.op_execution_context.partition_key_range
 
+    @deprecated(**_get_deprecation_kwargs("partition_time_window"))
     @public
     @property
     @_copy_docs_from_op_execution_context
     def partition_time_window(self) -> TimeWindow:
         return self.op_execution_context.partition_time_window
 
+    @deprecated(**_get_deprecation_kwargs("asset_partition_key_for_output"))
     @public
     @_copy_docs_from_op_execution_context
     def asset_partition_key_for_output(self, output_name: str = "result") -> str:
         return self.op_execution_context.asset_partition_key_for_output(output_name=output_name)
 
+    @deprecated(**_get_deprecation_kwargs("asset_partitions_time_window_for_output"))
     @public
     @_copy_docs_from_op_execution_context
     def asset_partitions_time_window_for_output(self, output_name: str = "result") -> TimeWindow:
         return self.op_execution_context.asset_partitions_time_window_for_output(output_name)
 
+    @deprecated(**_get_deprecation_kwargs("asset_partition_key_range_for_output"))
     @public
     @_copy_docs_from_op_execution_context
     def asset_partition_key_range_for_output(
@@ -1662,36 +1687,43 @@ class AssetExecutionContext(OpExecutionContext):
     ) -> PartitionKeyRange:
         return self.op_execution_context.asset_partition_key_range_for_output(output_name)
 
+    @deprecated(**_get_deprecation_kwargs("asset_partition_key_range_for_input"))
     @public
     @_copy_docs_from_op_execution_context
     def asset_partition_key_range_for_input(self, input_name: str) -> PartitionKeyRange:
         return self.op_execution_context.asset_partition_key_range_for_input(input_name)
 
+    @deprecated(**_get_deprecation_kwargs("asset_partition_key_for_input"))
     @public
     @_copy_docs_from_op_execution_context
     def asset_partition_key_for_input(self, input_name: str) -> str:
         return self.op_execution_context.asset_partition_key_for_input(input_name)
 
+    @deprecated(**_get_deprecation_kwargs("asset_partitions_def_for_output"))
     @public
     @_copy_docs_from_op_execution_context
     def asset_partitions_def_for_output(self, output_name: str = "result") -> PartitionsDefinition:
         return self.op_execution_context.asset_partitions_def_for_output(output_name=output_name)
 
+    @deprecated(**_get_deprecation_kwargs("asset_partitions_def_for_input"))
     @public
     @_copy_docs_from_op_execution_context
     def asset_partitions_def_for_input(self, input_name: str) -> PartitionsDefinition:
         return self.op_execution_context.asset_partitions_def_for_input(input_name=input_name)
 
+    @deprecated(**_get_deprecation_kwargs("asset_partition_keys_for_output"))
     @public
     @_copy_docs_from_op_execution_context
     def asset_partition_keys_for_output(self, output_name: str = "result") -> Sequence[str]:
         return self.op_execution_context.asset_partition_keys_for_output(output_name=output_name)
 
+    @deprecated(**_get_deprecation_kwargs("asset_partition_keys_for_input"))
     @public
     @_copy_docs_from_op_execution_context
     def asset_partition_keys_for_input(self, input_name: str) -> Sequence[str]:
         return self.op_execution_context.asset_partition_keys_for_input(input_name=input_name)
 
+    @deprecated(**_get_deprecation_kwargs("asset_partitions_time_window_for_input"))
     @public
     @_copy_docs_from_op_execution_context
     def asset_partitions_time_window_for_input(self, input_name: str = "result") -> TimeWindow:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -601,7 +601,7 @@ def test_partition_mapping_with_asset_deps():
     )
     def downstream(context: AssetExecutionContext):
         upstream_key = datetime.strptime(
-            context.asset_partition_key_for_input("upstream"), "%Y-%m-%d"
+            context.upstream_partition_info("upstream").key, "%Y-%m-%d"
         )
 
         current_partition_key = datetime.strptime(context.partition_key, "%Y-%m-%d")
@@ -653,12 +653,8 @@ def test_partition_mapping_with_asset_deps():
 
     @multi_asset(specs=[asset_3, asset_4], partitions_def=partitions_def)
     def multi_asset_2(context: AssetExecutionContext):
-        asset_1_key = datetime.strptime(
-            context.asset_partition_key_for_input("asset_1"), "%Y-%m-%d"
-        )
-        asset_2_key = datetime.strptime(
-            context.asset_partition_key_for_input("asset_2"), "%Y-%m-%d"
-        )
+        asset_1_key = datetime.strptime(context.upstream_partition_info("asset_1").key, "%Y-%m-%d")
+        asset_2_key = datetime.strptime(context.upstream_partition_info("asset_2").key, "%Y-%m-%d")
 
         current_partition_key = datetime.strptime(context.partition_key, "%Y-%m-%d")
 
@@ -760,7 +756,7 @@ def test_self_dependent_partition_mapping_with_asset_deps():
     )
     def self_dependent(context: AssetExecutionContext):
         upstream_key = datetime.strptime(
-            context.asset_partition_key_for_input("self_dependent"), "%Y-%m-%d"
+            context.upstream_partition_info("self_dependent").key, "%Y-%m-%d"
         )
 
         current_partition_key = datetime.strptime(context.partition_key, "%Y-%m-%d")
@@ -786,9 +782,7 @@ def test_self_dependent_partition_mapping_with_asset_deps():
 
     @multi_asset(specs=[asset_1], partitions_def=partitions_def)
     def the_multi_asset(context: AssetExecutionContext):
-        asset_1_key = datetime.strptime(
-            context.asset_partition_key_for_input("asset_1"), "%Y-%m-%d"
-        )
+        asset_1_key = datetime.strptime(context.upstream_partition_info("asset_1").key, "%Y-%m-%d")
 
         current_partition_key = datetime.strptime(context.partition_key, "%Y-%m-%d")
 
@@ -810,7 +804,7 @@ def test_dynamic_partition_mapping_with_asset_deps():
         deps=[AssetDep(upstream, partition_mapping=SpecificPartitionsPartitionMapping(["apple"]))],
     )
     def downstream(context: AssetExecutionContext):
-        assert context.asset_partition_key_for_input("upstream") == "apple"
+        assert context.upstream_partition_info("upstream").key == "apple"
         assert context.partition_key == "orange"
 
     with instance_for_test() as instance:
@@ -840,7 +834,7 @@ def test_dynamic_partition_mapping_with_asset_deps():
 
     @multi_asset(specs=[asset_2], partitions_def=partitions_def)
     def asset_2_multi_asset(context: AssetExecutionContext):
-        assert context.asset_partition_key_for_input("asset_1") == "apple"
+        assert context.upstream_partition_info("asset_1").key == "apple"
         assert context.partition_key == "orange"
 
     with instance_for_test() as instance:


### PR DESCRIPTION
## Summary & Motivation
This PR is a prototype for a potential API for partition methods on the `AssetExecutionContext`. Rather than fetching individual properties about the partition from different methods, the user will fetch a `PartitionInfo` (name tbd) object from the context that will contain the relevant partition properties. 

Hooli PR - https://github.com/dagster-io/hooli-data-eng-pipelines/pull/58
DOP PR -  https://github.com/dagster-io/internal/pull/7902

issues with this API design:
`time_window` on the `PartitionInfo` named tuple needs to be an optional field so that static partitions can have it set to `None`. this causes some linting errors in the code base when you want to access the `start` or `end` properties of the time window since the retrieved `time_window` may be `None` 

## How I Tested These Changes
