### PR TITLE
Replace `get_event_records` calls for planned materialization events with dedicated storage calls

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1008,19 +1008,12 @@ class GrapheneAssetNode(graphene.ObjectType):
         graphene_info: ResolveInfo,
         partition: str,
     ) -> Optional[GrapheneRun]:
-        event_records = list(
-            graphene_info.context.instance.event_log_storage.get_event_records(
-                EventRecordsFilter(
-                    event_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
-                    asset_key=self._external_asset_node.asset_key,
-                    asset_partitions=[partition],
-                ),
-                limit=1,
-            )
+        planned_info = graphene_info.context.instance.get_latest_planned_materialization_info(
+            asset_key=self._external_asset_node.asset_key, partition=partition
         )
-        if not event_records:
+        if not planned_info:
             return None
-        run_record = graphene_info.context.instance.get_run_record_by_id(event_records[0].run_id)
+        run_record = graphene_info.context.instance.get_run_record_by_id(planned_info.run_id)
         return GrapheneRun(run_record) if run_record else None
 
     def resolve_assetPartitionStatuses(

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -34,7 +34,7 @@ import yaml
 from typing_extensions import Protocol, Self, TypeAlias, TypeVar, runtime_checkable
 
 import dagster._check as check
-from dagster._annotations import experimental, public
+from dagster._annotations import deprecated, experimental, public
 from dagster._core.definitions.asset_check_evaluation import (
     AssetCheckEvaluation,
     AssetCheckEvaluationPlanned,
@@ -48,6 +48,7 @@ from dagster._core.errors import (
     DagsterRunAlreadyExists,
     DagsterRunConflict,
 )
+from dagster._core.event_api import EventLogCursor
 from dagster._core.log_manager import DagsterLogRecord
 from dagster._core.origin import JobPythonOrigin
 from dagster._core.storage.dagster_run import (
@@ -2009,8 +2010,8 @@ class DagsterInstance(DynamicPartitionsStore):
         """
         return self._event_storage.fetch_materializations(records_filter, limit, cursor, ascending)
 
-    @public
     @traced
+    @deprecated(breaking_version="2.0")
     def fetch_planned_materializations(
         self,
         records_filter: Union[AssetKey, "AssetRecordsFilter"],
@@ -2031,9 +2032,30 @@ class DagsterInstance(DynamicPartitionsStore):
         Returns:
             EventRecordsResult: Object containing a list of event log records and a cursor string
         """
-        return self._event_storage.fetch_planned_materializations(
-            records_filter, limit, cursor, ascending
+        from dagster._core.events import DagsterEventType
+        from dagster._core.storage.event_log.base import (
+            EventRecordsFilter,
+            EventRecordsResult,
         )
+
+        event_records_filter = (
+            EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION_PLANNED, records_filter)
+            if isinstance(records_filter, AssetKey)
+            else records_filter.to_event_records_filter(
+                DagsterEventType.ASSET_MATERIALIZATION_PLANNED, cursor=cursor, ascending=ascending
+            )
+        )
+        records = self._event_storage.get_event_records(
+            event_records_filter, limit=limit, ascending=ascending
+        )
+        if records:
+            new_cursor = EventLogCursor.from_storage_id(records[-1].storage_id).to_string()
+        elif cursor:
+            new_cursor = cursor
+        else:
+            new_cursor = EventLogCursor.from_storage_id(-1).to_string()
+        has_more = len(records) == limit
+        return EventRecordsResult(records, cursor=new_cursor, has_more=has_more)
 
     @public
     @traced

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -48,7 +48,6 @@ from dagster._core.errors import (
     DagsterRunAlreadyExists,
     DagsterRunConflict,
 )
-from dagster._core.event_api import EventLogCursor
 from dagster._core.log_manager import DagsterLogRecord
 from dagster._core.origin import JobPythonOrigin
 from dagster._core.storage.dagster_run import (
@@ -165,6 +164,7 @@ if TYPE_CHECKING:
         EventLogRecord,
         EventRecordsFilter,
         EventRecordsResult,
+        PlannedMaterializationInfo,
     )
     from dagster._core.storage.partition_status_cache import (
         AssetPartitionStatus,
@@ -2032,6 +2032,7 @@ class DagsterInstance(DynamicPartitionsStore):
         Returns:
             EventRecordsResult: Object containing a list of event log records and a cursor string
         """
+        from dagster._core.event_api import EventLogCursor
         from dagster._core.events import DagsterEventType
         from dagster._core.storage.event_log.base import (
             EventRecordsFilter,
@@ -2226,6 +2227,14 @@ class DagsterInstance(DynamicPartitionsStore):
         Returns a mapping of partition to storage id.
         """
         return self._event_storage.get_latest_storage_id_by_partition(asset_key, event_type)
+
+    @traced
+    def get_latest_planned_materialization_info(
+        self,
+        asset_key: AssetKey,
+        partition: Optional[str] = None,
+    ) -> Optional["PlannedMaterializationInfo"]:
+        return self._event_storage.get_latest_planned_materialization_info(asset_key, partition)
 
     @public
     @traced

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -499,16 +499,6 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         raise NotImplementedError()
 
     @abstractmethod
-    def fetch_planned_materializations(
-        self,
-        records_filter: Union[AssetKey, AssetRecordsFilter],
-        limit: int,
-        cursor: Optional[str] = None,
-        ascending: bool = False,
-    ) -> EventRecordsResult:
-        raise NotImplementedError()
-
-    @abstractmethod
     def fetch_run_status_changes(
         self,
         records_filter: Union[DagsterEventType, RunStatusChangeRecordsFilter],

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -106,6 +106,16 @@ class AssetRecord(NamedTuple):
     asset_entry: AssetEntry
 
 
+class PlannedMaterializationInfo(NamedTuple):
+    """Internal representation of an planned materialization event, containing storage_id / run_id.
+
+    Users should not invoke this class directly.
+    """
+
+    storage_id: int
+    run_id: str
+
+
 class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     """Abstract base class for storing structured event logs from pipeline runs.
 
@@ -506,4 +516,12 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         cursor: Optional[str] = None,
         ascending: bool = False,
     ) -> EventRecordsResult:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_latest_planned_materialization_info(
+        self,
+        asset_key: AssetKey,
+        partition: Optional[str] = None,
+    ) -> Optional[PlannedMaterializationInfo]:
         raise NotImplementedError()

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1108,31 +1108,6 @@ class SqlEventLogStorage(EventLogStorage):
 
         return self._get_event_records_result(event_records_filter, limit, cursor, ascending)
 
-    def fetch_planned_materializations(
-        self,
-        records_filter: Optional[Union[AssetKey, AssetRecordsFilter]],
-        limit: int,
-        cursor: Optional[str] = None,
-        ascending: bool = False,
-    ) -> EventRecordsResult:
-        enforce_max_records_limit(limit)
-        if isinstance(records_filter, AssetRecordsFilter):
-            event_records_filter = records_filter.to_event_records_filter(
-                event_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
-                cursor=cursor,
-                ascending=ascending,
-            )
-        else:
-            before_cursor, after_cursor = EventRecordsFilter.get_cursor_params(cursor, ascending)
-            asset_key = records_filter
-            event_records_filter = EventRecordsFilter(
-                event_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
-                asset_key=asset_key,
-                before_cursor=before_cursor,
-                after_cursor=after_cursor,
-            )
-        return self._get_event_records_result(event_records_filter, limit, cursor, ascending)
-
     def fetch_run_status_changes(
         self,
         records_filter: Union[DagsterEventType, RunStatusChangeRecordsFilter],

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -477,17 +477,6 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     ) -> EventRecordsResult:
         return self._storage.event_log_storage.fetch_observations(filters, limit, cursor, ascending)
 
-    def fetch_planned_materializations(
-        self,
-        filters: Union[AssetKey, "AssetRecordsFilter"],
-        limit: int,
-        cursor: Optional[str] = None,
-        ascending: bool = False,
-    ) -> EventRecordsResult:
-        return self._storage.event_log_storage.fetch_planned_materializations(
-            filters, limit, cursor, ascending
-        )
-
     def fetch_run_status_changes(
         self,
         filters: Union["DagsterEventType", "RunStatusChangeRecordsFilter"],

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -31,6 +31,7 @@ from .event_log.base import (
     EventLogStorage,
     EventRecordsFilter,
     EventRecordsResult,
+    PlannedMaterializationInfo,
 )
 from .runs.base import RunStorage
 from .schedules.base import ScheduleStorage
@@ -486,6 +487,15 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     ) -> EventRecordsResult:
         return self._storage.event_log_storage.fetch_run_status_changes(
             filters, limit, cursor, ascending
+        )
+
+    def get_latest_planned_materialization_info(
+        self,
+        asset_key: AssetKey,
+        partition: Optional[str] = None,
+    ) -> Optional[PlannedMaterializationInfo]:
+        return self._storage.event_log_storage.get_latest_planned_materialization_info(
+            asset_key, partition
         )
 
     def get_asset_records(

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -5,10 +5,8 @@ import pendulum
 
 from dagster import (
     AssetKey,
-    DagsterEventType,
     DagsterInstance,
     DagsterRunStatus,
-    EventRecordsFilter,
     _check as check,
 )
 from dagster._core.definitions.multi_dimensional_partitions import (
@@ -226,14 +224,11 @@ def get_validated_partition_keys(
 
 
 def _get_last_planned_storage_id(instance: DagsterInstance, asset_key: AssetKey):
-    planned_event_records = instance.get_event_records(
-        event_records_filter=EventRecordsFilter(
-            event_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
-            asset_key=asset_key,
-        ),
-        limit=1,
-    )
-    return next(iter(planned_event_records)).storage_id if planned_event_records else 0
+    info = instance.get_latest_planned_materialization_info(asset_key)
+    if not info:
+        return 0
+
+    return info.storage_id
 
 
 def _build_status_cache(

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -3095,15 +3095,6 @@ class TestEventLogStorage:
         assert bar_info.run_id == test_run_id
         assert bar_info.storage_id == bar_record.storage_id
 
-        # new API
-        result = storage.fetch_planned_materializations(a, limit=100)
-        assert isinstance(result, EventRecordsResult)
-        assert len(result.records) == 1
-        record = result.records[0]
-        assert record.event_log_entry.dagster_event
-        assert record.event_log_entry.dagster_event.asset_key == a
-        assert result.cursor == EventLogCursor.from_storage_id(record.storage_id).to_string()
-
     def test_asset_key_exists_on_observation(
         self,
         storage: EventLogStorage,


### PR DESCRIPTION
## Summary & Motivation
We currently fetch planned materializations in two places:
1. in the partition status cache, fetching the last planned materialization by asset
2. in the graphql layer, to power the asset graph status view, split by partition

In both scenarios, we only want to fetch the latest planned materialization for a given asset or for a given asset partition.

This PR gives us a hook to more efficiently query the latest data, by restricting the API to guarantee that the whole planned materialization history is not being fetched.

This is part of the ongoing effort to narrow the surface area of `get_event_records` calls that we need to service.

## How I Tested These Changes
BK