### PR TITLE
Carbon copy of Automaterialize policy page components

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/AssetAutomaterializePolicyPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/AssetAutomaterializePolicyPage.tsx
@@ -1,0 +1,119 @@
+import {Box, Subheading, colorTextLight} from '@dagster-io/ui-components';
+import * as React from 'react';
+import styled from 'styled-components';
+
+import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../../app/QueryRefresh';
+import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
+import {AssetKey} from '../types';
+
+import {AutoMaterializeExperimentalBanner} from './AutoMaterializeExperimentalBanner';
+import {AutomaterializeLeftPanel} from './AutomaterializeLeftPanel';
+import {AutomaterializeMiddlePanel} from './AutomaterializeMiddlePanel';
+import {AutomaterializeRightPanel} from './AutomaterializeRightPanel';
+import {useEvaluationsQueryResult} from './useEvaluationsQueryResult';
+
+export const AssetAutomaterializePolicyPage = ({
+  assetKey,
+  assetHasDefinedPartitions,
+}: {
+  assetKey: AssetKey;
+  assetHasDefinedPartitions: boolean;
+}) => {
+  const {queryResult, paginationProps} = useEvaluationsQueryResult({assetKey});
+
+  useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
+
+  const {evaluations} = React.useMemo(() => {
+    if (
+      queryResult.data?.autoMaterializeAssetEvaluationsOrError?.__typename ===
+        'AutoMaterializeAssetEvaluationRecords' &&
+      queryResult.data?.assetNodeOrError?.__typename === 'AssetNode'
+    ) {
+      return {
+        evaluations: queryResult.data?.autoMaterializeAssetEvaluationsOrError.records,
+        currentAutoMaterializeEvaluationId:
+          queryResult.data.assetNodeOrError.currentAutoMaterializeEvaluationId,
+      };
+    }
+    return {evaluations: [], currentAutoMaterializeEvaluationId: null};
+  }, [
+    queryResult.data?.autoMaterializeAssetEvaluationsOrError,
+    queryResult.data?.assetNodeOrError,
+  ]);
+
+  const isFirstPage = !paginationProps.hasPrevCursor;
+
+  const [selectedEvaluationId, setSelectedEvaluationId] = useQueryPersistedState<
+    number | undefined
+  >({
+    queryKey: 'evaluation',
+    decode: (raw) => {
+      const value = parseInt(raw.evaluation);
+      return isNaN(value) ? undefined : value;
+    },
+  });
+
+  const selectedEvaluation = React.useMemo(() => {
+    // If we're looking at the most recent slice and have not selected an evaluation ID,
+    // default to the first item in the list. Otherwise, don't assume that we should
+    // automatically select the first item -- an evaluation on another page might be our
+    // active evaluation ID.
+    if (selectedEvaluationId === undefined && isFirstPage) {
+      return evaluations[0];
+    }
+    return evaluations.find((evaluation) => evaluation.evaluationId === selectedEvaluationId);
+  }, [selectedEvaluationId, isFirstPage, evaluations]);
+
+  return (
+    <AutomaterializePage
+      style={{flex: 1, minHeight: 0, color: colorTextLight(), overflow: 'hidden'}}
+      flex={{direction: 'column'}}
+    >
+      <Box padding={{horizontal: 24, vertical: 12}} border="bottom">
+        <AutoMaterializeExperimentalBanner />
+      </Box>
+      <Box flex={{direction: 'row'}} style={{minHeight: 0, flex: 1}}>
+        <Box flex={{direction: 'column', grow: 1}}>
+          <Box
+            flex={{alignItems: 'center'}}
+            padding={{vertical: 16, horizontal: 24}}
+            border="bottom"
+          >
+            <Subheading>Evaluation history</Subheading>
+          </Box>
+          <Box flex={{direction: 'row'}} style={{flex: 1, minHeight: 0}}>
+            <Box border="right" flex={{grow: 0, direction: 'column'}} style={{flex: '0 0 296px'}}>
+              <AutomaterializeLeftPanel
+                assetHasDefinedPartitions={assetHasDefinedPartitions}
+                evaluations={evaluations}
+                paginationProps={paginationProps}
+                onSelectEvaluation={(evaluation) => {
+                  setSelectedEvaluationId(evaluation.evaluationId);
+                }}
+                selectedEvaluation={selectedEvaluation}
+              />
+            </Box>
+            <Box flex={{grow: 1}} style={{minHeight: 0, overflowY: 'auto'}}>
+              <AutomaterializeMiddlePanel
+                assetKey={assetKey}
+                assetHasDefinedPartitions={assetHasDefinedPartitions}
+                // Use the evaluation ID of the current evaluation object, if any. Otherwise
+                // fall back to the evaluation ID from the query parameter, if any.
+                selectedEvaluationId={selectedEvaluation?.evaluationId || selectedEvaluationId}
+              />
+            </Box>
+          </Box>
+        </Box>
+        <Box border="left">
+          <AutomaterializeRightPanel assetKey={assetKey} />
+        </Box>
+      </Box>
+    </AutomaterializePage>
+  );
+};
+
+const AutomaterializePage = styled(Box)`
+  a span {
+    white-space: normal;
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/AssetKeysDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/AssetKeysDialog.tsx
@@ -1,0 +1,79 @@
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogFooter,
+  NonIdealState,
+  TextInput,
+} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+interface Props {
+  isOpen: boolean;
+  setIsOpen: (value: boolean) => void;
+  header: React.ReactNode;
+  content: React.ReactNode;
+  height?: number;
+}
+
+export const AssetKeysDialog = (props: Props) => {
+  const {isOpen, setIsOpen, header, content, height = 272} = props;
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={() => setIsOpen(false)}
+      style={{width: '750px', maxWidth: '80vw', minWidth: '500px', transform: 'scale(1)'}}
+      canOutsideClickClose
+      canEscapeKeyClose
+    >
+      {header}
+      <div style={{height: `${height}px`, overflow: 'hidden'}}>{content}</div>
+      <DialogFooter topBorder>
+        <Button onClick={() => setIsOpen(false)}>Close</Button>
+      </DialogFooter>
+    </Dialog>
+  );
+};
+
+interface HeaderProps {
+  title: React.ReactNode;
+  showSearch: boolean;
+  placeholder: string;
+  queryString: string;
+  setQueryString: (value: string) => void;
+}
+
+export const AssetKeysDialogHeader = (props: HeaderProps) => {
+  const {title, showSearch, placeholder, queryString, setQueryString} = props;
+  return (
+    <Box
+      padding={{horizontal: 24, vertical: 16}}
+      flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
+      border="bottom"
+    >
+      <div style={{fontSize: '16px'}}>{title}</div>
+      {showSearch ? (
+        <TextInput
+          icon="search"
+          value={queryString}
+          onChange={(e) => setQueryString(e.target.value)}
+          placeholder={placeholder}
+          style={{width: '252px'}}
+        />
+      ) : null}
+    </Box>
+  );
+};
+
+interface EmptyStateProps {
+  title: string;
+  description: React.ReactNode;
+}
+
+export const AssetKeysDialogEmptyState = ({title, description}: EmptyStateProps) => {
+  return (
+    <Box padding={32}>
+      <NonIdealState icon="search" title={title} description={description} />
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/AutoMaterializeExperimentalBanner.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/AutoMaterializeExperimentalBanner.tsx
@@ -1,0 +1,34 @@
+import {Alert, Icon, Tag, Tooltip, colorAccentBlue} from '@dagster-io/ui-components';
+import React from 'react';
+
+const LearnMoreLink =
+  'https://docs.dagster.io/concepts/assets/asset-auto-execution#auto-materializing-assets-';
+
+export const AutoMaterializeExperimentalBanner = () => {
+  return (
+    <Alert
+      intent="info"
+      title="Auto-materialize policies are experimental"
+      icon={<Icon name="info" color={colorAccentBlue()} />}
+      description={
+        <span>
+          You can learn more about this new feature and provide feedback{' '}
+          <a target="_blank" href={LearnMoreLink} rel="noreferrer">
+            here
+          </a>
+          .
+        </span>
+      }
+    />
+  );
+};
+
+export const AutoMaterializeExperimentalTag = () => {
+  return (
+    <Tooltip content="Click to learn more about this new feature and provide feedback">
+      <a target="_blank" href={LearnMoreLink} rel="noreferrer">
+        <Tag intent="primary">Experimental</Tag>
+      </a>
+    </Tooltip>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/AutomaterializeLeftPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/AutomaterializeLeftPanel.tsx
@@ -1,0 +1,143 @@
+import {
+  Box,
+  Caption,
+  CursorPaginationControls,
+  colorBackgroundBlue,
+  colorBackgroundBlueHover,
+  colorBackgroundDefault,
+  colorBackgroundDefaultHover,
+  colorBackgroundLight,
+  colorKeylineDefault,
+  colorTextBlue,
+  colorTextDefault,
+} from '@dagster-io/ui-components';
+import * as React from 'react';
+import styled from 'styled-components';
+
+import {TimestampDisplay} from '../../schedules/TimestampDisplay';
+
+import {EvaluationCounts} from './EvaluationCounts';
+import {AutoMaterializeEvaluationRecordItemFragment} from './types/GetEvaluationsQuery.types';
+import {useEvaluationsQueryResult} from './useEvaluationsQueryResult';
+
+interface Props extends ListProps {
+  evaluations: AutoMaterializeEvaluationRecordItemFragment[];
+  paginationProps: ReturnType<typeof useEvaluationsQueryResult>['paginationProps'];
+}
+
+export const AutomaterializeLeftPanel = ({
+  assetHasDefinedPartitions,
+  evaluations,
+  paginationProps,
+  onSelectEvaluation,
+  selectedEvaluation,
+}: Props) => {
+  return (
+    <Box flex={{direction: 'column', grow: 1}} style={{overflowY: 'auto'}}>
+      <AutomaterializeLeftList
+        assetHasDefinedPartitions={assetHasDefinedPartitions}
+        evaluations={evaluations}
+        onSelectEvaluation={onSelectEvaluation}
+        selectedEvaluation={selectedEvaluation}
+      />
+      {evaluations.length ? (
+        <PaginationWrapper>
+          <CursorPaginationControls {...paginationProps} />
+        </PaginationWrapper>
+      ) : null}
+    </Box>
+  );
+};
+
+interface ListProps {
+  assetHasDefinedPartitions: boolean;
+  evaluations: AutoMaterializeEvaluationRecordItemFragment[];
+  onSelectEvaluation: (evaluation: AutoMaterializeEvaluationRecordItemFragment) => void;
+  selectedEvaluation?: AutoMaterializeEvaluationRecordItemFragment;
+}
+
+export const AutomaterializeLeftList = (props: ListProps) => {
+  const {assetHasDefinedPartitions, evaluations, onSelectEvaluation, selectedEvaluation} = props;
+
+  return (
+    <Box
+      padding={{vertical: 8, horizontal: 12}}
+      style={{flex: 1, minHeight: 0, overflowY: 'auto'}}
+      flex={{grow: 1, direction: 'column'}}
+    >
+      {evaluations.map((evaluation) => {
+        const isSelected = selectedEvaluation?.evaluationId === evaluation.evaluationId;
+        const {numRequested, numSkipped, numDiscarded} = evaluation;
+
+        return (
+          <EvaluationListItem
+            key={`skip-${evaluation.timestamp}`}
+            onClick={() => {
+              onSelectEvaluation(evaluation);
+            }}
+            $selected={isSelected}
+          >
+            <Box flex={{direction: 'column', gap: 4}}>
+              <TimestampDisplay timestamp={evaluation.timestamp} />
+              <EvaluationCounts
+                numRequested={numRequested}
+                numSkipped={numSkipped}
+                numDiscarded={numDiscarded}
+                isPartitionedAsset={assetHasDefinedPartitions}
+                selected={isSelected}
+              />
+            </Box>
+          </EvaluationListItem>
+        );
+      })}
+      <Box border="top" padding={{vertical: 20, horizontal: 12}} margin={{top: 12}}>
+        <Caption>Evaluations are retained for 30 days</Caption>
+      </Box>
+    </Box>
+  );
+};
+
+const PaginationWrapper = styled.div`
+  position: sticky;
+  bottom: 0;
+  background: ${colorBackgroundLight()};
+  border-right: 1px solid ${colorKeylineDefault()};
+  box-shadow: inset 0 1px ${colorKeylineDefault()};
+  margin-top: -1px;
+  padding-bottom: 16px;
+  padding-top: 16px;
+  > * {
+    margin-top: 0;
+  }
+`;
+
+interface EvaluationListItemProps {
+  $selected: boolean;
+}
+
+const EvaluationListItem = styled.button<EvaluationListItemProps>`
+  background-color: ${({$selected}) =>
+    $selected ? colorBackgroundBlue() : colorBackgroundDefault()};
+  border: none;
+  border-radius: 8px;
+  color: ${({$selected}) => ($selected ? colorTextBlue() : colorTextDefault())};
+  cursor: pointer;
+  margin: 2px 0;
+  text-align: left;
+  transition:
+    100ms background-color linear,
+    100ms color linear;
+  user-select: none;
+
+  &:hover {
+    background-color: ${({$selected}) =>
+      $selected ? colorBackgroundBlueHover() : colorBackgroundDefaultHover()};
+  }
+
+  &:focus,
+  &:active {
+    outline: none;
+  }
+
+  padding: 8px 12px;
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/AutomaterializeMiddlePanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/AutomaterializeMiddlePanel.tsx
@@ -1,0 +1,190 @@
+import {useQuery} from '@apollo/client';
+import {Box, NonIdealState, Subheading} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {ErrorWrapper} from '../../app/PythonErrorInfo';
+import {AutoMaterializeDecisionType, AutoMaterializeRule} from '../../graphql/types';
+import {AssetKey} from '../types';
+
+import {AutomaterializeRequestedPartitionsLink} from './AutomaterializeRequestedPartitionsLink';
+import {AutomaterializeRunTag} from './AutomaterializeRunTag';
+import {GET_EVALUATIONS_QUERY} from './GetEvaluationsQuery';
+import {RuleEvaluationOutcomes} from './RuleEvaluationOutcomes';
+import {EvaluationOrEmpty, NoConditionsMetEvaluation} from './types';
+import {
+  OldGetEvaluationsQuery,
+  OldGetEvaluationsQueryVariables,
+  RuleWithEvaluationsFragment,
+  AutoMaterializeEvaluationRecordItemFragment,
+} from './types/GetEvaluationsQuery.types';
+
+interface Props {
+  assetKey: AssetKey;
+  assetHasDefinedPartitions: boolean;
+  selectedEvaluationId: number | undefined;
+}
+
+const EMPTY: EvaluationOrEmpty = {
+  __typename: 'no_conditions_met',
+  evaluationId: 0,
+  amount: 0,
+  endTimestamp: 0,
+  startTimestamp: 0,
+};
+
+const extractRequestedPartitionKeys = (rulesWithEvaluations: RuleWithEvaluationsFragment[]) => {
+  let requested: string[] = [];
+  let skippedOrDiscarded: string[] = [];
+
+  rulesWithEvaluations.forEach(({rule, ruleEvaluations}) => {
+    const partitionKeys = ruleEvaluations.flatMap((e) =>
+      e.partitionKeysOrError?.__typename === 'PartitionKeys'
+        ? e.partitionKeysOrError.partitionKeys
+        : [],
+    );
+    if (rule.decisionType === AutoMaterializeDecisionType.MATERIALIZE) {
+      requested = requested.concat(partitionKeys);
+    } else {
+      skippedOrDiscarded = skippedOrDiscarded.concat(partitionKeys);
+    }
+  });
+
+  const skippedOrDiscardedSet = new Set(skippedOrDiscarded);
+  return new Set(requested.filter((partitionKey) => !skippedOrDiscardedSet.has(partitionKey)));
+};
+
+export const AutomaterializeMiddlePanel = (props: Props) => {
+  const {assetKey, assetHasDefinedPartitions, selectedEvaluationId} = props;
+
+  // We receive the selected evaluation ID and retrieve it here because the middle panel
+  // may be displaying an evaluation that was not retrieved at the page level for the
+  // left panel, e.g. as we paginate away from it, we don't want to lose it.
+  const {data, loading, error} = useQuery<OldGetEvaluationsQuery, OldGetEvaluationsQueryVariables>(
+    GET_EVALUATIONS_QUERY,
+    {
+      variables: {
+        assetKey,
+        cursor: selectedEvaluationId ? `${selectedEvaluationId + 1}` : undefined,
+        limit: 2,
+      },
+    },
+  );
+
+  if (loading && !data) {
+    return (
+      <Box flex={{direction: 'column', grow: 1}}>
+        <Box
+          style={{flex: '0 0 48px'}}
+          border="bottom"
+          padding={{horizontal: 16}}
+          flex={{alignItems: 'center', justifyContent: 'space-between'}}
+        >
+          <Subheading>Result</Subheading>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box flex={{direction: 'column', grow: 1}}>
+        <Box flex={{direction: 'row', justifyContent: 'center'}} padding={24}>
+          <ErrorWrapper>{JSON.stringify(error)}</ErrorWrapper>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (
+    data?.autoMaterializeAssetEvaluationsOrError?.__typename ===
+    'AutoMaterializeAssetEvaluationNeedsMigrationError'
+  ) {
+    return (
+      <Box flex={{direction: 'column', grow: 1}}>
+        <Box flex={{direction: 'row', justifyContent: 'center'}} padding={{vertical: 24}}>
+          <NonIdealState
+            icon="error"
+            title="Error"
+            description={data.autoMaterializeAssetEvaluationsOrError.message}
+          />
+        </Box>
+      </Box>
+    );
+  }
+
+  const currentRules =
+    (data?.assetNodeOrError.__typename === 'AssetNode' &&
+      data.assetNodeOrError.autoMaterializePolicy?.rules) ||
+    [];
+
+  const evaluations = data?.autoMaterializeAssetEvaluationsOrError?.records || [];
+  const selectedEvaluation =
+    evaluations.find((evaluation) => evaluation.evaluationId === selectedEvaluationId) || EMPTY;
+
+  return (
+    <AutomaterializeMiddlePanelWithData
+      currentRules={currentRules}
+      assetHasDefinedPartitions={assetHasDefinedPartitions}
+      selectedEvaluation={selectedEvaluation}
+    />
+  );
+};
+
+export const AutomaterializeMiddlePanelWithData = ({
+  currentRules,
+  selectedEvaluation,
+  assetHasDefinedPartitions,
+}: {
+  currentRules: AutoMaterializeRule[];
+  selectedEvaluation: NoConditionsMetEvaluation | AutoMaterializeEvaluationRecordItemFragment;
+  assetHasDefinedPartitions: boolean;
+}) => {
+  const runIds =
+    selectedEvaluation?.__typename === 'AutoMaterializeAssetEvaluationRecord'
+      ? selectedEvaluation.runIds
+      : [];
+  const rulesWithRuleEvaluations =
+    selectedEvaluation?.__typename === 'AutoMaterializeAssetEvaluationRecord'
+      ? selectedEvaluation.rulesWithRuleEvaluations
+      : [];
+  const rules =
+    selectedEvaluation?.__typename === 'AutoMaterializeAssetEvaluationRecord' &&
+    selectedEvaluation.rules
+      ? selectedEvaluation.rules
+      : currentRules;
+
+  const headerRight = () => {
+    if (runIds.length === 0) {
+      return null;
+    }
+    if (assetHasDefinedPartitions) {
+      return (
+        <AutomaterializeRequestedPartitionsLink
+          runIds={runIds}
+          partitionKeys={Array.from(extractRequestedPartitionKeys(rulesWithRuleEvaluations))}
+          intent="success"
+        />
+      );
+    }
+    return <AutomaterializeRunTag runId={runIds[0]!} />;
+  };
+
+  return (
+    <Box flex={{direction: 'column', grow: 1}}>
+      <Box
+        style={{flex: '0 0 48px'}}
+        padding={{horizontal: 16}}
+        border="bottom"
+        flex={{alignItems: 'center', justifyContent: 'space-between'}}
+      >
+        <Subheading>Result</Subheading>
+        <div>{headerRight()}</div>
+      </Box>
+      <RuleEvaluationOutcomes
+        rules={rules}
+        ruleEvaluations={rulesWithRuleEvaluations}
+        assetHasDefinedPartitions={assetHasDefinedPartitions}
+      />
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/AutomaterializeRequestedPartitionsLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/AutomaterializeRequestedPartitionsLink.tsx
@@ -1,0 +1,311 @@
+import {gql, useQuery} from '@apollo/client';
+import {
+  Box,
+  Button,
+  ButtonLink,
+  Dialog,
+  DialogFooter,
+  NonIdealState,
+  Spinner,
+  Tag,
+  TextInput,
+  Caption,
+} from '@dagster-io/ui-components';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+import styled from 'styled-components';
+
+import {showCustomAlert} from '../../app/CustomAlertProvider';
+import {PYTHON_ERROR_FRAGMENT} from '../../app/PythonErrorFragment';
+import {PythonErrorInfo} from '../../app/PythonErrorInfo';
+import {RunStatusTagWithID} from '../../runs/RunStatusTag';
+import {DagsterTag} from '../../runs/RunTag';
+import {Container, Inner, Row} from '../../ui/VirtualizedTable';
+
+import {
+  OldRunStatusAndPartitionKeyQuery,
+  OldRunStatusAndPartitionKeyQueryVariables,
+  OldRunStatusAndTagsFragment,
+} from './types/AutomaterializeRequestedPartitionsLink.types';
+
+interface Props {
+  runIds?: string[];
+  partitionKeys: string[];
+  intent?: React.ComponentProps<typeof Tag>['intent'];
+}
+
+export const AutomaterializeRequestedPartitionsLink = ({runIds, partitionKeys, intent}: Props) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [queryString, setQueryString] = React.useState('');
+  const queryLowercase = queryString.toLocaleLowerCase();
+
+  const count = partitionKeys.length;
+
+  const filteredPartitionKeys = React.useMemo(() => {
+    if (queryLowercase === '') {
+      return partitionKeys;
+    }
+    return partitionKeys.filter((partitionKey) =>
+      partitionKey.toLocaleLowerCase().includes(queryLowercase),
+    );
+  }, [partitionKeys, queryLowercase]);
+
+  const label = React.useMemo(() => {
+    if (runIds) {
+      return count === 1 ? '1 partition launched' : `${count} partitions launched`;
+    }
+    return count === 1 ? '1 partition' : `${count} partitions`;
+  }, [count, runIds]);
+
+  const content = () => {
+    if (queryString && !filteredPartitionKeys.length) {
+      return <NoMatchesEmptyState queryString={queryString} />;
+    }
+
+    return runIds ? (
+      <PartitionAndRunList runIds={runIds} partitionKeys={filteredPartitionKeys} intent={intent} />
+    ) : (
+      <VirtualizedPartitionList partitionKeys={partitionKeys} />
+    );
+  };
+
+  return (
+    <>
+      <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+        <Tag intent={intent}>{label}</Tag>
+        <ButtonLink onClick={() => setIsOpen(true)}>
+          <Caption>View details</Caption>
+        </ButtonLink>
+      </Box>
+      <Dialog
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        style={{width: '750px', maxWidth: '80vw', minWidth: '500px'}}
+        canOutsideClickClose
+        canEscapeKeyClose
+      >
+        <Box
+          padding={{horizontal: 24, vertical: 16}}
+          flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
+          border="bottom"
+        >
+          <div style={{fontSize: '16px'}}>
+            {count === 1 ? '1 partition' : `${count} partitions`}
+          </div>
+          {count > 0 ? (
+            <TextInput
+              icon="search"
+              value={queryString}
+              onChange={(e) => setQueryString(e.target.value)}
+              placeholder="Filter by partition…"
+              style={{width: '252px'}}
+            />
+          ) : null}
+        </Box>
+        <div style={{height: '272px', overflow: 'hidden'}}>{content()}</div>
+        <DialogFooter topBorder>
+          <Button onClick={() => setIsOpen(false)}>Close</Button>
+        </DialogFooter>
+      </Dialog>
+    </>
+  );
+};
+
+type PartitionRunTuple = [string, OldRunStatusAndTagsFragment];
+
+const PartitionAndRunList = ({runIds, partitionKeys}: Props) => {
+  const {data, loading} = useQuery<
+    OldRunStatusAndPartitionKeyQuery,
+    OldRunStatusAndPartitionKeyQueryVariables
+  >(RUN_STATUS_AND_PARTITION_KEY, {
+    variables: {filter: {runIds}},
+  });
+
+  const runs = data?.runsOrError;
+
+  if (!runs) {
+    if (loading) {
+      return (
+        <Box
+          padding={32}
+          flex={{direction: 'row', justifyContent: 'center', gap: 12, alignItems: 'center'}}
+        >
+          <Spinner purpose="body-text" />
+          <div>Loading partitions and runs…</div>
+        </Box>
+      );
+    }
+
+    return (
+      <Box padding={32}>
+        <NonIdealState
+          icon="error"
+          title="Unexpected error"
+          description="An unexpected error occurred"
+        />
+      </Box>
+    );
+  }
+
+  if (runs.__typename === 'PythonError') {
+    return (
+      <Box padding={32}>
+        <NonIdealState
+          icon="error"
+          title="Python error"
+          description={
+            <Button
+              onClick={() => {
+                showCustomAlert({
+                  title: 'Python error',
+                  body: <PythonErrorInfo error={runs} />,
+                });
+              }}
+            >
+              View error
+            </Button>
+          }
+        />
+      </Box>
+    );
+  }
+
+  if (runs.__typename === 'InvalidPipelineRunsFilterError' || !runs.results.length) {
+    return (
+      <Box padding={32}>
+        <NonIdealState
+          icon="error"
+          title="Runs not found"
+          description="No runs found for these partitions"
+        />
+      </Box>
+    );
+  }
+
+  const {results} = runs;
+
+  const runsByPartitionKey: Record<string, OldRunStatusAndTagsFragment> = Object.fromEntries(
+    results
+      .map((run) => {
+        const {tags} = run;
+        const partitionTag = tags.find(({key}) => key === DagsterTag.Partition);
+        return partitionTag ? [partitionTag.value, run] : null;
+      })
+      .filter((tupleOrNull): tupleOrNull is PartitionRunTuple => !!tupleOrNull),
+  );
+
+  return (
+    <VirtualizedPartitionList
+      partitionKeys={partitionKeys}
+      runsByPartitionKey={runsByPartitionKey}
+    />
+  );
+};
+
+const NoMatchesEmptyState = ({queryString}: {queryString: string}) => {
+  return (
+    <Box padding={32}>
+      <NonIdealState
+        icon="search"
+        title="No matching partitions"
+        description={
+          <>
+            No matching partitions for <strong>{queryString}</strong>
+          </>
+        }
+      />
+    </Box>
+  );
+};
+
+interface VirtualizedListProps {
+  partitionKeys: string[];
+  runsByPartitionKey?: Record<string, OldRunStatusAndTagsFragment>;
+}
+
+const VirtualizedPartitionList = ({partitionKeys, runsByPartitionKey}: VirtualizedListProps) => {
+  const container = React.useRef<HTMLDivElement | null>(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: partitionKeys.length,
+    getScrollElement: () => container.current,
+    estimateSize: () => 40,
+    overscan: 10,
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const items = rowVirtualizer.getVirtualItems();
+  const showRunTag = !!runsByPartitionKey;
+
+  return (
+    <Container ref={container} style={{padding: '8px 24px'}}>
+      <Inner $totalHeight={totalHeight}>
+        {items.map(({index, key, size, start}) => {
+          const partitionKey = partitionKeys[index]!;
+          const runForPartition = runsByPartitionKey ? runsByPartitionKey[partitionKey] : null;
+
+          return (
+            <Row $height={size} $start={start} key={key}>
+              <Box
+                style={{height: '100%'}}
+                flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
+                border={index < partitionKeys.length - 1 ? 'bottom' : null}
+              >
+                <div>{partitionKeys[index]}</div>
+                {showRunTag ? (
+                  <div>
+                    {runForPartition ? (
+                      <TagLink to={`/runs/${runForPartition.id}`}>
+                        <RunStatusTagWithID
+                          runId={runForPartition.id}
+                          status={runForPartition.status}
+                        />
+                      </TagLink>
+                    ) : (
+                      <Tag>Run not found</Tag>
+                    )}
+                  </div>
+                ) : null}
+              </Box>
+            </Row>
+          );
+        })}
+      </Inner>
+    </Container>
+  );
+};
+
+export const RUN_STATUS_AND_PARTITION_KEY = gql`
+  query OldRunStatusAndPartitionKey($filter: RunsFilter) {
+    runsOrError(filter: $filter) {
+      ... on Runs {
+        results {
+          id
+          ...OldRunStatusAndTagsFragment
+        }
+      }
+      ... on InvalidPipelineRunsFilterError {
+        message
+      }
+      ...PythonErrorFragment
+    }
+  }
+
+  fragment OldRunStatusAndTagsFragment on Run {
+    id
+    status
+    tags {
+      key
+      value
+    }
+  }
+
+  ${PYTHON_ERROR_FRAGMENT}
+`;
+
+const TagLink = styled(Link)`
+  :focus {
+    outline: none;
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/AutomaterializeRightPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/AutomaterializeRightPanel.tsx
@@ -1,0 +1,209 @@
+import {gql, useQuery} from '@apollo/client';
+import {
+  Box,
+  Subheading,
+  Body,
+  ExternalAnchorButton,
+  Icon,
+  NonIdealState,
+  Spinner,
+  Mono,
+} from '@dagster-io/ui-components';
+import * as React from 'react';
+import {Link, Redirect} from 'react-router-dom';
+
+import {ErrorWrapper} from '../../app/PythonErrorInfo';
+import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../../app/QueryRefresh';
+import {AutomaterializePolicyTag} from '../AutomaterializePolicyTag';
+import {assetDetailsPathForKey} from '../assetDetailsPathForKey';
+import {AssetKey} from '../types';
+
+import {
+  OldGetPolicyInfoQuery,
+  OldGetPolicyInfoQueryVariables,
+} from './types/AutomaterializeRightPanel.types';
+
+interface Props {
+  assetKey: AssetKey;
+}
+
+export const AutomaterializeRightPanel = ({assetKey}: Props) => {
+  const queryResult = useQuery<OldGetPolicyInfoQuery, OldGetPolicyInfoQueryVariables>(
+    GET_POLICY_INFO_QUERY,
+    {variables: {assetKey}},
+  );
+
+  useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
+  const {data, error} = queryResult;
+
+  return (
+    <Box flex={{direction: 'column'}} style={{width: '294px', height: '100%'}} border="left">
+      <Box padding={16} border="bottom">
+        <Subheading>Overview</Subheading>
+      </Box>
+      <div style={{overflowY: 'auto'}}>
+        {error ? (
+          <Box padding={24}>
+            <ErrorWrapper>{JSON.stringify(error)}</ErrorWrapper>
+          </Box>
+        ) : !data ? (
+          <Box flex={{direction: 'row', justifyContent: 'center'}} padding={{vertical: 24}}>
+            <Spinner purpose="section" />
+          </Box>
+        ) : data.assetNodeOrError.__typename === 'AssetNotFoundError' ? (
+          <Redirect to="/assets" />
+        ) : (
+          <>
+            {data.assetNodeOrError.autoMaterializePolicy ? (
+              <RightPanelSection
+                title={
+                  <Box
+                    flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
+                  >
+                    Auto-materialize policy
+                    <AutomaterializePolicyTag
+                      policy={data.assetNodeOrError.autoMaterializePolicy}
+                    />
+                  </Box>
+                }
+              >
+                <Body style={{flex: 1}}>
+                  This asset will be automatically materialized when at least one of the conditions
+                  to the left is met and no skip conditions are met.
+                </Body>
+              </RightPanelSection>
+            ) : (
+              <Box padding={8}>
+                <NonIdealState
+                  title="No auto-materialize policy found"
+                  shrinkable
+                  description={
+                    <Box flex={{direction: 'column', gap: 8}}>
+                      <div>
+                        An auto-materialize policy specifies how Dagster should attempt to keep an
+                        asset up-to-date.
+                      </div>
+                      <div>
+                        <ExternalAnchorButton
+                          href="https://docs.dagster.io/_apidocs/assets#dagster.AutoMaterializePolicy"
+                          target="_blank"
+                          rel="noreferrer"
+                          icon={<Icon name="open_in_new" />}
+                        >
+                          View documentation
+                        </ExternalAnchorButton>
+                      </div>
+                    </Box>
+                  }
+                />
+              </Box>
+            )}
+            {data.assetNodeOrError.freshnessPolicy ? (
+              <RightPanelSection title="Freshness policy">
+                <RightPanelDetail
+                  title="Maximum lag minutes"
+                  value={data.assetNodeOrError.freshnessPolicy.maximumLagMinutes}
+                />
+                <Box flex={{direction: 'column', gap: 8}}>
+                  This asset will be considered late if it is not materialized within{' '}
+                  {data.assetNodeOrError.freshnessPolicy.maximumLagMinutes} minutes of it’s upstream
+                  dependencies.
+                  <Link
+                    to={assetDetailsPathForKey(assetKey, {
+                      view: 'lineage',
+                      lineageScope: 'upstream',
+                    })}
+                  >
+                    View upstream assets
+                  </Link>
+                </Box>
+              </RightPanelSection>
+            ) : (
+              <Box padding={8}>
+                <NonIdealState
+                  title="No freshness policy found"
+                  shrinkable
+                  description={
+                    <Box flex={{direction: 'column', gap: 8}}>
+                      <div>
+                        A FreshnessPolicy specifies how up-to-date you want a given asset to be.
+                      </div>
+                      <div>
+                        <ExternalAnchorButton
+                          href="https://docs.dagster.io/_apidocs/assets#dagster.FreshnessPolicy"
+                          target="_blank"
+                          rel="noreferrer"
+                          icon={<Icon name="open_in_new" />}
+                        >
+                          View documentation
+                        </ExternalAnchorButton>
+                      </div>
+                    </Box>
+                  }
+                />
+              </Box>
+            )}
+          </>
+        )}
+      </div>
+    </Box>
+  );
+};
+
+const RightPanelSection = ({
+  title,
+  children,
+}: {
+  title: React.ReactNode;
+  children: React.ReactNode;
+}) => {
+  return (
+    <Box
+      flex={{direction: 'column', gap: 12}}
+      border="bottom"
+      padding={{vertical: 12, horizontal: 16}}
+    >
+      <Subheading>{title}</Subheading>
+      {children}
+    </Box>
+  );
+};
+
+const RightPanelDetail = ({
+  title,
+  value,
+}: {
+  title: React.ReactNode;
+  tooltip?: React.ReactNode;
+  value: React.ReactNode;
+}) => {
+  return (
+    <Box flex={{direction: 'column', gap: 4}}>
+      <div>{title}</div>
+      <Mono style={{fontSize: '16px', fontWeight: 500}}>{value}</Mono>
+    </Box>
+  );
+};
+
+export const GET_POLICY_INFO_QUERY = gql`
+  query OldGetPolicyInfoQuery($assetKey: AssetKeyInput!) {
+    assetNodeOrError(assetKey: $assetKey) {
+      ... on AssetNode {
+        id
+        freshnessPolicy {
+          maximumLagMinutes
+          cronSchedule
+          cronScheduleTimezone
+        }
+        autoMaterializePolicy {
+          policyType
+          maxMaterializationsPerMinute
+          rules {
+            description
+            decisionType
+          }
+        }
+      }
+    }
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/AutomaterializeRunTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/AutomaterializeRunTag.tsx
@@ -1,0 +1,54 @@
+import {gql, useQuery} from '@apollo/client';
+import {Tag} from '@dagster-io/ui-components';
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+
+import {RunStatusTagWithID} from '../../runs/RunStatusTag';
+
+import {
+  OldRunStatusOnlyQuery,
+  OldRunStatusOnlyQueryVariables,
+} from './types/AutomaterializeRunTag.types';
+
+interface Props {
+  runId: string;
+}
+
+export const AutomaterializeRunTag = ({runId}: Props) => {
+  const {data, loading} = useQuery<OldRunStatusOnlyQuery, OldRunStatusOnlyQueryVariables>(
+    RUN_STATUS_ONLY,
+    {
+      variables: {runId},
+    },
+  );
+
+  if (loading && !data) {
+    return <Tag icon="spinner">Loading</Tag>;
+  }
+
+  const run = data?.runOrError;
+  if (run?.__typename !== 'Run') {
+    return (
+      <Tag icon="error" intent="danger">
+        Run not found
+      </Tag>
+    );
+  }
+
+  return (
+    <Link to={`/runs/${runId}`}>
+      <RunStatusTagWithID runId={runId} status={run.status} />
+    </Link>
+  );
+};
+
+export const RUN_STATUS_ONLY = gql`
+  query OldRunStatusOnlyQuery($runId: ID!) {
+    runOrError(runId: $runId) {
+      ... on Run {
+        id
+        status
+      }
+    }
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/CollapsibleSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/CollapsibleSection.tsx
@@ -1,0 +1,85 @@
+import {
+  Box,
+  Icon,
+  Subheading,
+  Tooltip,
+  colorAccentGray,
+  colorBackgroundLight,
+} from '@dagster-io/ui-components';
+import * as React from 'react';
+import styled from 'styled-components';
+
+interface Props {
+  header: React.ReactNode;
+  details: JSX.Element | string;
+  headerRightSide?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const CollapsibleSection = ({header, details, headerRightSide, children}: Props) => {
+  return (
+    <Collapsible
+      header={
+        <Box
+          flex={{
+            justifyContent: 'space-between',
+            gap: 12,
+            grow: 1,
+          }}
+        >
+          <Box flex={{direction: 'row', alignItems: 'center', gap: 8, grow: 1}}>
+            <Subheading>{header}</Subheading>
+            {details ? (
+              <Tooltip content={details} placement="top">
+                <Icon color={colorAccentGray()} name="info" />
+              </Tooltip>
+            ) : null}
+          </Box>
+          {headerRightSide}
+        </Box>
+      }
+    >
+      <Box padding={{vertical: 12, left: 32, right: 16}}>{children}</Box>
+    </Collapsible>
+  );
+};
+
+export const Collapsible = ({
+  header,
+  children,
+}: {
+  header: React.ReactNode;
+  children: React.ReactNode;
+}) => {
+  const [isCollapsed, setIsCollapsed] = React.useState(false);
+  return (
+    <Box flex={{direction: 'column'}} border="bottom">
+      <SectionHeader onClick={() => setIsCollapsed(!isCollapsed)}>
+        <Box
+          flex={{direction: 'row', alignItems: 'center', gap: 6}}
+          padding={{vertical: 8, horizontal: 12}}
+          border="bottom"
+        >
+          <Icon
+            name="arrow_drop_down"
+            style={{transform: isCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)'}}
+          />
+          <div>{header}</div>
+        </Box>
+      </SectionHeader>
+      {isCollapsed ? null : children}
+    </Box>
+  );
+};
+
+const SectionHeader = styled.button`
+  background-color: ${colorBackgroundLight()};
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+
+  :focus {
+    outline: none;
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/EvaluationCounts.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/EvaluationCounts.tsx
@@ -1,0 +1,73 @@
+import {
+  Box,
+  Caption,
+  colorTextBlue,
+  colorTextGreen,
+  colorTextLight,
+  colorTextLighter,
+  colorTextRed,
+  colorTextYellow,
+} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {compactNumber} from '../../ui/formatters';
+
+interface Props {
+  numRequested: number;
+  numSkipped: number;
+  numDiscarded: number;
+  isPartitionedAsset: boolean;
+  selected: boolean;
+}
+
+export const EvaluationCounts = React.memo((props: Props) => {
+  const {numRequested, numSkipped, numDiscarded, isPartitionedAsset, selected} = props;
+
+  const requested =
+    numRequested || isPartitionedAsset ? (
+      <Caption
+        key="requested"
+        color={selected ? colorTextBlue() : numRequested ? colorTextGreen() : colorTextLight()}
+      >
+        {isPartitionedAsset ? `${compactNumber(numRequested)} launched` : 'Launched'}
+      </Caption>
+    ) : null;
+
+  const skipped =
+    numSkipped || isPartitionedAsset ? (
+      <Caption
+        key="skipped"
+        color={selected ? colorTextBlue() : numSkipped ? colorTextYellow() : colorTextLight()}
+      >
+        {isPartitionedAsset ? `${compactNumber(numSkipped)} skipped` : 'Skipped'}
+      </Caption>
+    ) : null;
+
+  const discarded =
+    numDiscarded || isPartitionedAsset ? (
+      <Caption
+        key="discarded"
+        color={selected ? colorTextBlue() : numDiscarded ? colorTextRed() : colorTextLight()}
+      >
+        {isPartitionedAsset ? `${compactNumber(numDiscarded)} discarded` : 'Discarded'}
+      </Caption>
+    ) : null;
+
+  const filtered = [requested, skipped, discarded].filter(
+    (element): element is React.ReactElement => !!element,
+  );
+
+  return (
+    <Box flex={{direction: 'row', gap: 2, alignItems: 'center'}} style={{whiteSpace: 'nowrap'}}>
+      {filtered
+        .map((element, ii) => [
+          element,
+          <Caption key={`spacer-${ii}`} color={selected ? colorTextBlue() : colorTextLighter()}>
+            /
+          </Caption>,
+        ])
+        .flat()
+        .slice(0, -1)}
+    </Box>
+  );
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/GetEvaluationsQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/GetEvaluationsQuery.tsx
@@ -1,0 +1,86 @@
+import {gql} from '@apollo/client';
+
+export const GET_EVALUATIONS_QUERY = gql`
+  query OldGetEvaluationsQuery($assetKey: AssetKeyInput!, $limit: Int!, $cursor: String) {
+    assetNodeOrError(assetKey: $assetKey) {
+      __typename
+      ... on AssetNode {
+        id
+        autoMaterializePolicy {
+          rules {
+            description
+            decisionType
+            className
+          }
+        }
+        currentAutoMaterializeEvaluationId
+      }
+    }
+
+    autoMaterializeAssetEvaluationsOrError(assetKey: $assetKey, limit: $limit, cursor: $cursor) {
+      ... on AutoMaterializeAssetEvaluationRecords {
+        records {
+          id
+          ...AutoMaterializeEvaluationRecordItem
+        }
+      }
+      ... on AutoMaterializeAssetEvaluationNeedsMigrationError {
+        message
+      }
+    }
+  }
+
+  fragment AutoMaterializeEvaluationRecordItem on AutoMaterializeAssetEvaluationRecord {
+    id
+    evaluationId
+    numRequested
+    numSkipped
+    numDiscarded
+    timestamp
+    runIds
+    rulesWithRuleEvaluations {
+      ...RuleWithEvaluationsFragment
+    }
+    rules {
+      description
+      decisionType
+      className
+    }
+  }
+
+  fragment RuleWithEvaluationsFragment on AutoMaterializeRuleWithRuleEvaluations {
+    rule {
+      description
+      decisionType
+      className
+    }
+    ruleEvaluations {
+      evaluationData {
+        ... on TextRuleEvaluationData {
+          text
+        }
+        ... on ParentMaterializedRuleEvaluationData {
+          updatedAssetKeys {
+            path
+          }
+          willUpdateAssetKeys {
+            path
+          }
+        }
+        ... on WaitingOnKeysRuleEvaluationData {
+          waitingOnAssetKeys {
+            path
+          }
+        }
+      }
+      partitionKeysOrError {
+        ... on PartitionKeys {
+          partitionKeys
+        }
+        ... on Error {
+          message
+        }
+      }
+    }
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/ParentUpdatedLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/ParentUpdatedLink.tsx
@@ -1,0 +1,84 @@
+import {ButtonLink, Box} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {sortAssetKeys} from '../../asset-graph/Utils';
+import {VirtualizedItemListForDialog} from '../../ui/VirtualizedItemListForDialog';
+import {AssetLink} from '../AssetLink';
+import {AssetKey} from '../types';
+
+import {AssetKeysDialog, AssetKeysDialogEmptyState, AssetKeysDialogHeader} from './AssetKeysDialog';
+import {AssetDetailType, detailTypeToLabel} from './assetDetailUtils';
+import {useFilterAssetKeys} from './assetFilters';
+
+type AssetKeyDetail = {assetKey: AssetKey; detailType: AssetDetailType};
+
+interface Props {
+  updatedAssetKeys: AssetKey[];
+  willUpdateAssetKeys: AssetKey[];
+}
+
+export const ParentUpdatedLink = ({updatedAssetKeys, willUpdateAssetKeys}: Props) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [queryString, setQueryString] = React.useState('');
+  const count = updatedAssetKeys.length + willUpdateAssetKeys.length;
+
+  const filteredUpdatedAssetKeys = useFilterAssetKeys(updatedAssetKeys, queryString);
+  const filteredWillUpdateAssetKeys = useFilterAssetKeys(willUpdateAssetKeys, queryString);
+  const filteredCount = filteredUpdatedAssetKeys.length + filteredWillUpdateAssetKeys.length;
+
+  const filteredAssetKeys: AssetKeyDetail[] = React.useMemo(() => {
+    return [
+      ...[...filteredUpdatedAssetKeys].sort(sortAssetKeys).map((assetKey) => ({
+        assetKey,
+        detailType: AssetDetailType.Updated,
+      })),
+      ...[...filteredWillUpdateAssetKeys].sort(sortAssetKeys).map((assetKey) => ({
+        assetKey,
+        detailType: AssetDetailType.WillUpdate,
+      })),
+    ];
+  }, [filteredUpdatedAssetKeys, filteredWillUpdateAssetKeys]);
+
+  return (
+    <>
+      <ButtonLink onClick={() => setIsOpen(true)}>
+        {count === 1 ? '1 parent updated' : `${count} parents updated`}
+      </ButtonLink>
+      <AssetKeysDialog
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        header={
+          <AssetKeysDialogHeader
+            title={count === 1 ? '1 asset' : `${count} assets`}
+            showSearch={count > 0}
+            placeholder="Filter by asset key…"
+            queryString={queryString}
+            setQueryString={setQueryString}
+          />
+        }
+        content={
+          queryString && !filteredCount ? (
+            <AssetKeysDialogEmptyState
+              title="No matching asset keys"
+              description={
+                <>
+                  No matching asset keys for <strong>{queryString}</strong>
+                </>
+              }
+            />
+          ) : (
+            <VirtualizedItemListForDialog
+              items={filteredAssetKeys}
+              renderItem={(item) => (
+                <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+                  <AssetLink path={item.assetKey.path} icon="asset" />
+                  <span>({detailTypeToLabel(item.detailType)})</span>
+                </Box>
+              )}
+            />
+          )
+        }
+      />
+    </>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/ParentUpdatedPartitionLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/ParentUpdatedPartitionLink.tsx
@@ -1,0 +1,99 @@
+import {ButtonLink, Box, Tag, Caption} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {sortAssetKeys} from '../../asset-graph/Utils';
+import {AssetLink} from '../AssetLink';
+import {AssetKey} from '../types';
+
+import {AssetKeysDialog, AssetKeysDialogEmptyState, AssetKeysDialogHeader} from './AssetKeysDialog';
+import {VirtualizedAssetPartitionListForDialog} from './VirtualizedAssetPartitionListForDialog';
+import {AssetDetailType, detailTypeToLabel} from './assetDetailUtils';
+import {useFilterPartitionNames} from './assetFilters';
+
+interface Props {
+  updatedAssetKeys: Record<string, AssetKey[]>;
+  willUpdateAssetKeys: Record<string, AssetKey[]>;
+}
+
+export const ParentUpdatedPartitionLink = ({updatedAssetKeys, willUpdateAssetKeys}: Props) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [queryString, setQueryString] = React.useState('');
+
+  const partitionNames = React.useMemo(() => {
+    return Array.from(
+      new Set([...Object.keys(updatedAssetKeys), ...Object.keys(willUpdateAssetKeys)]),
+    );
+  }, [updatedAssetKeys, willUpdateAssetKeys]);
+
+  const count = partitionNames.length;
+  const filteredPartitionNames = useFilterPartitionNames(partitionNames, queryString);
+
+  const visiblePartitions = React.useMemo(() => {
+    return Object.fromEntries(
+      filteredPartitionNames.map((partitionName) => {
+        return [
+          partitionName,
+          [
+            ...(updatedAssetKeys[partitionName] || []).sort(sortAssetKeys).map((assetKey) => ({
+              assetKey,
+              detailType: AssetDetailType.Updated,
+            })),
+            ...(willUpdateAssetKeys[partitionName] || []).sort(sortAssetKeys).map((assetKey) => ({
+              assetKey,
+              detailType: AssetDetailType.WillUpdate,
+            })),
+          ],
+        ];
+      }),
+    );
+  }, [updatedAssetKeys, willUpdateAssetKeys, filteredPartitionNames]);
+
+  return (
+    <>
+      <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+        <Tag>{count === 1 ? `1 partition` : `${count} partitions`}</Tag>
+        <ButtonLink onClick={() => setIsOpen(true)}>
+          <Caption>View details</Caption>
+        </ButtonLink>
+      </Box>
+      <AssetKeysDialog
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        header={
+          <AssetKeysDialogHeader
+            title={count === 1 ? '1 partition' : `${count} partitions`}
+            placeholder="Filter by partition…"
+            queryString={queryString}
+            setQueryString={setQueryString}
+            showSearch={count > 0}
+          />
+        }
+        content={
+          queryString && !filteredPartitionNames.length ? (
+            <AssetKeysDialogEmptyState
+              title="No matching partitions"
+              description={
+                <>
+                  No matching partitions for <strong>{queryString}</strong>
+                </>
+              }
+            />
+          ) : (
+            <VirtualizedAssetPartitionListForDialog
+              assetKeysByPartition={visiblePartitions}
+              renderPartitionDetail={({assetCount}) =>
+                assetCount === 1 ? `(1 parent updated)` : `(${assetCount} parents updated)`
+              }
+              renderItem={(item) => (
+                <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+                  <AssetLink path={item.assetKey.path} icon="asset" />
+                  <span>({detailTypeToLabel(item.detailType)})</span>
+                </Box>
+              )}
+            />
+          )
+        }
+      />
+    </>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/PartitionSegmentWithPopover.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/PartitionSegmentWithPopover.tsx
@@ -1,0 +1,202 @@
+import {
+  Box,
+  MiddleTruncate,
+  Popover,
+  TextInput,
+  TextInputContainer,
+  colorAccentGray,
+  colorAccentGrayHover,
+  colorAccentGreen,
+  colorAccentGreenHover,
+  colorAccentYellow,
+  colorAccentYellowHover,
+} from '@dagster-io/ui-components';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import * as React from 'react';
+import styled from 'styled-components';
+
+import {assertUnreachable} from '../../app/Util';
+import {Container, Inner, Row} from '../../ui/VirtualizedTable';
+
+import {PolicyEvaluationStatusTag} from './PolicyEvaluationStatusTag';
+import {AssetConditionEvaluationStatus, AssetSubset} from './types';
+
+const statusToColors = (status: AssetConditionEvaluationStatus) => {
+  switch (status) {
+    case AssetConditionEvaluationStatus.TRUE:
+      return {color: colorAccentGreen(), hoverColor: colorAccentGreenHover()};
+    case AssetConditionEvaluationStatus.FALSE:
+      return {color: colorAccentYellow(), hoverColor: colorAccentYellowHover()};
+    case AssetConditionEvaluationStatus.SKIPPED:
+      return {color: colorAccentGray(), hoverColor: colorAccentGrayHover()};
+    default:
+      return assertUnreachable(status);
+  }
+};
+
+interface Props {
+  description: string;
+  status: AssetConditionEvaluationStatus;
+  subset: AssetSubset | null;
+  width: number;
+}
+
+export const PartitionSegmentWithPopover = ({description, width, status, subset}: Props) => {
+  const {color, hoverColor} = React.useMemo(() => statusToColors(status), [status]);
+  const segment = <PartitionSegment $color={color} $hoverColor={hoverColor} $width={width} />;
+  if (!subset) {
+    return segment;
+  }
+
+  return (
+    <SegmentContainer $width={width}>
+      <Popover
+        interactionKind="hover"
+        placement="bottom"
+        hoverOpenDelay={50}
+        hoverCloseDelay={50}
+        content={<PartitionSubsetList description={description} status={status} subset={subset} />}
+      >
+        {segment}
+      </Popover>
+    </SegmentContainer>
+  );
+};
+
+interface ListProps {
+  description: string;
+  status: AssetConditionEvaluationStatus;
+  subset: AssetSubset;
+}
+
+const ITEM_HEIGHT = 32;
+const MAX_ITEMS_BEFORE_TRUNCATION = 4;
+
+const PartitionSubsetList = ({description, status, subset}: ListProps) => {
+  const container = React.useRef<HTMLDivElement | null>(null);
+  const [searchValue, setSearchValue] = React.useState('');
+
+  const {color, hoverColor} = React.useMemo(() => statusToColors(status), [status]);
+
+  const partitionKeys = React.useMemo(() => subset.subsetValue.partitionKeys || [], [subset]);
+
+  const filteredKeys = React.useMemo(() => {
+    const searchLower = searchValue.toLocaleLowerCase();
+    return partitionKeys.filter((key) => key.toLocaleLowerCase().includes(searchLower));
+  }, [partitionKeys, searchValue]);
+
+  const count = filteredKeys.length;
+
+  const rowVirtualizer = useVirtualizer({
+    count: filteredKeys.length,
+    getScrollElement: () => container.current,
+    estimateSize: () => ITEM_HEIGHT,
+    overscan: 10,
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const virtualItems = rowVirtualizer.getVirtualItems();
+
+  return (
+    <div style={{width: '292px'}}>
+      <Box
+        padding={{vertical: 8, left: 12, right: 8}}
+        border="bottom"
+        flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
+      >
+        <strong>
+          <MiddleTruncate text={description} />
+        </strong>
+        <PolicyEvaluationStatusTag status={status} />
+      </Box>
+      {partitionKeys.length > MAX_ITEMS_BEFORE_TRUNCATION ? (
+        <SearchContainer padding={{vertical: 4, horizontal: 8}}>
+          <TextInput
+            icon="search"
+            placeholder="Filter partitions…"
+            value={searchValue}
+            onChange={(e) => setSearchValue(e.target.value)}
+          />
+        </SearchContainer>
+      ) : null}
+      <div
+        style={{
+          height: count > MAX_ITEMS_BEFORE_TRUNCATION ? '150px' : count * ITEM_HEIGHT,
+          overflow: 'hidden',
+        }}
+      >
+        <Container ref={container}>
+          <Inner $totalHeight={totalHeight}>
+            {virtualItems.map(({index, key, size, start}) => {
+              const partitionKey = filteredKeys[index]!;
+              return (
+                <Row $height={size} $start={start} key={key}>
+                  <Box
+                    style={{height: '100%'}}
+                    padding={{vertical: 8, horizontal: 16}}
+                    flex={{direction: 'row', alignItems: 'center', gap: 8}}
+                  >
+                    <PartitionStatusDot $color={color} $hoverColor={hoverColor} />
+                    <div>
+                      <MiddleTruncate text={partitionKey} />
+                    </div>
+                  </Box>
+                </Row>
+              );
+            })}
+          </Inner>
+        </Container>
+      </div>
+    </div>
+  );
+};
+
+const SegmentContainer = styled.div.attrs<{$width: number}>(({$width}) => ({
+  style: {
+    flexBasis: `${$width}px`,
+  },
+}))<{$width: number}>`
+  .bp4-popover2-target {
+    display: block;
+  }
+`;
+
+const SearchContainer = styled(Box)`
+  display: flex;
+  ${TextInputContainer} {
+    flex: 1;
+  }
+`;
+
+interface PartitionSegmentProps {
+  $color: string;
+  $hoverColor: string;
+  $width: number;
+}
+
+const PartitionSegment = styled.div.attrs<PartitionSegmentProps>(({$width}) => ({
+  style: {
+    flexBasis: `${$width}px`,
+  },
+}))<PartitionSegmentProps>`
+  background-color: ${({$color}) => $color};
+  border-radius: 2px;
+  height: 20px;
+  transition: background-color 100ms linear;
+
+  :hover {
+    background-color: ${({$hoverColor}) => $hoverColor};
+  }
+`;
+
+const PartitionStatusDot = styled.div<{$color: string; $hoverColor: string}>`
+  background-color: ${({$color}) => $color};
+  height: 8px;
+  width: 8px;
+  border-radius: 50%;
+  transition: background-color 100ms linear;
+
+  :hover {
+    background-color: ${({$hoverColor}) => $hoverColor};
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/PolicyEvaluationCondition.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/PolicyEvaluationCondition.tsx
@@ -1,0 +1,59 @@
+import {
+  Box,
+  Icon,
+  IconName,
+  colorAccentPrimary,
+  colorKeylineDefault,
+  colorTextDefault,
+  colorTextDisabled,
+} from '@dagster-io/ui-components';
+import * as React from 'react';
+import styled from 'styled-components';
+
+export type ConditionType = 'group' | 'leaf';
+
+interface Props {
+  depth: number;
+  icon: IconName;
+  label: React.ReactNode;
+  type: ConditionType;
+  skipped?: boolean;
+}
+
+export const PolicyEvaluationCondition = (props: Props) => {
+  const {depth, icon, label, type, skipped = false} = props;
+  const depthLines = React.useMemo(() => {
+    return new Array(depth).fill(null).map((_, ii) => <DepthLine key={ii} />);
+  }, [depth]);
+
+  return (
+    <Box
+      padding={{vertical: 2, horizontal: 8}}
+      flex={{direction: 'row', alignItems: 'center', gap: 8}}
+      style={{height: '48px'}}
+    >
+      {depthLines}
+      <Icon name={icon} color={colorAccentPrimary()} />
+      <ConditionLabel $type={type} $skipped={skipped}>
+        {label}
+      </ConditionLabel>
+    </Box>
+  );
+};
+
+const DepthLine = styled.div`
+  background-color: ${colorKeylineDefault()};
+  height: 100%;
+  margin: 0 4px 0 7px; /* 7px to align with center of icon in row above */
+  width: 2px;
+`;
+
+interface ConditionLabelProps {
+  $type: ConditionType;
+  $skipped: boolean;
+}
+
+const ConditionLabel = styled.div<ConditionLabelProps>`
+  font-weight: ${({$type}) => ($type === 'group' ? '600' : '400')};
+  color: ${({$skipped}) => ($skipped ? colorTextDisabled() : colorTextDefault())};
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/PolicyEvaluationStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/PolicyEvaluationStatusTag.tsx
@@ -1,0 +1,27 @@
+import {Tag} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {assertUnreachable} from '../../app/Util';
+
+import {AssetConditionEvaluationStatus} from './types';
+
+export const PolicyEvaluationStatusTag = ({status}: {status: AssetConditionEvaluationStatus}) => {
+  switch (status) {
+    case AssetConditionEvaluationStatus.FALSE:
+      return (
+        <Tag intent="warning" icon="cancel">
+          False
+        </Tag>
+      );
+    case AssetConditionEvaluationStatus.TRUE:
+      return (
+        <Tag intent="success" icon="check_circle">
+          True
+        </Tag>
+      );
+    case AssetConditionEvaluationStatus.SKIPPED:
+      return <Tag intent="none">Skipped</Tag>;
+    default:
+      return assertUnreachable(status);
+  }
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/PolicyEvaluationTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/PolicyEvaluationTable.tsx
@@ -1,0 +1,239 @@
+import {
+  Box,
+  Table,
+  colorBackgroundDefault,
+  colorBackgroundDefaultHover,
+  colorBackgroundLightHover,
+  colorKeylineDefault,
+} from '@dagster-io/ui-components';
+import * as React from 'react';
+import styled, {css} from 'styled-components';
+
+import {TimeElapsed} from '../../runs/TimeElapsed';
+
+import {PartitionSegmentWithPopover} from './PartitionSegmentWithPopover';
+import {PolicyEvaluationCondition} from './PolicyEvaluationCondition';
+import {PolicyEvaluationStatusTag} from './PolicyEvaluationStatusTag';
+import {flattenEvaluations} from './flattenEvaluations';
+import {
+  AssetConditionEvaluation,
+  AssetConditionEvaluationStatus,
+  PartitionedAssetConditionEvaluation,
+  UnpartitionedAssetConditionEvaluation,
+} from './types';
+
+interface Props<T> {
+  rootEvaluation: T;
+}
+
+export const PolicyEvaluationTable = <T extends AssetConditionEvaluation>({
+  rootEvaluation,
+}: Props<T>) => {
+  if (rootEvaluation.__typename === 'UnpartitionedAssetConditionEvaluation') {
+    return <UnpartitionedPolicyEvaluationTable rootEvaluation={rootEvaluation} />;
+  }
+
+  return <PartitionedPolicyEvaluationTable rootEvaluation={rootEvaluation} />;
+};
+
+const UnpartitionedPolicyEvaluationTable = ({
+  rootEvaluation,
+}: {
+  rootEvaluation: UnpartitionedAssetConditionEvaluation;
+}) => {
+  const [hoveredKey, setHoveredKey] = React.useState<number | null>(null);
+  const flattened = React.useMemo(() => flattenEvaluations(rootEvaluation), [rootEvaluation]);
+  return (
+    <VeryCompactTable>
+      <thead>
+        <tr>
+          <th>Condition</th>
+          <th>Result</th>
+          <th>Duration</th>
+          <th>Details</th>
+        </tr>
+      </thead>
+      <tbody>
+        {flattened.map(({evaluation, id, parentId, depth, type}) => {
+          const {description, endTimestamp, startTimestamp, status} = evaluation;
+          return (
+            <EvaluationRow
+              key={id}
+              $highlight={
+                hoveredKey === id ? 'hovered' : parentId === hoveredKey ? 'highlighted' : 'none'
+              }
+              onMouseEnter={() => setHoveredKey(id)}
+              onMouseLeave={() => setHoveredKey(null)}
+            >
+              <td>
+                <PolicyEvaluationCondition
+                  icon={type === 'group' ? 'resource' : 'wysiwyg'}
+                  label={description}
+                  skipped={status === AssetConditionEvaluationStatus.SKIPPED}
+                  depth={depth}
+                  type={type}
+                />
+              </td>
+              <td>
+                <PolicyEvaluationStatusTag status={status} />
+              </td>
+              <td>
+                <TimeElapsed startUnix={startTimestamp} endUnix={endTimestamp} />
+              </td>
+              <td></td>
+            </EvaluationRow>
+          );
+        })}
+      </tbody>
+    </VeryCompactTable>
+  );
+};
+
+const FULL_SEGMENTS_WIDTH = 200;
+
+const PartitionedPolicyEvaluationTable = ({
+  rootEvaluation,
+}: {
+  rootEvaluation: PartitionedAssetConditionEvaluation;
+}) => {
+  const [hoveredKey, setHoveredKey] = React.useState<number | null>(null);
+  const flattened = React.useMemo(() => flattenEvaluations(rootEvaluation), [rootEvaluation]);
+  return (
+    <VeryCompactTable>
+      <thead>
+        <tr>
+          <th>Condition</th>
+          <th>Result</th>
+          <th>Duration</th>
+        </tr>
+      </thead>
+      <tbody>
+        {flattened.map(({evaluation, id, parentId, depth, type}) => {
+          const {
+            description,
+            endTimestamp,
+            startTimestamp,
+            numTrue,
+            numFalse,
+            numSkipped,
+            trueSubset,
+            falseSubset,
+            candidateSubset,
+          } = evaluation;
+          const total = numTrue + numFalse + numSkipped;
+
+          return (
+            <EvaluationRow
+              key={id}
+              $highlight={
+                hoveredKey === id ? 'hovered' : parentId === hoveredKey ? 'highlighted' : 'none'
+              }
+              onMouseEnter={() => setHoveredKey(id)}
+              onMouseLeave={() => setHoveredKey(null)}
+            >
+              <td>
+                <PolicyEvaluationCondition
+                  icon={type === 'group' ? 'resource' : 'wysiwyg'}
+                  label={description}
+                  depth={depth}
+                  type={type}
+                />
+              </td>
+              <td style={{width: 0}}>
+                <Box
+                  flex={{direction: 'row', alignItems: 'center', gap: 2}}
+                  style={{width: FULL_SEGMENTS_WIDTH}}
+                >
+                  {numTrue > 0 ? (
+                    <PartitionSegmentWithPopover
+                      description={description}
+                      status={AssetConditionEvaluationStatus.TRUE}
+                      subset={trueSubset}
+                      width={Math.ceil((numTrue / total) * FULL_SEGMENTS_WIDTH)}
+                    />
+                  ) : null}
+                  {numFalse > 0 ? (
+                    <PartitionSegmentWithPopover
+                      status={AssetConditionEvaluationStatus.FALSE}
+                      description={description}
+                      subset={falseSubset}
+                      width={Math.ceil((numFalse / total) * FULL_SEGMENTS_WIDTH)}
+                    />
+                  ) : null}
+                  {numSkipped > 0 ? (
+                    <PartitionSegmentWithPopover
+                      status={AssetConditionEvaluationStatus.SKIPPED}
+                      description={description}
+                      subset={candidateSubset}
+                      width={Math.ceil((numSkipped / total) * FULL_SEGMENTS_WIDTH)}
+                    />
+                  ) : null}
+                </Box>
+              </td>
+              <td>
+                <TimeElapsed startUnix={startTimestamp} endUnix={endTimestamp} />
+              </td>
+            </EvaluationRow>
+          );
+        })}
+      </tbody>
+    </VeryCompactTable>
+  );
+};
+
+const VeryCompactTable = styled(Table)`
+  & tr td {
+    vertical-align: middle;
+  }
+
+  & tr td:first-child {
+    padding: 2px 16px;
+  }
+
+  & tr th:last-child,
+  & tr td:last-child {
+    box-shadow:
+      inset 1px 1px 0 ${colorKeylineDefault()},
+      inset -1px 0 0 ${colorKeylineDefault()} !important;
+  }
+
+  & tr:last-child td:last-child {
+    box-shadow:
+      inset -1px -1px 0 ${colorKeylineDefault()},
+      inset 1px 1px 0 ${colorKeylineDefault()} !important;
+  }
+`;
+
+type RowHighlightType = 'hovered' | 'highlighted' | 'none';
+
+const EvaluationRow = styled.tr<{$highlight: RowHighlightType}>`
+  background-color: ${({$highlight}) => {
+    switch ($highlight) {
+      case 'hovered':
+        return colorBackgroundLightHover();
+      case 'highlighted':
+        return colorBackgroundDefaultHover();
+      case 'none':
+        return colorBackgroundDefault();
+    }
+  }};
+
+  ${({$highlight}) => {
+    if ($highlight === 'hovered') {
+      return css`
+        && td {
+          box-shadow:
+            inset 0 -1px 0 ${colorKeylineDefault()},
+            inset 1px 1px 0 ${colorKeylineDefault()} !important;
+        }
+
+        && td:last-child {
+          box-shadow:
+            inset -1px -1px 0 ${colorKeylineDefault()},
+            inset 1px 1px 0 ${colorKeylineDefault()} !important;
+        }
+      `;
+    }
+    return '';
+  }}
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/RuleEvaluationOutcomes.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/RuleEvaluationOutcomes.tsx
@@ -1,0 +1,236 @@
+import {
+  Box,
+  Icon,
+  Tag,
+  colorTextDefault,
+  colorTextLight,
+  colorTextLighter,
+} from '@dagster-io/ui-components';
+import groupBy from 'lodash/groupBy';
+import * as React from 'react';
+
+import {assertUnreachable} from '../../app/Util';
+import {
+  AutoMaterializeDecisionType,
+  AutoMaterializeRule,
+  AutoMaterializeRuleEvaluation,
+} from '../../graphql/types';
+
+import {AutomaterializeRequestedPartitionsLink} from './AutomaterializeRequestedPartitionsLink';
+import {CollapsibleSection} from './CollapsibleSection';
+import {ParentUpdatedLink} from './ParentUpdatedLink';
+import {ParentUpdatedPartitionLink} from './ParentUpdatedPartitionLink';
+import {WaitingOnAssetKeysLink} from './WaitingOnAssetKeysLink';
+import {WaitingOnAssetKeysPartitionLink} from './WaitingOnAssetKeysPartitionLink';
+import {RuleWithEvaluationsFragment} from './types/GetEvaluationsQuery.types';
+
+interface RuleEvaluationOutcomeProps {
+  text: string;
+  met: boolean;
+  rightElement?: React.ReactNode;
+}
+
+const RuleEvaluationOutcome = ({text, met, rightElement}: RuleEvaluationOutcomeProps) => {
+  return (
+    <Box
+      flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
+      style={{height: 24}}
+    >
+      <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+        <Icon name={met ? 'done' : 'close'} color={met ? colorTextDefault() : colorTextLight()} />
+        <div style={{color: met ? colorTextDefault() : colorTextLight()}}>
+          {text.slice(0, 1).toUpperCase()}
+          {text.slice(1)}
+        </div>
+      </Box>
+      {rightElement}
+    </Box>
+  );
+};
+
+const SECTIONS: {
+  decisionType: AutoMaterializeDecisionType;
+  header: string;
+  details: string;
+  intent?: React.ComponentProps<typeof Tag>['intent'];
+  partitionedOnly?: boolean;
+}[] = [
+  {
+    decisionType: AutoMaterializeDecisionType.MATERIALIZE,
+    header: 'Materialization conditions met',
+    details:
+      'These conditions trigger a materialization, unless they are blocked by a skip or discard condition.',
+  },
+  {
+    decisionType: AutoMaterializeDecisionType.SKIP,
+    header: 'Skip conditions met',
+    details: 'Skips will materialize in a future evaluation, once the skip condition is resolved.',
+  },
+  {
+    decisionType: AutoMaterializeDecisionType.DISCARD,
+    header: 'Discard conditions met',
+    details:
+      'Discarded partitions will not be materialized unless new materialization conditions occur. You may want to run a manual backfill to respond to the materialize conditions.',
+    intent: 'danger',
+    partitionedOnly: true,
+  },
+];
+
+interface RuleEvaluationOutcomesProps {
+  rules: AutoMaterializeRule[];
+  ruleEvaluations: RuleWithEvaluationsFragment[];
+  assetHasDefinedPartitions: boolean;
+}
+
+export const RuleEvaluationOutcomes = ({
+  rules,
+  ruleEvaluations,
+  assetHasDefinedPartitions,
+}: RuleEvaluationOutcomesProps) => {
+  const groupedRules = groupBy(rules, (rule) => rule.decisionType);
+
+  return (
+    <>
+      {SECTIONS.filter(
+        (section) =>
+          groupedRules[section.decisionType] &&
+          (assetHasDefinedPartitions || !section.partitionedOnly),
+      ).map((section) => (
+        <CollapsibleSection
+          key={section.decisionType}
+          header={section.header}
+          details={section.details}
+        >
+          <Box flex={{direction: 'column', gap: 8}}>
+            {(groupedRules[section.decisionType] || []).map(({description}, idx) => {
+              const evaluations =
+                ruleEvaluations.find((e) => e.rule?.description === description)?.ruleEvaluations ||
+                [];
+              return (
+                <RuleEvaluationOutcome
+                  key={idx}
+                  text={description}
+                  met={evaluations.length > 0}
+                  rightElement={
+                    assetHasDefinedPartitions ? (
+                      <RightElementForPartitionedEvaluations
+                        evaluations={evaluations}
+                        intent={section.intent}
+                      />
+                    ) : (
+                      <RightElementForEvaluations
+                        evaluations={evaluations}
+                        intent={section.intent}
+                      />
+                    )
+                  }
+                />
+              );
+            })}
+          </Box>
+        </CollapsibleSection>
+      ))}
+    </>
+  );
+};
+
+const RightElementForEvaluations = ({
+  evaluations,
+}: {
+  evaluations: AutoMaterializeRuleEvaluation[];
+  intent?: React.ComponentProps<typeof Tag>['intent'];
+}) => {
+  const first = evaluations.map((e) => e.evaluationData!).find(Boolean);
+  if (!first) {
+    return <div style={{color: colorTextLighter()}}>&ndash;</div>;
+  }
+  switch (first.__typename) {
+    case 'ParentMaterializedRuleEvaluationData':
+      return (
+        <ParentUpdatedLink
+          updatedAssetKeys={first.updatedAssetKeys || []}
+          willUpdateAssetKeys={first.willUpdateAssetKeys || []}
+        />
+      );
+    case 'WaitingOnKeysRuleEvaluationData':
+      return <WaitingOnAssetKeysLink assetKeys={first.waitingOnAssetKeys || []} />;
+    case 'TextRuleEvaluationData':
+      return <span>{first.text}</span>;
+    default:
+      assertUnreachable(first);
+  }
+
+  return <span />;
+};
+
+const partitionKeysOf = (e: AutoMaterializeRuleEvaluation) =>
+  e.partitionKeysOrError?.__typename === 'PartitionKeys'
+    ? e.partitionKeysOrError.partitionKeys
+    : [];
+
+const RightElementForPartitionedEvaluations = ({
+  evaluations,
+  intent,
+}: {
+  evaluations: AutoMaterializeRuleEvaluation[];
+  intent?: React.ComponentProps<typeof Tag>['intent'];
+}) => {
+  const evaluationsWithData = evaluations.filter((e) => !!e.evaluationData);
+  const first = evaluationsWithData[0]?.evaluationData;
+  if (!first) {
+    const partitionKeys = evaluations.flatMap(partitionKeysOf);
+    return partitionKeys.length ? (
+      <AutomaterializeRequestedPartitionsLink partitionKeys={partitionKeys} intent={intent} />
+    ) : (
+      <div style={{color: colorTextLighter()}}>&ndash;</div>
+    );
+  }
+
+  const typename = first.__typename;
+  switch (typename) {
+    case 'ParentMaterializedRuleEvaluationData':
+      const updatedAssetKeys = Object.fromEntries(
+        evaluationsWithData.flatMap((e) =>
+          partitionKeysOf(e).map((key) => [
+            key,
+            (e.evaluationData?.__typename === 'ParentMaterializedRuleEvaluationData' &&
+              e.evaluationData.updatedAssetKeys) ||
+              [],
+          ]),
+        ),
+      );
+      const willUpdateAssetKeys = Object.fromEntries(
+        evaluationsWithData.flatMap((e) =>
+          partitionKeysOf(e).map((key) => [
+            key,
+            (e.evaluationData?.__typename === 'ParentMaterializedRuleEvaluationData' &&
+              e.evaluationData.willUpdateAssetKeys) ||
+              [],
+          ]),
+        ),
+      );
+
+      return (
+        <ParentUpdatedPartitionLink
+          updatedAssetKeys={updatedAssetKeys}
+          willUpdateAssetKeys={willUpdateAssetKeys}
+        />
+      );
+    case 'WaitingOnKeysRuleEvaluationData':
+      const assetKeysByPartition = Object.fromEntries(
+        evaluationsWithData.flatMap((e) =>
+          partitionKeysOf(e).map((key) => [
+            key,
+            (e.evaluationData?.__typename === 'WaitingOnKeysRuleEvaluationData' &&
+              e.evaluationData.waitingOnAssetKeys) ||
+              [],
+          ]),
+        ),
+      );
+      return <WaitingOnAssetKeysPartitionLink assetKeysByPartition={assetKeysByPartition} />;
+    case 'TextRuleEvaluationData':
+      return <span>{first.text}</span>;
+    default:
+      assertUnreachable(typename);
+  }
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/VirtualizedAssetPartitionListForDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/VirtualizedAssetPartitionListForDialog.tsx
@@ -1,0 +1,144 @@
+import {Box, Icon} from '@dagster-io/ui-components';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import * as React from 'react';
+import styled from 'styled-components';
+
+import {COMMON_COLLATOR} from '../../app/Util';
+import {Container, Inner, Row} from '../../ui/VirtualizedTable';
+
+interface Props<A> {
+  assetKeysByPartition: Record<string, A[]>;
+  renderPartitionDetail: (item: PartitionRow) => React.ReactNode;
+  renderItem: (item: A) => React.ReactNode;
+}
+
+type PartitionRow = {
+  type: 'partition-name';
+  partitionName: string;
+  expanded: boolean;
+  assetCount: number;
+};
+
+type Row<A> = PartitionRow | {type: 'asset-key'; assetKey: A};
+
+export function VirtualizedAssetPartitionListForDialog<A>({
+  assetKeysByPartition,
+  renderPartitionDetail,
+  renderItem,
+}: Props<A>) {
+  const [expandedPartitions, setExpandedPartitions] = React.useState<Set<string>>(
+    () => new Set([]),
+  );
+  const container = React.useRef<HTMLDivElement | null>(null);
+
+  const allRows = React.useMemo(() => {
+    const rows = [] as Row<A>[];
+    const partitionNames = Object.keys(assetKeysByPartition).sort((a, b) =>
+      COMMON_COLLATOR.compare(a, b),
+    );
+    partitionNames.forEach((partitionName) => {
+      const assetKeys = assetKeysByPartition[partitionName]!;
+      const expanded = expandedPartitions.has(partitionName);
+      rows.push({type: 'partition-name', partitionName, expanded, assetCount: assetKeys.length});
+      if (expanded) {
+        const assetRows: Row<A>[] = assetKeys.map((assetKey) => ({type: 'asset-key', assetKey}));
+        rows.push(...assetRows);
+      }
+    });
+    return rows;
+  }, [assetKeysByPartition, expandedPartitions]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: allRows.length,
+    getScrollElement: () => container.current,
+    estimateSize: () => 40,
+    overscan: 10,
+  });
+
+  const onToggle = React.useCallback((partitionName: string) => {
+    setExpandedPartitions((current) => {
+      const copy = new Set(Array.from(current));
+      if (current.has(partitionName)) {
+        copy.delete(partitionName);
+      } else {
+        copy.add(partitionName);
+      }
+      return copy;
+    });
+  }, []);
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const items = rowVirtualizer.getVirtualItems();
+
+  return (
+    <Container ref={container} style={{padding: '8px 24px'}}>
+      <Inner $totalHeight={totalHeight}>
+        {items.map(({index, key, size, start}) => {
+          const row = allRows[index]!;
+          return (
+            <Row $height={size} $start={start} key={key}>
+              <Box
+                style={{height: '100%'}}
+                flex={{direction: 'row', alignItems: 'center'}}
+                border={index < allRows.length - 1 ? 'bottom' : null}
+              >
+                {row.type === 'partition-name' ? (
+                  <ExpandablePartitionName
+                    partitionName={row.partitionName}
+                    expanded={row.expanded}
+                    detail={renderPartitionDetail(row)}
+                    onToggle={onToggle}
+                  />
+                ) : (
+                  <Box padding={{left: 24}}>{renderItem(row.assetKey)}</Box>
+                )}
+              </Box>
+            </Row>
+          );
+        })}
+      </Inner>
+    </Container>
+  );
+}
+
+interface ExpandablePartitionNameProps {
+  partitionName: string;
+  expanded: boolean;
+  detail: React.ReactNode;
+  onToggle: (partitionName: string) => void;
+}
+
+const ExpandablePartitionName = ({
+  partitionName,
+  detail,
+  expanded,
+  onToggle,
+}: ExpandablePartitionNameProps) => {
+  return (
+    <PartitionNameButton onClick={() => onToggle(partitionName)}>
+      <Icon
+        name="arrow_drop_down"
+        style={{transform: expanded ? 'rotate(0deg)' : 'rotate(-90deg)'}}
+      />
+      <div>{partitionName}</div>
+      <div>{detail}</div>
+    </PartitionNameButton>
+  );
+};
+
+const PartitionNameButton = styled.button`
+  background-color: transparent;
+  cursor: pointer;
+  padding: 0;
+  border: 0;
+  display: flex;
+  height: 100%;
+  width: 100%;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+
+  :focus {
+    outline: none;
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/WaitingOnAssetKeysLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/WaitingOnAssetKeysLink.tsx
@@ -1,0 +1,58 @@
+import {ButtonLink} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {VirtualizedItemListForDialog} from '../../ui/VirtualizedItemListForDialog';
+import {AssetLink} from '../AssetLink';
+import {AssetKey} from '../types';
+
+import {AssetKeysDialog, AssetKeysDialogEmptyState, AssetKeysDialogHeader} from './AssetKeysDialog';
+import {useFilterAssetKeys} from './assetFilters';
+
+interface Props {
+  assetKeys: AssetKey[];
+}
+
+export const WaitingOnAssetKeysLink = ({assetKeys}: Props) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [queryString, setQueryString] = React.useState('');
+  const count = assetKeys.length;
+  const filteredAssetKeys = useFilterAssetKeys(assetKeys, queryString);
+
+  return (
+    <>
+      <ButtonLink onClick={() => setIsOpen(true)}>
+        {count === 1 ? 'Waiting on 1 asset' : `Waiting on ${count} assets`}
+      </ButtonLink>
+      <AssetKeysDialog
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        header={
+          <AssetKeysDialogHeader
+            title={count === 1 ? '1 asset' : `${count} assets`}
+            queryString={queryString}
+            setQueryString={setQueryString}
+            showSearch={count > 0}
+            placeholder="Filter by asset key…"
+          />
+        }
+        content={
+          queryString && !filteredAssetKeys.length ? (
+            <AssetKeysDialogEmptyState
+              title="No matching asset keys"
+              description={
+                <>
+                  No matching asset keys for <strong>{queryString}</strong>
+                </>
+              }
+            />
+          ) : (
+            <VirtualizedItemListForDialog
+              items={filteredAssetKeys}
+              renderItem={(item: AssetKey) => <AssetLink path={item.path} icon="asset" />}
+            />
+          )
+        }
+      />
+    </>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/WaitingOnAssetKeysPartitionLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/WaitingOnAssetKeysPartitionLink.tsx
@@ -1,0 +1,75 @@
+import {ButtonLink, Box, Tag, Caption} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {sortAssetKeys} from '../../asset-graph/Utils';
+import {AssetLink} from '../AssetLink';
+import {AssetKey} from '../types';
+
+import {AssetKeysDialog, AssetKeysDialogEmptyState, AssetKeysDialogHeader} from './AssetKeysDialog';
+import {VirtualizedAssetPartitionListForDialog} from './VirtualizedAssetPartitionListForDialog';
+import {useFilterPartitionNames} from './assetFilters';
+
+interface Props {
+  assetKeysByPartition: Record<string, AssetKey[]>;
+}
+
+export const WaitingOnAssetKeysPartitionLink = ({assetKeysByPartition}: Props) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [queryString, setQueryString] = React.useState('');
+  const partitionNames = Object.keys(assetKeysByPartition);
+  const count = partitionNames.length;
+  const filteredPartitionNames = useFilterPartitionNames(partitionNames, queryString);
+
+  const visiblePartitions = React.useMemo(() => {
+    return Object.fromEntries(
+      filteredPartitionNames.map((partitionName) => [
+        partitionName,
+        [...assetKeysByPartition[partitionName]!].sort(sortAssetKeys),
+      ]),
+    );
+  }, [assetKeysByPartition, filteredPartitionNames]);
+
+  return (
+    <>
+      <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+        <Tag intent="warning">{count === 1 ? `1 partition` : `${count} partitions`}</Tag>
+        <ButtonLink onClick={() => setIsOpen(true)}>
+          <Caption>View details</Caption>
+        </ButtonLink>
+      </Box>
+      <AssetKeysDialog
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        header={
+          <AssetKeysDialogHeader
+            title={count === 1 ? '1 partition' : `${count} partitions`}
+            queryString={queryString}
+            setQueryString={setQueryString}
+            showSearch={count > 0}
+            placeholder="Filter by partition…"
+          />
+        }
+        content={
+          queryString && !filteredPartitionNames.length ? (
+            <AssetKeysDialogEmptyState
+              title="No matching partitions"
+              description={
+                <>
+                  No matching partitions for <strong>{queryString}</strong>
+                </>
+              }
+            />
+          ) : (
+            <VirtualizedAssetPartitionListForDialog
+              assetKeysByPartition={visiblePartitions}
+              renderPartitionDetail={({assetCount}) =>
+                assetCount === 1 ? `(Waiting on 1 asset)` : `(Waiting on ${assetCount} assets)`
+              }
+              renderItem={(item: AssetKey) => <AssetLink path={item.path} icon="asset" />}
+            />
+          )
+        }
+      />
+    </>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__fixtures__/AutoMaterializePolicyPage.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__fixtures__/AutoMaterializePolicyPage.fixtures.ts
@@ -1,0 +1,436 @@
+import {MockedResponse} from '@apollo/client/testing';
+import {DocumentNode} from 'graphql';
+
+import {
+  AutoMaterializeDecisionType,
+  AutoMaterializePolicyType,
+  buildAssetKey,
+  buildAssetNode,
+  buildAutoMaterializeAssetEvaluationNeedsMigrationError,
+  buildAutoMaterializeAssetEvaluationRecord,
+  buildAutoMaterializeAssetEvaluationRecords,
+  buildAutoMaterializePolicy,
+  buildAutoMaterializeRule,
+  buildAutoMaterializeRuleEvaluation,
+  buildAutoMaterializeRuleWithRuleEvaluations,
+  buildFreshnessPolicy,
+  buildParentMaterializedRuleEvaluationData,
+  buildPartitionKeys,
+} from '../../../graphql/types';
+import {GET_POLICY_INFO_QUERY} from '../AutomaterializeRightPanel';
+import {GET_EVALUATIONS_QUERY} from '../GetEvaluationsQuery';
+import {
+  OldGetPolicyInfoQuery,
+  OldGetPolicyInfoQueryVariables,
+} from '../types/AutomaterializeRightPanel.types';
+import {
+  OldGetEvaluationsQuery,
+  OldGetEvaluationsQueryVariables,
+} from '../types/GetEvaluationsQuery.types';
+import {PAGE_SIZE} from '../useEvaluationsQueryResult';
+
+export function buildQueryMock<
+  TQuery extends {__typename: 'Query'},
+  TVariables extends Record<string, any>,
+>({
+  query,
+  variables,
+  data,
+}: {
+  query: DocumentNode;
+  variables: TVariables;
+  data: Omit<TQuery, '__typename'>;
+}): MockedResponse<TQuery> {
+  return {
+    request: {
+      query,
+      variables,
+    },
+    result: {
+      data: {
+        __typename: 'Query',
+        ...data,
+      } as TQuery,
+    },
+  };
+}
+
+export const buildGetEvaluationsQuery = ({
+  variables,
+  data,
+}: {
+  variables: OldGetEvaluationsQueryVariables;
+  data: Omit<OldGetEvaluationsQuery, '__typename'>;
+}): MockedResponse<OldGetEvaluationsQuery> => {
+  return buildQueryMock({
+    query: GET_EVALUATIONS_QUERY,
+    variables,
+    data,
+  });
+};
+
+export const buildGetPolicyInfoQuery = ({
+  variables,
+  data,
+}: {
+  variables: OldGetPolicyInfoQueryVariables;
+  data: Omit<OldGetPolicyInfoQuery, '__typename'>;
+}): MockedResponse<OldGetPolicyInfoQuery> => {
+  return buildQueryMock({
+    query: GET_POLICY_INFO_QUERY,
+    variables,
+    data,
+  });
+};
+
+const ONE_MINUTE = 1000 * 60;
+
+export const TEST_EVALUATION_ID = 27;
+
+export const buildEvaluationRecordsWithPartitions = () => {
+  const now = Date.now();
+  return [
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'g',
+      evaluationId: TEST_EVALUATION_ID,
+      timestamp: (now - ONE_MINUTE * 6) / 1000,
+      numRequested: 2,
+      numSkipped: 2,
+      numDiscarded: 2,
+    }),
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'f',
+      evaluationId: 24,
+      timestamp: (now - ONE_MINUTE * 5) / 1000,
+      numRequested: 2,
+      numSkipped: 2,
+      numDiscarded: 0,
+    }),
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'e',
+      evaluationId: 20,
+      timestamp: (now - ONE_MINUTE * 4) / 1000,
+      numRequested: 0,
+      numSkipped: 2410,
+      numDiscarded: 3560,
+    }),
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'd',
+      evaluationId: 13,
+      timestamp: (now - ONE_MINUTE * 3) / 1000,
+      numRequested: 2,
+      numSkipped: 0,
+      numDiscarded: 2,
+    }),
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'c',
+      timestamp: (now - ONE_MINUTE * 2) / 1000,
+      evaluationId: 12,
+      numRequested: 0,
+      numSkipped: 0,
+      numDiscarded: 2,
+    }),
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'b',
+      evaluationId: 4,
+      timestamp: (now - ONE_MINUTE) / 1000,
+      numRequested: 0,
+      numSkipped: 2,
+      numDiscarded: 0,
+    }),
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'a',
+      evaluationId: 0,
+      timestamp: now / 1000,
+      numRequested: 2,
+      numSkipped: 0,
+      numDiscarded: 0,
+    }),
+  ];
+};
+
+export const buildEvaluationRecordsWithoutPartitions = () => {
+  const now = Date.now();
+  return [
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'g',
+      evaluationId: TEST_EVALUATION_ID,
+      timestamp: (now - ONE_MINUTE * 6) / 1000,
+      numRequested: 1,
+      numSkipped: 0,
+      numDiscarded: 0,
+    }),
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'f',
+      evaluationId: 24,
+      timestamp: (now - ONE_MINUTE * 5) / 1000,
+      numRequested: 0,
+      numSkipped: 1,
+      numDiscarded: 0,
+    }),
+    buildAutoMaterializeAssetEvaluationRecord({
+      id: 'e',
+      evaluationId: 20,
+      timestamp: (now - ONE_MINUTE * 4) / 1000,
+      numRequested: 0,
+      numSkipped: 0,
+      numDiscarded: 1,
+    }),
+  ];
+};
+
+export const SINGLE_MATERIALIZE_RECORD_WITH_PARTITIONS = buildAutoMaterializeAssetEvaluationRecord({
+  evaluationId: TEST_EVALUATION_ID,
+  runIds: ['abcdef12'],
+  rulesWithRuleEvaluations: [
+    buildAutoMaterializeRuleWithRuleEvaluations({
+      rule: buildAutoMaterializeRule({
+        decisionType: AutoMaterializeDecisionType.MATERIALIZE,
+        description: `Upstream data has changed since latest materialization`,
+      }),
+      ruleEvaluations: [
+        buildAutoMaterializeRuleEvaluation({
+          evaluationData: buildParentMaterializedRuleEvaluationData({
+            updatedAssetKeys: [buildAssetKey({path: ['upstream_1']})],
+          }),
+          partitionKeysOrError: buildPartitionKeys({
+            partitionKeys: ['bar'],
+          }),
+        }),
+        buildAutoMaterializeRuleEvaluation({
+          evaluationData: buildParentMaterializedRuleEvaluationData({
+            updatedAssetKeys: [
+              buildAssetKey({path: ['upstream_1']}),
+              buildAssetKey({path: ['upstream_2']}),
+            ],
+          }),
+          partitionKeysOrError: buildPartitionKeys({
+            partitionKeys: ['foo'],
+          }),
+        }),
+      ],
+    }),
+    buildAutoMaterializeRuleWithRuleEvaluations({
+      rule: buildAutoMaterializeRule({
+        decisionType: AutoMaterializeDecisionType.SKIP,
+        description: `Waiting on upstream data`,
+      }),
+      ruleEvaluations: [
+        buildAutoMaterializeRuleEvaluation({
+          evaluationData: null,
+          partitionKeysOrError: buildPartitionKeys({
+            partitionKeys: ['gomez'],
+          }),
+        }),
+      ],
+    }),
+  ],
+});
+
+export const SINGLE_MATERIALIZE_RECORD_NO_PARTITIONS = buildAutoMaterializeAssetEvaluationRecord({
+  evaluationId: TEST_EVALUATION_ID,
+  runIds: ['abcdef12'],
+  rulesWithRuleEvaluations: [
+    buildAutoMaterializeRuleWithRuleEvaluations({
+      rule: buildAutoMaterializeRule({
+        decisionType: AutoMaterializeDecisionType.MATERIALIZE,
+        description: `Materialization is missing`,
+      }),
+      ruleEvaluations: [
+        buildAutoMaterializeRuleEvaluation({
+          evaluationData: null,
+          partitionKeysOrError: null,
+        }),
+      ],
+    }),
+  ],
+});
+
+export const BASE_AUTOMATERIALIZE_RULES = [
+  buildAutoMaterializeRule({
+    decisionType: AutoMaterializeDecisionType.MATERIALIZE,
+    description: `Materialization is missing`,
+  }),
+  buildAutoMaterializeRule({
+    decisionType: AutoMaterializeDecisionType.MATERIALIZE,
+    description: `Upstream data has changed since latest materialization`,
+  }),
+  buildAutoMaterializeRule({
+    decisionType: AutoMaterializeDecisionType.MATERIALIZE,
+    description: `Required to meet this or downstream asset's freshness policy`,
+  }),
+  buildAutoMaterializeRule({
+    decisionType: AutoMaterializeDecisionType.SKIP,
+    description: `Waiting on upstream data`,
+  }),
+];
+
+export const DISCARD_RULE = buildAutoMaterializeRule({
+  decisionType: AutoMaterializeDecisionType.DISCARD,
+  description: `Exceeds 5 materializations per minute`,
+});
+
+export const Evaluations = {
+  None: (assetKeyPath: string[], single?: boolean) => {
+    return buildGetEvaluationsQuery({
+      variables: {
+        assetKey: {path: assetKeyPath},
+        cursor: single ? '2' : undefined,
+        limit: (single ? 1 : PAGE_SIZE) + 1,
+      },
+      data: {
+        assetNodeOrError: buildAssetNode({
+          autoMaterializePolicy: buildAutoMaterializePolicy({
+            rules: BASE_AUTOMATERIALIZE_RULES,
+          }),
+          currentAutoMaterializeEvaluationId: 1000,
+        }),
+        autoMaterializeAssetEvaluationsOrError: buildAutoMaterializeAssetEvaluationRecords({
+          records: [],
+        }),
+      },
+    });
+  },
+  Errors: (assetKeyPath: string[], single?: boolean) => {
+    return buildGetEvaluationsQuery({
+      variables: {
+        assetKey: {path: assetKeyPath},
+        cursor: single ? '2' : undefined,
+        limit: (single ? 1 : PAGE_SIZE) + 1,
+      },
+      data: {
+        assetNodeOrError: buildAssetNode({
+          autoMaterializePolicy: buildAutoMaterializePolicy({
+            rules: BASE_AUTOMATERIALIZE_RULES,
+          }),
+        }),
+        autoMaterializeAssetEvaluationsOrError:
+          buildAutoMaterializeAssetEvaluationNeedsMigrationError({
+            message: 'Test message',
+          }),
+      },
+    });
+  },
+  Single: (assetKeyPath?: string[], cursor?: string) => {
+    return buildGetEvaluationsQuery({
+      variables: {
+        assetKey: {path: assetKeyPath || ['test']},
+        cursor,
+        limit: 2,
+      },
+      data: {
+        assetNodeOrError: buildAssetNode({
+          autoMaterializePolicy: buildAutoMaterializePolicy({
+            rules: [...BASE_AUTOMATERIALIZE_RULES, DISCARD_RULE],
+          }),
+        }),
+        autoMaterializeAssetEvaluationsOrError: buildAutoMaterializeAssetEvaluationRecords({
+          records: assetKeyPath ? [SINGLE_MATERIALIZE_RECORD_NO_PARTITIONS] : [],
+        }),
+      },
+    });
+  },
+  SinglePartitioned: (assetKeyPath: string[], cursor?: string) => {
+    return buildGetEvaluationsQuery({
+      variables: {
+        assetKey: {path: assetKeyPath},
+        cursor,
+        limit: 2,
+      },
+      data: {
+        assetNodeOrError: buildAssetNode({
+          autoMaterializePolicy: buildAutoMaterializePolicy({
+            rules: [...BASE_AUTOMATERIALIZE_RULES, DISCARD_RULE],
+          }),
+        }),
+        autoMaterializeAssetEvaluationsOrError: buildAutoMaterializeAssetEvaluationRecords({
+          records: assetKeyPath ? [SINGLE_MATERIALIZE_RECORD_WITH_PARTITIONS] : [],
+        }),
+      },
+    });
+  },
+  Some: (assetKeyPath: string[]) => {
+    return buildGetEvaluationsQuery({
+      variables: {
+        assetKey: {path: assetKeyPath},
+        cursor: undefined,
+        limit: PAGE_SIZE + 1,
+      },
+      data: {
+        assetNodeOrError: buildAssetNode({
+          autoMaterializePolicy: buildAutoMaterializePolicy({
+            rules: [...BASE_AUTOMATERIALIZE_RULES, DISCARD_RULE],
+          }),
+        }),
+        autoMaterializeAssetEvaluationsOrError: buildAutoMaterializeAssetEvaluationRecords({
+          records: buildEvaluationRecordsWithPartitions(),
+        }),
+      },
+    });
+  },
+};
+
+export const Policies = {
+  YesAutomaterializeNoFreshnessPolicy: (
+    assetKeyPath: string[],
+    policyType: AutoMaterializePolicyType = AutoMaterializePolicyType.EAGER,
+  ) => {
+    return buildGetPolicyInfoQuery({
+      variables: {
+        assetKey: {path: assetKeyPath},
+      },
+      data: {
+        assetNodeOrError: buildAssetNode({
+          freshnessPolicy: null,
+          autoMaterializePolicy: buildAutoMaterializePolicy({
+            policyType,
+          }),
+        }),
+      },
+    });
+  },
+  YesAutomaterializeYesFreshnessPolicy: (
+    assetKeyPath: string[],
+    policyType: AutoMaterializePolicyType = AutoMaterializePolicyType.EAGER,
+  ) => {
+    return buildGetPolicyInfoQuery({
+      variables: {
+        assetKey: {path: assetKeyPath},
+      },
+      data: {
+        assetNodeOrError: buildAssetNode({
+          freshnessPolicy: buildFreshnessPolicy({}),
+          autoMaterializePolicy: buildAutoMaterializePolicy({
+            policyType,
+          }),
+        }),
+      },
+    });
+  },
+  NoAutomaterializeYesFreshnessPolicy: (assetKeyPath: string[]) => {
+    return buildGetPolicyInfoQuery({
+      variables: {
+        assetKey: {path: assetKeyPath},
+      },
+      data: {
+        assetNodeOrError: buildAssetNode({
+          freshnessPolicy: buildFreshnessPolicy(),
+          autoMaterializePolicy: null,
+        }),
+      },
+    });
+  },
+  NoAutomaterializeNoFreshnessPolicy: (assetKeyPath: string[]) => {
+    return buildGetPolicyInfoQuery({
+      variables: {
+        assetKey: {path: assetKeyPath},
+      },
+      data: {
+        assetNodeOrError: buildAssetNode({
+          freshnessPolicy: null,
+          autoMaterializePolicy: null,
+        }),
+      },
+    });
+  },
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__fixtures__/AutomaterializeRequestedPartitionsLink.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__fixtures__/AutomaterializeRequestedPartitionsLink.fixtures.ts
@@ -1,0 +1,51 @@
+import {MockedResponse} from '@apollo/client/testing';
+import faker from 'faker';
+
+import {RunStatus, buildPipelineTag, buildRun, buildRuns} from '../../../graphql/types';
+import {DagsterTag} from '../../../runs/RunTag';
+import {RUN_STATUS_AND_PARTITION_KEY} from '../AutomaterializeRequestedPartitionsLink';
+import {
+  OldRunStatusAndPartitionKeyQuery,
+  OldRunStatusAndPartitionKeyQueryVariables,
+} from '../types/AutomaterializeRequestedPartitionsLink.types';
+
+const MOCKED_STATUSES = [
+  RunStatus.CANCELED,
+  RunStatus.FAILURE,
+  RunStatus.STARTED,
+  RunStatus.SUCCESS,
+  RunStatus.QUEUED,
+];
+
+const pickStatus = () => {
+  const random = faker.datatype.number(MOCKED_STATUSES.length - 1);
+  return MOCKED_STATUSES[random]!;
+};
+
+export const buildRunStatusAndPartitionKeyQuery = (
+  partitionKeys: string[],
+  runIds: string[],
+): MockedResponse<OldRunStatusAndPartitionKeyQuery, OldRunStatusAndPartitionKeyQueryVariables> => {
+  return {
+    request: {
+      query: RUN_STATUS_AND_PARTITION_KEY,
+      variables: {
+        filter: {runIds},
+      },
+    },
+    result: {
+      data: {
+        __typename: 'Query',
+        runsOrError: buildRuns({
+          results: runIds.map((runId, ii) => {
+            return buildRun({
+              id: runId,
+              status: pickStatus(),
+              tags: [buildPipelineTag({key: DagsterTag.Partition, value: partitionKeys[ii]!})],
+            });
+          }),
+        }),
+      },
+    },
+  };
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__fixtures__/RunStatusOnlyQuery.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__fixtures__/RunStatusOnlyQuery.fixtures.ts
@@ -1,0 +1,29 @@
+import {MockedResponse} from '@apollo/client/testing';
+
+import {RunStatus, buildRun} from '../../../graphql/types';
+import {RUN_STATUS_ONLY} from '../AutomaterializeRunTag';
+import {
+  OldRunStatusOnlyQuery,
+  OldRunStatusOnlyQueryVariables,
+} from '../types/AutomaterializeRunTag.types';
+
+export const buildRunStatusOnlyQuery = (
+  runId: string,
+  status: RunStatus,
+): MockedResponse<OldRunStatusOnlyQuery, OldRunStatusOnlyQueryVariables> => {
+  return {
+    request: {
+      query: RUN_STATUS_ONLY,
+      variables: {runId},
+    },
+    result: {
+      data: {
+        __typename: 'Query',
+        runOrError: buildRun({
+          id: runId,
+          status,
+        }),
+      },
+    },
+  };
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__stories__/AutoMaterializePolicyPage.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__stories__/AutoMaterializePolicyPage.stories.tsx
@@ -1,0 +1,96 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {Box, ButtonGroup, Checkbox, JoinedButtons} from '@dagster-io/ui-components';
+import React from 'react';
+
+import {AutoMaterializePolicyType} from '../../../graphql/types';
+import {AssetAutomaterializePolicyPage} from '../AssetAutomaterializePolicyPage';
+import {Evaluations, Policies} from '../__fixtures__/AutoMaterializePolicyPage.fixtures';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Asset Details/Automaterialize',
+  component: AssetAutomaterializePolicyPage,
+};
+
+const path = ['test'];
+
+export const EmptyState = () => {
+  return (
+    <MockedProvider
+      mocks={[Policies.NoAutomaterializeNoFreshnessPolicy(path), Evaluations.None(path, true)]}
+    >
+      <AssetAutomaterializePolicyPage assetKey={{path}} assetHasDefinedPartitions />
+    </MockedProvider>
+  );
+};
+
+export const Errors = () => {
+  return (
+    <MockedProvider
+      mocks={[
+        Evaluations.Errors(path),
+        Evaluations.Errors(path, true),
+        Policies.NoAutomaterializeNoFreshnessPolicy(path),
+      ]}
+    >
+      <AssetAutomaterializePolicyPage assetKey={{path}} assetHasDefinedPartitions />
+    </MockedProvider>
+  );
+};
+
+export const Controlled = () => {
+  const [policyType, setPolicyType] = React.useState<any>(AutoMaterializePolicyType.EAGER);
+  const [freshnessPolicy, setFreshnessPolicy] = React.useState(true);
+
+  const policyMock = React.useMemo(() => {
+    if (policyType === 'None') {
+      return freshnessPolicy
+        ? Policies.NoAutomaterializeYesFreshnessPolicy(path)
+        : Policies.NoAutomaterializeNoFreshnessPolicy(path);
+    } else {
+      return freshnessPolicy
+        ? Policies.YesAutomaterializeYesFreshnessPolicy(path, policyType)
+        : Policies.NoAutomaterializeYesFreshnessPolicy(path);
+    }
+  }, [freshnessPolicy, policyType]);
+
+  return (
+    <div key={policyType + freshnessPolicy.toString()}>
+      <MockedProvider
+        mocks={[
+          policyMock,
+          Evaluations.Some(path),
+          Evaluations.SinglePartitioned(path, '9798'),
+          Evaluations.SinglePartitioned(path, '28'),
+        ]}
+      >
+        <div>
+          <Box padding={24}>
+            <Checkbox
+              format="switch"
+              label="Freshness policy"
+              checked={freshnessPolicy}
+              onChange={() => {
+                setFreshnessPolicy((policy) => !policy);
+              }}
+            />
+            <JoinedButtons>
+              <ButtonGroup
+                activeItems={new Set([policyType])}
+                buttons={[
+                  {id: AutoMaterializePolicyType.EAGER, label: 'Eager'},
+                  {id: AutoMaterializePolicyType.LAZY, label: 'Lazy'},
+                  {id: 'None', label: 'None'},
+                ]}
+                onClick={(id: string) => {
+                  setPolicyType(id as any);
+                }}
+              />
+            </JoinedButtons>
+          </Box>
+          <AssetAutomaterializePolicyPage assetKey={{path}} assetHasDefinedPartitions />
+        </div>
+      </MockedProvider>
+    </div>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__stories__/AutomaterializeLeftList.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__stories__/AutomaterializeLeftList.stories.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+
+import {AutomaterializeLeftList} from '../AutomaterializeLeftPanel';
+import {
+  buildEvaluationRecordsWithPartitions,
+  buildEvaluationRecordsWithoutPartitions,
+} from '../__fixtures__/AutoMaterializePolicyPage.fixtures';
+import {AutoMaterializeEvaluationRecordItemFragment} from '../types/GetEvaluationsQuery.types';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Asset Details/Automaterialize/AutomaterializeLeftList',
+  component: AutomaterializeLeftList,
+};
+
+export const WithPartitions = () => {
+  const [selectedEvaluation, setSelectedEvaluation] = React.useState<
+    AutoMaterializeEvaluationRecordItemFragment | undefined
+  >();
+
+  const evaluations = buildEvaluationRecordsWithPartitions();
+
+  return (
+    <div style={{width: '320px'}}>
+      <AutomaterializeLeftList
+        assetHasDefinedPartitions
+        evaluations={evaluations}
+        onSelectEvaluation={(evaluation: AutoMaterializeEvaluationRecordItemFragment) =>
+          setSelectedEvaluation(evaluation)
+        }
+        selectedEvaluation={selectedEvaluation}
+      />
+    </div>
+  );
+};
+
+export const NoPartitions = () => {
+  const [selectedEvaluation, setSelectedEvaluation] = React.useState<
+    AutoMaterializeEvaluationRecordItemFragment | undefined
+  >();
+
+  const evaluations = buildEvaluationRecordsWithoutPartitions();
+
+  return (
+    <div style={{width: '320px'}}>
+      <AutomaterializeLeftList
+        assetHasDefinedPartitions={false}
+        evaluations={evaluations}
+        onSelectEvaluation={(evaluation: AutoMaterializeEvaluationRecordItemFragment) =>
+          setSelectedEvaluation(evaluation)
+        }
+        selectedEvaluation={selectedEvaluation}
+      />
+    </div>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__stories__/AutomaterializeMiddlePanel.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__stories__/AutomaterializeMiddlePanel.stories.tsx
@@ -1,0 +1,72 @@
+import {MockedProvider} from '@apollo/client/testing';
+import * as React from 'react';
+
+import {RunStatus} from '../../../graphql/types';
+import {
+  AutomaterializeMiddlePanel,
+  AutomaterializeMiddlePanelWithData,
+} from '../AutomaterializeMiddlePanel';
+import {Evaluations, TEST_EVALUATION_ID} from '../__fixtures__/AutoMaterializePolicyPage.fixtures';
+import {buildRunStatusOnlyQuery} from '../__fixtures__/RunStatusOnlyQuery.fixtures';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Asset Details/Automaterialize/AutomaterializeMiddlePanelWithData',
+  component: AutomaterializeMiddlePanelWithData,
+};
+
+const path = ['test'];
+
+export const Empty = () => {
+  return (
+    <MockedProvider
+      mocks={[Evaluations.Single(path), buildRunStatusOnlyQuery('abcdef12', RunStatus.STARTED)]}
+    >
+      <div style={{width: '800px'}}>
+        <AutomaterializeMiddlePanel
+          assetKey={{path}}
+          assetHasDefinedPartitions={false}
+          selectedEvaluationId={undefined}
+        />
+      </div>
+    </MockedProvider>
+  );
+};
+
+export const WithoutPartitions = () => {
+  return (
+    <MockedProvider
+      mocks={[
+        Evaluations.Single(path, `${TEST_EVALUATION_ID + 1}`),
+        buildRunStatusOnlyQuery('abcdef12', RunStatus.STARTED),
+      ]}
+    >
+      <div style={{width: '800px'}}>
+        <AutomaterializeMiddlePanel
+          assetKey={{path}}
+          assetHasDefinedPartitions={false}
+          selectedEvaluationId={TEST_EVALUATION_ID}
+        />
+      </div>
+    </MockedProvider>
+  );
+};
+
+export const WithPartitions = () => {
+  return (
+    <MockedProvider
+      mocks={[
+        Evaluations.SinglePartitioned(path, `${TEST_EVALUATION_ID + 1}`),
+        buildRunStatusOnlyQuery('abcdef12', RunStatus.STARTED),
+      ]}
+    >
+      <div style={{width: '800px'}}>
+        <AutomaterializeMiddlePanel
+          assetKey={{path}}
+          assetHasDefinedPartitions={true}
+          selectedEvaluationId={TEST_EVALUATION_ID}
+        />
+      </div>
+    </MockedProvider>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__stories__/AutomaterializeRequestedPartitionsLink.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__stories__/AutomaterializeRequestedPartitionsLink.stories.tsx
@@ -1,0 +1,27 @@
+import {MockedProvider} from '@apollo/client/testing';
+import faker from 'faker';
+import * as React from 'react';
+
+import {AutomaterializeRequestedPartitionsLink} from '../AutomaterializeRequestedPartitionsLink';
+import {buildRunStatusAndPartitionKeyQuery} from '../__fixtures__/AutomaterializeRequestedPartitionsLink.fixtures';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Asset Details/Automaterialize/AutomaterializeRequestedPartitionsLink',
+  component: AutomaterializeRequestedPartitionsLink,
+};
+
+export const ManyPartitionsAndRuns = () => {
+  const partitionKeys = new Array(40).fill(null).map((_) => faker.lorem.words(3));
+  const runIds = new Array(40).fill(null).map((_) => faker.datatype.uuid());
+  return (
+    <MockedProvider mocks={[buildRunStatusAndPartitionKeyQuery(partitionKeys, runIds)]}>
+      <AutomaterializeRequestedPartitionsLink partitionKeys={partitionKeys} runIds={runIds} />
+    </MockedProvider>
+  );
+};
+
+export const OnlyPartitions = () => {
+  const partitionKeys = new Array(40).fill(null).map((_) => faker.lorem.words(3));
+  return <AutomaterializeRequestedPartitionsLink partitionKeys={partitionKeys} />;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__stories__/PartitionSegmentWithPopover.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__stories__/PartitionSegmentWithPopover.stories.tsx
@@ -1,0 +1,126 @@
+import {Box} from '@dagster-io/ui-components';
+import faker from 'faker';
+import * as React from 'react';
+
+import {PartitionSegmentWithPopover} from '../PartitionSegmentWithPopover';
+import {AssetConditionEvaluationStatus, AssetSubset} from '../types';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Asset Details/Automaterialize/PartitionSegmentWithPopover',
+  component: PartitionSegmentWithPopover,
+};
+
+const PARTITION_COUNT = 300;
+
+export const TruePartitions = () => {
+  const subset: AssetSubset = React.useMemo(() => {
+    const partitionKeys = new Array(PARTITION_COUNT)
+      .fill(null)
+      .map(() => faker.random.words(2).toLowerCase().replace(/ /g, '-'));
+    return {
+      assetKey: {path: ['foo', 'bar']},
+      subsetValue: {
+        boolValue: true,
+        partitionKeys,
+        partitionKeyRanges: null,
+        isPartitioned: true,
+      },
+    };
+  }, []);
+
+  return (
+    <Box flex={{direction: 'row'}}>
+      <PartitionSegmentWithPopover
+        description="is_missing"
+        status={AssetConditionEvaluationStatus.TRUE}
+        width={200}
+        subset={subset}
+      />
+    </Box>
+  );
+};
+
+export const FalsePartitions = () => {
+  const subset: AssetSubset = React.useMemo(() => {
+    const partitionKeys = new Array(PARTITION_COUNT)
+      .fill(null)
+      .map(() => faker.random.words(2).toLowerCase().replace(/ /g, '-'));
+    return {
+      assetKey: {path: ['foo', 'bar']},
+      subsetValue: {
+        boolValue: false,
+        partitionKeys,
+        partitionKeyRanges: null,
+        isPartitioned: true,
+      },
+    };
+  }, []);
+
+  return (
+    <Box flex={{direction: 'row'}}>
+      <PartitionSegmentWithPopover
+        description="is_missing"
+        status={AssetConditionEvaluationStatus.FALSE}
+        width={200}
+        subset={subset}
+      />
+    </Box>
+  );
+};
+
+export const SkippedPartitions = () => {
+  const subset: AssetSubset = React.useMemo(() => {
+    const partitionKeys = new Array(PARTITION_COUNT)
+      .fill(null)
+      .map(() => faker.random.words(2).toLowerCase().replace(/ /g, '-'));
+    return {
+      assetKey: {path: ['foo', 'bar']},
+      subsetValue: {
+        boolValue: null,
+        partitionKeys,
+        partitionKeyRanges: null,
+        isPartitioned: true,
+      },
+    };
+  }, []);
+
+  return (
+    <Box flex={{direction: 'row'}}>
+      <PartitionSegmentWithPopover
+        description="is_missing"
+        status={AssetConditionEvaluationStatus.SKIPPED}
+        width={200}
+        subset={subset}
+      />
+    </Box>
+  );
+};
+
+export const FewPartitions = () => {
+  const subset: AssetSubset = React.useMemo(() => {
+    const partitionKeys = new Array(2)
+      .fill(null)
+      .map(() => faker.random.words(2).toLowerCase().replace(/ /g, '-'));
+    return {
+      assetKey: {path: ['foo', 'bar']},
+      subsetValue: {
+        boolValue: true,
+        partitionKeys,
+        partitionKeyRanges: null,
+        isPartitioned: true,
+      },
+    };
+  }, []);
+
+  return (
+    <Box flex={{direction: 'row'}}>
+      <PartitionSegmentWithPopover
+        description="is_missing"
+        status={AssetConditionEvaluationStatus.TRUE}
+        width={200}
+        subset={subset}
+      />
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__stories__/PolicyEvaluationCondition.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__stories__/PolicyEvaluationCondition.stories.tsx
@@ -1,0 +1,75 @@
+import {Table} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {PolicyEvaluationCondition} from '../PolicyEvaluationCondition';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Asset Details/Automaterialize/PolicyEvaluationCondition',
+  component: PolicyEvaluationCondition,
+};
+
+export const Default = () => {
+  return (
+    <Table $compact>
+      <tbody>
+        <tr>
+          <td>
+            <PolicyEvaluationCondition
+              depth={0}
+              icon="resource"
+              label="All are true:"
+              type="group"
+            />
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <PolicyEvaluationCondition
+              depth={1}
+              icon="resource"
+              label="Any are true:"
+              type="group"
+            />
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <PolicyEvaluationCondition
+              depth={2}
+              icon="wysiwyg"
+              label="parent_updated"
+              type="leaf"
+            />
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <PolicyEvaluationCondition
+              depth={2}
+              icon="wysiwyg"
+              label="is_missing"
+              type="leaf"
+              skipped
+            />
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <PolicyEvaluationCondition depth={1} icon="resource" label="Not:" type="group" />
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <PolicyEvaluationCondition
+              depth={2}
+              icon="wysiwyg"
+              label="parent_updated"
+              type="leaf"
+            />
+          </td>
+        </tr>
+      </tbody>
+    </Table>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__stories__/PolicyEvaluationTable.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/__stories__/PolicyEvaluationTable.stories.tsx
@@ -1,0 +1,356 @@
+import * as React from 'react';
+
+import {PolicyEvaluationTable} from '../PolicyEvaluationTable';
+import {
+  AssetConditionEvaluationStatus,
+  PartitionedAssetConditionEvaluation,
+  UnpartitionedAssetConditionEvaluation,
+} from '../types';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Asset Details/Automaterialize/PolicyEvaluationTable',
+  component: PolicyEvaluationTable,
+};
+
+export const NonPartitioned = () => {
+  const evaluation: UnpartitionedAssetConditionEvaluation = {
+    __typename: 'UnpartitionedAssetConditionEvaluation' as const,
+    description: 'All are true:',
+    startTimestamp: 1,
+    endTimestamp: 200,
+    status: AssetConditionEvaluationStatus.TRUE,
+    childEvaluations: [
+      {
+        __typename: 'UnpartitionedAssetConditionEvaluation' as const,
+        description: 'Any are true:',
+        startTimestamp: 1,
+        endTimestamp: 4,
+        status: AssetConditionEvaluationStatus.TRUE,
+        childEvaluations: [
+          {
+            __typename: 'UnpartitionedAssetConditionEvaluation' as const,
+            description: 'parent_updated',
+            startTimestamp: 1,
+            endTimestamp: 2,
+            // metadataEntries: [MetadataEntry!]!
+            status: AssetConditionEvaluationStatus.TRUE,
+            childEvaluations: null,
+          },
+          {
+            __typename: 'UnpartitionedAssetConditionEvaluation' as const,
+            description: 'is_missing',
+            startTimestamp: 1,
+            endTimestamp: 2,
+            // metadataEntries: [MetadataEntry!]!
+            status: AssetConditionEvaluationStatus.SKIPPED,
+            childEvaluations: null,
+          },
+        ],
+      },
+      {
+        __typename: 'UnpartitionedAssetConditionEvaluation' as const,
+        description: 'Not:',
+        startTimestamp: 6,
+        endTimestamp: 12,
+        status: AssetConditionEvaluationStatus.TRUE,
+        childEvaluations: [
+          {
+            __typename: 'UnpartitionedAssetConditionEvaluation' as const,
+            description: 'parent_updated',
+            startTimestamp: 6,
+            endTimestamp: 12,
+            // metadataEntries: [MetadataEntry!]!
+            status: AssetConditionEvaluationStatus.FALSE,
+            childEvaluations: null,
+          },
+        ],
+      },
+      {
+        __typename: 'UnpartitionedAssetConditionEvaluation' as const,
+        description: 'all_parents_up_to_date',
+        startTimestamp: 12,
+        endTimestamp: 14,
+        status: AssetConditionEvaluationStatus.TRUE,
+        childEvaluations: null,
+      },
+      {
+        __typename: 'UnpartitionedAssetConditionEvaluation' as const,
+        description: 'not_any_parent_missing',
+        startTimestamp: 14,
+        endTimestamp: 28,
+        status: AssetConditionEvaluationStatus.TRUE,
+        childEvaluations: null,
+      },
+    ],
+  };
+
+  return <PolicyEvaluationTable rootEvaluation={evaluation} />;
+};
+
+export const Partitioned = () => {
+  const evaluation: PartitionedAssetConditionEvaluation = {
+    __typename: 'PartitionedAssetConditionEvaluation' as const,
+    description: 'All are true:',
+    startTimestamp: 1,
+    endTimestamp: 200,
+    numTrue: 0,
+    numFalse: 100,
+    numSkipped: 0,
+    trueSubset: {
+      assetKey: {path: ['foo']},
+      subsetValue: {
+        boolValue: true,
+        partitionKeys: [],
+        partitionKeyRanges: null,
+        isPartitioned: true,
+      },
+    },
+    falseSubset: {
+      assetKey: {path: ['foo']},
+      subsetValue: {
+        boolValue: false,
+        partitionKeys: new Array(100).fill(null).map((_, ii) => `false-${ii}`),
+        partitionKeyRanges: null,
+        isPartitioned: true,
+      },
+    },
+    candidateSubset: null,
+    childEvaluations: [
+      {
+        __typename: 'PartitionedAssetConditionEvaluation' as const,
+        description: 'Any are true:',
+        startTimestamp: 1,
+        endTimestamp: 4,
+        numTrue: 30,
+        numFalse: 70,
+        numSkipped: 0,
+        trueSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: true,
+            partitionKeys: new Array(30).fill(null).map((_, ii) => `true-${ii}`),
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        falseSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: false,
+            partitionKeys: new Array(70).fill(null).map((_, ii) => `false-${ii}`),
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        candidateSubset: null,
+        childEvaluations: [
+          {
+            __typename: 'PartitionedAssetConditionEvaluation' as const,
+            description: 'parent_updated',
+            startTimestamp: 1,
+            endTimestamp: 2,
+            // metadataEntries: [MetadataEntry!]!
+            numTrue: 30,
+            numFalse: 20,
+            numSkipped: 50,
+            trueSubset: {
+              assetKey: {path: ['foo']},
+              subsetValue: {
+                boolValue: true,
+                partitionKeys: new Array(30).fill(null).map((_, ii) => `true-${ii}`),
+                partitionKeyRanges: null,
+                isPartitioned: true,
+              },
+            },
+            falseSubset: {
+              assetKey: {path: ['foo']},
+              subsetValue: {
+                boolValue: false,
+                partitionKeys: new Array(20).fill(null).map((_, ii) => `false-${ii}`),
+                partitionKeyRanges: null,
+                isPartitioned: true,
+              },
+            },
+            candidateSubset: {
+              assetKey: {path: ['foo']},
+              subsetValue: {
+                boolValue: null,
+                partitionKeys: new Array(50).fill(null).map((_, ii) => `true-${ii}`),
+                partitionKeyRanges: null,
+                isPartitioned: true,
+              },
+            },
+            childEvaluations: null,
+          },
+          {
+            __typename: 'PartitionedAssetConditionEvaluation' as const,
+            description: 'is_missing',
+            startTimestamp: 1,
+            endTimestamp: 2,
+            // metadataEntries: [MetadataEntry!]!
+            numTrue: 0,
+            numFalse: 30,
+            numSkipped: 70,
+            trueSubset: {
+              assetKey: {path: ['foo']},
+              subsetValue: {
+                boolValue: true,
+                partitionKeys: new Array(30).fill(null).map((_, ii) => `true-${ii}`),
+                partitionKeyRanges: null,
+                isPartitioned: true,
+              },
+            },
+            falseSubset: {
+              assetKey: {path: ['foo']},
+              subsetValue: {
+                boolValue: false,
+                partitionKeys: new Array(30).fill(null).map((_, ii) => `false-${ii}`),
+                partitionKeyRanges: null,
+                isPartitioned: true,
+              },
+            },
+            candidateSubset: {
+              assetKey: {path: ['foo']},
+              subsetValue: {
+                boolValue: null,
+                partitionKeys: new Array(70).fill(null).map((_, ii) => `true-${ii}`),
+                partitionKeyRanges: null,
+                isPartitioned: true,
+              },
+            },
+            childEvaluations: null,
+          },
+        ],
+      },
+      {
+        __typename: 'PartitionedAssetConditionEvaluation' as const,
+        description: 'Not:',
+        startTimestamp: 6,
+        endTimestamp: 12,
+        numTrue: 30,
+        numFalse: 70,
+        numSkipped: 0,
+        trueSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: true,
+            partitionKeys: new Array(30).fill(null).map((_, ii) => `true-${ii}`),
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        falseSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: false,
+            partitionKeys: new Array(70).fill(null).map((_, ii) => `false-${ii}`),
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        candidateSubset: null,
+        childEvaluations: [
+          {
+            __typename: 'PartitionedAssetConditionEvaluation' as const,
+            description: 'parent_updated',
+            startTimestamp: 6,
+            endTimestamp: 12,
+            // metadataEntries: [MetadataEntry!]!
+            numTrue: 80,
+            numFalse: 20,
+            numSkipped: 0,
+            trueSubset: {
+              assetKey: {path: ['foo']},
+              subsetValue: {
+                boolValue: true,
+                partitionKeys: new Array(80).fill(null).map((_, ii) => `true-${ii}`),
+                partitionKeyRanges: null,
+                isPartitioned: true,
+              },
+            },
+            falseSubset: {
+              assetKey: {path: ['foo']},
+              subsetValue: {
+                boolValue: false,
+                partitionKeys: new Array(20).fill(null).map((_, ii) => `false-${ii}`),
+                partitionKeyRanges: null,
+                isPartitioned: true,
+              },
+            },
+            candidateSubset: null,
+            childEvaluations: null,
+          },
+        ],
+      },
+      {
+        __typename: 'PartitionedAssetConditionEvaluation' as const,
+        description: 'all_parents_up_to_date',
+        startTimestamp: 12,
+        endTimestamp: 14,
+        numTrue: 0,
+        numFalse: 100,
+        numSkipped: 0,
+        trueSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: true,
+            partitionKeys: [],
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        falseSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: false,
+            partitionKeys: new Array(100).fill(null).map((_, ii) => `false-${ii}`),
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        candidateSubset: null,
+        childEvaluations: null,
+      },
+      {
+        __typename: 'PartitionedAssetConditionEvaluation' as const,
+        description: 'not_any_parent_missing',
+        startTimestamp: 14,
+        endTimestamp: 28,
+        numTrue: 0,
+        numFalse: 0,
+        numSkipped: 100,
+        trueSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: true,
+            partitionKeys: [],
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        falseSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: false,
+            partitionKeys: [],
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        candidateSubset: {
+          assetKey: {path: ['foo']},
+          subsetValue: {
+            boolValue: null,
+            partitionKeys: new Array(100).fill(null).map((_, ii) => `true-${ii}`),
+            partitionKeyRanges: null,
+            isPartitioned: true,
+          },
+        },
+        childEvaluations: null,
+      },
+    ],
+  };
+
+  return <PolicyEvaluationTable rootEvaluation={evaluation} />;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/assetDetailUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/assetDetailUtils.tsx
@@ -1,0 +1,13 @@
+export enum AssetDetailType {
+  Updated,
+  WillUpdate,
+}
+
+export const detailTypeToLabel = (detailType: AssetDetailType) => {
+  switch (detailType) {
+    case AssetDetailType.Updated:
+      return 'Updated';
+    case AssetDetailType.WillUpdate:
+      return 'Will update';
+  }
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/assetFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/assetFilters.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+import {sortAssetKeys} from '../../asset-graph/Utils';
+import {AssetKey} from '../types';
+
+export const useFilterAssetKeys = (assetKeys: AssetKey[], queryString: string) => {
+  const queryLowercase = queryString.toLocaleLowerCase();
+  return React.useMemo(() => {
+    if (queryLowercase === '') {
+      return assetKeys;
+    }
+    return assetKeys
+      .filter((assetKey) =>
+        assetKey.path.some((part) => part.toLowerCase().includes(queryLowercase)),
+      )
+      .sort(sortAssetKeys);
+  }, [assetKeys, queryLowercase]);
+};
+
+export const useFilterPartitionNames = (partitionNames: string[], queryString: string) => {
+  const queryLowercase = queryString.toLocaleLowerCase();
+  return React.useMemo(() => {
+    if (queryLowercase === '') {
+      return partitionNames;
+    }
+    return partitionNames.filter((partitionName) =>
+      partitionName.toLowerCase().includes(queryLowercase),
+    );
+  }, [partitionNames, queryLowercase]);
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/flattenEvaluations.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/flattenEvaluations.tsx
@@ -1,0 +1,42 @@
+import {ConditionType} from './PolicyEvaluationCondition';
+import {AssetConditionEvaluation} from './types';
+
+type FlattenedConditionEvaluation<T> = {
+  evaluation: T;
+  id: number;
+  parentId: number | null;
+  depth: number;
+  type: ConditionType;
+};
+
+export const flattenEvaluations = <T extends AssetConditionEvaluation>(rootEvaluation: T) => {
+  const all: FlattenedConditionEvaluation<T>[] = [];
+  let counter = 0;
+
+  const append = (evaluation: T, parentId: number | null, depth: number) => {
+    const id = counter + 1;
+
+    const type =
+      evaluation.childEvaluations && evaluation.childEvaluations.length > 0 ? 'group' : 'leaf';
+
+    all.push({
+      evaluation,
+      id,
+      parentId: parentId === null ? counter : parentId,
+      depth,
+      type,
+    } as FlattenedConditionEvaluation<T>);
+    counter = id;
+
+    if (evaluation.childEvaluations) {
+      const parentCounter = counter;
+      evaluation.childEvaluations.forEach((child) => {
+        append(child as T, parentCounter, depth + 1);
+      });
+    }
+  };
+
+  append(rootEvaluation, null, 0);
+
+  return all;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/types.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/types.tsx
@@ -1,0 +1,71 @@
+import {PartitionKeyRange} from '../../graphql/types';
+import {AssetKey} from '../types';
+
+import {AutoMaterializeEvaluationRecordItemFragment} from './types/GetEvaluationsQuery.types';
+
+export type NoConditionsMetEvaluation = {
+  __typename: 'no_conditions_met';
+  evaluationId: number;
+  amount: number;
+  endTimestamp: number | 'now';
+  startTimestamp: number;
+  numSkipped?: undefined;
+  numRequested?: undefined;
+  numDiscarded?: undefined;
+  numRequests?: undefined;
+  conditions?: undefined;
+};
+
+export type EvaluationOrEmpty =
+  | AutoMaterializeEvaluationRecordItemFragment
+  | NoConditionsMetEvaluation;
+
+/* todo dish: Replace these types with GraphQL generated types */
+
+export enum AssetConditionEvaluationStatus {
+  TRUE = 'TRUE',
+  FALSE = 'FALSE',
+  SKIPPED = 'SKIPPED',
+}
+
+export type AssetConditionEvaluation =
+  | UnpartitionedAssetConditionEvaluation
+  | PartitionedAssetConditionEvaluation;
+
+export type AssetSubset = {
+  assetKey: AssetKey;
+  subsetValue: AssetSubsetValue;
+};
+
+export type AssetSubsetValue = {
+  boolValue: boolean | null;
+  partitionKeys: string[] | null;
+  partitionKeyRanges: PartitionKeyRange[] | null;
+  isPartitioned: boolean;
+};
+
+export type UnpartitionedAssetConditionEvaluation = {
+  __typename: 'UnpartitionedAssetConditionEvaluation';
+  description: string;
+  startTimestamp: number;
+  endTimestamp: number;
+  // metadataEntries: [MetadataEntry!]!
+  status: AssetConditionEvaluationStatus;
+  childEvaluations: UnpartitionedAssetConditionEvaluation[] | null;
+};
+
+export type PartitionedAssetConditionEvaluation = {
+  __typename: 'PartitionedAssetConditionEvaluation';
+  description: string;
+  startTimestamp: number;
+  endTimestamp: number;
+  numTrue: number;
+  numFalse: number;
+  numSkipped: number;
+  childEvaluations: PartitionedAssetConditionEvaluation[] | null;
+
+  // We may want to query for these separately
+  trueSubset: AssetSubset;
+  falseSubset: AssetSubset;
+  candidateSubset: AssetSubset | null;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/types/AutomaterializeRequestedPartitionsLink.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/types/AutomaterializeRequestedPartitionsLink.types.ts
@@ -1,0 +1,39 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../../graphql/types';
+
+export type OldRunStatusAndPartitionKeyQueryVariables = Types.Exact<{
+  filter?: Types.InputMaybe<Types.RunsFilter>;
+}>;
+
+export type OldRunStatusAndPartitionKeyQuery = {
+  __typename: 'Query';
+  runsOrError:
+    | {__typename: 'InvalidPipelineRunsFilterError'; message: string}
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      }
+    | {
+        __typename: 'Runs';
+        results: Array<{
+          __typename: 'Run';
+          id: string;
+          status: Types.RunStatus;
+          tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
+        }>;
+      };
+};
+
+export type OldRunStatusAndTagsFragment = {
+  __typename: 'Run';
+  id: string;
+  status: Types.RunStatus;
+  tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/types/AutomaterializeRightPanel.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/types/AutomaterializeRightPanel.types.ts
@@ -1,0 +1,33 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../../graphql/types';
+
+export type OldGetPolicyInfoQueryVariables = Types.Exact<{
+  assetKey: Types.AssetKeyInput;
+}>;
+
+export type OldGetPolicyInfoQuery = {
+  __typename: 'Query';
+  assetNodeOrError:
+    | {
+        __typename: 'AssetNode';
+        id: string;
+        freshnessPolicy: {
+          __typename: 'FreshnessPolicy';
+          maximumLagMinutes: number;
+          cronSchedule: string | null;
+          cronScheduleTimezone: string | null;
+        } | null;
+        autoMaterializePolicy: {
+          __typename: 'AutoMaterializePolicy';
+          policyType: Types.AutoMaterializePolicyType;
+          maxMaterializationsPerMinute: number | null;
+          rules: Array<{
+            __typename: 'AutoMaterializeRule';
+            description: string;
+            decisionType: Types.AutoMaterializeDecisionType;
+          }>;
+        } | null;
+      }
+    | {__typename: 'AssetNotFoundError'};
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/types/AutomaterializeRunTag.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/types/AutomaterializeRunTag.types.ts
@@ -1,0 +1,15 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../../graphql/types';
+
+export type OldRunStatusOnlyQueryVariables = Types.Exact<{
+  runId: Types.Scalars['ID'];
+}>;
+
+export type OldRunStatusOnlyQuery = {
+  __typename: 'Query';
+  runOrError:
+    | {__typename: 'PythonError'}
+    | {__typename: 'Run'; id: string; status: Types.RunStatus}
+    | {__typename: 'RunNotFoundError'};
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/types/GetEvaluationsQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/types/GetEvaluationsQuery.types.ts
@@ -1,0 +1,156 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../../graphql/types';
+
+export type OldGetEvaluationsQueryVariables = Types.Exact<{
+  assetKey: Types.AssetKeyInput;
+  limit: Types.Scalars['Int'];
+  cursor?: Types.InputMaybe<Types.Scalars['String']>;
+}>;
+
+export type OldGetEvaluationsQuery = {
+  __typename: 'Query';
+  assetNodeOrError:
+    | {
+        __typename: 'AssetNode';
+        id: string;
+        currentAutoMaterializeEvaluationId: number | null;
+        autoMaterializePolicy: {
+          __typename: 'AutoMaterializePolicy';
+          rules: Array<{
+            __typename: 'AutoMaterializeRule';
+            description: string;
+            decisionType: Types.AutoMaterializeDecisionType;
+            className: string;
+          }>;
+        } | null;
+      }
+    | {__typename: 'AssetNotFoundError'};
+  autoMaterializeAssetEvaluationsOrError:
+    | {__typename: 'AutoMaterializeAssetEvaluationNeedsMigrationError'; message: string}
+    | {
+        __typename: 'AutoMaterializeAssetEvaluationRecords';
+        records: Array<{
+          __typename: 'AutoMaterializeAssetEvaluationRecord';
+          id: string;
+          evaluationId: number;
+          numRequested: number;
+          numSkipped: number;
+          numDiscarded: number;
+          timestamp: number;
+          runIds: Array<string>;
+          rulesWithRuleEvaluations: Array<{
+            __typename: 'AutoMaterializeRuleWithRuleEvaluations';
+            rule: {
+              __typename: 'AutoMaterializeRule';
+              description: string;
+              decisionType: Types.AutoMaterializeDecisionType;
+              className: string;
+            };
+            ruleEvaluations: Array<{
+              __typename: 'AutoMaterializeRuleEvaluation';
+              evaluationData:
+                | {
+                    __typename: 'ParentMaterializedRuleEvaluationData';
+                    updatedAssetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
+                    willUpdateAssetKeys: Array<{
+                      __typename: 'AssetKey';
+                      path: Array<string>;
+                    }> | null;
+                  }
+                | {__typename: 'TextRuleEvaluationData'; text: string | null}
+                | {
+                    __typename: 'WaitingOnKeysRuleEvaluationData';
+                    waitingOnAssetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
+                  }
+                | null;
+              partitionKeysOrError:
+                | {__typename: 'PartitionKeys'; partitionKeys: Array<string>}
+                | {__typename: 'PartitionSubsetDeserializationError'; message: string}
+                | null;
+            }>;
+          }>;
+          rules: Array<{
+            __typename: 'AutoMaterializeRule';
+            description: string;
+            decisionType: Types.AutoMaterializeDecisionType;
+            className: string;
+          }> | null;
+        }>;
+      }
+    | null;
+};
+
+export type AutoMaterializeEvaluationRecordItemFragment = {
+  __typename: 'AutoMaterializeAssetEvaluationRecord';
+  id: string;
+  evaluationId: number;
+  numRequested: number;
+  numSkipped: number;
+  numDiscarded: number;
+  timestamp: number;
+  runIds: Array<string>;
+  rulesWithRuleEvaluations: Array<{
+    __typename: 'AutoMaterializeRuleWithRuleEvaluations';
+    rule: {
+      __typename: 'AutoMaterializeRule';
+      description: string;
+      decisionType: Types.AutoMaterializeDecisionType;
+      className: string;
+    };
+    ruleEvaluations: Array<{
+      __typename: 'AutoMaterializeRuleEvaluation';
+      evaluationData:
+        | {
+            __typename: 'ParentMaterializedRuleEvaluationData';
+            updatedAssetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
+            willUpdateAssetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
+          }
+        | {__typename: 'TextRuleEvaluationData'; text: string | null}
+        | {
+            __typename: 'WaitingOnKeysRuleEvaluationData';
+            waitingOnAssetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
+          }
+        | null;
+      partitionKeysOrError:
+        | {__typename: 'PartitionKeys'; partitionKeys: Array<string>}
+        | {__typename: 'PartitionSubsetDeserializationError'; message: string}
+        | null;
+    }>;
+  }>;
+  rules: Array<{
+    __typename: 'AutoMaterializeRule';
+    description: string;
+    decisionType: Types.AutoMaterializeDecisionType;
+    className: string;
+  }> | null;
+};
+
+export type RuleWithEvaluationsFragment = {
+  __typename: 'AutoMaterializeRuleWithRuleEvaluations';
+  rule: {
+    __typename: 'AutoMaterializeRule';
+    description: string;
+    decisionType: Types.AutoMaterializeDecisionType;
+    className: string;
+  };
+  ruleEvaluations: Array<{
+    __typename: 'AutoMaterializeRuleEvaluation';
+    evaluationData:
+      | {
+          __typename: 'ParentMaterializedRuleEvaluationData';
+          updatedAssetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
+          willUpdateAssetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
+        }
+      | {__typename: 'TextRuleEvaluationData'; text: string | null}
+      | {
+          __typename: 'WaitingOnKeysRuleEvaluationData';
+          waitingOnAssetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
+        }
+      | null;
+    partitionKeysOrError:
+      | {__typename: 'PartitionKeys'; partitionKeys: Array<string>}
+      | {__typename: 'PartitionSubsetDeserializationError'; message: string}
+      | null;
+  }>;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/useEvaluationsQueryResult.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPageOld/useEvaluationsQueryResult.tsx
@@ -1,0 +1,41 @@
+import {useCursorPaginatedQuery} from '../../runs/useCursorPaginatedQuery';
+import {AssetKey} from '../types';
+
+import {GET_EVALUATIONS_QUERY} from './GetEvaluationsQuery';
+import {
+  OldGetEvaluationsQuery,
+  OldGetEvaluationsQueryVariables,
+} from './types/GetEvaluationsQuery.types';
+
+export const PAGE_SIZE = 30;
+
+// This function exists mostly to use the return type later
+export function useEvaluationsQueryResult({assetKey}: {assetKey: AssetKey}) {
+  return useCursorPaginatedQuery<OldGetEvaluationsQuery, OldGetEvaluationsQueryVariables>({
+    nextCursorForResult: (data) => {
+      if (
+        data.autoMaterializeAssetEvaluationsOrError?.__typename ===
+        'AutoMaterializeAssetEvaluationRecords'
+      ) {
+        return data.autoMaterializeAssetEvaluationsOrError.records[
+          PAGE_SIZE - 1
+        ]?.evaluationId.toString();
+      }
+      return undefined;
+    },
+    getResultArray: (data) => {
+      if (
+        data?.autoMaterializeAssetEvaluationsOrError?.__typename ===
+        'AutoMaterializeAssetEvaluationRecords'
+      ) {
+        return data.autoMaterializeAssetEvaluationsOrError.records;
+      }
+      return [];
+    },
+    variables: {
+      assetKey,
+    },
+    query: GET_EVALUATIONS_QUERY,
+    pageSize: PAGE_SIZE,
+  });
+}


### PR DESCRIPTION
## Summary & Motivation

In case something goes wrong with the new AMP migration we want a way to easily switch back to the old AMP page. To make that easy this PR clones the existing AMP page into a new folder: "AutoMaterializePolicyPageOld" which we will delete once we finalize the migration. I opted for this instead of creating a "New" folder to preserve the existing git history for after the migration.

## How I Tested These Changes
yarn build