### PR TITLE
Don't hit the gRPC server at all during asset backfill or AMP ticks

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -485,7 +485,7 @@ class GrapheneRun(graphene.ObjectType):
         return from_captured_log_data(log_data)
 
     def resolve_executionPlan(self, graphene_info: ResolveInfo):
-        if not (self.dagster_run.execution_plan_snapshot_id and self.dagster_run.job_snapshot_id):
+        if not self.dagster_run.execution_plan_snapshot_id:
             return None
 
         instance = graphene_info.context.instance

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1097,7 +1097,7 @@ def submit_run_request(
 
     code_location = workspace.get_code_location(repo_handle.code_location_origin.location_name)
 
-    if not code_location.can_create_snapshots_in_run_worker():
+    if not code_location.can_create_snapshots_in_run_worker(repo_handle.repository_name):
         pipeline_selector = JobSubsetSelector(
             location_name=location_name,
             repository_name=repo_handle.repository_name,

--- a/python_modules/dagster/dagster/_core/host_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/code_location.py
@@ -115,7 +115,7 @@ class CodeLocation(AbstractContextManager):
     def name(self) -> str:
         return self.origin.location_name
 
-    def can_create_snapshots_in_run_worker(self) -> bool:
+    def can_create_snapshots_in_run_worker(self, repo_name: str) -> bool:
         return False
 
     @abstractmethod
@@ -623,7 +623,7 @@ class GrpcServerCodeLocation(CodeLocation):
         self._container_context = None
         self._repository_code_pointer_dict = None
         self._entry_point = None
-        self._can_create_snapshots_in_run_worker = False
+        self._can_create_snapshots_in_run_worker = {}
 
         try:
             self.client = DagsterGrpcClient(
@@ -691,8 +691,8 @@ class GrpcServerCodeLocation(CodeLocation):
             self.cleanup()
             raise
 
-    def can_create_snapshots_in_run_worker(self) -> bool:
-        return self._can_create_snapshots_in_run_worker
+    def can_create_snapshots_in_run_worker(self, repo_name: str) -> bool:
+        return self._can_create_snapshots_in_run_worker.get(repo_name, False)
 
     @property
     def origin(self) -> CodeLocationOrigin:

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -191,6 +191,16 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
             new_tags (Dict[string, string])
         """
 
+    # @abstractmethod
+    # Need to fill in the other storage impls
+    def add_execution_plan_snapshot_to_run(self, run_id: str, execution_plan_snapshot_id: str):
+        """Add an execution plan snapshot to a run.
+
+        Args:
+            run_id (str)
+            execution_plan_snapshot_id (str)
+        """
+
     @abstractmethod
     def has_run(self, run_id: str) -> bool:
         """Check if the storage contains a run.

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -438,6 +438,24 @@ class SqlRunStorage(RunStorage):
         rows = self.fetchall(query)
         return sorted([r["key"] for r in rows])
 
+    def add_execution_plan_snapshot_to_run(self, run_id: str, execution_plan_snapshot_id: str):
+        run = self._get_run_by_id(run_id)
+        if not run:
+            raise DagsterRunNotFoundError(
+                f"Run {run_id} was not found in instance.", invalid_run_id=run_id
+            )
+        with self.connect() as conn:
+            run = run._replace(execution_plan_snapshot_id=execution_plan_snapshot_id)
+            conn.execute(
+                RunsTable.update()  # pylint: disable=no-value-for-parameter
+                .where(RunsTable.c.run_id == run_id)
+                .values(
+                    run_body=serialize_value(run),
+                    update_timestamp=pendulum.now("UTC"),
+                )
+            )
+        return run
+
     def add_run_tags(self, run_id: str, new_tags: Mapping[str, str]) -> None:
         check.str_param(run_id, "run_id")
         check.mapping_param(new_tags, "new_tags", key_type=str, value_type=str)

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -845,7 +845,7 @@ def submit_asset_run(
             )
         )
 
-        if not code_location.can_create_snapshots_in_run_worker():
+        if not code_location.can_create_snapshots_in_run_worker(repository_name):
             job_selector = JobSubsetSelector(
                 location_name=location_name,
                 repository_name=repository_name,

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -191,6 +191,7 @@ class LoadedRepositories:
         self._recon_repos_by_name: Dict[str, ReconstructableRepository] = {}
         self._repo_defs_by_name: Dict[str, RepositoryDefinition] = {}
         self._loadable_repository_symbols: List[LoadableRepositorySymbol] = []
+        self._has_repository_data_by_name: Dict[str, bool] = {}
 
         if not loadable_target_origin:
             # empty workspace
@@ -540,7 +541,10 @@ class DagsterApiServer(DagsterApiServicer):
                     container_image=self._container_image,
                     container_context=self._container_context,
                     dagster_library_versions=DagsterLibraryRegistry.get(),
-                    can_create_snapshots_in_run_worker=True,
+                    can_create_snapshots_in_run_worker={
+                        repo_name: repo_def.repository_load_data is None
+                        for repo_name, repo_def in loaded_repositories.definitions_by_name.items()
+                    },
                 )
             )
         except Exception:

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -540,6 +540,7 @@ class DagsterApiServer(DagsterApiServicer):
                     container_image=self._container_image,
                     container_context=self._container_context,
                     dagster_library_versions=DagsterLibraryRegistry.get(),
+                    can_create_snapshots_in_run_worker=True,
                 )
             )
         except Exception:

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -324,6 +324,7 @@ class ListRepositoriesResponse(
             ("container_image", Optional[str]),
             ("container_context", Optional[Mapping[str, Any]]),
             ("dagster_library_versions", Optional[Mapping[str, str]]),
+            ("can_create_snapshots_in_run_worker", bool),
         ],
     )
 ):
