### PR TITLE
[Sensor AMP page] ticks -> allTicks

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
@@ -116,7 +116,7 @@ export const SensorPageAutomaterialize = (props: Props) => {
     () => {
       return (
         allTicks.map((tick, index) => {
-          const nextTick = ticks[index - 1];
+          const nextTick = allTicks[index - 1];
           // For ticks that get stuck in "Started" state without an endTimestamp.
           if (nextTick && isStuckStartedTick(tick, index)) {
             const copy = {...tick};


### PR DESCRIPTION
## Summary & Motivation

fixes `Cannot access 'ticks' before initialization` error

## How I Tested These Changes
inspection
👀 