### PR TITLE
feat(declarative-instigator-status): add mutations to reset instigator status

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -1629,6 +1629,10 @@ type StopRunningScheduleMutation {
   Output: ScheduleMutationResult!
 }
 
+type ResetScheduleMutation {
+  Output: ScheduleMutationResult!
+}
+
 type AssetKey {
   path: [String!]!
 }
@@ -2916,6 +2920,10 @@ type SetSensorCursorMutation {
   Output: SensorOrError!
 }
 
+type ResetSensorMutation {
+  Output: SensorOrError!
+}
+
 type CompositeSolidDefinition implements ISolidDefinition & SolidContainer {
   name: String!
   description: String
@@ -3406,9 +3414,11 @@ type Mutation {
     scheduleOriginId: String!
     scheduleSelectorId: String!
   ): ScheduleMutationResult!
+  resetSchedule(scheduleSelector: ScheduleSelector!): ScheduleMutationResult!
   startSensor(sensorSelector: SensorSelector!): SensorOrError!
   setSensorCursor(cursor: String, sensorSelector: SensorSelector!): SensorOrError!
   stopSensor(jobOriginId: String!, jobSelectorId: String!): StopSensorMutationResultOrError!
+  resetSensor(sensorSelector: SensorSelector!): SensorOrError!
   sensorDryRun(cursor: String, selectorData: SensorSelector!): SensorDryRunResult!
   scheduleDryRun(selectorData: ScheduleSelector!, timestamp: Float): ScheduleDryRunResult!
   terminatePipelineExecution(

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2094,6 +2094,8 @@ export type Mutation = {
   reloadRepositoryLocation: ReloadRepositoryLocationMutationResult;
   reloadWorkspace: ReloadWorkspaceMutationResult;
   reportRunlessAssetEvents: ReportRunlessAssetEventsResult;
+  resetSchedule: ScheduleMutationResult;
+  resetSensor: SensorOrError;
   resumePartitionBackfill: ResumeBackfillResult;
   scheduleDryRun: ScheduleDryRunResult;
   sensorDryRun: SensorDryRunResult;
@@ -2174,6 +2176,14 @@ export type MutationReloadRepositoryLocationArgs = {
 
 export type MutationReportRunlessAssetEventsArgs = {
   eventParams: ReportRunlessAssetEventsParams;
+};
+
+export type MutationResetScheduleArgs = {
+  scheduleSelector: ScheduleSelector;
+};
+
+export type MutationResetSensorArgs = {
+  sensorSelector: SensorSelector;
 };
 
 export type MutationResumePartitionBackfillArgs = {
@@ -3364,6 +3374,16 @@ export type RequestedMaterializationsForAsset = {
   __typename: 'RequestedMaterializationsForAsset';
   assetKey: AssetKey;
   partitionKeys: Array<Scalars['String']>;
+};
+
+export type ResetScheduleMutation = {
+  __typename: 'ResetScheduleMutation';
+  Output: ScheduleMutationResult;
+};
+
+export type ResetSensorMutation = {
+  __typename: 'ResetSensorMutation';
+  Output: SensorOrError;
 };
 
 export type Resource = {
@@ -8609,6 +8629,18 @@ export const buildMutation = (
         : relationshipsToOmit.has('PythonError')
         ? ({} as PythonError)
         : buildPythonError({}, relationshipsToOmit),
+    resetSchedule:
+      overrides && overrides.hasOwnProperty('resetSchedule')
+        ? overrides.resetSchedule!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+    resetSensor:
+      overrides && overrides.hasOwnProperty('resetSensor')
+        ? overrides.resetSensor!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
     resumePartitionBackfill:
       overrides && overrides.hasOwnProperty('resumePartitionBackfill')
         ? overrides.resumePartitionBackfill!
@@ -10786,6 +10818,40 @@ export const buildRequestedMaterializationsForAsset = (
         : buildAssetKey({}, relationshipsToOmit),
     partitionKeys:
       overrides && overrides.hasOwnProperty('partitionKeys') ? overrides.partitionKeys! : [],
+  };
+};
+
+export const buildResetScheduleMutation = (
+  overrides?: Partial<ResetScheduleMutation>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'ResetScheduleMutation'} & ResetScheduleMutation => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('ResetScheduleMutation');
+  return {
+    __typename: 'ResetScheduleMutation',
+    Output:
+      overrides && overrides.hasOwnProperty('Output')
+        ? overrides.Output!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
+  };
+};
+
+export const buildResetSensorMutation = (
+  overrides?: Partial<ResetSensorMutation>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'ResetSensorMutation'} & ResetSensorMutation => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('ResetSensorMutation');
+  return {
+    __typename: 'ResetSensorMutation',
+    Output:
+      overrides && overrides.hasOwnProperty('Output')
+        ? overrides.Output!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -81,6 +81,24 @@ def stop_schedule(
     return GrapheneScheduleStateResult(GrapheneInstigationState(schedule_state))
 
 
+def reset_schedule(
+    graphene_info: ResolveInfo, schedule_selector: ScheduleSelector
+) -> "GrapheneScheduleStateResult":
+    from ..schema.instigation import GrapheneInstigationState
+    from ..schema.schedules import GrapheneScheduleStateResult
+
+    check.inst_param(schedule_selector, "schedule_selector", ScheduleSelector)
+
+    location = graphene_info.context.get_code_location(schedule_selector.location_name)
+    repository = location.get_repository(schedule_selector.repository_name)
+
+    schedule_state = graphene_info.context.instance.reset_schedule(
+        repository.get_external_schedule(schedule_selector.schedule_name)
+    )
+
+    return GrapheneScheduleStateResult(GrapheneInstigationState(schedule_state))
+
+
 def get_scheduler_or_error(graphene_info: ResolveInfo) -> "GrapheneScheduler":
     from ..schema.errors import GrapheneSchedulerNotDefinedError
     from ..schema.schedules import GrapheneScheduler

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -74,9 +74,14 @@ from ..runs import (
     parse_run_config_input,
 )
 from ..schedule_dry_run import GrapheneScheduleDryRunMutation
-from ..schedules import GrapheneStartScheduleMutation, GrapheneStopRunningScheduleMutation
+from ..schedules import (
+    GrapheneResetScheduleMutation,
+    GrapheneStartScheduleMutation,
+    GrapheneStopRunningScheduleMutation,
+)
 from ..sensor_dry_run import GrapheneSensorDryRunMutation
 from ..sensors import (
+    GrapheneResetSensorMutation,
     GrapheneSetSensorCursorMutation,
     GrapheneStartSensorMutation,
     GrapheneStopSensorMutation,
@@ -884,9 +889,11 @@ class GrapheneMutation(graphene.ObjectType):
     launchRunReexecution = GrapheneLaunchRunReexecutionMutation.Field()
     startSchedule = GrapheneStartScheduleMutation.Field()
     stopRunningSchedule = GrapheneStopRunningScheduleMutation.Field()
+    resetSchedule = GrapheneResetScheduleMutation.Field()
     startSensor = GrapheneStartSensorMutation.Field()
     setSensorCursor = GrapheneSetSensorCursorMutation.Field()
     stopSensor = GrapheneStopSensorMutation.Field()
+    resetSensor = GrapheneResetSensorMutation.Field()
     sensorDryRun = GrapheneSensorDryRunMutation.Field()
     scheduleDryRun = GrapheneScheduleDryRunMutation.Field()
     terminatePipelineExecution = GrapheneTerminateRunMutation.Field()

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -251,6 +251,27 @@ mutation($jobOriginId: String!, $jobSelectorId: String!) {
 }
 """
 
+RESET_SENSORS_QUERY = """
+mutation($sensorSelector: SensorSelector!) {
+  resetSensor(sensorSelector: $sensorSelector) {
+    __typename
+    ... on PythonError {
+      message
+      className
+      stack
+    }
+    ... on Sensor {
+      id
+      jobOriginId
+      sensorState {
+        selectorId
+        status
+      }
+    }
+  }
+}
+"""
+
 GET_SENSOR_CURSOR_QUERY = """
 query SensorCursorQuery($sensorSelector: SensorSelector!) {
   sensorOrError(sensorSelector: $sensorSelector) {
@@ -819,7 +840,34 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
 
         assert stop_result.data["stopSensor"]["instigationState"]["status"] == "STOPPED"
 
-        # Now can be restarted
+        # Now can be manually started
+        start_result = execute_dagster_graphql(
+            graphql_context,
+            START_SENSORS_QUERY,
+            variables={"sensorSelector": sensor_selector},
+        )
+
+        instigator_state = graphql_context.instance.get_instigator_state(
+            sensor_origin_id, sensor_selector_id
+        )
+
+        assert instigator_state
+        assert instigator_state.status == InstigatorStatus.RUNNING
+        assert start_result.data["startSensor"]["sensorState"]["status"] == "RUNNING"
+
+    def test_reset_sensor(self, graphql_context: WorkspaceRequestContext):
+        sensor_selector = infer_sensor_selector(graphql_context, "always_no_config_sensor")
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_SENSOR_STATUS_QUERY,
+            variables={"sensorSelector": sensor_selector},
+        )
+
+        assert result.data["sensorOrError"]["sensorState"]["status"] == "STOPPED"
+
+        sensor_origin_id = result.data["sensorOrError"]["sensorState"]["id"]
+        sensor_selector_id = result.data["sensorOrError"]["sensorState"]["selectorId"]
+
         start_result = execute_dagster_graphql(
             graphql_context,
             START_SENSORS_QUERY,
@@ -827,6 +875,74 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
         )
 
         assert start_result.data["startSensor"]["sensorState"]["status"] == "RUNNING"
+
+        # Resetting a sensor that is already running stops it
+        reset_result = execute_dagster_graphql(
+            graphql_context,
+            RESET_SENSORS_QUERY,
+            variables={"sensorSelector": sensor_selector},
+        )
+
+        instigator_state = graphql_context.instance.get_instigator_state(
+            sensor_origin_id, sensor_selector_id
+        )
+
+        assert instigator_state
+        assert instigator_state.status == InstigatorStatus.STOPPED
+        assert reset_result.data["resetSensor"]["sensorState"]["status"] == "STOPPED"
+
+        # Resetting a stopped sensor is a noop
+        reset_result = execute_dagster_graphql(
+            graphql_context,
+            RESET_SENSORS_QUERY,
+            variables={"sensorSelector": sensor_selector},
+        )
+
+        instigator_state = graphql_context.instance.get_instigator_state(
+            sensor_origin_id, sensor_selector_id
+        )
+
+        assert instigator_state
+        assert instigator_state.status == InstigatorStatus.STOPPED
+        assert reset_result.data["resetSensor"]["sensorState"]["status"] == "STOPPED"
+
+    def test_reset_sensor_with_default_status(self, graphql_context: WorkspaceRequestContext):
+        sensor_selector = infer_sensor_selector(graphql_context, "running_in_code_sensor")
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_SENSOR_STATUS_QUERY,
+            variables={"sensorSelector": sensor_selector},
+        )
+
+        assert result.data["sensorOrError"]["sensorState"]["status"] == "RUNNING"
+        assert result.data["sensorOrError"]["sensorState"]["hasStartPermission"] is True
+        assert result.data["sensorOrError"]["sensorState"]["hasStopPermission"] is True
+
+        sensor_origin_id = result.data["sensorOrError"]["sensorState"]["id"]
+        sensor_selector_id = result.data["sensorOrError"]["sensorState"]["selectorId"]
+
+        stop_result = execute_dagster_graphql(
+            graphql_context,
+            STOP_SENSORS_QUERY,
+            variables={"jobOriginId": sensor_origin_id, "jobSelectorId": sensor_selector_id},
+        )
+
+        assert stop_result.data["stopSensor"]["instigationState"]["status"] == "STOPPED"
+
+        # Now can be restarted
+        start_result = execute_dagster_graphql(
+            graphql_context,
+            RESET_SENSORS_QUERY,
+            variables={"sensorSelector": sensor_selector},
+        )
+
+        instigator_state = graphql_context.instance.get_instigator_state(
+            sensor_origin_id, sensor_selector_id
+        )
+
+        assert instigator_state
+        assert instigator_state.status == InstigatorStatus.DECLARED_IN_CODE
+        assert start_result.data["resetSensor"]["sensorState"]["status"] == "RUNNING"
 
 
 def test_sensor_next_ticks(graphql_context: WorkspaceRequestContext):

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -2644,6 +2644,27 @@ def test_status_in_code_sensor(executor, instance):
                 == 0
             )
 
+            # The instigator state status can be manually updated, as well as reset.
+            instance.stop_sensor(
+                always_running_origin.get_id(), running_sensor.selector_id, running_sensor
+            )
+            stopped_instigator_state = instance.get_instigator_state(
+                always_running_origin.get_id(), running_sensor.selector_id
+            )
+
+            assert stopped_instigator_state
+            assert stopped_instigator_state.status == InstigatorStatus.STOPPED
+
+            instance.reset_sensor(running_sensor)
+            reset_instigator_state = instance.get_instigator_state(
+                always_running_origin.get_id(), running_sensor.selector_id
+            )
+
+            assert reset_instigator_state
+            assert reset_instigator_state.status == InstigatorStatus.DECLARED_IN_CODE
+
+            evaluate_sensors(workspace_context, executor)
+
         freeze_datetime = freeze_datetime.add(seconds=30)
         with pendulum.test(freeze_datetime):
             evaluate_sensors(workspace_context, executor)
@@ -2654,7 +2675,7 @@ def test_status_in_code_sensor(executor, instance):
             ticks = instance.get_ticks(
                 running_sensor.get_external_origin_id(), running_sensor.selector_id
             )
-            assert len(ticks) == 2
+            assert len(ticks) == 3
 
             expected_datetime = create_pendulum_time(
                 year=2019, month=2, day=28, hour=0, minute=0, second=29

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -905,6 +905,25 @@ def test_status_in_code_schedule(instance: DagsterInstance, executor: ThreadPool
                 == 0
             )
 
+            # The instigator state status can be manually updated, as well as reset.
+            instance.stop_schedule(
+                always_running_origin.get_id(), running_schedule.selector_id, running_schedule
+            )
+            stopped_instigator_state = instance.get_instigator_state(
+                always_running_origin.get_id(), running_schedule.selector_id
+            )
+
+            assert stopped_instigator_state
+            assert stopped_instigator_state.status == InstigatorStatus.STOPPED
+
+            instance.reset_schedule(running_schedule)
+            reset_instigator_state = instance.get_instigator_state(
+                always_running_origin.get_id(), running_schedule.selector_id
+            )
+
+            assert reset_instigator_state
+            assert reset_instigator_state.status == InstigatorStatus.DECLARED_IN_CODE
+
         freeze_datetime = freeze_datetime.add(seconds=2)
         with pendulum.test(freeze_datetime):
             evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))


### PR DESCRIPTION
## Summary & Motivation
Adds two mutations, `resetSchedule` and `resetSensor`. These mutations allow instigators with a internal and manually set status like `RUNNING` or `STOPPED` to be reset back to `SET_IN_CODE` (fka `DECLARATIVE`). This reset only occurs if the external instigator definition has a default status. Otherwise, `resetSchedule` and `resetSensor` behave like setting the status to `STOPPED`.

## How I Tested These Changes
pytest
