### PR TITLE
rfc: AMP blocking asset check rule

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -2,7 +2,6 @@ import datetime
 from abc import ABC, abstractmethod, abstractproperty
 from collections import defaultdict
 from typing import (
-    TYPE_CHECKING,
     AbstractSet,
     Dict,
     Iterable,
@@ -17,6 +16,7 @@ import pytz
 
 import dagster._check as check
 from dagster._annotations import experimental, public
+from dagster._core.definitions.asset_condition import AssetConditionResult
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeDecisionType,
@@ -45,9 +45,6 @@ from dagster._utils.schedules import (
 
 from .asset_condition_evaluation_context import AssetConditionEvaluationContext
 from .asset_graph import sort_key_for_asset_partition
-
-if TYPE_CHECKING:
-    from dagster._core.definitions.asset_condition import AssetConditionResult
 
 
 class AutoMaterializeRule(ABC):
@@ -951,10 +948,9 @@ class BlockingAssetCheckRule(AutoMaterializeRule, NamedTuple("_BlockingAssetchec
         parent_assets = context.instance_queryer.asset_graph.get_parents(context.asset_key)
         checks_on_parent_assets = [
             key
-            for key in context.instance_queryer.asset_graph.asset_check_keys
+            for key in context.instance_queryer.asset_graph.blocking_asset_check_keys
             if key.asset_key in parent_assets
         ]
-        # todo: filter to blocking
         check_executions = context.instance_queryer.instance.event_log_storage.get_latest_asset_check_execution_by_key(
             checks_on_parent_assets
         ).values()

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1131,6 +1131,7 @@ class ExternalAssetCheck(
             ("description", Optional[str]),
             ("atomic_execution_unit_id", Optional[str]),
             ("job_names", Sequence[str]),
+            ("blocking", bool),
         ],
     )
 ):
@@ -1143,6 +1144,7 @@ class ExternalAssetCheck(
         description: Optional[str],
         atomic_execution_unit_id: Optional[str] = None,
         job_names: Optional[Sequence[str]] = None,
+        blocking: bool = False,
     ):
         return super(ExternalAssetCheck, cls).__new__(
             cls,
@@ -1153,6 +1155,7 @@ class ExternalAssetCheck(
                 atomic_execution_unit_id, "automic_execution_unit_id"
             ),
             job_names=check.opt_sequence_param(job_names, "job_names", of_type=str),
+            blocking=check.bool_param(blocking, "blocking"),
         )
 
     @property
@@ -1519,6 +1522,7 @@ def external_asset_checks_from_defs(
                 description=spec.description,
                 atomic_execution_unit_id=atomic_execution_unit_id,
                 job_names=job_names_by_check_key[check_key],
+                blocking=spec.blocking,
             )
         )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -91,6 +91,7 @@ class RunSpec(NamedTuple):
     partition_key: Optional[str] = None
     failed_asset_keys: Optional[Sequence[AssetKey]] = None
     is_observation: bool = False
+    tags: Optional[Mapping[str, str]] = None
 
 
 class AssetEvaluationSpec(NamedTuple):
@@ -371,6 +372,7 @@ class AssetReconciliationScenario(
                         all_assets=self.assets,
                         instance=instance,
                         failed_asset_keys=run.failed_asset_keys,
+                        tags=run.tags,
                     )
 
         if self.evaluation_delta is not None:
@@ -577,6 +579,7 @@ def run(
     partition_key: Optional[str] = None,
     failed_asset_keys: Optional[Iterable[str]] = None,
     is_observation: bool = False,
+    tags: Optional[Mapping[str, str]] = None,
 ):
     return RunSpec(
         asset_keys=list(
@@ -585,6 +588,7 @@ def run(
         failed_asset_keys=list(map(AssetKey.from_coercible, failed_asset_keys or [])),
         partition_key=partition_key,
         is_observation=is_observation,
+        tags=tags,
     )
 
 


### PR DESCRIPTION
First pass

When a check has `blocking=True`, downstream assets skip unless the check has passed.

Questions:
- should this skip if the check result is missing? Currently it won't. This could be a toggle on the rule