### PR TITLE
feat(declarative-instigator-status): add fields to query instigator default status

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -1571,11 +1571,18 @@ type Schedule {
   mode: String!
   executionTimezone: String
   description: String
+  defaultStatus: InstigationStatus!
+  canReset: Boolean!
   scheduleState: InstigationState!
   partitionSet: PartitionSet
   futureTicks(cursor: Float, limit: Int, until: Float): DryRunInstigationTicks!
   futureTick(tickTimestamp: Int!): DryRunInstigationTick!
   potentialTickTimestamps(startTimestamp: Float, upperLimit: Int, lowerLimit: Int): [Float!]!
+}
+
+enum InstigationStatus {
+  RUNNING
+  STOPPED
 }
 
 union ScheduleMutationResult = PythonError | UnauthorizedError | ScheduleStateResult
@@ -2447,11 +2454,6 @@ enum InstigationType {
   AUTO_MATERIALIZE
 }
 
-enum InstigationStatus {
-  RUNNING
-  STOPPED
-}
-
 type InstigationStateNotFoundError implements Error {
   message: String!
   name: String!
@@ -2870,6 +2872,8 @@ type Sensor {
   jobOriginId: String!
   name: String!
   targets: [Target!]
+  defaultStatus: InstigationStatus!
+  canReset: Boolean!
   sensorState: InstigationState!
   minIntervalSeconds: Int!
   description: String

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -4490,7 +4490,9 @@ export type ScalarUnionConfigType = ConfigType & {
 
 export type Schedule = {
   __typename: 'Schedule';
+  canReset: Scalars['Boolean'];
   cronSchedule: Scalars['String'];
+  defaultStatus: InstigationStatus;
   description: Maybe<Scalars['String']>;
   executionTimezone: Maybe<Scalars['String']>;
   futureTick: DryRunInstigationTick;
@@ -4607,6 +4609,8 @@ export type SelectorTypeConfigError = PipelineConfigValidationError & {
 export type Sensor = {
   __typename: 'Sensor';
   assetSelection: Maybe<AssetSelection>;
+  canReset: Scalars['Boolean'];
+  defaultStatus: InstigationStatus;
   description: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   jobOriginId: Scalars['String'];
@@ -12805,8 +12809,13 @@ export const buildSchedule = (
   relationshipsToOmit.add('Schedule');
   return {
     __typename: 'Schedule',
+    canReset: overrides && overrides.hasOwnProperty('canReset') ? overrides.canReset! : false,
     cronSchedule:
       overrides && overrides.hasOwnProperty('cronSchedule') ? overrides.cronSchedule! : 'possimus',
+    defaultStatus:
+      overrides && overrides.hasOwnProperty('defaultStatus')
+        ? overrides.defaultStatus!
+        : InstigationStatus.RUNNING,
     description:
       overrides && overrides.hasOwnProperty('description') ? overrides.description! : 'porro',
     executionTimezone:
@@ -13053,6 +13062,11 @@ export const buildSensor = (
         : relationshipsToOmit.has('AssetSelection')
         ? ({} as AssetSelection)
         : buildAssetSelection({}, relationshipsToOmit),
+    canReset: overrides && overrides.hasOwnProperty('canReset') ? overrides.canReset! : true,
+    defaultStatus:
+      overrides && overrides.hasOwnProperty('defaultStatus')
+        ? overrides.defaultStatus!
+        : InstigationStatus.RUNNING,
     description:
       overrides && overrides.hasOwnProperty('description') ? overrides.description! : 'sapiente',
     id:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -39,10 +39,11 @@ def start_schedule(
     check.inst_param(schedule_selector, "schedule_selector", ScheduleSelector)
     location = graphene_info.context.get_code_location(schedule_selector.location_name)
     repository = location.get_repository(schedule_selector.repository_name)
-    instance = graphene_info.context.instance
-    schedule_state = instance.start_schedule(
-        repository.get_external_schedule(schedule_selector.schedule_name)
-    )
+
+    external_schedule = repository.get_external_schedule(schedule_selector.schedule_name)
+    stored_state = graphene_info.context.instance.start_schedule(external_schedule)
+    schedule_state = external_schedule.get_current_instigator_state(stored_state)
+
     return GrapheneScheduleStateResult(GrapheneInstigationState(schedule_state))
 
 
@@ -92,9 +93,9 @@ def reset_schedule(
     location = graphene_info.context.get_code_location(schedule_selector.location_name)
     repository = location.get_repository(schedule_selector.repository_name)
 
-    schedule_state = graphene_info.context.instance.reset_schedule(
-        repository.get_external_schedule(schedule_selector.schedule_name)
-    )
+    external_schedule = repository.get_external_schedule(schedule_selector.schedule_name)
+    stored_state = graphene_info.context.instance.reset_schedule(external_schedule)
+    schedule_state = external_schedule.get_current_instigator_state(stored_state)
 
     return GrapheneScheduleStateResult(GrapheneInstigationState(schedule_state))
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -129,7 +129,7 @@ class RepositoryScopedBatchLoader:
         states = self._get(RepositoryDataType.SCHEDULE_STATES, schedule_name, 1)
         return states[0] if states else None
 
-    def get_sensor_state(self, sensor_name: str) -> Optional[Sequence[Any]]:
+    def get_sensor_state(self, sensor_name: str) -> Optional[InstigatorState]:
         check.invariant(self._repository.has_external_sensor(sensor_name))
         states = self._get(RepositoryDataType.SENSOR_STATES, sensor_name, 1)
         return states[0] if states else None

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -293,17 +293,16 @@ class GrapheneRepository(graphene.ObjectType):
         )
 
     def resolve_sensors(self, _graphene_info: ResolveInfo):
-        return sorted(
-            [
-                GrapheneSensor(
-                    sensor,
-                    self._batch_loader.get_sensor_state(sensor.name),
-                    self._batch_loader,
-                )
-                for sensor in self._repository.get_external_sensors()
-            ],
-            key=lambda sensor: sensor.name,
-        )
+        return [
+            GrapheneSensor(
+                sensor,
+                self._batch_loader.get_sensor_state(sensor.name),
+                self._batch_loader,
+            )
+            for sensor in sorted(
+                self._repository.get_external_sensors(), key=lambda sensor: sensor.name
+            )
+        ]
 
     def resolve_pipelines(self, _graphene_info: ResolveInfo):
         return [

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -1,11 +1,14 @@
+from typing import Optional
+
 import dagster._check as check
 import graphene
+from dagster import DefaultSensorStatus
 from dagster._core.definitions.selector import SensorSelector
 from dagster._core.definitions.sensor_definition import (
     SensorType,
 )
 from dagster._core.host_representation import ExternalSensor, ExternalTargetData
-from dagster._core.scheduler.instigation import InstigatorState
+from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus
 from dagster._core.workspace.permissions import Permissions
 
 from dagster_graphql.implementation.loader import RepositoryScopedBatchLoader
@@ -31,7 +34,11 @@ from .errors import (
     GrapheneUnauthorizedError,
 )
 from .inputs import GrapheneSensorSelector
-from .instigation import GrapheneDryRunInstigationTick, GrapheneInstigationState
+from .instigation import (
+    GrapheneDryRunInstigationTick,
+    GrapheneInstigationState,
+    GrapheneInstigationStatus,
+)
 from .util import ResolveInfo, non_null_list
 
 
@@ -69,6 +76,8 @@ class GrapheneSensor(graphene.ObjectType):
     jobOriginId = graphene.NonNull(graphene.String)
     name = graphene.NonNull(graphene.String)
     targets = graphene.List(graphene.NonNull(GrapheneTarget))
+    defaultStatus = graphene.NonNull(GrapheneInstigationStatus)
+    canReset = graphene.NonNull(graphene.Boolean)
     sensorState = graphene.NonNull(GrapheneInstigationState)
     minIntervalSeconds = graphene.NonNull(graphene.Int)
     description = graphene.String()
@@ -80,7 +89,12 @@ class GrapheneSensor(graphene.ObjectType):
     class Meta:
         name = "Sensor"
 
-    def __init__(self, external_sensor, sensor_state, batch_loader=None):
+    def __init__(
+        self,
+        external_sensor: ExternalSensor,
+        sensor_state: Optional[InstigatorState],
+        batch_loader: Optional[RepositoryScopedBatchLoader] = None,
+    ):
         self._external_sensor = check.inst_param(external_sensor, "external_sensor", ExternalSensor)
 
         # optional run loader, provided by a parent GrapheneRepository object that instantiates
@@ -88,6 +102,8 @@ class GrapheneSensor(graphene.ObjectType):
         self._batch_loader = check.opt_inst_param(
             batch_loader, "batch_loader", RepositoryScopedBatchLoader
         )
+
+        self._stored_state = sensor_state
         self._sensor_state = self._external_sensor.get_current_instigator_state(sensor_state)
 
         super().__init__(
@@ -107,6 +123,19 @@ class GrapheneSensor(graphene.ObjectType):
 
     def resolve_id(self, _):
         return self._external_sensor.get_external_origin_id()
+
+    def resolve_defaultStatus(self, _graphene_info: ResolveInfo):
+        default_sensor_status = self._external_sensor.default_status
+
+        if default_sensor_status == DefaultSensorStatus.RUNNING:
+            return GrapheneInstigationStatus.RUNNING
+        elif default_sensor_status == DefaultSensorStatus.STOPPED:
+            return GrapheneInstigationStatus.STOPPED
+
+    def resolve_canReset(self, _graphene_info: ResolveInfo):
+        return bool(
+            self._stored_state and self._stored_state.status != InstigatorStatus.DECLARED_IN_CODE
+        )
 
     def resolve_sensorState(self, _graphene_info: ResolveInfo):
         # forward the batch run loader to the instigation state, which provides the sensor runs

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -162,6 +162,8 @@ query SensorStateQuery($sensorSelector: SensorSelector!) {
   sensorOrError(sensorSelector: $sensorSelector) {
     __typename
     ... on Sensor {
+      canReset
+      defaultStatus
       sensorState {
         id
         status
@@ -209,6 +211,7 @@ mutation($sensorSelector: SensorSelector!) {
     ... on Sensor {
       id
       jobOriginId
+      canReset
       sensorState {
         selectorId
         status
@@ -248,6 +251,7 @@ mutation($sensorSelector: SensorSelector!) {
     ... on Sensor {
       id
       jobOriginId
+      canReset
       sensorState {
         selectorId
         status
@@ -802,6 +806,7 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
             variables={"sensorSelector": sensor_selector},
         )
 
+        assert result.data["sensorOrError"]["defaultStatus"] == "RUNNING"
         assert result.data["sensorOrError"]["sensorState"]["status"] == "RUNNING"
         sensor_origin_id = result.data["sensorOrError"]["sensorState"]["id"]
         sensor_selector_id = result.data["sensorOrError"]["sensorState"]["selectorId"]
@@ -848,6 +853,8 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
             variables={"sensorSelector": sensor_selector},
         )
 
+        assert result.data["sensorOrError"]["defaultStatus"] == "STOPPED"
+        assert result.data["sensorOrError"]["canReset"] is False
         assert result.data["sensorOrError"]["sensorState"]["status"] == "STOPPED"
 
         sensor_origin_id = result.data["sensorOrError"]["sensorState"]["id"]
@@ -859,6 +866,7 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
             variables={"sensorSelector": sensor_selector},
         )
 
+        assert start_result.data["startSensor"]["canReset"] is True
         assert start_result.data["startSensor"]["sensorState"]["status"] == "RUNNING"
 
         # Resetting a sensor that is already running stops it
@@ -873,7 +881,8 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
         )
 
         assert instigator_state
-        assert instigator_state.status == InstigatorStatus.STOPPED
+        assert instigator_state.status == InstigatorStatus.DECLARED_IN_CODE
+        assert reset_result.data["resetSensor"]["canReset"] is False
         assert reset_result.data["resetSensor"]["sensorState"]["status"] == "STOPPED"
 
         # Resetting a stopped sensor is a noop
@@ -888,7 +897,8 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
         )
 
         assert instigator_state
-        assert instigator_state.status == InstigatorStatus.STOPPED
+        assert instigator_state.status == InstigatorStatus.DECLARED_IN_CODE
+        assert reset_result.data["resetSensor"]["canReset"] is False
         assert reset_result.data["resetSensor"]["sensorState"]["status"] == "STOPPED"
 
     def test_reset_sensor_with_default_status(self, graphql_context: WorkspaceRequestContext):
@@ -899,6 +909,8 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
             variables={"sensorSelector": sensor_selector},
         )
 
+        assert result.data["sensorOrError"]["defaultStatus"] == "RUNNING"
+        assert result.data["sensorOrError"]["canReset"] is False
         assert result.data["sensorOrError"]["sensorState"]["status"] == "RUNNING"
         assert result.data["sensorOrError"]["sensorState"]["hasStartPermission"] is True
         assert result.data["sensorOrError"]["sensorState"]["hasStopPermission"] is True
@@ -914,6 +926,14 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
 
         assert stop_result.data["stopSensor"]["instigationState"]["status"] == "STOPPED"
 
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_SENSOR_STATUS_QUERY,
+            variables={"sensorSelector": sensor_selector},
+        )
+
+        assert result.data["sensorOrError"]["canReset"] is True
+
         # Now can be restarted
         start_result = execute_dagster_graphql(
             graphql_context,
@@ -927,6 +947,7 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
 
         assert instigator_state
         assert instigator_state.status == InstigatorStatus.DECLARED_IN_CODE
+        assert start_result.data["resetSensor"]["canReset"] is False
         assert start_result.data["resetSensor"]["sensorState"]["status"] == "RUNNING"
 
 

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -753,11 +753,7 @@ class ExternalSchedule:
 
     @property
     def default_status(self) -> DefaultScheduleStatus:
-        return (
-            self._external_schedule_data.default_status
-            if self._external_schedule_data.default_status
-            else DefaultScheduleStatus.STOPPED
-        )
+        return self._external_schedule_data.default_status or DefaultScheduleStatus.STOPPED
 
     def get_current_instigator_state(
         self, stored_state: Optional["InstigatorState"]
@@ -952,12 +948,8 @@ class ExternalSensor:
         return self._external_sensor_data.metadata
 
     @property
-    def default_status(self) -> Optional[DefaultSensorStatus]:
-        return (
-            self._external_sensor_data.default_status
-            if self._external_sensor_data
-            else DefaultSensorStatus.STOPPED
-        )
+    def default_status(self) -> DefaultSensorStatus:
+        return self._external_sensor_data.default_status or DefaultSensorStatus.STOPPED
 
 
 class ExternalPartitionSet:

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -588,6 +588,7 @@ class ExternalSensorData(
                 target_dict, "target_dict", str, ExternalTargetData
             ),
             metadata=check.opt_inst_param(metadata, "metadata", ExternalSensorMetadata),
+            # Leave default_status as None if it's STOPPED to maintain stable back-compat IDs
             default_status=(
                 DefaultSensorStatus.RUNNING
                 if default_status == DefaultSensorStatus.RUNNING

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2749,8 +2749,7 @@ class DagsterInstance(DynamicPartitionsStore):
 
     def reset_sensor(self, external_sensor: "ExternalSensor") -> "InstigatorState":
         """If the given sensor has a default sensor status, then update the status to
-        `InstigatorStatus.DECLARED_IN_CODE` in instigator storage. Otherwise, update the status to
-        `InstigatorStatus.STOPPED`.
+        `InstigatorStatus.DECLARED_IN_CODE` in instigator storage.
 
         Args:
             instance (DagsterInstance): The current instance.
@@ -2770,11 +2769,7 @@ class DagsterInstance(DynamicPartitionsStore):
             min_interval=external_sensor.min_interval_seconds,
             sensor_type=external_sensor.sensor_type,
         )
-        new_status = (
-            InstigatorStatus.DECLARED_IN_CODE
-            if external_sensor._external_sensor_data.default_status  # noqa: SLF001
-            else InstigatorStatus.STOPPED
-        )
+        new_status = InstigatorStatus.DECLARED_IN_CODE
 
         if not stored_state:
             reset_state = self.add_instigator_state(

--- a/python_modules/dagster/dagster/_core/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_core/scheduler/scheduler.py
@@ -157,8 +157,7 @@ class Scheduler(abc.ABC):
         self, instance: DagsterInstance, external_schedule: ExternalSchedule
     ) -> InstigatorState:
         """If the given schedule has a default schedule status, then update the status to
-        `InstigatorStatus.DECLARED_IN_CODE` in schedule storage. Otherwise, update the status to
-        `InstigatorStatus.STOPPED`.
+        `InstigatorStatus.DECLARED_IN_CODE` in schedule storage.
 
         This should not be overridden by subclasses.
 
@@ -176,11 +175,7 @@ class Scheduler(abc.ABC):
             external_schedule.cron_schedule,
             start_timestamp=None,
         )
-        new_status = (
-            InstigatorStatus.DECLARED_IN_CODE
-            if external_schedule._external_schedule_data.default_status  # noqa: SLF001
-            else InstigatorStatus.STOPPED
-        )
+        new_status = InstigatorStatus.DECLARED_IN_CODE
 
         if not stored_state:
             reset_state = instance.add_instigator_state(


### PR DESCRIPTION
## Summary & Motivation
We need these fields to display the default status and reset button on an instigator page.

## How I Tested These Changes
pytest, used in https://github.com/dagster-io/dagster/pull/19258
