### PR TITLE
Add submit_asset_run / submit_asset_runs_in_chunks utility

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -7,7 +7,6 @@ from enum import Enum
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
-    Dict,
     Iterable,
     List,
     Mapping,
@@ -21,10 +20,7 @@ from typing import (
 
 import pendulum
 
-from dagster import (
-    PartitionKeyRange,
-    _check as check,
-)
+import dagster._check as check
 from dagster._core.definitions.asset_daemon_context import (
     build_run_requests,
     build_run_requests_with_backfill_policies,
@@ -32,15 +28,12 @@ from dagster._core.definitions.asset_daemon_context import (
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_selection import AssetSelection
-from dagster._core.definitions.assets_job import is_base_asset_job_name
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
-from dagster._core.definitions.partition import (
-    PartitionsDefinition,
-    PartitionsSubset,
-)
+from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
+from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.run_request import RunRequest
-from dagster._core.definitions.selector import JobSubsetSelector, PartitionsByAssetSelector
+from dagster._core.definitions.selector import PartitionsByAssetSelector
 from dagster._core.definitions.time_window_partitions import (
     DatetimeFieldSerializer,
     TimeWindowPartitionsSubset,
@@ -53,12 +46,7 @@ from dagster._core.errors import (
 )
 from dagster._core.event_api import EventRecordsFilter
 from dagster._core.events import DagsterEventType
-from dagster._core.host_representation import (
-    ExternalExecutionPlan,
-    ExternalJob,
-)
 from dagster._core.instance import DagsterInstance, DynamicPartitionsStore
-from dagster._core.snap import ExecutionPlanSnapshot
 from dagster._core.storage.dagster_run import (
     CANCELABLE_RUN_STATUSES,
     IN_PROGRESS_RUN_STATUSES,
@@ -77,8 +65,10 @@ from dagster._core.workspace.context import (
 )
 from dagster._core.workspace.workspace import IWorkspace
 from dagster._serdes import whitelist_for_serdes
-from dagster._utils import hash_collection, utc_datetime_from_timestamp
+from dagster._utils import utc_datetime_from_timestamp
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
+
+from .submit_asset_runs import submit_asset_runs_in_chunks
 
 if TYPE_CHECKING:
     from .backfill import PartitionBackfill
@@ -677,7 +667,6 @@ def _submit_runs_and_update_backfill_in_chunks(
     logger: logging.Logger,
 ) -> Iterable[Optional[AssetBackfillData]]:
     from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
-    from dagster._daemon.controller import RELOAD_WORKSPACE_INTERVAL
 
     run_requests = asset_backfill_iteration_result.run_requests
     submitted_partitions = previous_asset_backfill_data.requested_subset
@@ -689,78 +678,29 @@ def _submit_runs_and_update_backfill_in_chunks(
     )
 
     mid_iteration_cancel_requested = False
-
-    # Iterate through runs to request, submitting runs in chunks.
-    # In between each chunk, check that the backfill is still marked as 'requested',
-    # to ensure that no more runs are requested if the backfill is marked as canceled/canceling.
-    unsubmitted_run_request_idx = 0
-    run_request_execution_data_cache: Dict[int, RunRequestExecutionData] = {}
-    num_retries_allowed = 1
-    while unsubmitted_run_request_idx < len(run_requests):
-        chunk_end_idx = min(unsubmitted_run_request_idx + RUN_CHUNK_SIZE, len(run_requests))
-        run_requests_chunk = run_requests[unsubmitted_run_request_idx:chunk_end_idx]
-
-        # Refetch, in case the backfill was requested for cancellation in the meantime
+    for run_requests_chunk in submit_asset_runs_in_chunks(
+        run_requests=run_requests,
+        reserved_run_ids=None,
+        chunk_size=RUN_CHUNK_SIZE,
+        instance=instance,
+        workspace_process_context=workspace_process_context,
+        asset_graph=asset_graph,
+        logger=logger,
+        debug_crash_flags={},
+    ):
+        # refetch, backfill status
         backfill = cast(PartitionBackfill, instance.get_backfill(backfill_id))
         if backfill.status != BulkActionStatus.REQUESTED:
             mid_iteration_cancel_requested = True
             break
 
-        # Submit runs in the chunk
-        run_requests_i = 0
-        while run_requests_i < len(run_requests_chunk):
-            run_request = run_requests_chunk[run_requests_i]
+        if run_requests_chunk is None:
+            # allow the daemon to heartbeat
             yield None
-
-            # create a new request context for each run in case the code location server
-            # is swapped out in the middle of the backfill
-            workspace = workspace_process_context.create_request_context()
-            execution_data = get_job_execution_data_from_run_request(
-                asset_graph,
-                run_request,
-                instance,
-                workspace=workspace,
-                run_request_execution_data_cache=run_request_execution_data_cache,
-            )
-
-            if _execution_plan_targets_asset_selection(
-                execution_data.external_execution_plan.execution_plan_snapshot,
-                check.not_none(run_request.asset_selection),
-            ):
-                submit_run_request(
-                    run_request=run_request,
-                    workspace=workspace,
-                    instance=instance,
-                    run_request_execution_data=execution_data,
-                )
-                run_requests_i += 1
-
-            elif num_retries_allowed > 0:
-                logger.warning(
-                    "Execution plan is out of sync with the workspace. Pausing the backfill for "
-                    f"{RELOAD_WORKSPACE_INTERVAL} to allow the execution plan to rebuild with the updated workspace."
-                )
-                # Sleep for RELOAD_WORKSPACE_INTERVAL seconds since the workspace can be refreshed
-                # at most once every interval
-                time.sleep(RELOAD_WORKSPACE_INTERVAL)
-                # Clear the execution plan cache as this data is no longer valid
-                run_request_execution_data_cache = {}
-                num_retries_allowed -= 1
-                # If the execution plan does not targets the asset selection, the asset graph
-                # likely is outdated and targeting the wrong job, refetch the asset
-                # graph from the workspace
-                workspace = workspace_process_context.create_request_context()
-                asset_graph = ExternalAssetGraph.from_workspace(workspace)
-
-            else:  # Already hit the max number of retries
-                check.failed(
-                    f"Failed to target asset selection {run_request.asset_selection} in run after retrying."
-                )
-
-        unsubmitted_run_request_idx = chunk_end_idx
+            continue
 
         requested_partitions_in_chunk = _get_requested_asset_partitions_from_run_requests(
-            run_requests_chunk, asset_graph, instance_queryer
+            [rr for (rr, _) in run_requests_chunk], asset_graph, instance_queryer
         )
         submitted_partitions = submitted_partitions | AssetGraphSubset.from_asset_partition_set(
             set(requested_partitions_in_chunk), asset_graph=asset_graph
@@ -1122,129 +1062,6 @@ def get_canceling_asset_backfill_iteration_data(
     )
 
     yield updated_backfill_data
-
-
-class RunRequestExecutionData(NamedTuple):
-    external_job: ExternalJob
-    external_execution_plan: ExternalExecutionPlan
-    partitions_def: Optional[PartitionsDefinition]
-
-
-def get_job_execution_data_from_run_request(
-    asset_graph: ExternalAssetGraph,
-    run_request: RunRequest,
-    instance: DagsterInstance,
-    workspace: BaseWorkspaceRequestContext,
-    run_request_execution_data_cache: Dict[int, RunRequestExecutionData],
-) -> RunRequestExecutionData:
-    """Creates and submits a run for the given run request."""
-    repo_handle = asset_graph.get_repository_handle(
-        cast(Sequence[AssetKey], run_request.asset_selection)[0]
-    )
-    location_name = repo_handle.code_location_origin.location_name
-    job_name = _get_implicit_job_name_for_assets(
-        asset_graph, cast(Sequence[AssetKey], run_request.asset_selection)
-    )
-    if job_name is None:
-        check.failed(
-            "Could not find an implicit asset job for the given assets:"
-            f" {run_request.asset_selection}"
-        )
-
-    if not run_request.asset_selection:
-        check.failed("Expected RunRequest to have an asset selection")
-
-    pipeline_selector = JobSubsetSelector(
-        location_name=location_name,
-        repository_name=repo_handle.repository_name,
-        job_name=job_name,
-        asset_selection=run_request.asset_selection,
-        op_selection=None,
-    )
-
-    selector_id = hash_collection(pipeline_selector)
-
-    if selector_id not in run_request_execution_data_cache:
-        code_location = workspace.get_code_location(repo_handle.code_location_origin.location_name)
-        external_job = code_location.get_external_job(pipeline_selector)
-
-        external_execution_plan = code_location.get_external_execution_plan(
-            external_job,
-            {},
-            step_keys_to_execute=None,
-            known_state=None,
-            instance=instance,
-        )
-
-        partitions_def = code_location.get_asset_job_partitions_def(external_job)
-
-        run_request_execution_data_cache[selector_id] = RunRequestExecutionData(
-            external_job,
-            external_execution_plan,
-            partitions_def,
-        )
-
-    return run_request_execution_data_cache[selector_id]
-
-
-def submit_run_request(
-    run_request: RunRequest,
-    instance: DagsterInstance,
-    workspace: BaseWorkspaceRequestContext,
-    run_request_execution_data: RunRequestExecutionData,
-) -> None:
-    external_job = run_request_execution_data.external_job
-    external_execution_plan = run_request_execution_data.external_execution_plan
-    partitions_def = run_request_execution_data.partitions_def
-
-    if not run_request.asset_selection:
-        check.failed("Expected RunRequest to have an asset selection")
-
-    run = instance.create_run(
-        job_snapshot=external_job.job_snapshot,
-        execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,
-        parent_job_snapshot=external_job.parent_job_snapshot,
-        job_name=external_job.name,
-        run_id=None,
-        resolved_op_selection=None,
-        op_selection=None,
-        run_config={},
-        step_keys_to_execute=None,
-        tags=run_request.tags,
-        root_run_id=None,
-        parent_run_id=None,
-        status=DagsterRunStatus.NOT_STARTED,
-        external_job_origin=external_job.get_external_origin(),
-        job_code_origin=external_job.get_python_origin(),
-        asset_selection=frozenset(run_request.asset_selection),
-        asset_check_selection=None,
-        asset_job_partitions_def=partitions_def,
-    )
-
-    instance.submit_run(run.run_id, workspace)
-
-
-def _execution_plan_targets_asset_selection(
-    execution_plan_snapshot: ExecutionPlanSnapshot, asset_selection: Sequence[AssetKey]
-) -> bool:
-    output_asset_keys = set()
-    for step in execution_plan_snapshot.steps:
-        if step.key in execution_plan_snapshot.step_keys_to_execute:
-            for output in step.outputs:
-                asset_key = check.not_none(output.properties).asset_key
-                if asset_key:
-                    output_asset_keys.add(asset_key)
-    return all(key in output_asset_keys for key in asset_selection)
-
-
-def _get_implicit_job_name_for_assets(
-    asset_graph: ExternalAssetGraph, asset_keys: Sequence[AssetKey]
-) -> Optional[str]:
-    job_names = set(asset_graph.get_materialization_job_names(asset_keys[0]))
-    for asset_key in asset_keys[1:]:
-        job_names &= set(asset_graph.get_materialization_job_names(asset_key))
-
-    return next(job_name for job_name in job_names if is_base_asset_job_name(job_name))
 
 
 def get_asset_backfill_iteration_materialized_partitions(

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -678,6 +678,9 @@ def _submit_runs_and_update_backfill_in_chunks(
     )
 
     mid_iteration_cancel_requested = False
+    # Iterate through runs to request, submitting runs in chunks.
+    # In between each chunk, check that the backfill is still marked as 'requested',
+    # to ensure that no more runs are requested if the backfill is marked as canceled/canceling.
     for run_requests_chunk in submit_asset_runs_in_chunks(
         run_requests=run_requests,
         reserved_run_ids=None,
@@ -688,7 +691,7 @@ def _submit_runs_and_update_backfill_in_chunks(
         logger=logger,
         debug_crash_flags={},
     ):
-        # refetch, backfill status
+        # Refetch backfill status
         backfill = cast(PartitionBackfill, instance.get_backfill(backfill_id))
         if backfill.status != BulkActionStatus.REQUESTED:
             mid_iteration_cancel_requested = True

--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -168,9 +168,6 @@ def _create_asset_run(
                 asset_job_partitions_def=partitions_def,
             )
 
-            check_for_debug_crash(debug_crash_flags, "RUN_CREATED")
-            check_for_debug_crash(debug_crash_flags, f"RUN_CREATED_{run_request_index}")
-
             return run
 
         logger.warning(
@@ -244,6 +241,9 @@ def submit_asset_run(
             logger,
         )
 
+    check_for_debug_crash(debug_crash_flags, "RUN_CREATED")
+    check_for_debug_crash(debug_crash_flags, f"RUN_CREATED_{run_request_index}")
+
     instance.submit_run(run_to_submit.run_id, workspace_process_context.create_request_context())
 
     check_for_debug_crash(debug_crash_flags, "RUN_SUBMITTED")
@@ -281,6 +281,8 @@ def submit_asset_runs_in_chunks(
     for chunk_start in range(0, len(run_requests), chunk_size):
         run_request_chunk = run_requests[chunk_start : chunk_start + chunk_size]
         chunk_submitted_runs: List[Tuple[RunRequest, DagsterRun]] = []
+
+        logger.critical(f"{chunk_size}, {chunk_start}, {len(run_request_chunk)}")
 
         # submit each run in the chunk
         for chunk_idx, run_request in enumerate(run_request_chunk):

--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -1,0 +1,304 @@
+import logging
+import time
+from typing import Dict, Iterator, List, NamedTuple, Optional, Sequence, Tuple, cast
+
+import dagster._check as check
+from dagster._core.definitions.assets_job import is_base_asset_job_name
+from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.partition import PartitionsDefinition
+from dagster._core.definitions.run_request import RunRequest
+from dagster._core.definitions.selector import JobSubsetSelector
+from dagster._core.host_representation import ExternalExecutionPlan, ExternalJob
+from dagster._core.instance import DagsterInstance
+from dagster._core.snap import ExecutionPlanSnapshot
+from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
+from dagster._core.workspace.context import BaseWorkspaceRequestContext, IWorkspaceProcessContext
+from dagster._utils import SingleInstigatorDebugCrashFlags, check_for_debug_crash, hash_collection
+
+EXECUTION_PLAN_CREATION_RETRIES = 1
+
+
+class RunRequestExecutionData(NamedTuple):
+    external_job: ExternalJob
+    external_execution_plan: ExternalExecutionPlan
+    partitions_def: Optional[PartitionsDefinition]
+
+
+def _get_implicit_job_name_for_assets(
+    asset_graph: ExternalAssetGraph, asset_keys: Sequence[AssetKey]
+) -> Optional[str]:
+    job_names = set(asset_graph.get_materialization_job_names(asset_keys[0]))
+    for asset_key in asset_keys[1:]:
+        job_names &= set(asset_graph.get_materialization_job_names(asset_key))
+
+    return next(job_name for job_name in job_names if is_base_asset_job_name(job_name))
+
+
+def _execution_plan_targets_asset_selection(
+    execution_plan_snapshot: ExecutionPlanSnapshot, asset_selection: Sequence[AssetKey]
+) -> bool:
+    output_asset_keys = set()
+    for step in execution_plan_snapshot.steps:
+        if step.key in execution_plan_snapshot.step_keys_to_execute:
+            for output in step.outputs:
+                asset_key = check.not_none(output.properties).asset_key
+                if asset_key:
+                    output_asset_keys.add(asset_key)
+    return all(key in output_asset_keys for key in asset_selection)
+
+
+def _get_job_execution_data_from_run_request(
+    asset_graph: ExternalAssetGraph,
+    run_request: RunRequest,
+    instance: DagsterInstance,
+    workspace: BaseWorkspaceRequestContext,
+    run_request_execution_data_cache: Dict[int, RunRequestExecutionData],
+) -> RunRequestExecutionData:
+    repo_handle = asset_graph.get_repository_handle(
+        cast(Sequence[AssetKey], run_request.asset_selection)[0]
+    )
+    location_name = repo_handle.code_location_origin.location_name
+    job_name = _get_implicit_job_name_for_assets(
+        asset_graph, cast(Sequence[AssetKey], run_request.asset_selection)
+    )
+    if job_name is None:
+        check.failed(
+            "Could not find an implicit asset job for the given assets:"
+            f" {run_request.asset_selection}"
+        )
+
+    if not run_request.asset_selection:
+        check.failed("Expected RunRequest to have an asset selection")
+
+    pipeline_selector = JobSubsetSelector(
+        location_name=location_name,
+        repository_name=repo_handle.repository_name,
+        job_name=job_name,
+        asset_selection=run_request.asset_selection,
+        op_selection=None,
+    )
+
+    selector_id = hash_collection(pipeline_selector)
+
+    if selector_id not in run_request_execution_data_cache:
+        code_location = workspace.get_code_location(repo_handle.code_location_origin.location_name)
+        external_job = code_location.get_external_job(pipeline_selector)
+
+        external_execution_plan = code_location.get_external_execution_plan(
+            external_job,
+            {},
+            step_keys_to_execute=None,
+            known_state=None,
+            instance=instance,
+        )
+
+        partitions_def = code_location.get_asset_job_partitions_def(external_job)
+
+        run_request_execution_data_cache[selector_id] = RunRequestExecutionData(
+            external_job,
+            external_execution_plan,
+            partitions_def,
+        )
+
+    return run_request_execution_data_cache[selector_id]
+
+
+def _create_asset_run(
+    run_id: Optional[str],
+    run_request: RunRequest,
+    run_request_index: int,
+    instance: DagsterInstance,
+    run_request_execution_data_cache: Dict[int, RunRequestExecutionData],
+    asset_graph: ExternalAssetGraph,
+    workspace_process_context: IWorkspaceProcessContext,
+    debug_crash_flags: SingleInstigatorDebugCrashFlags,
+    logger: logging.Logger,
+) -> DagsterRun:
+    """Creates a run on the instance for the given run request. Ensures that the created run results
+    in an ExecutionPlan that targets the given asset selection. If it does not, attempts to create
+    a valid ExecutionPlan by reloading the workspace.
+    """
+    from dagster._daemon.controller import RELOAD_WORKSPACE_INTERVAL
+
+    if not run_request.asset_selection:
+        check.failed("Expected RunRequest to have an asset selection")
+
+    for _ in range(EXECUTION_PLAN_CREATION_RETRIES + 1):
+        # create a new request context for each run in case the code location server
+        # is swapped out in the middle of the submission process
+        workspace = workspace_process_context.create_request_context()
+        execution_data = _get_job_execution_data_from_run_request(
+            asset_graph,
+            run_request,
+            instance,
+            workspace=workspace,
+            run_request_execution_data_cache=run_request_execution_data_cache,
+        )
+        check_for_debug_crash(debug_crash_flags, "EXECUTION_PLAN_CREATED")
+        check_for_debug_crash(debug_crash_flags, f"EXECUTION_PLAN_CREATED_{run_request_index}")
+
+        # retry until the execution plan targets the asset selection
+        if _execution_plan_targets_asset_selection(
+            execution_data.external_execution_plan.execution_plan_snapshot,
+            check.not_none(run_request.asset_selection),
+        ):
+            external_job = execution_data.external_job
+            external_execution_plan = execution_data.external_execution_plan
+            partitions_def = execution_data.partitions_def
+
+            run = instance.create_run(
+                job_snapshot=external_job.job_snapshot,
+                execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,
+                parent_job_snapshot=external_job.parent_job_snapshot,
+                job_name=external_job.name,
+                run_id=run_id,
+                resolved_op_selection=None,
+                op_selection=None,
+                run_config={},
+                step_keys_to_execute=None,
+                tags=run_request.tags,
+                root_run_id=None,
+                parent_run_id=None,
+                status=DagsterRunStatus.NOT_STARTED,
+                external_job_origin=external_job.get_external_origin(),
+                job_code_origin=external_job.get_python_origin(),
+                asset_selection=frozenset(run_request.asset_selection),
+                asset_check_selection=None,
+                asset_job_partitions_def=partitions_def,
+            )
+
+            check_for_debug_crash(debug_crash_flags, "RUN_CREATED")
+            check_for_debug_crash(debug_crash_flags, f"RUN_CREATED_{run_request_index}")
+
+            return run
+
+        logger.warning(
+            "Execution plan is out of sync with the workspace. Pausing run submission for "
+            f"{RELOAD_WORKSPACE_INTERVAL} to allow the execution plan to rebuild with the updated workspace."
+        )
+        # Sleep for RELOAD_WORKSPACE_INTERVAL seconds since the workspace can be refreshed
+        # at most once every interval
+        time.sleep(RELOAD_WORKSPACE_INTERVAL)
+        # Clear the execution plan cache as this data is no longer valid
+        run_request_execution_data_cache = {}
+
+        # If the execution plan does not targets the asset selection, the asset graph
+        # likely is outdated and targeting the wrong job, refetch the asset
+        # graph from the workspace
+        workspace = workspace_process_context.create_request_context()
+        asset_graph = ExternalAssetGraph.from_workspace(workspace)
+
+    check.failed(
+        f"Failed to target asset selection {run_request.asset_selection} in run after retrying."
+    )
+
+
+def submit_asset_run(
+    run_id: Optional[str],
+    run_request: RunRequest,
+    run_request_index: int,
+    instance: DagsterInstance,
+    workspace_process_context: IWorkspaceProcessContext,
+    asset_graph: ExternalAssetGraph,
+    run_request_execution_data_cache: Dict[int, RunRequestExecutionData],
+    debug_crash_flags: SingleInstigatorDebugCrashFlags,
+    logger: logging.Logger,
+) -> DagsterRun:
+    """Submits a run for a run request that targets an asset selection. If the run already exists,
+    submits the existing run. If the run does not exist, creates a new run and submits it, ensuring
+    that the created run targets the given asset selection.
+    """
+    check.invariant(not run_request.run_config, "Asset run requests have no custom run config")
+    asset_keys = check.not_none(run_request.asset_selection)
+
+    check.invariant(len(asset_keys) > 0)
+
+    # check if the run already exists
+    existing_run = instance.get_run_by_id(run_id) if run_id else None
+    if existing_run:
+        if existing_run.status != DagsterRunStatus.NOT_STARTED:
+            logger.warn(
+                f"Run {run_id} already submitted on a previously interrupted tick, skipping"
+            )
+
+            check_for_debug_crash(debug_crash_flags, "RUN_SUBMITTED")
+            check_for_debug_crash(debug_crash_flags, f"RUN_SUBMITTED_{run_request_index}")
+
+            return existing_run
+        else:
+            logger.warn(
+                f"Run {run_id} already created on a previously interrupted tick, submitting"
+            )
+            run_to_submit = existing_run
+    else:
+        run_to_submit = _create_asset_run(
+            run_id,
+            run_request,
+            run_request_index,
+            instance,
+            run_request_execution_data_cache,
+            asset_graph,
+            workspace_process_context,
+            debug_crash_flags,
+            logger,
+        )
+
+    instance.submit_run(run_to_submit.run_id, workspace_process_context.create_request_context())
+
+    check_for_debug_crash(debug_crash_flags, "RUN_SUBMITTED")
+    check_for_debug_crash(debug_crash_flags, f"RUN_SUBMITTED_{run_request_index}")
+
+    asset_key_str = ", ".join([asset_key.to_user_string() for asset_key in asset_keys])
+
+    logger.info(
+        f"Submitted run {run_to_submit.run_id} for assets {asset_key_str} with tags"
+        f" {run_request.tags}"
+    )
+
+    return run_to_submit
+
+
+def submit_asset_runs_in_chunks(
+    run_requests: Sequence[RunRequest],
+    reserved_run_ids: Optional[Sequence[str]],
+    chunk_size: int,
+    instance: DagsterInstance,
+    workspace_process_context: IWorkspaceProcessContext,
+    asset_graph: ExternalAssetGraph,
+    debug_crash_flags: SingleInstigatorDebugCrashFlags,
+    logger: logging.Logger,
+) -> Iterator[Optional[Sequence[Tuple[RunRequest, DagsterRun]]]]:
+    """Submits runs for a sequence of run requests that target asset selections in chunks. Yields
+    None after each run is submitted to allow the daemon to heartbeat, and yields a list of tuples
+    of the run request and the submitted run after each chunk is submitted to allow the caller to
+    interrupt this process if needed.
+    """
+    if reserved_run_ids is not None:
+        check.invariant(len(run_requests) == len(reserved_run_ids))
+
+    run_request_execution_data_cache = {}
+    for chunk_start in range(0, len(run_requests), chunk_size):
+        run_request_chunk = run_requests[chunk_start : chunk_start + chunk_size]
+        chunk_submitted_runs: List[Tuple[RunRequest, DagsterRun]] = []
+
+        # submit each run in the chunk
+        for chunk_idx, run_request in enumerate(run_request_chunk):
+            run_request_idx = chunk_start + chunk_idx
+            run_id = reserved_run_ids[run_request_idx] if reserved_run_ids else None
+            submitted_run = submit_asset_run(
+                run_id,
+                run_request,
+                run_request_idx,
+                instance,
+                workspace_process_context,
+                asset_graph,
+                run_request_execution_data_cache,
+                debug_crash_flags,
+                logger,
+            )
+            chunk_submitted_runs.append((run_request, submitted_run))
+            # allow the daemon to heartbeat while runs are submitted
+            yield None
+
+        yield chunk_submitted_runs

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -811,14 +811,13 @@ class AssetDaemon(DagsterDaemon):
                         )
                         updated_evaluation_asset_keys.add(asset_key)
 
-                evaluations_to_update = [
-                    evaluations_by_asset_key[asset_key]
-                    for asset_key in updated_evaluation_asset_keys
-                ]
-                if evaluations_to_update:
-                    schedule_storage.add_auto_materialize_asset_evaluations(
-                        evaluation_id, evaluations_to_update
-                    )
+            evaluations_to_update = [
+                evaluations_by_asset_key[asset_key] for asset_key in updated_evaluation_asset_keys
+            ]
+            if evaluations_to_update:
+                schedule_storage.add_auto_materialize_asset_evaluations(
+                    evaluation_id, evaluations_to_update
+                )
 
             check_for_debug_crash(debug_crash_flags, "RUN_IDS_ADDED_TO_EVALUATIONS")
 

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import ExitStack
 from types import TracebackType
-from typing import Dict, Optional, Sequence, Tuple, Type, cast
+from typing import Dict, Optional, Sequence, Type, cast
 
 import pendulum
 
@@ -24,7 +24,6 @@ from dagster._core.definitions.run_request import (
     InstigatorType,
     RunRequest,
 )
-from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.definitions.sensor_definition import (
     DefaultSensorStatus,
     SensorType,
@@ -33,9 +32,8 @@ from dagster._core.errors import (
     DagsterCodeLocationLoadError,
     DagsterUserCodeUnreachableError,
 )
+from dagster._core.execution.submit_asset_runs import submit_asset_runs_in_chunks
 from dagster._core.host_representation import (
-    ExternalExecutionPlan,
-    ExternalJob,
     ExternalSensor,
 )
 from dagster._core.host_representation.origin import ExternalInstigatorOrigin
@@ -48,7 +46,6 @@ from dagster._core.scheduler.instigation import (
     TickData,
     TickStatus,
 )
-from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.tags import (
     ASSET_EVALUATION_ID_TAG,
     AUTO_MATERIALIZE_TAG,
@@ -57,13 +54,11 @@ from dagster._core.storage.tags import (
 )
 from dagster._core.utils import InheritContextThreadPoolExecutor, make_new_run_id
 from dagster._core.workspace.context import IWorkspaceProcessContext
-from dagster._core.workspace.workspace import IWorkspace
 from dagster._daemon.daemon import DaemonIterator, DagsterDaemon
 from dagster._daemon.sensor import is_under_min_interval, mark_sensor_state_for_tick
 from dagster._utils import (
     SingleInstigatorDebugCrashFlags,
     check_for_debug_crash,
-    hash_collection,
 )
 from dagster._utils.error import serializable_error_info_from_exc_info
 
@@ -773,42 +768,36 @@ class AssetDaemon(DagsterDaemon):
                 f" {evaluation_id}{print_group_name}"
             )
 
-            pipeline_and_execution_plan_cache: Dict[
-                int, Tuple[ExternalJob, ExternalExecutionPlan]
-            ] = {}
-
             check.invariant(len(run_requests) == len(reserved_run_ids))
-
             updated_evaluation_asset_keys = set()
 
-            # here, we make sure to re-fetch the asset graph to ensure that these runs are submitted
-            # against the latest version of the graph, which may have changed since the tick started
-            workspace = workspace_process_context.create_request_context()
-            asset_graph = ExternalAssetGraph.from_workspace(workspace)
-
-            for i in range(len(run_requests)):
-                reserved_run_id = reserved_run_ids[i]
-                run_request = run_requests[i]
-
-                asset_keys = check.not_none(run_request.asset_selection)
-
-                submitted_run = submit_asset_run(
-                    reserved_run_id,
-                    run_request._replace(
+            for run_request_chunk in submit_asset_runs_in_chunks(
+                run_requests=[
+                    rr._replace(
                         tags={
-                            **run_request.tags,
+                            **rr.tags,
                             AUTO_MATERIALIZE_TAG: "true",
                             ASSET_EVALUATION_ID_TAG: str(evaluation_id),
                         }
-                    ),
-                    instance,
-                    workspace,
-                    asset_graph,
-                    pipeline_and_execution_plan_cache,
-                    self._logger,
-                    debug_crash_flags,
-                    i,
-                )
+                    )
+                    for rr in run_requests
+                ],
+                reserved_run_ids=reserved_run_ids,
+                chunk_size=1,
+                instance=instance,
+                workspace_process_context=workspace_process_context,
+                asset_graph=asset_graph,
+                debug_crash_flags=debug_crash_flags,
+                logger=self._logger,
+            ):
+                # heartbeat after each run is submitted
+                if run_request_chunk is None:
+                    yield
+                    continue
+
+                check.invariant(len(run_request_chunk) == 1)
+                run_request, submitted_run = run_request_chunk[0]
+                asset_keys = check.not_none(run_request.asset_selection)
 
                 tick_context.add_run_info(run_id=submitted_run.run_id)
 
@@ -822,13 +811,14 @@ class AssetDaemon(DagsterDaemon):
                         )
                         updated_evaluation_asset_keys.add(asset_key)
 
-            evaluations_to_update = [
-                evaluations_by_asset_key[asset_key] for asset_key in updated_evaluation_asset_keys
-            ]
-            if evaluations_to_update:
-                schedule_storage.add_auto_materialize_asset_evaluations(
-                    evaluation_id, evaluations_to_update
-                )
+                evaluations_to_update = [
+                    evaluations_by_asset_key[asset_key]
+                    for asset_key in updated_evaluation_asset_keys
+                ]
+                if evaluations_to_update:
+                    schedule_storage.add_auto_materialize_asset_evaluations(
+                        evaluation_id, evaluations_to_update
+                    )
 
             check_for_debug_crash(debug_crash_flags, "RUN_IDS_ADDED_TO_EVALUATIONS")
 
@@ -842,129 +832,3 @@ class AssetDaemon(DagsterDaemon):
             )
 
         self._logger.info("Finished auto-materialization tick")
-
-
-def submit_asset_run(
-    run_id: str,
-    run_request: RunRequest,
-    instance: DagsterInstance,
-    workspace: IWorkspace,
-    asset_graph: ExternalAssetGraph,
-    pipeline_and_execution_plan_cache: Dict[int, Tuple[ExternalJob, ExternalExecutionPlan]],
-    logger: logging.Logger,
-    debug_crash_flags: SingleInstigatorDebugCrashFlags,
-    run_request_index: int,
-) -> DagsterRun:
-    check.invariant(
-        not run_request.run_config, "Asset materialization run requests have no custom run config"
-    )
-    asset_keys = check.not_none(run_request.asset_selection)
-
-    check.invariant(len(asset_keys) > 0)
-
-    # check if the run already exists
-
-    run_to_submit = None
-
-    existing_run = instance.get_run_by_id(run_id)
-    if existing_run:
-        if existing_run.status != DagsterRunStatus.NOT_STARTED:
-            logger.warn(
-                f"Run {run_id} already submitted on a previously interrupted tick, skipping"
-            )
-
-            check_for_debug_crash(debug_crash_flags, "RUN_SUBMITTED")
-            check_for_debug_crash(debug_crash_flags, f"RUN_SUBMITTED_{run_request_index}")
-
-            return existing_run
-        else:
-            logger.warn(
-                f"Run {run_id} already created on a previously interrupted tick, submitting"
-            )
-            run_to_submit = existing_run
-
-    if not run_to_submit:
-        repo_handle = asset_graph.get_repository_handle(asset_keys[0])
-
-        # Check that all asset keys are from the same repo
-        for key in asset_keys[1:]:
-            check.invariant(repo_handle == asset_graph.get_repository_handle(key))
-
-        location_name = repo_handle.code_location_origin.location_name
-        repository_name = repo_handle.repository_name
-        code_location = workspace.get_code_location(location_name)
-        job_name = check.not_none(
-            asset_graph.get_implicit_job_name_for_assets(
-                asset_keys, code_location.get_repository(repository_name)
-            )
-        )
-
-        job_selector = JobSubsetSelector(
-            location_name=location_name,
-            repository_name=repository_name,
-            job_name=job_name,
-            op_selection=None,
-            asset_selection=asset_keys,
-        )
-
-        selector_id = hash_collection(job_selector)
-
-        if selector_id not in pipeline_and_execution_plan_cache:
-            external_job = code_location.get_external_job(job_selector)
-
-            external_execution_plan = code_location.get_external_execution_plan(
-                external_job,
-                run_config={},
-                step_keys_to_execute=None,
-                known_state=None,
-                instance=instance,
-            )
-            pipeline_and_execution_plan_cache[selector_id] = (
-                external_job,
-                external_execution_plan,
-            )
-
-        check_for_debug_crash(debug_crash_flags, "EXECUTION_PLAN_CREATED")
-        check_for_debug_crash(debug_crash_flags, f"EXECUTION_PLAN_CREATED_{run_request_index}")
-
-        external_job, external_execution_plan = pipeline_and_execution_plan_cache[selector_id]
-
-        execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
-
-        run_to_submit = instance.create_run(
-            job_name=external_job.name,
-            run_id=run_id,
-            run_config=None,
-            resolved_op_selection=None,
-            step_keys_to_execute=None,
-            status=DagsterRunStatus.NOT_STARTED,
-            op_selection=None,
-            root_run_id=None,
-            parent_run_id=None,
-            tags=run_request.tags,
-            job_snapshot=external_job.job_snapshot,
-            execution_plan_snapshot=execution_plan_snapshot,
-            parent_job_snapshot=external_job.parent_job_snapshot,
-            external_job_origin=external_job.get_external_origin(),
-            job_code_origin=external_job.get_python_origin(),
-            asset_selection=frozenset(asset_keys),
-            asset_check_selection=None,
-            asset_job_partitions_def=code_location.get_asset_job_partitions_def(external_job),
-        )
-
-    check_for_debug_crash(debug_crash_flags, "RUN_CREATED")
-    check_for_debug_crash(debug_crash_flags, f"RUN_CREATED_{run_request_index}")
-
-    instance.submit_run(run_to_submit.run_id, workspace)
-
-    check_for_debug_crash(debug_crash_flags, "RUN_SUBMITTED")
-    check_for_debug_crash(debug_crash_flags, f"RUN_SUBMITTED_{run_request_index}")
-
-    asset_key_str = ", ".join([asset_key.to_user_string() for asset_key in asset_keys])
-
-    logger.info(
-        f"Submitted run {run_to_submit.run_id} for assets {asset_key_str} with tags"
-        f" {run_request.tags}"
-    )
-
-    return run_to_submit


### PR DESCRIPTION
## Summary & Motivation

In both the asset daemon and the backfill daemon, we had a bunch of kinda-duplicated code, all aimed at solving the same problem: submitting a bunch of runs which target selections of assets while a) not having to generate execution plans over GRPC for each individual partition if there were a bunch and b) dealing with the case in which the asset graph changed while runs were being submitted.

This PR creates a single utility function which both daemons can make use of.

## How I Tested These Changes
