### PR TITLE
[ui] Improve theme support for composite ops, communituy NUX

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/src/NUX/CommunityNux.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/NUX/CommunityNux.tsx
@@ -11,6 +11,7 @@ import {
   Spinner,
   TextInput,
   colorAccentRed,
+  colorBackgroundDefault,
   colorTextLight,
   colorTextRed,
 } from '@dagster-io/ui-components';
@@ -94,7 +95,7 @@ const Form = ({dismiss, submit}: FormProps) => {
   return (
     <Box
       flex={{direction: 'column', gap: 16}}
-      style={{padding: '36px', width: '680px', background: 'white'}}
+      style={{padding: '36px', width: '680px', background: colorBackgroundDefault()}}
     >
       <Box
         flex={{direction: 'row', gap: 24, alignItems: 'center'}}

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/ExternalConnectionNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/ExternalConnectionNode.tsx
@@ -1,4 +1,10 @@
-import {colorBackgroundLight, colorBackgroundLightHover} from '@dagster-io/ui-components';
+import {
+  colorBackgroundDefault,
+  colorBackgroundLightHover,
+  colorLineageEdge,
+  colorLineageEdgeHighlighted,
+  colorTextDefault,
+} from '@dagster-io/ui-components';
 import {LinkVertical as Link} from '@vx/shape';
 import * as React from 'react';
 import styled from 'styled-components';
@@ -35,7 +41,7 @@ export const ExternalConnectionNode = ({
   const textProps = {width: 0, size: minified ? 24 : 12, text: label};
   const textSize = SVGMonospaceText.intrinsicSizeForProps(textProps);
   const highlighted = edges.some((e) => isHighlighted(highlightedEdges, e));
-  const color = highlighted ? '#555' : '#C7CBCD';
+  const color = highlighted ? colorLineageEdgeHighlighted() : colorLineageEdge();
 
   // https://github.com/dagster-io/dagster/issues/1504
   if (!layout) {
@@ -59,7 +65,7 @@ export const ExternalConnectionNode = ({
         }}
       />
       <ellipse cx={layout.x} cy={layout.y} rx={7} ry={7} fill={color} />
-      <SVGMonospaceText {...textProps} {...textSize} {...textOrigin} />
+      <SVGMonospaceText {...textProps} {...textSize} {...textOrigin} fill={colorTextDefault()} />
       <Link style={{stroke: color, strokeWidth: 6, fill: 'none'}} data={{source: layout, target}} />
     </g>
   );
@@ -67,8 +73,8 @@ export const ExternalConnectionNode = ({
 
 const BackingRect = styled('rect')`
   stroke-width: 10px;
-  fill: ${colorBackgroundLight()};
-  stroke: ${colorBackgroundLight()};
+  fill: ${colorBackgroundDefault()};
+  stroke: ${colorBackgroundDefault()};
   &:hover {
     fill: ${colorBackgroundLightHover()};
     stroke: ${colorBackgroundLightHover()};

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/MappingLine.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/MappingLine.tsx
@@ -1,3 +1,8 @@
+import {
+  colorBackgroundDefault,
+  colorLineageEdge,
+  colorLineageEdgeHighlighted,
+} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {Edge} from './OpEdges';
@@ -29,16 +34,16 @@ export const MappingLine = ({
       <path
         d={`M ${source.x} ${source.y} H ${leftEdgeX} V ${target.y} H ${target.x}`}
         fill="none"
-        strokeWidth={minified ? 6 : 5}
+        strokeWidth={minified ? 10 : 6}
         strokeLinecap="round"
-        stroke={highlighted ? 'black' : 'rgb(137, 206, 206)'}
+        stroke={highlighted ? colorLineageEdgeHighlighted() : colorLineageEdge()}
       />
       <path
         d={`M ${source.x} ${source.y} H ${leftEdgeX} V ${target.y} H ${target.x}`}
         fill="none"
-        strokeWidth={4}
+        strokeWidth={3}
         strokeLinecap="round"
-        stroke="white"
+        stroke={colorBackgroundDefault()}
       />
     </g>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/OpGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/OpGraph.tsx
@@ -3,8 +3,7 @@ import {
   colorAccentBlue,
   colorBackgroundBlue,
   colorBackgroundBlueHover,
-  colorBackgroundYellow,
-  colorKeylineDefault,
+  colorLineageEdge,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled from 'styled-components';
@@ -13,7 +12,7 @@ import {OpNameOrPath} from '../ops/OpNameOrPath';
 
 import {OpEdges} from './OpEdges';
 import {OpNode, OP_NODE_DEFINITION_FRAGMENT, OP_NODE_INVOCATION_FRAGMENT} from './OpNode';
-import {ParentOpNode, SVGLabeledParentRect} from './ParentOpNode';
+import {ParentOpNode} from './ParentOpNode';
 import {DEFAULT_MAX_ZOOM, DETAIL_ZOOM, SVGViewport, SVGViewportInteractor} from './SVGViewport';
 import {OpGraphLayout} from './asyncGraphLayout';
 import {
@@ -72,15 +71,6 @@ const OpGraphContents = React.memo((props: OpGraphContentsProps) => {
 
   return (
     <>
-      {parentOp && layout.parent && layout.parent.invocationBoundingBox.width > 0 && (
-        <SVGLabeledParentRect
-          {...layout.parent.invocationBoundingBox}
-          key={`composite-rect-${parentHandleID}`}
-          label=""
-          fill={colorBackgroundYellow()}
-          minified={minified}
-        />
-      )}
       {parentOp && (
         <ParentOpNode
           onClickOp={onClickOp}
@@ -96,7 +86,7 @@ const OpGraphContents = React.memo((props: OpGraphContentsProps) => {
       <OpEdges
         ops={ops}
         layout={layout}
-        color={colorKeylineDefault()}
+        color={colorLineageEdge()}
         edges={layout.edges}
         onHighlight={setHighlighted}
       />

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/ParentOpNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/ParentOpNode.tsx
@@ -1,4 +1,4 @@
-import {colorBackgroundGray} from '@dagster-io/ui-components';
+import {colorBackgroundYellow, colorKeylineDefault} from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled from 'styled-components';
 
@@ -7,8 +7,8 @@ import {OpNameOrPath} from '../ops/OpNameOrPath';
 
 import {ExternalConnectionNode} from './ExternalConnectionNode';
 import {MappingLine} from './MappingLine';
-import {metadataForCompositeParentIO, PARENT_IN, PARENT_OUT, OpIOBox} from './OpIOBox';
-import {SVGLabeledRect} from './SVGComponents';
+import {OpIOBox, PARENT_IN, PARENT_OUT, metadataForCompositeParentIO} from './OpIOBox';
+import {SVGMonospaceText} from './SVGComponents';
 import {OpGraphLayout} from './asyncGraphLayout';
 import {Edge} from './common';
 import {OpGraphOpFragment} from './types/OpGraph.types';
@@ -53,7 +53,7 @@ export const ParentOpNode = (props: ParentOpNodeProps) => {
       <SVGLabeledParentRect
         {...bounds}
         label={op.definition.name}
-        fill={colorBackgroundGray()}
+        fill={colorBackgroundYellow()}
         minified={minified}
       />
       {def.inputMappings.map(({definition, mappedInput}, idx) => {
@@ -127,71 +127,110 @@ export const ParentOpNode = (props: ParentOpNodeProps) => {
           />
         );
       })}
+      {op.definition.inputDefinitions.map((input, idx) => {
+        const metadata = metadataForCompositeParentIO(op.definition, input);
+        const invocationInput = op.inputs.find((i) => i.definition.name === input.name)!;
+        return (
+          <React.Fragment key={idx}>
+            {invocationInput.dependsOn.map((dependsOn, iidx) => (
+              <ExternalConnectionNode
+                {...highlightingProps}
+                {...metadata}
+                key={iidx}
+                labelAttachment="top"
+                label={titleOfIO(dependsOn)}
+                minified={minified}
+                layout={parentLayout.dependsOn[titleOfIO(dependsOn)]!}
+                target={parentLayout.inputs[input.name]!.port}
+                onDoubleClickLabel={() => props.onClickOp({path: ['..', dependsOn.solid.name]})}
+              />
+            ))}
+          </React.Fragment>
+        );
+      })}
+      {op.definition.outputDefinitions.map((output, idx) => {
+        const metadata = metadataForCompositeParentIO(op.definition, output);
+        const invocationOutput = op.outputs.find((i) => i.definition.name === output.name)!;
+        return (
+          <React.Fragment key={idx}>
+            {invocationOutput.dependedBy.map((dependedBy, iidx) => (
+              <ExternalConnectionNode
+                {...highlightingProps}
+                {...metadata}
+                key={iidx}
+                labelAttachment="bottom"
+                label={titleOfIO(dependedBy)}
+                minified={minified}
+                layout={parentLayout.dependedBy[titleOfIO(dependedBy)]!}
+                target={parentLayout.outputs[output.name]!.port}
+                onDoubleClickLabel={() => props.onClickOp({path: ['..', dependedBy.solid.name]})}
+              />
+            ))}
+          </React.Fragment>
+        );
+      })}
       <foreignObject width={layout.width} height={layout.height} style={{pointerEvents: 'none'}}>
-        {op.definition.inputDefinitions.map((input, idx) => {
-          const metadata = metadataForCompositeParentIO(op.definition, input);
-          const invocationInput = op.inputs.find((i) => i.definition.name === input.name)!;
-
-          return (
-            <React.Fragment key={idx}>
-              {invocationInput.dependsOn.map((dependsOn, iidx) => (
-                <ExternalConnectionNode
-                  {...highlightingProps}
-                  {...metadata}
-                  key={iidx}
-                  labelAttachment="top"
-                  label={titleOfIO(dependsOn)}
-                  minified={minified}
-                  layout={parentLayout.dependsOn[titleOfIO(dependsOn)]!}
-                  target={parentLayout.inputs[input.name]!.port}
-                  onDoubleClickLabel={() => props.onClickOp({path: ['..', dependsOn.solid.name]})}
-                />
-              ))}
-              <OpIOBox
-                {...highlightingProps}
-                {...metadata}
-                minified={minified}
-                colorKey="input"
-                item={input}
-                layoutInfo={parentLayout.inputs[input.name]}
-              />
-            </React.Fragment>
-          );
-        })}
-        {op.definition.outputDefinitions.map((output, idx) => {
-          const metadata = metadataForCompositeParentIO(op.definition, output);
-          const invocationOutput = op.outputs.find((i) => i.definition.name === output.name)!;
-
-          return (
-            <React.Fragment key={idx}>
-              {invocationOutput.dependedBy.map((dependedBy, iidx) => (
-                <ExternalConnectionNode
-                  {...highlightingProps}
-                  {...metadata}
-                  key={iidx}
-                  labelAttachment="bottom"
-                  label={titleOfIO(dependedBy)}
-                  minified={minified}
-                  layout={parentLayout.dependedBy[titleOfIO(dependedBy)]!}
-                  target={parentLayout.outputs[output.name]!.port}
-                  onDoubleClickLabel={() => props.onClickOp({path: ['..', dependedBy.solid.name]})}
-                />
-              ))}
-              <OpIOBox
-                {...highlightingProps}
-                {...metadata}
-                minified={minified}
-                colorKey="output"
-                item={output}
-                layoutInfo={parentLayout.outputs[output.name]}
-              />
-            </React.Fragment>
-          );
-        })}
+        {op.definition.inputDefinitions.map((input, idx) => (
+          <OpIOBox
+            {...highlightingProps}
+            {...metadataForCompositeParentIO(op.definition, input)}
+            key={idx}
+            minified={minified}
+            colorKey="input"
+            item={input}
+            layoutInfo={parentLayout.inputs[input.name]}
+          />
+        ))}
+        {op.definition.outputDefinitions.map((output, idx) => (
+          <OpIOBox
+            {...highlightingProps}
+            {...metadataForCompositeParentIO(op.definition, output)}
+            key={idx}
+            minified={minified}
+            colorKey="output"
+            item={output}
+            layoutInfo={parentLayout.outputs[output.name]}
+          />
+        ))}
       </foreignObject>
     </>
   );
 };
+
+const SVGLabeledRect = ({
+  minified,
+  label,
+  fill,
+  className,
+  ...rect
+}: {
+  x: number;
+  y: number;
+  minified: boolean;
+  width: number;
+  height: number;
+  label: string;
+  fill: string;
+  className?: string;
+}) => (
+  <g>
+    <rect
+      {...rect}
+      fill={fill}
+      stroke={colorKeylineDefault()}
+      strokeWidth={1}
+      className={className}
+    />
+    <SVGMonospaceText
+      x={rect.x + (minified ? 10 : 5)}
+      y={rect.y + (minified ? 10 : 5)}
+      height={undefined}
+      size={minified ? 30 : 16}
+      text={label}
+      fill="#979797"
+    />
+  </g>
+);
 
 export const SVGLabeledParentRect = styled(SVGLabeledRect)`
   transition:

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/SVGComponents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/SVGComponents.tsx
@@ -89,32 +89,3 @@ export class SVGMonospaceText extends React.PureComponent<
     );
   }
 }
-
-export const SVGLabeledRect = ({
-  minified,
-  label,
-  fill,
-  className,
-  ...rect
-}: {
-  x: number;
-  y: number;
-  minified: boolean;
-  width: number;
-  height: number;
-  label: string;
-  fill: string;
-  className?: string;
-}) => (
-  <g>
-    <rect {...rect} fill={fill} stroke="#979797" strokeWidth={1} className={className} />
-    <SVGMonospaceText
-      x={rect.x + (minified ? 10 : 5)}
-      y={rect.y + (minified ? 10 : 5)}
-      height={undefined}
-      size={minified ? 30 : 16}
-      text={label}
-      fill="#979797"
-    />
-  </g>
-);

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphExplorer.tsx
@@ -91,7 +91,7 @@ export const GraphExplorer = (props: GraphExplorerProps) => {
         if (arg.path[0] !== '..') {
           opNames.length = 0;
         }
-        if (arg.path[0] === '..' && opNames[opNames.length - 1] !== '') {
+        if (arg.path[0] === '..') {
           opNames.pop(); // remove the last path component indicating selection
         }
         while (arg.path[0] === '..') {


### PR DESCRIPTION
## Summary & Motivation

This PR makes two changes:

- I fixed a white background on the community NUX modal

- I fixed a duplicate box in composite op graphs

- I fixed Op graphs using a lighter arrow color (keyline gray) that was difficult to see on large graphs

- I fixed the "external links" shown when zoomed into a composite -- these are rendered with SVG elements but were inside an HTML foreignObject, so they weren't displaying at all. I also updated their use of colors to match the new themes!

## How I Tested These Changes

Just visual inspection, before after comparison is below.