### PR TITLE
fix(declarative-instigator-status): use stored state for declarative instigators with stopped status

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -783,8 +783,12 @@ class ExternalSchedule:
             # isn't DefaultScheduleStatus.RUNNING - this would indicate that the schedule's
             # default has been changed in code but there's still a lingering DECLARED_IN_CODE
             # row in the database that can be ignored
-            if stored_state and stored_state.status != InstigatorStatus.DECLARED_IN_CODE:
-                return stored_state
+            if stored_state:
+                return (
+                    stored_state.with_status(InstigatorStatus.STOPPED)
+                    if stored_state.status == InstigatorStatus.DECLARED_IN_CODE
+                    else stored_state
+                )
 
             return InstigatorState(
                 self.get_external_origin(),
@@ -926,8 +930,12 @@ class ExternalSensor:
             # Ignore DECLARED_IN_CODE states in the DB if the default status
             # isn't DefaultSensorStatus.RUNNING - this would indicate that the schedule's
             # default has changed
-            if stored_state and stored_state.status != InstigatorStatus.DECLARED_IN_CODE:
-                return stored_state
+            if stored_state:
+                return (
+                    stored_state.with_status(InstigatorStatus.STOPPED)
+                    if stored_state.status == InstigatorStatus.DECLARED_IN_CODE
+                    else stored_state
+                )
 
             return InstigatorState(
                 self.get_external_origin(),

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -924,6 +924,19 @@ def test_status_in_code_schedule(instance: DagsterInstance, executor: ThreadPool
             assert reset_instigator_state
             assert reset_instigator_state.status == InstigatorStatus.DECLARED_IN_CODE
 
+            running_to_not_running_schedule = ExternalSchedule(
+                external_schedule_data=running_schedule._external_schedule_data._replace(  # noqa: SLF001
+                    default_status=DefaultScheduleStatus.STOPPED
+                ),
+                handle=running_schedule.handle.repository_handle,
+            )
+            current_state = running_to_not_running_schedule.get_current_instigator_state(
+                stored_state=reset_instigator_state
+            )
+
+            assert current_state.status == InstigatorStatus.STOPPED
+            assert current_state.instigator_data == reset_instigator_state.instigator_data
+
         freeze_datetime = freeze_datetime.add(seconds=2)
         with pendulum.test(freeze_datetime):
             evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))


### PR DESCRIPTION
## Summary & Motivation
If an existing sensor with `RUNNING` default status switches to `STOPPED`, cursor information disappears from the UI. This information is still in the database, but we are not passing it down.

This fix passes that information down.

## How I Tested These Changes
pytest
