### PR TITLE
[Asset graph] Fix sidebar showing assets for group

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -148,7 +148,7 @@ export const AssetGraphExplorerSidebar = React.memo(
           groupsCount += 1;
         }
         codeLocationNodes[codeLocation]!.groups[groupId] = codeLocationNodes[codeLocation]!.groups[
-          groupName
+          groupId
         ] || {
           groupName,
           assets: [],


### PR DESCRIPTION
## Summary & Motivation

This object is keyed by groupId

broken in https://github.com/dagster-io/dagster/pull/19240

## How I Tested These Changes

loaded the asset graph while viewing only a single group