### PR TITLE
[dagster webserver] fix websockets on py3.11

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/graphql.py
+++ b/python_modules/dagster-webserver/dagster_webserver/graphql.py
@@ -182,7 +182,7 @@ class GraphQLServer(ABC):
         """
         tasks: Dict[str, Task] = {}
 
-        await websocket.accept(subprotocol=GraphQLWS.PROTOCOL)
+        await websocket.accept(subprotocol=GraphQLWS.PROTOCOL.value)
 
         try:
             while (


### PR DESCRIPTION
another place effected by https://github.com/python/cpython/issues/100458

the string `<GraphQLWS.PROTOCOL: 'graphql-ws'>` was being sent instead of `graphql-ws` 

## How I Tested These Changes

added assert to test that would have caught this


