### PR TITLE
[ui] Remove dark prop on MetadataTable

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/MetadataTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/MetadataTable.tsx
@@ -1,21 +1,18 @@
 import * as React from 'react';
 import styled from 'styled-components';
 
-import {colorTextDefault, colorTextLight} from '../theme/color';
-
 import {Box} from './Box';
 import {Table, TableProps} from './Table';
 
 export type MetadataTableRow = {key: string; label?: React.ReactNode; value: React.ReactNode};
 
 interface Props {
-  dark?: boolean;
   rows: (MetadataTableRow | null | undefined)[];
   spacing: 0 | 2 | 4;
 }
 
 export const MetadataTable = (props: Props) => {
-  const {rows, spacing, dark = false} = props;
+  const {rows, spacing} = props;
 
   return (
     <StyledTable>
@@ -29,7 +26,7 @@ export const MetadataTable = (props: Props) => {
             <tr key={key}>
               <td>
                 <Box padding={{vertical: spacing, right: 32}}>
-                  <MetadataKey $dark={dark}>{label ?? key}</MetadataKey>
+                  <MetadataKey>{label ?? key}</MetadataKey>
                 </Box>
               </td>
               <td>
@@ -58,8 +55,7 @@ export const StyledTable = styled.table`
   }
 `;
 
-const MetadataKey = styled.div<{$dark: boolean}>`
-  color: ${({$dark}) => ($dark ? colorTextDefault() : colorTextLight())};
+const MetadataKey = styled.div`
   font-weight: 400;
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowComponents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowComponents.tsx
@@ -178,7 +178,6 @@ export const TimestampColumn = React.memo((props: TimestampColumnProps) => {
         content={
           <MetadataTable
             spacing={0}
-            dark
             rows={[
               {
                 key: 'Since start of run',


### PR DESCRIPTION
## Summary & Motivation

The `dark` prop on `MetadataTable` is used on the log row timestamp tooltip, but as far as I can tell, it's not really needed -- the default text colors seem fine here. We applied the wrong text color here during theming, and the keys are currently invisible to people using light mode.

I think maybe the key color was slightly different from the value color before theming, but I'm not sure we really need it.

## How I Tested These Changes

In light mode, view run logs, hover on timestmap. Verify that the elapsed time label is visible. Switch to dark mode, verify same.
