### PR TITLE
fixing an issue where mapped partitions are not bundled with parent to run

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -2,11 +2,13 @@ import json
 import logging
 import os
 import time
+from collections import defaultdict
 from datetime import datetime
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
+    Dict,
     Iterable,
     List,
     Mapping,
@@ -1325,9 +1327,9 @@ def should_backfill_atomic_asset_partitions_unit(
                 f" {parent_partitions_result.required_but_nonexistent_parents_partitions}"
             )
 
-        asset_partitions_to_request_map: Dict[AssetKey, Set[str]] = {}
+        asset_partitions_to_request_map: Dict[AssetKey, Set[Optional[str]]] = defaultdict(set)
         for asset_partition in asset_partitions_to_request:
-            asset_partitions_to_request_map.setdefault(asset_partition.asset_key, set()).add(
+            asset_partitions_to_request_map[asset_partition.asset_key].add(
                 asset_partition.partition_key
             )
         candidate_backfill_policy = asset_graph.get_backfill_policy(candidate.asset_key)
@@ -1343,10 +1345,9 @@ def should_backfill_atomic_asset_partitions_unit(
                     parent_backfill_policy.max_partitions_per_run is None
                     # multi-run backfill policy
                     or parent_backfill_policy.max_partitions_per_run
-                    >= len(asset_partitions_to_request_map.get(parent.asset_key, set()))
+                    >= len(asset_partitions_to_request_map[parent.asset_key])
                 )
-                and candidate.partition_key
-                in asset_partitions_to_request_map.get(parent.asset_key, set())
+                and candidate.partition_key in asset_partitions_to_request_map[parent.asset_key]
             )
             can_run_with_parent = (
                 (parent in asset_partitions_to_request or parent in candidates_unit)

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1335,9 +1335,19 @@ def should_backfill_atomic_asset_partitions_unit(
                 (parent in asset_partitions_to_request or parent in candidates_unit)
                 and asset_graph.have_same_partitioning(parent.asset_key, candidate.asset_key)
                 and (
-                    parent.partition_key == candidate.partition_key
+                    (
+                        parent.partition_key == candidate.partition_key
+                        and not asset_graph.get_backfill_policy(parent.asset_key)
+                    )
                     # candidate shares a partition key that is already being requested by the parent
-                    or candidate.partition_key in asset_partitions_to_request_map[parent.asset_key]
+                    # and both candidate and parent have backfill policies and max_partitions_per_run is not 1
+                    or (
+                        asset_graph.get_backfill_policy(parent.asset_key)
+                        and asset_graph.get_backfill_policy(parent.asset_key).max_partitions_per_run
+                        != 1
+                        and candidate.partition_key
+                        in asset_partitions_to_request_map[parent.asset_key]
+                    )
                 )
                 and asset_graph.get_repository_handle(candidate.asset_key)
                 is asset_graph.get_repository_handle(parent.asset_key)

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
@@ -704,14 +704,15 @@ def test_assets_backfill_with_partition_mapping_without_backfill_policy():
     )
     assert len(result.run_requests) == 2
 
-    assert set(result.run_requests[0].asset_selection) == {upstream_a.key, downstream_b.key}
-    assert result.run_requests[0].partition_key == "2023-03-02"
-    # downstream_b's 03-03 partition should be skipped because upstream_a's 03-02 partition is not materialized
-    assert set(result.run_requests[1].asset_selection) == {upstream_a.key}
-    assert result.run_requests[1].partition_key == "2023-03-03"
+    for run_request in result.run_requests:
+        if run_request.partition_key == "2023-03-02":
+            assert set(run_request.asset_selection) == {upstream_a.key, downstream_b.key}
+        elif run_request.partition_key == "2023-03-03":
+            # downstream_b's 03-03 partition should be skipped because upstream_a's 03-02 partition is not materialized
+            assert set(run_request.asset_selection) == {upstream_a.key}
 
 
-def test_assets_backfill_with_partition_mapping_with_one_partition_multi_run():
+def test_assets_backfill_with_partition_mapping_with_one_partition_multi_run_backfill_policy():
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
     time_now = pendulum.now("UTC")
 
@@ -763,9 +764,128 @@ def test_assets_backfill_with_partition_mapping_with_one_partition_multi_run():
     )
     assert len(result.run_requests) == 2
 