@@ -336,6 +337,7 @@ class ListRepositoriesResponse(
         container_image: Optional[str] = None,
         container_context: Optional[Mapping] = None,
         dagster_library_versions: Optional[Mapping[str, str]] = None,
+        can_create_snapshots_in_run_worker: Optional[bool] = None,
     ):
         return super(ListRepositoriesResponse, cls).__new__(
             cls,
@@ -363,6 +365,7 @@ class ListRepositoriesResponse(
             dagster_library_versions=check.opt_nullable_mapping_param(
                 dagster_library_versions, "dagster_library_versions"
             ),
+            can_create_snapshots_in_run_worker=can_create_snapshots_in_run_worker or False,
         )
 
 

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -324,7 +324,7 @@ class ListRepositoriesResponse(
             ("container_image", Optional[str]),
             ("container_context", Optional[Mapping[str, Any]]),
             ("dagster_library_versions", Optional[Mapping[str, str]]),
-            ("can_create_snapshots_in_run_worker", bool),
+            ("can_create_snapshots_in_run_worker", Mapping[str, bool]),
         ],
     )
 ):
@@ -337,7 +337,7 @@ class ListRepositoriesResponse(
         container_image: Optional[str] = None,
         container_context: Optional[Mapping] = None,
         dagster_library_versions: Optional[Mapping[str, str]] = None,
-        can_create_snapshots_in_run_worker: Optional[bool] = None,
+        can_create_snapshots_in_run_worker: Optional[Mapping[str, bool]] = None,
     ):
         return super(ListRepositoriesResponse, cls).__new__(
             cls,
@@ -365,7 +365,7 @@ class ListRepositoriesResponse(
             dagster_library_versions=check.opt_nullable_mapping_param(
                 dagster_library_versions, "dagster_library_versions"
             ),
-            can_create_snapshots_in_run_worker=can_create_snapshots_in_run_worker or False,
+            can_create_snapshots_in_run_worker=can_create_snapshots_in_run_worker or {},
         )
 
 


### PR DESCRIPTION
Summary:
This is a prototype of a way to run AMP and asset backfills without going through the gRPC server at all (other than to initially generate the workspace and asset graph that is used by the tick).

Today the way that we interact with user code in these systems is we:
- Load the workspace / asset graph (from the DB in cloud)
- Once we decide what runs to create, we make a gRPC call to generate a job snapshot and an execution plan snapshot for each run (possibly running newer code that is not compatible with what is in the DB)
- Enqueue the run - it then runs in a container image based on what is in the DB, but is using a snapshot that was potentially generated on newer code

If we land this PR, we will instead use the code in the DB for everything and never make any gRPC calls. We do this by:
- Not worrying about the job snapshot at all and just not storing it on the run, I have not found anything yet that breaks from doing this for asset runs of the type produced by AMP and asset backfills
- Waiting to generate the execution plan snapshot until the run starts, relying on the fact that it will be running using the same image as opposed to newer, potentially incompatible code. The only user-visible result of this change is that you don't see the gantt chart in the UI until the run is dequeued.

## Summary & Motivation

## How I Tested These Changes
