### PR TITLE
Allow sensor intervals < 30 seconds to be shown in the UI

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
@@ -28,7 +28,6 @@ export const humanizeSensorInterval = (minIntervalSeconds?: number) => {
   if (!minIntervalSeconds) {
     minIntervalSeconds = 30; // should query sensor interval config when available
   }
-  minIntervalSeconds = Math.max(30, minIntervalSeconds);
   if (minIntervalSeconds < 60 || minIntervalSeconds % 60) {
     return `~${minIntervalSeconds} sec`;
   }


### PR DESCRIPTION
Summary:
This was written back when we enforced a minimum 30 second interval i think. That is no logner the case.

Test Plan:
Sensor with a 15 second interval is now displayed correctly

## Summary & Motivation

## How I Tested These Changes
