### PR TITLE
Support partitioned assets for fetching latest AssetMaterializations

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -4,6 +4,7 @@ from contextvars import ContextVar
 from inspect import (
     _empty as EmptyAnnotation,
 )
+import pstats
 from typing import (
     AbstractSet,
     Any,
@@ -1485,13 +1486,17 @@ class AssetExecutionContext(OpExecutionContext):
         materialization_events = (
             self.op_execution_context._step_execution_context.upstream_asset_materialization_events  # noqa: SLF001
         )
-        if AssetKey.from_coercible(key) in materialization_events.keys():
-            return materialization_events.get(AssetKey.from_coercible(key))
+        if self.has_partition_key:
+            # if the asset is par
+            pass
+        else:
+            if AssetKey.from_coercible(key) in materialization_events.keys():
+                return materialization_events.get(AssetKey.from_coercible(key))
 
-        raise DagsterInvariantViolationError(
-            f"Cannot fetch AssetMaterialization for asset {key}. {key} must be an upstream dependency"
-            "in order to call latest_materialization_for_upstream_asset."
-        )
+            raise DagsterInvariantViolationError(
+                f"Cannot fetch AssetMaterialization for asset {key}. {key} must be an upstream dependency"
+                "in order to call latest_materialization_for_upstream_asset."
+            )
 
     ######## Deprecated methods
 


### PR DESCRIPTION
## Summary & Motivation
In https://github.com/dagster-io/dagster/pull/18971 we piggy-back on the versioning code path to provide `AssetMaterialization`s for the direct upstream dependencies for a currently materializing asset on the context. However, due to scaling constraints, the versioning code path always fetches the latest `AssetMaterialization` without considering the partitions that are relevant to the current execution. 

This means that for partitioned assets, the information provided via `latest_materialization_for_upstream_asset` could be incorrect. Consider the following scenario:

```python
partitions_def = DailyPartitionsDefinition(start_date="2024-01-01")

@asset(partitions_def=partitions_def)
def upstream(context):
    return MaterializeResult(metadata={"partition_key": context.partition_key})

@asset(partitions_def=partitions_def, deps=[upstream])
def downstream(context: AssetExecutionContext):
    mat = context.latest_materialization_for_upstream_asset("upstream")
    assert mat is not None
    assert mat.metadata["partition_key"].value == context.partition_key
```

If we materialized partition `2024-01-01` of `upstream`, then materialized partition `2024-01-02` of `upstream`. At this point the latest `AssetMaterialization` for `upstream` is the one for the `2024-01-02` partition. If we then materialized partition `2024-01-01` of downstream, the final assertion would fail. Reasonable behavior to expect would be that the `AssetMaterialization` returned by `latest_materailization_for_upstream_asset` is the one for the most recent materialization of the partition of `upstream` that the currently materializing partition of `downstream` depends on. But the latest `AssetMaterialization` for `upstream` is for a different partition, so we get that `AssetMaterialization` instead. 

This PR proposes adding additional logic to `latest_materialization_for_upstream_asset` so that for partitioned assets, we get the latest `AssetMaterialization` for the correct partition. This unfortunately requires a call to the DB. Renaming the function `fetch_latest_materialization_for_upstream_asset` should help indicate this to the user. For non-partitioned assets, we still use the `AssetMaterialization`s fetched during the versioning code path, so those calls should remain efficient. 

## How I Tested These Changes
