### PR TITLE
[docs] Fix a few typos

### DIFF
--- a/docs/content/guides.mdx
+++ b/docs/content/guides.mdx
@@ -26,7 +26,7 @@ Learn to apply [Dagster concepts](/concepts) to your work, explore experimental 
 
 - [Moving to Software-defined Assets](/guides/dagster/enriching-with-software-defined-assets) - Already using ops and graphs, but not Software-defined Assets? Learn why and how to use Software-defined Assets
 
-- [Using Software-defined assets with Pandas and PySpark](/guides/dagster/software-defined-assets) - A quick introduction to Sofware-defined Assets, featuring Pandas and PySpark
+- [Using Software-defined assets with Pandas and PySpark](/guides/dagster/software-defined-assets) - A quick introduction to Software-defined Assets, featuring Pandas and PySpark
 
 - [Testing assets](/guides/dagster/testing-assets) - Learn to test your Software-defined Assets
 

--- a/docs/content/guides/dagster/asset-versioning-and-caching.mdx
+++ b/docs/content/guides/dagster/asset-versioning-and-caching.mdx
@@ -27,7 +27,7 @@ Dagster has two versioning concepts to represent the code and input data used fo
 - **Code version.** A string that represents the version of the code that computes an asset. This is the `code_version` argument of <PyObject object="asset" decorator="true" />.
 - **Data version.** A string that represents the version of the data represented by the asset. This is represented as a <PyObject object="DataVersion" /> object.
 
