### PR TITLE
[ui] Use hourCycle value in log row timestamps

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/HourCycleSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/HourCycleSelect.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import {HourCycle} from './HourCycle';
 import {TimeContext} from './TimeContext';
+import {browserHourCycle} from './browserTimezone';
 
 /**
  * Show the "hour cycle" options available to the user:
@@ -30,16 +31,12 @@ export const HourCycleSelect = () => {
   }, []);
 
   const labels = React.useMemo(() => {
-    // Detect the hour cycle based on the presence of a dayPeriod in a formatted time string,
-    // since the `hourCycle` property on the Intl.Locale object may be undefined.
-    const parts = formats.automatic.formatToParts(new Date());
-    const partKeys = parts.map((part) => part.type);
     return {
-      automatic: `Automatic (${partKeys.includes('dayPeriod') ? '12-hour' : '24-hour'})`,
+      automatic: `Automatic (${browserHourCycle() === 'h12' ? '12-hour' : '24-hour'})`,
       h12: '12-hour',
       h23: '24-hour',
     };
-  }, [formats.automatic]);
+  }, []);
 
   React.useEffect(() => {
     const interval = setInterval(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/browserTimezone.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/browserTimezone.ts
@@ -12,3 +12,12 @@ export const timezoneAbbreviation = memoize((timeZone: string) => {
   return abbreviation!;
 });
 export const automaticLabel = memoize(() => `Automatic (${browserTimezoneAbbreviation()})`);
+
+// Detect the hour cycle based on the presence of a dayPeriod in a formatted time string,
+// since the `hourCycle` property on the Intl.Locale object may be undefined.
+export const browserHourCycle = memoize(() => {
+  const format = new Intl.DateTimeFormat(navigator.language, {timeStyle: 'short'});
+  const parts = format.formatToParts(new Date());
+  const partKeys = parts.map((part) => part.type);
+  return partKeys.includes('dayPeriod') ? 'h12' : 'h23';
+});


### PR DESCRIPTION
## Summary & Motivation

When rendering log table timestamps, we aren't properly respecting the user's hour cycle setting (12-hour vs 24-hour) and are instead always rendering times in 24-hour format. This is potentially confusing for users who aren't otherwise using this hour cycle, since it makes it look like it's a UTC timestamp or something.

Fix this issue by properly incorporating the user's hour cycle setting. I also fixed the alignment of the "elapsed time" values in the tooltip.

https://github.com/dagster-io/dagster/assets/2823852/aa9aa02a-32ed-4f61-afa0-641129bedd1e

<img width="329" alt="Screenshot 2024-01-10 at 9 51 07 AM" src="https://github.com/dagster-io/dagster/assets/2823852/fc849868-d595-46ee-8e11-0fd9ba6ee7d7">



## How I Tested These Changes

See video.
