### PR TITLE
[wip] Graphviz + wasm based DAG layout

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/jest/mocks/dagre_layout.worker.ts
+++ b/js_modules/dagster-ui/packages/ui-core/jest/mocks/dagre_layout.worker.ts
@@ -12,13 +12,13 @@ export default class MockWorker {
   onmessage = (_: any) => {};
 
   // mock expects data: { } instead of e: { data: { } }
-  postMessage(data: WorkerMessageData) {
+  async postMessage(data: WorkerMessageData) {
     if (data.type === 'layoutOpGraph') {
       const {ops, opts} = data;
       this.onmessage({data: layoutOpGraph(ops, opts)});
     } else if (data.type === 'layoutAssetGraph') {
       const {graphData, opts} = data;
-      this.onmessage({data: layoutAssetGraph(graphData, opts)});
+      this.onmessage({data: await layoutAssetGraph(graphData, opts)});
     }
   }
 }

--- a/js_modules/dagster-ui/packages/ui-core/package.json
+++ b/js_modules/dagster-ui/packages/ui-core/package.json
@@ -32,6 +32,7 @@
     "styled-components": "^5.3.3"
   },
   "dependencies": {
+    "@hpcc-js/wasm": "^2.15.3",
     "@tanstack/react-virtual": "^3.0.1",
     "@testing-library/react-hooks": "^7.0.2",
     "@vx/shape": "^0.0.192",

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -11,6 +11,7 @@ export const FeatureFlag = {
   flagDisableWebsockets: 'flagDisableWebsockets' as const,
   flagSidebarResources: 'flagSidebarResources' as const,
   flagDisableAutoLoadDefaults: 'flagDisableAutoLoadDefaults' as const,
+  flagGraphvizRendering: 'flagGraphvizRendering' as const,
 };
 export type FeatureFlagType = keyof typeof FeatureFlag;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
@@ -5,6 +5,10 @@ import {FeatureFlag} from './Flags';
  */
 export const getVisibleFeatureFlagRows = () => [
   {
+    key: 'Experimental DAG layout algorithm',
+    flagType: FeatureFlag.flagGraphvizRendering,
+  },
+  {
     key: 'Display resources in navigation sidebar',
     flagType: FeatureFlag.flagSidebarResources,
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -11,7 +11,7 @@ import {ILayoutOp, layoutOpGraph, LayoutOpGraphOptions, OpGraphLayout} from './l
 const ASYNC_LAYOUT_SOLID_COUNT = 50;
 
 // If you're working on the layout logic, set to false so hot-reloading re-computes the layout
-const CACHING_ENABLED = true;
+const CACHING_ENABLED = false;
 
 // Op Graph
 
@@ -185,10 +185,13 @@ export function useAssetLayout(_graphData: GraphData, expandedGroups: string[]) 
     [expandedGroups, _graphData],
   );
 
-  const opts = React.useMemo(() => ({horizontalDAGs: true}), []);
+  const opts = React.useMemo(
+    () => ({horizontalDAGs: true, graphviz: flags.flagGraphvizRendering}),
+    [flags.flagGraphvizRendering],
+  );
   const cacheKey = _assetLayoutCacheKey(graphData, opts);
   const nodeCount = Object.keys(graphData.nodes).length;
-  const runAsync = nodeCount >= ASYNC_LAYOUT_SOLID_COUNT;
+  const runAsync = flags.flagGraphvizRendering || nodeCount >= ASYNC_LAYOUT_SOLID_COUNT;
 
   React.useEffect(() => {
     async function runAsyncLayout() {

--- a/js_modules/dagster-ui/packages/ui-core/src/workers/dagre_layout.worker.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workers/dagre_layout.worker.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-globals */
 
 import {layoutAssetGraph} from '../asset-graph/layout';
+import {layoutAssetGraphGraphviz} from '../asset-graph/layout-graphviz';
 import {layoutOpGraph} from '../graph/layout';
 
 /**
@@ -12,7 +13,7 @@ import {layoutOpGraph} from '../graph/layout';
  * try to remove it.
  */
 
-self.addEventListener('message', (event) => {
+self.addEventListener('message', async (event) => {
   const {data} = event;
 
   switch (data.type) {
@@ -23,7 +24,11 @@ self.addEventListener('message', (event) => {
     }
     case 'layoutAssetGraph': {
       const {graphData, opts} = data;
-      self.postMessage(layoutAssetGraph(graphData, opts));
+      if (opts.graphviz) {
+        self.postMessage(await layoutAssetGraphGraphviz(graphData, opts));
+      } else {
+        self.postMessage(await layoutAssetGraph(graphData, opts));
+      }
     }
   }
 });

--- a/js_modules/dagster-ui/yarn.lock
+++ b/js_modules/dagster-ui/yarn.lock
@@ -2528,6 +2528,7 @@ __metadata:
     "@graphql-eslint/eslint-plugin": "npm:^3.18.0"
     "@graphql-tools/mock": "npm:^8.5.0"
     "@graphql-tools/schema": "npm:^8.3.1"
+    "@hpcc-js/wasm": "npm:^2.15.3"
     "@mdx-js/react": "npm:^1.6.22"
     "@storybook/addon-actions": "npm:^7.4.5"
     "@storybook/addon-docs": "npm:^7.4.5"
@@ -3599,6 +3600,17 @@ __metadata:
   peerDependencies:
     graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
   checksum: fa44443accd28c8cf4cb96aaaf39d144a22e8b091b13366843f4e97d19c7bfeaf609ce3c7603a4aeffe385081eaf8ea245d078633a7324c11c5ec4b2011bb76d
+  languageName: node
+  linkType: hard
+
+"@hpcc-js/wasm@npm:^2.15.3":
+  version: 2.15.3
+  resolution: "@hpcc-js/wasm@npm:2.15.3"
+  dependencies:
+    yargs: "npm:17.7.2"
+  bin:
+    dot-wasm: bin/dot-wasm.js
+  checksum: 3df3bcbcfbde6636242a7083c94221059b4097633501698655ba4a8da589d21798f2a9ddfe2cd293e2d331b6da33b07d388cf6418196b2d329bd67ca91ef3903
   languageName: node
   linkType: hard
 
@@ -23970,6 +23982,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yargs@npm:17.7.2, yargs@npm:^17.0.0, yargs@npm:^17.3.1":
+  version: 17.7.2
+  resolution: "yargs@npm:17.7.2"
+  dependencies:
+    cliui: "npm:^8.0.1"
+    escalade: "npm:^3.1.1"
+    get-caller-file: "npm:^2.0.5"
+    require-directory: "npm:^2.1.1"
+    string-width: "npm:^4.2.3"
+    y18n: "npm:^5.0.5"
+    yargs-parser: "npm:^21.1.1"
+  checksum: abb3e37678d6e38ea85485ed86ebe0d1e3464c640d7d9069805ea0da12f69d5a32df8e5625e370f9c96dd1c2dc088ab2d0a4dd32af18222ef3c4224a19471576
+  languageName: node
+  linkType: hard
+
 "yargs@npm:^15.3.1":
   version: 15.4.1
   resolution: "yargs@npm:15.4.1"
@@ -24001,21 +24028,6 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^20.2.2"
   checksum: 807fa21211d2117135d557f95fcd3c3d390530cda2eca0c840f1d95f0f40209dcfeb5ec18c785a1f3425896e623e3b2681e8bb7b6600060eda1c3f4804e7957e
-  languageName: node
-  linkType: hard
-
-"yargs@npm:^17.0.0, yargs@npm:^17.3.1":
-  version: 17.7.2
-  resolution: "yargs@npm:17.7.2"
-  dependencies:
-    cliui: "npm:^8.0.1"
-    escalade: "npm:^3.1.1"
-    get-caller-file: "npm:^2.0.5"
-    require-directory: "npm:^2.1.1"
-    string-width: "npm:^4.2.3"
-    y18n: "npm:^5.0.5"
-    yargs-parser: "npm:^21.1.1"
-  checksum: abb3e37678d6e38ea85485ed86ebe0d1e3464c640d7d9069805ea0da12f69d5a32df8e5625e370f9c96dd1c2dc088ab2d0a4dd32af18222ef3c4224a19471576
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary & Motivation

This is a bit of a research branch still - need to put this new rendering behind a feature flag and look for ways to make it more synchronous for small graphs.

This uses the Graphviz C library's "dot" rendering algorithm for clustered directed graphs via WASM (https://graphviz.org/Gallery/directed/cluster.html, playable demo here: http://magjac.com/graphviz-visual-editor/). One odd aspect of this is that we need to generate a `dot` string representing the graph, layout that, and then parse the layout JSON. Unlike dagre, there is not a JS API for specifying the edges and nodes.

The benefit of this dot syntax intermediate is that you can copy-paste it into that visual editor and fiddle with it, which is cool.

## How I Tested These Changes

So far just comparing the layouts of varying dags locally. This algorithm is slower, but not as slow as dagre's network-simplex, but generates much more compact layouts with less "random dead space". In some of my tests, the graph is ~40% less px tall. It also does nice things, like packing groups in:

![image](https://github.com/dagster-io/dagster/assets/1037212/e2d2ba80-805e-41af-82b0-3825752aea55)

