### PR TITLE
Retrieve more granular resource utilization metrics

### DIFF
--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -136,7 +136,7 @@ def _record_utilization_metrics(logger: logging.Logger) -> None:
         last_cpu_measurement_time = _UTILIZATION_METRICS["resource_utilization"].get(
             "measurement_timestamp"
         )
-        last_cpu_measurement = _UTILIZATION_METRICS["resource_utilization"].get("cpu_time")
+        last_cpu_measurement = _UTILIZATION_METRICS["resource_utilization"].get("cpu_usage")
         utilization_metrics = retrieve_containerized_utilization_metrics(
             logger, last_cpu_measurement_time, last_cpu_measurement
         )

--- a/python_modules/dagster/dagster/_utils/container.py
+++ b/python_modules/dagster/dagster/_utils/container.py
@@ -13,6 +13,30 @@ def cpu_usage_path():
     return os.getenv("DAGSTER_CPU_USAGE_PATH", "/sys/fs/cgroup/cpuacct/cpuacct.usage")
 
 
+def cpu_cfs_quota_us_path():
+    """Path to the cgroup file containing the CPU quota in microseconds.
+
+    We use cgroup files instead of the psutil library because psutil uses the host machine's CPU allocation in virtualized environments like Docker, K8s, ECS, etc.
+    """
+    return os.getenv("DAGSTER_CPU_CFS_QUOTA_US_PATH", "/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+
+
+def cpu_cfs_period_us_path():
+    """Path to the cgroup file containing the CPU period in microseconds.
+
+    We use cgroup files instead of the psutil library because psutil uses the host machine's CPU allocation in virtualized environments like Docker, K8s, ECS, etc.
+    """
+    return os.getenv("DAGSTER_CPU_CFS_PERIOD_US_PATH", "/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+
+
+def cpu_shares_path():
+    """Path to the cgroup file containing the CPU shares.
+
+    We use cgroup files instead of the psutil library because psutil uses the host machine's CPU allocation in virtualized environments like Docker, K8s, ECS, etc.
+    """
+    return os.getenv("DAGSTER_CPU_SHARES_PATH", "/sys/fs/cgroup/cpu/cpu.shares")
+
+
 def cpu_info_path():
     """Path to the file containing the number of cores allocated to the container."""
     return os.getenv("DAGSTER_CPU_INFO_PATH", "/proc/cpuinfo")
@@ -36,48 +60,36 @@ def memory_limit_path():
 
 class UtilizationMetrics(TypedDict):
     num_allocated_cores: Optional[int]
-    cpu_time: Optional[float]
-    cpu_utilization: Optional[float]
-    memory_utilization: Optional[float]
+    cpu_usage: Optional[float]
+    cpu_cfs_quota_us: Optional[float]
+    cpu_cfs_period_us: Optional[float]
+    memory_usage: Optional[float]
     memory_limit: Optional[int]
     measurement_timestamp: float
+    previous_cpu_usage: Optional[float]
+    previous_measurement_timestamp: Optional[float]
 
 
 def retrieve_containerized_utilization_metrics(
     logger: Optional[logging.Logger],
     previous_measurement_timestamp: Optional[float],
-    previous_cpu_time: Optional[float],
+    previous_cpu_usage: Optional[float],
 ) -> UtilizationMetrics:
     """Retrieve the CPU and memory utilization metrics from cgroup and proc files."""
-    measurement_timestamp = pendulum.now("UTC").timestamp()
-    cpu_time = _retrieve_containerized_cpu_time(logger)
-    num_cores = _retrieve_containerized_num_allocated_cores(logger)
-    if cpu_time and previous_measurement_timestamp and previous_cpu_time and num_cores:
-        cpu_utilization = (
-            (cpu_time - previous_cpu_time)
-            / (measurement_timestamp - previous_measurement_timestamp)
-            / num_cores
-        )
-    else:
-        cpu_utilization = None
-
-    memory_usage = _retrieve_containerized_memory_usage(logger)
-    memory_limit = _retrieve_containerized_memory_limit(logger)
-    if memory_usage and memory_limit:
-        memory_utilization = memory_usage / memory_limit
-    else:
-        memory_utilization = None
     return {
-        "num_allocated_cores": num_cores,
-        "cpu_time": cpu_time,
-        "cpu_utilization": cpu_utilization,
-        "memory_utilization": memory_utilization,
-        "memory_limit": memory_limit,
-        "measurement_timestamp": measurement_timestamp,
+        "num_allocated_cores": _retrieve_containerized_num_allocated_cores(logger),
+        "cpu_usage": _retrieve_containerized_cpu_usage(logger),
+        "previous_cpu_usage": previous_cpu_usage,
+        "previous_measurement_timestamp": previous_measurement_timestamp,
+        "cpu_cfs_quota_us": _retrieve_containerized_cpu_cfs_quota_us(logger),
+        "cpu_cfs_period_us": _retrieve_containerized_cpu_cfs_period_us(logger),
+        "memory_usage": _retrieve_containerized_memory_usage(logger),
+        "memory_limit": _retrieve_containerized_memory_limit(logger),
+        "measurement_timestamp": pendulum.now("UTC").float_timestamp,
     }
 
 
-def _retrieve_containerized_cpu_time(logger: Optional[logging.Logger]) -> Optional[float]:
+def _retrieve_containerized_cpu_usage(logger: Optional[logging.Logger]) -> Optional[float]:
     """Retrieve the CPU time in seconds from the cgroup file."""
     try:
         with open(cpu_usage_path()) as f:
@@ -118,4 +130,26 @@ def _retrieve_containerized_memory_limit(logger: Optional[logging.Logger]) -> Op
     except:
         if logger:
             logger.exception("Failed to retrieve memory limit from cgroup")
+        return None
+
+
+def _retrieve_containerized_cpu_cfs_period_us(logger: Optional[logging.Logger]) -> Optional[float]:
+    """Retrieve the CPU period in microseconds from the cgroup file."""
+    try:
+        with open(cpu_cfs_period_us_path()) as f:
+            return float(f.read())
+    except:
+        if logger:
+            logger.exception("Failed to retrieve CPU period from cgroup")
+        return None
+
+
+def _retrieve_containerized_cpu_cfs_quota_us(logger: Optional[logging.Logger]) -> Optional[float]:
+    """Retrieve the CPU quota in microseconds from the cgroup file."""
+    try:
+        with open(cpu_cfs_quota_us_path()) as f:
+            return float(f.read())
+    except:
+        if logger:
+            logger.exception("Failed to retrieve CPU quota from cgroup")
         return None

--- a/python_modules/dagster/dagster_tests/utils_tests/test_container_utils.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_container_utils.py
@@ -12,6 +12,8 @@ def temp_dir(tmp_path: Path):
         {
             "DAGSTER_CPU_USAGE_PATH": f"{tmp_path}/cpuacct.usage",
             "DAGSTER_CPU_INFO_PATH": f"{tmp_path}/cpuinfo",
+            "DAGSTER_CPU_CFS_QUOTA_US_PATH": f"{tmp_path}/cpu.cfs_quota_us",
+            "DAGSTER_CPU_CFS_PERIOD_US_PATH": f"{tmp_path}/cpu.cfs_period_us",
             "DAGSTER_MEMORY_USAGE_PATH": f"{tmp_path}/memory.usage_in_bytes",
             "DAGSTER_MEMORY_LIMIT_PATH": f"{tmp_path}/memory.limit_in_bytes",
         }
@@ -19,8 +21,12 @@ def temp_dir(tmp_path: Path):
         yield tmp_path
 
 
-@pytest.mark.parametrize("cpu_time_val", [1.0, None], ids=["cpu-set", "cpu-not-set"])
+@pytest.mark.parametrize("cpu_usage_val", [1.0, None], ids=["cpu-set", "cpu-not-set"])
 @pytest.mark.parametrize("cpu_cores_val", [1, None], ids=["cpu-cores-set", "cpu-cores-not-set"])
+@pytest.mark.parametrize("cpu_quota_val", [1.0, None], ids=["cpu-quota-set", "cpu-quota-not-set"])
+@pytest.mark.parametrize(
+    "cpu_period_val", [1.0, None], ids=["cpu-period-set", "cpu-period-not-set"]
+)
 @pytest.mark.parametrize(
     "memory_usage_val", [1, None], ids=["memory-usage-set", "memory-usage-not-set"]
 )
@@ -39,20 +45,30 @@ def temp_dir(tmp_path: Path):
 )
 def test_containerized_utilization_metrics(
     temp_dir: str,
-    cpu_time_val: Optional[float],
+    cpu_usage_val: Optional[float],
     cpu_cores_val: Optional[int],
+    cpu_quota_val: Optional[float],
+    cpu_period_val: Optional[float],
     memory_usage_val: Optional[int],
     memory_limit_val: Optional[int],
     was_cpu_previously_retrieved: bool,
     was_previous_timestamp_previously_set: bool,
 ):
-    if cpu_time_val:
+    if cpu_usage_val:
         with open(f"{temp_dir}/cpuacct.usage", "w") as f:
-            f.write(str(cpu_time_val * 1e9))
+            f.write(str(cpu_usage_val * 1e9))
 
     if cpu_cores_val:
         with open(f"{temp_dir}/cpuinfo", "w") as f:
             f.write("\n".join([f"processor : {i}" for i in range(cpu_cores_val)]))
+
+    if cpu_quota_val:
+        with open(f"{temp_dir}/cpu.cfs_quota_us", "w") as f:
+            f.write(str(cpu_quota_val))
+
+    if cpu_period_val:
+        with open(f"{temp_dir}/cpu.cfs_period_us", "w") as f:
+            f.write(str(cpu_period_val))
 
     if memory_usage_val:
         with open(f"{temp_dir}/memory.usage_in_bytes", "w") as f:
@@ -62,25 +78,23 @@ def test_containerized_utilization_metrics(
         with open(f"{temp_dir}/memory.limit_in_bytes", "w") as f:
             f.write(str(memory_limit_val))
 
-    previous_cpu_time = 1.0 if was_cpu_previously_retrieved else None
+    previous_cpu_usage = 1.0 if was_cpu_previously_retrieved else None
     previous_measurement_timestamp = 1.0 if was_previous_timestamp_previously_set else None
     utilization_metrics = retrieve_containerized_utilization_metrics(
         logger=None,
         previous_measurement_timestamp=previous_measurement_timestamp,
-        previous_cpu_time=previous_cpu_time,
+        previous_cpu_usage=previous_cpu_usage,
     )
-    assert utilization_metrics["cpu_time"] == (1.0 if cpu_time_val else None)
+    assert utilization_metrics["cpu_usage"] == (1.0 if cpu_usage_val else None)
     assert utilization_metrics["num_allocated_cores"] == (1 if cpu_cores_val else None)
-    assert utilization_metrics["memory_utilization"] == (
-        1 if memory_usage_val and memory_limit_val else None
-    )
+    assert utilization_metrics["cpu_cfs_quota_us"] == (1.0 if cpu_quota_val else None)
+    assert utilization_metrics["cpu_cfs_period_us"] == (1.0 if cpu_period_val else None)
+
+    assert utilization_metrics["memory_usage"] == (1 if memory_usage_val else None)
     assert utilization_metrics["memory_limit"] == (1 if memory_limit_val else None)
-    if (
-        cpu_time_val
-        and was_cpu_previously_retrieved
-        and was_previous_timestamp_previously_set
-        and cpu_cores_val
-    ):
-        assert utilization_metrics["cpu_utilization"] == 0.0
-    else:
-        assert utilization_metrics["cpu_utilization"] is None
+    assert utilization_metrics["previous_cpu_usage"] == (
+        1.0 if was_cpu_previously_retrieved else None
+    )
+    assert utilization_metrics["previous_measurement_timestamp"] == (
+        1.0 if was_previous_timestamp_previously_set else None
+    )


### PR DESCRIPTION
Previously, we were calculating utilization metrics at the container level rather than in whichever callsite is using this information. I think we want to move to just retrieving as granular metrics as possible, since it's possible for any of this information to be present or not present. Then, we can make more granular decisions about how to use this information in the callsite.

I've added cpu_quota_us and cpu_period_fs, which you can learn more about [here](https://unix.stackexchange.com/questions/417506/what-is-the-effect-of-setting-cpu-cpu-quota-us-in-cpu-cgroup). Essentially allows us to retrieve number of virtualized cpus, as well as cpu usage under certain scenarios.

This actually makes a lot of the logic and testing simpler.