### PR TITLE
Fix automation policy sensor log spew in sensor daemon

### DIFF
--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -323,6 +323,10 @@ def execute_sensor_iteration(
     all_sensor_states = {
         sensor_state.selector_id: sensor_state
         for sensor_state in instance.all_instigator_state(instigator_type=InstigatorType.SENSOR)
+        if (
+            not sensor_state.instigator_data
+            or sensor_state.instigator_data.sensor_type != SensorType.AUTOMATION_POLICY
+        )
     }
 
     tick_retention_settings = instance.get_tick_retention_settings(InstigatorType.SENSOR)


### PR DESCRIPTION
Summary:
Once you start an automation policy sensor, the sensor states cause some logspew in the sensor daemon because their rows in the DB are incorrectly flagged as not matching to a sensor being ticked in the daemon. Remove those rows from consideration in this context.

Test Plan:
BK
Run an AMP sensor locally, no more snesor daemon logspew

## Summary & Motivation

## How I Tested These Changes
