### PR TITLE
[amp-refactor][16/n] Re-enable legacy GQL queries

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -1,18 +1,16 @@
-from collections import defaultdict
 from typing import Optional, Sequence, Tuple
 
-import dagster._check as check
 import graphene
 from dagster import PartitionsDefinition
+from dagster._core.definitions.asset_condition import (
+    AssetConditionEvaluation,
+    AssetSubsetWithMetadata,
+    RuleCondition,
+)
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeDecisionType,
-    AutoMaterializeRuleEvaluation,
-    AutoMaterializeRuleEvaluationData,
-    ParentUpdatedRuleEvaluationData,
-    TextRuleEvaluationData,
-    WaitingOnAssetsRuleEvaluationData,
 )
-from dagster._core.definitions.partition import SerializedPartitionsSubset
+from dagster._core.definitions.metadata import DagsterAssetMetadataValue
 from dagster._core.scheduler.instigation import AutoMaterializeAssetEvaluationRecord
 
 from dagster_graphql.schema.errors import GrapheneError
@@ -104,72 +102,131 @@ class GrapheneAutoMaterializeRuleWithRuleEvaluations(graphene.ObjectType):
 
 
 def create_graphene_auto_materialize_rule_evaluation(
-    evaluation_data_tuple: Tuple[
-        AutoMaterializeRuleEvaluationData,
-        Optional[SerializedPartitionsSubset],
-    ],
-    partitions_def: Optional[PartitionsDefinition],
-):
-    rule_evaluation_data, serialized_partition_subset = evaluation_data_tuple
-
-    if not serialized_partition_subset:
+    asset_subset_with_metadata: AssetSubsetWithMetadata,
+) -> Optional[GrapheneAutoMaterializeRuleEvaluation]:
+    if not asset_subset_with_metadata.subset.is_partitioned:
         partition_keys_or_error = None
