### PR TITLE
feat(instigator-tick-logs): add empty state when no logs can be displayed

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/TickLogDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/TickLogDialog.tsx
@@ -6,6 +6,9 @@ import {
   Dialog,
   DialogBody,
   colorTextLight,
+  NonIdealState,
+  ExternalAnchorButton,
+  Icon,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
 
@@ -98,13 +101,62 @@ export const QueryfulTickLogsTable = ({instigationSelector, tick}: TickLogTableP
     return <TickLogsTable events={events} />;
   }
 
+  const tickStatus =
+    data?.instigationStateOrError.__typename === 'InstigationState'
+      ? data?.instigationStateOrError.tick.status
+      : undefined;
+  const instigationType =
+    data?.instigationStateOrError.__typename === 'InstigationState'
+      ? data?.instigationStateOrError.instigationType
+      : undefined;
+  const instigationLoggingDocsUrl =
+    instigationType === 'SENSOR'
+      ? 'https://docs.dagster.io/concepts/partitions-schedules-sensors/sensors#logging-in-sensors'
+      : instigationType === 'SCHEDULE'
+      ? 'https://docs.dagster.io/concepts/partitions-schedules-sensors/schedules#logging-in-schedules'
+      : undefined;
+
   return (
     <Box
       style={{height: 500}}
       flex={{justifyContent: 'center', alignItems: 'center'}}
       padding={{vertical: 48}}
     >
-      {loading ? 'Loading logs…' : 'No logs available'}
+      {loading ? (
+        'Loading logs…'
+      ) : (
+        <NonIdealState
+          icon="no-results"
+          title="No logs to display"
+          description={
+            <Box flex={{direction: 'column', gap: 12}}>
+              <div>
+                Your evaluation did not emit any logs. To learn how to emit logs in your evaluation,
+                visit the documentation for more information.
+              </div>
+              {tickStatus === 'FAILURE' && (
+                <>
+                  <div>
+                    For failed evaluations, logs will only be displayed if your Dagster and Dagster
+                    Cloud agent versions 1.5.14 or higher.
+                  </div>
+                  <div>Upgrade your Dagster versions to view logs for failed evaluations.</div>
+                </>
+              )}
+            </Box>
+          }
+          action={
+            instigationLoggingDocsUrl && (
+              <ExternalAnchorButton
+                href={instigationLoggingDocsUrl}
+                rightIcon={<Icon name="open_in_new" />}
+              >
+                View documentation
+              </ExternalAnchorButton>
+            )
+          }
+        />
+      )}
     </Box>
   );
 };
@@ -165,6 +217,7 @@ const TICK_LOG_EVENTS_QUERY = gql`
     instigationStateOrError(instigationSelector: $instigationSelector) {
       ... on InstigationState {
         id
+        instigationType
         tick(tickId: $tickId) {
           id
           status

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/types/TickLogDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/types/TickLogDialog.types.ts
@@ -13,6 +13,7 @@ export type TickLogEventsQuery = {
     | {
         __typename: 'InstigationState';
         id: string;
+        instigationType: Types.InstigationType;
         tick: {
           __typename: 'InstigationTick';
           id: string;


### PR DESCRIPTION
## Summary & Motivation
Two cases for why sensor/schedule logs are empty:

1. The user did not emit any logs in their evaluation code.
2. The user emitted logs in their evaluation code, but their Dagster user code or Dagster Cloud agent version are out of date. Their versions should be at least `1.5.14`.

Add an empty state to direct users in these cases.

## How I Tested These Changes
local dev

### Case 1
<img width="1075" alt="Screenshot 2024-01-10 at 12 50 18 PM" src="https://github.com/dagster-io/dagster/assets/16431325/25520976-bf7f-48de-9c78-95a90072a225">

### Case 2
<img width="1077" alt="Screenshot 2024-01-10 at 12 46 00 PM" src="https://github.com/dagster-io/dagster/assets/16431325/30f13b33-67d4-4fcf-935c-3358a16843a0">