### PR TITLE
[dagster-helm] 3.11 str enum compat

### DIFF
--- a/helm/dagster/schema/schema/charts/utils/utils.py
+++ b/helm/dagster/schema/schema/charts/utils/utils.py
@@ -47,7 +47,7 @@ class BaseModel(PydanticBaseModel):
                     value["anyOf"].append({"type": "null"})
 
 
-def create_definition_ref(definition: str, version: str = SupportedKubernetes.V1_18) -> str:
+def create_definition_ref(definition: str, version: str = SupportedKubernetes.V1_18.value) -> str:
     return (
         f"https://kubernetesjsonschema.dev/v{version}/_definitions.json#/definitions/{definition}"
     )


### PR DESCRIPTION
in 3.11 these f strings change for the enum
https://github.com/python/cpython/issues/100458

so just do `.value`

## How I Tested These Changes

bk passes