-    assert set(result.run_requests[0].asset_selection) == {upstream_a.key}
+
+def test_assets_backfill_with_partition_mapping_with_multi_partitions_multi_run_backfill_policy():
+    daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
+    time_now = pendulum.now("UTC")
+
+    @asset(
+        name="upstream_a",
+        partitions_def=daily_partitions_def,
+        backfill_policy=BackfillPolicy.multi_run(2),
+    )
+    def upstream_a():
+        return 1
+
+    @asset(
+        name="downstream_b",
+        partitions_def=daily_partitions_def,
+        backfill_policy=BackfillPolicy.multi_run(2),
+        deps=[
+            AssetDep(
+                upstream_a,
+                partition_mapping=TimeWindowPartitionMapping(
+                    start_offset=-1, end_offset=0, allow_nonexistent_upstream_partitions=True
+                ),
+            )
+        ],
+    )
+    def downstream_b():
+        return 2
+
+    assets_by_repo_name = {"repo": [upstream_a, downstream_b]}
+    asset_graph = get_asset_graph(assets_by_repo_name)
+    instance = DagsterInstance.ephemeral()
+
+    backfill_data = AssetBackfillData.from_asset_partitions(
+        partition_names=[
+            "2023-03-02",
+            "2023-03-03",
+            "2023-03-04",
+            "2023-03-05",
+            "2023-03-06",
+            "2023-03-07",
+            "2023-03-08",
+            "2023-03-09",
+        ],
+        asset_graph=asset_graph,
+        asset_selection=[upstream_a.key, downstream_b.key],
+        dynamic_partitions_store=MagicMock(),
+        backfill_start_time=time_now,
+        all_partitions=False,
+    )
+    assert backfill_data
+    result = execute_asset_backfill_iteration_consume_generator(
+        backfill_id="test_backfill_id",
+        asset_backfill_data=backfill_data,
+        asset_graph=asset_graph,
+        instance=instance,
+    )
+    assert len(result.run_requests) == 4
+
+    for run_request in result.run_requests:
+        # there is no parallel runs for downstream_b before upstream_a's targeted partitions are materialized
+        assert set(run_request.asset_selection) == {upstream_a.key}
+
+
+def test_assets_backfill_with_partition_mapping_with_single_run_backfill_policy():
+    daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
+    time_now = pendulum.now("UTC")
+
+    @asset(
+        name="upstream_a",
+        partitions_def=daily_partitions_def,
+        backfill_policy=BackfillPolicy.single_run(),
+    )
+    def upstream_a():
+        return 1
+
+    @asset(
+        name="downstream_b",
+        partitions_def=daily_partitions_def,
+        backfill_policy=BackfillPolicy.single_run(),
+        deps=[
+            AssetDep(
+                upstream_a,
+                partition_mapping=TimeWindowPartitionMapping(
+                    start_offset=-1, end_offset=0, allow_nonexistent_upstream_partitions=True
+                ),
+            )
+        ],
+    )
+    def downstream_b():
+        return 2
+
+    assets_by_repo_name = {"repo": [upstream_a, downstream_b]}
+    asset_graph = get_asset_graph(assets_by_repo_name)
+    instance = DagsterInstance.ephemeral()
+
+    backfill_data = AssetBackfillData.from_asset_partitions(
+        partition_names=[
+            "2023-03-02",
+            "2023-03-03",
+            "2023-03-04",
+            "2023-03-05",
+            "2023-03-06",
+            "2023-03-07",
+            "2023-03-08",
+            "2023-03-09",
+        ],
+        asset_graph=asset_graph,
+        asset_selection=[upstream_a.key, downstream_b.key],
+        dynamic_partitions_store=MagicMock(),
+        backfill_start_time=time_now,
+        all_partitions=False,
+    )
+    assert backfill_data
+    result = execute_asset_backfill_iteration_consume_generator(
+        backfill_id="test_backfill_id",
+        asset_backfill_data=backfill_data,
+        asset_graph=asset_graph,
+        instance=instance,
+    )
+
+    assert len(result.run_requests) == 1
+    assert set(result.run_requests[0].asset_selection) == {upstream_a.key, downstream_b.key}
     assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "2023-03-02"
-    assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_END_TAG) == "2023-03-02"
-    assert set(result.run_requests[1].asset_selection) == {upstream_a.key}
-    assert result.run_requests[1].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "2023-03-03"
-    assert result.run_requests[1].tags.get(ASSET_PARTITION_RANGE_END_TAG) == "2023-03-03"
+    assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_END_TAG) == "2023-03-09"

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
@@ -4,10 +4,12 @@ from unittest.mock import MagicMock
 import pendulum
 import pytest
 from dagster import (
+    AssetDep,
     BackfillPolicy,
     DagsterInstance,
     DailyPartitionsDefinition,
     DynamicPartitionsDefinition,
+    TimeWindowPartitionMapping,
     WeeklyPartitionsDefinition,
     asset,
 )
@@ -524,3 +526,60 @@ def test_dynamic_partitions():
     assert len(result.run_requests) == 1
     assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "foo"
     assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_END_TAG) == "bar"
+
+
+def test_assets_backfill_with_partition_mapping():
+    daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
+    time_now = pendulum.now("UTC")
+
+    @asset(
+        name="upstream_a",
+        partitions_def=daily_partitions_def,
+        backfill_policy=BackfillPolicy.multi_run(30),
+    )
+    def upstream_a():
+        return 1
+
+    @asset(
+        name="downstream_b",
+        partitions_def=daily_partitions_def,
+        backfill_policy=BackfillPolicy.multi_run(30),
+        deps=[
+            AssetDep(
+                upstream_a,
+                partition_mapping=TimeWindowPartitionMapping(
+                    start_offset=-3, end_offset=0, allow_nonexistent_upstream_partitions=True
+                ),
+            )
+        ],
+    )
+    def downstream_b():
+        return 2
+
+    assets_by_repo_name = {"repo": [upstream_a, downstream_b]}
+    asset_graph = get_asset_graph(assets_by_repo_name)
+    instance = DagsterInstance.ephemeral()
+
+    backfill_data = AssetBackfillData.from_asset_partitions(
+        partition_names=[
+            "2023-03-01",
+            "2023-03-02",
+            "2023-03-03",
+        ],
+        asset_graph=asset_graph,
+        asset_selection=[upstream_a.key, downstream_b.key],
+        dynamic_partitions_store=MagicMock(),
+        backfill_start_time=time_now,
+        all_partitions=False,
+    )
+    assert backfill_data
+    result = execute_asset_backfill_iteration_consume_generator(
+        backfill_id="test_backfill_id",
+        asset_backfill_data=backfill_data,
+        asset_graph=asset_graph,
+        instance=instance,
+    )
+    assert len(result.run_requests) == 1
+    assert set(result.run_requests[0].asset_selection) == {upstream_a.key, downstream_b.key}
+    assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "2023-03-01"
+    assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_END_TAG) == "2023-03-03"


### PR DESCRIPTION
## Summary & Motivation
Fixes the provided test case by refusing to materialize a child asset alongside its parent asset when there is a non-default, offset time window partition mapping.

## How I Tested These Changes
