### PR TITLE
Typed GRPC server metrics

### DIFF
--- a/python_modules/dagster/dagster/_core/utils.py
+++ b/python_modules/dagster/dagster/_core/utils.py
@@ -14,6 +14,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    TypedDict,
     TypeVar,
     Union,
     cast,
@@ -125,6 +126,14 @@ def parse_env_var(env_var_str: str) -> Tuple[str, str]:
         return (env_var_str, cast(str, env_var_value))
 
 
+class RequestUtilizationMetrics(TypedDict):
+    """A dict of utilization metrics for a threadpool executor. We use generic language in case we use this metrics in a scenario where we switch away from a threadpool executor at a later time."""
+
+    max_concurrent_requests: Optional[int]
+    num_running_requests: Optional[int]
+    num_queued_requests: Optional[int]
+
+
 class FuturesAwareThreadPoolExecutor(ThreadPoolExecutor):
     def __init__(
         self,
@@ -160,6 +169,13 @@ class FuturesAwareThreadPoolExecutor(ThreadPoolExecutor):
     @property
     def num_queued_futures(self) -> int:
         return self._work_queue.qsize()
+
+    def get_current_utilization_metrics(self) -> RequestUtilizationMetrics:
+        return {
+            "max_concurrent_requests": self.max_workers,
+            "num_running_requests": self.num_running_futures,
+            "num_queued_requests": self.num_queued_futures,
+        }
 
 
 class InheritContextThreadPoolExecutor(FuturesAwareThreadPoolExecutor):

--- a/python_modules/dagster/dagster/_utils/container.py
+++ b/python_modules/dagster/dagster/_utils/container.py
@@ -58,14 +58,14 @@ def memory_limit_path():
     return os.getenv("DAGSTER_MEMORY_LIMIT_PATH", "/sys/fs/cgroup/memory/memory.limit_in_bytes")
 
 
-class UtilizationMetrics(TypedDict):
+class ContainerUtilizationMetrics(TypedDict):
     num_allocated_cores: Optional[int]
     cpu_usage: Optional[float]
     cpu_cfs_quota_us: Optional[float]
     cpu_cfs_period_us: Optional[float]
     memory_usage: Optional[float]
     memory_limit: Optional[int]
-    measurement_timestamp: float
+    measurement_timestamp: Optional[float]
     previous_cpu_usage: Optional[float]
     previous_measurement_timestamp: Optional[float]
 
@@ -74,7 +74,7 @@ def retrieve_containerized_utilization_metrics(
     logger: Optional[logging.Logger],
     previous_measurement_timestamp: Optional[float],
     previous_cpu_usage: Optional[float],
-) -> UtilizationMetrics:
+) -> ContainerUtilizationMetrics:
     """Retrieve the CPU and memory utilization metrics from cgroup and proc files."""
     return {
         "num_allocated_cores": _retrieve_containerized_num_allocated_cores(logger),

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_metrics.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_metrics.py
@@ -101,15 +101,14 @@ def test_ping_metrics_retrieval(provide_flag: bool):
                 ).start()
             time.sleep(2)  # wait for sensor execution to begin
             res = client.ping("blah")
-            metadata = json.loads(res["serialized_server_utilization_metrics"])
             if provide_flag:
-                assert "resource_utilization" in metadata
-                assert "max_concurrent_requests" in metadata["resource_utilization"]
-                assert isinstance(metadata["resource_utilization"]["max_concurrent_requests"], int)
-                assert "SyncExternalSensorExecution" in metadata
-                assert metadata["SyncExternalSensorExecution"] == {"current_request_count": 2}
+                metadata = json.loads(res["serialized_server_utilization_metrics"])
+                assert "SyncExternalSensorExecution" in metadata["per_api_metrics"]
+                assert metadata["per_api_metrics"]["SyncExternalSensorExecution"] == {
+                    "current_request_count": 2
+                }
             else:
-                assert metadata == {}
+                assert res["serialized_server_utilization_metrics"] == ""
     finally:
         process.terminate()
         process.wait()

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -68,7 +68,7 @@ def test_load_grpc_server(entrypoint):
         wait_for_grpc_server(process, client, subprocess_args)
         assert client.ping("foobar") == {
             "echo": "foobar",
-            "serialized_server_utilization_metrics": "{}",
+            "serialized_server_utilization_metrics": "",
         }
 
         list_repositories_response = sync_list_repositories_grpc(client)
@@ -246,7 +246,7 @@ def test_load_via_auto_env_var_prefix():
             client = DagsterGrpcClient(port=port)
             assert client.ping("foobar") == {
                 "echo": "foobar",
-                "serialized_server_utilization_metrics": "{}",
+                "serialized_server_utilization_metrics": "",
             }
 
             list_repositories_response = sync_list_repositories_grpc(client)
@@ -290,7 +290,7 @@ def test_load_via_env_var():
             )
             assert DagsterGrpcClient(port=port).ping("foobar") == {
                 "echo": "foobar",
-                "serialized_server_utilization_metrics": "{}",
+                "serialized_server_utilization_metrics": "",
             }
         finally:
             process.terminate()
@@ -329,7 +329,7 @@ def test_load_code_server_via_env_var():
             )
             assert DagsterGrpcClient(port=port).ping("foobar") == {
                 "echo": "foobar",
-                "serialized_server_utilization_metrics": "{}",
+                "serialized_server_utilization_metrics": "",
             }
         finally:
             process.terminate()
@@ -442,7 +442,7 @@ def test_load_with_empty_working_directory(capfd):
             )
             assert DagsterGrpcClient(port=port).ping("foobar") == {
                 "echo": "foobar",
-                "serialized_server_utilization_metrics": "{}",
+                "serialized_server_utilization_metrics": "",
             }
         finally:
             process.terminate()
@@ -894,7 +894,7 @@ def test_load_with_container_context(entrypoint):
         wait_for_grpc_server(process, client, subprocess_args)
         assert client.ping("foobar") == {
             "echo": "foobar",
-            "serialized_server_utilization_metrics": "{}",
+            "serialized_server_utilization_metrics": "",
         }
 
         list_repositories_response = sync_list_repositories_grpc(client)


### PR DESCRIPTION
This adds some typing to the grpc server metrics collection code paths, and changes up the format to separate out different kinds of metrics more coherently. The idea is that we can reuse these classes in multiple places if they are scoped enough. To describe what's added:
- RequestUtilizationMetrics (to measure the throughput of a dagster system component, usually in the form of a threadpool, but kept language in terms of requests in case there are non-threadpool use cases we would like to cover.
- GrpcApiMetrics (to measure various statistics about current request throughput of a particular grpc api)
These are encapsulated by `DagsterCodeServerUtilizationMetrics`, which contains RequestUtilizationMetrics(throughput of the threadpool), ContainerUtilizationMetrics (kernel-level mem and cpu info) and a dictionary mapping a grpc API name to an instance of GrpcApiMetrics (which right now is just tracking the total number of requests of that type being concurrently served.