### PR TITLE
[docs] Updating BD guide to use actual GHA arg name

### DIFF
--- a/docs/content/guides/dagster/branch_deployments.mdx
+++ b/docs/content/guides/dagster/branch_deployments.mdx
@@ -302,7 +302,7 @@ name: Dagster Branch Deployments
           with:
             location_name: ${{ matrix.location.name }}
             deployment: ${{ steps.deploy.outputs.deployment }}
-            job: clone_prod
+            job_name: clone_prod
           env:
             DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_URL }}
             DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
@@ -437,7 +437,7 @@ name: Dagster Branch Deployments
           with:
             location_name: ${{ matrix.location.name }}
             deployment: ${{ steps.deploy.outputs.deployment }}
-            job: drop_prod_clone
+            job_name: drop_prod_clone
           env:
             DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_URL }}
             DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/branch_deployments/clone_prod.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/branch_deployments/clone_prod.yaml
@@ -22,7 +22,7 @@ name: Dagster Branch Deployments
           with:
             location_name: ${{ matrix.location.name }}
             deployment: ${{ steps.deploy.outputs.deployment }}
-            job: clone_prod
+            job_name: clone_prod
           env:
             DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_URL }}
             DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/branch_deployments/drop_db_clone.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/branch_deployments/drop_db_clone.yaml
@@ -24,7 +24,7 @@ name: Dagster Branch Deployments
           with:
             location_name: ${{ matrix.location.name }}
             deployment: ${{ steps.deploy.outputs.deployment }}
-            job: drop_prod_clone
+            job_name: drop_prod_clone
           env:
             DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_URL }}
             DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}


### PR DESCRIPTION
## Summary & Motivation
Context: https://dagsterlabs.slack.com/archives/C03E60FPJCU/p1705552397002939

Looks like the GHA was updated over a year ago to use an explicit `job_name` arg rather than the `job` arg and the docs weren't updated. Swapping to `job_name` to reflect the state of the github action

## How I Tested These Changes
