### PR TITLE
perf: remove unnecessary db fetch when starting a sensor

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -95,11 +95,7 @@ def start_sensor(graphene_info: ResolveInfo, sensor_selector: SensorSelector) ->
     if not repository.has_external_sensor(sensor_selector.sensor_name):
         raise UserFacingGraphQLError(GrapheneSensorNotFoundError(sensor_selector.sensor_name))
     external_sensor = repository.get_external_sensor(sensor_selector.sensor_name)
-    graphene_info.context.instance.start_sensor(external_sensor)
-    sensor_state = graphene_info.context.instance.get_instigator_state(
-        external_sensor.get_external_origin_id(),
-        external_sensor.selector_id,
-    )
+    sensor_state = graphene_info.context.instance.start_sensor(external_sensor)
     return GrapheneSensor(external_sensor, sensor_state)
 
 


### PR DESCRIPTION
## Summary & Motivation
Saw this while looking browsing through the code. We don't need to fetch the state again since we already have a reference on the updated state.

## How I Tested These Changes
existing bk
