### PR TITLE
Fix asset_selection checks that rely on it being truthy

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -650,7 +650,7 @@ class SensorDefinition(IHasInternalInit):
             default_status, "default_status", DefaultSensorStatus
         )
         self._asset_selection = (
-            AssetSelection.from_coercible(asset_selection) if asset_selection else None
+            AssetSelection.from_coercible(asset_selection) if asset_selection is not None else None
         )
         validate_resource_annotated_function(self._raw_fn)
         resource_arg_names: Set[str] = {arg.name for arg in get_resource_args(self._raw_fn)}
@@ -912,7 +912,7 @@ class SensorDefinition(IHasInternalInit):
                 "decorator."
             )
 
-        if asset_selection:
+        if asset_selection is not None:
             run_requests = [
                 *_run_requests_with_base_asset_jobs(run_requests, context, asset_selection)
             ]

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -562,7 +562,7 @@ class ExternalSensorData(
                 )
             }
 
-        if asset_selection:
+        if asset_selection is not None:
             check.opt_inst_param(asset_selection, "asset_selection", AssetSelection)
             check.invariant(
                 is_whitelisted_for_serdes_object(asset_selection),

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -219,7 +219,7 @@ class AssetReconciliationScenario(
             asset_graph = AssetGraph.from_assets(assets)
             auto_materialize_asset_keys = (
                 asset_selection.resolve(asset_graph)
-                if asset_selection
+                if asset_selection is not None
                 else asset_graph.materializable_asset_keys
             )
             assets_with_implicit_policies = with_implicit_auto_materialize_policies(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_automation_policy_sensor_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_automation_policy_sensor_definition.py
@@ -5,8 +5,10 @@ from dagster._core.definitions.automation_policy_sensor_definition import (
 )
 
 
-def test_constructor():
-    selection = AssetSelection.keys("asset1", "asset2")
+@pytest.mark.parametrize(
+    "selection", [AssetSelection.all(), AssetSelection.keys("asset1", "asset2")]
+)
+def test_constructor(selection):
     tags = {"apple": "banana", "orange": "kiwi"}
     automation_sensor = AutomationPolicySensorDefinition(
         "foo",


### PR DESCRIPTION
Summary:
Empty namedtuples are not truthy (!) so some of these checks can fail.

Test Plan: BK, new test case that failed before

## Summary & Motivation

## How I Tested These Changes
