### PR TITLE
[eslint-config] Prepare for eslint config v1.0.14

### DIFF
--- a/js_modules/dagster-ui/packages/eslint-config/CHANGES.md
+++ b/js_modules/dagster-ui/packages/eslint-config/CHANGES.md
@@ -1,3 +1,9 @@
+## 1.0.14 (January 19, 2024)
+
+- Alphabetize imports
+- Remove unused imports
+- Turn off `react/react-in-jsx-scope`
+
 ## 1.0.13 (September 20, 2023)
 
 - Dependency upgrades

--- a/js_modules/dagster-ui/packages/eslint-config/package.json
+++ b/js_modules/dagster-ui/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dagster-io/eslint-config",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Shared eslint configuration for @dagster-io",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/js_modules/dagster-ui/packages/ui-components/package.json
+++ b/js_modules/dagster-ui/packages/ui-components/package.json
@@ -45,7 +45,7 @@
     "@babel/preset-env": "^7.16.7",
     "@babel/preset-react": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
-    "@dagster-io/eslint-config": "1.0.13",
+    "@dagster-io/eslint-config": "1.0.14",
     "@mdx-js/react": "^1.6.22",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^21.0.3",

--- a/js_modules/dagster-ui/yarn.lock
+++ b/js_modules/dagster-ui/yarn.lock
@@ -2395,7 +2395,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dagster-io/eslint-config@npm:1.0.13, @dagster-io/eslint-config@workspace:*, @dagster-io/eslint-config@workspace:packages/eslint-config":
+"@dagster-io/eslint-config@npm:1.0.14, @dagster-io/eslint-config@workspace:*, @dagster-io/eslint-config@workspace:packages/eslint-config":
   version: 0.0.0-use.local
   resolution: "@dagster-io/eslint-config@workspace:packages/eslint-config"
   dependencies:
@@ -2432,7 +2432,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.16.7"
     "@babel/preset-react": "npm:^7.16.7"
     "@babel/preset-typescript": "npm:^7.16.7"
-    "@dagster-io/eslint-config": "npm:1.0.13"
+    "@dagster-io/eslint-config": "npm:1.0.14"
     "@mdx-js/react": "npm:^1.6.22"
     "@react-hook/resize-observer": "npm:^1.2.6"
     "@rollup/plugin-babel": "npm:^5.3.1"


### PR DESCRIPTION
## Summary & Motivation

Bump the version number on eslint-config so that we can start using the new lint rules elsewhere.

## How I Tested These Changes

BK
