### PR TITLE
feat(dbt): add `required_resource_keys` argument to `@dbt_assets`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -56,6 +56,7 @@ def dbt_assets(
     dagster_dbt_translator: DagsterDbtTranslator = DagsterDbtTranslator(),
     backfill_policy: Optional[BackfillPolicy] = None,
     op_tags: Optional[Mapping[str, Any]] = None,
+    required_resource_keys: Optional[Set[str]] = None,
 ) -> Callable[..., AssetsDefinition]:
     """Create a definition for how to compute a set of dbt resources, described by a manifest.json.
     When invoking dbt commands using :py:class:`~dagster_dbt.DbtCliResource`'s
@@ -85,6 +86,7 @@ def dbt_assets(
             Frameworks may expect and require certain metadata to be attached to a op. Values that
             are not strings will be json encoded and must meet the criteria that
             `json.loads(json.dumps(value)) == value`.
+        required_resource_keys (Optional[Set[str]]): Set of required resource handles.
 
     Examples:
         Running ``dbt build`` for a dbt project:
@@ -186,6 +188,37 @@ def dbt_assets(
             def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
                 yield from dbt.cli(["build"], context=context).stream()
 
+        Using a custom resource key for dbt:
+
+        .. code-block:: python
+
+            from pathlib import Path
+
+            from dagster import AssetExecutionContext
+            from dagster_dbt import DbtCliResource, dbt_assets
+
+
+            @dbt_assets(manifest=Path("target", "manifest.json"))
+            def my_dbt_assets(context: AssetExecutionContext, my_custom_dbt_resource_key: DbtCliResource):
+                yield from my_custom_dbt_resource_key.cli(["build"], context=context).stream()
+
+        Using a dynamically generated resource key for dbt using `required_resource_keys`:
+
+        .. code-block:: python
+
+            from pathlib import Path
+
+            from dagster import AssetExecutionContext
+            from dagster_dbt import DbtCliResource, dbt_assets
+
+
+            dbt_resource_key = "my_custom_dbt_resource_key"
+
+            @dbt_assets(manifest=Path("target", "manifest.json"), required_resource_keys={my_custom_dbt_resource_key})
+            def my_dbt_assets(context: AssetExecutionContext):
+                dbt = getattr(context.resources, dbt_resource_key)
+                yield from dbt.cli(["build"], context=context).stream()
+
         Invoking another Dagster :py:class:`~dagster.ResourceDefinition` alongside dbt:
 
         .. code-block:: python
@@ -193,7 +226,7 @@ def dbt_assets(
             from pathlib import Path
 
             from dagster import AssetExecutionContext
-            from dagster_dbt import DagsterDbtTranslator, DbtCliResource, dbt_assets
+            from dagster_dbt import DbtCliResource, dbt_assets
             from dagster_slack import SlackResource
 
 
@@ -211,7 +244,7 @@ def dbt_assets(
             from pathlib import Path
 
             from dagster import AssetExecutionContext, Config
-            from dagster_dbt import DagsterDbtTranslator, DbtCliResource, dbt_assets
+            from dagster_dbt import DbtCliResource, dbt_assets
 
 
             class MyDbtConfig(Config):
@@ -305,6 +338,7 @@ def dbt_assets(
             name=name,
             internal_asset_deps=internal_asset_deps,
             deps=deps,
+            required_resource_keys=required_resource_keys,
             compute_kind="dbt",
             partitions_def=partitions_def,
             can_subset=True,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -19,6 +19,7 @@ from dagster import (
     PartitionsDefinition,
     TimeWindowPartitionMapping,
     asset,
+    materialize,
 )
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster._core.execution.context.compute import AssetExecutionContext
@@ -573,6 +574,26 @@ def test_dbt_with_downstream_asset():
     assert len(downstream_of_dbt.input_names) == 2
     assert downstream_of_dbt.op.ins["orders"].dagster_type.is_nothing
     assert downstream_of_dbt.op.ins["customized_staging_payments"].dagster_type.is_nothing
+
+
+def test_dbt_with_custom_resource_key() -> None:
+    dbt_resource_key = "my_custom_dbt_resource_key"
+
+    @dbt_assets(manifest=test_dagster_metadata_manifest, required_resource_keys={dbt_resource_key})
+    def my_dbt_assets(context: AssetExecutionContext):
+        dbt = getattr(context.resources, dbt_resource_key)
+
+        yield from dbt.cli(["build"], context=context).stream()
+
+    result = materialize(
+        [my_dbt_assets],
+        resources={
+            dbt_resource_key: DbtCliResource(
+                project_dir=os.fspath(test_dagster_metadata_manifest_path.joinpath("..").resolve())
+            )
+        },
+    )
+    assert result.success
 
 
 def test_dbt_with_python_interleaving() -> None:


### PR DESCRIPTION
## Summary & Motivation
Adds examples of customizing the dbt resource key in the static (e.g. changing the parameter name) and dynamic cases (accessing `context.resources`) when using `@dbt_assets`.

The dynamic case was a bit contrived, so make it more explicit by just using `required_resource_keys`. It's another argument that's passed down to the underlying `@multi_asset` decorator.

This way, we have a nice reference for users who have questions similar to https://github.com/dagster-io/dagster/discussions/19079.

## How I Tested These Changes
pytest
