### PR TITLE
Split apart run root query to gracefully handle timeouts

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunAssetTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunAssetTags.tsx
@@ -1,0 +1,38 @@
+import {gql, useQuery} from '@apollo/client';
+
+import {AssetKeyTagCollection} from './AssetTagCollections';
+import {RunAssetsQuery, RunAssetsQueryVariables} from './types/RunAssetTags.types';
+import {RunFragment} from './types/RunFragments.types';
+import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
+
+export const RunAssetTags = (props: {run: RunFragment}) => {
+  const {run} = props;
+  const {data, loading} = useQuery<RunAssetsQuery, RunAssetsQueryVariables>(RUN_ASSETS_QUERY, {
+    variables: {runId: run.id},
+    skip: isHiddenAssetGroupJob(run.pipelineName),
+  });
+
+  if (loading || !data || data.pipelineRunOrError.__typename !== 'Run') {
+    return null;
+  }
+
+  return (
+    <AssetKeyTagCollection useTags assetKeys={data.pipelineRunOrError.assets.map((a) => a.key)} />
+  );
+};
+
+const RUN_ASSETS_QUERY = gql`
+  query RunAssetsQuery($runId: ID!) {
+    pipelineRunOrError(runId: $runId) {
+      ... on Run {
+        id
+        assets {
+          id
+          key {
+            path
+          }
+        }
+      }
+    }
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunFragments.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunFragments.tsx
@@ -24,12 +24,6 @@ export const RUN_FRAGMENT = gql`
       key
       value
     }
-    assets {
-      id
-      key {
-        path
-      }
-    }
     rootRunId
     parentRunId
     pipelineName

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
@@ -1,5 +1,13 @@
 import {gql, useQuery} from '@apollo/client';
-import {Box, FontFamily, Heading, NonIdealState, PageHeader, Tag} from '@dagster-io/ui-components';
+import {
+  Box,
+  Colors,
+  FontFamily,
+  Heading,
+  NonIdealState,
+  PageHeader,
+  Tag,
+} from '@dagster-io/ui-components';
 import {useLayoutEffect, useMemo} from 'react';
 import {useParams} from 'react-router-dom';
 
@@ -13,7 +21,13 @@ import {DagsterTag} from './RunTag';
 import {RunTimingTags} from './RunTimingTags';
 import {assetKeysForRun} from './RunUtils';
 import {TickTagForRun} from './TickTagForRun';
-import {RunRootQuery, RunRootQueryVariables} from './types/RunRoot.types';
+import {RunFragment} from './types/RunFragments.types';
+import {
+  RunAssetsQuery,
+  RunAssetsQueryVariables,
+  RunRootQuery,
+  RunRootQueryVariables,
+} from './types/RunRoot.types';
 import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {AutomaterializeTagWithEvaluation} from '../assets/AutomaterializeTagWithEvaluation';
@@ -135,14 +149,7 @@ export const RunRoot = () => {
                     tickId={tickDetails.tickId}
                   />
                 ) : null}
