### PR TITLE
[Graphql codegen] set `useImplementingTypes: true`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/codegen.ts
+++ b/js_modules/dagster-ui/packages/ui-core/codegen.ts
@@ -18,6 +18,7 @@ const config: CodegenConfig = {
         namingConvention: {
           enumValues: 'keep',
         },
+        useImplementingTypes: true,
       },
       plugins: [
         'typescript',
@@ -34,6 +35,7 @@ const config: CodegenConfig = {
             typeNames: 'keep',
             enumValues: 'keep',
             terminateCircularRelationships: true,
+            useImplementingTypes: true,
           },
         },
       ],

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -9,6 +9,7 @@ import {
   buildAssetCheckEvaluation,
   buildAssetCheck,
   buildAssetKey,
+  buildAssetNode,
 } from '../../graphql/types';
 import {LiveDataForNode} from '../Utils';
 import {AssetNodeFragment} from '../types/AssetNode.types';
@@ -47,8 +48,7 @@ export const MockStaleReasonCode: StaleCause = {
 
 const TIMESTAMP = `${new Date('2023-02-12 00:00:00').getTime()}`;
 
-export const AssetNodeFragmentBasic: AssetNodeFragment = {
-  __typename: 'AssetNode',
+export const AssetNodeFragmentBasic: AssetNodeFragment = buildAssetNode({
   assetKey: {__typename: 'AssetKey', path: ['asset1']},
   computeKind: null,
   description: 'This is a test asset description',
@@ -61,7 +61,7 @@ export const AssetNodeFragmentBasic: AssetNodeFragment = {
   jobNames: ['job1'],
   opNames: ['asset1'],
   opVersion: '1',
-};
+});
 
 export const AssetNodeFragmentSource: AssetNodeFragment = {
   ...AssetNodeFragmentBasic,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/AssetNodeDefinition.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/AssetNodeDefinition.stories.tsx
@@ -6,9 +6,7 @@ import {
   buildAssetNode,
   buildAutoMaterializePolicy,
   buildCompositeConfigType,
-  buildConfigType,
   buildConfigTypeField,
-  buildDagsterType,
   buildFreshnessPolicy,
   buildIntMetadataEntry,
   buildPathMetadataEntry,
@@ -35,8 +33,6 @@ export const MinimalAsset = () => {
             description: null,
             freshnessPolicy: null,
             autoMaterializePolicy: null,
-            configField: buildConfigTypeField({configType: buildConfigType({key: 'Any'})}),
-            type: buildDagsterType({displayName: 'Any'}),
             metadataEntries: [],
           }) as any
         }
@@ -91,7 +87,6 @@ export const FullUseAsset = () => {
                 fields: [],
               }),
             }),
-            type: buildDagsterType(),
             metadataEntries: [buildIntMetadataEntry({}), buildPathMetadataEntry()],
           }) as any
         }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/buildAssetTabs.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/buildAssetTabs.test.tsx
@@ -1,6 +1,7 @@
 import {
   AutoMaterializeDecisionType,
   AutoMaterializePolicyType,
+  buildAssetNode,
   buildAutoMaterializePolicy,
   buildAutoMaterializeRule,
 } from '../../graphql/types';
