### PR TITLE
feat: Add optional resources to initContainers

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -101,6 +101,7 @@ class Daemon(BaseModel):
     schedulerName: Optional[str]
     volumeMounts: Optional[List[kubernetes.VolumeMount]]
     volumes: Optional[List[kubernetes.Volume]]
+    initContainers: Optional[Dict[str, kubernetes.Resources]]
 
     class Config:
         extra = Extra.forbid

--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -101,7 +101,7 @@ class Daemon(BaseModel):
     schedulerName: Optional[str]
     volumeMounts: Optional[List[kubernetes.VolumeMount]]
     volumes: Optional[List[kubernetes.Volume]]
-    initContainers: Optional[Dict[str, kubernetes.Resources]]
+    initContainerResources: kubernetes.Resources
 
     class Config:
         extra = Extra.forbid

--- a/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
@@ -48,6 +48,7 @@ class Webserver(BaseModel):
     schedulerName: Optional[str]
     volumeMounts: Optional[List[kubernetes.VolumeMount]]
     volumes: Optional[List[kubernetes.Volume]]
+    initContainers: Optional[Dict[str, kubernetes.Resources]]
 
     class Config:
         extra = Extra.forbid

--- a/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
@@ -48,7 +48,7 @@ class Webserver(BaseModel):
     schedulerName: Optional[str]
     volumeMounts: Optional[List[kubernetes.VolumeMount]]
     volumes: Optional[List[kubernetes.Volume]]
-    initContainers: Optional[Dict[str, kubernetes.Resources]]
+    initContainerResources: kubernetes.Resources
 
     class Config:
         extra = Extra.forbid

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -503,6 +503,31 @@ def test_webserver_security_context(deployment_template: HelmTemplate):
         for container in webserver_deployment.spec.template.spec.init_containers
     )
 
+def test_init_container_resources(deployment_template: HelmTemplate):
+    init_container_resources = {
+        "limits": {
+            "cpu": "200m"
+        },
+        "requests": {
+            "memory": "1Gi"
+        }
+    }
+    helm_values = DagsterHelmValues.construct(
+        dagsterWebserver=Webserver.construct(initContainerResources=init_container_resources)
+    )
+
+    [webserver_deployment] = deployment_template.render(helm_values)
+
+    assert len(webserver_deployment.spec.template.spec.init_containers) == 2
+
+    assert all(
+        container.resources
+        == k8s_model_from_dict(
+            k8s_client.models.v1_resource_requirements.V1ResourceRequirements,
+            k8s_snake_case_dict(k8s_client.models.v1_resource_requirements.V1ResourceRequirements, init_container_resources),
+        )
+        for container in webserver_deployment.spec.template.spec.init_containers
+    )
 
 def test_env(deployment_template: HelmTemplate):
     helm_values = DagsterHelmValues.construct(dagsterWebserver=Webserver.construct())

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -503,15 +503,9 @@ def test_webserver_security_context(deployment_template: HelmTemplate):
         for container in webserver_deployment.spec.template.spec.init_containers
     )
 
+
 def test_init_container_resources(deployment_template: HelmTemplate):
-    init_container_resources = {
-        "limits": {
-            "cpu": "200m"
-        },
-        "requests": {
-            "memory": "1Gi"
-        }
-    }
+    init_container_resources = {"limits": {"cpu": "200m"}, "requests": {"memory": "1Gi"}}
     helm_values = DagsterHelmValues.construct(
         dagsterWebserver=Webserver.construct(initContainerResources=init_container_resources)
     )
@@ -524,10 +518,14 @@ def test_init_container_resources(deployment_template: HelmTemplate):
         container.resources
         == k8s_model_from_dict(
             k8s_client.models.v1_resource_requirements.V1ResourceRequirements,
-            k8s_snake_case_dict(k8s_client.models.v1_resource_requirements.V1ResourceRequirements, init_container_resources),
+            k8s_snake_case_dict(
+                k8s_client.models.v1_resource_requirements.V1ResourceRequirements,
+                init_container_resources,
+            ),
         )
         for container in webserver_deployment.spec.template.spec.init_containers
     )
+
 
 def test_env(deployment_template: HelmTemplate):
     helm_values = DagsterHelmValues.construct(dagsterWebserver=Webserver.construct())

--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -538,14 +538,7 @@ def test_scheduler_name(template: HelmTemplate):
 
 
 def test_init_container_resources(template: HelmTemplate):
