### PR TITLE
Added mime-types for UI files

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -40,6 +40,9 @@ from .external_assets import (
 from .graphql import GraphQLServer
 from .version import __version__
 
+import mimetypes
+mimetypes.init()
+
 T_IWorkspaceProcessContext = TypeVar("T_IWorkspaceProcessContext", bound=IWorkspaceProcessContext)
 
 
@@ -226,6 +229,9 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
             with open(index_path, encoding="utf8") as f:
                 rendered_template = f.read()
                 nonce = uuid.uuid4().hex
+                mimetypes.add_type('application/javascript', '.js')
+                mimetypes.add_type('text/css', '.css')
+                mimetypes.add_type('image/svg+xml', '.svg')
                 headers = {
                     **{"Content-Security-Policy": self.make_csp_header(nonce)},
                     **self.make_security_headers(),

--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -229,9 +229,6 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
             with open(index_path, encoding="utf8") as f:
                 rendered_template = f.read()
                 nonce = uuid.uuid4().hex
-                mimetypes.add_type('application/javascript', '.js')
-                mimetypes.add_type('text/css', '.css')
-                mimetypes.add_type('image/svg+xml', '.svg')
                 headers = {
                     **{"Content-Security-Policy": self.make_csp_header(nonce)},
                     **self.make_security_headers(),
@@ -268,7 +265,11 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
                 path,
                 lambda _: FileResponse(path=file_path),
                 name="root_static",
-            )
+            )            
+                
+        mimetypes.add_type('application/javascript', '.js')
+        mimetypes.add_type('text/css', '.css')
+        mimetypes.add_type('image/svg+xml', '.svg')
 
         routes = []
         base_dir = self.relative_path("webapp/build/")


### PR DESCRIPTION
## Summary & Motivation

https://github.com/dagster-io/dagster/issues/18986

Graphs over a certain size were not rendering anymore, cause was a mime-type of 'text/plain' for js files. This fix adds explicit mime-types for js, svg, and css files.

Credit to this post on Stackoverflow: https://stackoverflow.com/questions/60269909/is-there-a-way-to-explicitly-set-mime-types-for-starlette-uvicorn

## How I Tested These Changes

I edited the dagster-webserver Python module in my environment directly, all graphs now render.