### PR TITLE
refactor(declarative-instigator-status): deprecate `AUTOMATICALLY_RUNNING` in favor of `DECLARED_IN_CODE`

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -620,7 +620,7 @@ class GrapheneQuery(graphene.ObjectType):
         scheduleStatus: Optional[GrapheneInstigationStatus] = None,
     ):
         if scheduleStatus == GrapheneInstigationStatus.RUNNING:
-            instigator_statuses = {InstigatorStatus.RUNNING, InstigatorStatus.AUTOMATICALLY_RUNNING}
+            instigator_statuses = {InstigatorStatus.RUNNING, InstigatorStatus.DECLARED_IN_CODE}
         elif scheduleStatus == GrapheneInstigationStatus.STOPPED:
             instigator_statuses = {InstigatorStatus.STOPPED}
         else:
@@ -665,7 +665,7 @@ class GrapheneQuery(graphene.ObjectType):
         sensorStatus: Optional[GrapheneInstigationStatus] = None,
     ):
         if sensorStatus == GrapheneInstigationStatus.RUNNING:
-            instigator_statuses = {InstigatorStatus.RUNNING, InstigatorStatus.AUTOMATICALLY_RUNNING}
+            instigator_statuses = {InstigatorStatus.RUNNING, InstigatorStatus.DECLARED_IN_CODE}
         elif sensorStatus == GrapheneInstigationStatus.STOPPED:
             instigator_statuses = {InstigatorStatus.STOPPED}
         else:

--- a/python_modules/dagster-test/dagster_test/toys/sensors.py
+++ b/python_modules/dagster-test/dagster_test/toys/sensors.py
@@ -2,6 +2,7 @@ import os
 
 from dagster import (
     AssetKey,
+    DefaultSensorStatus,
     RunFailureSensorContext,
     RunRequest,
     SkipReason,
@@ -149,7 +150,11 @@ def get_toys_sensors():
                 tags={"fee": "fifofum"},
             )
 
-    @sensor(job=simple_config_job, minimum_interval_seconds=2)
+    @sensor(
+        job=simple_config_job,
+        minimum_interval_seconds=2,
+        default_status=DefaultSensorStatus.STOPPED,
+    )
     def tick_logging_sensor(context):
         cursor = int(context.cursor) if context.cursor else 1
         context.update_cursor(str(cursor + 1))

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -775,15 +775,15 @@ class ExternalSchedule:
             return InstigatorState(
                 self.get_external_origin(),
                 InstigatorType.SCHEDULE,
-                InstigatorStatus.AUTOMATICALLY_RUNNING,
+                InstigatorStatus.DECLARED_IN_CODE,
                 ScheduleInstigatorData(self.cron_schedule, start_timestamp=None),
             )
         else:
-            # Ignore AUTOMATICALLY_RUNNING states in the DB if the default status
+            # Ignore DECLARED_IN_CODE states in the DB if the default status
             # isn't DefaultScheduleStatus.RUNNING - this would indicate that the schedule's
-            # default has been changed in code but there's still a lingering AUTOMATICALLY_RUNNING
+            # default has been changed in code but there's still a lingering DECLARED_IN_CODE
             # row in the database that can be ignored
