### PR TITLE
Add properties to InheritContextThreadpoolExecutor

### DIFF
--- a/python_modules/dagster/dagster/_daemon/daemon.py
+++ b/python_modules/dagster/dagster/_daemon/daemon.py
@@ -30,8 +30,6 @@ from dagster._scheduler.scheduler import execute_scheduler_iteration_loop
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
 if TYPE_CHECKING:
-    from concurrent.futures import ThreadPoolExecutor
-
     from pendulum.datetime import DateTime
 
 
@@ -266,8 +264,8 @@ class SensorDaemon(DagsterDaemon):
     def __init__(self, settings: Mapping[str, Any]) -> None:
         super().__init__()
         self._exit_stack = ExitStack()
-        self._threadpool_executor: Optional[ThreadPoolExecutor] = None
-        self._submit_threadpool_executor: Optional[ThreadPoolExecutor] = None
+        self._threadpool_executor: Optional[InheritContextThreadPoolExecutor] = None
+        self._submit_threadpool_executor: Optional[InheritContextThreadPoolExecutor] = None
 
         if settings.get("use_threads"):
             self._threadpool_executor = self._exit_stack.enter_context(

--- a/python_modules/dagster/dagster_tests/core_tests/test_utils.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_utils.py
@@ -1,3 +1,4 @@
+import time
 import warnings
 from concurrent.futures import as_completed
 from contextvars import ContextVar
@@ -119,3 +120,25 @@ def test_inherit_context_threadpool():
 
         for f in as_completed(futures):
             assert f.result()
+
+
+def test_inherit_context_threadpool_properties():
+    def sleepy_thread():
+        time.sleep(1)
+        return True
+
+    with InheritContextThreadPoolExecutor(max_workers=5) as executor:
+        futures = []
+        for i in range(10):
+            futures.append(executor.submit(sleepy_thread))
+
+        time.sleep(0.1)
+        assert executor.max_workers == 5
+        assert executor.num_running_futures == 5
+        assert executor.num_queued_futures == 5
+
+        for f in as_completed(futures):
+            assert f.result()
+
+        assert executor.num_running_futures == 0
+        assert executor.num_queued_futures == 0


### PR DESCRIPTION
Adds some convenience properties to InheritContextThreadpoolExecutor; specifically max workers, queue size, and number of running futures. These properties are useful when collecting metrics from the sensor daemon.
