### PR TITLE
[ui] Clean up remaining CoreColors usage

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/index.ts
+++ b/js_modules/dagster-ui/packages/ui-components/src/index.ts
@@ -57,9 +57,6 @@ export * from './components/ifPlural';
 export * from './theme/color';
 export * from './theme/theme';
 
-// todo dish: Delete this
-export * from './palettes/Colors';
-
 // Global font styles, exported as styled-component components to render in
 // your app tree root. E.g. <GlobalInconsolata />
 export * from './fonts/GlobalInconsolata';

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav.tsx
@@ -339,11 +339,11 @@ const NavButton = styled.button`
   }
 
   :hover ${IconWrapper} {
-    background: ${colorNavText()};
+    background: ${colorNavTextHover()};
   }
 
   :active ${IconWrapper} {
-    background: ${colorNavText()};
+    background: ${colorNavTextHover()};
   }
 
   :focus {

--- a/js_modules/dagster-ui/packages/ui-core/src/app/ShortcutHandler.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ShortcutHandler.tsx
@@ -1,4 +1,9 @@
-import {CoreColors, colorShadowDefault} from '@dagster-io/ui-components';
+import {
+  colorBorderHover,
+  colorShadowDefault,
+  colorTooltipBackground,
+  colorTooltipText,
+} from '@dagster-io/ui-components';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import styled from 'styled-components';
@@ -205,9 +210,9 @@ const ShortcutAnnotation = styled.div`
   padding: 2px;
   z-index: 20;
   transform: translate(-90%, -10px);
-  color: ${CoreColors.Gray100};
-  background: ${CoreColors.Gray800};
-  border: 1px solid ${CoreColors.Gray300};
+  color: ${colorTooltipText()};
+  background: ${colorTooltipBackground()};
+  border: 1px solid ${colorBorderHover()};
   border-radius: 3px;
   box-shadow: 0 1px 3px ${colorShadowDefault()};
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsButton.tsx
@@ -1,4 +1,9 @@
-import {IconWrapper, Icon, CoreColors} from '@dagster-io/ui-components';
+import {
+  IconWrapper,
+  Icon,
+  colorNavTextSelected,
+  colorNavTextHover,
+} from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled from 'styled-components';
 
@@ -16,18 +21,18 @@ const SettingsButton = styled.button`
   }
 
   &:hover ${IconWrapper} {
-    background: ${CoreColors.White};
+    background: ${colorNavTextHover()};
   }
 
   &:active ${IconWrapper} {
-    background: ${CoreColors.White};
+    background: ${colorNavTextHover()};
   }
 
   &:focus {
     outline: none;
 
     ${IconWrapper} {
-      background: ${CoreColors.White};
+      background: ${colorNavTextHover()};
     }
   }
 `;