-            if stored_state and stored_state.status != InstigatorStatus.AUTOMATICALLY_RUNNING:
+            if stored_state and stored_state.status != InstigatorStatus.DECLARED_IN_CODE:
                 return stored_state
 
             return InstigatorState(
@@ -915,7 +915,7 @@ class ExternalSensor:
                 else InstigatorState(
                     self.get_external_origin(),
                     InstigatorType.SENSOR,
-                    InstigatorStatus.AUTOMATICALLY_RUNNING,
+                    InstigatorStatus.DECLARED_IN_CODE,
                     SensorInstigatorData(
                         min_interval=self.min_interval_seconds,
                         sensor_type=self.sensor_type,
@@ -923,10 +923,10 @@ class ExternalSensor:
                 )
             )
         else:
-            # Ignore AUTOMATICALLY_RUNNING states in the DB if the default status
+            # Ignore DECLARED_IN_CODE states in the DB if the default status
             # isn't DefaultSensorStatus.RUNNING - this would indicate that the schedule's
             # default has changed
-            if stored_state and stored_state.status != InstigatorStatus.AUTOMATICALLY_RUNNING:
+            if stored_state and stored_state.status != InstigatorStatus.DECLARED_IN_CODE:
                 return stored_state
 
             return InstigatorState(

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -409,7 +409,7 @@ class AssetDaemon(DagsterDaemon):
                     auto_materialize_state = InstigatorState(
                         sensor.get_external_origin(),
                         InstigatorType.SENSOR,
-                        InstigatorStatus.AUTOMATICALLY_RUNNING,
+                        InstigatorStatus.DECLARED_IN_CODE,
                         SensorInstigatorData(
                             min_interval=sensor.min_interval_seconds,
                             cursor=None,

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -405,7 +405,7 @@ def execute_sensor_iteration(
             sensor_state = InstigatorState(
                 external_sensor.get_external_origin(),
                 InstigatorType.SENSOR,
-                InstigatorStatus.AUTOMATICALLY_RUNNING,
+                InstigatorStatus.DECLARED_IN_CODE,
                 SensorInstigatorData(
                     min_interval=external_sensor.min_interval_seconds,
                     last_sensor_start_timestamp=pendulum.now("UTC").timestamp(),

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -256,14 +256,14 @@ def launch_scheduled_runs(
                 )
             error_locations.add(location_entry.origin.location_name)
 
-    # Remove any schedule states that were previously created with AUTOMATICALLY_RUNNING
+    # Remove any schedule states that were previously created with DECLARED_IN_CODE
     # and can no longer be found in the workspace (so that if they are later added
     # back again, their timestamps will start at the correct place)
     states_to_delete = [
         schedule_state
         for selector_id, schedule_state in all_schedule_states.items()
         if selector_id not in schedules
-        and schedule_state.status == InstigatorStatus.AUTOMATICALLY_RUNNING
+        and schedule_state.status == InstigatorStatus.DECLARED_IN_CODE
     ]
     for state in states_to_delete:
         location_name = state.origin.external_repository_origin.code_location_origin.location_name
@@ -332,7 +332,7 @@ def launch_scheduled_runs(
                 schedule_state = InstigatorState(
                     external_schedule.get_external_origin(),
                     InstigatorType.SCHEDULE,
-                    InstigatorStatus.AUTOMATICALLY_RUNNING,
+                    InstigatorStatus.DECLARED_IN_CODE,
                     ScheduleInstigatorData(
                         external_schedule.cron_schedule,
                         end_datetime_utc.timestamp(),

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -2621,7 +2621,7 @@ def test_status_in_code_sensor(executor, instance):
             instigator_state = instance.get_instigator_state(
                 always_running_origin.get_id(), running_sensor.selector_id
             )
-            assert instigator_state.status == InstigatorStatus.AUTOMATICALLY_RUNNING
+            assert instigator_state.status == InstigatorStatus.DECLARED_IN_CODE
 
             ticks = instance.get_ticks(
                 running_sensor.get_external_origin_id(), running_sensor.selector_id

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -888,7 +888,7 @@ def test_status_in_code_schedule(instance: DagsterInstance, executor: ThreadPool
             assert instigator_state
             assert isinstance(instigator_state.instigator_data, ScheduleInstigatorData)
 
-            assert instigator_state.status == InstigatorStatus.AUTOMATICALLY_RUNNING
+            assert instigator_state.status == InstigatorStatus.DECLARED_IN_CODE
             assert (
                 instigator_state.instigator_data.start_timestamp == pendulum.now("UTC").timestamp()
             )
@@ -1005,7 +1005,7 @@ def test_change_default_status(instance: DagsterInstance, executor: ThreadPoolEx
         schedule_state = InstigatorState(
             not_running_schedule.get_external_origin(),
             InstigatorType.SCHEDULE,
-            InstigatorStatus.AUTOMATICALLY_RUNNING,
+            InstigatorStatus.DECLARED_IN_CODE,
             ScheduleInstigatorData(
                 not_running_schedule.cron_schedule,
                 freeze_datetime.timestamp(),
@@ -1023,7 +1023,7 @@ def test_change_default_status(instance: DagsterInstance, executor: ThreadPoolEx
             )
             assert len(ticks) == 0
 
-            # AUTOMATICALLY_RUNNING row has been removed from the database
+            # DECLARED_IN_CODE row has been removed from the database
             instigator_state = instance.get_instigator_state(
                 never_running_origin.get_id(), not_running_schedule.selector_id
             )


### PR DESCRIPTION
## Summary & Motivation
`AUTOMATICALLY_RUNNING` is a confusing name. Whether the instigator is running actually depends on the default status of the instigator in code.

Deprecate it in favor of `DECLARED_IN_CODE`. When deserializing `AUTOMATICALLY_RUNNING` from storage, recreate it as `DECLARED_IN_CODE`.

## How I Tested These Changes
pytest
