### PR TITLE
[graphql] Warn and fix invalid multi-asset selection when materializing from the UI

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/CustomConfirmationProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/CustomConfirmationProvider.tsx
@@ -1,6 +1,8 @@
 import {Button, Dialog, DialogBody, DialogFooter} from '@dagster-io/ui-components';
 import * as React from 'react';
 
+import {testId} from '../testing/testId';
+
 interface ConfirmationOptions {
   catchOnCancel?: boolean;
   title?: string;
@@ -33,7 +35,7 @@ const ConfirmationDialog = ({
       <DialogBody>{description}</DialogBody>
       <DialogFooter topBorder>
         <Button onClick={onClose}>Cancel</Button>
-        <Button onClick={onSubmit} intent={intent}>
+        <Button onClick={onSubmit} intent={intent} data-testid={testId('confirm-button-ok')}>
           {buttonText}
         </Button>
       </DialogFooter>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -75,7 +75,7 @@ const buildSidebarQueryMock = (
         backfillPolicy: null,
         configField: null,
         metadataEntries: [],
-        assetChecksOrError: buildAssetChecks({checks: []}),
+        assetChecksOrError: buildAssetChecks(),
         jobNames: ['test_job'],
         autoMaterializePolicy: null,
         freshnessPolicy: null,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetDefinedInMultipleReposNotice.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetDefinedInMultipleReposNotice.tsx
@@ -13,6 +13,7 @@ import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 export const MULTIPLE_DEFINITIONS_WARNING = 'Multiple asset definitions found';
+export const ADDITIONAL_REQUIRED_KEYS_WARNING = 'Additional assets will be materialized';
 
 export const AssetDefinedInMultipleReposNotice = ({
   assetKey,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -349,13 +349,12 @@ export const useMaterializationAction = (preferredJobName?: string) => {
       setState({type: 'none'});
       try {
         await confirm(buildAssetAdditionalRequiredKeysAlert(data));
-
-        if (assetKeysOrJob instanceof Array) {
-          data = await onLoad([...assetKeysOrJob, ...data.assetNodeAdditionalRequiredKeys]);
-        }
-        setState({type: 'loading'});
       } catch {
-        return;
+        return; // user declined confirm
+      }
+      setState({type: 'loading'});
+      if (assetKeysOrJob instanceof Array) {
+        data = await onLoad([...assetKeysOrJob, ...data.assetNodeAdditionalRequiredKeys]);
       }
     }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -346,13 +346,12 @@ export const useMaterializationAction = (preferredJobName?: string) => {
     }
 
     if ('assetNodeAdditionalRequiredKeys' in data && data.assetNodeAdditionalRequiredKeys.length) {
-      setState({type: 'none'});
       try {
         await confirm(buildAssetAdditionalRequiredKeysAlert(data));
       } catch {
+        setState({type: 'none'});
         return; // user declined confirm
       }
-      setState({type: 'loading'});
       if (assetKeysOrJob instanceof Array) {
         data = await onLoad([...assetKeysOrJob, ...data.assetNodeAdditionalRequiredKeys]);
       }
@@ -363,22 +362,18 @@ export const useMaterializationAction = (preferredJobName?: string) => {
 
     const next = await stateForLaunchingAssets(client, assets, forceLaunchpad, preferredJobName);
     if (next.type === 'error') {
-      showCustomAlert({
-        title: 'Unable to Materialize',
-        body: next.error,
-      });
+      showCustomAlert({title: 'Unable to Materialize', body: next.error});
       setState({type: 'none'});
       return;
     }
 
     const missing = await upstreamAssetsWithNoMaterializations(client, assets);
     if (missing.length) {
-      setState({type: 'none'});
       try {
         await confirm(buildUpstreamAssetsWithNoMaterializationsAlert(missing));
-        setState({type: 'loading'});
       } catch {
-        return;
+        setState({type: 'none'});
+        return; // user declined confirm
       }
     }
 
@@ -699,6 +694,7 @@ export function buildAssetCollisionsAlert(data: LaunchAssetLoaderQuery) {
 
 export function buildAssetAdditionalRequiredKeysAlert(data: LaunchAssetLoaderQuery) {
   return {
+    catchOnCancel: true,
     title: ADDITIONAL_REQUIRED_KEYS_WARNING,
     description: (
       <div style={{overflow: 'auto'}}>
@@ -720,6 +716,7 @@ export function buildAssetAdditionalRequiredKeysAlert(data: LaunchAssetLoaderQue
 }
 export function buildUpstreamAssetsWithNoMaterializationsAlert(missing: AssetKey[]) {
   return {
+    catchOnCancel: true,
     title: 'Are you sure?',
     description: (
       <>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetTables.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetTables.fixtures.ts
@@ -93,7 +93,7 @@ export const SingleAssetQueryMaterializedWithLatestRun: MockedResponse<AssetGrap
               __typename: 'MaterializationEvent',
             },
           ],
-          assetChecksOrError: buildAssetChecks({checks: []}),
+          assetChecksOrError: buildAssetChecks(),
           freshnessInfo: null,
           assetObservations: [
             {
@@ -147,7 +147,7 @@ export const SingleAssetQueryMaterializedStaleAndLate: MockedResponse<AssetGraph
             path: ['late_asset'],
             __typename: 'AssetKey',
           },
-          assetChecksOrError: buildAssetChecks({checks: []}),
+          assetChecksOrError: buildAssetChecks(),
           assetMaterializations: [
             {
               timestamp: '1674603891025',
@@ -211,7 +211,7 @@ export const SingleAssetQueryLastRunFailed: MockedResponse<AssetGraphLiveQuery> 
             path: ['run_failing_asset'],
             __typename: 'AssetKey',
           },
-          assetChecksOrError: buildAssetChecks({checks: []}),
+          assetChecksOrError: buildAssetChecks(),
           assetMaterializations: [
             {
               timestamp: '1666373060112',

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
@@ -3,7 +3,6 @@ import without from 'lodash/without';
 
 import {generateDailyTimePartitions} from './PartitionHealthSummary.fixtures';
 import {tokenForAssetKey} from '../../asset-graph/Utils';
-import {AssetNodeForGraphQueryFragment} from '../../asset-graph/types/useAssetGraphData.types';
 import {
   AssetKeyInput,
   LaunchBackfillParams,
@@ -11,12 +10,21 @@ import {
   PartitionRangeStatus,
   buildAssetCheck,
   buildAssetChecks,
+  buildAssetKey,
+  buildAssetNode,
   buildConfigTypeField,
   buildDaemonHealth,
   buildDaemonStatus,
   buildDimensionDefinitionType,
   buildInstance,
+  buildMaterializationEvent,
+  buildMode,
+  buildPartitionDefinition,
   buildPartitionSets,
+  buildRegularConfigType,
+  buildRepository,
+  buildRepositoryLocation,
+  buildRun,
   buildRunLauncher,
 } from '../../graphql/types';
 import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../../instance/backfill/BackfillUtils';
@@ -44,21 +52,42 @@ import {
 import {PartitionHealthQuery} from '../types/usePartitionHealthData.types';
 import {PARTITION_HEALTH_QUERY} from '../usePartitionHealthData';
 
-export const UNPARTITIONED_ASSET: AssetNodeForGraphQueryFragment = {
-  __typename: 'AssetNode',
+const REPO = buildRepository({
+  id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+  name: 'repo',
+  location: buildRepositoryLocation({
+    id: 'test.py',
+    name: 'test.py',
+  }),
+});
+
+const OTHER_REPO = buildRepository({
+  id: '000000000000000000000000000000000000000',
+  name: 'other-repo',
+  location: buildRepositoryLocation({
+    id: 'other-location.py',
+    name: 'other-location.py',
+  }),
+});
+
+const BASE_CONFIG_TYPE_FIELD = buildConfigTypeField({
+  name: 'config',
+  isRequired: false,
+  configType: buildRegularConfigType({
+    givenName: 'Any',
+    key: 'Any',
+    description: null,
+    isSelector: false,
+    typeParamKeys: [],
+    recursiveConfigTypes: [],
+  }),
+});
+
+export const UNPARTITIONED_ASSET = buildAssetNode({
   id: 'test.py.repo.["unpartitioned_asset"]',
   groupName: 'mapped',
   hasMaterializePermission: true,
-  repository: {
-    __typename: 'Repository',
-    id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
-    name: 'repo',
-    location: {
-      __typename: 'RepositoryLocation',
-      id: 'test.py',
-      name: 'test.py',
-    },
-  },
+  repository: REPO,
   dependencyKeys: [],
   dependedByKeys: [],
   graphName: null,
@@ -71,119 +100,90 @@ export const UNPARTITIONED_ASSET: AssetNodeForGraphQueryFragment = {
   isObservable: false,
   isExecutable: true,
   isSource: false,
-  assetKey: {
-    __typename: 'AssetKey',
-    path: ['unpartitioned_asset'],
-  },
-};
+  assetKey: buildAssetKey({path: ['unpartitioned_asset']}),
+  requiredResources: [],
+  configField: BASE_CONFIG_TYPE_FIELD,
+  assetChecksOrError: buildAssetChecks({checks: []}),
+  backfillPolicy: null,
+  partitionDefinition: null,
+});
 
-export const CHECKED_ASSET: AssetNodeForGraphQueryFragment = {
+export const CHECKED_ASSET = buildAssetNode({
   ...UNPARTITIONED_ASSET,
   id: 'test.py.repo.["checked_asset"]',
   jobNames: ['__ASSET_JOB_7', 'checks_included_job', 'checks_excluded_job'],
-  assetKey: {
-    __typename: 'AssetKey',
-    path: ['checked_asset'],
-  },
-};
+  assetKey: buildAssetKey({path: ['checked_asset']}),
+  configField: BASE_CONFIG_TYPE_FIELD,
+  assetChecksOrError: buildAssetChecks({
+    checks: [
+      buildAssetCheck({
+        name: 'CHECK_1',
+        assetKey: buildAssetKey({path: ['checked_asset']}),
+        jobNames: ['checks_included_job', '__ASSET_JOB_0'],
+      }),
+    ],
+  }),
+});
 
-export const UNPARTITIONED_SOURCE_ASSET: AssetNodeForGraphQueryFragment = {
+export const UNPARTITIONED_SOURCE_ASSET = buildAssetNode({
   ...UNPARTITIONED_ASSET,
   id: 'test.py.repo.["unpartitioned_source_asset"]',
   isSource: true,
-  assetKey: {
-    __typename: 'AssetKey',
-    path: ['unpartitioned_source_asset'],
-  },
-};
+  assetKey: buildAssetKey({path: ['unpartitioned_source_asset']}),
+});
 
-export const UNPARTITIONED_NON_EXECUTABLE_ASSET: AssetNodeForGraphQueryFragment = {
+export const UNPARTITIONED_NON_EXECUTABLE_ASSET = buildAssetNode({
   ...UNPARTITIONED_ASSET,
   id: 'test.py.repo.["unpartitioned_non_executable_asset"]',
   isExecutable: false,
-  assetKey: {
-    __typename: 'AssetKey',
-    path: ['unpartitioned_non_executable_asset'],
-  },
-};
+  assetKey: buildAssetKey({path: ['unpartitioned_non_executable_asset']}),
+});
 
-export const UNPARTITIONED_ASSET_OTHER_REPO: AssetNodeForGraphQueryFragment = {
+export const UNPARTITIONED_ASSET_OTHER_REPO = buildAssetNode({
   ...UNPARTITIONED_ASSET,
   id: 'test.py.repo.["unpartitioned_asset_other_repo"]',
   opNames: ['unpartitioned_asset_other_repo'],
-  assetKey: {
-    __typename: 'AssetKey',
-    path: ['unpartitioned_asset_other_repo'],
-  },
-  repository: {
-    __typename: 'Repository',
-    id: '000000000000000000000000000000000000000',
-    name: 'other-repo',
-    location: {
-      __typename: 'RepositoryLocation',
-      id: 'other-location.py',
-      name: 'other-location.py',
-    },
-  },
-};
+  assetKey: buildAssetKey({path: ['unpartitioned_asset_other_repo']}),
+  repository: OTHER_REPO,
+});
 
-export const UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG: AssetNodeForGraphQueryFragment = {
+export const UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG = buildAssetNode({
   ...UNPARTITIONED_ASSET,
   id: 'test.py.repo.["unpartitioned_asset_with_required_config"]',
   opNames: ['unpartitioned_asset_with_required_config'],
-  assetKey: {
-    __typename: 'AssetKey',
+  assetKey: buildAssetKey({
     path: ['unpartitioned_asset_with_required_config'],
-  },
-};
+  }),
+  configField: {...BASE_CONFIG_TYPE_FIELD, isRequired: true},
+  assetChecksOrError: buildAssetChecks({checks: []}),
+});
 
-export const MULTI_ASSET_OUT_1: AssetNodeForGraphQueryFragment = {
+export const MULTI_ASSET_OUT_1 = buildAssetNode({
   ...UNPARTITIONED_ASSET,
   id: 'test.py.repo.["multi_asset_out_1"]',
   jobNames: ['__ASSET_JOB_7'],
-  assetKey: {
-    __typename: 'AssetKey',
-    path: ['multi_asset_out_1'],
-  },
-};
+  assetKey: buildAssetKey({path: ['multi_asset_out_1']}),
+});
 
-export const MULTI_ASSET_OUT_2: AssetNodeForGraphQueryFragment = {
+export const MULTI_ASSET_OUT_2 = buildAssetNode({
   ...UNPARTITIONED_ASSET,
   id: 'test.py.repo.["multi_asset_out_2"]',
   jobNames: ['__ASSET_JOB_7'],
-  assetKey: {
-    __typename: 'AssetKey',
-    path: ['multi_asset_out_2'],
-  },
-};
+  assetKey: buildAssetKey({path: ['multi_asset_out_2']}),
+});
 
 export const ASSET_DAILY_PARTITION_KEYS = generateDailyTimePartitions(
   new Date('2020-01-01'),
   new Date('2023-02-22'),
 );
 
-export const ASSET_DAILY: AssetNodeForGraphQueryFragment = {
-  __typename: 'AssetNode',
+export const ASSET_DAILY = buildAssetNode({
   id: 'test.py.repo.["asset_daily"]',
   groupName: 'mapped',
   hasMaterializePermission: true,
-  repository: {
-    __typename: 'Repository',
-    id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
-    name: 'repo',
-    location: {
-      __typename: 'RepositoryLocation',
-      id: 'test.py',
-      name: 'test.py',
-    },
-  },
+  repository: REPO,
   dependencyKeys: [],
-  dependedByKeys: [
-    {
-      __typename: 'AssetKey',
-      path: ['asset_weekly'],
-    },
-  ],
+  dependedByKeys: [{__typename: 'AssetKey', path: ['asset_weekly']}],
   graphName: null,
   jobNames: ['__ASSET_JOB_7', 'my_asset_job'],
   opNames: ['asset_daily'],
@@ -194,32 +194,28 @@ export const ASSET_DAILY: AssetNodeForGraphQueryFragment = {
   isObservable: false,
   isExecutable: true,
   isSource: false,
-  assetKey: {
-    __typename: 'AssetKey',
-    path: ['asset_daily'],
-  },
-};
+  assetKey: buildAssetKey({path: ['asset_daily']}),
+  requiredResources: [],
+  configField: BASE_CONFIG_TYPE_FIELD,
+  assetChecksOrError: buildAssetChecks({checks: []}),
+  backfillPolicy: null,
+  partitionDefinition: buildPartitionDefinition({
+    name: 'Foo',
+    type: PartitionDefinitionType.TIME_WINDOW,
+    description: 'Daily, starting 2020-01-01 UTC.',
+    dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
+  }),
+});
 
-export const ASSET_WEEKLY: AssetNodeForGraphQueryFragment = {
+export const ASSET_WEEKLY = buildAssetNode({
   __typename: 'AssetNode',
   id: 'test.py.repo.["asset_weekly"]',
   groupName: 'mapped',
   hasMaterializePermission: true,
-  repository: {
-    __typename: 'Repository',
-    id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
-    name: 'repo',
-    location: {
-      __typename: 'RepositoryLocation',
-      id: 'test.py',
-      name: 'test.py',
-    },
-  },
+  repository: REPO,
   dependencyKeys: [
-    {
-      __typename: 'AssetKey',
-      path: ['asset_daily'],
-    },
+    buildAssetKey({path: ['asset_daily']}),
+    buildAssetKey({path: ['asset_weekly_root']}),
   ],
   dependedByKeys: [],
   graphName: null,
@@ -232,28 +228,38 @@ export const ASSET_WEEKLY: AssetNodeForGraphQueryFragment = {
   isObservable: false,
   isExecutable: true,
   isSource: false,
-  assetKey: {
-    __typename: 'AssetKey',
-    path: ['asset_weekly'],
-  },
-};
+  assetKey: buildAssetKey({path: ['asset_weekly']}),
+  requiredResources: [],
+  configField: BASE_CONFIG_TYPE_FIELD,
+  assetChecksOrError: buildAssetChecks({checks: []}),
+  backfillPolicy: null,
+  partitionDefinition: buildPartitionDefinition({
+    name: 'Foo',
+    type: PartitionDefinitionType.TIME_WINDOW,
+    description: 'Weekly, starting 2020-01-01 UTC.',
+    dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
+  }),
+});
 
-export const ASSET_WEEKLY_ROOT: AssetNodeForGraphQueryFragment = {
+export const ASSET_WEEKLY_ROOT = buildAssetNode({
   ...ASSET_WEEKLY,
   id: 'test.py.repo.["asset_weekly_root"]',
   dependencyKeys: [],
-  assetKey: {
-    __typename: 'AssetKey',
-    path: ['asset_weekly_root'],
-  },
-};
+  assetKey: buildAssetKey({path: ['asset_weekly_root']}),
+  opNames: ['asset_weekly_root'],
+  assetMaterializations: [
+    buildMaterializationEvent({
+      runId: '8fec6fcd-7a05-4f1c-8cf8-4bfd6965eeba',
+    }),
+  ],
+});
 
 export const buildLaunchAssetWarningsMock = (
   upstreamAssetKeys: AssetKeyInput[],
 ): MockedResponse<LaunchAssetWarningsQuery> => ({
   request: {
     query: LAUNCH_ASSET_WARNINGS_QUERY,
-    variables: {upstreamAssetKeys: upstreamAssetKeys.map((a) => ({path: a.path}))},
+    variables: {upstreamAssetKeys: upstreamAssetKeys.map(asAssetKeyInput)},
   },
   result: {
     data: {
@@ -329,7 +335,7 @@ export const PartitionHealthAssetDailyMock: MockedResponse<PartitionHealthQuery>
   result: {
     data: {
       __typename: 'Query',
-      assetNodeOrError: {
+      assetNodeOrError: buildAssetNode({
         id: 'test.py.repo.["asset_daily"]',
         partitionKeysByDimension: [
           {
@@ -343,8 +349,7 @@ export const PartitionHealthAssetDailyMock: MockedResponse<PartitionHealthQuery>
           ranges: PartitionHealthAssetDailyMaterializedRanges,
           __typename: 'TimePartitionStatuses',
         },
-        __typename: 'AssetNode',
-      },
+      }),
     },
   },
 };
@@ -368,7 +373,7 @@ export const PartitionHealthAssetWeeklyMock: MockedResponse<PartitionHealthQuery
   result: {
     data: {
       __typename: 'Query',
-      assetNodeOrError: {
+      assetNodeOrError: buildAssetNode({
         id: 'test.py.repo.["asset_weekly"]',
         partitionKeysByDimension: [
           {
@@ -386,8 +391,7 @@ export const PartitionHealthAssetWeeklyMock: MockedResponse<PartitionHealthQuery
           ranges: [],
           __typename: 'TimePartitionStatuses',
         },
-        __typename: 'AssetNode',
-      },
+      }),
     },
   },
 };
@@ -404,7 +408,7 @@ export const PartitionHealthAssetWeeklyRootMock: MockedResponse<PartitionHealthQ
   result: {
     data: {
       __typename: 'Query',
-      assetNodeOrError: {
+      assetNodeOrError: buildAssetNode({
         id: 'test.py.repo.["asset_weekly_root"]',
         partitionKeysByDimension: [
           {
@@ -422,8 +426,7 @@ export const PartitionHealthAssetWeeklyRootMock: MockedResponse<PartitionHealthQ
           ranges: [],
           __typename: 'TimePartitionStatuses',
         },
-        __typename: 'AssetNode',
-      },
+      }),
     },
   },
 };
@@ -445,11 +448,10 @@ export const buildLaunchAssetLoaderGenericJobMock = (jobName: string) => {
         pipelineOrError: {
           id: '8e2d3f9597c4a45bb52fe9ab5656419f4329d4fb',
           modes: [
-            {
+            buildMode({
               id: 'da3055161c528f4c839339deb4a362ec1be4f079-default',
               resources: [],
-              __typename: 'Mode',
-            },
+            }),
           ],
           __typename: 'Pipeline',
         },
@@ -695,31 +697,16 @@ export const LaunchAssetLoaderResourceMyAssetJobMock: MockedResponse<LaunchAsset
         pipelineOrError: {
           id: '8689a9dcd052f769b73d73dfe57e89065dac369d',
           modes: [
-            {
-              __typename: 'Mode',
+            buildMode({
               id: '719d9b2c592b98ae0f4a7ec570cae0a06667db31-default',
               resources: [],
-            },
+            }),
           ],
           __typename: 'Pipeline',
         },
       },
     },
   };
-
-const BaseRegularConfigType = buildConfigTypeField({
-  name: 'config',
-  isRequired: false,
-  configType: {
-    __typename: 'RegularConfigType',
-    givenName: 'Any',
-    key: 'Any',
-    description: null,
-    isSelector: false,
-    typeParamKeys: [],
-    recursiveConfigTypes: [],
-  },
-});
 
 export const LaunchAssetLoaderAssetDailyWeeklyMock: MockedResponse<LaunchAssetLoaderQuery> = {
   request: {
@@ -731,38 +718,7 @@ export const LaunchAssetLoaderAssetDailyWeeklyMock: MockedResponse<LaunchAssetLo
   result: {
     data: {
       __typename: 'Query',
-      assetNodes: [
-        {
-          ...ASSET_DAILY,
-          requiredResources: [],
-          configField: BaseRegularConfigType,
-          assetChecksOrError: buildAssetChecks({checks: []}),
-          backfillPolicy: null,
-          partitionDefinition: {
-            name: 'Foo',
-            type: PartitionDefinitionType.TIME_WINDOW,
-            description: 'Daily, starting 2020-01-01 UTC.',
-            dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
-            __typename: 'PartitionDefinition',
-          },
-          __typename: 'AssetNode',
-        },
-        {
-          ...ASSET_WEEKLY,
-          requiredResources: [],
-          configField: BaseRegularConfigType,
-          assetChecksOrError: buildAssetChecks({checks: []}),
-          backfillPolicy: null,
-          partitionDefinition: {
-            name: 'Foo',
-            type: PartitionDefinitionType.TIME_WINDOW,
-            description: 'Weekly, starting 2020-01-01 UTC.',
-            dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
-            __typename: 'PartitionDefinition',
-          },
-          __typename: 'AssetNode',
-        },
-      ],
+      assetNodes: [ASSET_DAILY, ASSET_WEEKLY],
       assetNodeDefinitionCollisions: [],
       assetNodeAdditionalRequiredKeys: [],
     },
@@ -780,25 +736,7 @@ export const LaunchAssetCheckUpstreamWeeklyRootMock: MockedResponse<LaunchAssetC
     result: {
       data: {
         __typename: 'Query',
-        assetNodes: [
-          {
-            id: 'test.py.repo.["asset_weekly_root"]',
-            assetKey: {
-              path: ['asset_weekly_root'],
-              __typename: 'AssetKey',
-            },
-            isSource: false,
-            opNames: ['asset_weekly_root'],
-            graphName: null,
-            assetMaterializations: [
-              {
-                runId: '8fec6fcd-7a05-4f1c-8cf8-4bfd6965eeba',
-                __typename: 'MaterializationEvent',
-              },
-            ],
-            __typename: 'AssetNode',
-          },
-        ],
+        assetNodes: [ASSET_WEEKLY_ROOT],
       },
     },
   };
@@ -856,157 +794,16 @@ export function buildConfigPartitionSelectionLatestPartitionMock(
   };
 }
 
-type LaunchAssetLoaderQueryAssetNode = LaunchAssetLoaderQuery['assetNodes'][0];
-
-const ASSET_DAILY_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
-  ...ASSET_DAILY,
-  requiredResources: [],
-  configField: BaseRegularConfigType,
-  assetChecksOrError: buildAssetChecks({checks: []}),
-  backfillPolicy: null,
-  partitionDefinition: {
-    name: 'Foo',
-    type: PartitionDefinitionType.TIME_WINDOW,
-    description: 'Daily, starting 2020-01-01 UTC.',
-    dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
-    __typename: 'PartitionDefinition',
-  },
-  __typename: 'AssetNode',
-};
-
-const ASSET_WEEKLY_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
-  ...ASSET_WEEKLY,
-  requiredResources: [],
-  configField: BaseRegularConfigType,
-  assetChecksOrError: buildAssetChecks({checks: []}),
-  backfillPolicy: null,
-  partitionDefinition: {
-    name: 'Foo',
-    type: PartitionDefinitionType.TIME_WINDOW,
-    description: 'Weekly, starting 2020-01-01 UTC.',
-    dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
-    __typename: 'PartitionDefinition',
-  },
-  dependencyKeys: [
-    {
-      __typename: 'AssetKey',
-      path: ['asset_daily'],
-    },
-    {
-      __typename: 'AssetKey',
-      path: ['asset_weekly_root'],
-    },
-  ],
-  __typename: 'AssetNode',
-};
-
-const ASSET_WEEKLY_ROOT_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
-  ...ASSET_WEEKLY_ROOT,
-  requiredResources: [],
-  configField: BaseRegularConfigType,
-  assetChecksOrError: buildAssetChecks({checks: []}),
-  backfillPolicy: null,
-  partitionDefinition: {
-    name: 'Foo',
-    type: PartitionDefinitionType.TIME_WINDOW,
-    description: 'Weekly, starting 2020-01-01 UTC.',
-    dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
-    __typename: 'PartitionDefinition',
-  },
-  __typename: 'AssetNode',
-};
-
-const UNPARTITIONED_ASSET_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
-  ...UNPARTITIONED_ASSET,
-  requiredResources: [],
-  assetChecksOrError: buildAssetChecks({checks: []}),
-  backfillPolicy: null,
-  partitionDefinition: null,
-  configField: {
-    name: 'config',
-    isRequired: false,
-    configType: {
-      __typename: 'RegularConfigType',
-      givenName: 'Any',
-      key: 'Any',
-      description: null,
-      isSelector: false,
-      typeParamKeys: [],
-      recursiveConfigTypes: [],
-    },
-    __typename: 'ConfigTypeField',
-  },
-  __typename: 'AssetNode',
-};
-
-const MULTI_ASSET_OUT_1_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
-  ...MULTI_ASSET_OUT_1,
-  requiredResources: [],
-  configField: BaseRegularConfigType,
-  assetChecksOrError: buildAssetChecks({checks: []}),
-  backfillPolicy: null,
-  partitionDefinition: null,
-  __typename: 'AssetNode',
-};
-
-const MULTI_ASSET_OUT_2_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
-  ...MULTI_ASSET_OUT_2,
-  requiredResources: [],
-  configField: BaseRegularConfigType,
-  assetChecksOrError: buildAssetChecks({checks: []}),
-  backfillPolicy: null,
-  partitionDefinition: null,
-  __typename: 'AssetNode',
-};
-
-const UNPARTITIONED_ASSET_OTHER_REPO_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
-  ...UNPARTITIONED_ASSET_OTHER_REPO,
-  requiredResources: [],
-  configField: BaseRegularConfigType,
-  assetChecksOrError: buildAssetChecks({checks: []}),
-  backfillPolicy: null,
-  partitionDefinition: null,
-  __typename: 'AssetNode',
-};
-
-const UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
-  ...UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG,
-  requiredResources: [],
-  configField: {...BaseRegularConfigType, isRequired: true},
-  assetChecksOrError: buildAssetChecks({checks: []}),
-  backfillPolicy: null,
-  partitionDefinition: null,
-  __typename: 'AssetNode',
-};
-
-const CHECKED_ASSET_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
-  ...CHECKED_ASSET,
-  requiredResources: [],
-  configField: BaseRegularConfigType,
-  assetChecksOrError: buildAssetChecks({
-    checks: [
-      buildAssetCheck({
-        name: 'CHECK_1',
-        assetKey: CHECKED_ASSET.assetKey,
-        jobNames: ['checks_included_job', '__ASSET_JOB_0'],
-      }),
-    ],
-  }),
-  backfillPolicy: null,
-  partitionDefinition: null,
-  __typename: 'AssetNode',
-};
-
 export const LOADER_RESULTS = [
-  ASSET_DAILY_LOADER_RESULT,
-  ASSET_WEEKLY_LOADER_RESULT,
-  ASSET_WEEKLY_ROOT_LOADER_RESULT,
-  UNPARTITIONED_ASSET_LOADER_RESULT,
-  UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG_LOADER_RESULT,
-  UNPARTITIONED_ASSET_OTHER_REPO_LOADER_RESULT,
-  MULTI_ASSET_OUT_1_LOADER_RESULT,
-  MULTI_ASSET_OUT_2_LOADER_RESULT,
-  CHECKED_ASSET_LOADER_RESULT,
+  ASSET_DAILY,
+  ASSET_WEEKLY,
+  ASSET_WEEKLY_ROOT,
+  UNPARTITIONED_ASSET,
+  UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG,
+  UNPARTITIONED_ASSET_OTHER_REPO,
+  MULTI_ASSET_OUT_1,
+  MULTI_ASSET_OUT_2,
+  CHECKED_ASSET,
 ];
 
 export const PartitionHealthAssetMocks = [
@@ -1070,12 +867,11 @@ export function buildExpectedLaunchSingleRunMutation(
         __typename: 'Mutation',
         launchPipelineExecution: {
           __typename: 'LaunchRunSuccess',
-          run: {
-            __typename: 'Run',
+          run: buildRun({
             runId: 'RUN_ID',
             id: 'RUN_ID',
             pipelineName: executionParams['selector']['pipelineName']!,
-          },
+          }),
         },
       },
     })),

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
@@ -11,6 +11,7 @@ import {
   PartitionRangeStatus,
   buildAssetCheck,
   buildAssetChecks,
+  buildConfigTypeField,
   buildDaemonHealth,
   buildDaemonStatus,
   buildDimensionDefinitionType,
@@ -33,6 +34,7 @@ import {
   LAUNCH_ASSET_LOADER_QUERY,
   LAUNCH_ASSET_LOADER_RESOURCE_QUERY,
 } from '../LaunchAssetExecutionButton';
+import {asAssetKeyInput} from '../asInput';
 import {LaunchAssetWarningsQuery} from '../types/LaunchAssetChoosePartitionsDialog.types';
 import {
   LaunchAssetCheckUpstreamQuery,
@@ -132,6 +134,26 @@ export const UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG: AssetNodeForGraphQueryFra
   assetKey: {
     __typename: 'AssetKey',
     path: ['unpartitioned_asset_with_required_config'],
+  },
+};
+
+export const MULTI_ASSET_OUT_1: AssetNodeForGraphQueryFragment = {
+  ...UNPARTITIONED_ASSET,
+  id: 'test.py.repo.["multi_asset_out_1"]',
+  jobNames: ['__ASSET_JOB_7'],
+  assetKey: {
+    __typename: 'AssetKey',
+    path: ['multi_asset_out_1'],
+  },
+};
+
+export const MULTI_ASSET_OUT_2: AssetNodeForGraphQueryFragment = {
+  ...UNPARTITIONED_ASSET,
+  id: 'test.py.repo.["multi_asset_out_2"]',
+  jobNames: ['__ASSET_JOB_7'],
+  assetKey: {
+    __typename: 'AssetKey',
+    path: ['multi_asset_out_2'],
   },
 };
 
@@ -685,6 +707,20 @@ export const LaunchAssetLoaderResourceMyAssetJobMock: MockedResponse<LaunchAsset
     },
   };
 
+const BaseRegularConfigType = buildConfigTypeField({
+  name: 'config',
+  isRequired: false,
+  configType: {
+    __typename: 'RegularConfigType',
+    givenName: 'Any',
+    key: 'Any',
+    description: null,
+    isSelector: false,
+    typeParamKeys: [],
+    recursiveConfigTypes: [],
+  },
+});
+
 export const LaunchAssetLoaderAssetDailyWeeklyMock: MockedResponse<LaunchAssetLoaderQuery> = {
   request: {
     query: LAUNCH_ASSET_LOADER_QUERY,
@@ -699,6 +735,7 @@ export const LaunchAssetLoaderAssetDailyWeeklyMock: MockedResponse<LaunchAssetLo
         {
           ...ASSET_DAILY,
           requiredResources: [],
+          configField: BaseRegularConfigType,
           assetChecksOrError: buildAssetChecks({checks: []}),
           backfillPolicy: null,
           partitionDefinition: {
@@ -708,25 +745,12 @@ export const LaunchAssetLoaderAssetDailyWeeklyMock: MockedResponse<LaunchAssetLo
             dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
             __typename: 'PartitionDefinition',
           },
-          configField: {
-            name: 'config',
-            isRequired: false,
-            configType: {
-              __typename: 'RegularConfigType',
-              givenName: 'Any',
-              key: 'Any',
-              description: null,
-              isSelector: false,
-              typeParamKeys: [],
-              recursiveConfigTypes: [],
-            },
-            __typename: 'ConfigTypeField',
-          },
           __typename: 'AssetNode',
         },
         {
           ...ASSET_WEEKLY,
           requiredResources: [],
+          configField: BaseRegularConfigType,
           assetChecksOrError: buildAssetChecks({checks: []}),
           backfillPolicy: null,
           partitionDefinition: {
@@ -736,24 +760,11 @@ export const LaunchAssetLoaderAssetDailyWeeklyMock: MockedResponse<LaunchAssetLo
             dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
             __typename: 'PartitionDefinition',
           },
-          configField: {
-            name: 'config',
-            isRequired: false,
-            configType: {
-              __typename: 'RegularConfigType',
-              givenName: 'Any',
-              key: 'Any',
-              description: null,
-              isSelector: false,
-              typeParamKeys: [],
-              recursiveConfigTypes: [],
-            },
-            __typename: 'ConfigTypeField',
-          },
           __typename: 'AssetNode',
         },
       ],
       assetNodeDefinitionCollisions: [],
+      assetNodeAdditionalRequiredKeys: [],
     },
   },
 };
@@ -850,6 +861,7 @@ type LaunchAssetLoaderQueryAssetNode = LaunchAssetLoaderQuery['assetNodes'][0];
 const ASSET_DAILY_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
   ...ASSET_DAILY,
   requiredResources: [],
+  configField: BaseRegularConfigType,
   assetChecksOrError: buildAssetChecks({checks: []}),
   backfillPolicy: null,
   partitionDefinition: {
@@ -859,26 +871,13 @@ const ASSET_DAILY_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
     dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
     __typename: 'PartitionDefinition',
   },
-  configField: {
-    name: 'config',
-    isRequired: false,
-    configType: {
-      __typename: 'RegularConfigType',
-      givenName: 'Any',
-      key: 'Any',
-      description: null,
-      isSelector: false,
-      typeParamKeys: [],
-      recursiveConfigTypes: [],
-    },
-    __typename: 'ConfigTypeField',
-  },
   __typename: 'AssetNode',
 };
 
 const ASSET_WEEKLY_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
   ...ASSET_WEEKLY,
   requiredResources: [],
+  configField: BaseRegularConfigType,
   assetChecksOrError: buildAssetChecks({checks: []}),
   backfillPolicy: null,
   partitionDefinition: {
@@ -888,7 +887,6 @@ const ASSET_WEEKLY_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
     dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
     __typename: 'PartitionDefinition',
   },
-
   dependencyKeys: [
     {
       __typename: 'AssetKey',
@@ -899,26 +897,13 @@ const ASSET_WEEKLY_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
       path: ['asset_weekly_root'],
     },
   ],
-  configField: {
-    name: 'config',
-    isRequired: false,
-    configType: {
-      __typename: 'RegularConfigType',
-      givenName: 'Any',
-      key: 'Any',
-      description: null,
-      isSelector: false,
-      typeParamKeys: [],
-      recursiveConfigTypes: [],
-    },
-    __typename: 'ConfigTypeField',
-  },
   __typename: 'AssetNode',
 };
 
 const ASSET_WEEKLY_ROOT_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
   ...ASSET_WEEKLY_ROOT,
   requiredResources: [],
+  configField: BaseRegularConfigType,
   assetChecksOrError: buildAssetChecks({checks: []}),
   backfillPolicy: null,
   partitionDefinition: {
@@ -927,20 +912,6 @@ const ASSET_WEEKLY_ROOT_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
     description: 'Weekly, starting 2020-01-01 UTC.',
     dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
     __typename: 'PartitionDefinition',
-  },
-  configField: {
-    name: 'config',
-    isRequired: false,
-    configType: {
-      __typename: 'RegularConfigType',
-      givenName: 'Any',
-      key: 'Any',
-      description: null,
-      isSelector: false,
-      typeParamKeys: [],
-      recursiveConfigTypes: [],
-    },
-    __typename: 'ConfigTypeField',
   },
   __typename: 'AssetNode',
 };
@@ -968,55 +939,50 @@ const UNPARTITIONED_ASSET_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
   __typename: 'AssetNode',
 };
 
-const UNPARTITIONED_ASSET_OTHER_REPO_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
-  ...UNPARTITIONED_ASSET_OTHER_REPO,
+const MULTI_ASSET_OUT_1_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
+  ...MULTI_ASSET_OUT_1,
   requiredResources: [],
+  configField: BaseRegularConfigType,
   assetChecksOrError: buildAssetChecks({checks: []}),
   backfillPolicy: null,
   partitionDefinition: null,
-  configField: {
-    name: 'config',
-    isRequired: false,
-    configType: {
-      __typename: 'RegularConfigType',
-      givenName: 'Any',
-      key: 'Any',
-      description: null,
-      isSelector: false,
-      typeParamKeys: [],
-      recursiveConfigTypes: [],
-    },
-    __typename: 'ConfigTypeField',
-  },
+  __typename: 'AssetNode',
+};
+
+const MULTI_ASSET_OUT_2_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
+  ...MULTI_ASSET_OUT_2,
+  requiredResources: [],
+  configField: BaseRegularConfigType,
+  assetChecksOrError: buildAssetChecks({checks: []}),
+  backfillPolicy: null,
+  partitionDefinition: null,
+  __typename: 'AssetNode',
+};
+
+const UNPARTITIONED_ASSET_OTHER_REPO_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
+  ...UNPARTITIONED_ASSET_OTHER_REPO,
+  requiredResources: [],
+  configField: BaseRegularConfigType,
+  assetChecksOrError: buildAssetChecks({checks: []}),
+  backfillPolicy: null,
+  partitionDefinition: null,
   __typename: 'AssetNode',
 };
 
 const UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
   ...UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG,
   requiredResources: [],
+  configField: {...BaseRegularConfigType, isRequired: true},
   assetChecksOrError: buildAssetChecks({checks: []}),
   backfillPolicy: null,
   partitionDefinition: null,
-  configField: {
-    name: 'config',
-    isRequired: true,
-    configType: {
-      __typename: 'RegularConfigType',
-      givenName: 'Any',
-      key: 'Any',
-      description: null,
-      isSelector: false,
-      typeParamKeys: [],
-      recursiveConfigTypes: [],
-    },
-    __typename: 'ConfigTypeField',
-  },
   __typename: 'AssetNode',
 };
 
 const CHECKED_ASSET_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
   ...CHECKED_ASSET,
   requiredResources: [],
+  configField: BaseRegularConfigType,
   assetChecksOrError: buildAssetChecks({
     checks: [
       buildAssetCheck({
@@ -1028,20 +994,6 @@ const CHECKED_ASSET_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
   }),
   backfillPolicy: null,
   partitionDefinition: null,
-  configField: {
-    name: 'config',
-    isRequired: false,
-    configType: {
-      __typename: 'RegularConfigType',
-      givenName: 'Any',
-      key: 'Any',
-      description: null,
-      isSelector: false,
-      typeParamKeys: [],
-      recursiveConfigTypes: [],
-    },
-    __typename: 'ConfigTypeField',
-  },
   __typename: 'AssetNode',
 };
 
@@ -1052,6 +1004,8 @@ export const LOADER_RESULTS = [
   UNPARTITIONED_ASSET_LOADER_RESULT,
   UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG_LOADER_RESULT,
   UNPARTITIONED_ASSET_OTHER_REPO_LOADER_RESULT,
+  MULTI_ASSET_OUT_1_LOADER_RESULT,
+  MULTI_ASSET_OUT_2_LOADER_RESULT,
   CHECKED_ASSET_LOADER_RESULT,
 ];
 
@@ -1063,21 +1017,24 @@ export const PartitionHealthAssetMocks = [
 
 export function buildLaunchAssetLoaderMock(
   assetKeys: AssetKeyInput[],
+  overrides: Partial<LaunchAssetLoaderQuery> = {},
 ): MockedResponse<LaunchAssetLoaderQuery> {
   return {
     request: {
       query: LAUNCH_ASSET_LOADER_QUERY,
       variables: {
-        assetKeys: assetKeys.map((a) => ({path: a.path})),
+        assetKeys: assetKeys.map(asAssetKeyInput),
       },
     },
     result: {
       data: {
         __typename: 'Query',
         assetNodeDefinitionCollisions: [],
+        assetNodeAdditionalRequiredKeys: [],
         assetNodes: LOADER_RESULTS.filter((a) =>
           assetKeys.some((k) => tokenForAssetKey(k) === tokenForAssetKey(a.assetKey)),
         ),
+        ...overrides,
       },
     },
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
@@ -16,16 +16,19 @@ import {
   buildDaemonHealth,
   buildDaemonStatus,
   buildDimensionDefinitionType,
+  buildDimensionPartitionKeys,
   buildInstance,
   buildMaterializationEvent,
   buildMode,
   buildPartitionDefinition,
+  buildPartitionSet,
   buildPartitionSets,
   buildRegularConfigType,
   buildRepository,
   buildRepositoryLocation,
   buildRun,
   buildRunLauncher,
+  buildTimePartitionStatuses,
 } from '../../graphql/types';
 import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../../instance/backfill/BackfillUtils';
 import {LaunchPartitionBackfillMutation} from '../../instance/backfill/types/BackfillUtils.types';
@@ -103,7 +106,7 @@ export const UNPARTITIONED_ASSET = buildAssetNode({
   assetKey: buildAssetKey({path: ['unpartitioned_asset']}),
   requiredResources: [],
   configField: BASE_CONFIG_TYPE_FIELD,
-  assetChecksOrError: buildAssetChecks({checks: []}),
+  assetChecksOrError: buildAssetChecks(),
   backfillPolicy: null,
   partitionDefinition: null,
 });
@@ -155,7 +158,7 @@ export const UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG = buildAssetNode({
     path: ['unpartitioned_asset_with_required_config'],
   }),
   configField: {...BASE_CONFIG_TYPE_FIELD, isRequired: true},
-  assetChecksOrError: buildAssetChecks({checks: []}),
+  assetChecksOrError: buildAssetChecks(),
 });
 
 export const MULTI_ASSET_OUT_1 = buildAssetNode({
@@ -197,7 +200,7 @@ export const ASSET_DAILY = buildAssetNode({
   assetKey: buildAssetKey({path: ['asset_daily']}),
   requiredResources: [],
   configField: BASE_CONFIG_TYPE_FIELD,
-  assetChecksOrError: buildAssetChecks({checks: []}),
+  assetChecksOrError: buildAssetChecks(),
   backfillPolicy: null,
   partitionDefinition: buildPartitionDefinition({
     name: 'Foo',
@@ -231,7 +234,7 @@ export const ASSET_WEEKLY = buildAssetNode({
   assetKey: buildAssetKey({path: ['asset_weekly']}),
   requiredResources: [],
   configField: BASE_CONFIG_TYPE_FIELD,
-  assetChecksOrError: buildAssetChecks({checks: []}),
+  assetChecksOrError: buildAssetChecks(),
   backfillPolicy: null,
   partitionDefinition: buildPartitionDefinition({
     name: 'Foo',
@@ -338,17 +341,15 @@ export const PartitionHealthAssetDailyMock: MockedResponse<PartitionHealthQuery>
       assetNodeOrError: buildAssetNode({
         id: 'test.py.repo.["asset_daily"]',
         partitionKeysByDimension: [
-          {
+          buildDimensionPartitionKeys({
             name: 'default',
-            __typename: 'DimensionPartitionKeys',
             partitionKeys: ASSET_DAILY_PARTITION_KEYS,
             type: PartitionDefinitionType.TIME_WINDOW,
-          },
+          }),
         ],
-        assetPartitionStatuses: {
+        assetPartitionStatuses: buildTimePartitionStatuses({
           ranges: PartitionHealthAssetDailyMaterializedRanges,
-          __typename: 'TimePartitionStatuses',
-        },
+        }),
       }),
     },
   },
@@ -376,21 +377,19 @@ export const PartitionHealthAssetWeeklyMock: MockedResponse<PartitionHealthQuery
       assetNodeOrError: buildAssetNode({
         id: 'test.py.repo.["asset_weekly"]',
         partitionKeysByDimension: [
-          {
+          buildDimensionPartitionKeys({
             name: 'default',
-            __typename: 'DimensionPartitionKeys',
             type: PartitionDefinitionType.TIME_WINDOW,
             partitionKeys: generateDailyTimePartitions(
               new Date('2020-01-01'),
               new Date('2023-02-22'),
               7,
             ),
-          },
+          }),
         ],
-        assetPartitionStatuses: {
+        assetPartitionStatuses: buildTimePartitionStatuses({
           ranges: [],
-          __typename: 'TimePartitionStatuses',
-        },
+        }),
       }),
     },
   },
@@ -411,21 +410,19 @@ export const PartitionHealthAssetWeeklyRootMock: MockedResponse<PartitionHealthQ
       assetNodeOrError: buildAssetNode({
         id: 'test.py.repo.["asset_weekly_root"]',
         partitionKeysByDimension: [
-          {
+          buildDimensionPartitionKeys({
             name: 'default',
-            __typename: 'DimensionPartitionKeys',
             type: PartitionDefinitionType.TIME_WINDOW,
             partitionKeys: generateDailyTimePartitions(
               new Date('2020-01-01'),
               new Date('2023-02-22'),
               7,
             ),
-          },
+          }),
         ],
-        assetPartitionStatuses: {
+        assetPartitionStatuses: buildTimePartitionStatuses({
           ranges: [],
-          __typename: 'TimePartitionStatuses',
-        },
+        }),
       }),
     },
   },
@@ -475,11 +472,10 @@ export const LaunchAssetLoaderResourceJob7Mock: MockedResponse<LaunchAssetLoader
       __typename: 'Query',
       partitionSetsOrError: {
         results: [
-          {
+          buildPartitionSet({
             id: '5b10aae97b738c48a4262b1eca530f89b13e9afc',
             name: '__ASSET_JOB_7_partition_set',
-            __typename: 'PartitionSet',
-          },
+          }),
         ],
         __typename: 'PartitionSets',
       },
@@ -580,11 +576,10 @@ export const LaunchAssetLoaderResourceJob8Mock: MockedResponse<LaunchAssetLoader
       __typename: 'Query',
       partitionSetsOrError: {
         results: [
-          {
+          buildPartitionSet({
             id: '129179973a9144278c2429d3ba680bf0f809a59b',
             name: '__ASSET_JOB_8_partition_set',
-            __typename: 'PartitionSet',
-          },
+          }),
         ],
         __typename: 'PartitionSets',
       },
@@ -686,11 +681,10 @@ export const LaunchAssetLoaderResourceMyAssetJobMock: MockedResponse<LaunchAsset
         __typename: 'Query',
         partitionSetsOrError: {
           results: [
-            {
+            buildPartitionSet({
               id: '129179973a9144278c2429d3ba680bf0f809a59b',
               name: 'my_asset_job_partition_set',
-              __typename: 'PartitionSet',
-            },
+            }),
           ],
           __typename: 'PartitionSets',
         },

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetLoaderQuery.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetLoaderQuery.fixtures.tsx
@@ -8,6 +8,7 @@ import {
   buildConfigTypeField,
   buildDimensionDefinitionType,
   buildPartitionDefinition,
+  buildQuery,
   buildRegularConfigType,
   buildRepository,
   buildRepositoryLocation,
@@ -277,10 +278,10 @@ export const ReleasesWorkspace: MockedResponse<LaunchAssetLoaderQuery> = {
     },
   },
   result: {
-    data: {
-      __typename: 'Query' as const,
-      assetNodes: assetNodes as any[],
+    data: buildQuery({
+      assetNodes,
       assetNodeDefinitionCollisions: [],
-    },
+      assetNodeAdditionalRequiredKeys: [],
+    }),
   },
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/LaunchAssetExecutionButton.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/LaunchAssetExecutionButton.types.ts
@@ -1236,6 +1236,7 @@ export type LaunchAssetLoaderQuery = {
           };
     } | null;
   }>;
+  assetNodeAdditionalRequiredKeys: Array<{__typename: 'AssetKey'; path: Array<string>}>;
   assetNodeDefinitionCollisions: Array<{
     __typename: 'AssetNodeDefinitionCollision';
     assetKey: {__typename: 'AssetKey'; path: Array<string>};

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3007,6 +3007,7 @@ type OutputDefinition {
   name: String!
   description: String
   isDynamic: Boolean
+  isRequired: Boolean
   type: DagsterType!
   metadataEntries: [MetadataEntry!]!
 }
@@ -3177,7 +3178,8 @@ type Query {
     loadMaterializations: Boolean = false
   ): [AssetNode!]!
   assetNodeOrError(assetKey: AssetKeyInput!): AssetNodeOrError!
-  assetNodeDefinitionCollisions(assetKeys: [AssetKeyInput!]): [AssetNodeDefinitionCollision!]!
+  assetNodeAdditionalRequiredKeys(assetKeys: [AssetKeyInput!]!): [AssetKey!]!
+  assetNodeDefinitionCollisions(assetKeys: [AssetKeyInput!]!): [AssetNodeDefinitionCollision!]!
   partitionBackfillOrError(backfillId: String!): PartitionBackfillOrError!
   assetBackfillPreview(params: AssetBackfillPreviewParams!): [AssetPartitions!]!
   partitionBackfillsOrError(

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3007,7 +3007,6 @@ type OutputDefinition {
   name: String!
   description: String
   isDynamic: Boolean
-  isRequired: Boolean
   type: DagsterType!
   metadataEntries: [MetadataEntry!]!
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2893,6 +2893,7 @@ export type OutputDefinition = {
   __typename: 'OutputDefinition';
   description: Maybe<Scalars['String']>;
   isDynamic: Maybe<Scalars['Boolean']>;
+  isRequired: Maybe<Scalars['Boolean']>;
   metadataEntries: Array<
     | AssetMetadataEntry
     | BoolMetadataEntry
@@ -3540,6 +3541,7 @@ export type Query = {
   assetConditionEvaluationForPartition: Maybe<AssetConditionEvaluation>;
   assetConditionEvaluationRecordsOrError: Maybe<AssetConditionEvaluationRecordsOrError>;
   assetConditionEvaluationsForEvaluationId: Maybe<AssetConditionEvaluationRecordsOrError>;
+  assetNodeAdditionalRequiredKeys: Array<AssetKey>;
   assetNodeDefinitionCollisions: Array<AssetNodeDefinitionCollision>;
   assetNodeOrError: AssetNodeOrError;
   assetNodes: Array<AssetNode>;
@@ -3621,8 +3623,12 @@ export type QueryAssetConditionEvaluationsForEvaluationIdArgs = {
   evaluationId: Scalars['Int'];
 };
 
+export type QueryAssetNodeAdditionalRequiredKeysArgs = {
+  assetKeys: Array<AssetKeyInput>;
+};
+
 export type QueryAssetNodeDefinitionCollisionsArgs = {
-  assetKeys?: InputMaybe<Array<AssetKeyInput>>;
+  assetKeys: Array<AssetKeyInput>;
 };
 
 export type QueryAssetNodeOrErrorArgs = {
@@ -10227,6 +10233,7 @@ export const buildOutputDefinition = (
     description:
       overrides && overrides.hasOwnProperty('description') ? overrides.description! : 'quis',
     isDynamic: overrides && overrides.hasOwnProperty('isDynamic') ? overrides.isDynamic! : false,
+    isRequired: overrides && overrides.hasOwnProperty('isRequired') ? overrides.isRequired! : true,
     metadataEntries:
       overrides && overrides.hasOwnProperty('metadataEntries') ? overrides.metadataEntries! : [],
     name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : 'repellendus',
@@ -11463,6 +11470,10 @@ export const buildQuery = (
         : relationshipsToOmit.has('AssetConditionEvaluationRecords')
         ? ({} as AssetConditionEvaluationRecords)
         : buildAssetConditionEvaluationRecords({}, relationshipsToOmit),
+    assetNodeAdditionalRequiredKeys:
+      overrides && overrides.hasOwnProperty('assetNodeAdditionalRequiredKeys')
+        ? overrides.assetNodeAdditionalRequiredKeys!
+        : [],
     assetNodeDefinitionCollisions:
       overrides && overrides.hasOwnProperty('assetNodeDefinitionCollisions')
         ? overrides.assetNodeDefinitionCollisions!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2893,7 +2893,6 @@ export type OutputDefinition = {
   __typename: 'OutputDefinition';
   description: Maybe<Scalars['String']>;
   isDynamic: Maybe<Scalars['Boolean']>;
-  isRequired: Maybe<Scalars['Boolean']>;
   metadataEntries: Array<
     | AssetMetadataEntry
     | BoolMetadataEntry
@@ -10233,7 +10232,6 @@ export const buildOutputDefinition = (
     description:
       overrides && overrides.hasOwnProperty('description') ? overrides.description! : 'quis',
     isDynamic: overrides && overrides.hasOwnProperty('isDynamic') ? overrides.isDynamic! : false,
-    isRequired: overrides && overrides.hasOwnProperty('isRequired') ? overrides.isRequired! : true,
     metadataEntries:
       overrides && overrides.hasOwnProperty('metadataEntries') ? overrides.metadataEntries! : [],
     name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : 'repellendus',

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -13,7 +13,6 @@ from typing import (
     Union,
     cast,
 )
-from dagster._core.snap.node import OpDefSnap
 
 import dagster._seven as seven
 from dagster import (
@@ -65,7 +64,6 @@ if TYPE_CHECKING:
     from ..schema.freshness_policy import GrapheneAssetFreshnessInfo
     from ..schema.pipelines.pipeline import (
         GrapheneAsset,
-        GrapheneAssetKey,
         GrapheneDefaultPartitionStatuses,
         GrapheneMultiPartitionStatuses,
         GrapheneTimePartitionStatuses,
@@ -140,6 +138,7 @@ def asset_node_iter(
         for external_asset_node in repository.get_external_asset_nodes():
             yield location, repository, external_asset_node
 
+
 def get_additional_required_keys(
     graphene_info: "ResolveInfo", asset_keys: AbstractSet[AssetKey]
 ) -> List["AssetKey"]:
@@ -159,6 +158,7 @@ def get_additional_required_keys(
     }
 
     return list(required_asset_keys - asset_keys)
+
 
 def get_asset_node_definition_collisions(
     graphene_info: "ResolveInfo", asset_keys: AbstractSet[AssetKey]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -104,8 +104,8 @@ from ...implementation.utils import (
 )
 from ..asset_checks import GrapheneAssetCheckExecution
 from ..asset_graph import (
-    GrapheneAssetLatestInfo,
     GrapheneAssetKey,
+    GrapheneAssetLatestInfo,
     GrapheneAssetNode,
     GrapheneAssetNodeDefinitionCollision,
     GrapheneAssetNodeOrError,
@@ -423,7 +423,7 @@ class GrapheneQuery(graphene.ObjectType):
     assetNodeAdditionalRequiredKeys = graphene.Field(
         non_null_list(GrapheneAssetKey),
         assetKeys=graphene.Argument(non_null_list(GrapheneAssetKeyInput)),
-        description="Retrieve a list of additional asset keys that must be materialized with the provided selection (with @multi_asset is_required=True within the same ops.)"
+        description="Retrieve a list of additional asset keys that must be materialized with the provided selection (with @multi_asset is_required=True within the same ops.)",
     )
 
     assetNodeDefinitionCollisions = graphene.Field(
@@ -1009,10 +1009,11 @@ class GrapheneQuery(graphene.ObjectType):
     def resolve_assetOrError(self, graphene_info: ResolveInfo, assetKey: GrapheneAssetKeyInput):
         return get_asset(graphene_info, AssetKey.from_graphql_input(assetKey))
 
-    def resolve_assetNodeAdditionalRequiredKeys(self,
+    def resolve_assetNodeAdditionalRequiredKeys(
+        self,
         graphene_info: ResolveInfo,
         assetKeys: Sequence[GrapheneAssetKeyInput],
- ):
+    ):
         assert assetKeys is not None
         raw_asset_keys = cast(Sequence[Mapping[str, Sequence[str]]], assetKeys)
         asset_keys = set(AssetKey.from_graphql_input(asset_key) for asset_key in raw_asset_keys)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -423,7 +423,7 @@ class GrapheneQuery(graphene.ObjectType):
     assetNodeAdditionalRequiredKeys = graphene.Field(
         non_null_list(GrapheneAssetKey),
         assetKeys=graphene.Argument(non_null_list(GrapheneAssetKeyInput)),
-        description="Retrieve a list of additional asset keys that must be materialized with the provided selection (with @multi_asset is_required=True within the same ops.)",
+        description="Retrieve a list of additional asset keys that must be materialized with the provided selection (due to @multi_assets with can_subset=False constraints.)",
     )
 
     assetNodeDefinitionCollisions = graphene.Field(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -66,7 +66,6 @@ class GrapheneOutputDefinition(graphene.ObjectType):
     name = graphene.NonNull(graphene.String)
     description = graphene.String()
     is_dynamic = graphene.Boolean()
-    is_required = graphene.Boolean()
     type = graphene.NonNull(GrapheneDagsterType)
     metadata_entries = non_null_list(GrapheneMetadataEntry)
 
@@ -79,7 +78,6 @@ class GrapheneOutputDefinition(graphene.ObjectType):
         solid_def_name: str,
         output_def_name: str,
         is_dynamic: bool,
-        is_required: bool,
     ):
         self._represented_pipeline = check.inst_param(
             represented_pipeline, "represented_pipeline", RepresentedJob
@@ -94,7 +92,6 @@ class GrapheneOutputDefinition(graphene.ObjectType):
             name=self._output_def_snap.name,
             description=self._output_def_snap.description,
             is_dynamic=is_dynamic,
-            is_required=is_required,
         )
 
     def resolve_type(self, _graphene_info) -> GrapheneDagsterTypeUnion:
@@ -203,7 +200,6 @@ class GrapheneOutput(graphene.ObjectType):
             self._solid_def_snap.name,
             self._output_name,
             self._output_def_snap.is_dynamic,
-            self._output_def_snap.is_required,
         )
 
     def resolve_depended_by(self, _graphene_info: ResolveInfo) -> Sequence[GrapheneInput]:
@@ -302,7 +298,6 @@ class GrapheneOutputMapping(graphene.ObjectType):
             self._solid_def_snap.name,
             self._output_mapping_snap.external_output_name,
             self._output_def_snap.is_dynamic,
-            self._output_def_snap.is_required,
         )
 
 
@@ -414,7 +409,6 @@ class ISolidDefinitionMixin:
                 self.solid_def_name,
                 output_def_snap.name,
                 output_def_snap.is_dynamic,
-                output_def_snap.is_required,
             )
             for output_def_snap in self._solid_def_snap.output_def_snaps
         ]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -66,6 +66,7 @@ class GrapheneOutputDefinition(graphene.ObjectType):
     name = graphene.NonNull(graphene.String)
     description = graphene.String()
     is_dynamic = graphene.Boolean()
+    is_required = graphene.Boolean()
     type = graphene.NonNull(GrapheneDagsterType)
     metadata_entries = non_null_list(GrapheneMetadataEntry)
 
@@ -78,6 +79,7 @@ class GrapheneOutputDefinition(graphene.ObjectType):
         solid_def_name: str,
         output_def_name: str,
         is_dynamic: bool,
+        is_required: bool,
     ):
         self._represented_pipeline = check.inst_param(
             represented_pipeline, "represented_pipeline", RepresentedJob
@@ -92,6 +94,7 @@ class GrapheneOutputDefinition(graphene.ObjectType):
             name=self._output_def_snap.name,
             description=self._output_def_snap.description,
             is_dynamic=is_dynamic,
+            is_required=is_required,
         )
 
     def resolve_type(self, _graphene_info) -> GrapheneDagsterTypeUnion:
@@ -200,6 +203,7 @@ class GrapheneOutput(graphene.ObjectType):
             self._solid_def_snap.name,
             self._output_name,
             self._output_def_snap.is_dynamic,
+            self._output_def_snap.is_required,
         )
 
     def resolve_depended_by(self, _graphene_info: ResolveInfo) -> Sequence[GrapheneInput]:
@@ -298,6 +302,7 @@ class GrapheneOutputMapping(graphene.ObjectType):
             self._solid_def_snap.name,
             self._output_mapping_snap.external_output_name,
             self._output_def_snap.is_dynamic,
+            self._output_def_snap.is_required,
         )
 
 
@@ -409,6 +414,7 @@ class ISolidDefinitionMixin:
                 self.solid_def_name,
                 output_def_snap.name,
                 output_def_snap.is_dynamic,
+                output_def_snap.is_required,
             )
             for output_def_snap in self._solid_def_snap.output_def_snaps
         ]


### PR DESCRIPTION
## Summary & Motivation

This PR resolves https://linear.app/dagster-labs/issue/FE-37/ui-should-obey-the-is-required-and-can-subset-attributes-of-multi  / https://github.com/dagster-io/dagster/issues/17328. 

A new pre-flight check in the materialize modal checks to see if other assets have the same `atomic_execution_unit_id`, which indicates that they need to be materialized together. If we find any, we present a modal warning you and clicking "Confirm" adds them to your selection.

## How I Tested These Changes
 
I tested this using two multi_assets, one with `can_subset=True` (no restrictions, ok to materialize just one) and another with `can_subset=False` (asset outputs must be materialized together)

I also expanded our Launch button tests to include a new one for the front-end logic, since it feels unlikely we'll remember to test this!

<img width="1395" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/3f8b2511-71fb-466f-9c55-37df8f3dc3d7">