@@ -22,7 +23,7 @@ const autoMaterializePolicy = buildAutoMaterializePolicy({
 });
 
 describe('buildAssetTabs', () => {
-  const definitionWithPartition: AssetViewDefinitionNodeFragment = {
+  const definitionWithPartition: AssetViewDefinitionNodeFragment = buildAssetNode({
     id: 'dagster_test.toys.repo.auto_materialize_repo_2.["eager_downstream_3_partitioned"]',
     hasAssetChecks: false,
     groupName: 'default',
@@ -164,7 +165,7 @@ describe('buildAssetTabs', () => {
       outputSchemaType: null,
       innerTypes: [],
     },
-  };
+  });
 
   // Copied from browser
   const definitionWithoutPartition: AssetViewDefinitionNodeFragment = {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/buildAssetTabs.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/buildAssetTabs.test.tsx
@@ -1,9 +1,16 @@
 import {
   AutoMaterializeDecisionType,
   AutoMaterializePolicyType,
+  buildAssetKey,
   buildAssetNode,
   buildAutoMaterializePolicy,
   buildAutoMaterializeRule,
+  buildCompositeConfigType,
+  buildConfigTypeField,
+  buildDimensionPartitionKeys,
+  buildPartitionDefinition,
+  buildRepository,
+  buildRepositoryLocation,
 } from '../../graphql/types';
 import {buildAssetTabs} from '../AssetTabs';
 import {AssetViewDefinitionNodeFragment} from '../types/AssetView.types';
@@ -27,27 +34,22 @@ describe('buildAssetTabs', () => {
     id: 'dagster_test.toys.repo.auto_materialize_repo_2.["eager_downstream_3_partitioned"]',
     hasAssetChecks: false,
     groupName: 'default',
-    partitionDefinition: {
+    partitionDefinition: buildPartitionDefinition({
       description: 'Daily, starting 2023-02-01 UTC.',
-      __typename: 'PartitionDefinition',
-    },
+    }),
     partitionKeysByDimension: [
-      {
+      buildDimensionPartitionKeys({
         name: 'default',
-        __typename: 'DimensionPartitionKeys',
-      },
+      }),
     ],
-    repository: {
+    repository: buildRepository({
       id: 'cbff94a5bb24f8af0414f4041c450c02725a6ee6',
       name: 'auto_materialize_repo_2',
-      location: {
+      location: buildRepositoryLocation({
         id: 'dagster_test.toys.repo',
         name: 'dagster_test.toys.repo',
-        __typename: 'RepositoryLocation',
-      },
-      __typename: 'Repository',
-    },
-    __typename: 'AssetNode',
+      }),
+    }),
     description: null,
     graphName: null,
     targetingInstigators: [],
@@ -58,30 +60,15 @@ describe('buildAssetTabs', () => {
     backfillPolicy: null,
     freshnessPolicy: null,
     requiredResources: [],
-    configField: {
-      name: 'config',
-      isRequired: false,
-      configType: {
-        givenName: 'Any',
-        __typename: 'RegularConfigType',
-        key: 'Any',
-        description: null,
-        isSelector: false,
-        typeParamKeys: [],
-        recursiveConfigTypes: [],
-      },
-      __typename: 'ConfigTypeField',
-    },
     hasMaterializePermission: true,
     computeKind: null,
     isPartitioned: true,
     isObservable: false,
     isExecutable: true,
     isSource: false,
-    assetKey: {
+    assetKey: buildAssetKey({
       path: ['eager_downstream_3_partitioned'],
-      __typename: 'AssetKey',
-    },
+    }),
     metadataEntries: [],
     type: {
       __typename: 'RegularDagsterType',
@@ -94,74 +81,55 @@ describe('buildAssetTabs', () => {
       isBuiltin: true,
       isNothing: false,
       metadataEntries: [],
-      inputSchemaType: {
+      inputSchemaType: buildCompositeConfigType({
         key: 'Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4',
         description: null,
         isSelector: true,
         typeParamKeys: [],
         fields: [
-          {
+          buildConfigTypeField({
             name: 'json',
             description: null,
             isRequired: true,
             configTypeKey: 'Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2',
             defaultValueAsJson: null,
-            __typename: 'ConfigTypeField',
-          },
-          {
+          }),
+          buildConfigTypeField({
             name: 'pickle',
             description: null,
             isRequired: true,
             configTypeKey: 'Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2',
             defaultValueAsJson: null,
             __typename: 'ConfigTypeField',
-          },
-          {
+          }),
+          buildConfigTypeField({
             name: 'value',
             description: null,
             isRequired: true,
             configTypeKey: 'Any',
             defaultValueAsJson: null,
             __typename: 'ConfigTypeField',
-          },
+          }),
         ],
-        __typename: 'CompositeConfigType',
         recursiveConfigTypes: [
-          {
+          buildCompositeConfigType({
             key: 'Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2',
             description: null,
             isSelector: false,
             typeParamKeys: [],
             fields: [
-              {
+              buildConfigTypeField({
                 name: 'path',
                 description: null,
                 isRequired: true,
                 configTypeKey: 'String',
                 defaultValueAsJson: null,
                 __typename: 'ConfigTypeField',
-              },
+              }),
             ],
-            __typename: 'CompositeConfigType',
-          },
-          {
-            givenName: 'String',
-            __typename: 'RegularConfigType',
-            key: 'String',
-            description: '',
-            isSelector: false,
-            typeParamKeys: [],
-          },
-          {
-            givenName: 'Any',
-            __typename: 'RegularConfigType',
-            key: 'Any',
-            description: null,
-            isSelector: false,
-            typeParamKeys: [],
-          },
+          }),
         ],
-      },
+      }),
       outputSchemaType: null,
       innerTypes: [],
     },

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -74,8 +74,23 @@ export type ArrayConfigType = ConfigType &
     description: Maybe<Scalars['String']>;
     isSelector: Scalars['Boolean'];
     key: Scalars['String'];
-    ofType: ConfigType;
-    recursiveConfigTypes: Array<ConfigType>;
+    ofType:
+      | ArrayConfigType
+      | CompositeConfigType
+      | EnumConfigType
+      | MapConfigType
+      | NullableConfigType
+      | RegularConfigType
+      | ScalarUnionConfigType;
+    recursiveConfigTypes: Array<
+      | ArrayConfigType
+      | CompositeConfigType
+      | EnumConfigType
+      | MapConfigType
+      | NullableConfigType
+      | RegularConfigType
+      | ScalarUnionConfigType
+    >;
     typeParamKeys: Array<Scalars['String']>;
   };
 
@@ -144,7 +159,24 @@ export type AssetCheckEvaluation = {
   __typename: 'AssetCheckEvaluation';
   assetKey: AssetKey;
   checkName: Scalars['String'];
-  metadataEntries: Array<MetadataEntry>;
+  metadataEntries: Array<
+    | AssetMetadataEntry
+    | BoolMetadataEntry
+    | FloatMetadataEntry
+    | IntMetadataEntry
+    | JobMetadataEntry
+    | JsonMetadataEntry
+    | MarkdownMetadataEntry
+    | NotebookMetadataEntry
+    | NullMetadataEntry
+    | PathMetadataEntry
+    | PipelineRunMetadataEntry
+    | PythonArtifactMetadataEntry
+    | TableMetadataEntry
+    | TableSchemaMetadataEntry
+    | TextMetadataEntry
+    | UrlMetadataEntry
+  >;
   severity: AssetCheckSeverity;
   success: Scalars['Boolean'];
   targetMaterialization: Maybe<AssetCheckEvaluationTargetMaterializationData>;
@@ -364,7 +396,24 @@ export type AssetNode = {
   jobs: Array<Pipeline>;
   latestMaterializationByPartition: Array<Maybe<MaterializationEvent>>;
   latestRunForPartition: Maybe<Run>;
-  metadataEntries: Array<MetadataEntry>;
+  metadataEntries: Array<
+    | AssetMetadataEntry
+    | BoolMetadataEntry
+    | FloatMetadataEntry
+    | IntMetadataEntry
+    | JobMetadataEntry
+    | JsonMetadataEntry
+    | MarkdownMetadataEntry
+    | NotebookMetadataEntry
+    | NullMetadataEntry
+    | PathMetadataEntry
+    | PipelineRunMetadataEntry
+    | PythonArtifactMetadataEntry
+    | TableMetadataEntry
+    | TableSchemaMetadataEntry
+    | TextMetadataEntry
+    | UrlMetadataEntry
+  >;
   op: Maybe<SolidDefinition>;
   opName: Maybe<Scalars['String']>;
   opNames: Array<Scalars['String']>;
@@ -380,7 +429,7 @@ export type AssetNode = {
   staleStatus: Maybe<StaleStatus>;
   staleStatusByPartition: Array<StaleStatus>;
   targetingInstigators: Array<Instigator>;
-  type: Maybe<DagsterType>;
+  type: Maybe<ListDagsterType | NullableDagsterType | RegularDagsterType>;
 };
 
 export type AssetNodeAssetChecksOrErrorArgs = {
@@ -632,7 +681,15 @@ export type CompositeConfigType = ConfigType & {
   fields: Array<ConfigTypeField>;
   isSelector: Scalars['Boolean'];
   key: Scalars['String'];
-  recursiveConfigTypes: Array<ConfigType>;
+  recursiveConfigTypes: Array<
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType
+  >;
   typeParamKeys: Array<Scalars['String']>;
 };
 
@@ -702,13 +759,28 @@ export type ConfigType = {
   description: Maybe<Scalars['String']>;
   isSelector: Scalars['Boolean'];
   key: Scalars['String'];
-  recursiveConfigTypes: Array<ConfigType>;
+  recursiveConfigTypes: Array<
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType
+  >;
   typeParamKeys: Array<Scalars['String']>;
 };
 
 export type ConfigTypeField = {
   __typename: 'ConfigTypeField';
-  configType: ConfigType;
+  configType:
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType;
   configTypeKey: Scalars['String'];
   defaultValueAsJson: Maybe<Scalars['String']>;
   description: Maybe<Scalars['String']>;
@@ -869,16 +941,49 @@ export type DagsterRunEvent =
 export type DagsterType = {
   description: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
-  innerTypes: Array<DagsterType>;
-  inputSchemaType: Maybe<ConfigType>;
+  innerTypes: Array<ListDagsterType | NullableDagsterType | RegularDagsterType>;
+  inputSchemaType: Maybe<
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType
+  >;
   isBuiltin: Scalars['Boolean'];
   isList: Scalars['Boolean'];
   isNothing: Scalars['Boolean'];
   isNullable: Scalars['Boolean'];
   key: Scalars['String'];
-  metadataEntries: Array<MetadataEntry>;
+  metadataEntries: Array<
+    | AssetMetadataEntry
+    | BoolMetadataEntry
+    | FloatMetadataEntry
+    | IntMetadataEntry
+    | JobMetadataEntry
+    | JsonMetadataEntry
+    | MarkdownMetadataEntry
+    | NotebookMetadataEntry
+    | NullMetadataEntry
+    | PathMetadataEntry
+    | PipelineRunMetadataEntry
+    | PythonArtifactMetadataEntry
+    | TableMetadataEntry
+    | TableSchemaMetadataEntry
+    | TextMetadataEntry
+    | UrlMetadataEntry
+  >;
   name: Maybe<Scalars['String']>;
-  outputSchemaType: Maybe<ConfigType>;
+  outputSchemaType: Maybe<
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType
+  >;
 };
 
 export type DagsterTypeNotFoundError = Error & {
@@ -936,7 +1041,24 @@ export type DimensionPartitionKeys = {
 export type DisplayableEvent = {
   description: Maybe<Scalars['String']>;
   label: Maybe<Scalars['String']>;
-  metadataEntries: Array<MetadataEntry>;
+  metadataEntries: Array<
+    | AssetMetadataEntry
+    | BoolMetadataEntry
+    | FloatMetadataEntry
+    | IntMetadataEntry
+    | JobMetadataEntry
+    | JsonMetadataEntry
+    | MarkdownMetadataEntry
+    | NotebookMetadataEntry
+    | NullMetadataEntry
+    | PathMetadataEntry
+    | PipelineRunMetadataEntry
+    | PythonArtifactMetadataEntry
+    | TableMetadataEntry
+    | TableSchemaMetadataEntry
+    | TextMetadataEntry
+    | UrlMetadataEntry
+  >;
 };
 
 export type DryRunInstigationTick = {
@@ -992,7 +1114,24 @@ export type EngineEvent = DisplayableEvent &
     markerEnd: Maybe<Scalars['String']>;
     markerStart: Maybe<Scalars['String']>;
     message: Scalars['String'];
-    metadataEntries: Array<MetadataEntry>;
+    metadataEntries: Array<
+      | AssetMetadataEntry
+      | BoolMetadataEntry
+      | FloatMetadataEntry
+      | IntMetadataEntry
+      | JobMetadataEntry
+      | JsonMetadataEntry
+      | MarkdownMetadataEntry
+      | NotebookMetadataEntry
+      | NullMetadataEntry
+      | PathMetadataEntry
+      | PipelineRunMetadataEntry
+      | PythonArtifactMetadataEntry
+      | TableMetadataEntry
+      | TableSchemaMetadataEntry
+      | TextMetadataEntry
+      | UrlMetadataEntry
+    >;
     runId: Scalars['String'];
     solidHandleID: Maybe<Scalars['String']>;
     stepKey: Maybe<Scalars['String']>;
@@ -1005,7 +1144,15 @@ export type EnumConfigType = ConfigType & {
   givenName: Scalars['String'];
   isSelector: Scalars['Boolean'];
   key: Scalars['String'];
-  recursiveConfigTypes: Array<ConfigType>;
+  recursiveConfigTypes: Array<
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType
+  >;
   typeParamKeys: Array<Scalars['String']>;
   values: Array<EnumConfigValue>;
 };
@@ -1205,7 +1352,24 @@ export type ExecutionStepOutputEvent = DisplayableEvent &
     label: Maybe<Scalars['String']>;
     level: LogLevel;
     message: Scalars['String'];
-    metadataEntries: Array<MetadataEntry>;
+    metadataEntries: Array<
+      | AssetMetadataEntry
+      | BoolMetadataEntry
+      | FloatMetadataEntry
+      | IntMetadataEntry
+      | JobMetadataEntry
+      | JsonMetadataEntry
+      | MarkdownMetadataEntry
+      | NotebookMetadataEntry
+      | NullMetadataEntry
+      | PathMetadataEntry
+      | PipelineRunMetadataEntry
+      | PythonArtifactMetadataEntry
+      | TableMetadataEntry
+      | TableSchemaMetadataEntry
+      | TextMetadataEntry
+      | UrlMetadataEntry
+    >;
     outputName: Scalars['String'];
     runId: Scalars['String'];
     solidHandleID: Maybe<Scalars['String']>;
@@ -1286,7 +1450,24 @@ export type ExpectationResult = DisplayableEvent & {
   __typename: 'ExpectationResult';
   description: Maybe<Scalars['String']>;
   label: Maybe<Scalars['String']>;
-  metadataEntries: Array<MetadataEntry>;
+  metadataEntries: Array<
+    | AssetMetadataEntry
+    | BoolMetadataEntry
+    | FloatMetadataEntry
+    | IntMetadataEntry
+    | JobMetadataEntry
+    | JsonMetadataEntry
+    | MarkdownMetadataEntry
+    | NotebookMetadataEntry
+    | NullMetadataEntry
+    | PathMetadataEntry
+    | PipelineRunMetadataEntry
+    | PythonArtifactMetadataEntry
+    | TableMetadataEntry
+    | TableSchemaMetadataEntry
+    | TextMetadataEntry
+    | UrlMetadataEntry
+  >;
   success: Scalars['Boolean'];
 };
 
@@ -1294,7 +1475,24 @@ export type FailureMetadata = DisplayableEvent & {
   __typename: 'FailureMetadata';
   description: Maybe<Scalars['String']>;
   label: Maybe<Scalars['String']>;
-  metadataEntries: Array<MetadataEntry>;
+  metadataEntries: Array<
+    | AssetMetadataEntry
+    | BoolMetadataEntry
+    | FloatMetadataEntry
+    | IntMetadataEntry
+    | JobMetadataEntry
+    | JsonMetadataEntry
+    | MarkdownMetadataEntry
+    | NotebookMetadataEntry
+    | NullMetadataEntry
+    | PathMetadataEntry
+    | PipelineRunMetadataEntry
+    | PythonArtifactMetadataEntry
+    | TableMetadataEntry
+    | TableSchemaMetadataEntry
+    | TextMetadataEntry
+    | UrlMetadataEntry
+  >;
 };
 
 export type FeatureFlag = {
@@ -1381,7 +1579,24 @@ export type HandledOutputEvent = DisplayableEvent &
     level: LogLevel;
     managerKey: Scalars['String'];
     message: Scalars['String'];
-    metadataEntries: Array<MetadataEntry>;
+    metadataEntries: Array<
+      | AssetMetadataEntry
+      | BoolMetadataEntry
+      | FloatMetadataEntry
+      | IntMetadataEntry
+      | JobMetadataEntry
+      | JsonMetadataEntry
+      | MarkdownMetadataEntry
+      | NotebookMetadataEntry
+      | NullMetadataEntry
+      | PathMetadataEntry
+      | PipelineRunMetadataEntry
+      | PythonArtifactMetadataEntry
+      | TableMetadataEntry
+      | TableSchemaMetadataEntry
+      | TextMetadataEntry
+      | UrlMetadataEntry
+    >;
     outputName: Scalars['String'];
     runId: Scalars['String'];
     solidHandleID: Maybe<Scalars['String']>;
@@ -1429,10 +1644,27 @@ export type HookSkippedEvent = MessageEvent &
 
 export type IPipelineSnapshot = {
   dagsterTypeOrError: DagsterTypeOrError;
-  dagsterTypes: Array<DagsterType>;
+  dagsterTypes: Array<ListDagsterType | NullableDagsterType | RegularDagsterType>;
   description: Maybe<Scalars['String']>;
   graphName: Scalars['String'];
-  metadataEntries: Array<MetadataEntry>;
+  metadataEntries: Array<
+    | AssetMetadataEntry
+    | BoolMetadataEntry
+    | FloatMetadataEntry
+    | IntMetadataEntry
+    | JobMetadataEntry
+    | JsonMetadataEntry
+    | MarkdownMetadataEntry
+    | NotebookMetadataEntry
+    | NullMetadataEntry
+    | PathMetadataEntry
+    | PipelineRunMetadataEntry
+    | PythonArtifactMetadataEntry
+    | TableMetadataEntry
+    | TableSchemaMetadataEntry
+    | TextMetadataEntry
+    | UrlMetadataEntry
+  >;
   modes: Array<Mode>;
   name: Scalars['String'];
   parentSnapshotId: Maybe<Scalars['String']>;
@@ -1483,9 +1715,26 @@ export type Input = {
 export type InputDefinition = {
   __typename: 'InputDefinition';
   description: Maybe<Scalars['String']>;
-  metadataEntries: Array<MetadataEntry>;
+  metadataEntries: Array<
+    | AssetMetadataEntry
+    | BoolMetadataEntry
+    | FloatMetadataEntry
+    | IntMetadataEntry
+    | JobMetadataEntry
+    | JsonMetadataEntry
+    | MarkdownMetadataEntry
+    | NotebookMetadataEntry
+    | NullMetadataEntry
+    | PathMetadataEntry
+    | PipelineRunMetadataEntry
+    | PythonArtifactMetadataEntry
+    | TableMetadataEntry
+    | TableSchemaMetadataEntry
+    | TextMetadataEntry
+    | UrlMetadataEntry
+  >;
   name: Scalars['String'];
-  type: DagsterType;
+  type: ListDagsterType | NullableDagsterType | RegularDagsterType;
 };
 
 export type InputMapping = {
@@ -1680,13 +1929,30 @@ export type Job = IPipelineSnapshot &
   SolidContainer & {
     __typename: 'Job';
     dagsterTypeOrError: DagsterTypeOrError;
-    dagsterTypes: Array<DagsterType>;
+    dagsterTypes: Array<ListDagsterType | NullableDagsterType | RegularDagsterType>;
     description: Maybe<Scalars['String']>;
     graphName: Scalars['String'];
     id: Scalars['ID'];
     isAssetJob: Scalars['Boolean'];
     isJob: Scalars['Boolean'];
-    metadataEntries: Array<MetadataEntry>;
+    metadataEntries: Array<
+      | AssetMetadataEntry
+      | BoolMetadataEntry
+      | FloatMetadataEntry
+      | IntMetadataEntry
+      | JobMetadataEntry
+      | JsonMetadataEntry
+      | MarkdownMetadataEntry
+      | NotebookMetadataEntry
+      | NullMetadataEntry
+      | PathMetadataEntry
+      | PipelineRunMetadataEntry
+      | PythonArtifactMetadataEntry
+      | TableMetadataEntry
+      | TableSchemaMetadataEntry
+      | TextMetadataEntry
+      | UrlMetadataEntry
+    >;
     modes: Array<Mode>;
     name: Scalars['String'];
     parentSnapshotId: Maybe<Scalars['String']>;
@@ -1841,17 +2107,50 @@ export type ListDagsterType = DagsterType &
     __typename: 'ListDagsterType';
     description: Maybe<Scalars['String']>;
     displayName: Scalars['String'];
-    innerTypes: Array<DagsterType>;
-    inputSchemaType: Maybe<ConfigType>;
+    innerTypes: Array<ListDagsterType | NullableDagsterType | RegularDagsterType>;
+    inputSchemaType: Maybe<
+      | ArrayConfigType
+      | CompositeConfigType
+      | EnumConfigType
+      | MapConfigType
+      | NullableConfigType
+      | RegularConfigType
+      | ScalarUnionConfigType
+    >;
     isBuiltin: Scalars['Boolean'];
     isList: Scalars['Boolean'];
     isNothing: Scalars['Boolean'];
     isNullable: Scalars['Boolean'];
     key: Scalars['String'];
-    metadataEntries: Array<MetadataEntry>;
+    metadataEntries: Array<
+      | AssetMetadataEntry
+      | BoolMetadataEntry
+      | FloatMetadataEntry
+      | IntMetadataEntry
+      | JobMetadataEntry
+      | JsonMetadataEntry
+      | MarkdownMetadataEntry
+      | NotebookMetadataEntry
+      | NullMetadataEntry
+      | PathMetadataEntry
+      | PipelineRunMetadataEntry
+      | PythonArtifactMetadataEntry
+      | TableMetadataEntry
+      | TableSchemaMetadataEntry
+      | TextMetadataEntry
+      | UrlMetadataEntry
+    >;
     name: Maybe<Scalars['String']>;
-    ofType: DagsterType;
-    outputSchemaType: Maybe<ConfigType>;
+    ofType: ListDagsterType | NullableDagsterType | RegularDagsterType;
+    outputSchemaType: Maybe<
+      | ArrayConfigType
+      | CompositeConfigType
+      | EnumConfigType
+      | MapConfigType
+      | NullableConfigType
+      | RegularConfigType
+      | ScalarUnionConfigType
+    >;
   };
 
 export type LoadedInputEvent = DisplayableEvent &
@@ -1865,7 +2164,24 @@ export type LoadedInputEvent = DisplayableEvent &
     level: LogLevel;
     managerKey: Scalars['String'];
     message: Scalars['String'];
-    metadataEntries: Array<MetadataEntry>;
+    metadataEntries: Array<
+      | AssetMetadataEntry
+      | BoolMetadataEntry
+      | FloatMetadataEntry
+      | IntMetadataEntry
+      | JobMetadataEntry
+      | JsonMetadataEntry
+      | MarkdownMetadataEntry
+      | NotebookMetadataEntry
+      | NullMetadataEntry
+      | PathMetadataEntry
+      | PipelineRunMetadataEntry
+      | PythonArtifactMetadataEntry
+      | TableMetadataEntry
+      | TableSchemaMetadataEntry
+      | TextMetadataEntry
+      | UrlMetadataEntry
+    >;
     runId: Scalars['String'];
     solidHandleID: Maybe<Scalars['String']>;
     stepKey: Maybe<Scalars['String']>;
@@ -1951,10 +2267,32 @@ export type MapConfigType = ConfigType & {
   isSelector: Scalars['Boolean'];
   key: Scalars['String'];
   keyLabelName: Maybe<Scalars['String']>;
-  keyType: ConfigType;
-  recursiveConfigTypes: Array<ConfigType>;
+  keyType:
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType;
+  recursiveConfigTypes: Array<
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType
+  >;
   typeParamKeys: Array<Scalars['String']>;
-  valueType: ConfigType;
+  valueType:
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType;
 };
 
 export type MarkdownMetadataEntry = MetadataEntry & {
@@ -1990,7 +2328,24 @@ export type MaterializationEvent = DisplayableEvent &
     label: Maybe<Scalars['String']>;
     level: LogLevel;
     message: Scalars['String'];
-    metadataEntries: Array<MetadataEntry>;
+    metadataEntries: Array<
+      | AssetMetadataEntry
+      | BoolMetadataEntry
+      | FloatMetadataEntry
+      | IntMetadataEntry
+      | JobMetadataEntry
+      | JsonMetadataEntry
+      | MarkdownMetadataEntry
+      | NotebookMetadataEntry
+      | NullMetadataEntry
+      | PathMetadataEntry
+      | PipelineRunMetadataEntry
+      | PythonArtifactMetadataEntry
+      | TableMetadataEntry
+      | TableSchemaMetadataEntry
+      | TextMetadataEntry
+      | UrlMetadataEntry
+    >;
     partition: Maybe<Scalars['String']>;
     runId: Scalars['String'];
     runOrError: RunOrError;
@@ -2308,8 +2663,23 @@ export type NullableConfigType = ConfigType &
     description: Maybe<Scalars['String']>;
     isSelector: Scalars['Boolean'];
     key: Scalars['String'];
-    ofType: ConfigType;
-    recursiveConfigTypes: Array<ConfigType>;
+    ofType:
+      | ArrayConfigType
+      | CompositeConfigType
+      | EnumConfigType
+      | MapConfigType
+      | NullableConfigType
+      | RegularConfigType
+      | ScalarUnionConfigType;
+    recursiveConfigTypes: Array<
+      | ArrayConfigType
+      | CompositeConfigType
+      | EnumConfigType
+      | MapConfigType
+      | NullableConfigType
+      | RegularConfigType
+      | ScalarUnionConfigType
+    >;
     typeParamKeys: Array<Scalars['String']>;
   };
 
@@ -2318,17 +2688,50 @@ export type NullableDagsterType = DagsterType &
     __typename: 'NullableDagsterType';
     description: Maybe<Scalars['String']>;
     displayName: Scalars['String'];
-    innerTypes: Array<DagsterType>;
-    inputSchemaType: Maybe<ConfigType>;
+    innerTypes: Array<ListDagsterType | NullableDagsterType | RegularDagsterType>;
+    inputSchemaType: Maybe<
+      | ArrayConfigType
+      | CompositeConfigType
+      | EnumConfigType
+      | MapConfigType
+      | NullableConfigType
+      | RegularConfigType
+      | ScalarUnionConfigType
+    >;
     isBuiltin: Scalars['Boolean'];
     isList: Scalars['Boolean'];
     isNothing: Scalars['Boolean'];
     isNullable: Scalars['Boolean'];
     key: Scalars['String'];
-    metadataEntries: Array<MetadataEntry>;
+    metadataEntries: Array<
+      | AssetMetadataEntry
+      | BoolMetadataEntry
+      | FloatMetadataEntry
+      | IntMetadataEntry
+      | JobMetadataEntry
+      | JsonMetadataEntry
+      | MarkdownMetadataEntry
+      | NotebookMetadataEntry
+      | NullMetadataEntry
+      | PathMetadataEntry
+      | PipelineRunMetadataEntry
+      | PythonArtifactMetadataEntry
+      | TableMetadataEntry
+      | TableSchemaMetadataEntry
+      | TextMetadataEntry
+      | UrlMetadataEntry
+    >;
     name: Maybe<Scalars['String']>;
-    ofType: DagsterType;
-    outputSchemaType: Maybe<ConfigType>;
+    ofType: ListDagsterType | NullableDagsterType | RegularDagsterType;
+    outputSchemaType: Maybe<
+      | ArrayConfigType
+      | CompositeConfigType
+      | EnumConfigType
+      | MapConfigType
+      | NullableConfigType
+      | RegularConfigType
+      | ScalarUnionConfigType
+    >;
   };
 
 export type ObjectStoreOperationEvent = MessageEvent &
@@ -2348,7 +2751,24 @@ export type ObjectStoreOperationResult = DisplayableEvent & {
   __typename: 'ObjectStoreOperationResult';
   description: Maybe<Scalars['String']>;
   label: Maybe<Scalars['String']>;
-  metadataEntries: Array<MetadataEntry>;
+  metadataEntries: Array<
+    | AssetMetadataEntry
+    | BoolMetadataEntry
+    | FloatMetadataEntry
+    | IntMetadataEntry
+    | JobMetadataEntry
+    | JsonMetadataEntry
+    | MarkdownMetadataEntry
+    | NotebookMetadataEntry
+    | NullMetadataEntry
+    | PathMetadataEntry
+    | PipelineRunMetadataEntry
+    | PythonArtifactMetadataEntry
+    | TableMetadataEntry
+    | TableSchemaMetadataEntry
+    | TextMetadataEntry
+    | UrlMetadataEntry
+  >;
   op: ObjectStoreOperationType;
 };
 
@@ -2369,7 +2789,24 @@ export type ObservationEvent = DisplayableEvent &
     label: Maybe<Scalars['String']>;
     level: LogLevel;
     message: Scalars['String'];
-    metadataEntries: Array<MetadataEntry>;
+    metadataEntries: Array<
+      | AssetMetadataEntry
+      | BoolMetadataEntry
+      | FloatMetadataEntry
+      | IntMetadataEntry
+      | JobMetadataEntry
+      | JsonMetadataEntry
+      | MarkdownMetadataEntry
+      | NotebookMetadataEntry
+      | NullMetadataEntry
+      | PathMetadataEntry
+      | PipelineRunMetadataEntry
+      | PythonArtifactMetadataEntry
+      | TableMetadataEntry
+      | TableSchemaMetadataEntry
+      | TextMetadataEntry
+      | UrlMetadataEntry
+    >;
     partition: Maybe<Scalars['String']>;
     runId: Scalars['String'];
     runOrError: RunOrError;
@@ -2391,9 +2828,26 @@ export type OutputDefinition = {
   __typename: 'OutputDefinition';
   description: Maybe<Scalars['String']>;
   isDynamic: Maybe<Scalars['Boolean']>;
-  metadataEntries: Array<MetadataEntry>;
+  metadataEntries: Array<
+    | AssetMetadataEntry
+    | BoolMetadataEntry
+    | FloatMetadataEntry
+    | IntMetadataEntry
+    | JobMetadataEntry
+    | JsonMetadataEntry
+    | MarkdownMetadataEntry
+    | NotebookMetadataEntry
+    | NullMetadataEntry
+    | PathMetadataEntry
+    | PipelineRunMetadataEntry
+    | PythonArtifactMetadataEntry
+    | TableMetadataEntry
+    | TableSchemaMetadataEntry
+    | TextMetadataEntry
+    | UrlMetadataEntry
+  >;
   name: Scalars['String'];
-  type: DagsterType;
+  type: ListDagsterType | NullableDagsterType | RegularDagsterType;
 };
 
 export type OutputMapping = {
@@ -2672,13 +3126,30 @@ export type Pipeline = IPipelineSnapshot &
   SolidContainer & {
     __typename: 'Pipeline';
     dagsterTypeOrError: DagsterTypeOrError;
-    dagsterTypes: Array<DagsterType>;
+    dagsterTypes: Array<ListDagsterType | NullableDagsterType | RegularDagsterType>;
     description: Maybe<Scalars['String']>;
     graphName: Scalars['String'];
     id: Scalars['ID'];
     isAssetJob: Scalars['Boolean'];
     isJob: Scalars['Boolean'];
-    metadataEntries: Array<MetadataEntry>;
+    metadataEntries: Array<
+      | AssetMetadataEntry
+      | BoolMetadataEntry
+      | FloatMetadataEntry
+      | IntMetadataEntry
+      | JobMetadataEntry
+      | JsonMetadataEntry
+      | MarkdownMetadataEntry
+      | NotebookMetadataEntry
+      | NullMetadataEntry
+      | PathMetadataEntry
+      | PipelineRunMetadataEntry
+      | PythonArtifactMetadataEntry
+      | TableMetadataEntry
+      | TableSchemaMetadataEntry
+      | TextMetadataEntry
+      | UrlMetadataEntry
+    >;
     modes: Array<Mode>;
     name: Scalars['String'];
     parentSnapshotId: Maybe<Scalars['String']>;
@@ -2719,7 +3190,14 @@ export type PipelineConfigValidationError = {
 };
 
 export type PipelineConfigValidationInvalid = {
-  errors: Array<PipelineConfigValidationError>;
+  errors: Array<
+    | FieldNotDefinedConfigError
+    | FieldsNotDefinedConfigError
+    | MissingFieldConfigError
+    | MissingFieldsConfigError
+    | RuntimeMismatchConfigError
+    | SelectorTypeConfigError
+  >;
   pipelineName: Scalars['String'];
 };
 
@@ -2770,7 +3248,7 @@ export type PipelineRun = {
   jobName: Scalars['String'];
   mode: Scalars['String'];
   parentRunId: Maybe<Scalars['String']>;
-  pipeline: PipelineReference;
+  pipeline: PipelineSnapshot | UnknownPipeline;
   pipelineName: Scalars['String'];
   pipelineSnapshotId: Maybe<Scalars['String']>;
   repositoryOrigin: Maybe<RepositoryOrigin>;
@@ -2874,11 +3352,28 @@ export type PipelineSnapshot = IPipelineSnapshot &
   SolidContainer & {
     __typename: 'PipelineSnapshot';
     dagsterTypeOrError: DagsterTypeOrError;
-    dagsterTypes: Array<DagsterType>;
+    dagsterTypes: Array<ListDagsterType | NullableDagsterType | RegularDagsterType>;
     description: Maybe<Scalars['String']>;
     graphName: Scalars['String'];
     id: Scalars['ID'];
-    metadataEntries: Array<MetadataEntry>;
+    metadataEntries: Array<
+      | AssetMetadataEntry
+      | BoolMetadataEntry
+      | FloatMetadataEntry
+      | IntMetadataEntry
+      | JobMetadataEntry
+      | JsonMetadataEntry
+      | MarkdownMetadataEntry
+      | NotebookMetadataEntry
+      | NullMetadataEntry
+      | PathMetadataEntry
+      | PipelineRunMetadataEntry
+      | PythonArtifactMetadataEntry
+      | TableMetadataEntry
+      | TableSchemaMetadataEntry
+      | TextMetadataEntry
+      | UrlMetadataEntry
+    >;
     modes: Array<Mode>;
     name: Scalars['String'];
     parentSnapshotId: Maybe<Scalars['String']>;
@@ -3238,7 +3733,15 @@ export type RegularConfigType = ConfigType & {
   givenName: Scalars['String'];
   isSelector: Scalars['Boolean'];
   key: Scalars['String'];
-  recursiveConfigTypes: Array<ConfigType>;
+  recursiveConfigTypes: Array<
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType
+  >;
   typeParamKeys: Array<Scalars['String']>;
 };
 
@@ -3246,16 +3749,49 @@ export type RegularDagsterType = DagsterType & {
   __typename: 'RegularDagsterType';
   description: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
-  innerTypes: Array<DagsterType>;
-  inputSchemaType: Maybe<ConfigType>;
+  innerTypes: Array<ListDagsterType | NullableDagsterType | RegularDagsterType>;
+  inputSchemaType: Maybe<
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType
+  >;
   isBuiltin: Scalars['Boolean'];
   isList: Scalars['Boolean'];
   isNothing: Scalars['Boolean'];
   isNullable: Scalars['Boolean'];
   key: Scalars['String'];
-  metadataEntries: Array<MetadataEntry>;
+  metadataEntries: Array<
+    | AssetMetadataEntry
+    | BoolMetadataEntry
+    | FloatMetadataEntry
+    | IntMetadataEntry
+    | JobMetadataEntry
+    | JsonMetadataEntry
+    | MarkdownMetadataEntry
+    | NotebookMetadataEntry
+    | NullMetadataEntry
+    | PathMetadataEntry
+    | PipelineRunMetadataEntry
+    | PythonArtifactMetadataEntry
+    | TableMetadataEntry
+    | TableSchemaMetadataEntry
+    | TextMetadataEntry
+    | UrlMetadataEntry
+  >;
   name: Maybe<Scalars['String']>;
-  outputSchemaType: Maybe<ConfigType>;
+  outputSchemaType: Maybe<
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType
+  >;
 };
 
 export type ReloadNotSupported = Error & {
@@ -3441,7 +3977,24 @@ export type ResourceInitFailureEvent = DisplayableEvent &
     markerEnd: Maybe<Scalars['String']>;
     markerStart: Maybe<Scalars['String']>;
     message: Scalars['String'];
-    metadataEntries: Array<MetadataEntry>;
+    metadataEntries: Array<
+      | AssetMetadataEntry
+      | BoolMetadataEntry
+      | FloatMetadataEntry
+      | IntMetadataEntry
+      | JobMetadataEntry
+      | JsonMetadataEntry
+      | MarkdownMetadataEntry
+      | NotebookMetadataEntry
+      | NullMetadataEntry
+      | PathMetadataEntry
+      | PipelineRunMetadataEntry
+      | PythonArtifactMetadataEntry
+      | TableMetadataEntry
+      | TableSchemaMetadataEntry
+      | TextMetadataEntry
+      | UrlMetadataEntry
+    >;
     runId: Scalars['String'];
     solidHandleID: Maybe<Scalars['String']>;
     stepKey: Maybe<Scalars['String']>;
@@ -3460,7 +4013,24 @@ export type ResourceInitStartedEvent = DisplayableEvent &
     markerEnd: Maybe<Scalars['String']>;
     markerStart: Maybe<Scalars['String']>;
     message: Scalars['String'];
-    metadataEntries: Array<MetadataEntry>;
+    metadataEntries: Array<
+      | AssetMetadataEntry
+      | BoolMetadataEntry
+      | FloatMetadataEntry
+      | IntMetadataEntry
+      | JobMetadataEntry
+      | JsonMetadataEntry
+      | MarkdownMetadataEntry
+      | NotebookMetadataEntry
+      | NullMetadataEntry
+      | PathMetadataEntry
+      | PipelineRunMetadataEntry
+      | PythonArtifactMetadataEntry
+      | TableMetadataEntry
+      | TableSchemaMetadataEntry
+      | TextMetadataEntry
+      | UrlMetadataEntry
+    >;
     runId: Scalars['String'];
     solidHandleID: Maybe<Scalars['String']>;
     stepKey: Maybe<Scalars['String']>;
@@ -3479,7 +4049,24 @@ export type ResourceInitSuccessEvent = DisplayableEvent &
     markerEnd: Maybe<Scalars['String']>;
     markerStart: Maybe<Scalars['String']>;
     message: Scalars['String'];
-    metadataEntries: Array<MetadataEntry>;
+    metadataEntries: Array<
+      | AssetMetadataEntry
+      | BoolMetadataEntry
+      | FloatMetadataEntry
+      | IntMetadataEntry
+      | JobMetadataEntry
+      | JsonMetadataEntry
+      | MarkdownMetadataEntry
+      | NotebookMetadataEntry
+      | NullMetadataEntry
+      | PathMetadataEntry
+      | PipelineRunMetadataEntry
+      | PythonArtifactMetadataEntry
+      | TableMetadataEntry
+      | TableSchemaMetadataEntry
+      | TextMetadataEntry
+      | UrlMetadataEntry
+    >;
     runId: Scalars['String'];
     solidHandleID: Maybe<Scalars['String']>;
     stepKey: Maybe<Scalars['String']>;
@@ -3533,7 +4120,7 @@ export type Run = PipelineRun & {
   mode: Scalars['String'];
   parentPipelineSnapshotId: Maybe<Scalars['String']>;
   parentRunId: Maybe<Scalars['String']>;
-  pipeline: PipelineReference;
+  pipeline: PipelineSnapshot | UnknownPipeline;
   pipelineName: Scalars['String'];
   pipelineSnapshotId: Maybe<Scalars['String']>;
   repositoryOrigin: Maybe<RepositoryOrigin>;
@@ -3592,9 +4179,24 @@ export type RunCancelingEvent = MessageEvent &
 
 export type RunConfigSchema = {
   __typename: 'RunConfigSchema';
-  allConfigTypes: Array<ConfigType>;
+  allConfigTypes: Array<
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType
+  >;
   isRunConfigValid: PipelineConfigValidationResult;
-  rootConfigType: ConfigType;
+  rootConfigType:
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType;
   rootDefaultYaml: Scalars['String'];
 };
 
@@ -3611,7 +4213,14 @@ export type RunConfigSchemaOrError =
 
 export type RunConfigValidationInvalid = PipelineConfigValidationInvalid & {
   __typename: 'RunConfigValidationInvalid';
-  errors: Array<PipelineConfigValidationError>;
+  errors: Array<
+    | FieldNotDefinedConfigError
+    | FieldsNotDefinedConfigError
+    | MissingFieldConfigError
+    | MissingFieldsConfigError
+    | RuntimeMismatchConfigError
+    | SelectorTypeConfigError
+  >;
   pipelineName: Scalars['String'];
 };
 
@@ -3854,10 +4463,32 @@ export type ScalarUnionConfigType = ConfigType & {
   description: Maybe<Scalars['String']>;
   isSelector: Scalars['Boolean'];
   key: Scalars['String'];
-  nonScalarType: ConfigType;
+  nonScalarType:
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType;
   nonScalarTypeKey: Scalars['String'];
-  recursiveConfigTypes: Array<ConfigType>;
-  scalarType: ConfigType;
+  recursiveConfigTypes: Array<
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType
+  >;
+  scalarType:
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType;
   scalarTypeKey: Scalars['String'];
   typeParamKeys: Array<Scalars['String']>;
 };
@@ -4061,7 +4692,7 @@ export type ShutdownRepositoryLocationSuccess = {
 
 export type Solid = {
   __typename: 'Solid';
-  definition: ISolidDefinition;
+  definition: CompositeSolidDefinition | SolidDefinition;
   inputs: Array<Input>;
   isDynamicMapped: Scalars['Boolean'];
   name: Scalars['String'];
@@ -4203,7 +4834,24 @@ export type StepWorkerStartedEvent = DisplayableEvent &
     markerEnd: Maybe<Scalars['String']>;
     markerStart: Maybe<Scalars['String']>;
     message: Scalars['String'];
-    metadataEntries: Array<MetadataEntry>;
+    metadataEntries: Array<
+      | AssetMetadataEntry
+      | BoolMetadataEntry
+      | FloatMetadataEntry
+      | IntMetadataEntry
+      | JobMetadataEntry
+      | JsonMetadataEntry
+      | MarkdownMetadataEntry
+      | NotebookMetadataEntry
+      | NullMetadataEntry
+      | PathMetadataEntry
+      | PipelineRunMetadataEntry
+      | PythonArtifactMetadataEntry
+      | TableMetadataEntry
+      | TableSchemaMetadataEntry
+      | TextMetadataEntry
+      | UrlMetadataEntry
+    >;
     runId: Scalars['String'];
     solidHandleID: Maybe<Scalars['String']>;
     stepKey: Maybe<Scalars['String']>;
@@ -4222,7 +4870,24 @@ export type StepWorkerStartingEvent = DisplayableEvent &
     markerEnd: Maybe<Scalars['String']>;
     markerStart: Maybe<Scalars['String']>;
     message: Scalars['String'];
-    metadataEntries: Array<MetadataEntry>;
+    metadataEntries: Array<
+      | AssetMetadataEntry
+      | BoolMetadataEntry
+      | FloatMetadataEntry
+      | IntMetadataEntry
+      | JobMetadataEntry
+      | JsonMetadataEntry
+      | MarkdownMetadataEntry
+      | NotebookMetadataEntry
+      | NullMetadataEntry
+      | PathMetadataEntry
+      | PipelineRunMetadataEntry
+      | PythonArtifactMetadataEntry
+      | TableMetadataEntry
+      | TableSchemaMetadataEntry
+      | TextMetadataEntry
+      | UrlMetadataEntry
+    >;
     runId: Scalars['String'];
     solidHandleID: Maybe<Scalars['String']>;
     stepKey: Maybe<Scalars['String']>;
@@ -4416,7 +5081,24 @@ export type TypeCheck = DisplayableEvent & {
   __typename: 'TypeCheck';
   description: Maybe<Scalars['String']>;
   label: Maybe<Scalars['String']>;
-  metadataEntries: Array<MetadataEntry>;
+  metadataEntries: Array<
+    | AssetMetadataEntry
+    | BoolMetadataEntry
+    | FloatMetadataEntry
+    | IntMetadataEntry
+    | JobMetadataEntry
+    | JsonMetadataEntry
+    | MarkdownMetadataEntry
+    | NotebookMetadataEntry
+    | NullMetadataEntry
+    | PathMetadataEntry
+    | PipelineRunMetadataEntry
+    | PythonArtifactMetadataEntry
+    | TableMetadataEntry
+    | TableSchemaMetadataEntry
+    | TextMetadataEntry
+    | UrlMetadataEntry
+  >;
   success: Scalars['Boolean'];
 };
 
@@ -4448,7 +5130,7 @@ export type UrlMetadataEntry = MetadataEntry & {
 
 export type UsedSolid = {
   __typename: 'UsedSolid';
-  definition: ISolidDefinition;
+  definition: CompositeSolidDefinition | SolidDefinition;
   invocations: Array<NodeInvocationSite>;
 };
 
@@ -4493,11 +5175,18 @@ export type WorkspaceLocationStatusEntry = {
 export type WorkspaceOrError = PythonError | Workspace;
 
 export type WrappingConfigType = {
-  ofType: ConfigType;
+  ofType:
+    | ArrayConfigType
+    | CompositeConfigType
+    | EnumConfigType
+    | MapConfigType
+    | NullableConfigType
+    | RegularConfigType
+    | ScalarUnionConfigType;
 };
 
 export type WrappingDagsterType = {
-  ofType: DagsterType;
+  ofType: ListDagsterType | NullableDagsterType | RegularDagsterType;
 };
 
 export const buildAddDynamicPartitionSuccess = (
@@ -4606,9 +5295,26 @@ export const buildArrayConfigType = (
     ofType:
       overrides && overrides.hasOwnProperty('ofType')
         ? overrides.ofType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
     recursiveConfigTypes:
       overrides && overrides.hasOwnProperty('recursiveConfigTypes')
         ? overrides.recursiveConfigTypes!
@@ -5351,9 +6057,15 @@ export const buildAssetNode = (
     type:
       overrides && overrides.hasOwnProperty('type')
         ? overrides.type!
-        : relationshipsToOmit.has('DagsterType')
-        ? ({} as DagsterType)
-        : buildDagsterType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ListDagsterType')
+        ? ({} as ListDagsterType)
+        : buildListDagsterType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableDagsterType')
+        ? ({} as NullableDagsterType)
+        : buildNullableDagsterType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularDagsterType')
+        ? ({} as RegularDagsterType)
+        : buildRegularDagsterType({}, relationshipsToOmit),
   };
 };
 
@@ -5907,9 +6619,26 @@ export const buildConfigTypeField = (
     configType:
       overrides && overrides.hasOwnProperty('configType')
         ? overrides.configType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
     configTypeKey:
       overrides && overrides.hasOwnProperty('configTypeKey')
         ? overrides.configTypeKey!
@@ -6050,9 +6779,26 @@ export const buildDagsterType = (
     inputSchemaType:
       overrides && overrides.hasOwnProperty('inputSchemaType')
         ? overrides.inputSchemaType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
     isBuiltin: overrides && overrides.hasOwnProperty('isBuiltin') ? overrides.isBuiltin! : true,
     isList: overrides && overrides.hasOwnProperty('isList') ? overrides.isList! : true,
     isNothing: overrides && overrides.hasOwnProperty('isNothing') ? overrides.isNothing! : true,
@@ -6064,9 +6810,26 @@ export const buildDagsterType = (
     outputSchemaType:
       overrides && overrides.hasOwnProperty('outputSchemaType')
         ? overrides.outputSchemaType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
   };
 };
 
@@ -7313,9 +8076,15 @@ export const buildInputDefinition = (
     type:
       overrides && overrides.hasOwnProperty('type')
         ? overrides.type!
-        : relationshipsToOmit.has('DagsterType')
-        ? ({} as DagsterType)
-        : buildDagsterType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ListDagsterType')
+        ? ({} as ListDagsterType)
+        : buildListDagsterType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableDagsterType')
+        ? ({} as NullableDagsterType)
+        : buildNullableDagsterType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularDagsterType')
+        ? ({} as RegularDagsterType)
+        : buildRegularDagsterType({}, relationshipsToOmit),
   };
 };
 
@@ -8007,9 +8776,26 @@ export const buildListDagsterType = (
     inputSchemaType:
       overrides && overrides.hasOwnProperty('inputSchemaType')
         ? overrides.inputSchemaType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
     isBuiltin: overrides && overrides.hasOwnProperty('isBuiltin') ? overrides.isBuiltin! : true,
     isList: overrides && overrides.hasOwnProperty('isList') ? overrides.isList! : true,
     isNothing: overrides && overrides.hasOwnProperty('isNothing') ? overrides.isNothing! : true,
@@ -8021,15 +8807,38 @@ export const buildListDagsterType = (
     ofType:
       overrides && overrides.hasOwnProperty('ofType')
         ? overrides.ofType!
-        : relationshipsToOmit.has('DagsterType')
-        ? ({} as DagsterType)
-        : buildDagsterType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ListDagsterType')
+        ? ({} as ListDagsterType)
+        : buildListDagsterType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableDagsterType')
+        ? ({} as NullableDagsterType)
+        : buildNullableDagsterType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularDagsterType')
+        ? ({} as RegularDagsterType)
+        : buildRegularDagsterType({}, relationshipsToOmit),
     outputSchemaType:
       overrides && overrides.hasOwnProperty('outputSchemaType')
         ? overrides.outputSchemaType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
   };
 };
 
@@ -8219,9 +9028,26 @@ export const buildMapConfigType = (
     keyType:
       overrides && overrides.hasOwnProperty('keyType')
         ? overrides.keyType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
     recursiveConfigTypes:
       overrides && overrides.hasOwnProperty('recursiveConfigTypes')
         ? overrides.recursiveConfigTypes!
@@ -8231,9 +9057,26 @@ export const buildMapConfigType = (
     valueType:
       overrides && overrides.hasOwnProperty('valueType')
         ? overrides.valueType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
   };
 };
 
@@ -8864,9 +9707,26 @@ export const buildNullableConfigType = (
     ofType:
       overrides && overrides.hasOwnProperty('ofType')
         ? overrides.ofType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
     recursiveConfigTypes:
       overrides && overrides.hasOwnProperty('recursiveConfigTypes')
         ? overrides.recursiveConfigTypes!
@@ -8894,9 +9754,26 @@ export const buildNullableDagsterType = (
     inputSchemaType:
       overrides && overrides.hasOwnProperty('inputSchemaType')
         ? overrides.inputSchemaType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
     isBuiltin: overrides && overrides.hasOwnProperty('isBuiltin') ? overrides.isBuiltin! : false,
     isList: overrides && overrides.hasOwnProperty('isList') ? overrides.isList! : false,
     isNothing: overrides && overrides.hasOwnProperty('isNothing') ? overrides.isNothing! : true,
@@ -8908,15 +9785,38 @@ export const buildNullableDagsterType = (
     ofType:
       overrides && overrides.hasOwnProperty('ofType')
         ? overrides.ofType!
-        : relationshipsToOmit.has('DagsterType')
-        ? ({} as DagsterType)
-        : buildDagsterType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ListDagsterType')
+        ? ({} as ListDagsterType)
+        : buildListDagsterType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableDagsterType')
+        ? ({} as NullableDagsterType)
+        : buildNullableDagsterType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularDagsterType')
+        ? ({} as RegularDagsterType)
+        : buildRegularDagsterType({}, relationshipsToOmit),
     outputSchemaType:
       overrides && overrides.hasOwnProperty('outputSchemaType')
         ? overrides.outputSchemaType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
   };
 };
 
@@ -9060,9 +9960,15 @@ export const buildOutputDefinition = (
     type:
       overrides && overrides.hasOwnProperty('type')
         ? overrides.type!
-        : relationshipsToOmit.has('DagsterType')
-        ? ({} as DagsterType)
-        : buildDagsterType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ListDagsterType')
+        ? ({} as ListDagsterType)
+        : buildListDagsterType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableDagsterType')
+        ? ({} as NullableDagsterType)
+        : buildNullableDagsterType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularDagsterType')
+        ? ({} as RegularDagsterType)
+        : buildRegularDagsterType({}, relationshipsToOmit),
   };
 };
 
@@ -9850,9 +10756,12 @@ export const buildPipelineRun = (
     pipeline:
       overrides && overrides.hasOwnProperty('pipeline')
         ? overrides.pipeline!
-        : relationshipsToOmit.has('PipelineReference')
-        ? ({} as PipelineReference)
-        : buildPipelineReference({}, relationshipsToOmit),
+        : relationshipsToOmit.has('PipelineSnapshot')
+        ? ({} as PipelineSnapshot)
+        : buildPipelineSnapshot({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('UnknownPipeline')
+        ? ({} as UnknownPipeline)
+        : buildUnknownPipeline({}, relationshipsToOmit),
     pipelineName:
       overrides && overrides.hasOwnProperty('pipelineName') ? overrides.pipelineName! : 'animi',
     pipelineSnapshotId:
@@ -10552,9 +11461,26 @@ export const buildRegularDagsterType = (
     inputSchemaType:
       overrides && overrides.hasOwnProperty('inputSchemaType')
         ? overrides.inputSchemaType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
     isBuiltin: overrides && overrides.hasOwnProperty('isBuiltin') ? overrides.isBuiltin! : true,
     isList: overrides && overrides.hasOwnProperty('isList') ? overrides.isList! : false,
     isNothing: overrides && overrides.hasOwnProperty('isNothing') ? overrides.isNothing! : false,
@@ -10566,9 +11492,26 @@ export const buildRegularDagsterType = (
     outputSchemaType:
       overrides && overrides.hasOwnProperty('outputSchemaType')
         ? overrides.outputSchemaType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
   };
 };
 
@@ -11187,9 +12130,12 @@ export const buildRun = (
     pipeline:
       overrides && overrides.hasOwnProperty('pipeline')
         ? overrides.pipeline!
-        : relationshipsToOmit.has('PipelineReference')
-        ? ({} as PipelineReference)
-        : buildPipelineReference({}, relationshipsToOmit),
+        : relationshipsToOmit.has('PipelineSnapshot')
+        ? ({} as PipelineSnapshot)
+        : buildPipelineSnapshot({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('UnknownPipeline')
+        ? ({} as UnknownPipeline)
+        : buildUnknownPipeline({}, relationshipsToOmit),
     pipelineName:
       overrides && overrides.hasOwnProperty('pipelineName') ? overrides.pipelineName! : 'enim',
     pipelineSnapshotId:
@@ -11300,9 +12246,26 @@ export const buildRunConfigSchema = (
     rootConfigType:
       overrides && overrides.hasOwnProperty('rootConfigType')
         ? overrides.rootConfigType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
     rootDefaultYaml:
       overrides && overrides.hasOwnProperty('rootDefaultYaml') ? overrides.rootDefaultYaml! : 'cum',
   };
@@ -11787,9 +12750,26 @@ export const buildScalarUnionConfigType = (
     nonScalarType:
       overrides && overrides.hasOwnProperty('nonScalarType')
         ? overrides.nonScalarType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
     nonScalarTypeKey:
       overrides && overrides.hasOwnProperty('nonScalarTypeKey')
         ? overrides.nonScalarTypeKey!
@@ -11801,9 +12781,26 @@ export const buildScalarUnionConfigType = (
     scalarType:
       overrides && overrides.hasOwnProperty('scalarType')
         ? overrides.scalarType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
     scalarTypeKey:
       overrides && overrides.hasOwnProperty('scalarTypeKey') ? overrides.scalarTypeKey! : 'esse',
     typeParamKeys:
@@ -12243,9 +13240,12 @@ export const buildSolid = (
     definition:
       overrides && overrides.hasOwnProperty('definition')
         ? overrides.definition!
-        : relationshipsToOmit.has('ISolidDefinition')
-        ? ({} as ISolidDefinition)
-        : buildISolidDefinition({}, relationshipsToOmit),
+        : relationshipsToOmit.has('CompositeSolidDefinition')
+        ? ({} as CompositeSolidDefinition)
+        : buildCompositeSolidDefinition({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('SolidDefinition')
+        ? ({} as SolidDefinition)
+        : buildSolidDefinition({}, relationshipsToOmit),
     inputs: overrides && overrides.hasOwnProperty('inputs') ? overrides.inputs! : [],
     isDynamicMapped:
       overrides && overrides.hasOwnProperty('isDynamicMapped') ? overrides.isDynamicMapped! : true,
@@ -13072,9 +14072,12 @@ export const buildUsedSolid = (
     definition:
       overrides && overrides.hasOwnProperty('definition')
         ? overrides.definition!
-        : relationshipsToOmit.has('ISolidDefinition')
-        ? ({} as ISolidDefinition)
-        : buildISolidDefinition({}, relationshipsToOmit),
+        : relationshipsToOmit.has('CompositeSolidDefinition')
+        ? ({} as CompositeSolidDefinition)
+        : buildCompositeSolidDefinition({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('SolidDefinition')
+        ? ({} as SolidDefinition)
+        : buildSolidDefinition({}, relationshipsToOmit),
     invocations: overrides && overrides.hasOwnProperty('invocations') ? overrides.invocations! : [],
   };
 };
@@ -13188,9 +14191,26 @@ export const buildWrappingConfigType = (
     ofType:
       overrides && overrides.hasOwnProperty('ofType')
         ? overrides.ofType!
-        : relationshipsToOmit.has('ConfigType')
-        ? ({} as ConfigType)
-        : buildConfigType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ArrayConfigType')
+        ? ({} as ArrayConfigType)
+        : buildArrayConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('CompositeConfigType')
+        ? ({} as CompositeConfigType)
+        : buildCompositeConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('EnumConfigType')
+        ? ({} as EnumConfigType)
+        : buildEnumConfigType({}, relationshipsToOmit) || relationshipsToOmit.has('MapConfigType')
+        ? ({} as MapConfigType)
+        : buildMapConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableConfigType')
+        ? ({} as NullableConfigType)
+        : buildNullableConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularConfigType')
+        ? ({} as RegularConfigType)
+        : buildRegularConfigType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('ScalarUnionConfigType')
+        ? ({} as ScalarUnionConfigType)
+        : buildScalarUnionConfigType({}, relationshipsToOmit),
   };
 };
 
@@ -13205,8 +14225,14 @@ export const buildWrappingDagsterType = (
     ofType:
       overrides && overrides.hasOwnProperty('ofType')
         ? overrides.ofType!
-        : relationshipsToOmit.has('DagsterType')
-        ? ({} as DagsterType)
-        : buildDagsterType({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ListDagsterType')
+        ? ({} as ListDagsterType)
+        : buildListDagsterType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('NullableDagsterType')
+        ? ({} as NullableDagsterType)
+        : buildNullableDagsterType({}, relationshipsToOmit) ||
+          relationshipsToOmit.has('RegularDagsterType')
+        ? ({} as RegularDagsterType)
+        : buildRegularDagsterType({}, relationshipsToOmit),
   };
 };


### PR DESCRIPTION
## Summary & Motivation

Fixes an issue where interfaces generated in the typescript types caused our `build` functions to be unusable in certain scenarios (see screenshot):
<img width="1005" alt="Screenshot 2024-01-18 at 3 12 57 PM" src="https://github.com/dagster-io/dagster/assets/2286579/5aaba9da-d651-46ca-a555-95f7b13beac7">

 After this pr the typescript generation instead uses the "implementing types" as do the builders:
<img width="1295" alt="Screenshot 2024-01-18 at 3 14 26 PM" src="https://github.com/dagster-io/dagster/assets/2286579/0b5a2a58-5200-4a51-adfc-1dfdee97243e">.

Note: `useImplementingTypes` is required on both the plugin config and the main config of our type generation

## How I Tested These Changes

yarn ts
used the builder in a spot where typescript previously complained and saw we no longer got an error