### PR TITLE
[asset backfills] Handle UI error when unpartitioned root becomes partitioned

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -275,6 +275,8 @@ class AssetBackfillData(NamedTuple):
             asset_key
             for asset_key in self.target_subset.asset_keys
             if asset_graph.get_partitions_def(asset_key) is not None
+            # Check that the asset was partitioned at backfill creation time
+            and asset_key in self.target_subset.partitions_subsets_by_asset_key
         }
 
         root_partitioned_asset_keys = (

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -271,16 +271,12 @@ class AssetBackfillData(NamedTuple):
         self, asset_graph: AssetGraph
     ) -> Optional[PartitionsSubset]:
         """Returns the most upstream partitions subset that was targeted by the backfill."""
-        partitioned_asset_keys = {
-            asset_key
-            for asset_key in self.target_subset.asset_keys
-            if asset_graph.get_partitions_def(asset_key) is not None
-            # Check that the asset was partitioned at backfill creation time
-            and asset_key in self.target_subset.partitions_subsets_by_asset_key
+        target_partitioned_asset_keys = {
+            asset_key for asset_key in self.target_subset.partitions_subsets_by_asset_key
         }
 
         root_partitioned_asset_keys = (
-            AssetSelection.keys(*partitioned_asset_keys).sources().resolve(asset_graph)
+            AssetSelection.keys(*target_partitioned_asset_keys).sources().resolve(asset_graph)
         )
 
         # Return the targeted partitions for the root partitioned asset keys


### PR DESCRIPTION
A graphQL error occurs when loading the asset backfill page if an asset backfill is created with an unpartitioned root asset but the asset is later changed to be partitioned. The `AssetBackfillData` attempts to fetch the root target partitions subset for the root asset, but this causes a key error as the backfill did not target a partitions subset for this asset.

This PR fixes this by checking that an asset was partitioned at storage time in order to consider it as a partitioned root.