### PR TITLE
Cycle safe asset graph subset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -153,6 +153,15 @@ class AssetGraph:
     def get_auto_observe_interval_minutes(self, asset_key: AssetKey) -> Optional[float]:
         return self._auto_observe_interval_minutes_by_key.get(asset_key)
 
+    def cycle_safe_subset(self) -> "AssetGraph":
+        """It is currently possible to create an ExternalAssetGraph with a cycle in the dependency
+        graph, as we are not able to validate the dependency graph until we have loaded all the
+        separate code locations. This method returns a new ExternalAssetGraph that is guaranteed to
+        not contain any cycles, although it may be missing some edges. Therefore, this should not
+        be used outside of specialized circumstances where this is acceptable.
+        """
+        return self
+
     @staticmethod
     def from_assets(
         all_assets: Iterable[Union[AssetsDefinition, SourceAsset]],

--- a/python_modules/dagster/dagster/_core/definitions/data_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_version.py
@@ -383,11 +383,11 @@ class CachingStaleStatusResolver:
         self._instance = instance
         self._instance_queryer = None
         if isinstance(asset_graph, AssetGraph):
-            self._asset_graph = asset_graph
+            self._asset_graph = asset_graph.cycle_safe_subset()
             self._asset_graph_load_fn = None
         else:
             self._asset_graph = None
-            self._asset_graph_load_fn = asset_graph
+            self._asset_graph_load_fn = lambda: asset_graph().cycle_safe_subset()
 
     def get_status(self, key: "AssetKey", partition_key: Optional[str] = None) -> StaleStatus:
         from dagster._core.definitions.events import AssetKeyPartitionKey

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -253,12 +253,15 @@ class ExternalAssetGraph(AssetGraph):
                 "upstream": new_upstream,
                 "downstream": new_downstream,
             }
+            new_partition_mappings_by_key = {
+                k: vs for k, vs in self._partition_mappings_by_key.items() if k != cycle_key
+            }
             # recursively call cycle_safe_subset until there are no more cycles
             return ExternalAssetGraph(
                 asset_dep_graph=new_dep_graph,
                 source_asset_keys=self.source_asset_keys,
                 partitions_defs_by_key=self._partitions_defs_by_key,
-                partition_mappings_by_key=self._partition_mappings_by_key,
+                partition_mappings_by_key=new_partition_mappings_by_key,
                 group_names_by_key=self.group_names_by_key,
                 freshness_policies_by_key=self.freshness_policies_by_key,
                 auto_materialize_policies_by_key=self.auto_materialize_policies_by_key,

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -15,7 +15,6 @@ from typing import (
 import toposort
 
 import dagster._check as check
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.assets_job import ASSET_BASE_JOB_PREFIX
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.host_representation.external import ExternalRepository


### PR DESCRIPTION
## Summary & Motivation

It is possible to create an ExternalAssetGraph with cycles, as we can't do cross-code-location validation. We naturally have some bits of logic that end up with recursion errors if you have cycles, as they assume the asset graph has no cycles.

This allows you to access a minimally-incorrect asset graph which is guaranteed to not contain any cycles in it, which can be operated over in scenarios where this tradeoff in accuracy is acceptable.

## How I Tested These Changes
