### PR TITLE
chore: add Edge as browser target for compatiblity testing

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/package.json
+++ b/js_modules/dagster-ui/packages/app-oss/package.json
@@ -65,7 +65,8 @@
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",
-      "last 1 safari version"
+      "last 1 safari version",
+      "last 1 edge version"
     ]
   }
 }


### PR DESCRIPTION
## Summary & Motivation
Add Microsoft Edge browser for compatiblity testing during development as it's different from Chrome in various minor details.

## How I Tested These Changes
N/A
