### PR TITLE
Allow TimestampDisplay to show msec

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
@@ -93,10 +93,14 @@ export const formatElapsedTimeWithoutMsec = (msec: number) => {
 
 export const formatElapsedTimeWithMsec = (msec: number) => {
   const {hours, minutes, seconds, milliseconds} = timeByParts(msec);
+
+  const hasHourOrMinutes = hours || minutes;
+  const hasHoursOrMinutesOrSeconds = hours || minutes || seconds;
+
   const negative = msec < 0;
-  return `${negative ? '-' : ''}${hours}:${twoDigit(minutes)}:${twoDigit(
-    seconds,
-  )}${formatMsecMantissa(milliseconds)}`;
+  return `${negative ? '-' : ''}${hours ? hours + ':' : ''}${
+    hasHourOrMinutes ? twoDigit(minutes) + ':' : ''
+  }${hasHoursOrMinutesOrSeconds ? twoDigit(seconds) : '0'}${formatMsecMantissa(milliseconds)}`;
 };
 
 export function breakOnUnderscores(str: string) {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/TimeElapsed.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/TimeElapsed.tsx
@@ -1,15 +1,16 @@
 import {Group, Icon, colorTextLight} from '@dagster-io/ui-components';
 import * as React from 'react';
 
-import {formatElapsedTimeWithoutMsec} from '../app/Util';
+import {formatElapsedTimeWithMsec, formatElapsedTimeWithoutMsec} from '../app/Util';
 
 export interface Props {
   startUnix: number | null;
   endUnix: number | null;
+  msec?: boolean;
 }
 
 export const TimeElapsed = (props: Props) => {
-  const {startUnix, endUnix} = props;
+  const {startUnix, endUnix, msec} = props;
 
   const [endTime, setEndTime] = React.useState(() => (endUnix ? endUnix * 1000 : null));
   const interval = React.useRef<ReturnType<typeof setInterval>>();
@@ -44,7 +45,11 @@ export const TimeElapsed = (props: Props) => {
     <Group direction="row" spacing={4} alignItems="center">
       <Icon name="timer" color={colorTextLight()} />
       <span style={{fontVariantNumeric: 'tabular-nums'}}>
-        {startTime ? formatElapsedTimeWithoutMsec((endTime || Date.now()) - startTime) : '–'}
+        {startTime
+          ? msec
+            ? formatElapsedTimeWithMsec((endTime || Date.now()) - startTime)
+            : formatElapsedTimeWithoutMsec((endTime || Date.now()) - startTime)
+          : '–'}
       </span>
     </Group>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__stories__/TimeElapsed.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__stories__/TimeElapsed.stories.tsx
@@ -14,6 +14,10 @@ const Template: Story<Props> = (props) => <TimeElapsed {...props} />;
 const now = Date.now() / 1000;
 const startUnix = now - 60;
 
+const SECOND = 1;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+
 export const Completed = Template.bind({});
 Completed.args = {
   startUnix,
@@ -28,4 +32,45 @@ Running.args = {
 export const LongRunning = Template.bind({});
 LongRunning.args = {
   startUnix: now - 60 * 60 * 1.5,
+};
+
+export const HoursMinuteSecondsMsec = Template.bind({});
+HoursMinuteSecondsMsec.args = {
+  startUnix: 1,
+  endUnix: 1 + HOUR + MINUTE + SECOND + 0.069,
+  msec: true,
+};
+
+export const HoursSecondsMsec = Template.bind({});
+HoursSecondsMsec.args = {
+  startUnix: 1,
+  endUnix: 1 + HOUR + SECOND + 0.069,
+  msec: true,
+};
+
+export const HoursMsec = Template.bind({});
+HoursMsec.args = {
+  startUnix: 1,
+  endUnix: 1 + HOUR + 0.069,
+  msec: true,
+};
+
+export const MinutesMsec = Template.bind({});
+MinutesMsec.args = {
+  startUnix: 1,
+  endUnix: 1 + MINUTE + 0.069,
+  msec: true,
+};
+export const SecMsec = Template.bind({});
+SecMsec.args = {
+  startUnix: 1,
+  endUnix: 1 + SECOND + 0.069,
+  msec: true,
+};
+
+export const Msec = Template.bind({});
+Msec.args = {
+  startUnix: 1,
+  endUnix: 1 + 0.069,
+  msec: true,
 };


### PR DESCRIPTION
## Summary & Motivation
For AMP evaluations we want to show milliseconds

## How I Tested These Changes
<img width="110" alt="Screenshot 2024-01-09 at 1 51 12 PM" src="https://github.com/dagster-io/dagster/assets/2286579/f2cece3b-1a1f-4642-ad3b-44900a1e5090">
<img width="87" alt="Screenshot 2024-01-09 at 1 50 54 PM" src="https://github.com/dagster-io/dagster/assets/2286579/58555033-d8fe-450f-858c-ff42ea8c0353">
<img width="136" alt="Screenshot 2024-01-09 at 1 50 29 PM" src="https://github.com/dagster-io/dagster/assets/2286579/bfdfd070-a3c2-410f-b37f-d78cb538bdc1">
<img width="145" alt="Screenshot 2024-01-09 at 1 49 38 PM" src="https://github.com/dagster-io/dagster/assets/2286579/91bec3cf-6438-4397-902e-cdf99f89b845">
<img width="161" alt="Screenshot 2024-01-09 at 1 49 34 PM" src="https://github.com/dagster-io/dagster/assets/2286579/3134fbc9-7906-4157-b7b6-778c96220e4b">
<img width="171" alt="Screenshot 2024-01-09 at 1 49 30 PM" src="https://github.com/dagster-io/dagster/assets/2286579/4efbd322-6e09-451e-85f7-f4761b1437f4">
