### PR TITLE
chore(docs/comm): update dirname for example to develop webserver/UI

### DIFF
--- a/docs/content/community/contributing.mdx
+++ b/docs/content/community/contributing.mdx
@@ -74,7 +74,7 @@ Some notes on developing in Dagster:
 For development, run an instance of the webserver providing GraphQL service on a different port than the webapp, with any pipeline. For example:
 
 ```bash
-cd dagster/examples/docs_snippets/docs_snippets/intro_tutorial/basics/connecting_solids/
+cd dagster/examples/docs_snippets/docs_snippets/intro_tutorial/basics/connecting_ops/
 dagster-webserver -p 3333 -f complex_pipeline.py
 ```
 


### PR DESCRIPTION
## Summary & Motivation
Fix outdated [doc](https://docs.dagster.io/community/contributing#developing-the-dagster-webserverui) referring to obsolete dirname

## How I Tested These Changes
N/A 
