### PR TITLE
[ui] allow meta+click to select all assets in group

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -386,7 +386,7 @@ const AssetGraphExplorerWithData = ({
     selectNodeById(e, nextId);
   };
 
-  const selectAllGroupNodesById = React.useCallback(
+  const toggleSelectAllGroupNodesById = React.useCallback(
     (e: React.MouseEvent<any> | React.KeyboardEvent<any>, groupId: string) => {
       const assets = groupedAssets[groupId] || [];
       const childNodeTokens = assets.map((n) => tokenForAssetKey(n.assetKey));
@@ -418,7 +418,7 @@ const AssetGraphExplorerWithData = ({
         zoomToGroup(modifiedNodeId);
 
         if (e.metaKey) {
-          selectAllGroupNodesById(e, modifiedNodeId);
+          toggleSelectAllGroupNodesById(e, modifiedNodeId);
         }
 
         return;
@@ -442,7 +442,7 @@ const AssetGraphExplorerWithData = ({
       onSelectNode,
       layout,
       zoomToGroup,
-      selectAllGroupNodesById,
+      toggleSelectAllGroupNodesById,
       setExpandedGroups,
       expandedGroups,
     ],
@@ -550,13 +550,12 @@ const AssetGraphExplorerWithData = ({
                     assets: groupedAssets[group.id] || [],
                   }}
                   minimal={scale < MINIMAL_SCALE}
-                  onCollapse={(e) => {
-                    if (e.metaKey) {
-                      selectAllGroupNodesById(e, group.id);
-                    } else {
-                      focusGroupIdAfterLayoutRef.current = group.id;
-                      setExpandedGroups(expandedGroups.filter((g) => g !== group.id));
-                    }
+                  onCollapse={() => {
+                    focusGroupIdAfterLayoutRef.current = group.id;
+                    setExpandedGroups(expandedGroups.filter((g) => g !== group.id));
+                  }}
+                  toggleSelectAllNodes={(e: React.MouseEvent) => {
+                    toggleSelectAllGroupNodesById(e, group.id);
                   }}
                 />
               </foreignObject>
@@ -602,13 +601,12 @@ const AssetGraphExplorerWithData = ({
                     assetCount: allGroupCounts[group.id] || 0,
                     assets: groupedAssets[group.id] || [],
                   }}
-                  onExpand={(e) => {
-                    if (e.metaKey) {
-                      selectAllGroupNodesById(e, group.id);
-                    } else {
-                      focusGroupIdAfterLayoutRef.current = group.id;
-                      setExpandedGroups([...expandedGroups, group.id]);
-                    }
+                  onExpand={() => {
+                    focusGroupIdAfterLayoutRef.current = group.id;
+                    setExpandedGroups([...expandedGroups, group.id]);
+                  }}
+                  toggleSelectAllNodes={(e: React.MouseEvent) => {
+                    toggleSelectAllGroupNodesById(e, group.id);
                   }}
                 />
               </foreignObject>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -413,12 +413,11 @@ const AssetGraphExplorerWithData = ({
       if (!nodeId) {
         return;
       }
-      const modifiedNodeId = '__repository__@' + nodeId;
-      if (isGroupId(modifiedNodeId)) {
-        zoomToGroup(modifiedNodeId);
+      if (isGroupId(nodeId)) {
+        zoomToGroup(nodeId);
 
         if (e.metaKey) {
-          toggleSelectAllGroupNodesById(e, modifiedNodeId);
+          toggleSelectAllGroupNodesById(e, nodeId);
         }
 
         return;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -386,13 +386,41 @@ const AssetGraphExplorerWithData = ({
     selectNodeById(e, nextId);
   };
 
+  const selectAllGroupNodesById = React.useCallback(
+    (e: React.MouseEvent<any> | React.KeyboardEvent<any>, groupId: string) => {
+      const assets = groupedAssets[groupId] || [];
+      const childNodeTokens = assets.map((n) => tokenForAssetKey(n.assetKey));
+
+      const existing = explorerPath.opNames[0]!.split(',');
+
+      const nextOpsNameSelection = childNodeTokens.every((token) => existing.includes(token))
+        ? uniq(without(existing, ...childNodeTokens)).join(',')
+        : uniq([...existing, ...childNodeTokens]).join(',');
+
+      onChangeExplorerPath(
+        {
+          ...explorerPath,
+          opNames: [nextOpsNameSelection],
+        },
+        'replace',
+      );
+    },
+    [groupedAssets, explorerPath, onChangeExplorerPath],
+  );
+
   const selectNodeById = React.useCallback(
     (e: React.MouseEvent<any> | React.KeyboardEvent<any>, nodeId?: string) => {
       if (!nodeId) {
         return;
       }
-      if (isGroupId(nodeId)) {
-        zoomToGroup(nodeId);
+      const modifiedNodeId = '__repository__@' + nodeId;
+      if (isGroupId(modifiedNodeId)) {
+        zoomToGroup(modifiedNodeId);
+
+        if (e.metaKey) {
+          selectAllGroupNodesById(e, modifiedNodeId);
+        }
+
         return;
       }
       const node = assetGraphData.nodes[nodeId];
@@ -409,7 +437,15 @@ const AssetGraphExplorerWithData = ({
         setExpandedGroups([...expandedGroups, groupIdForNode(node)]);
       }
     },
-    [assetGraphData.nodes, layout, onSelectNode, zoomToGroup, expandedGroups, setExpandedGroups],
+    [
+      assetGraphData.nodes,
+      onSelectNode,
+      layout,
+      zoomToGroup,
+      selectAllGroupNodesById,
+      setExpandedGroups,
+      expandedGroups,
+    ],
   );
 
   const [showSidebar, setShowSidebar] = React.useState(isGlobalGraph);
@@ -514,9 +550,13 @@ const AssetGraphExplorerWithData = ({
                     assets: groupedAssets[group.id] || [],
                   }}
                   minimal={scale < MINIMAL_SCALE}
-                  onCollapse={() => {
-                    focusGroupIdAfterLayoutRef.current = group.id;
-                    setExpandedGroups(expandedGroups.filter((g) => g !== group.id));
+                  onCollapse={(e) => {
+                    if (e.metaKey) {
+                      selectAllGroupNodesById(e, group.id);
+                    } else {
+                      focusGroupIdAfterLayoutRef.current = group.id;
+                      setExpandedGroups(expandedGroups.filter((g) => g !== group.id));
+                    }
                   }}
                 />
               </foreignObject>
@@ -562,9 +602,13 @@ const AssetGraphExplorerWithData = ({
                     assetCount: allGroupCounts[group.id] || 0,
                     assets: groupedAssets[group.id] || [],
                   }}
-                  onExpand={() => {
-                    focusGroupIdAfterLayoutRef.current = group.id;
-                    setExpandedGroups([...expandedGroups, group.id]);
+                  onExpand={(e) => {
+                    if (e.metaKey) {
+                      selectAllGroupNodesById(e, group.id);
+                    } else {
+                      focusGroupIdAfterLayoutRef.current = group.id;
+                      setExpandedGroups([...expandedGroups, group.id]);
+                    }
                   }}
                 />
               </foreignObject>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
@@ -70,7 +70,7 @@ export const CollapsedGroupNode = ({
   onFilterToGroup,
 }: {
   minimal: boolean;
-  onExpand: () => void;
+  onExpand: (e: React.MouseEvent) => void;
   group: GroupLayout & {assetCount: number; assets: GraphNode[]};
   preferredJobName: string;
   onFilterToGroup: () => void;
@@ -84,7 +84,7 @@ export const CollapsedGroupNode = ({
     <ContextMenuWrapper menu={menu} stopPropagation>
       <CollapsedGroupNodeContainer
         onClick={(e) => {
-          onExpand();
+          onExpand(e);
           e.stopPropagation();
         }}
       >

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
@@ -66,11 +66,13 @@ export const CollapsedGroupNode = ({
   group,
   minimal,
   onExpand,
+  toggleSelectAllNodes,
   preferredJobName,
   onFilterToGroup,
 }: {
   minimal: boolean;
-  onExpand: (e: React.MouseEvent) => void;
+  onExpand: () => void;
+  toggleSelectAllNodes?: (e: React.MouseEvent) => void;
   group: GroupLayout & {assetCount: number; assets: GraphNode[]};
   preferredJobName: string;
   onFilterToGroup: () => void;
@@ -84,7 +86,11 @@ export const CollapsedGroupNode = ({
     <ContextMenuWrapper menu={menu} stopPropagation>
       <CollapsedGroupNodeContainer
         onClick={(e) => {
-          onExpand(e);
+          if (e.metaKey && toggleSelectAllNodes) {
+            toggleSelectAllNodes(e);
+          } else {
+            onExpand();
+          }
           e.stopPropagation();
         }}
       >

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ExpandedGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ExpandedGroupNode.tsx
@@ -25,7 +25,7 @@ export const ExpandedGroupNode = ({
 }: {
   group: GroupLayout & {assets: GraphNode[]};
   minimal: boolean;
-  onCollapse?: () => void;
+  onCollapse?: (e: React.MouseEvent) => void;
   preferredJobName?: string;
   onFilterToGroup?: () => void;
   setHighlighted: (ids: string[] | null) => void;
@@ -43,7 +43,7 @@ export const ExpandedGroupNode = ({
           onMouseEnter={() => setHighlighted(group.assets.map((a) => a.id))}
           onMouseLeave={() => setHighlighted(null)}
           onClick={(e) => {
-            onCollapse?.();
+            onCollapse?.(e);
             e.stopPropagation();
           }}
         >

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ExpandedGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ExpandedGroupNode.tsx
@@ -19,13 +19,15 @@ export const ExpandedGroupNode = ({
   group,
   minimal,
   onCollapse,
+  toggleSelectAllNodes,
   preferredJobName,
   onFilterToGroup,
   setHighlighted,
 }: {
   group: GroupLayout & {assets: GraphNode[]};
   minimal: boolean;
-  onCollapse?: (e: React.MouseEvent) => void;
+  onCollapse?: () => void;
+  toggleSelectAllNodes?: (e: React.MouseEvent) => void;
   preferredJobName?: string;
   onFilterToGroup?: () => void;
   setHighlighted: (ids: string[] | null) => void;
@@ -43,7 +45,11 @@ export const ExpandedGroupNode = ({
           onMouseEnter={() => setHighlighted(group.assets.map((a) => a.id))}
           onMouseLeave={() => setHighlighted(null)}
           onClick={(e) => {
-            onCollapse?.(e);
+            if (e.metaKey && toggleSelectAllNodes) {
+              toggleSelectAllNodes(e);
+            } else {
+              onCollapse?.();
+            }
             e.stopPropagation();
           }}
         >

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
@@ -107,7 +107,7 @@ export const AssetSidebarNode = ({
             )}
             <GrayOnHoverBox
               onClick={selectThisNode}
-              onDoubleClick={toggleOpen}
+              onDoubleClick={(e) => !e.metaKey && toggleOpen()}
               style={{
                 width: '100%',
                 borderRadius: '8px',

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -337,6 +337,8 @@ export const AssetGraphExplorerSidebar = React.memo(
                 const isCodelocationNode = 'locationName' in node;
                 const isGroupNode = 'groupName' in node;
                 const row = !isCodelocationNode && !isGroupNode ? graphData.nodes[node.id] : node;
+                const isSelected =
+                  selectedNode?.id === node.id || selectedNodes.includes(row as GraphNode);
                 return (
                   <Row $height={size} $start={start} key={key} data-key={key}>
                     <AssetSidebarNode
@@ -345,9 +347,7 @@ export const AssetGraphExplorerSidebar = React.memo(
                       node={row!}
                       level={node.level}
                       isLastSelected={lastSelectedNode?.id === node.id}
-                      isSelected={
-                        selectedNode?.id === node.id || selectedNodes.includes(row as GraphNode)
-                      }
+                      isSelected={isSelected}
                       toggleOpen={() => {
                         setOpenNodes((nodes) => {
                           const openNodes = new Set(nodes);


### PR DESCRIPTION
## Summary

Small prototype of allowing assets in a group to be selected by meta+clicking the group in the asset graph or sidebar - prob needs some work before it's mergable


## Test Plan

Tested locally

https://github.com/dagster-io/dagster/assets/10215173/8def206d-43ed-4c89-a7c1-1cd11131711d


