### PR TITLE
[daggy u] Fix iframed snippet copy behavior

### DIFF
--- a/docs/dagster-university/components/CodeBlock.tsx
+++ b/docs/dagster-university/components/CodeBlock.tsx
@@ -20,16 +20,17 @@ export const CodeBlock = (props: Props) => {
   const [hidden, setHidden] = React.useState(obfuscated);
   const [copied, setCopied] = React.useState(false);
 
+  const copy = useCopyToClipboard();
+
   const copyToClipboard = React.useCallback(() => {
-    const clipboardAPI = navigator.clipboard;
-    if (clipboardAPI && typeof text === 'string') {
-      clipboardAPI.writeText(text);
+    if (typeof text === 'string') {
+      copy(text);
       setCopied(true);
       setTimeout(() => {
         setCopied(false);
       }, COPY_CONFIRMATION_MSC);
     }
-  }, [text]);
+  }, [copy, text]);
 
   React.useEffect(() => {
     Prism.highlightAll();
@@ -97,4 +98,26 @@ export const CodeBlock = (props: Props) => {
       ) : null}
     </div>
   );
+};
+
+export const useCopyToClipboard = () => {
+  const node = React.useRef<HTMLTextAreaElement | null>(null);
+
+  React.useEffect(() => {
+    node.current = document.createElement('textarea');
+    node.current.style.position = 'fixed';
+    node.current.style.top = '-10000px';
+    document.body.appendChild(node.current);
+    return () => {
+      node.current && document.body.removeChild(node.current);
+    };
+  }, []);
+
+  return React.useCallback((text: string) => {
+    if (node.current) {
+      node.current.value = text;
+      node.current.select();
+      document.execCommand('copy');
+    }
+  }, []);
 };


### PR DESCRIPTION
## Summary & Motivation

We received a report from a Dagster University user that the button to copy code snippets is failing in Chrome, due to a permissions limitation on the Clipboard API. I'm not sure if this has been broken for a while, but I was able to repro the issue.

Work around this by using the old fashioned `execCommand` behavior to write to the clipboard without the Clipboard API.

## How I Tested These Changes

yarn build, yarn start. Load an iframe with no `allow` values set, with a course page loaded:

```
<html>
  <body>
    <iframe src="http://localhost:3000/dagster-essentials/lesson-3/defining-your-first-asset" />
  </body>
</html>
```

(In comparison, the Thinkific iframe allows a handful of features, but similarly does not allow any Clipboard access.)

Scroll to a code snippet, verify that I can successfully copy the snippet using the clipboard button. Verify also that newlines and whitespace are correct.
