### PR TITLE
Expand grpc threadpool metrics

### DIFF
--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -15,6 +15,7 @@ from dagster._cli.workspace.cli_target import (
 )
 from dagster._core.instance import InstanceRef
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+from dagster._core.utils import FuturesAwareThreadPoolExecutor
 from dagster._serdes import deserialize_value
 from dagster._utils.interrupts import setup_interrupt_handlers
 from dagster._utils.log import configure_loggers
@@ -215,6 +216,7 @@ def start_command(
 
     server_termination_event = threading.Event()
 
+    threadpool_executor = FuturesAwareThreadPoolExecutor(max_workers=max_workers)
     api_servicer = DagsterProxyApiServicer(
         loadable_target_origin=loadable_target_origin,
         fixed_server_id=fixed_server_id,
@@ -236,7 +238,7 @@ def start_command(
         port=port,
         socket=socket,
         host=host,
-        max_workers=max_workers,
+        threadpool_executor=threadpool_executor,
         logger=logger,
     )
 

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_metrics.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_metrics.py
@@ -105,7 +105,7 @@ def test_ping_metrics_retrieval(provide_flag: bool):
             if provide_flag:
                 assert "resource_utilization" in metadata
                 assert "max_concurrent_requests" in metadata["resource_utilization"]
-                assert metadata["resource_utilization"]["max_concurrent_requests"] == -1
+                assert isinstance(metadata["resource_utilization"]["max_concurrent_requests"], int)
                 assert "SyncExternalSensorExecution" in metadata
                 assert metadata["SyncExternalSensorExecution"] == {"current_request_count": 2}
             else:

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_ping.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_ping.py
@@ -11,6 +11,7 @@ import dagster._seven as seven
 import pytest
 from dagster._core.errors import DagsterUserCodeUnreachableError
 from dagster._core.test_utils import instance_for_test
+from dagster._core.utils import FuturesAwareThreadPoolExecutor
 from dagster._grpc import DagsterGrpcClient, DagsterGrpcServer, ephemeral_grpc_api_client
 from dagster._grpc.server import GrpcServerProcess, open_server_process
 from dagster._serdes.ipc import interrupt_ipc_subprocess_pid
@@ -35,6 +36,7 @@ def test_server_socket_on_windows():
                 dagster_api_servicer=mock.MagicMock(),
                 logger=logging.getLogger("dagster.code_server"),
                 socket=skt,
+                threadpool_executor=FuturesAwareThreadPoolExecutor(),
             )
 
 
@@ -50,6 +52,7 @@ def test_server_port_and_socket():
                 logger=logging.getLogger("dagster.code_server"),
                 socket=skt,
                 port=find_free_port(),
+                threadpool_executor=FuturesAwareThreadPoolExecutor(),
             )
 
 


### PR DESCRIPTION
This makes use of the newly-created FuturesAwareThreadpoolExecutor (above PR in stack) to also track total threadpool utilization for the grpc server.