-    elif not partitions_def:
-        partition_keys_or_error = GraphenePartitionSubsetDeserializationError(
-            message="PartitionsDefinition not found, cannot display partition keys"
+    else:
+        partition_keys_or_error = GraphenePartitionKeys(
+            partitionKeys=asset_subset_with_metadata.subset.subset_value.get_partition_keys()
         )
-    elif not serialized_partition_subset.can_deserialize(partitions_def):
-        partition_keys_or_error = GraphenePartitionSubsetDeserializationError(
-            message=(
-                "Partition subset cannot be deserialized. The PartitionsDefinition may have"
-                " changed."
-            )
+
+    metadata = asset_subset_with_metadata.metadata
+    if "text" in metadata.keys() and isinstance(metadata["text"], str):
+        rule_evaluation_data = GrapheneTextRuleEvaluationData(text=metadata["text"])
+    elif any(key.startswith("updated_parent") for key in metadata.keys()):
+        updatedAssetKeys = {
+            value.asset_key
+            for key, value in metadata.items()
+            if key.startswith("updated_parent") and isinstance(value, DagsterAssetMetadataValue)
+        }
+        willUpdateAssetKeys = {
+            value.asset_key
+            for key, value in metadata.items()
+            if key.startswith("will_update_parent") and isinstance(value, DagsterAssetMetadataValue)
+        }
+        rule_evaluation_data = GrapheneParentMaterializedRuleEvaluationData(
+            updatedAssetKeys=updatedAssetKeys, willUpdateAssetKeys=willUpdateAssetKeys
+        )
+    elif any(key.startswith("waiting_on_ancestor") for key in metadata.keys()):
+        waitingOnAssetKeys = {
+            value.asset_key
+            for key, value in metadata.items()
+            if key.startswith("waiting_on_ancestor")
+            and isinstance(value, DagsterAssetMetadataValue)
+        }
+        rule_evaluation_data = GrapheneWaitingOnKeysRuleEvaluationData(
+            waitingOnAssetKeys=waitingOnAssetKeys
         )
     else:
-        subset = serialized_partition_subset.deserialize(partitions_def)
-        partition_keys_or_error = GraphenePartitionKeys(partitionKeys=subset.get_partition_keys())
-
-    if isinstance(rule_evaluation_data, TextRuleEvaluationData):
-        rule_evaluation_data = GrapheneTextRuleEvaluationData(text=rule_evaluation_data.text)
-    elif isinstance(rule_evaluation_data, ParentUpdatedRuleEvaluationData):
-        rule_evaluation_data = GrapheneParentMaterializedRuleEvaluationData(
-            updatedAssetKeys=rule_evaluation_data.updated_asset_keys,
-            willUpdateAssetKeys=rule_evaluation_data.will_update_asset_keys,
-        )
-    elif isinstance(rule_evaluation_data, WaitingOnAssetsRuleEvaluationData):
-        rule_evaluation_data = GrapheneWaitingOnKeysRuleEvaluationData(
-            waitingOnAssetKeys=rule_evaluation_data.waiting_on_asset_keys
-        )
-    elif rule_evaluation_data is not None:
-        check.failed(f"Unexpected rule evaluation data type {type(rule_evaluation_data)}")
+        rule_evaluation_data = None
 
     return GrapheneAutoMaterializeRuleEvaluation(
         partitionKeysOrError=partition_keys_or_error, evaluationData=rule_evaluation_data
     )
 
 
-def create_graphene_auto_materialize_rules_with_rule_evaluations(
-    partition_subsets_by_condition: Sequence[
-        Tuple[AutoMaterializeRuleEvaluation, Optional[SerializedPartitionsSubset]]
-    ],
-    partitions_def: Optional[PartitionsDefinition],
-) -> Sequence[GrapheneAutoMaterializeRuleWithRuleEvaluations]:
-    rule_mapping = defaultdict(list)
-    for rule_evaluation, serialized_partition_subset in partition_subsets_by_condition:
-        rule_mapping[rule_evaluation.rule_snapshot].append(
-            (rule_evaluation.evaluation_data, serialized_partition_subset)
-        )
+def _create_rules_with_rule_evaluations_for_decision_type(
+    evaluation: AssetConditionEvaluation, decision_type: AutoMaterializeDecisionType
+) -> Tuple[
+    Sequence[GrapheneAutoMaterializeRule], Sequence[GrapheneAutoMaterializeRuleWithRuleEvaluations]
+]:
+    rules = []
+    rules_with_rule_evaluations = []
+    leaf_evaluations = evaluation.child_evaluations
+    for le in leaf_evaluations:
+        snapshot = le.condition_snapshot
+        if snapshot.class_name != RuleCondition.__name__:
+            continue
+        rule = GrapheneAutoMaterializeRule(snapshot.description, decision_type)
+        rules.append(rule)
+        if le.subsets_with_metadata:
+            rules_with_rule_evaluations.append(
+                GrapheneAutoMaterializeRuleWithRuleEvaluations(
+                    rule=rule,
+                    ruleEvaluations=[
+                        create_graphene_auto_materialize_rule_evaluation(sswm)
+                        for sswm in le.subsets_with_metadata
+                    ],
+                )
+            )
+        elif le.true_subset.size > 0:
+            rules_with_rule_evaluations.append(
+                GrapheneAutoMaterializeRuleWithRuleEvaluations(
+                    rule=rule,
+                    ruleEvaluations=[
+                        GrapheneAutoMaterializeRuleEvaluation(
+                            partitionKeysOrError=GraphenePartitionKeys(
+                                partitionKeys=le.true_subset.subset_value.get_partition_keys()
+                            )
+                            if le.true_subset.is_partitioned
+                            else None,
+                            evaluationData=None,
+                        )
+                    ],
+                )
+            )
+    return rules, rules_with_rule_evaluations
 
-    return [
-        GrapheneAutoMaterializeRuleWithRuleEvaluations(
-            rule=GrapheneAutoMaterializeRule(rule_snapshot),
-            ruleEvaluations=[
-                create_graphene_auto_materialize_rule_evaluation(tup, partitions_def)
-                for tup in tups
-            ],
+
+def create_graphene_auto_materialize_rules_with_rule_evaluations(
+    evaluation: AssetConditionEvaluation,
+) -> Tuple[
+    Sequence[GrapheneAutoMaterializeRule], Sequence[GrapheneAutoMaterializeRuleWithRuleEvaluations]
+]:
+    rules, rules_with_rule_evaluations = [], []
+
+    if len(evaluation.child_evaluations) > 0:
+        materialize_evaluation = evaluation.child_evaluations[0]
+        rs, rwres = _create_rules_with_rule_evaluations_for_decision_type(
+            materialize_evaluation, AutoMaterializeDecisionType.MATERIALIZE
         )
-        for rule_snapshot, tups in rule_mapping.items()
-    ]
+        rules.extend(rs)
+        rules_with_rule_evaluations.extend(rwres)
+
+    if (
+        len(evaluation.child_evaluations) > 1
+        and len(evaluation.child_evaluations[1].child_evaluations) == 1
+    ):
+        skip_evaluation = evaluation.child_evaluations[1].child_evaluations[0]
+        rs, rwres = _create_rules_with_rule_evaluations_for_decision_type(
+            skip_evaluation, AutoMaterializeDecisionType.SKIP
+        )
+        rules.extend(rs)
+        rules_with_rule_evaluations.extend(rwres)
+
+    if (
+        len(evaluation.child_evaluations) > 2
+        and len(evaluation.child_evaluations[2].child_evaluations) == 1
+    ):
+        discard_evaluation = evaluation.child_evaluations[2]
+        rs, rwres = _create_rules_with_rule_evaluations_for_decision_type(
+            discard_evaluation, AutoMaterializeDecisionType.DISCARD
+        )
+        rules.extend(rs)
+        rules_with_rule_evaluations.extend(rwres)
+
+    return rules, rules_with_rule_evaluations
 
 
 class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
@@ -193,16 +250,21 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
         partitions_def: Optional[PartitionsDefinition],
     ):
         evaluation_with_run_ids = record.get_evaluation_with_run_ids(partitions_def=partitions_def)
+        evaluation = evaluation_with_run_ids.evaluation
+        (
+            rules,
+            rules_with_rule_evaluations,
+        ) = create_graphene_auto_materialize_rules_with_rule_evaluations(evaluation)
         super().__init__(
             id=record.id,
             evaluationId=record.evaluation_id,
             numRequested=evaluation_with_run_ids.evaluation.true_subset.size,
-            numSkipped=0,
-            numDiscarded=0,
-            rulesWithRuleEvaluations=[],
+            numSkipped=evaluation.legacy_num_skipped(),
+            numDiscarded=evaluation.legacy_num_discarded(),
+            rulesWithRuleEvaluations=rules_with_rule_evaluations,
             timestamp=record.timestamp,
             runIds=evaluation_with_run_ids.run_ids,
-            rules=[],
+            rules=sorted(rules, key=lambda rule: rule.className),
             assetKey=GrapheneAssetKey(path=record.asset_key.path),
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition.py
@@ -184,21 +184,19 @@ class AssetConditionEvaluation(NamedTuple):
             )
         )
 
-    def discarded_subset(self, condition: "AssetCondition") -> Optional[AssetSubset]:
+    def discarded_subset(self) -> Optional[AssetSubset]:
         """Returns the AssetSubset representing asset partitions that were discarded during this
         evaluation. Note that 'discarding' is a deprecated concept that is only used for backwards
         compatibility.
         """
-        not_discard_condition = condition.not_discard_condition
-        if not not_discard_condition or len(self.child_evaluations) != 3:
+        if len(self.child_evaluations) != 3:
             return None
-
-        not_discard_evaluation = self.child_evaluations[2]
+        not_discard_evaluation = self.child_evaluations[-1]
         discard_evaluation = not_discard_evaluation.child_evaluations[0]
         return discard_evaluation.true_subset
 
-    def get_requested_or_discarded_subset(self, condition: "AssetCondition") -> AssetSubset:
-        discarded_subset = self.discarded_subset(condition)
+    def get_requested_or_discarded_subset(self) -> AssetSubset:
+        discarded_subset = self.discarded_subset()
         if discarded_subset is None:
             return self.true_subset
         else:
@@ -217,6 +215,20 @@ class AssetConditionEvaluation(NamedTuple):
 
     def with_run_ids(self, run_ids: AbstractSet[str]) -> "AssetConditionEvaluationWithRunIds":
         return AssetConditionEvaluationWithRunIds(evaluation=self, run_ids=frozenset(run_ids))
+
+    def legacy_num_skipped(self) -> int:
+        if len(self.child_evaluations) < 2:
+            return 0
+
+        not_skip_evaluation = self.child_evaluations[-1]
+        skip_evaluation = not_skip_evaluation.child_evaluations[0]
+        return skip_evaluation.true_subset.size - self.legacy_num_discarded()
+
+    def legacy_num_discarded(self) -> int:
+        discarded_subset = self.discarded_subset()
+        if discarded_subset is None:
+            return 0
+        return discarded_subset.size
 
 
 @whitelist_for_serdes
@@ -352,6 +364,12 @@ class AssetCondition(ABC):
     @property
     def children(self) -> Sequence["AssetCondition"]:
         return []
+
+    @property
+    def not_skip_condition(self) -> Optional["AssetCondition"]:
+        if not self.is_legacy:
+            return None
+        return self.children[1]
 
     @property
     def not_discard_condition(self) -> Optional["AssetCondition"]:

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition_evaluation_context.py
@@ -208,8 +208,8 @@ class AssetConditionEvaluationContext:
         ):
             return self.empty_subset()
 
-        return self.previous_evaluation_state.previous_evaluation.get_requested_or_discarded_subset(
-            self.condition
+        return (
+            self.previous_evaluation_state.previous_evaluation.get_requested_or_discarded_subset()
         )
 
     @property


### PR DESCRIPTION
## Summary & Motivation

Downstack, a few queries that power the evaluations UI were broken when we started storing evaluations in a new format. When that happened tests were updated to reflect that. This PR restores those tests, confirming that the behavior of those old queries remains the same after updating the storage format.

## How I Tested These Changes
