### PR TITLE
[docs] reference #ask-ai as resource for getting help

### DIFF
--- a/docs/content/getting-started/getting-help.mdx
+++ b/docs/content/getting-started/getting-help.mdx
@@ -15,6 +15,8 @@ Search engines like Google generally do a good job at surfacing relevant Dagster
 
 Unfortunately, ChatGPT is not currently a great resource for answering questions about Dagster, because the corpus it was trained on doesn’t include Dagster’s latest APIs.
 
+However, one can interact with a fine-tuned Language Learning Model (LLM) trained on Dagster docs in the [#ask-ai](https://dagster.slack.com/archives/C066HKS7EG1) channel of the Dagster Slack.
+
 ---
 
 ## Bugs and feature requests


### PR DESCRIPTION
## Summary & Motivation

Adds a reference to the #ask-ai channel in the "Getting Help" section of the Dagster documentation.

@PedramNavid , I believe this is your baby, so I'd be curious to know if you think this is ready for inclusion in the main docs, but I've been super impressed by the answers I've seen so far. I was perusing the docs, and thought it would fit nicely in this section.

## How I Tested These Changes

Previewed rendered markdown.