### PR TITLE
[prototype] sub-context for each upstream dependency 

### DIFF
--- a/examples/partition_example/partition_example.py
+++ b/examples/partition_example/partition_example.py
@@ -33,7 +33,7 @@ def relativedelta(*args, **kwargs):
     metadata={"partition_expr": "LastModifiedDate"},
 )
 def salesforce_customers(context: AssetExecutionContext) -> pd.DataFrame:
-    start_date_str = context.asset_partition_key_for_output()
+    start_date_str = context.partition_key
 
     timezone = pytz.timezone("GMT")  # Replace 'Your_Timezone' with the desired timezone
     start_obj = datetime.datetime.strptime(start_date_str, "%Y-%m-%d").replace(tzinfo=timezone)
@@ -65,7 +65,7 @@ def realized_vol(context: AssetExecutionContext, orats_daily_prices: pd.DataFram
     The volatility is calculated using various methods such as close-to-close, Parkinson, Hodges-Tompkins, and Yang-Zhang.
     The function returns a DataFrame with the calculated volatilities.
     """
-    trade_date = context.asset_partition_key_for_output()
+    trade_date = context.partition_key
     ticker_id = 1
 
     df = all_realvols(orats_daily_prices, ticker_id, trade_date)
@@ -80,7 +80,7 @@ hourly_partitions = HourlyPartitionsDefinition(start_date="2024-01-01")
 
 @asset(io_manager_def="parquet_io_manager", partitions_def=hourly_partitions)
 def my_custom_df(context: AssetExecutionContext) -> pd.DataFrame:
-    start, end = context.asset_partitions_time_window_for_output()
+    start, end = context.partition_time_window
 
     df = pd.DataFrame({"timestamp": pd.date_range(start, end, freq="5T")})
     df["count"] = df["timestamp"].map(lambda a: random.randint(1, 1000))
@@ -93,7 +93,7 @@ def fetch_blog_posts_from_external_api(*args, **kwargs):
 
 @asset(partitions_def=HourlyPartitionsDefinition(start_date="2022-01-01-00:00"))
 def blog_posts(context: AssetExecutionContext) -> List[Dict]:
-    partition_datetime_str = context.asset_partition_key_for_output()
+    partition_datetime_str = context.partition_key
     hour = datetime.datetime.fromisoformat(partition_datetime_str)
     posts = fetch_blog_posts_from_external_api(hour_when_posted=hour)
     return posts
@@ -106,7 +106,7 @@ def blog_posts(context: AssetExecutionContext) -> List[Dict]:
     key_prefix=["snowflake", "eldermark_proxy"],
 )
 def resident(context: AssetExecutionContext) -> Output[pd.DataFrame]:
-    start, end = context.asset_partitions_time_window_for_output()
+    start, end = context.partition_time_window
     filter_str = f"LastMod_Stamp >= {start.timestamp()} AND LastMod_Stamp < {end.timestamp()}"
 
     records = context.resources.eldermark.fetch_obj(obj="Resident", filter=filter_str)


### PR DESCRIPTION
## Summary & Motivation
This PR is a prototype for a potential API for partition methods on the `AssetExecutionContext`. This version adds a `DepContext` that contains various methods that are scoped to a particular upstream dependency, including partition methods

No Hooli or DOP PR for this one since those repos just use partition methods for the currently materializing asset. They would look identical to the PRs for API 1 (Hooli PR - https://github.com/dagster-io/hooli-data-eng-pipelines/pull/59 DOP PR - https://github.com/dagster-io/internal/pull/7903)


## How I Tested These Changes

