### PR TITLE
logging the URL of the Databricks run after submitting job

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -740,3 +740,6 @@ class DatabricksJobRunner:
                 num_attempts += 1
                 time.sleep(waiter_delay)
         log.warn("Could not retrieve cluster logs!")
+
+    def get_run_url(self, run_id: int) -> Optional[str]:
+        return self._client.workspace_client.jobs.get_run(run_id).run_page_url

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -454,7 +454,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
 
     def _format_permissions(
         self, input_permissions: Mapping[str, Sequence[Mapping[str, str]]]
-    ) -> Sequence[Mapping[str, str]]:
+    ) -> Sequence[jobs.JobAccessControlRequest]:
         access_control_list = []
         for permission, accessors in input_permissions.items():
             access_control_list.extend(

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -281,6 +281,10 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         task = self._get_databricks_task(run_id, step_key)
         databricks_run_id = self.databricks_runner.submit_run(self.run_config, task)
 
+        run_url = self.databricks_runner.get_run_url(databricks_run_id)
+        if run_url is not None:
+            step_context.log.info(f"Run URL: {run_url}")
+
         if self.permissions:
             self._grant_permissions(log, databricks_run_id)
 
@@ -583,6 +587,9 @@ class DatabricksPySparkStepLauncher(StepLauncher):
             ]
         )
         return f"/dbfs/{path}"
+
+    def get_run_url(self, run_id: int) -> str:
+        return self.databricks_runner(run_id)
 
 
 class DatabricksConfig:

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -589,7 +589,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         return f"/dbfs/{path}"
 
     def get_run_url(self, run_id: int) -> str:
-        return self.databricks_runner(run_id)
+        return self.databricks_runner.get_run_url(run_id)
 
 
 class DatabricksConfig:

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -588,9 +588,6 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         )
         return f"/dbfs/{path}"
 
-    def get_run_url(self, run_id: int) -> str:
-        return self.databricks_runner.get_run_url(run_id)
-
 
 class DatabricksConfig:
     """Represents configuration required by Databricks to run jobs.

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -454,7 +454,8 @@ class DatabricksPySparkStepLauncher(StepLauncher):
 
     def _format_permissions(
         self, input_permissions: Mapping[str, Sequence[Mapping[str, str]]]
-    ) -> Sequence[jobs.JobAccessControlRequest]:
+    ) -> Sequence["jobs.JobAccessControlRequest"]:
+
         access_control_list = []
         for permission, accessors in input_permissions.items():
             access_control_list.extend(

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
@@ -231,7 +231,7 @@ def test_pyspark_databricks(
         )
         assert result.success
         assert mock_perform_query.call_count == 2
-        assert mock_get_run.call_count == 1
+        assert mock_get_run.call_count == 2
         assert mock_get_run_state.call_count == 6
         assert mock_get_step_events.call_count == 6
         assert mock_put_file.call_count == 4


### PR DESCRIPTION
## Summary & Motivation

Making it easier to get to the run page for a run that has been submitted from the step launcher

## How I Tested These Changes

Confirmed unit tests run successfully, ran a Dagster job from a local deployment using the Databricks step launcher to confirm the run page URL shows up in the logs