### PR TITLE
add mutation to delete concurrency limits

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3448,6 +3448,7 @@ type Mutation {
   ): AddDynamicPartitionResult!
   setAutoMaterializePaused(paused: Boolean!): Boolean!
   setConcurrencyLimit(concurrencyKey: String!, limit: Int!): Boolean!
+  deleteConcurrencyLimit(concurrencyKey: String!): Boolean!
   freeConcurrencySlotsForRun(runId: String!): Boolean!
   freeConcurrencySlots(runId: String!, stepKey: String): Boolean!
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2081,6 +2081,7 @@ export type Mutation = {
   __typename: 'Mutation';
   addDynamicPartition: AddDynamicPartitionResult;
   cancelPartitionBackfill: CancelBackfillResult;
+  deleteConcurrencyLimit: Scalars['Boolean'];
   deletePipelineRun: DeletePipelineRunResult;
   deleteRun: DeletePipelineRunResult;
   freeConcurrencySlots: Scalars['Boolean'];
@@ -2120,6 +2121,10 @@ export type MutationAddDynamicPartitionArgs = {
 
 export type MutationCancelPartitionBackfillArgs = {
   backfillId: Scalars['String'];
+};
+
+export type MutationDeleteConcurrencyLimitArgs = {
+  concurrencyKey: Scalars['String'];
 };
 
 export type MutationDeletePipelineRunArgs = {
@@ -8535,6 +8540,10 @@ export const buildMutation = (
         : relationshipsToOmit.has('CancelBackfillSuccess')
         ? ({} as CancelBackfillSuccess)
         : buildCancelBackfillSuccess({}, relationshipsToOmit),
+    deleteConcurrencyLimit:
+      overrides && overrides.hasOwnProperty('deleteConcurrencyLimit')
+        ? overrides.deleteConcurrencyLimit!
+        : false,
     deletePipelineRun:
       overrides && overrides.hasOwnProperty('deletePipelineRun')
         ? overrides.deletePipelineRun!

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
@@ -55,6 +55,8 @@ import {
   RunsForConcurrencyKeyQuery,
   RunsForConcurrencyKeyQueryVariables,
   RunQueueConfigFragment,
+  DeleteConcurrencyLimitMutation,
+  DeleteConcurrencyLimitMutationVariables,
   SetConcurrencyLimitMutation,
   SetConcurrencyLimitMutationVariables,
 } from './types/InstanceConcurrency.types';
@@ -634,16 +636,14 @@ const DeleteConcurrencyLimitDialog = ({
 }) => {
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
-  const [setConcurrencyLimit] = useMutation<
-    SetConcurrencyLimitMutation,
-    SetConcurrencyLimitMutationVariables
-  >(SET_CONCURRENCY_LIMIT_MUTATION);
+  const [deleteConcurrencyLimit] = useMutation<
+    DeleteConcurrencyLimitMutation,
+    DeleteConcurrencyLimitMutationVariables
+  >(DELETE_CONCURRENCY_LIMIT_MUTATION);
 
   const save = async () => {
     setIsSubmitting(true);
-    await setConcurrencyLimit({
-      variables: {concurrencyKey, limit: 0},
-    });
+    await deleteConcurrencyLimit({variables: {concurrencyKey}});
     setIsSubmitting(false);
     onComplete();
     onClose();
@@ -1013,6 +1013,12 @@ export const INSTANCE_CONCURRENCY_LIMITS_QUERY = gql`
 const SET_CONCURRENCY_LIMIT_MUTATION = gql`
   mutation SetConcurrencyLimit($concurrencyKey: String!, $limit: Int!) {
     setConcurrencyLimit(concurrencyKey: $concurrencyKey, limit: $limit)
+  }
+`;
+
+const DELETE_CONCURRENCY_LIMIT_MUTATION = gql`
+  mutation DeleteConcurrencyLimit($concurrencyKey: String!) {
+    deleteConcurrencyLimit(concurrencyKey: $concurrencyKey)
   }
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceConcurrency.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceConcurrency.types.ts
@@ -73,6 +73,15 @@ export type SetConcurrencyLimitMutationVariables = Types.Exact<{
 
 export type SetConcurrencyLimitMutation = {__typename: 'Mutation'; setConcurrencyLimit: boolean};
 
+export type DeleteConcurrencyLimitMutationVariables = Types.Exact<{
+  concurrencyKey: Types.Scalars['String'];
+}>;
+
+export type DeleteConcurrencyLimitMutation = {
+  __typename: 'Mutation';
+  deleteConcurrencyLimit: boolean;
+};
+
 export type FreeConcurrencySlotsMutationVariables = Types.Exact<{
   runId: Types.Scalars['String'];
   stepKey?: Types.InputMaybe<Types.Scalars['String']>;

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -831,6 +831,24 @@ class GrapheneSetConcurrencyLimitMutation(graphene.Mutation):
         return True
 
 
+class GrapheneDeleteConcurrencyLimitMutation(graphene.Mutation):
+    """Sets the concurrency limit for a given concurrency key."""
+
+    Output = graphene.NonNull(graphene.Boolean)
+
+    class Meta:
+        name = "DeleteConcurrencyLimitMutation"
+
+    class Arguments:
+        concurrencyKey = graphene.Argument(graphene.NonNull(graphene.String))
+
+    @capture_error
+    @check_permission(Permissions.EDIT_CONCURRENCY_LIMIT)
+    def mutate(self, graphene_info, concurrencyKey: str):
+        graphene_info.context.instance.event_log_storage.delete_concurrency_limit(concurrencyKey)
+        return True
+
+
 class GrapheneFreeConcurrencySlotsMutation(graphene.Mutation):
     """Frees concurrency slots."""
 
@@ -907,5 +925,6 @@ class GrapheneMutation(graphene.ObjectType):
     addDynamicPartition = GrapheneAddDynamicPartitionMutation.Field()
     setAutoMaterializePaused = GrapheneSetAutoMaterializePausedMutation.Field()
     setConcurrencyLimit = GrapheneSetConcurrencyLimitMutation.Field()
+    deleteConcurrencyLimit = GrapheneDeleteConcurrencyLimitMutation.Field()
     freeConcurrencySlotsForRun = GrapheneFreeConcurrencySlotsForRunMutation.Field()
     freeConcurrencySlots = GrapheneFreeConcurrencySlotsMutation.Field()

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -414,6 +414,11 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         raise NotImplementedError()
 
     @abstractmethod
+    def delete_concurrency_limit(self, concurrency_key: str) -> None:
+        """Delete concurrency limits and slots for the given concurrency key."""
+        raise NotImplementedError()
+
+    @abstractmethod
     def get_concurrency_keys(self) -> Set[str]:
         """Get the set of concurrency limited keys."""
         raise NotImplementedError()

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -628,6 +628,9 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     def set_concurrency_slots(self, concurrency_key: str, num: int) -> None:
         return self._storage.event_log_storage.set_concurrency_slots(concurrency_key, num)
 
+    def delete_concurrency_limit(self, concurrency_key: str) -> None:
+        return self._storage.event_log_storage.delete_concurrency_limit(concurrency_key)
+
     def get_concurrency_keys(self) -> Set[str]:
         return self._storage.event_log_storage.get_concurrency_keys()
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -4467,6 +4467,10 @@ class TestEventLogStorage:
         assert info.pending_step_count == 1
         assert info.assigned_step_count == 0
 
+        # delete the concurrency slot
+        storage.delete_concurrency_limit("foo")
+        assert storage.get_concurrency_keys() == set()
+
     def test_default_concurrency(
         self,
         storage: EventLogStorage,


### PR DESCRIPTION
[INTERNAL_BRANCH=prha/delete_concurrency_limit]

## Summary & Motivation
Previously, we interpreted zero concurrency limits as slot deletion.

Now that we accept zero as an acceptable limit value, we need an explicit delete concurrency limit storage method.

## How I Tested These Changes
BK