### PR TITLE
[ui] Split up JobMetadata.test

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/package.json
+++ b/js_modules/dagster-ui/packages/ui-core/package.json
@@ -136,7 +136,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-storybook": "^0.6.14",
     "faker": "5.5.3",
-    "graphql-codegen-typescript-mock-data": "^3.3.0",
+    "graphql-codegen-typescript-mock-data": "^3.7.1",
     "graphql-config": "^4.5.0",
     "graphql-tag": "^2.10.1",
     "identity-obj-proxy": "^3.0.0",

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/JobMetadata.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/JobMetadata.tsx
@@ -190,7 +190,7 @@ const RelatedAssetsTag = ({relatedAssets}: {relatedAssets: string[]}) => {
   );
 };
 
-const JOB_METADATA_QUERY = gql`
+export const JOB_METADATA_QUERY = gql`
   query JobMetadataQuery($params: PipelineSelector!, $runsFilter: RunsFilter!) {
     pipelineOrError(params: $params) {
       ... on Pipeline {

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/LatestRunTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/LatestRunTag.tsx
@@ -117,10 +117,10 @@ export const LatestRunTag = ({
   );
 };
 
-const LATEST_RUN_TAG_QUERY = gql`
+export const LATEST_RUN_TAG_QUERY = gql`
   query LatestRunTagQuery($runsFilter: RunsFilter) {
     pipelineRunsOrError(filter: $runsFilter, limit: 1) {
-      ... on PipelineRuns {
+      ... on Runs {
         results {
           id
           status

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/ScheduleOrSensorTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/ScheduleOrSensorTag.tsx
@@ -81,7 +81,7 @@ export const ScheduleOrSensorTag = ({
     );
   }
 
-  return null;
+  return <div style={{display: 'none'}}>No schedules or sensors</div>;
 };
 
 const MatchingSchedule = ({

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/ScheduleOrSensorTag.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/ScheduleOrSensorTag.test.tsx
@@ -1,0 +1,182 @@
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import {MemoryRouter} from 'react-router';
+
+import {
+  InstigationStatus,
+  buildInstigationState,
+  buildSchedule,
+  buildSensor,
+} from '../../graphql/types';
+import {DUNDER_REPO_NAME, buildRepoAddress} from '../../workspace/buildRepoAddress';
+import {ScheduleOrSensorTag} from '../ScheduleOrSensorTag';
+
+describe('ScheduleOrSensorTag', () => {
+  const CODE_LOCATION = 'my-location';
+  const SCHEDULE_NAME_A = 'my-schedule-a';
+  const SCHEDULE_NAME_B = 'my-schedule-b';
+  const SENSOR_NAME_A = 'my-sensor-a';
+  const SENSOR_NAME_B = 'my-sensor-b';
+
+  const REPO_ADDRESS = buildRepoAddress(DUNDER_REPO_NAME, CODE_LOCATION);
+
+  const SCHEDULE_A = buildSchedule({
+    name: SCHEDULE_NAME_A,
+    cronSchedule: '* * * * *',
+    executionTimezone: 'America/Chicago',
+    scheduleState: buildInstigationState({
+      status: InstigationStatus.RUNNING,
+    }),
+  });
+
+  const SCHEDULE_B = buildSchedule({
+    name: SCHEDULE_NAME_B,
+    cronSchedule: '1 * * * *',
+    executionTimezone: 'America/Chicago',
+    scheduleState: buildInstigationState({
+      status: InstigationStatus.RUNNING,
+    }),
+  });
+
+  const SENSOR_A = buildSensor({
+    name: SENSOR_NAME_A,
+    sensorState: buildInstigationState({
+      status: InstigationStatus.RUNNING,
+    }),
+  });
+
+  const SENSOR_B = buildSensor({
+    name: SENSOR_NAME_B,
+    sensorState: buildInstigationState({
+      status: InstigationStatus.RUNNING,
+    }),
+  });
+
+  it('renders empty message if no schedules or sensors', async () => {
+    render(<ScheduleOrSensorTag repoAddress={REPO_ADDRESS} />);
+    expect(await screen.findByText(/no schedules or sensors/i)).toBeInTheDocument();
+  });
+
+  it('renders single schedule', async () => {
+    render(
+      <MemoryRouter>
+        <ScheduleOrSensorTag
+          repoAddress={REPO_ADDRESS}
+          schedules={[SCHEDULE_A]}
+          showSwitch={false}
+        />
+      </MemoryRouter>,
+    );
+    const link = await screen.findByRole('link', {name: /every minute/i});
+    expect(link).toBeVisible();
+    expect(link.getAttribute('href')).toBe(
+      `/locations/${CODE_LOCATION}/schedules/${SCHEDULE_NAME_A}`,
+    );
+  });
+
+  it('renders multiple schedules', async () => {
+    const event = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <ScheduleOrSensorTag
+          repoAddress={REPO_ADDRESS}
+          schedules={[SCHEDULE_A, SCHEDULE_B]}
+          showSwitch={false}
+        />
+      </MemoryRouter>,
+    );
+
+    const buttonLink = await screen.findByRole('button', {name: /2 schedules/i});
+    expect(buttonLink).toBeVisible();
+
+    await event.click(buttonLink);
+
+    const linkA = await screen.findByRole('link', {name: /my-schedule-a/i});
+    expect(linkA.getAttribute('href')).toBe(
+      `/locations/${CODE_LOCATION}/schedules/${SCHEDULE_NAME_A}`,
+    );
+
+    const linkB = await screen.findByRole('link', {name: /my-schedule-b/i});
+    expect(linkB.getAttribute('href')).toBe(
+      `/locations/${CODE_LOCATION}/schedules/${SCHEDULE_NAME_B}`,
+    );
+  });
+
+  it('renders single sensor', async () => {
+    render(
+      <MemoryRouter>
+        <ScheduleOrSensorTag repoAddress={REPO_ADDRESS} sensors={[SENSOR_A]} showSwitch={false} />
+      </MemoryRouter>,
+    );
+    const link = await screen.findByRole('link', {name: /my-sensor-a/i});
+    expect(link).toBeVisible();
+    expect(link.getAttribute('href')).toBe(`/locations/${CODE_LOCATION}/sensors/${SENSOR_NAME_A}`);
+  });
+
+  it('renders multiple sensors', async () => {
+    const event = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <ScheduleOrSensorTag
+          repoAddress={REPO_ADDRESS}
+          sensors={[SENSOR_A, SENSOR_B]}
+          showSwitch={false}
+        />
+      </MemoryRouter>,
+    );
+
+    const buttonLink = await screen.findByRole('button', {name: /2 sensors/i});
+    expect(buttonLink).toBeVisible();
+
+    await event.click(buttonLink);
+
+    const linkA = await screen.findByRole('link', {name: /my-sensor-a/i});
+    expect(linkA.getAttribute('href')).toBe(`/locations/${CODE_LOCATION}/sensors/${SENSOR_NAME_A}`);
+
+    const linkB = await screen.findByRole('link', {name: /my-sensor-b/i});
+    expect(linkB.getAttribute('href')).toBe(`/locations/${CODE_LOCATION}/sensors/${SENSOR_NAME_B}`);
+  });
+
+  it('renders multiple schedules AND sensors', async () => {
+    const event = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <ScheduleOrSensorTag
+          repoAddress={REPO_ADDRESS}
+          schedules={[SCHEDULE_A, SCHEDULE_B]}
+          sensors={[SENSOR_A, SENSOR_B]}
+          showSwitch={false}
+        />
+      </MemoryRouter>,
+    );
+
+    const buttonLink = await screen.findByRole('button', {name: /4 schedules\/sensors/i});
+    expect(buttonLink).toBeVisible();
+
+    await event.click(buttonLink);
+
+    const scheduleLinkA = await screen.findByRole('link', {name: /my-schedule-a/i});
+    expect(scheduleLinkA.getAttribute('href')).toBe(
+      `/locations/${CODE_LOCATION}/schedules/${SCHEDULE_NAME_A}`,
+    );
+
+    const scheduleLinkB = await screen.findByRole('link', {name: /my-schedule-b/i});
+    expect(scheduleLinkB.getAttribute('href')).toBe(
+      `/locations/${CODE_LOCATION}/schedules/${SCHEDULE_NAME_B}`,
+    );
+
+    const sensorLinkA = await screen.findByRole('link', {name: /my-sensor-a/i});
+    expect(sensorLinkA.getAttribute('href')).toBe(
+      `/locations/${CODE_LOCATION}/sensors/${SENSOR_NAME_A}`,
+    );
+
+    const sensorLinkB = await screen.findByRole('link', {name: /my-sensor-b/i});
+    expect(sensorLinkB.getAttribute('href')).toBe(
+      `/locations/${CODE_LOCATION}/sensors/${SENSOR_NAME_B}`,
+    );
+  });
+});

--- a/js_modules/dagster-ui/yarn.lock
+++ b/js_modules/dagster-ui/yarn.lock
@@ -2587,7 +2587,7 @@ __metadata:
     faker: "npm:5.5.3"
     fuse.js: "npm:^6.4.2"
     graphql: "npm:^16.8.1"
-    graphql-codegen-typescript-mock-data: "npm:^3.3.0"
+    graphql-codegen-typescript-mock-data: "npm:^3.7.1"
     graphql-config: "npm:^4.5.0"
     graphql-tag: "npm:^2.10.1"
     highlight.js: "npm:11.6.0"
@@ -13934,9 +13934,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql-codegen-typescript-mock-data@npm:^3.3.0":
-  version: 3.5.0
-  resolution: "graphql-codegen-typescript-mock-data@npm:3.5.0"
+"graphql-codegen-typescript-mock-data@npm:^3.7.1":
+  version: 3.7.1
+  resolution: "graphql-codegen-typescript-mock-data@npm:3.7.1"
   dependencies:
     "@faker-js/faker": "npm:^7.5.0"
     "@graphql-codegen/plugin-helpers": "npm:^2.7.2"
@@ -13949,7 +13949,7 @@ __metadata:
     upper-case: "npm:^2.0.1"
   peerDependencies:
     graphql: ^14.6.0 || ^15.0.0 || ^16.0.0
-  checksum: fe52ee4d7b9834504ee4a5d1405c759e6034a37fbae273b86bce098a3a77d6db4e1bc107da6c65bd9eb4e7d4e858c08877b8aee28e885066172d42be23e92cf6
+  checksum: 605a183f576ae1558828f1c9394ae340def163ae6f89af9af0a0f646035a870e4607e2eeaecc36bdf6f691ff103afaf56d6aa1b5eafdb747a185ad2483b2723d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary & Motivation

Eliminate another TestProvider use case by splitting up JobMetadata and doing some cleanup.

## How I Tested These Changes

yarn jest
