### PR TITLE
add secondary deps to AssetCheckSpec

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_dep.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_dep.py
@@ -1,12 +1,13 @@
-from typing import NamedTuple, Optional, Union
+from typing import Iterable, NamedTuple, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._annotations import PublicAttr
+from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.source_asset import SourceAsset
-from dagster._core.errors import DagsterInvalidDefinitionError
+from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 
 from .events import (
     AssetKey,
@@ -97,3 +98,25 @@ def _get_asset_key(arg: "CoercibleToAssetDep") -> AssetKey:
         return arg.asset_key
     else:
         return AssetKey.from_coercible(arg)
+
+
+def coerce_to_deps_and_check_duplicates(
+    coercible_to_asset_deps: Optional[Iterable["CoercibleToAssetDep"]],
+    key: Union[AssetKey, AssetCheckKey],
+) -> Sequence[AssetDep]:
+    dep_set = {}
+    if coercible_to_asset_deps:
+        for dep in coercible_to_asset_deps:
+            asset_dep = AssetDep.from_coercible(dep)
+
+            # we cannot do deduplication via a set because MultiPartitionMappings have an internal
+            # dictionary that cannot be hashed. Instead deduplicate by making a dictionary and checking
+            # for existing keys.
+            if asset_dep.asset_key in dep_set.keys():
+                raise DagsterInvariantViolationError(
+                    f"Cannot set a dependency on asset {asset_dep.asset_key} more than once for"
+                    f" spec {key}"
+                )
+            dep_set[asset_dep.asset_key] = asset_dep
+
+    return list(dep_set.values())

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping, NamedTuple, Optional
 
 import dagster._check as check
 from dagster._annotations import PublicAttr
-from dagster._core.errors import DagsterInvariantViolationError
 
 from .auto_materialize_policy import AutoMaterializePolicy
 from .events import (
@@ -99,27 +98,15 @@ class AssetSpec(
         freshness_policy: Optional[FreshnessPolicy] = None,
         auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
     ):
-        from dagster._core.definitions.asset_dep import AssetDep
+        from dagster._core.definitions.asset_dep import coerce_to_deps_and_check_duplicates
 
-        dep_set = {}
-        if deps:
-            for dep in deps:
-                asset_dep = AssetDep.from_coercible(dep)
-
-                # we cannot do deduplication via a set because MultiPartitionMappings have an internal
-                # dictionary that cannot be hashed. Instead deduplicate by making a dictionary and checking
-                # for existing keys.
-                if asset_dep.asset_key in dep_set.keys():
-                    raise DagsterInvariantViolationError(
-                        f"Cannot set a dependency on asset {asset_dep.asset_key} more than once for"
-                        f" AssetSpec {key}"
-                    )
-                dep_set[asset_dep.asset_key] = asset_dep
+        key = AssetKey.from_coercible(key)
+        asset_deps = coerce_to_deps_and_check_duplicates(deps, key)
 
         return super().__new__(
             cls,
-            key=AssetKey.from_coercible(key),
-            deps=list(dep_set.values()),
+            key=key,
+            deps=asset_deps,
             description=check.opt_str_param(description, "description"),
             metadata=check.opt_mapping_param(metadata, "metadata", key_type=str),
             skippable=check.bool_param(skippable, "skippable"),

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -808,5 +808,5 @@ def test_required_assets_and_checks_by_key_multi_asset_single_asset(
 
     asset_graph = asset_graph_from_assets([asset_fn])
 
-    for key in [AssetKey(["asset0"]), foo_check, bar_check]:
+    for key in [AssetKey(["asset0"]), foo_check.key, bar_check.key]:
         assert asset_graph.get_required_asset_and_check_keys(key) == set()


### PR DESCRIPTION


Matches the way that asset upstreams get turned in to AssetDeps in AssetSpec: https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/_core/definitions/asset_spec.py#L54