### PR TITLE
[asset backfill] Retry fetching asset graph when outdated

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -15,7 +15,6 @@ from typing import (
     Optional,
     Sequence,
     Set,
-    Tuple,
     Union,
     cast,
 )
@@ -59,6 +58,7 @@ from dagster._core.host_representation import (
     ExternalJob,
 )
 from dagster._core.instance import DagsterInstance, DynamicPartitionsStore
+from dagster._core.snap import ExecutionPlanSnapshot
 from dagster._core.storage.dagster_run import (
     CANCELABLE_RUN_STATUSES,
     DagsterRunStatus,
@@ -693,9 +693,8 @@ def _submit_runs_and_update_backfill_in_chunks(
     # In between each chunk, check that the backfill is still marked as 'requested',
     # to ensure that no more runs are requested if the backfill is marked as canceled/canceling.
     unsubmitted_run_request_idx = 0
-    pipeline_and_execution_plan_cache: Dict[
-        int, Tuple[ExternalJob, ExternalExecutionPlan, Optional[PartitionsDefinition]]
-    ] = {}
+    run_request_execution_data_cache: Dict[int, RunRequestExecutionData] = {}
+    num_retries_allowed = 1
     while unsubmitted_run_request_idx < len(run_requests):
         chunk_end_idx = min(unsubmitted_run_request_idx + RUN_CHUNK_SIZE, len(run_requests))
         run_requests_chunk = run_requests[unsubmitted_run_request_idx:chunk_end_idx]
@@ -707,17 +706,50 @@ def _submit_runs_and_update_backfill_in_chunks(
             break
 
         # Submit runs in the chunk
-        for run_request in run_requests_chunk:
+        run_requests_i = 0
+        while run_requests_i < len(run_requests_chunk):
+            run_request = run_requests_chunk[run_requests_i]
             yield None
-            submit_run_request(
-                run_request=run_request,
-                asset_graph=asset_graph,
-                # create a new request context for each run in case the code location server
-                # is swapped out in the middle of the backfill
-                workspace=workspace_process_context.create_request_context(),
-                instance=instance,
-                pipeline_and_execution_plan_cache=pipeline_and_execution_plan_cache,
+
+            # create a new request context for each run in case the code location server
+            # is swapped out in the middle of the backfill
+            workspace = workspace_process_context.create_request_context()
+            execution_data = get_job_execution_data_from_run_request(
+                asset_graph,
+                run_request,
+                instance,
+                workspace=workspace,
+                run_request_execution_data_cache=run_request_execution_data_cache,
             )
+
+            if _execution_plan_targets_asset_selection(
+                execution_data.external_execution_plan.execution_plan_snapshot,
+                check.not_none(run_request.asset_selection),
+            ):
+                submit_run_request(
+                    run_request=run_request,
+                    workspace=workspace,
+                    instance=instance,
+                    run_request_execution_data=execution_data,
+                )
+                run_requests_i += 1
+
+            elif num_retries_allowed > 0:
+                # Sleep 60s since the workspace can be refreshed at most one every 60s
+                time.sleep(60)
+                # Clear the execution plan cache as this data is no longer valid
+                run_request_execution_data_cache = {}
+                num_retries_allowed -= 1
+                # If the execution plan does not targets the asset selection, the asset graph
+                # likely is outdated and targeting the wrong job, refetch the asset
+                # graph from the workspace
+                workspace = workspace_process_context.create_request_context()
+                asset_graph = ExternalAssetGraph.from_workspace(workspace)
+
+            else:  # Already hit the max number of retries
+                check.failed(
+                    f"Failed to target asset selection {run_request.asset_selection} in run after {num_retries_allowed} retries."
+                )
 
         unsubmitted_run_request_idx = chunk_end_idx
 
@@ -1069,15 +1101,19 @@ def get_canceling_asset_backfill_iteration_data(
     yield updated_backfill_data
 
 
-def submit_run_request(
+class RunRequestExecutionData(NamedTuple):
+    external_job: ExternalJob
+    external_execution_plan: ExternalExecutionPlan
+    partitions_def: Optional[PartitionsDefinition]
+
+
+def get_job_execution_data_from_run_request(
     asset_graph: ExternalAssetGraph,
     run_request: RunRequest,
     instance: DagsterInstance,
     workspace: BaseWorkspaceRequestContext,
-    pipeline_and_execution_plan_cache: Dict[
-        int, Tuple[ExternalJob, ExternalExecutionPlan, Optional[PartitionsDefinition]]
-    ],
-) -> None:
+    run_request_execution_data_cache: Dict[int, RunRequestExecutionData],
+) -> RunRequestExecutionData:
     """Creates and submits a run for the given run request."""
     repo_handle = asset_graph.get_repository_handle(
         cast(Sequence[AssetKey], run_request.asset_selection)[0]
@@ -1105,7 +1141,7 @@ def submit_run_request(
 
     selector_id = hash_collection(pipeline_selector)
 
-    if selector_id not in pipeline_and_execution_plan_cache:
+    if selector_id not in run_request_execution_data_cache:
         code_location = workspace.get_code_location(repo_handle.code_location_origin.location_name)
         external_job = code_location.get_external_job(pipeline_selector)
 
@@ -1119,17 +1155,27 @@ def submit_run_request(
 
         partitions_def = code_location.get_asset_job_partitions_def(external_job)
 
-        pipeline_and_execution_plan_cache[selector_id] = (
+        run_request_execution_data_cache[selector_id] = RunRequestExecutionData(
             external_job,
             external_execution_plan,
             partitions_def,
         )
 
-    (
-        external_job,
-        external_execution_plan,
-        partitions_def,
-    ) = pipeline_and_execution_plan_cache[selector_id]
+    return run_request_execution_data_cache[selector_id]
+
+
+def submit_run_request(
+    run_request: RunRequest,
+    instance: DagsterInstance,
+    workspace: BaseWorkspaceRequestContext,
+    run_request_execution_data: RunRequestExecutionData,
+) -> None:
+    external_job = run_request_execution_data.external_job
+    external_execution_plan = run_request_execution_data.external_execution_plan
+    partitions_def = run_request_execution_data.partitions_def
+
+    if not run_request.asset_selection:
+        check.failed("Expected RunRequest to have an asset selection")
 
     run = instance.create_run(
         job_snapshot=external_job.job_snapshot,
@@ -1153,6 +1199,19 @@ def submit_run_request(
     )
 
     instance.submit_run(run.run_id, workspace)
+
+
+def _execution_plan_targets_asset_selection(
+    execution_plan_snapshot: ExecutionPlanSnapshot, asset_selection: Sequence[AssetKey]
+) -> bool:
+    output_asset_keys = set()
+    for step in execution_plan_snapshot.steps:
+        if step.key in execution_plan_snapshot.step_keys_to_execute:
+            for output in step.outputs:
+                asset_key = check.not_none(output.properties).asset_key
+                if asset_key:
+                    output_asset_keys.add(asset_key)
+    return all(key in output_asset_keys for key in asset_selection)
 
 
 def _get_implicit_job_name_for_assets(

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -739,7 +739,7 @@ def _submit_runs_and_update_backfill_in_chunks(
             elif num_retries_allowed > 0:
                 logger.warning(
                     "Execution plan is out of sync with the workspace. Pausing the backfill for "
-                    "60s to allow the execution plan to rebuild with the updated workspace."
+                    f"{RELOAD_WORKSPACE_INTERVAL} to allow the execution plan to rebuild with the updated workspace."
                 )
                 # Sleep for RELOAD_WORKSPACE_INTERVAL seconds since the workspace can be refreshed
                 # at most once every interval
@@ -755,7 +755,7 @@ def _submit_runs_and_update_backfill_in_chunks(
 
             else:  # Already hit the max number of retries
                 check.failed(
-                    f"Failed to target asset selection {run_request.asset_selection} in run after {num_retries_allowed} retries."
+                    f"Failed to target asset selection {run_request.asset_selection} in run after retrying."
                 )
 
         unsubmitted_run_request_idx = chunk_end_idx

--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -150,3 +150,53 @@ def partitions_defs_changes_location_2_fixture(
         instance=instance_module_scoped,
     ) as workspace_context:
         yield workspace_context
+
+
+def base_job_name_changes_workspace_1_load_target(attribute=None):
+    return InProcessTestWorkspaceLoadTarget(
+        InProcessCodeLocationOrigin(
+            loadable_target_origin=LoadableTargetOrigin(
+                executable_path=sys.executable,
+                module_name="dagster_tests.daemon_tests.test_locations.base_job_name_changes_locations.location_1",
+                working_directory=os.getcwd(),
+                attribute=attribute,
+            ),
+            location_name="base_job_name_changes",
+        )
+    )
+
+
+@pytest.fixture(name="base_job_name_changes_location_1_workspace_context", scope="module")
+def base_job_name_changes_location_1_fixture(
+    instance_module_scoped,
+) -> Iterator[WorkspaceProcessContext]:
+    with create_test_daemon_workspace_context(
+        workspace_load_target=base_job_name_changes_workspace_1_load_target(),
+        instance=instance_module_scoped,
+    ) as workspace_context:
+        yield workspace_context
+
+
+def base_job_name_changes_workspace_2_load_target(attribute=None):
+    return InProcessTestWorkspaceLoadTarget(
+        InProcessCodeLocationOrigin(
+            loadable_target_origin=LoadableTargetOrigin(
+                executable_path=sys.executable,
+                module_name="dagster_tests.daemon_tests.test_locations.base_job_name_changes_locations.location_2",
+                working_directory=os.getcwd(),
+                attribute=attribute,
+            ),
+            location_name="base_job_name_changes",
+        )
+    )
+
+
+@pytest.fixture(name="base_job_name_changes_location_2_workspace_context", scope="module")
+def base_job_name_changes_location_2_fixture(
+    instance_module_scoped,
+) -> Iterator[WorkspaceProcessContext]:
+    with create_test_daemon_workspace_context(
+        workspace_load_target=base_job_name_changes_workspace_2_load_target(),
+        instance=instance_module_scoped,
+    ) as workspace_context:
+        yield workspace_context

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_locations/base_job_name_changes_locations/location_1.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_locations/base_job_name_changes_locations/location_1.py
@@ -1,0 +1,13 @@
+from dagster import HourlyPartitionsDefinition, WeeklyPartitionsDefinition, asset
+
+
+@asset(
+    partitions_def=HourlyPartitionsDefinition("2023-01-01-00:00"),
+)
+def hourly_asset():  # Exists in __ASSET_JOB_0
+    pass
+
+
+@asset(partitions_def=WeeklyPartitionsDefinition("2023-01-05"))
+def weekly_asset():  # Exists in __ASSET_JOB_1
+    pass

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_locations/base_job_name_changes_locations/location_2.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_locations/base_job_name_changes_locations/location_2.py
@@ -1,0 +1,15 @@
+from dagster import DailyPartitionsDefinition, HourlyPartitionsDefinition, asset
+
+
+@asset(
+    partitions_def=DailyPartitionsDefinition("2022-12-12"),
+)
+def daily_asset():  # Exists in __ASSET_JOB_0
+    pass
+
+
+@asset(
+    partitions_def=HourlyPartitionsDefinition("2023-01-01-00:00"),
+)
+def hourly_asset():  # Exists in __ASSET_JOB_1
+    pass


### PR DESCRIPTION
A backfill run was launched for a cloud customer that contained an asset selection but no steps. The cause of this is the asset graph changing mid-iteration, causing the targeted job name to be incorrect.

This PR catches when this error occurs and adds a retry step that sleeps for 60s (maximum time to that a workspace is cached) then refetches the asset graph.

The retry step occurs at most once per iteration, erroring otherwise, to prevent sleep time from throttling the daemon.