### PR TITLE
Include run tags in automation policy sensor runs

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -236,6 +236,7 @@ class ExternalRepository:
                     metadata=None,
                     default_status=None,
                     sensor_type=SensorType.AUTOMATION_POLICY,
+                    run_tags=None,
                 )
                 sensor_datas[default_sensor_data.name] = ExternalSensor(
                     default_sensor_data, self._handle
@@ -863,6 +864,10 @@ class ExternalSensor:
         ):
             return self._external_sensor_data.min_interval
         return DEFAULT_SENSOR_DAEMON_INTERVAL
+
+    @property
+    def run_tags(self) -> Mapping[str, str]:
+        return self._external_sensor_data.run_tags
 
     def get_external_origin(self) -> ExternalInstigatorOrigin:
         return self._handle.get_external_origin()

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -56,6 +56,9 @@ from dagster._core.definitions.asset_spec import (
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.assets_job import is_base_asset_job_name
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from dagster._core.definitions.automation_policy_sensor_definition import (
+    AutomationPolicySensorDefinition,
+)
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.definition_config_schema import ConfiguredDefinitionConfigSchema
 from dagster._core.definitions.dependency import (
@@ -532,6 +535,7 @@ class ExternalSensorData(
             ("default_status", Optional[DefaultSensorStatus]),
             ("sensor_type", Optional[SensorType]),
             ("asset_selection", Optional[AssetSelection]),
+            ("run_tags", Mapping[str, str]),
         ],
     )
 ):
@@ -548,6 +552,7 @@ class ExternalSensorData(
         default_status: Optional[DefaultSensorStatus] = None,
         sensor_type: Optional[SensorType] = None,
         asset_selection: Optional[AssetSelection] = None,
+        run_tags: Optional[Mapping[str, str]] = None,
     ):
         if job_name and not target_dict:
             # handle the legacy case where the ExternalSensorData was constructed from an earlier
@@ -590,6 +595,7 @@ class ExternalSensorData(
             ),
             sensor_type=sensor_type,
             asset_selection=asset_selection,
+            run_tags=run_tags or {},
         )
 
 
@@ -2080,6 +2086,11 @@ def external_sensor_data_from_def(
         default_status=sensor_def.default_status,
         sensor_type=sensor_def.sensor_type,
         asset_selection=serializable_asset_selection,
+        run_tags=(
+            sensor_def.run_tags
+            if isinstance(sensor_def, AutomationPolicySensorDefinition)
+            else None
+        ),
     )
 
 

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -661,7 +661,7 @@ class AssetDaemon(DagsterDaemon):
                 else:
                     evaluations_by_asset_key = {}
             else:
-                sensor_tags = {SENSOR_NAME_TAG: sensor.name} if sensor else {}
+                sensor_tags = {SENSOR_NAME_TAG: sensor.name, **sensor.run_tags} if sensor else {}
 
                 run_requests, new_cursor, evaluations = AssetDaemonContext(
                     evaluation_id=evaluation_id,


### PR DESCRIPTION
Summary:
Include the tags in the external data, and then include them in any runs launched by the sensor.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