-    init_container_resources = {
-        "limits": {
-            "cpu": "200m"
-        },
-        "requests": {
-            "memory": "1Gi"
-        }
-    }
+    init_container_resources = {"limits": {"cpu": "200m"}, "requests": {"memory": "1Gi"}}
     helm_values = DagsterHelmValues.construct(
         dagsterDaemon=Daemon.construct(initContainerResources=init_container_resources)
     )
@@ -558,10 +551,14 @@ def test_init_container_resources(template: HelmTemplate):
         container.resources
         == k8s_model_from_dict(
             k8s_client.models.v1_resource_requirements.V1ResourceRequirements,
-            k8s_snake_case_dict(k8s_client.models.v1_resource_requirements.V1ResourceRequirements, init_container_resources),
+            k8s_snake_case_dict(
+                k8s_client.models.v1_resource_requirements.V1ResourceRequirements,
+                init_container_resources,
+            ),
         )
         for container in webserver_deployment.spec.template.spec.init_containers
     )
+
 
 def test_env(template: HelmTemplate):
     helm_values = DagsterHelmValues.construct(dagsterDaemon=Daemon.construct())

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -54,6 +54,8 @@ spec:
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" . | squote }}]
           securityContext:
             {{- toYaml .Values.dagsterDaemon.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.dagsterDaemon.initContainers.resources | nindent 12 }}
         {{- if (and $userDeployments.enabled $userDeployments.enableSubchart) }}
         {{- range $deployment := $userDeployments.deployments }}
         - name: "init-user-deployment-{{- $deployment.name -}}"
@@ -61,6 +63,8 @@ spec:
           command: ['sh', '-c', "until nslookup {{ $deployment.name -}}; do echo waiting for user service; sleep 2; done"]
           securityContext:
             {{- toYaml $.Values.dagsterDaemon.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml $.Values.dagsterDaemon.initContainers.resources | nindent 12 }}
         {{- end }}
         {{- end }}
       containers:

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -55,7 +55,7 @@ spec:
           securityContext:
             {{- toYaml .Values.dagsterDaemon.securityContext | nindent 12 }}
           resources:
-            {{- toYaml .Values.dagsterDaemon.initContainers.resources | nindent 12 }}
+            {{- toYaml .Values.dagsterDaemon.initContainerResources | nindent 12 }}
         {{- if (and $userDeployments.enabled $userDeployments.enableSubchart) }}
         {{- range $deployment := $userDeployments.deployments }}
         - name: "init-user-deployment-{{- $deployment.name -}}"
@@ -64,7 +64,7 @@ spec:
           securityContext:
             {{- toYaml $.Values.dagsterDaemon.securityContext | nindent 12 }}
           resources:
-            {{- toYaml $.Values.dagsterDaemon.initContainers.resources | nindent 12 }}
+            {{- toYaml $.Values.dagsterDaemon.initContainerResources | nindent 12 }}
         {{- end }}
         {{- end }}
       containers:

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -52,6 +52,8 @@ spec:
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" . | squote }}]
           securityContext:
             {{- toYaml $_.Values.dagsterWebserver.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml $_.Values.dagsterWebserver.initContainers.resources | nindent 12 }}
         {{- if (and $userDeployments.enabled $userDeployments.enableSubchart) }}
         {{- range $deployment := $userDeployments.deployments }}
         - name: "init-user-deployment-{{- $deployment.name -}}"
@@ -59,6 +61,8 @@ spec:
           command: ['sh', '-c', "until nslookup {{ $deployment.name -}}; do echo waiting for user service; sleep 2; done"]
           securityContext:
             {{- toYaml $_.Values.dagsterWebserver.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml $_.Values.dagsterWebserver.initContainers.resources | nindent 12 }}
         {{- end }}
         {{- end }}
       containers:

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -53,7 +53,7 @@ spec:
           securityContext:
             {{- toYaml $_.Values.dagsterWebserver.securityContext | nindent 12 }}
           resources:
-            {{- toYaml $_.Values.dagsterWebserver.initContainers.resources | nindent 12 }}
+            {{- toYaml $_.Values.dagsterWebserver.initContainerResources | nindent 12 }}
         {{- if (and $userDeployments.enabled $userDeployments.enableSubchart) }}
         {{- range $deployment := $userDeployments.deployments }}
         - name: "init-user-deployment-{{- $deployment.name -}}"