@@ -37,7 +42,7 @@ export const UserSettingsButton = () => {
   return (
     <>
       <SettingsButton onClick={() => setIsOpen(true)} title="User settings">
-        <Icon name="settings" color={CoreColors.Gray200} />
+        <Icon name="settings" color={colorNavTextSelected()} />
       </SettingsButton>
       <UserSettingsDialog
         isOpen={isOpen}

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
@@ -8,7 +8,8 @@ import {
   colorBackgroundLight,
   colorBorderDefault,
   colorLineageDots,
-  CoreColors,
+  colorTooltipBackground,
+  colorTooltipText,
 } from '@dagster-io/ui-components';
 import animate from 'amator';
 import * as React from 'react';
@@ -697,8 +698,8 @@ const WheelInstructionTooltipContainer = styled.div`
   font-size: 12px;
   line-height: 16px;
   border-radius: 2px;
-  background: ${CoreColors.Gray900};
-  color: ${CoreColors.Gray50};
+  background: ${colorTooltipBackground()};
+  color: ${colorTooltipText()};
   padding: 8px 16px;
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Box, ButtonLink, CoreColors} from '@dagster-io/ui-components';
+import {Box, ButtonLink, colorAccentWhite} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {useHistory} from 'react-router-dom';
 import styled from 'styled-components';
@@ -266,7 +266,7 @@ const alreadyViewingCodeLocations = () => document.location.pathname.endsWith('/
 
 const ViewCodeLocationsButton = ({onClick}: {onClick: () => void}) => {
   return (
-    <ViewButton onClick={onClick} color={CoreColors.White}>
+    <ViewButton onClick={onClick} color={colorAccentWhite()}>
       View
     </ViewButton>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/CapturedLogPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/CapturedLogPanel.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery, useSubscription} from '@apollo/client';
-import {Box, Icon, CoreColors} from '@dagster-io/ui-components';
+import {Box, Icon, colorTooltipBackground, colorTooltipText} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {AppContext} from '../app/AppContext';
@@ -38,8 +38,8 @@ export const CapturedOrExternalLogPanel = React.memo(
       return (
         <Box
           flex={{direction: 'row', alignItems: 'center', justifyContent: 'center', gap: 1}}
-          background={CoreColors.Gray900}
-          style={{color: CoreColors.White, flex: 1, minHeight: 0}}
+          background={colorTooltipBackground()}
+          style={{color: colorTooltipText(), flex: 1, minHeight: 0}}
         >
           View logs at
           <a
@@ -47,7 +47,7 @@ export const CapturedOrExternalLogPanel = React.memo(
             target="_blank"
             rel="noreferrer"
             style={{
-              color: CoreColors.White,
+              color: colorTooltipText(),
               textDecoration: 'underline',
               marginLeft: 4,
               marginRight: 4,
@@ -55,7 +55,7 @@ export const CapturedOrExternalLogPanel = React.memo(
           >
             {externalUrl}
           </a>
-          <Icon name="open_in_new" color={CoreColors.White} size={20} style={{marginTop: 2}} />
+          <Icon name="open_in_new" color={colorTooltipText()} size={20} style={{marginTop: 2}} />
         </Box>
       );
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RawLogContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RawLogContent.tsx
@@ -4,14 +4,12 @@ import {
   Spinner,
   FontFamily,
   colorAccentYellow,
-  CoreColors,
   colorBackgroundLight,
   colorBackgroundLighter,
   colorKeylineDefault,
   colorBackgroundLightHover,
   colorTextDefault,
   colorTextLight,
-  colorBorderDefault,
   colorBackgroundYellow,
   colorTextLighter,
   colorAccentBlue,
@@ -21,6 +19,11 @@ import {
   colorAccentCyan,
   colorAccentGray,
   colorAccentOlive,
+  colorBackgroundDefault,
+  colorBackgroundLighterHover,
+  colorAccentPrimary,
+  colorBorderDefault,
+  colorBorderHover,
 } from '@dagster-io/ui-components';
 import Ansi from 'ansi-to-react';
 import * as React from 'react';
@@ -104,7 +107,7 @@ export const RawLogContent = React.memo((props: Props) => {
               onMouseOut={scheduleHideWarning}
             >
               <Group direction="row" spacing={8} alignItems="center">
-                <Icon name="arrow_upward" color={CoreColors.White} />
+                <Icon name="arrow_upward" color={colorAccentPrimary()} />
                 Scroll to top
               </Group>
             </ScrollToTop>
@@ -410,6 +413,7 @@ const LogContent = styled(ScrollContainer)`
   left: 0;
   right: 0;
 `;
+
 const LoadingContainer = styled.div`
   display: flex;
   justifycontent: center;
@@ -419,7 +423,7 @@ const LoadingContainer = styled.div`
   bottom: 0;
   left: 0;
   right: 0;
-  backgroundcolor: ${CoreColors.Gray800};
+  background-color: ${colorBackgroundDefault()};
   opacity: 0.3;
 `;
 
@@ -435,16 +439,22 @@ const ScrollToast = styled.div`
   align-items: flex-start;
   z-index: 1;
 `;
-const ScrollToTop = styled.div`
+
+const ScrollToTop = styled.button`
   background-color: ${colorBackgroundLighter()};
-  padding: 10px 20px;
+  padding: 12px 20px 12px 14px;
   border-bottom-right-radius: 5px;
   border-bottom-left-radius: 5px;
   color: ${colorTextDefault()};
-  border-bottom: 1px solid ${colorBorderDefault()};
-  border-left: 1px solid ${colorBorderDefault()};
-  border-right: 1px solid ${colorBorderDefault()};
+  border: 1px solid ${colorBorderDefault()};
+  border-width: 0 1px 1px 1px;
   cursor: pointer;
+  transition: background-color 100ms linear;
+
+  :hover {
+    background-color: ${colorBackgroundLighterHover()};
+    border-color: ${colorBorderHover()};
+  }
 `;
 
 const FileWarning = styled.div`

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunStats.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunStats.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Box, Spinner, CoreColors} from '@dagster-io/ui-components';
+import {Box, Spinner} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
@@ -80,11 +80,10 @@ const RUN_STATS_QUERY = gql`
 `;
 
 const RunStatsDetailsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
   min-width: 200px;
   padding: 12px;
-  color: ${CoreColors.White};
   font-size: 12px;
-  & > a {
-    display: block;
-  }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -10,12 +10,12 @@ import {
   colorTextLighter,
   colorBackgroundDefault,
   colorKeylineDefault,
-  CoreColors,
   colorDialogBackground,
   colorNavButton,
   colorNavButtonHover,
-  colorNavText,
   colorShadowDefault,
+  colorNavTextHover,
+  colorFocusRing,
 } from '@dagster-io/ui-components';
 import Fuse from 'fuse.js';
 import debounce from 'lodash/debounce';
@@ -206,8 +206,6 @@ export const SearchDialog = ({searchPlaceholder}: {searchPlaceholder: string}) =
             <Box flex={{alignItems: 'center', gap: 4}}>
               <div
                 style={{
-                  background: CoreColors.Gray900,
-                  borderRadius: '12px',
                   height: '24px',
                   width: '24px',
                   display: 'flex',
@@ -215,7 +213,7 @@ export const SearchDialog = ({searchPlaceholder}: {searchPlaceholder: string}) =
                   justifyContent: 'center',
                 }}
               >
-                <Icon name="search" color={CoreColors.Gray50} />
+                <Icon name="search" color={colorNavTextHover()} />
               </div>
               <div>{searchPlaceholder}</div>
             </Box>
@@ -259,7 +257,7 @@ const SearchTrigger = styled.button`
   background-color: ${colorNavButton()};
   border-radius: 24px;
   border: none;
-  color: ${CoreColors.Gray50};
+  color: ${colorNavTextHover()};
   font-size: 14px;
   cursor: pointer;
   padding: 4px 16px 4px 8px;
@@ -273,8 +271,8 @@ const SearchTrigger = styled.button`
     background-color: ${colorNavButtonHover()};
   }
 
