### PR TITLE
asset_decorator: Add type parameters to callable arguments

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -56,7 +56,7 @@ from ..utils import DEFAULT_IO_MANAGER_KEY, DEFAULT_OUTPUT, NoValueSentinel
 
 @overload
 def asset(
-    compute_fn: Callable,
+    compute_fn: Callable[..., Any],
 ) -> AssetsDefinition:
     ...
 
@@ -103,7 +103,7 @@ def asset(
     param="non_argument_deps", breaking_version="2.0.0", additional_warn_text="use `deps` instead."
 )
 def asset(
-    compute_fn: Optional[Callable] = None,
+    compute_fn: Optional[Callable[..., Any]] = None,
     *,
     name: Optional[str] = None,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,


### PR DESCRIPTION
## Summary & Motivation

Change the type annotation on `asset`'s `compute_fn` argument from `Callable` to `Callable[..., Any]`.

Without these parameters, the type according to pyright is `Callable[..., Unknown]` which causes
`reportUnknownParameterType` errors in projects that use pyright in strict mode.

## How I Tested These Changes

I ran `make pyright` with the changes applied, and verified that running `pyright` in strict mode on our workflows succeeds without the need for `# pyright: ignore[reportUnknownParameterType]`