### PR TITLE
Make AssetSelection objects always truthy even if they are empty namedtuples

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -305,6 +305,10 @@ class AssetSelection(ABC):
 
         return AndAssetSelection(operands)
 
+    def __bool__(self):
+        # Ensure that even if a subclass is a NamedTuple with no fields, it is still truthy
+        return True
+
     def __sub__(self, other: "AssetSelection") -> "SubtractAssetSelection":
         check.inst_param(other, "other", AssetSelection)
         return SubtractAssetSelection(self, other)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -530,3 +530,8 @@ def test_to_string_basic():
         str(AssetSelection.key_prefixes("marketing", ["foo", "bar"]))
         == "key_prefix:(marketing or foo/bar)"
     )
+
+
+def test_empty_namedtuple_truthy():
+    # namedtuples with no fields are still truthy
+    assert bool(AssetSelection.all())


### PR DESCRIPTION
Summary:
workaround for the odd python behavior where Namedtuples with no fields are not truthy, making it easy to accidentally exclude asset selections.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