-  :focus {
-    border-color: ${colorNavText()};
+  :focus-visible {
+    outline: ${colorFocusRing()} auto 1px;
   }
 `;
 
@@ -322,7 +320,7 @@ const SearchInput = styled.input`
 const SlashShortcut = styled.div`
   background-color: transparent;
   border-radius: 3px;
-  color: ${CoreColors.White};
+  color: ${colorNavTextHover()};
   font-size: 14px;
   padding: 2px;
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/FilterDropdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/FilterDropdown.tsx
@@ -11,7 +11,6 @@ import {
   colorBackgroundLight,
   colorPopoverBackground,
   colorTextLight,
-  CoreColors,
 } from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import React, {useState, useRef} from 'react';
@@ -432,7 +431,6 @@ export const FilterDropdownMenuItem = React.memo(
 
 const StyledMenuItem = styled(MenuItem)`
   &.bp4-active:focus {
-    color: ${CoreColors.White};
     box-shadow: initial;
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/TagActions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/TagActions.tsx
@@ -1,4 +1,11 @@
-import {Box, Caption, Popover, CoreColors} from '@dagster-io/ui-components';
+import {
+  Box,
+  Caption,
+  Popover,
+  colorTooltipBackground,
+  colorTooltipText,
+  colorBorderHover,
+} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
@@ -16,7 +23,7 @@ export type TagAction =
     };
 
 export const TagActions = ({data, actions}: {data: TagType; actions: TagAction[]}) => (
-  <ActionContainer background={CoreColors.Gray900} flex={{direction: 'row'}}>
+  <ActionContainer background={colorTooltipBackground()} flex={{direction: 'row'}}>
     {actions.map((action, ii) =>
       'to' in action ? (
         <Link to={action.to} key={ii}>
@@ -62,14 +69,16 @@ const ActionContainer = styled(Box)`
 
 const TagButton = styled.button`
   border: none;
-  background: ${CoreColors.Gray900};
-  color: ${CoreColors.Gray100};
+  background: ${colorTooltipBackground()};
+  color: ${colorTooltipText()};
   cursor: pointer;
   padding: 8px 12px;
   text-align: left;
+  opacity: 0.85;
+  transition: opacity 50ms linear;
 
   :not(:last-child) {
-    box-shadow: -1px 0 0 inset ${CoreColors.Gray600};
+    box-shadow: -1px 0 0 inset ${colorBorderHover()};
   }
 
   :focus {
@@ -77,7 +86,6 @@ const TagButton = styled.button`
   }
 
   :hover {
-    background-color: ${CoreColors.Gray800};
-    color: ${CoreColors.White};
+    opacity: 1;
   }
 `;


### PR DESCRIPTION
## Summary & Motivation

Remove remaining `CoreColors` usage outside of `ui-components`.

## How I Tested These Changes

Visually inspect light and dark mode for affected components. Verify that styles look appropriate.
