### PR TITLE
fix(storage): use Python3's `pathlib` for cross-platform filepath ops

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
@@ -227,10 +227,10 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
             filename = f"{filename}.partial"
         if len(filename) > MAX_FILENAME_LENGTH:
             filename = "{}.{}".format(non_secure_md5_hash_str(filebase.encode("utf-8")), extension)
-        baseDirLocation = Path(self._base_dir)
+        baseDirLocation = Path(self._base_dir).resolve()
         location = baseDirLocation.joinpath(*namespace, filename)
-        location = location.absolute().resolve()
-        if location not in baseDirLocation.parents:
+        location = location.resolve()
+        if baseDirLocation not in location.parents:
             raise ValueError("Invalid path")
         return location
 

--- a/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
@@ -3,6 +3,7 @@ import shutil
 import sys
 from collections import defaultdict
 from contextlib import contextmanager
+from pathlib import Path
 from typing import IO, TYPE_CHECKING, Generator, Iterator, Mapping, Optional, Sequence, Tuple
 
 from typing_extensions import Final
@@ -226,9 +227,10 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
             filename = f"{filename}.partial"
         if len(filename) > MAX_FILENAME_LENGTH:
             filename = "{}.{}".format(non_secure_md5_hash_str(filebase.encode("utf-8")), extension)
-        location = os.path.join(self._base_dir, *namespace, filename)
-        location = os.path.abspath(location)
-        if not location.startswith(self._base_dir):
+        baseDirLocation = Path(self._base_dir)
+        location = baseDirLocation.joinpath(*namespace, filename)
+        location = location.absolute().resolve()
+        if location not in baseDirLocation.parents:
             raise ValueError("Invalid path")
         return location
 

--- a/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
@@ -227,12 +227,11 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
             filename = f"{filename}.partial"
         if len(filename) > MAX_FILENAME_LENGTH:
             filename = "{}.{}".format(non_secure_md5_hash_str(filebase.encode("utf-8")), extension)
-        baseDirLocation = Path(self._base_dir).resolve()
-        location = baseDirLocation.joinpath(*namespace, filename)
-        location = location.resolve()
-        if baseDirLocation not in location.parents:
+        base_dir_path = Path(self._base_dir).resolve()
+        log_path = base_dir_path.joinpath(*namespace, filename).resolve()
+        if base_dir_path not in log_path.parents:
             raise ValueError("Invalid path")
-        return location
+        return str(log_path)
 
     def subscribe(
         self, log_key: Sequence[str], cursor: Optional[str] = None


### PR DESCRIPTION
## Summary & Motivation
Fixes #19349

## How I Tested These Changes
`python -m pytest python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_app.py`
