### PR TITLE
Update grouped graph status tag tooltip text

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeStatusContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeStatusContent.tsx
@@ -25,7 +25,9 @@ export enum StatusCase {
   SOURCE_NEVER_OBSERVED = 'SOURCE_NEVER_OBSERVED',
   SOURCE_NO_STATE = 'SOURCE_NO_STATE',
   MATERIALIZING = 'MATERIALIZING',
-  LATE_OR_FAILED = 'LATE_OR_FAILED',
+  FAILED_MATERIALIZATION = 'FAILED_MATERIALIZATION',
+  OVERDUE = 'OVERDUE',
+  CHECKS_FAILED = 'CHECKS_FAILED',
   NEVER_MATERIALIZED = 'NEVER_MATERIALIZED',
   MATERIALIZED = 'MATERIALIZED',
   PARTITIONS_FAILED = 'PARTITIONS_FAILED',
@@ -278,8 +280,17 @@ export function _buildAssetNodeStatusContent({
   ) : undefined;
 
   if (runWhichFailedToMaterialize || overdue || checksFailed) {
+    const statusCase = (() => {
+      if (runWhichFailedToMaterialize) {
+        return StatusCase.FAILED_MATERIALIZATION as const;
+      } else if (overdue) {
+        return StatusCase.OVERDUE as const;
+      } else {
+        return StatusCase.CHECKS_FAILED as const;
+      }
+    })();
     return {
-      case: StatusCase.LATE_OR_FAILED as const,
+      case: statusCase,
       background: Colors.backgroundRed(),
       border: Colors.accentRed(),
       content: (

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
@@ -138,11 +138,11 @@ const GroupNodeAssetStatusCounts = ({
           <>
             {statuses.successful.length ? (
               <Tooltip
-                content={`${statuses.successful.length} asset${ifPlural(
+                content={`${statuses.successful.length} materialized asset${ifPlural(
                   statuses.successful.length,
                   '',
                   's',
-                )} are up to date`}
+                )}`}
               >
                 <Tag icon="dot_filled" intent="success">
                   {statuses.successful.length}
@@ -154,9 +154,9 @@ const GroupNodeAssetStatusCounts = ({
             <Tooltip
               content={`${statuses.missing.length} asset${ifPlural(
                 statuses.missing.length,
-                '',
-                's',
-              )} are missing or have changed`}
+                ' has',
+                's have',
+              )} never been materialized`}
             >
               <Tag icon="dot_filled" intent="warning">
                 {statuses.missing.length}
@@ -165,11 +165,11 @@ const GroupNodeAssetStatusCounts = ({
           ) : null}
           {statuses.failed.length ? (
             <Tooltip
-              content={`${statuses.failed.length} asset${ifPlural(
+              content={`${statuses.failed.length} failed asset${ifPlural(
                 statuses.failed.length,
                 '',
                 's',
-              )} have failed or are overdue`}
+              )}`}
             >
               <Tag icon="dot_filled" intent="danger">
                 {statuses.failed.length}
@@ -180,9 +180,9 @@ const GroupNodeAssetStatusCounts = ({
             <Tooltip
               content={`${statuses.inprogress.length} asset${ifPlural(
                 statuses.inprogress.length,
-                '',
-                's',
-              )} are executing`}
+                ' is',
+                's are',
+              )} executing`}
             >
               <Tag icon="spinner" intent="primary">
                 {statuses.inprogress.length}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import {AssetDescription, NameTooltipCSS} from './AssetNode';
+import {StatusCase} from './AssetNodeStatusContent';
 import {ContextMenuWrapper} from './ContextMenuWrapper';
 import {GraphNode} from './Utils';
 import {GroupLayout} from './layout';
@@ -164,13 +165,7 @@ const GroupNodeAssetStatusCounts = ({
             </Tooltip>
           ) : null}
           {statuses.failed.length ? (
-            <Tooltip
-              content={`${statuses.failed.length} failed asset${ifPlural(
-                statuses.failed.length,
-                '',
-                's',
-              )}`}
-            >
+            <Tooltip content={<FailedStatusTooltip statuses={statuses.failed} />}>
               <Tag icon="dot_filled" intent="danger">
                 {statuses.failed.length}
               </Tag>
@@ -247,6 +242,39 @@ export const useGroupNodeContextMenu = ({
   );
 
   return {menu, dialog};
+};
+
+const FailedStatusTooltip = ({
+  statuses,
+}: {
+  statuses: ReturnType<typeof groupAssetsByStatus<any>>['failed'];
+}) => {
+  const checksFailed = statuses.filter(
+    ({status}) => status.case === StatusCase.CHECKS_FAILED,
+  ).length;
+  const overdue = statuses.filter(({status}) => status.case === StatusCase.OVERDUE).length;
+
+  const failed = statuses.length - checksFailed - overdue;
+
+  return (
+    <>
+      {failed ? (
+        <div>
+          {failed} failed asset{ifPlural(failed, '', 's')}
+        </div>
+      ) : null}
+      {checksFailed ? (
+        <div>
+          {checksFailed} failed asset check{ifPlural(failed, '', 's')}
+        </div>
+      ) : null}
+      {overdue ? (
+        <div>
+          {overdue} overdue asset{ifPlural(overdue, '', 's')}
+        </div>
+      ) : null}
+    </>
+  );
 };
 
 export const GroupNameTooltipStyle = JSON.stringify({

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.tsx
@@ -36,7 +36,9 @@ export function StatusCaseDot({statusCase}: {statusCase: StatusCase}) {
         return 'missing' as const;
       case StatusCase.MATERIALIZING:
         return 'inprogress' as const;
-      case StatusCase.LATE_OR_FAILED:
+      case StatusCase.FAILED_MATERIALIZATION:
+      case StatusCase.OVERDUE:
+      case StatusCase.CHECKS_FAILED:
         return 'failed' as const;
       case StatusCase.NEVER_MATERIALIZED:
         return 'missing' as const;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/util.ts
@@ -1,5 +1,6 @@
 import {StatusCase, buildAssetNodeStatusContent} from './AssetNodeStatusContent';
 import {LiveDataForNode, tokenForAssetKey} from './Utils';
+import {assertUnreachable} from '../app/Util';
 import {AssetKeyInput} from '../graphql/types';
 
 export function groupAssetsByStatus<
@@ -36,7 +37,8 @@ export function groupAssetsByStatus<
       liveData: assetLiveData,
       expanded: true,
     });
-    switch (status.case) {
+    const statusCase = status.case;
+    switch (statusCase) {
       case StatusCase.LOADING:
         statuses.loading = true;
         break;
@@ -55,7 +57,9 @@ export function groupAssetsByStatus<
       case StatusCase.MATERIALIZING:
         statuses.inprogress.push({asset, status});
         break;
-      case StatusCase.LATE_OR_FAILED:
+      case StatusCase.FAILED_MATERIALIZATION:
+      case StatusCase.OVERDUE:
+      case StatusCase.CHECKS_FAILED:
         statuses.failed.push({asset, status});
         break;
       case StatusCase.NEVER_MATERIALIZED:
@@ -73,6 +77,8 @@ export function groupAssetsByStatus<
       case StatusCase.PARTITIONS_MATERIALIZED:
         statuses.successful.push({asset, status});
         break;
+      default:
+        assertUnreachable(statusCase);
     }
   });
   return statuses;


### PR DESCRIPTION
## Summary & Motivation
This updates the tooltip text to be shorter and  more consistent with the rest of the product statuses.

<img width="351" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/d8ff7df0-8224-4b89-bf0a-d92d33ce0374">
<img width="287" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/181dfdfb-7619-46aa-9017-0b8aede91861">
<img width="308" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/76e0b76b-1998-4356-9b35-29a0f0a64ca9">
<img width="400" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/ab64a332-f586-43e6-8fe2-57c3f99a00c1">


## How I Tested These Changes
Booted up the UI and tested it