### PR TITLE
feat: support k8s pod debug info without logs

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_utils.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_utils.py
@@ -335,7 +335,7 @@ Last 25 log lines for container 'failpoddebug':"""
         pod_names = api_client.get_pod_names_in_job("failpoddebugnologs", namespace=namespace)
 
         pod_debug_info = api_client.get_pod_debug_info(
-            pod_names[0], namespace=namespace, skip_logs=True
+            pod_names[0], namespace=namespace, include_container_logs=False
         )
 
         print(pod_debug_info)  # noqa

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_utils.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_utils.py
@@ -320,6 +320,36 @@ Last 25 log lines for container 'failpoddebug':"""
         assert " whoops!\n" in pod_debug_info
         assert pod_debug_info.endswith("No warning events for pod.")
 
+        # Test case where the pod unexpectedly terminates and logs collection is skipped
+        api_client.batch_api.create_namespaced_job(
+            body=construct_job_manifest("failpoddebugnologs", 'echo "whoopsies!"; exit 1'),
+            namespace=namespace,
+        )
+
+        with pytest.raises(
+            DagsterK8sError,
+            match="Encountered failed job pods for job failpoddebugnologs with status:",
+        ):
+            api_client.wait_for_job_success("failpoddebugnologs", namespace=namespace)
+
+        pod_names = api_client.get_pod_names_in_job("failpoddebugnologs", namespace=namespace)
+
+        pod_debug_info = api_client.get_pod_debug_info(
+            pod_names[0], namespace=namespace, skip_logs=True
+        )
+
+        print(pod_debug_info)  # noqa
+
+        assert pod_debug_info.startswith(
+            f"""Debug information for pod {pod_names[0]}:
+
+Pod status: Failed
+Container 'failpoddebugnologs' status: Terminated with exit code 1: Error
+            """.strip()
+        )
+        assert " whoopsies!\n" not in pod_debug_info
+        assert pod_debug_info.endswith("No warning events for pod.")
+
         # Test case where the pod completes successfully
         api_client.batch_api.create_namespaced_job(
             body=construct_job_manifest("goodpod1", 'echo "hello world"'), namespace=namespace

--- a/python_modules/dagster/dagster/_core/launcher/base.py
+++ b/python_modules/dagster/dagster/_core/launcher/base.py
@@ -96,7 +96,9 @@ class RunLauncher(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
             "This run launcher does not support run monitoring. Please disable it on your instance."
         )
 
-    def get_run_worker_debug_info(self, run: DagsterRun) -> Optional[str]:
+    def get_run_worker_debug_info(
+        self, run: DagsterRun, skip_logs: Optional[bool] = False
+    ) -> Optional[str]:
         return None
 
     @property

--- a/python_modules/dagster/dagster/_core/launcher/base.py
+++ b/python_modules/dagster/dagster/_core/launcher/base.py
@@ -97,7 +97,7 @@ class RunLauncher(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         )
 
     def get_run_worker_debug_info(
-        self, run: DagsterRun, skip_logs: Optional[bool] = False
+        self, run: DagsterRun, include_container_logs: Optional[bool] = True
     ) -> Optional[str]:
         return None
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -736,6 +736,7 @@ class DagsterKubernetesClient:
         pod_name,
         namespace,
         pod: Optional[kubernetes.client.V1Pod] = None,  # the already fetched pod
+        skip_logs: bool = False,
     ) -> str:
         if pod is None:
             pods = self.core_api.list_namespaced_pod(
@@ -755,42 +756,45 @@ class DagsterKubernetesClient:
             else {}
         )
 
-        for container in pod.spec.containers if (pod and pod.spec and pod.spec.containers) else []:
-            container_name = container.name
-            log_str = ""
+        if not skip_logs:
+            for container in (
+                pod.spec.containers if (pod and pod.spec and pod.spec.containers) else []
+            ):
+                container_name = container.name
+                log_str = ""
 
-            container_status = container_statuses_by_name.get(container_name)
+                container_status = container_statuses_by_name.get(container_name)
 
