### PR TITLE
feat(declarative-instigator-status): add button to reset instigator status

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleDetails.tsx
@@ -11,6 +11,7 @@ import {
 import {useState} from 'react';
 
 import {SchedulePartitionStatus} from './SchedulePartitionStatus';
+import {ScheduleResetButton} from './ScheduleResetButton';
 import {ScheduleSwitch} from './ScheduleSwitch';
 import {TimestampDisplay} from './TimestampDisplay';
 import {humanCronString} from './humanCronString';
@@ -46,12 +47,7 @@ export const ScheduleDetails = (props: {
   return (
     <>
       <PageHeader
-        title={
-          <Box flex={{direction: 'row', alignItems: 'center', gap: 12}}>
-            <Heading>{name}</Heading>
-            <ScheduleSwitch repoAddress={repoAddress} schedule={schedule} />
-          </Box>
-        }
+        title={<Heading>{name}</Heading>}
         tags={
           <Tag icon="schedule">
             Schedule in <RepositoryLink repoAddress={repoAddress} />
@@ -125,6 +121,21 @@ export const ScheduleDetails = (props: {
                 pipelineHrefContext={repoAddress}
                 isJob={isJob}
               />
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <Box flex={{alignItems: 'center'}} style={{height: '32px'}}>
+                Running
+              </Box>
+            </td>
+            <td>
+              <Box flex={{direction: 'row', alignItems: 'center'}}>
+                <ScheduleSwitch repoAddress={repoAddress} schedule={schedule} />
+                {schedule.canReset && (
+                  <ScheduleResetButton repoAddress={repoAddress} schedule={schedule} />
+                )}
+              </Box>
             </td>
           </tr>
           <tr>

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleMutations.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleMutations.tsx
@@ -1,6 +1,10 @@
 import {gql} from '@apollo/client';
 
-import {StartThisScheduleMutation, StopScheduleMutation} from './types/ScheduleMutations.types';
+import {
+  ResetScheduleMutation,
+  StartThisScheduleMutation,
+  StopScheduleMutation,
+} from './types/ScheduleMutations.types';
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
@@ -48,8 +52,28 @@ export const STOP_SCHEDULE_MUTATION = gql`
   ${PYTHON_ERROR_FRAGMENT}
 `;
 
+export const RESET_SCHEDULE_MUTATION = gql`
+  mutation ResetSchedule($scheduleSelector: ScheduleSelector!) {
+    resetSchedule(scheduleSelector: $scheduleSelector) {
+      ... on ScheduleStateResult {
+        scheduleState {
+          id
+          status
+          runningCount
+        }
+      }
+      ... on UnauthorizedError {
+        message
+      }
+      ...PythonErrorFragment
+    }
+  }
+
+  ${PYTHON_ERROR_FRAGMENT}
+`;
+
 export const displayScheduleMutationErrors = (
-  data: StartThisScheduleMutation | StopScheduleMutation,
+  data: StartThisScheduleMutation | StopScheduleMutation | ResetScheduleMutation,
 ) => {
   let error;
   if ('startSchedule' in data && data.startSchedule.__typename === 'PythonError') {
@@ -59,6 +83,8 @@ export const displayScheduleMutationErrors = (
     data.stopRunningSchedule.__typename === 'PythonError'
   ) {
     error = data.stopRunningSchedule;
+  } else if ('resetSchedule' in data && data.resetSchedule.__typename === 'PythonError') {
+    error = data.resetSchedule;
   }
 
   if (error) {

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleResetButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleResetButton.tsx
@@ -1,0 +1,54 @@
+import {useMutation} from '@apollo/client';
+import {Button, Tooltip} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {RESET_SCHEDULE_MUTATION, displayScheduleMutationErrors} from './ScheduleMutations';
+import {
+  ResetScheduleMutation,
+  ResetScheduleMutationVariables,
+} from './types/ScheduleMutations.types';
+import {ScheduleFragment} from './types/ScheduleUtils.types';
+import {DEFAULT_DISABLED_REASON, usePermissionsForLocation} from '../app/Permissions';
+import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
+import {RepoAddress} from '../workspace/types';
+
+interface Props {
+  repoAddress: RepoAddress;
+  schedule: ScheduleFragment;
+}
+
+export const ScheduleResetButton = ({repoAddress, schedule}: Props) => {
+  const {
+    permissions: {canStartSchedule, canStopRunningSchedule},
+  } = usePermissionsForLocation(repoAddress.location);
+
+  const {name} = schedule;
+  const scheduleSelector = {
+    ...repoAddressToSelector(repoAddress),
+    scheduleName: name,
+  };
+
+  const [resetSchedule, {loading: toggleOnInFlight}] = useMutation<
+    ResetScheduleMutation,
+    ResetScheduleMutationVariables
+  >(RESET_SCHEDULE_MUTATION, {
+    onCompleted: displayScheduleMutationErrors,
+  });
+  const onClick = () => {
+    resetSchedule({variables: {scheduleSelector}});
+  };
+
+  const hasPermission = canStartSchedule && canStopRunningSchedule;
+  const disabled = toggleOnInFlight || !hasPermission;
+  const tooltipContent = hasPermission
+    ? `In code, a default status for "${name}" has been set to "${schedule.defaultStatus}". Click here to reset the schedule status to track the status set in code.`
+    : DEFAULT_DISABLED_REASON;
+
+  return (
+    <Tooltip content={tooltipContent} display="flex">
+      <Button disabled={disabled} onClick={onClick}>
+        Reset schedule status
+      </Button>
+    </Tooltip>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleUtils.tsx
@@ -16,6 +16,8 @@ export const SCHEDULE_FRAGMENT = gql`
       id
       name
     }
+    defaultStatus
+    canReset
     scheduleState {
       id
       ...InstigationStateFragment

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleMutations.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleMutations.types.ts
@@ -60,3 +60,32 @@ export type StopScheduleMutation = {
       }
     | {__typename: 'UnauthorizedError'; message: string};
 };
+
+export type ResetScheduleMutationVariables = Types.Exact<{
+  scheduleSelector: Types.ScheduleSelector;
+}>;
+
+export type ResetScheduleMutation = {
+  __typename: 'Mutation';
+  resetSchedule:
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      }
+    | {
+        __typename: 'ScheduleStateResult';
+        scheduleState: {
+          __typename: 'InstigationState';
+          id: string;
+          status: Types.InstigationStatus;
+          runningCount: number;
+        };
+      }
+    | {__typename: 'UnauthorizedError'; message: string};
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleRoot.types.ts
@@ -29,6 +29,8 @@ export type ScheduleRootQuery = {
         solidSelection: Array<string | null> | null;
         mode: string;
         description: string | null;
+        defaultStatus: Types.InstigationStatus;
+        canReset: boolean;
         partitionSet: {__typename: 'PartitionSet'; id: string; name: string} | null;
         scheduleState: {
           __typename: 'InstigationState';

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleUtils.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleUtils.types.ts
@@ -12,6 +12,8 @@ export type ScheduleFragment = {
   solidSelection: Array<string | null> | null;
   mode: string;
   description: string | null;
+  defaultStatus: Types.InstigationStatus;
+  canReset: boolean;
   partitionSet: {__typename: 'PartitionSet'; id: string; name: string} | null;
   scheduleState: {
     __typename: 'InstigationState';

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
@@ -12,6 +12,7 @@ import {useState} from 'react';
 
 import {EditCursorDialog} from './EditCursorDialog';
 import {SensorMonitoredAssets} from './SensorMonitoredAssets';
+import {SensorResetButton} from './SensorResetButton';
 import {SensorSwitch} from './SensorSwitch';
 import {SensorTargetList} from './SensorTargetList';
 import {SensorFragment} from './types/SensorFragment.types';
@@ -83,19 +84,12 @@ export const SensorDetails = ({
   return (
     <>
       <PageHeader
-        title={
-          <Box flex={{direction: 'row', alignItems: 'center', gap: 12}}>
-            <Heading>{name}</Heading>
-            <SensorSwitch repoAddress={repoAddress} sensor={sensor} />
-          </Box>
-        }
+        title={<Heading>{name}</Heading>}
         icon="sensors"
         tags={
-          <>
-            <Tag icon="sensors">
-              Sensor in <RepositoryLink repoAddress={repoAddress} />
-            </Tag>
-          </>
+          <Tag icon="sensors">
+            Sensor in <RepositoryLink repoAddress={repoAddress} />
+          </Tag>
         }
         right={
           <Box margin={{top: 4}} flex={{direction: 'row', alignItems: 'center', gap: 8}}>
@@ -164,6 +158,22 @@ export const SensorDetails = ({
               </td>
             </tr>
           ) : null}
+          <tr>
+            <td>
+              <Box flex={{alignItems: 'center'}} style={{height: '32px'}}>
+                Running
+              </Box>
+            </td>
+            <td>
+              <Box
+                flex={{direction: 'row', gap: 12, alignItems: 'center'}}
+                style={{height: '32px'}}
+              >
+                <SensorSwitch repoAddress={repoAddress} sensor={sensor} />
+                {sensor.canReset && <SensorResetButton repoAddress={repoAddress} sensor={sensor} />}
+              </Box>
+            </td>
+          </tr>
           <tr>
             <td>Frequency</td>
             <td>{humanizeSensorInterval(sensor.minIntervalSeconds)}</td>

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorFragment.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorFragment.tsx
@@ -13,6 +13,8 @@ export const SENSOR_FRAGMENT = gql`
     nextTick {
       timestamp
     }
+    defaultStatus
+    canReset
     sensorState {
       id
       ...InstigationStateFragment

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorMutations.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorMutations.tsx
@@ -1,6 +1,10 @@
 import {gql} from '@apollo/client';
 
-import {StartSensorMutation, StopRunningSensorMutation} from './types/SensorMutations.types';
+import {
+  ResetSensorMutation,
+  StartSensorMutation,
+  StopRunningSensorMutation,
+} from './types/SensorMutations.types';
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
@@ -47,19 +51,44 @@ export const STOP_SENSOR_MUTATION = gql`
   ${PYTHON_ERROR_FRAGMENT}
 `;
 
+export const RESET_SENSOR_MUTATION = gql`
+  mutation ResetSensor($sensorSelector: SensorSelector!) {
+    resetSensor(sensorSelector: $sensorSelector) {
+      ... on Sensor {
+        id
+        sensorState {
+          id
+          status
+        }
+      }
+      ... on SensorNotFoundError {
+        message
+      }
+      ... on UnauthorizedError {
+        message
+      }
+      ...PythonErrorFragment
+    }
+  }
+
+  ${PYTHON_ERROR_FRAGMENT}
+`;
+
 export const displaySensorMutationErrors = (
-  data: StartSensorMutation | StopRunningSensorMutation,
+  data: StartSensorMutation | StopRunningSensorMutation | ResetSensorMutation,
 ) => {
   let error;
   if ('startSensor' in data && data.startSensor.__typename === 'PythonError') {
     error = data.startSensor;
   } else if ('stopSensor' in data && data.stopSensor.__typename === 'PythonError') {
     error = data.stopSensor;
+  } else if ('resetSensor' in data && data.resetSensor.__typename === 'PythonError') {
+    error = data.resetSensor;
   }
 
   if (error) {
     showCustomAlert({
-      title: 'Schedule Response',
+      title: 'Sensor Response',
       body: <PythonErrorInfo error={error} />,
     });
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorResetButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorResetButton.tsx
@@ -1,0 +1,51 @@
+import {useMutation} from '@apollo/client';
+import {Button, Tooltip} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {RESET_SENSOR_MUTATION, displaySensorMutationErrors} from './SensorMutations';
+import {SensorFragment} from './types/SensorFragment.types';
+import {ResetSensorMutation, ResetSensorMutationVariables} from './types/SensorMutations.types';
+import {DEFAULT_DISABLED_REASON, usePermissionsForLocation} from '../app/Permissions';
+import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
+import {RepoAddress} from '../workspace/types';
+
+interface Props {
+  repoAddress: RepoAddress;
+  sensor: SensorFragment;
+}
+
+export const SensorResetButton = ({repoAddress, sensor}: Props) => {
+  const {
+    permissions: {canStartSensor, canStopSensor},
+  } = usePermissionsForLocation(repoAddress.location);
+
+  const {name} = sensor;
+  const sensorSelector = {
+    ...repoAddressToSelector(repoAddress),
+    sensorName: name,
+  };
+
+  const [resetSensor, {loading: toggleOnInFlight}] = useMutation<
+    ResetSensorMutation,
+    ResetSensorMutationVariables
+  >(RESET_SENSOR_MUTATION, {
+    onCompleted: displaySensorMutationErrors,
+  });
+  const onClick = () => {
+    resetSensor({variables: {sensorSelector}});
+  };
+
+  const hasPermission = canStartSensor && canStopSensor;
+  const disabled = toggleOnInFlight || !hasPermission;
+  const tooltipContent = hasPermission
+    ? `In code, a default status for "${name}" has been set to "${sensor.defaultStatus}". Click here to reset the sensor status to track the status set in code.`
+    : DEFAULT_DISABLED_REASON;
+
+  return (
+    <Tooltip content={tooltipContent} display="flex">
+      <Button disabled={disabled} onClick={onClick}>
+        Reset sensor status
+      </Button>
+    </Tooltip>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorFragment.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorFragment.types.ts
@@ -10,6 +10,8 @@ export type SensorFragment = {
   description: string | null;
   minIntervalSeconds: number;
   sensorType: Types.SensorType;
+  defaultStatus: Types.InstigationStatus;
+  canReset: boolean;
   nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number | null} | null;
   sensorState: {
     __typename: 'InstigationState';

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorMutations.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorMutations.types.ts
@@ -56,3 +56,29 @@ export type StopRunningSensorMutation = {
       }
     | {__typename: 'UnauthorizedError'; message: string};
 };
+
+export type ResetSensorMutationVariables = Types.Exact<{
+  sensorSelector: Types.SensorSelector;
+}>;
+
+export type ResetSensorMutation = {
+  __typename: 'Mutation';
+  resetSensor:
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      }
+    | {
+        __typename: 'Sensor';
+        id: string;
+        sensorState: {__typename: 'InstigationState'; id: string; status: Types.InstigationStatus};
+      }
+    | {__typename: 'SensorNotFoundError'; message: string}
+    | {__typename: 'UnauthorizedError'; message: string};
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorRoot.types.ts
@@ -27,6 +27,8 @@ export type SensorRootQuery = {
         description: string | null;
         minIntervalSeconds: number;
         sensorType: Types.SensorType;
+        defaultStatus: Types.InstigationStatus;
+        canReset: boolean;
         nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number | null} | null;
         sensorState: {
           __typename: 'InstigationState';


### PR DESCRIPTION
## Summary & Motivation

Building off of https://github.com/dagster-io/dagster/pull/19234 and https://github.com/dagster-io/dagster/pull/19242, add a button to reset the instigator status to track what's defined in code.

To do this, we've taken the instigator switch and put it in a row in the instigator details table. We render a button in this row if the user can reset the instigator. This button should only show up if you've taken manual intervention to change the instigator status.

In a follow-up PR, we can this reset behavior to the bulk actions menu.

## How I Tested These Changes

https://github.com/dagster-io/dagster/assets/16431325/f0f880d7-a8ba-4733-84f2-cb26d617e92e

