### PR TITLE
update iris_dataset asset definition in Delta Lake integration tutorial

### DIFF
--- a/docs/content/integrations/deltalake/using-deltalake-with-dagster.mdx
+++ b/docs/content/integrations/deltalake/using-deltalake-with-dagster.mdx
@@ -37,9 +37,12 @@ from dagster_deltalake import LocalConfig
 from dagster_deltalake_pandas import DeltaLakePandasIOManager
 
 from dagster import Definitions
+from . import assets
+
+all_assets = load_assets_from_modules([assets])
 
 defs = Definitions(
-    assets=[iris_dataset],
+    assets=all_assets,
     resources={
         "io_manager": DeltaLakePandasIOManager(
             root_uri="path/to/deltalake",  # required


### PR DESCRIPTION
## Summary & Motivation
When running this tutorial, the current asset definition errors out with a `NameError: name 'iris_dataset' is not defined`. This PR contains a quick workaround that does run. Probably this could be solved in a better way.

## How I Tested These Changes
Reloading definitions and running `dagster dev` locally.