-By keeping track of code and data versions, Dagster can predict whether a materialization will change the underlying value. This allows Dagster to skip redundant materializations and instead return the previously-computed value. In more technical terms, Dagster offers a limited form of [memoization](https://en.wikipedia.org/wiki/Memoization) for assets: the last-computed asset value is always cached.
+By keeping track of code and data versions, Dagster can predict whether a materialization will change the underlying value. This allows Dagster to skip redundant materializations and instead return the previously computed value. In more technical terms, Dagster offers a limited form of [memoization](https://en.wikipedia.org/wiki/Memoization) for assets: the last-computed asset value is always cached.
 
 In computationally expensive data pipelining, this approach can yield tremendous benefits.
 
@@ -115,7 +115,7 @@ width={2662}
 height={1618}
 />
 
-The asset is now has a label to indicate that its code version has changed since it was last materialized. We can see this in both asset graph and the sidebar, where details about the last materialization of a selected node are visible. You can see the code version associated with the last materialization of `versioned_number` is `v1`, but its current code version is `v2`. This is also explained in the tooltip that appears if you hover over the `(i)` icon on the indicator tag.
+The asset now has a label to indicate that its code version has changed since it was last materialized. We can see this in both the asset graph and the sidebar, where details about the last materialization of a selected node are visible. You can see the code version associated with the last materialization of `versioned_number` is `v1`, but its current code version is `v2`. This is also explained in the tooltip that appears if you hover over the `(i)` icon on the indicator tag.
 
 The `versioned_number` asset must be materialized again to become up-to-date. Click the toggle to the right side of the **Materialize** button to display the **Propagate changes** option. Clicking this will propagate the changed code version by materializing `versioned_number`. This will update the latest materialization `code_version` shown in the sidebar to `v2` and bring the asset up-to-date.
 
@@ -152,7 +152,7 @@ width={2662}
 height={1748}
 />
 
-Now let's update the `versioned_number` asset. Specifically, we'll change its return value and code version:
+Now, let's update the `versioned_number` asset. Specifically, we'll change its return value and code version:
 
 ```python file=/guides/dagster/asset_versioning_and_caching/dependencies_code_version_only_v2.py
 from dagster import asset
@@ -168,7 +168,7 @@ def multiplied_number(versioned_number):
     return versioned_number * 2
 ```
 
-As before, this will cause `versioned_number` to get a label indicating that its code version has changed since its latest materialization. But since `multiplied_number` depends on `versioned_number`, it must be recomputed as well, and so gets a label indicating that the code version of an upstream asset has changed. If you hover over the **Upstream code version** tag on `multiplied_number`, you will see the upstream asset whose code version has changed:
+As before, this will cause `versioned_number` to get a label indicating that its code version has changed since its latest materialization. But since `multiplied_number` depends on `versioned_number`, it must be recomputed as well and so gets a label indicating that the code version of an upstream asset has changed. If you hover over the **Upstream code version** tag on `multiplied_number`, you will see the upstream asset whose code version has changed:
 
 <!-- ![Dependencies code version only](/images/guides/asset-versioning-and-caching/dependencies-code-version-only.png) -->
 
@@ -234,7 +234,7 @@ def multiplied_number(versioned_number):
     return versioned_number * 2
 ```
 
-Once again, both assets have labels to indicate the change in code version. Dagster doesn't know that `v5` of the versioned number will return the same value as `v4`, as it only knows about code versions and data versions.
+Once again, both assets have labels to indicate the change in the code version. Dagster doesn't know that `v5` of the versioned number will return the same value as `v4`, as it only knows about code versions and data versions.
 
 Let's see what happens if only `versioned_number` is materialized. Select it in the asset graph and click **Materialize selected**. The sidebar shows the latest materialization now has a code_version of `v5`, and the data version is again `20`:
 
@@ -247,9 +247,9 @@ width={2662}
 height={1618}
 />
 
-Notice that `multiplied_number` no longer has a label, even though we didn't materialize it! Here's what happened: the new materialization of `versioned_number` with the explicitly supplied data version supercedes the code version of `versioned_number`. Dagster then compared the data version of `versioned_number` last used to materialize `multiplied_number` to the current data version of `versioned_number`. Since this comparison shows that the data version of `versioned_number` hasn't changed, Dagster knows that the change to the code version of `versioned_number` doesn't affect `multiplied_number`.
+Notice that `multiplied_number` no longer has a label, even though we didn't materialize it! Here's what happened: the new materialization of `versioned_number` with the explicitly supplied data version supersedes the code version of `versioned_number`. Dagster then compared the data version of `versioned_number` last used to materialize `multiplied_number` to the current data version of `versioned_number`. Since this comparison shows that the data version of `versioned_number` hasn't changed, Dagster knows that the change to the code version of `versioned_number` doesn't affect `multiplied_number`.
 
-If `versioned_number` had used a Dagster-generated data version, the data version of `versioned_number` would have changed due to its updated code version, despite the fact that the returned value did not change. `multiplied_number` would have a label indicating that an upstream data version had changed.
+If `versioned_number` had used a Dagster-generated data version, the data version of `versioned_number` would have changed due to its updated code version despite the fact that the returned value did not change. `multiplied_number` would have a label indicating that an upstream data version had changed.
 
 ---
 
@@ -259,13 +259,13 @@ In the real world, data pipelines depend on external upstream data. So far in th
 
 External data sources in Dagster are modeled by <PyObject object="SourceAsset" displayText="SourceAssets" />. We can add versioning to a `SourceAsset` by making it observable. An observable source asset has a user-defined function that computes and returns a data version.
 
-Let's add an <PyObject object="observable_source_asset" decorator="true" /> called `input_number`. This will represent a file written by an external process, upstream of our pipeline:
+Let's add an <PyObject object="observable_source_asset" decorator="true" /> called `input_number`. This will represent a file written by an external process upstream of our pipeline:
 
 ```python file=/guides/dagster/asset_versioning_and_caching/input_number.txt
 29034
 ```
 
-The body of the `input_number` function computes a hash of the file contents and returns it as a `DataVersion`. We'll set `input_number` as an upstream dependency of `versioned_number`, and have `versioned_number` return the value it reads from the file:
+The body of the `input_number` function computes a hash of the file contents and returns it as a `DataVersion`. We'll set `input_number` as an upstream dependency of `versioned_number` and have `versioned_number` return the value it reads from the file:
 
 ```python file=/guides/dagster/asset_versioning_and_caching/observable_source_asset_path_with_non_argument_deps.py
 from hashlib import sha256
@@ -336,4 +336,4 @@ Finally, let's manually alter the file to simulate the activity of an external p
 15397
 ```
 
-If we click the **Observe Sources** button again, the downstream assets will again have labels indicating that upstream data has changed. The observation run generated a new data version for `input_number`, because its content changed.
+If we click the **Observe Sources** button again, the downstream assets will again have labels indicating that upstream data has changed. The observation run generated a new data version for `input_number` because its content changed.

--- a/docs/content/guides/dagster/transitioning-data-pipelines-from-development-to-production.mdx
+++ b/docs/content/guides/dagster/transitioning-data-pipelines-from-development-to-production.mdx
@@ -309,7 +309,7 @@ class HNAPIClient(ConfigurableResource):
 
     @property
     def item_field_names(self) -> list:
-        # ommitted for brevity, see full code example for implementation
+        # omitted for brevity, see full code example for implementation
         return []
 ```
 

--- a/docs/content/guides/general.mdx
+++ b/docs/content/guides/general.mdx
@@ -24,7 +24,7 @@ title: General Dagster Guides | Dagster Docs
 
 - [Moving to Software-defined Assets](/guides/dagster/enriching-with-software-defined-assets) - Already using ops and graphs, but not Software-defined Assets? Learn why and how to use Software-defined Assets
 
-- [Using Software-defined assets with Pandas and PySpark](/guides/dagster/software-defined-assets) - A quick introduction to Sofware-defined Assets, featuring Pandas and PySpark
+- [Using Software-defined assets with Pandas and PySpark](/guides/dagster/software-defined-assets) - A quick introduction to Software-defined Assets, featuring Pandas and PySpark
 
 - [Testing assets](/guides/dagster/testing-assets) - Learn to test your Software-defined Assets
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/resources/resources_v1.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/resources/resources_v1.py
@@ -23,7 +23,7 @@ class HNAPIClient(ConfigurableResource):
 
     @property
     def item_field_names(self) -> list:
-        # ommitted for brevity, see full code example for implementation
+        # omitted for brevity, see full code example for implementation
         return []
 
 


### PR DESCRIPTION
## Summary & Motivation

Fixed a few spelling and punctuation errors in the documentation page as part of my new hire onboarding tasks.

## How I Tested These Changes

 - tested the documentation locally
 - validated the PR preview created by CI 