### PR TITLE
[AssetGraph] Show asset selection in filter bar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -786,13 +786,6 @@ const AssetGraphExplorerWithData = ({
                     popoverPosition="bottom-left"
                   />
                 </GraphQueryInputFlexWrap>
-                <Button
-                  onClick={() => {
-                    onChangeExplorerPath({...explorerPath, opsQuery: ''}, 'push');
-                  }}
-                >
-                  Clear query
-                </Button>
                 <AssetLiveDataRefresh />
                 <LaunchAssetObservationButton
                   preferredJobName={explorerPath.pipelineName}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -118,6 +118,8 @@ export const AssetGraphExplorer = (props: Props) => {
     );
   }, [visibleRepos]);
 
+  const {explorerPath, onChangeExplorerPath} = props;
+
   const {button, filterBar} = useAssetGraphExplorerFilters({
     nodes: React.useMemo(
       () => (fullAssetGraphData ? Object.values(fullAssetGraphData.nodes) : []),
@@ -138,6 +140,16 @@ export const AssetGraphExplorer = (props: Props) => {
         }),
       [props],
     ),
+    explorerPath: explorerPath.opsQuery,
+    clearExplorerPath: React.useCallback(() => {
+      onChangeExplorerPath(
+        {
+          ...explorerPath,
+          opsQuery: '',
+        },
+        'push',
+      );
+    }, [explorerPath, onChangeExplorerPath]),
   });
 
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import {AssetGroupSelector} from '../graphql/types';
 import {TruncatedTextWithFullTextOnHover} from '../nav/getLeftNavItemsForOption';
 import {useFilters} from '../ui/Filters';
-import {FilterObject} from '../ui/Filters/useFilter';
+import {FilterObject, FilterTag, FilterTagHighlightedText} from '../ui/Filters/useFilter';
 import {useStaticSetFilter} from '../ui/Filters/useStaticSetFilter';
 import {DagsterRepoOption, WorkspaceContext} from '../workspace/WorkspaceContext';
 import {buildRepoAddress, buildRepoPathForHuman} from '../workspace/buildRepoAddress';
@@ -31,6 +31,8 @@ type OptionalFilters =
 
 type Props = {
   nodes: GraphNode[];
+  clearExplorerPath: () => void;
+  explorerPath: string;
 } & OptionalFilters;
 
 const emptyArray: any[] = [];
@@ -42,6 +44,8 @@ export function useAssetGraphExplorerFilters({
   setGroupFilters,
   computeKindTags,
   setComputeKindTags,
+  explorerPath,
+  clearExplorerPath,
 }: Props) {
   const {allRepos, visibleRepos, toggleVisible, setVisible} = React.useContext(WorkspaceContext);
 
@@ -179,11 +183,25 @@ export function useAssetGraphExplorerFilters({
   }
   return {
     button,
-    filterBar: activeFiltersJsx.length ? (
-      <Box padding={{vertical: 8, horizontal: 12}} flex={{gap: 12}}>
-        {' '}
-        {activeFiltersJsx}
-      </Box>
-    ) : null,
+    filterBar:
+      activeFiltersJsx.length || explorerPath ? (
+        <Box padding={{vertical: 8, horizontal: 12}} flex={{gap: 12}}>
+          {' '}
+          {activeFiltersJsx}
+          {explorerPath ? (
+            <FilterTag
+              label={
+                <Box flex={{direction: 'row', alignItems: 'center'}}>
+                  Asset selection is&nbsp;
+                  <FilterTagHighlightedText tooltipText={explorerPath}>
+                    {explorerPath}
+                  </FilterTagHighlightedText>
+                </Box>
+              }
+              onRemove={clearExplorerPath}
+            />
+          ) : null}
+        </Box>
+      ) : null,
   };
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useFilter.tsx
@@ -37,12 +37,12 @@ export const FilterTag = ({
   onRemove,
 }: {
   label: JSX.Element;
-  iconName: IconName;
+  iconName?: IconName;
   onRemove: () => void;
 }) => (
   <div>
     <BaseTag
-      icon={<Icon name={iconName} color={colorLinkDefault()} />}
+      icon={iconName ? <Icon name={iconName} color={colorLinkDefault()} /> : undefined}
       rightIcon={
         <div onClick={onRemove} style={{cursor: 'pointer'}} tabIndex={0}>
           <Icon name="close" color={colorLinkDefault()} />


### PR DESCRIPTION
## Summary & Motivation

We want to show the asset selection in the filter bar so it's consistent with other filters. 

## How I Tested These Changes
![Screenshot 2024-01-17 at 8 53 09 AM](https://github.com/dagster-io/dagster/assets/2286579/76b16873-52c9-4c44-81d4-75e175164f94)

