### PR TITLE
RFC: change step delegating executor to defer event_log queries when no steps are in flight

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/active.py
@@ -586,6 +586,10 @@ class ActiveExecution:
     def retry_state(self) -> RetryState:
         return self._retry_state
 
+    @property
+    def has_in_flight_steps(self) -> bool:
+        return len(self._in_flight) > 0
+
     def get_known_state(self) -> KnownExecutionState:
         return KnownExecutionState(
             previous_retry_attempts=self._retry_state.snapshot_attempts(),

--- a/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
@@ -200,7 +200,6 @@ class StepDelegatingExecutor(Executor):
                 # Order of events is important here. During an interation, we call handle_event, then get_steps_to_execute,
                 # then is_complete. get_steps_to_execute updates the state of ActiveExecution, and without it
                 # is_complete can return true when we're just between steps.
-                has_unpopped_emitted_events = False
                 while not active_execution.is_complete:
                     if active_execution.check_for_interrupts():
                         active_execution.mark_interrupted()
@@ -234,7 +233,7 @@ class StepDelegatingExecutor(Executor):
 
                         return
 
-                    if has_unpopped_emitted_events or active_execution.has_in_flight_steps:
+                    if active_execution.has_in_flight_steps:
                         for dagster_event in self._pop_events(
                             plan_context.instance,
                             plan_context.run_id,
@@ -263,11 +262,9 @@ class StepDelegatingExecutor(Executor):
                                         active_execution.verify_complete(
                                             plan_context, dagster_event.step_key
                                         )
-                        has_unpopped_emitted_events = False
 
                     # process skips from failures or uncovered inputs
-                    skips = list(active_execution.plan_events_iterator(plan_context))
-                    has_unpopped_emitted_events = has_unpopped_emitted_events or len(skips) > 0
+                    list(active_execution.plan_events_iterator(plan_context))
 
                     curr_time = pendulum.now("UTC")
                     if (
@@ -284,7 +281,6 @@ class StepDelegatingExecutor(Executor):
                                     )
                                 )
                                 if not health_check_result.is_healthy:
-                                    has_unpopped_emitted_events = True
                                     DagsterEvent.step_failure_event(
                                         step_context=step_context,
                                         step_failure_data=StepFailureData(
@@ -302,7 +298,6 @@ class StepDelegatingExecutor(Executor):
                                 )
                                 # Log a step failure event if there was an error during the health
                                 # check
-                                has_unpopped_emitted_events = True
                                 DagsterEvent.step_failure_event(
                                     step_context=plan_context.for_step(step),
                                     step_failure_data=StepFailureData(
@@ -320,12 +315,7 @@ class StepDelegatingExecutor(Executor):
                         max_steps_to_run = None  # disables limit
 
                     # process events from concurrency blocked steps
-                    concurrency_events = list(
-                        active_execution.concurrency_event_iterator(plan_context)
-                    )
-                    has_unpopped_emitted_events = (
-                        has_unpopped_emitted_events or len(concurrency_events) > 0
-                    )
+                    list(active_execution.concurrency_event_iterator(plan_context))
 
                     for step in active_execution.get_steps_to_execute(max_steps_to_run):
                         running_steps[step.key] = step

--- a/python_modules/dagster/dagster/_utils/test/__init__.py
+++ b/python_modules/dagster/dagster/_utils/test/__init__.py
@@ -3,7 +3,7 @@ import shutil
 import tempfile
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Any, Dict, List, Mapping, Optional, Type, cast
+from typing import Any, Dict, List, Mapping, Optional, Set, Type, Union, cast
 
 # top-level include is dangerous in terms of incurring circular deps
 from dagster import (
@@ -26,6 +26,7 @@ from dagster._core.definitions.executor_definition import in_process_executor
 from dagster._core.definitions.job_base import InMemoryJob
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.definitions.resource_definition import ScopedResourcesBuilder
+from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.context.system import PlanExecutionContext
 from dagster._core.execution.context_creation_job import (
@@ -39,6 +40,7 @@ from dagster._core.execution.execute_in_process_result import ExecuteInProcessRe
 from dagster._core.instance import DagsterInstance
 from dagster._core.scheduler import Scheduler
 from dagster._core.storage.dagster_run import DagsterRun
+from dagster._core.storage.event_log.base import EventLogConnection
 from dagster._core.storage.event_log.sqlite.sqlite_event_log import SqliteEventLogStorage
 from dagster._core.storage.sqlite_storage import SqliteStorageConfig
 from dagster._core.utility_ops import create_stub_op
@@ -301,6 +303,7 @@ class ConcurrencyEnabledSqliteTestEventLogStorage(SqliteEventLogStorage, Configu
     ):
         self._sleep_interval = sleep_interval
         self._check_calls = defaultdict(int)
+        self._records_for_run_calls = defaultdict(int)
         super().__init__(base_dir, inst_data)
 
     @classmethod
@@ -317,8 +320,22 @@ class ConcurrencyEnabledSqliteTestEventLogStorage(SqliteEventLogStorage, Configu
     def supports_global_concurrency_limits(self) -> bool:
         return True
 
+    def get_records_for_run(
+        self,
+        run_id: str,
+        cursor: Optional[str] = None,
+        of_type: Optional[Union[DagsterEventType, Set[DagsterEventType]]] = None,
+        limit: Optional[int] = None,
+        ascending: bool = True,
+    ) -> EventLogConnection:
+        self._records_for_run_calls[run_id] = self._records_for_run_calls[run_id] + 1
+        return super().get_records_for_run(run_id, cursor, of_type, limit, ascending)
+
     def get_check_calls(self, step_key: str) -> int:
         return self._check_calls[step_key]
+
+    def get_records_for_run_calls(self, run_id: str) -> int:
+        return self._records_for_run_calls[run_id]
 
     def check_concurrency_claim(
         self, concurrency_key: str, run_id: str, step_key: str


### PR DESCRIPTION
## Summary & Motivation
Changes the step-delegating executor to defer event log queries when there are no in-progress steps

## How I Tested These Changes
BK