### PR TITLE
[dagster-embedded-elt] Sling Translator improvements

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/__init__.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/__init__.py
@@ -1,4 +1,6 @@
+from dagster_embedded_elt.sling.asset_decorator import sling_assets
 from dagster_embedded_elt.sling.asset_defs import build_assets_from_sling_stream, build_sling_asset
+from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
 from dagster_embedded_elt.sling.resources import (
     SlingConnectionResource,
     SlingMode,
@@ -6,6 +8,7 @@ from dagster_embedded_elt.sling.resources import (
     SlingSourceConnection,
     SlingTargetConnection,
 )
+from dagster_embedded_elt.sling.sling_replication import SlingReplicationParam
 
 __all__ = [
     "SlingResource",
@@ -15,4 +18,7 @@ __all__ = [
     "SlingSourceConnection",
     "SlingTargetConnection",
     "SlingConnectionResource",
+    "sling_assets",
+    "DagsterSlingTranslator",
+    "SlingReplicationParam",
 ]

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
@@ -9,6 +9,7 @@ from dagster import (
     multi_asset,
 )
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from sling.translator import DagsterSlingTranslator
 
 from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
 from dagster_embedded_elt.sling.sling_replication import SlingReplicationParam, validate_replication

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
@@ -1,0 +1,135 @@
+from typing import Any, Callable, Iterable, List, Mapping, Optional
+
+from dagster import (
+    AssetsDefinition,
+    AssetSpec,
+    BackfillPolicy,
+    FreshnessPolicy,
+    PartitionsDefinition,
+    multi_asset,
+)
+from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+
+from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
+from dagster_embedded_elt.sling.sling_replication import SlingReplicationParam, validate_replication
+
+
+def get_streams_from_replication(replication_config: Mapping[str, Any]) -> Iterable[str]:
+    """Returns a list of streams from a Sling replication config.
+
+    If an `asset_key` is provided, it will be used instead. For example, below the stream name
+    will be read as `public.foo_users`
+
+
+    .. code-block:: yaml
+
+        streams:
+          public.users:
+            meta:
+              dagster:
+                asset_key: public.foo_users
+
+    Args:
+        replication_config: Mapping[str, Any]: A dictionary of a Sling replication config.
+    """
+    keys = []
+
+    for key, value in replication_config["streams"].items():
+        if isinstance(value, dict):
+            asset_key_config = value.get("meta", {}).get("dagster", {}).get("asset_key", [])
+            keys.append(asset_key_config if asset_key_config else key)
+        else:
+            keys.append(key)
+    return keys
+
+
+def sling_assets(
+    *,
+    replication_config: SlingReplicationParam,
+    dagster_sling_translator: DagsterSlingTranslator = DagsterSlingTranslator(),
+    partitions_def: Optional[PartitionsDefinition] = None,
+    backfill_policy: Optional[BackfillPolicy] = None,
+    op_tags: Optional[Mapping[str, Any]] = None,
+    group_name: Optional[str] = None,
+    code_version: Optional[str] = None,
+    freshness_policy: Optional[FreshnessPolicy] = None,
+    auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
+) -> Callable[..., AssetsDefinition]:
+    """Create a definition for how to materialize a Sling replication stream as a Dagster Asset, as
+    described by a Sling replication config. This will create on Asset for every Sling target stream.
+
+    A Sling Replication config is a configuration that maps sources to destinations. For the full
+    spec and descriptions, see `Sling's Documentation <https://docs.slingdata.io/sling-cli/run/configuration>`_.
+
+    Args:
+        replication_config: SlingReplicationParam: A path to a Sling replication config, or a dictionary of a replication config.
+        dagster_sling_translator: DagsterSlingTranslator: Allows customization of how to map a Sling stream to a Dagster AssetKey.
+        partitions_def: Optional[PartitionsDefinition]: The partitions definition for this asset.
+        backfill_policy: Optional[BackfillPolicy]: The backfill policy for this asset.
+        op_tags: Optional[Mapping[str, Any]]: The tags for this asset.
+        group_name: Optional[str]: The group name for this asset.
+        code_version: Optional[str]: The code version for this asset.
+        freshness_policy: Optional[FreshnessPolicy]: The freshness policy for this asset.
+        auto_materialize_policy: Optional[AutoMaterializePolicy]: The auto materialize policy for this asset.
+
+    Examples:
+        Running a sync by providing a path to a Sling Replication config:
+
+        .. code-block:: python
+
+            from dagster_embedded_elt.sling import sling_assets, SlingResource, SlingConnectionResource
+
+            sling_resource = SlingResource(
+                connections=[
+                    SlingConnectionResource(
+                        name="MY_POSTGRES", type="postgres", connection_string=EnvVar("POSTGRES_URL")
+                    ),
+                    SlingConnectionResource(
+                        name="MY_DUCKDB",
+                        type="duckdb",
+                        connection_string="duckdb:///var/tmp/duckdb.db",
+                    ),
+                ]
+            )
+
+            config_path = "/path/to/replication.yaml"
+            @sling_assets(replication_config=config_path)
+            def my_assets(context, sling: SlingResource):
+                for lines in sling.replicate(
+                    replication_config=config_path,
+                    dagster_sling_translator=DagsterSlingTranslator(),
+                ):
+                    context.log.info(lines)
+
+        Running a sync using a custom translator:
+    """
+    replication_config = validate_replication(replication_config)
+    streams = get_streams_from_replication(replication_config)
+
+    specs: List[AssetSpec] = []
+    for stream in streams:
+        specs.append(
+            AssetSpec(
+                key=dagster_sling_translator.get_asset_key(stream),
+                deps=dagster_sling_translator.get_deps_asset_key(stream),
+                group_name=group_name,
+                code_version=code_version,
+                freshness_policy=freshness_policy,
+                auto_materialize_policy=auto_materialize_policy,
+            )
+        )
+
+    def inner(fn) -> AssetsDefinition:
+        asset_definition = multi_asset(
+            name="sling_asset_definition",
+            compute_kind="sling",
+            partitions_def=partitions_def,
+            can_subset=False,
+            op_tags=op_tags,
+            backfill_policy=backfill_policy,
+            specs=specs,
+        )(fn)
+
+        return asset_definition
+
+    return inner

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any, Mapping
 
 from dagster import AssetKey
 from dagster._annotations import public
@@ -31,11 +32,18 @@ class DagsterSlingTranslator:
 
     @public
     @classmethod
-    def get_asset_key(cls, stream_name: str, target_prefix: str = "target") -> AssetKey:
-        """A function that takes a stream name from a Sling replication config and returns a
+    def get_asset_key(
+        cls, stream_definition: Mapping[str, Any], target_prefix: str = "target"
+    ) -> AssetKey:
+        """A function that takes a stream definition from a Sling replication config and returns a
         Dagster AssetKey.
 
-        By default, this returns concatenates `target_` with the stream name. For example, a stream
+        The stream definition is a dictionary key/value pair where the key is the stream name and
+        the value is a dictionary representing the stream definition. For example:
+
+        stream_definition = {"public.users": {'sql': 'select all_user_id, name from public."all_Users"', 'object': 'public.all_users'}}
+
+        By default, this returns the target_prefix concatenated with the stream name. For example, a stream
         named "public.accounts" will create an AssetKey named "target_public_accounts".
 
         Override this function to customize how to map a Sling stream to a Dagster AssetKey.
@@ -51,8 +59,8 @@ class DagsterSlingTranslator:
                    asset_key: "mydb_users"
 
         Args:
-            stream_name (str): The name of the stream.
-            target_prefix (str): The prefix for the target stream.
+            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition
+            target_prefix (str): The prefix to use when creating the AssetKey
 
         Returns:
             AssetKey: The Dagster AssetKey for the replication stream.
@@ -60,20 +68,29 @@ class DagsterSlingTranslator:
         Examples:
             Using a custom mapping for streams:
 
-            .. code-block:: python
-
-                class CustomSlingTranslator(DagsterSlingTranslator):
-                    @classmethod
-                    def get_asset_key(cls, stream_name: str) -> AssetKey:
-                        map = {"stream1": "asset1", "stream2": "asset2"}
-                        return AssetKey(map[stream_name])
+            class CustomSlingTranslator(DagsterSlingTranslator):
+                @classmethod
+                def get_asset_key_for_target(cls, stream_definition) -> AssetKey:
+                    map = {"stream1": "asset1", "stream2": "asset2"}
+                    return AssetKey(map[stream_name])
         """
+        meta = stream_definition.get("meta", {}).get("dagster", {})
+        asset_key = meta.get("asset_key")
+        if asset_key and cls.sanitize_stream_name(asset_key) != asset_key:
+            raise ValueError(
+                f"Asset key {asset_key} for stream {stream_definition['name']} is not "
+                "sanitized. Please use only alphanumeric characters and underscores."
+            )
+        elif asset_key:
+            return AssetKey(asset_key)
+
+        stream_name = next(iter(stream_definition.keys()))
         components = cls.sanitize_stream_name(stream_name).split(".")
         return AssetKey([target_prefix] + components)
 
     @public
     @classmethod
-    def get_deps_asset_key(cls, stream_name: str) -> AssetKey:
+    def get_deps_asset_key(cls, stream_definition: Mapping[str, Any]) -> AssetKey:
         """A function that takes a stream name from a Sling replication config and returns a
         Dagster AssetKey for the dependencies of the replication stream.
 
@@ -107,5 +124,16 @@ class DagsterSlingTranslator:
 
 
         """
+        meta = stream_definition.get("meta", {}).get("dagster", {})
+        asset_key = meta.get("deps")
+        if asset_key and cls.sanitize_stream_name(asset_key) != asset_key:
+            raise ValueError(
+                f"Asset key {asset_key} for stream {stream_definition['name']} is not "
+                "sanitized. Please use only alphanumeric characters and underscores."
+            )
+        elif asset_key:
+            return AssetKey(asset_key)
+
+        stream_name = next(iter(stream_definition.keys()))
         components = cls.sanitize_stream_name(stream_name).split(".")
         return AssetKey(components)

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
@@ -1,11 +1,24 @@
 import re
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping, Optional
 
-from dagster import AssetKey
+from dagster import (
+    AssetKey,
+    AutoMaterializePolicy,
+    FreshnessPolicy,
+    MetadataValue,
+)
 from dagster._annotations import public
 
 
 class DagsterSlingTranslator:
+    def __init__(self, target_prefix="target"):
+        """A class that allows customization of how to map a Sling stream to a Dagster AssetKey.
+
+        Args:
+            target_prefix (str): The prefix to use when creating the AssetKey
+        """
+        self.target_prefix = target_prefix
+
     @public
     @classmethod
     def sanitize_stream_name(cls, stream_name: str) -> str:
@@ -31,10 +44,7 @@ class DagsterSlingTranslator:
         return re.sub(r"[^a-zA-Z0-9_.]", "_", stream_name.replace('"', ""))
 
     @public
-    @classmethod
-    def get_asset_key(
-        cls, stream_definition: Mapping[str, Any], target_prefix: str = "target"
-    ) -> AssetKey:
+    def get_asset_key(self, stream_definition: Mapping[str, Any]) -> AssetKey:
         """A function that takes a stream definition from a Sling replication config and returns a
         Dagster AssetKey.
 
@@ -43,7 +53,7 @@ class DagsterSlingTranslator:
 
         stream_definition = {"public.users": {'sql': 'select all_user_id, name from public."all_Users"', 'object': 'public.all_users'}}
 
-        By default, this returns the target_prefix concatenated with the stream name. For example, a stream
+        By default, this returns the class's target_prefix paramater concatenated with the stream name. For example, a stream
         named "public.accounts" will create an AssetKey named "target_public_accounts".
 
         Override this function to customize how to map a Sling stream to a Dagster AssetKey.
@@ -60,7 +70,6 @@ class DagsterSlingTranslator:
 
         Args:
             stream_definition (Mapping[str, Any]): A dictionary representing the stream definition
-            target_prefix (str): The prefix to use when creating the AssetKey
 
         Returns:
             AssetKey: The Dagster AssetKey for the replication stream.
@@ -74,23 +83,25 @@ class DagsterSlingTranslator:
                     map = {"stream1": "asset1", "stream2": "asset2"}
                     return AssetKey(map[stream_name])
         """
-        meta = stream_definition.get("meta", {}).get("dagster", {})
-        asset_key = meta.get("asset_key")
-        if asset_key and cls.sanitize_stream_name(asset_key) != asset_key:
-            raise ValueError(
-                f"Asset key {asset_key} for stream {stream_definition['name']} is not "
-                "sanitized. Please use only alphanumeric characters and underscores."
-            )
-        elif asset_key:
-            return AssetKey(asset_key)
+        config = stream_definition.get("config", {}) or {}
+        meta = config.get("meta", {})
+        asset_key = meta.get("dagster", {}).get("asset_key")
 
-        stream_name = next(iter(stream_definition.keys()))
-        components = cls.sanitize_stream_name(stream_name).split(".")
-        return AssetKey([target_prefix] + components)
+        if asset_key:
+            if self.sanitize_stream_name(asset_key) != asset_key:
+                raise ValueError(
+                    f"Asset key {asset_key} for stream {stream_definition['name']} is not "
+                    "sanitized. Please use only alphanumeric characters and underscores."
+                )
+            return AssetKey(asset_key.split("."))
+
+        stream_name = stream_definition["name"]
+        sanitized_components = self.sanitize_stream_name(stream_name).split(".")
+        return AssetKey([self.target_prefix] + sanitized_components)
 
     @public
     @classmethod
-    def get_deps_asset_key(cls, stream_definition: Mapping[str, Any]) -> AssetKey:
+    def get_deps_asset_key(cls, stream_definition: Mapping[str, Any]) -> Iterable[AssetKey]:
         """A function that takes a stream name from a Sling replication config and returns a
         Dagster AssetKey for the dependencies of the replication stream.
 
@@ -124,16 +135,71 @@ class DagsterSlingTranslator:
 
 
         """
-        meta = stream_definition.get("meta", {}).get("dagster", {})
-        asset_key = meta.get("deps")
-        if asset_key and cls.sanitize_stream_name(asset_key) != asset_key:
-            raise ValueError(
-                f"Asset key {asset_key} for stream {stream_definition['name']} is not "
-                "sanitized. Please use only alphanumeric characters and underscores."
-            )
-        elif asset_key:
-            return AssetKey(asset_key)
+        config = stream_definition.get("config", {}) or {}
+        meta = config.get("meta", {})
+        deps = meta.get("dagster", {}).get("deps")
+        deps_out = []
+        if deps and isinstance(deps, str):
+            deps = [deps]
+        if deps:
+            assert isinstance(deps, list)
+            for asset_key in deps:
+                if cls.sanitize_stream_name(asset_key) != asset_key:
+                    raise ValueError(
+                        f"Deps Asset key {asset_key} for stream {stream_definition['name']} is not "
+                        "sanitized. Please use only alphanumeric characters and underscores."
+                    )
+                deps_out.append(AssetKey(asset_key.split(".")))
+            return deps_out
 
-        stream_name = next(iter(stream_definition.keys()))
+        stream_name = stream_definition["name"]
         components = cls.sanitize_stream_name(stream_name).split(".")
-        return AssetKey(components)
+        return [AssetKey(components)]
+
+    @classmethod
+    @public
+    def get_description(cls, stream_definition: Mapping[str, Any]) -> Optional[str]:
+        config = stream_definition.get("config", {}) or {}
+        if "sql" in config:
+            return config["sql"]
+        meta = config.get("meta", {})
+        description = meta.get("dagster", {}).get("description")
+        return description
+
+    @classmethod
+    @public
+    def get_metadata(cls, stream_definition: Mapping[str, Any]) -> Mapping[str, Any]:
+        return {"stream_config": MetadataValue.json(stream_definition.get("config", {}))}
+
+    @classmethod
+    @public
+    def get_group_name(cls, stream_definition: Mapping[str, Any]) -> Optional[str]:
+        config = stream_definition.get("config", {}) or {}
+        meta = config.get("meta", {})
+        return meta.get("dagster", {}).get("group")
+
+    @classmethod
+    @public
+    def get_freshness_policy(
+        cls, stream_definition: Mapping[str, Any]
+    ) -> Optional[FreshnessPolicy]:
+        config = stream_definition.get("config", {}) or {}
+        meta = config.get("meta", {})
+        freshness_policy_config = meta.get("dagster", {}).get("freshness_policy")
+        if freshness_policy_config:
+            return FreshnessPolicy(
+                maximum_lag_minutes=float(freshness_policy_config["maximum_lag_minutes"]),
+                cron_schedule=freshness_policy_config.get("cron_schedule"),
+                cron_schedule_timezone=freshness_policy_config.get("cron_schedule_timezone"),
+            )
+
+    @classmethod
+    @public
+    def get_auto_materialize_policy(
+        cls, stream_definition: Mapping[str, Any]
+    ) -> Optional[AutoMaterializePolicy]:
+        config = stream_definition.get("config", {}) or {}
+        meta = config.get("meta", {})
+        auto_materialize_policy_config = "auto_materialize_policy" in meta.get("dagster", {})
+        if auto_materialize_policy_config:
+            return AutoMaterializePolicy.eager()

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
@@ -1,0 +1,111 @@
+import re
+
+from dagster import AssetKey
+from dagster._annotations import public
+
+
+class DagsterSlingTranslator:
+    @public
+    @classmethod
+    def sanitize_stream_name(cls, stream_name: str) -> str:
+        """A function that takes a stream name from a Sling replication config and returns a
+        sanitized name for the stream.
+
+        By default, this removes any non-alphanumeric characters from the stream name and replaces
+        them with underscores, while removing any double quotes.
+
+        Args:
+            stream_name (str): The name of the stream.
+
+        Examples:
+            Using a custom stream name sanitizer:
+
+            .. code-block:: python
+
+                class CustomSlingTranslator(DagsterSlingTranslator):
+                    @classmethod
+                    def sanitize_stream_name(cls, stream_name: str) -> str:
+                        return stream_name.replace(".", "")
+        """
+        return re.sub(r"[^a-zA-Z0-9_.]", "_", stream_name.replace('"', ""))
+
+    @public
+    @classmethod
+    def get_asset_key(cls, stream_name: str, target_prefix: str = "target") -> AssetKey:
+        """A function that takes a stream name from a Sling replication config and returns a
+        Dagster AssetKey.
+
+        By default, this returns concatenates `target_` with the stream name. For example, a stream
+        named "public.accounts" will create an AssetKey named "target_public_accounts".
+
+        Override this function to customize how to map a Sling stream to a Dagster AssetKey.
+
+        Alternatively, you can provide metadata in your Sling replication config to specify the
+        Dagster AssetKey for a stream as follows:
+
+        .. code-block:: yaml
+
+            public.users:
+               meta:
+                 dagster:
+                   asset_key: "mydb_users"
+
+        Args:
+            stream_name (str): The name of the stream.
+            target_prefix (str): The prefix for the target stream.
+
+        Returns:
+            AssetKey: The Dagster AssetKey for the replication stream.
+
+        Examples:
+            Using a custom mapping for streams:
+
+            .. code-block:: python
+
+                class CustomSlingTranslator(DagsterSlingTranslator):
+                    @classmethod
+                    def get_asset_key(cls, stream_name: str) -> AssetKey:
+                        map = {"stream1": "asset1", "stream2": "asset2"}
+                        return AssetKey(map[stream_name])
+        """
+        components = cls.sanitize_stream_name(stream_name).split(".")
+        return AssetKey([target_prefix] + components)
+
+    @public
+    @classmethod
+    def get_deps_asset_key(cls, stream_name: str) -> AssetKey:
+        """A function that takes a stream name from a Sling replication config and returns a
+        Dagster AssetKey for the dependencies of the replication stream.
+
+        By default, this returns the stream name. For example, a stream
+        named "public.accounts" will create an AssetKey named "target_public_accounts" and a
+        dependency named "public_accounts".
+
+        Override this function to customize how to map a Sling stream to a Dagster depenency.
+        Alternatively, you can provide metadata in your Sling replication config to specify the
+        Dagster AssetKey for a stream as follows:
+
+        public.users:
+           meta:
+             dagster:
+               deps: "sourcedb_users"
+
+        Args:
+            stream_name (str): The name of the stream.
+
+        Returns:
+            AssetKey: The Dagster AssetKey dependency for the replication stream.
+
+        Examples:
+            Using a custom mapping for streams:
+
+            class CustomSlingTranslator(DagsterSlingTranslator):
+                @classmethod
+                def get_deps_asset_key(cls, stream_name: str) -> AssetKey:
+                    map = {"stream1": "asset1", "stream2": "asset2"}
+                    return AssetKey(map[stream_name])
+
+
+        """
+        components = cls.sanitize_stream_name(stream_name).split(".")
+        return AssetKey(components)

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -8,7 +8,6 @@ from typing import IO, Any, AnyStr, Dict, Generator, Iterator, List, Optional
 
 from dagster import (
     ConfigurableResource,
-    MaterializeResult,
     PermissiveConfig,
     get_dagster_logger,
 )
@@ -17,8 +16,6 @@ from dagster._config.field_utils import EnvVar
 from dagster._utils.env import environ
 from pydantic import ConfigDict, Extra, Field
 from sling import Sling
-
-from dagster_embedded_elt.sling.asset_decorator import DagsterSlingTranslator
 
 logger = get_dagster_logger()
 
@@ -131,7 +128,6 @@ class _SlingSyncBase:
     def replicate(
         self,
         *,
-        dagster_sling_translator: DagsterSlingTranslator,
         source_stream: str,
         target_object: str,
         mode: SlingMode,
@@ -153,9 +149,6 @@ class _SlingSyncBase:
             logger.info(line)
             logs += line
             # TODO: capture actual metadata here
-
-        output_name = dagster_sling_translator.get_asset_key(target_object)
-        yield MaterializeResult(asset_key=output_name, metadata={"logs": logs})
 
     def sync(
         self,

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -6,12 +6,19 @@ from enum import Enum
 from subprocess import PIPE, STDOUT, Popen
 from typing import IO, Any, AnyStr, Dict, Generator, Iterator, List, Optional
 
-from dagster import ConfigurableResource, PermissiveConfig, get_dagster_logger
+from dagster import (
+    ConfigurableResource,
+    MaterializeResult,
+    PermissiveConfig,
+    get_dagster_logger,
+)
 from dagster._annotations import experimental
 from dagster._config.field_utils import EnvVar
 from dagster._utils.env import environ
 from pydantic import ConfigDict, Extra, Field
 from sling import Sling
+
+from dagster_embedded_elt.sling.asset_decorator import DagsterSlingTranslator
 
 logger = get_dagster_logger()
 
@@ -120,6 +127,35 @@ class _SlingSyncBase:
             proc.wait()
             if proc.returncode != 0:
                 raise Exception("Sling command failed with error code %s", proc.returncode)
+
+    def replicate(
+        self,
+        *,
+        dagster_sling_translator: DagsterSlingTranslator,
+        source_stream: str,
+        target_object: str,
+        mode: SlingMode,
+        primary_key: Optional[List[str]] = None,
+        update_key: Optional[str] = None,
+        source_options: Optional[Dict[str, Any]] = None,
+        target_options: Optional[Dict[str, Any]] = None,
+    ):
+        logs = ""
+        for line in self.sync(
+            source_stream,
+            target_object,
+            mode,
+            primary_key,
+            update_key,
+            source_options,
+            target_options,
+        ):
+            logger.info(line)
+            logs += line
+            # TODO: capture actual metadata here
+
+        output_name = dagster_sling_translator.get_asset_key(target_object)
+        yield MaterializeResult(asset_key=output_name, metadata={"logs": logs})
 
     def sync(
         self,

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_replication.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_replication.py
@@ -1,0 +1,31 @@
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Mapping, Union, cast
+
+import dagster._check as check
+import yaml
+
+SlingReplicationParam = Union[Mapping[str, Any], str, Path]
+
+
+@lru_cache(maxsize=None)
+def read_replication_path(replication_path: Path) -> Mapping[str, Any]:
+    """Reads a Sling replication config from a path and returns a dict.
+
+    This function is cached to ensure that we don't read the same path multiple times, which
+    creates multiple copies of the parsed manifest in memory.
+    """
+    return cast(Mapping[str, Any], yaml.safe_load(replication_path.read_bytes()))
+
+
+def validate_replication(replication: SlingReplicationParam) -> Mapping[str, Any]:
+    check.inst_param(replication, "manifest", (Path, str, dict))
+
+    if isinstance(replication, str):
+        replication = Path(replication)
+
+    if isinstance(replication, Path):
+        # Resolve the path to ensure a consistent key for the cache
+        replication = read_replication_path(replication.resolve())
+
+    return replication

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/conftest.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/conftest.py
@@ -1,0 +1,38 @@
+import os
+import sqlite3
+import tempfile
+
+import pytest
+from dagster import file_relative_path
+from dagster_embedded_elt.sling import (
+    SlingResource,
+    SlingSourceConnection,
+    SlingTargetConnection,
+)
+
+
+@pytest.fixture
+def test_csv():
+    return os.path.abspath(file_relative_path(__file__, "test.csv"))
+
+
+@pytest.fixture
+def sqlite_connection(temp_db):
+    yield sqlite3.connect(temp_db)
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir_path:
+        dbpath = os.path.join(tmpdir_path, "sqlite.db")
+        yield dbpath
+
+
+@pytest.fixture
+def sling_sqlite_resource(temp_db):
+    return SlingResource(
+        source_connection=SlingSourceConnection(type="file"),
+        target_connection=SlingTargetConnection(
+            type="sqlite", connection_string=f"sqlite://{temp_db}"
+        ),
+    )

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_replication.yaml
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_replication.yaml
@@ -16,7 +16,11 @@ streams:
     object: "departments" # overwrite default object
     source_options:
       empty_as_null: false
-
+    meta:
+      dagster:
+        deps:
+          - foo_one
+          - foo_two
   public."Transactions":
     mode: incremental # overwrite default mode
     primary_key: id

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_replication.yaml
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_replication.yaml
@@ -1,0 +1,33 @@
+source: MY_SOURCE
+target: MY_TARGET
+
+defaults:
+  mode: full-refresh
+  object: "{stream_schema}_{stream_table}"
+
+streams:
+  public.accounts:
+  public.users:
+    disabled: true
+    meta:
+      dagster:
+        asset_key: public.foo_users
+  public.finance_departments_old:
+    object: "departments" # overwrite default object
+    source_options:
+      empty_as_null: false
+
+  public."Transactions":
+    mode: incremental # overwrite default mode
+    primary_key: id
+    update_key: last_updated_at
+
+  public.all_users:
+    sql: |
+      select all_user_id, name 
+      from public."all_Users"
+    object: public.all_users # need to add 'object' key for custom SQL
+
+env:
+  SLING_LOADED_AT_COLUMN: true # adds the _sling_loaded_at timestamp column
+  SLING_STREAM_URL_COLUMN: true # if source is file, adds a _sling_stream_url column with file path / url

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
@@ -1,0 +1,46 @@
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+from dagster import AssetKey
+from dagster_embedded_elt.sling import (
+    SlingReplicationParam,
+    sling_assets,
+)
+from dagster_embedded_elt.sling.asset_decorator import get_streams_from_replication
+
+replication_path = Path(__file__).joinpath("..", "sling_replication.yaml").resolve()
+with replication_path.open("r") as f:
+    replication = yaml.safe_load(f)
+
+
+@pytest.mark.parametrize(
+    "replication", [replication, replication_path, os.fspath(replication_path)]
+)
+def test_replication_argument(replication: SlingReplicationParam):
+    @sling_assets(replication_config=replication)
+    def my_sling_assets():
+        ...
+
+    assert my_sling_assets.keys == {
+        AssetKey.from_user_string(key)
+        for key in [
+            "target/public/accounts",
+            "target/public/foo_users",
+            "target/public/Transactions",
+            "target/public/all_users",
+            "target/public/finance_departments_old",
+        ]
+    }
+
+
+def test_streams_from_replication():
+    streams = get_streams_from_replication(replication)
+    assert set(streams) == {
+        "public.accounts",
+        "public.foo_users",
+        'public."Transactions"',
+        "public.all_users",
+        "public.finance_departments_old",
+    }

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_dagster_sling_translator.py
@@ -1,0 +1,150 @@
+import pytest
+from dagster import AssetKey, AutoMaterializePolicy, FreshnessPolicy, JsonMetadataValue
+from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
+
+
+@pytest.mark.parametrize(
+    "test,expected",
+    [
+        ("foo", "foo"),
+        ("foo.bar", "foo.bar"),
+        ("foo.$bar$", "foo._bar_"),
+    ],
+)
+def test_sling_translator_sanitize(test, expected):
+    translator = DagsterSlingTranslator()
+
+    assert translator.sanitize_stream_name(test) == expected
+
+
+@pytest.mark.parametrize(
+    "stream,expected",
+    [
+        ({"name": "foo"}, "target/foo"),
+        ({"name": "public.foo"}, "target/public/foo"),
+        (
+            {"name": "foo", "config": {"meta": {"dagster": {"asset_key": "foo.bar"}}}},
+            "foo/bar",
+        ),
+    ],
+)
+def test_get_asset_key(stream, expected):
+    translator = DagsterSlingTranslator()
+    assert translator.get_asset_key(stream) == AssetKey.from_user_string(expected)
+
+
+def test_get_asset_key_error():
+    stream_definition = {"name": "foo", "config": {"meta": {"dagster": {"asset_key": "foo$bar"}}}}
+    translator = DagsterSlingTranslator()
+    with pytest.raises(ValueError):
+        translator.get_asset_key(stream_definition)
+
+
+@pytest.mark.parametrize(
+    "stream,expected",
+    [
+        ({"name": "foo"}, ["foo"]),
+        ({"name": "public.foo"}, ["public/foo"]),
+        (
+            {"name": "foo", "config": {"meta": {"dagster": {"deps": "foo.bar"}}}},
+            ["foo/bar"],
+        ),
+        (
+            {"name": "foo", "config": {"meta": {"dagster": {"deps": ["foo_one", "foo_two"]}}}},
+            ["foo_one", "foo_two"],
+        ),
+    ],
+)
+def test_get_deps_asset_key(stream, expected):
+    translator = DagsterSlingTranslator()
+    assert translator.get_deps_asset_key(stream) == [AssetKey.from_user_string(e) for e in expected]
+
+
+def test_get_deps_asset_key_error():
+    stream_definition = {"name": "foo", "config": {"meta": {"dagster": {"deps": "foo$bar"}}}}
+    translator = DagsterSlingTranslator()
+    with pytest.raises(ValueError):
+        translator.get_deps_asset_key(stream_definition)
+
+
+@pytest.mark.parametrize(
+    "stream,expected",
+    [
+        ({"name": "foo"}, None),
+        ({"name": "public.foo"}, None),
+        (
+            {"name": "foo", "config": {"meta": {"dagster": {"description": "foo.bar"}}}},
+            "foo.bar",
+        ),
+    ],
+)
+def test_get_description(stream, expected):
+    translator = DagsterSlingTranslator()
+    assert translator.get_description(stream) == expected
+
+
+@pytest.mark.parametrize(
+    "stream,expected",
+    [
+        ({"name": "foo"}, None),
+        (
+            {"name": "foo", "config": {"meta": {"dagster": {"description": "foo.bar"}}}},
+            "foo.bar",
+        ),
+    ],
+)
+def test_get_metadata(stream, expected):
+    translator = DagsterSlingTranslator()
+    stream = {"name": "foo", "config": {"foo": "bar"}}
+    assert translator.get_metadata(stream) == {"stream_config": JsonMetadataValue(stream["config"])}
+
+
+@pytest.mark.parametrize(
+    "stream,expected",
+    [
+        ({"name": "foo"}, None),
+        (
+            {"name": "foo", "config": {"meta": {"dagster": {"group": "foo.bar"}}}},
+            "foo.bar",
+        ),
+    ],
+)
+def test_get_group_name(stream, expected):
+    translator = DagsterSlingTranslator()
+    assert translator.get_group_name(stream) == expected
+
+
+@pytest.mark.parametrize(
+    "stream,expected",
+    [
+        ({"name": "foo"}, None),
+        (
+            {
+                "name": "foo",
+                "config": {"meta": {"dagster": {"freshness_policy": {"maximum_lag_minutes": 5}}}},
+            },
+            FreshnessPolicy(maximum_lag_minutes=5),
+        ),
+    ],
+)
+def test_get_freshness_policy(stream, expected):
+    translator = DagsterSlingTranslator()
+    assert translator.get_freshness_policy(stream) == expected
+
+
+@pytest.mark.parametrize(
+    "stream,expected",
+    [
+        ({"name": "foo"}, None),
+        (
+            {
+                "name": "foo",
+                "config": {"meta": {"dagster": {"auto_materialize_policy": {}}}},
+            },
+            AutoMaterializePolicy.eager(),
+        ),
+    ],
+)
+def test_get_auto_materialize_policy(stream, expected):
+    translator = DagsterSlingTranslator()
+    assert translator.get_auto_materialize_policy(stream) == expected

--- a/python_modules/libraries/dagster-embedded-elt/setup.py
+++ b/python_modules/libraries/dagster-embedded-elt/setup.py
@@ -33,7 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_embedded_elt_tests*"]),
-    install_requires=[f"dagster{pin}", "sling>=1.0.20"],
+    install_requires=[f"dagster{pin}", "sling>=1.1.5"],
     zip_safe=False,
     extras_require={},
 )


### PR DESCRIPTION
## Summary & Motivation

Moves the Sling Translator into its own module, and adds some default functions for AMP, Freshness Policies, and group name. 

These can be supplied as a `meta:` field in the replication config. 

## How I Tested These Changes

Unit tests