### PR TITLE
method to init an empty typeddict

### DIFF
--- a/python_modules/dagster/dagster/_utils/typed_dict.py
+++ b/python_modules/dagster/dagster/_utils/typed_dict.py
@@ -1,0 +1,27 @@
+from typing import Type, TypeVar, cast
+
+from typing_extensions import NotRequired, get_origin, is_typeddict
+
+_TypedDictClass = TypeVar("_TypedDictClass")
+
+
+def init_optional_typeddict(cls: Type[_TypedDictClass]) -> _TypedDictClass:
+    """Initialize a TypedDict with optional values."""
+    from dagster._config.pythonic_config.type_check_utils import is_optional
+
+    if not is_typeddict(cls):
+        raise Exception("Must pass a TypedDict class to init_optional_typeddict")
+    result = {}
+    for key, value in cls.__annotations__.items():
+        # If the value is a typed dict, recursively initialize it
+        if is_typeddict(value):
+            result[key] = init_optional_typeddict(value)
+        elif is_optional(value):
+            result[key] = None
+        elif get_origin(value) is dict:
+            result[key] = {}
+        elif get_origin(value) is NotRequired:
+            continue
+        else:
+            raise Exception("fields must be either optional or typed dicts")
+    return cast(_TypedDictClass, result)

--- a/python_modules/dagster/dagster_tests/utils_tests/test_typed_dict_utils.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_typed_dict_utils.py
@@ -1,0 +1,23 @@
+from typing import Any, Dict, Optional, TypedDict
+
+from dagster._utils.typed_dict import init_optional_typeddict
+from typing_extensions import NotRequired
+
+
+class MyNestedTypedDict(TypedDict):
+    nested: Optional[str]
+
+
+class MyTypedDict(TypedDict):
+    nested: MyNestedTypedDict
+    optional_field: Optional[str]
+    dict_field: Dict[str, Any]
+    not_required_field: NotRequired[str]
+
+
+def test_init_optional_typeddict():
+    assert init_optional_typeddict(MyTypedDict) == {
+        "nested": {"nested": None},
+        "optional_field": None,
+        "dict_field": {},
+    }


### PR DESCRIPTION
Method to recursively initialize an empty TypedDict. Requires that every field is optional on the requisite typeddict.

Downstream from this PR, I start to build up pretty complicated typed dictionaries, where the keys are almost all nullable due to being potentially unretrievable. This makes it possible to one-line initialize those.