@@ -62,7 +62,7 @@ spec:
           securityContext:
             {{- toYaml $_.Values.dagsterWebserver.securityContext | nindent 12 }}
           resources:
-            {{- toYaml $_.Values.dagsterWebserver.initContainers.resources | nindent 12 }}
+            {{- toYaml $_.Values.dagsterWebserver.initContainerResources | nindent 12 }}
         {{- end }}
         {{- end }}
       containers:

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -516,6 +516,20 @@
                             "type": "null"
                         }
                     ]
+                },
+                "initContainers": {
+                    "title": "Initcontainers",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/Resources"
+                    },
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [
@@ -2866,6 +2880,20 @@
                     "anyOf": [
                         {
                             "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "initContainers": {
+                    "title": "Initcontainers",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/Resources"
+                    },
+                    "anyOf": [
+                        {
+                            "type": "object"
                         },
                         {
                             "type": "null"

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -517,19 +517,8 @@
                         }
                     ]
                 },
-                "initContainers": {
-                    "title": "Initcontainers",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/Resources"
-                    },
-                    "anyOf": [
-                        {
-                            "type": "object"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                "initContainerResources": {
+                    "$ref": "#/definitions/Resources"
                 }
             },
             "required": [
@@ -553,7 +542,8 @@
                 "livenessProbe",
                 "startupProbe",
                 "annotations",
-                "enableReadOnly"
+                "enableReadOnly",
+                "initContainerResources"
             ],
             "additionalProperties": false
         },
@@ -2886,19 +2876,8 @@
                         }
                     ]
                 },
-                "initContainers": {
-                    "title": "Initcontainers",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/Resources"
-                    },
-                    "anyOf": [
-                        {
-                            "type": "object"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                "initContainerResources": {
+                    "$ref": "#/definitions/Resources"
                 }
             },
             "required": [
@@ -2924,7 +2903,8 @@
                 "runMonitoring",
                 "runRetries",
                 "sensors",
-                "schedules"
+                "schedules",
+                "initContainerResources"
             ],
             "additionalProperties": false
         },

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -163,6 +163,10 @@ dagsterWebserver:
   securityContext: {}
   resources: {}
 
+  # Configure initContainer resources separately from main container
+  initContainers:
+    resources: {}
+
   # Override the default K8s scheduler
   # schedulerName: ~
 
@@ -1198,6 +1202,10 @@ dagsterDaemon:
   podSecurityContext: {}
   securityContext: {}
   resources: {}
+
+  # Configure initContainer resources separately from main container
+  initContainers:
+    resources: {}
 
   # Override the default K8s scheduler
   # schedulerName: ~

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -164,9 +164,7 @@ dagsterWebserver:
   resources: {}
 
   # Configure initContainer resources separately from main container
-  initContainers:
-    resources: {}
-
+  initContainerResources: {}
   # Override the default K8s scheduler
   # schedulerName: ~
 
@@ -1204,9 +1202,7 @@ dagsterDaemon:
   resources: {}
 
   # Configure initContainer resources separately from main container
-  initContainers:
-    resources: {}
-
+  initContainerResources: {}
   # Override the default K8s scheduler
   # schedulerName: ~
 


### PR DESCRIPTION
## Summary & Motivation
In our organization, strict OPA policies are enforced to make sure `resources` are specified on every container, including `initContainers`. To this end, this PR allows users to specify limits for `initContainers` within the daemon and the webserver.

I made it so that both init containers have their resources specified in the same block. I don't think anything more precise than that is necessary.

## How I Tested These Changes
I tested these changes by packaging the helm chart locally, then installing to my local Docker desktop cluster via the following:

```
helm install dagster dagster-0.0.1-dev.tgz --set dagsterWebserver.image.tag=latest --set dagsterDaemon.image.tag=latest --set pipelineRun.image.tag=latest --set dagsterDaemon.initContainers.resources.limits.cpu=200m
```

I also made some changes to the `values` before packaging for updating the user deployments.

I then verified that the interface works and that the resources I specified were present. I also verified that there were no resources present on the `dagsterWebserver` pod:
```
  initContainers:
  - command:
    - sh
    - -c
    - until pg_isready -h dagster-postgresql -p 5432 -U test; do echo waiting for
      database; sleep 2; done;
    image: library/postgres:14.6
    imagePullPolicy: IfNotPresent
    name: check-db-ready
    resources:
      limits:
        cpu: 200m
      requests:
        cpu: 200m
```

