### PR TITLE
[ui] Fix error box themed colors

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppError.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppError.tsx
@@ -1,7 +1,13 @@
 import {ServerError} from '@apollo/client';
 import {ErrorResponse, onError} from '@apollo/client/link/error';
 import {Observable} from '@apollo/client/utilities';
-import {FontFamily, Toaster, colorBackgroundRed} from '@dagster-io/ui-components';
+import {
+  FontFamily,
+  Toaster,
+  colorAccentRed,
+  colorBackgroundRed,
+  colorTextDefault,
+} from '@dagster-io/ui-components';
 import {GraphQLError} from 'graphql';
 import memoize from 'lodash/memoize';
 import * as React from 'react';
@@ -78,7 +84,7 @@ interface AppStackTraceLinkProps {
   operationName?: string;
 }
 
-const AppStackTraceLink = ({error, operationName}: AppStackTraceLinkProps) => {
+export const AppStackTraceLink = ({error, operationName}: AppStackTraceLinkProps) => {
   const title = 'Error';
   const stackTrace = error?.extensions?.errorInfo?.stack;
   const cause = error?.extensions?.errorInfo?.cause;
@@ -134,13 +140,13 @@ const AppStackTraceLink = ({error, operationName}: AppStackTraceLinkProps) => {
         className="errorInfo"
         style={{
           backgroundColor: colorBackgroundRed(),
-          border: '1px solid #d17257',
+          border: `1px solid ${colorAccentRed()}`,
           borderRadius: 3,
           maxWidth: '90vw',
           maxHeight: '80vh',
           padding: '1em 2em',
           overflow: 'auto',
-          color: 'rgb(41, 50, 56)',
+          color: colorTextDefault(),
           fontFamily: FontFamily.monospace,
           fontSize: '1em',
           whiteSpace: 'pre',

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__stories__/AppStackTraceLink.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__stories__/AppStackTraceLink.stories.tsx
@@ -1,0 +1,22 @@
+// eslint-disable-next-line no-restricted-imports
+import {Meta} from '@storybook/react';
+import {GraphQLError} from 'graphql';
+import * as React from 'react';
+
+import {AppStackTraceLink} from '../AppError';
+import {CustomAlertProvider} from '../CustomAlertProvider';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'AppStackTraceLink',
+} as Meta;
+
+export const Default = () => {
+  const error = new GraphQLError('failure');
+  return (
+    <>
+      <CustomAlertProvider />
+      <AppStackTraceLink error={error} operationName="FooQuery" />
+    </>
+  );
+};


### PR DESCRIPTION
## Summary & Motivation

The text on the GraphQL error box isn't showing up in dark mode, because it's a hardcoded rgb value. Clean it up.

<img width="1002" alt="Screenshot 2024-01-17 at 4 04 59 PM" src="https://github.com/dagster-io/dagster/assets/2823852/b11b056d-40ec-4261-8d33-d1dfea3e9990">
<img width="1007" alt="Screenshot 2024-01-17 at 3 56 27 PM" src="https://github.com/dagster-io/dagster/assets/2823852/a0386808-7ae2-49eb-a0f5-22b34b172d3f">


## How I Tested These Changes

Storybook example in light/dark.
