### PR TITLE
[ui] Fix dark mode colors on op definition display

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ops/OpTypeSignature.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ops/OpTypeSignature.tsx
@@ -1,7 +1,5 @@
 import {gql} from '@apollo/client';
-// eslint-disable-next-line no-restricted-imports
-import {Code} from '@blueprintjs/core';
-import {FontFamily, colorBackgroundBlue} from '@dagster-io/ui-components';
+import {Code} from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled from 'styled-components';
 
@@ -56,12 +54,7 @@ export const OP_TYPE_SIGNATURE_FRAGMENT = gql`
 `;
 
 const TypeSignature = styled(Code)`
-  && {
-    background: ${colorBackgroundBlue()};
-    font-family: ${FontFamily.monospace};
-    font-size: 14px;
-    padding: 4px;
-    box-shadow: none;
-    color: black;
-  }
+  padding: 4px;
+  box-shadow: none;
+  line-height: 20px;
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/ops/OpsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ops/OpsRoot.tsx
@@ -8,12 +8,12 @@ import {
   TokenizingFieldValue,
   stringFromValue,
   tokenizedValuesFromString,
-  FontFamily,
   colorKeylineDefault,
-  colorBackgroundLight,
   colorBackgroundDefault,
   colorAccentLime,
   colorTextLight,
+  colorTextDefault,
+  colorBackgroundLighter,
 } from '@dagster-io/ui-components';
 import qs from 'qs';
 import * as React from 'react';
@@ -306,11 +306,13 @@ const OpList = (props: OpListProps) => {
             <CellMeasurer cache={cache.current} index={index} parent={parent} key={key}>
               <OpListItem
                 style={style}
-                selected={solid === props.selected}
+                $selected={solid === props.selected}
                 onClick={() => props.onClickOp(solid.definition.name)}
               >
                 <OpName>{solid.definition.name}</OpName>
-                <OpTypeSignature definition={solid.definition} />
+                <div>
+                  <OpTypeSignature definition={solid.definition} />
+                </div>
               </OpListItem>
             </CellMeasurer>
           );
@@ -356,25 +358,20 @@ const OPS_ROOT_QUERY = gql`
   ${OP_TYPE_SIGNATURE_FRAGMENT}
 `;
 
-const OpListItem = styled.div<{selected: boolean}>`
-  background: ${({selected}) => (selected ? colorBackgroundLight() : colorBackgroundDefault())};
+const OpListItem = styled.div<{$selected: boolean}>`
+  align-items: flex-start;
+  background: ${({$selected}) => ($selected ? colorBackgroundLighter() : colorBackgroundDefault())};
   box-shadow:
-    ${({selected}) => (selected ? colorAccentLime() : 'transparent')} 4px 0 0 inset,
+    ${({$selected}) => ($selected ? colorAccentLime() : 'transparent')} 4px 0 0 inset,
     ${colorKeylineDefault()} 0 -1px 0 inset;
-  color: ${colorTextLight()};
+  color: ${({$selected}) => ($selected ? colorTextDefault() : colorTextLight())};
   cursor: pointer;
   font-size: 14px;
   display: flex;
   flex-direction: column;
+  gap: 8px;
   padding: 12px 24px;
   user-select: none;
-
-  & > code.bp4-code {
-    color: ${colorTextLight()};
-    background: transparent;
-    font-family: ${FontFamily.monospace};
-    padding: 5px 0 0 0;
-  }
 `;
 
 const OpName = styled.div`

--- a/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/TypeWithTooltip.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/TypeWithTooltip.tsx
@@ -44,14 +44,12 @@ const TypeLink = styled(Link)`
 const TypeName = styled.code`
   background: ${colorBackgroundBlue()};
   border: none;
-  padding: 1px 4px;
+  padding: 2px 4px;
   border-bottom: 1px solid ${colorAccentBlue()};
   border-radius: 0.25em;
   font-size: 14px;
   font-weight: 500;
-  display: inline-block;
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
-  vertical-align: middle;
 `;


### PR DESCRIPTION
## Summary & Motivation

The colors on type definition `Code` blocks are broken in dark mode. Fix this, and clean up the styles a bit too.

<img width="370" alt="Screenshot 2024-01-17 at 2 52 07 PM" src="https://github.com/dagster-io/dagster/assets/2823852/acd94e87-d421-4ae2-9c40-29d820f9bac7">

<img width="1169" alt="Screenshot 2024-01-17 at 2 51 56 PM" src="https://github.com/dagster-io/dagster/assets/2823852/f769bed2-829f-44bd-a9a9-a24b7bbef0e3">

<img width="1168" alt="Screenshot 2024-01-17 at 2 51 37 PM" src="https://github.com/dagster-io/dagster/assets/2823852/ce6732b1-f6bb-441a-9222-5fa05d7eb9c7">


## How I Tested These Changes

View op explorer and a single op sidebar in light and dark modes. Verify correct rendering.