-            if not container_status or not self._has_container_logs(container_status):
-                log_str = f"No logs for container '{container_name}'."
-            else:
-                try:
-                    pod_logs = self.retrieve_pod_logs(
-                        pod_name,
-                        namespace,
-                        container_name,
-                        tail_lines=25,
-                        timestamps=True,
-                    )
-                    # Remove trailing newline if present
-                    pod_logs = pod_logs[:-1] if pod_logs.endswith("\n") else pod_logs
-
-                    if "exec format error" in pod_logs:
-                        specific_warnings.append(
-                            f"Logs for container '{container_name}' contained `exec format error`, which usually means that your"
-                            " Docker image was built using the wrong architecture.\nTry rebuilding your"
-                            " docker image with the `--platform linux/amd64` flag set."
+                if not container_status or not self._has_container_logs(container_status):
+                    log_str = f"No logs for container '{container_name}'."
+                else:
+                    try:
+                        pod_logs = self.retrieve_pod_logs(
+                            pod_name,
+                            namespace,
+                            container_name,
+                            tail_lines=25,
+                            timestamps=True,
                         )
-                    log_str = (
-                        f"Last 25 log lines for container '{container_name}':\n{pod_logs}"
-                        if pod_logs
-                        else f"No logs for container '{container_name}'."
-                    )
+                        # Remove trailing newline if present
+                        pod_logs = pod_logs[:-1] if pod_logs.endswith("\n") else pod_logs
 
-                except kubernetes.client.rest.ApiException as e:
-                    log_str = f"Failure fetching pod logs for container '{container_name}': {e}"
+                        if "exec format error" in pod_logs:
+                            specific_warnings.append(
+                                f"Logs for container '{container_name}' contained `exec format error`, which usually means that your"
+                                " Docker image was built using the wrong architecture.\nTry rebuilding your"
+                                " docker image with the `--platform linux/amd64` flag set."
+                            )
+                        log_str = (
+                            f"Last 25 log lines for container '{container_name}':\n{pod_logs}"
+                            if pod_logs
+                            else f"No logs for container '{container_name}'."
+                        )
 
-            log_strs.append(log_str)
+                    except kubernetes.client.rest.ApiException as e:
+                        log_str = f"Failure fetching pod logs for container '{container_name}': {e}"
+
+                log_strs.append(log_str)
 
         if not K8S_EVENTS_API_PRESENT:
             warning_str = (

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -736,7 +736,7 @@ class DagsterKubernetesClient:
         pod_name,
         namespace,
         pod: Optional[kubernetes.client.V1Pod] = None,  # the already fetched pod
-        skip_logs: bool = False,
+        include_container_logs: Optional[bool] = True,
     ) -> str:
         if pod is None:
             pods = self.core_api.list_namespaced_pod(
@@ -756,7 +756,7 @@ class DagsterKubernetesClient:
             else {}
         )
 
-        if not skip_logs:
+        if include_container_logs:
             for container in (
                 pod.spec.containers if (pod and pod.spec and pod.spec.containers) else []
             ):

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -367,7 +367,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         return True
 
     def get_run_worker_debug_info(
-        self, run: DagsterRun, skip_logs: Optional[bool] = False
+        self, run: DagsterRun, include_container_logs: Optional[bool] = True
     ) -> Optional[str]:
         container_context = self.get_container_context_for_run(run)
         if self.supports_run_worker_crash_recovery:
@@ -381,7 +381,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         full_msg = ""
         try:
             pod_debug_info = [
-                self._api_client.get_pod_debug_info(pod_name, namespace, skip_logs=skip_logs)
+                self._api_client.get_pod_debug_info(pod_name, namespace, include_container_logs=include_container_logs)
                 for pod_name in pod_names
             ]
             full_msg = "\n".join(pod_debug_info)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -366,7 +366,9 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
     def supports_run_worker_crash_recovery(self):
         return True
 
-    def get_run_worker_debug_info(self, run: DagsterRun) -> Optional[str]:
+    def get_run_worker_debug_info(
+        self, run: DagsterRun, skip_logs: Optional[bool] = False
+    ) -> Optional[str]:
         container_context = self.get_container_context_for_run(run)
         if self.supports_run_worker_crash_recovery:
             resume_attempt_number = self._instance.count_resume_run_attempts(run.run_id)
@@ -379,7 +381,8 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         full_msg = ""
         try:
             pod_debug_info = [
-                self._api_client.get_pod_debug_info(pod_name, namespace) for pod_name in pod_names
+                self._api_client.get_pod_debug_info(pod_name, namespace, skip_logs=skip_logs)
+                for pod_name in pod_names
             ]
             full_msg = "\n".join(pod_debug_info)
         except Exception:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -381,7 +381,9 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         full_msg = ""
         try:
             pod_debug_info = [
-                self._api_client.get_pod_debug_info(pod_name, namespace, include_container_logs=include_container_logs)
+                self._api_client.get_pod_debug_info(
+                    pod_name, namespace, include_container_logs=include_container_logs
+                )
                 for pod_name in pod_names
             ]
             full_msg = "\n".join(pod_debug_info)


### PR DESCRIPTION
## Summary & Motivation

This supports a feature request to include the pod debug information in run worker failure messages, while skipping to log to avoid saturating the heartbeat payload.


## How I Tested These Changes

I added the case to preexisting integration test `test_pod_debug_info_failure` in k8s-test-suite