### PR TITLE
feat(dbt): deprecate `load_assets_from_dbt_project` and `load_assets_from_dbt_manifest`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -1,8 +1,4 @@
 from .asset_decorator import dbt_assets as dbt_assets
-from .asset_defs import (
-    load_assets_from_dbt_manifest as load_assets_from_dbt_manifest,
-    load_assets_from_dbt_project as load_assets_from_dbt_project,
-)
 from .asset_utils import (
     build_dbt_asset_selection as build_dbt_asset_selection,
     build_schedule_from_dbt_selection as build_schedule_from_dbt_selection,
@@ -88,6 +84,13 @@ if TYPE_CHECKING:
         dbt_test_op as dbt_test_op,
     )
 
+    ##### Deprecating load_assets_from_XXX
+    # isort: split
+    from .asset_defs import (
+        load_assets_from_dbt_manifest as load_assets_from_dbt_manifest,
+        load_assets_from_dbt_project as load_assets_from_dbt_project,
+    )
+
 _DEPRECATED: Final[Mapping[str, Tuple[str, str, str]]] = {
     ##### EXAMPLE
     # "Foo": (
@@ -128,7 +131,12 @@ _DEPRECATED: Final[Mapping[str, Tuple[str, str, str]]] = {
         value: (
             module,
             "0.24.0",
-            "Use the @op decorator and DbtCliResource instead.",
+            (
+                "Use the @op decorator and DbtCliResource instead.\n\n"
+                "For examples on how to use @op and DbtCliResource to execute commands like"
+                " `dbt run` or `dbt build`, see our API docs:"
+                " https://docs.dagster.io/_apidocs/libraries/dagster-dbt#dagster_dbt.DbtCliResource.cli."
+            ),
         )
         for value, module in [
             ("dbt_build_op", "dagster_dbt.ops"),
@@ -139,6 +147,38 @@ _DEPRECATED: Final[Mapping[str, Tuple[str, str, str]]] = {
             ("dbt_seed_op", "dagster_dbt.ops"),
             ("dbt_snapshot_op", "dagster_dbt.ops"),
             ("dbt_test_op", "dagster_dbt.ops"),
+        ]
+    },
+    **{
+        value: (
+            module,
+            "0.24.0",
+            (
+                "Use the @dbt_assets decorator, DbtCliResource, and DagsterDbtTranslator instead.\n\n"
+                "For examples on how to use @dbt_assets and DbtCliResource to execute commands like"
+                " `dbt run` or `dbt build` on your dbt project, see our API docs:"
+                " https://docs.dagster.io/_apidocs/libraries/dagster-dbt#dagster_dbt.dbt_assets.\n\n"
+                "For examples on how to customize your dbt assets using DagsterDbtTranslator"
+                " see the reference:"
+                " https://docs.dagster.io/integrations/dbt/reference#understanding-asset-definition-attributes."
+                f"{additional_text}"
+            ),
+        )
+        for value, module, additional_text in [
+            (
+                "load_assets_from_dbt_manifest",
+                "dagster_dbt.asset_defs",
+                "",
+            ),
+            (
+                "load_assets_from_dbt_project",
+                "dagster_dbt.asset_defs",
+                (
+                    "\n\nTo generate a dbt manifest for @dbt_assets at run time using `dbt parse`,"
+                    " see the reference:"
+                    " https://docs.dagster.io/integrations/dbt/reference#loading-dbt-models-from-a-dbt-project.",
+                ),
+            ),
         ]
     },
 }


### PR DESCRIPTION
## Summary & Motivation
The utility of these functions is completely subsumed with `@dbt_assets`, `DbtCliResource`, and `DagsterDbtTranslator`, which were new APIs released in `0.20.0`. Furthermore, the patterns for generating a dbt manifest at run time and build time with the new APIs are already documented: https://docs.dagster.io/integrations/dbt/reference#loading-dbt-models-from-a-dbt-project.

To ensure a single point of entry for creating software-defined assets from a dbt Core project, mark these old functions as deprecated.

By July 2024, when we remove these functions, we will have provided explicit step-by-step guides to help users transition away from `load_assets_from_dbt_project` and `load_assets_from_dbt_manifest`.

## How I Tested These Changes
N/A
