### PR TITLE
[ui] Hover-to-highlight edges on asset group boxes

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetEdges.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetEdges.tsx
@@ -7,7 +7,7 @@ import {AssetLayoutEdge} from './layout';
 interface AssetEdgesProps {
   edges: AssetLayoutEdge[];
   selected: string[] | null;
-  highlighted: string | null;
+  highlighted: string[] | null;
   strokeWidth?: number;
   viewportRect: {top: number; left: number; right: number; bottom: number};
 }
@@ -42,8 +42,8 @@ export const AssetEdges = ({
           ({fromId, toId}) =>
             selected?.includes(fromId) ||
             selected?.includes(toId) ||
-            highlighted === fromId ||
-            highlighted === toId,
+            highlighted?.includes(fromId) ||
+            highlighted?.includes(toId),
         )}
         strokeWidth={strokeWidth}
         viewportRect={viewportRect}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -203,7 +203,7 @@ const AssetGraphExplorerWithData = ({
   trace,
 }: WithDataProps) => {
   const findAssetLocation = useFindAssetLocation();
-  const [highlighted, setHighlighted] = React.useState<string | null>(null);
+  const [highlighted, setHighlighted] = React.useState<string[] | null>(null);
 
   const {allGroups, allGroupCounts, groupedAssets} = React.useMemo(() => {
     const groupedAssets: Record<string, GraphNode[]> = {};
@@ -485,6 +485,7 @@ const AssetGraphExplorerWithData = ({
                 }}
               >
                 <ExpandedGroupNode
+                  setHighlighted={setHighlighted}
                   preferredJobName={explorerPath.pipelineName}
                   onFilterToGroup={() => onFilterToGroup(group)}
                   group={{
@@ -517,6 +518,8 @@ const AssetGraphExplorerWithData = ({
                 key={group.id}
                 {...group.bounds}
                 className="group"
+                onMouseEnter={() => setHighlighted([group.id])}
+                onMouseLeave={() => setHighlighted(null)}
                 onDoubleClick={(e) => {
                   if (!viewportEl.current) {
                     return;
@@ -569,7 +572,7 @@ const AssetGraphExplorerWithData = ({
                 <foreignObject
                   {...bounds}
                   key={id}
-                  onMouseEnter={() => setHighlighted(id)}
+                  onMouseEnter={() => setHighlighted([id])}
                   onMouseLeave={() => setHighlighted(null)}
                   onClick={(e) => onSelectNode(e, {path}, graphNode)}
                   onDoubleClick={(e) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ExpandedGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ExpandedGroupNode.tsx
@@ -21,12 +21,14 @@ export const ExpandedGroupNode = ({
   onCollapse,
   preferredJobName,
   onFilterToGroup,
+  setHighlighted,
 }: {
   group: GroupLayout & {assets: GraphNode[]};
   minimal: boolean;
   onCollapse?: () => void;
   preferredJobName?: string;
   onFilterToGroup?: () => void;
+  setHighlighted: (ids: string[] | null) => void;
 }) => {
   const {menu, dialog} = useGroupNodeContextMenu({
     onFilterToGroup,
@@ -38,6 +40,8 @@ export const ExpandedGroupNode = ({
       <ContextMenuWrapper menu={menu} stopPropagation>
         <GroupNodeHeaderBox
           $minimal={minimal}
+          onMouseEnter={() => setHighlighted(group.assets.map((a) => a.id))}
+          onMouseLeave={() => setHighlighted(null)}
           onClick={(e) => {
             onCollapse?.();
             e.stopPropagation();

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -41,7 +41,7 @@ export const AssetNodeLineageGraph = ({
     return {allGroups: Object.keys(groupedAssets), groupedAssets};
   }, [assetGraphData]);
 
-  const [highlighted, setHighlighted] = React.useState<string | null>(null);
+  const [highlighted, setHighlighted] = React.useState<string[] | null>(null);
 
   // Use the pathname as part of the key so that different deployments don't invalidate each other's cached layout
   // and so that different assets dont invalidate each others layout
@@ -98,6 +98,7 @@ export const AssetNodeLineageGraph = ({
                     assets: groupedAssets[group.id]!,
                   }}
                   minimal={scale < MINIMAL_SCALE}
+                  setHighlighted={setHighlighted}
                 />
               </foreignObject>
             ))}
@@ -125,7 +126,7 @@ export const AssetNodeLineageGraph = ({
                   {...bounds}
                   key={id}
                   style={{overflow: 'visible'}}
-                  onMouseEnter={() => setHighlighted(id)}
+                  onMouseEnter={() => setHighlighted([id])}
                   onMouseLeave={() => setHighlighted(null)}
                   onClick={() => onClickAsset({path})}
                   onDoubleClick={(e) => {


### PR DESCRIPTION
## Summary & Motivation

Fixes #18103

- Hovering over collapsed asset groups, or the headers of expanded asset groups highlights all inbound and outbound edges. (similar to the behavior with plain asset nodes)

## How I Tested These Changes

![image](https://github.com/dagster-io/dagster/assets/1037212/017d0412-61e3-4312-8aed-c0757ee6edcf)
![image](https://github.com/dagster-io/dagster/assets/1037212/adab9f78-7168-49a6-a1d9-238d17caaa9a)
