### PR TITLE
Fix sorting in event_log_storage test

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -3197,7 +3197,8 @@ class TestEventLogStorage:
                     records = storage.get_asset_records()  # should select all assets
                     assert len(records) == 2
 
-                    list(records).sort(
+                    records = list(records)
+                    records.sort(
                         key=lambda record: record.asset_entry.asset_key
                     )  # order by asset key
                     asset_entry = records[0].asset_entry


### PR DESCRIPTION
## Summary & Motivation
This test was passing because the records were in sorted order by accident

## How I Tested These Changes
Existing tests