-                <AssetKeyTagCollection
-                  useTags
-                  assetKeys={
-                    isHiddenAssetGroupJob(run.pipelineName)
-                      ? assetKeysForRun(run)
-                      : run.assets.map((a) => a.key)
-                  }
-                />
+                <RunAssetTags run={run} />
                 <AssetCheckTagCollection useTags assetChecks={run.assetCheckSelection} />
                 <RunTimingTags run={run} loading={loading} />
                 {automaterializeTag && run.assetSelection?.length ? (
@@ -166,6 +173,30 @@ export const RunRoot = () => {
 // eslint-disable-next-line import/no-default-export
 export default RunRoot;
 
+const RunAssetTags = (props: {run: RunFragment}) => {
+  const {run} = props;
+  const {data, loading} = useQuery<RunAssetsQuery, RunAssetsQueryVariables>(RUN_ASSETS_QUERY, {
+    variables: {runId: run.id},
+    skip: isHiddenAssetGroupJob(run.pipelineName),
+  });
+
+  if (isHiddenAssetGroupJob(run.pipelineName)) {
+    return <AssetKeyTagCollection useTags assetKeys={assetKeysForRun(run)} />;
+  }
+
+  if (loading) {
+    return <div style={{color: Colors.textLight()}}>Loading…</div>;
+  }
+
+  if (!data || data.pipelineRunOrError.__typename !== 'Run') {
+    return null;
+  }
+
+  return (
+    <AssetKeyTagCollection useTags assetKeys={data.pipelineRunOrError.assets.map((a) => a.key)} />
+  );
+};
+
 const RunById = (props: {data: RunRootQuery | undefined; runId: string; trace: RunRootTrace}) => {
   const {data, runId, trace} = props;
 
@@ -188,7 +219,7 @@ const RunById = (props: {data: RunRootQuery | undefined; runId: string; trace: R
   return <Run run={data.pipelineRunOrError} runId={runId} trace={trace} />;
 };
 
-const RUN_ROOT_QUERY = gql`
+export const RUN_ROOT_QUERY = gql`
   query RunRootQuery($runId: ID!) {
     pipelineRunOrError(runId: $runId) {
       ... on Run {
@@ -199,4 +230,20 @@ const RUN_ROOT_QUERY = gql`
   }
 
   ${RUN_PAGE_FRAGMENT}
+`;
+
+export const RUN_ASSETS_QUERY = gql`
+  query RunAssetsQuery($runId: ID!) {
+    pipelineRunOrError(runId: $runId) {
+      ... on Run {
+        id
+        assets {
+          id
+          key {
+            path
+          }
+        }
+      }
+    }
+  }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/types/RunActionButtonsTestQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/types/RunActionButtonsTestQuery.types.ts
@@ -36,11 +36,6 @@ export type RunActionButtonsTestQuery = {
           repositoryLocationName: string;
         } | null;
         tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
-        assets: Array<{
-          __typename: 'Asset';
-          id: string;
-          key: {__typename: 'AssetKey'; path: Array<string>};
-        }>;
         assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
         assetCheckSelection: Array<{
           __typename: 'AssetCheckhandle';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunAssetTags.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunAssetTags.types.ts
@@ -1,0 +1,23 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type RunAssetsQueryVariables = Types.Exact<{
+  runId: Types.Scalars['ID'];
+}>;
+
+export type RunAssetsQuery = {
+  __typename: 'Query';
+  pipelineRunOrError:
+    | {__typename: 'PythonError'}
+    | {
+        __typename: 'Run';
+        id: string;
+        assets: Array<{
+          __typename: 'Asset';
+          id: string;
+          key: {__typename: 'AssetKey'; path: Array<string>};
+        }>;
+      }
+    | {__typename: 'RunNotFoundError'};
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunFragments.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunFragments.types.ts
@@ -29,11 +29,6 @@ export type RunFragment = {
     repositoryLocationName: string;
   } | null;
   tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
-  assets: Array<{
-    __typename: 'Asset';
-    id: string;
-    key: {__typename: 'AssetKey'; path: Array<string>};
-  }>;
   assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
   assetCheckSelection: Array<{
     __typename: 'AssetCheckhandle';
@@ -2548,11 +2543,6 @@ export type RunPageFragment = {
     repositoryLocationName: string;
   } | null;
   tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
-  assets: Array<{
-    __typename: 'Asset';
-    id: string;
-    key: {__typename: 'AssetKey'; path: Array<string>};
-  }>;
   assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
   assetCheckSelection: Array<{
     __typename: 'AssetCheckhandle';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunRoot.types.ts
@@ -38,11 +38,6 @@ export type RunRootQuery = {
           repositoryLocationName: string;
         } | null;
         tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
-        assets: Array<{
-          __typename: 'Asset';
-          id: string;
-          key: {__typename: 'AssetKey'; path: Array<string>};
-        }>;
         assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
         assetCheckSelection: Array<{
           __typename: 'AssetCheckhandle';
@@ -78,6 +73,26 @@ export type RunRootQuery = {
             startTime: number | null;
             endTime: number | null;
           }>;
+        }>;
+      }
+    | {__typename: 'RunNotFoundError'};
+};
+
+export type RunAssetsQueryVariables = Types.Exact<{
+  runId: Types.Scalars['ID'];
+}>;
+
+export type RunAssetsQuery = {
+  __typename: 'Query';
+  pipelineRunOrError:
+    | {__typename: 'PythonError'}
+    | {
+        __typename: 'Run';
+        id: string;
+        assets: Array<{
+          __typename: 'Asset';
+          id: string;
+          key: {__typename: 'AssetKey'; path: Array<string>};
         }>;
       }
     | {__typename: 'RunNotFoundError'};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunRoot.types.ts
@@ -77,23 +77,3 @@ export type RunRootQuery = {
       }
     | {__typename: 'RunNotFoundError'};
 };
-
-export type RunAssetsQueryVariables = Types.Exact<{
-  runId: Types.Scalars['ID'];
-}>;
-
-export type RunAssetsQuery = {
-  __typename: 'Query';
-  pipelineRunOrError:
-    | {__typename: 'PythonError'}
-    | {
-        __typename: 'Run';
-        id: string;
-        assets: Array<{
-          __typename: 'Asset';
-          id: string;
-          key: {__typename: 'AssetKey'; path: Array<string>};
-        }>;
-      }
-    | {__typename: 'RunNotFoundError'};
-};


### PR DESCRIPTION
## Summary & Motivation
The `assets` field of the RunRootQuery sometimes times out for very large runs...

This PR splits apart the UI query so that the rest of the page will load (but not the little asset tag blurb).

## How I Tested These Changes
BK