### PR TITLE
add trailing slash to .idea/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,7 +143,7 @@ data
 dask-worker-space
 
 # PyCharm IDE Config files
-.idea
+.idea/
 
 # Codemod bookmarks
 .codemod.bookmark


### PR DESCRIPTION
## Summary & Motivation
We want to ignore only the _directory_ `.idea` not a link, file, or directory.  The correct way to express this is using a trailing slash

## How I Tested These Changes
make dev_install, boot up Dagster locally