### PR TITLE
[buildkite] dont run celery-k8s-test-suite on 3.11

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
@@ -1,10 +1,10 @@
 import os
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Union
 
 import packaging.version
 
 from ..defines import GCP_CREDS_FILENAME, GCP_CREDS_LOCAL_FILE, LATEST_DAGSTER_RELEASE
-from ..package_spec import PackageSpec
+from ..package_spec import PackageSpec, UnsupportedVersionsFunction
 from ..python_version import AvailablePythonVersion
 from ..utils import (
     BuildkiteStep,
@@ -155,7 +155,12 @@ def build_celery_k8s_suite_steps() -> List[BuildkiteTopLevelStep]:
     ]
     directory = os.path.join("integration_tests", "test_suites", "celery-k8s-test-suite")
     return build_integration_suite_steps(
-        directory, pytest_tox_factors, always_run_if=has_helm_changes
+        directory,
+        pytest_tox_factors,
+        always_run_if=has_helm_changes,
+        unsupported_python_versions=[
+            AvailablePythonVersion.V3_11,  # mysteriously causes buildkite agents to crash
+        ],
     )
 
 
@@ -214,6 +219,9 @@ def build_integration_suite_steps(
     pytest_extra_cmds: Optional[Callable] = None,
     queue=None,
     always_run_if: Optional[Callable[[], bool]] = None,
+    unsupported_python_versions: Optional[
+        Union[List[AvailablePythonVersion], UnsupportedVersionsFunction]
+    ] = None,
 ) -> List[BuildkiteTopLevelStep]:
     pytest_extra_cmds = pytest_extra_cmds or default_integration_suite_pytest_extra_cmds
     return PackageSpec(
@@ -233,6 +241,7 @@ def build_integration_suite_steps(
         timeout_in_minutes=30,
         queue=queue,
         always_run_if=always_run_if,
+        unsupported_python_versions=unsupported_python_versions,
     ).build_steps()
 
 


### PR DESCRIPTION
buildkite agents crash resulting in "agent lost" when this test gets run 

## How I Tested These Changes

bk NO_SKIP
