### PR TITLE
[ui] Fix datepicker themes

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/DateRangePickerWrapper.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/DateRangePickerWrapper.tsx
@@ -1,12 +1,133 @@
+import {
+  colorAccentBlue,
+  colorBackgroundBlue,
+  colorBackgroundBlueHover,
+  colorBackgroundDefault,
+  colorBackgroundLight,
+  colorBorderDefault,
+  colorBorderHover,
+  colorKeylineDefault,
+  colorTextDefault,
+  colorTextLight,
+  colorTextLighter,
+} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {DateRangePicker} from 'react-dates';
+import styled from 'styled-components';
 
 import 'react-dates/initialize';
 import 'react-dates/lib/css/_datepicker.css';
 
 export const DateRangePickerWrapper = (props: React.ComponentProps<typeof DateRangePicker>) => {
-  return <DateRangePicker {...props} />;
+  return (
+    <DatePickerContainer>
+      <DateRangePicker {...props} />
+    </DatePickerContainer>
+  );
 };
 
+const DatePickerContainer = styled.div`
+  .DateRangePickerInput {
+    background-color: ${colorBackgroundDefault()};
+  }
+
+  .DateRangePickerInput__withBorder {
+    border-color: ${colorBorderDefault()};
+  }
+
+  .DateInput {
+    background-color: ${colorBackgroundDefault()};
+  }
+
+  .DateRangePickerInput_arrow_svg {
+    fill: ${colorTextLighter()};
+  }
+
+  .DateInput_input {
+    background-color: ${colorBackgroundDefault()};
+    color: ${colorTextDefault()};
+  }
+
+  .DateInput_input::placeholder {
+    color: ${colorTextLight()};
+  }
+
+  .DateInput_input__focused {
+    border-color: ${colorAccentBlue()};
+    outline: none;
+  }
+
+  .DateInput_fangShape {
+    fill: ${colorBackgroundLight()};
+  }
+
+  .DateInput_fangStroke {
+    stroke: ${colorKeylineDefault()};
+  }
+
+  .DateRangePicker_picker {
+    background-color: ${colorBackgroundLight()};
+    color: ${colorTextDefault()};
+  }
+
+  .DayPicker {
+    background-color: ${colorBackgroundLight()};
+    color: ${colorTextDefault()};
+  }
+
+  .DayPickerNavigation_button__default {
+    background-color: ${colorBackgroundLight()};
+    border-color: ${colorBorderDefault()};
+
+    :hover {
+      border-color: ${colorBorderHover()};
+    }
+  }
+
+  .DayPickerNavigation_svg__horizontal {
+    fill: ${colorTextLight()};
+  }
+
+  .DayPicker_weekHeader {
+    color: ${colorTextLighter()};
+  }
+
+  .CalendarMonthGrid,
+  .CalendarMonth {
+    background-color: ${colorBackgroundLight()};
+    color: ${colorTextDefault()};
+  }
+
+  .CalendarMonth_caption {
+    color: ${colorTextLight()};
+  }
+
+  .CalendarDay__default {
+    background-color: ${colorBackgroundLight()};
+    border-color: ${colorKeylineDefault()};
+    color: ${colorTextLight()};
+
+    :hover {
+      background-color: ${colorBackgroundBlue()};
+      border-color: ${colorKeylineDefault()};
+    }
+  }
+
+  .CalendarDay__selected {
+    background-color: ${colorBackgroundBlueHover()};
+
+    :active,
+    :hover {
+      border-color: ${colorKeylineDefault()};
+    }
+  }
+
+  .CalendarDay__hovered_span,
+  .CalendarDay__hovered_span_3 {
+    background-color: ${colorBackgroundBlue()};
+    border-color: ${colorKeylineDefault()};
+  }
+`;
+
 // eslint-disable-next-line import/no-default-export
-export default DateRangePicker;
+export default DateRangePickerWrapper;


### PR DESCRIPTION
## Summary & Motivation

The react-dates datepicker we use for run filtering hasn't been themed. Fix it.


<img width="689" alt="Screenshot 2024-01-16 at 5 04 17 PM" src="https://github.com/dagster-io/dagster/assets/2823852/844ce6b1-f67d-40fb-8693-bf7e599e8cb1">
<img width="687" alt="Screenshot 2024-01-16 at 5 03 57 PM" src="https://github.com/dagster-io/dagster/assets/2823852/4fc1995f-e083-4b45-ab4b-4509f58ed6ae">

## How I Tested These Changes

View datepicker in dark and light modes, hover over dates and select them.
