### PR TITLE
[ui] Improve handling of unknown browser timezones

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/browserTimezone.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/browserTimezone.ts
@@ -1,6 +1,13 @@
 import memoize from 'lodash/memoize';
 
-export const browserTimezone = memoize(() => Intl.DateTimeFormat().resolvedOptions().timeZone);
+export const browserTimezone = memoize(() => {
+  const {timeZone} = Intl.DateTimeFormat().resolvedOptions();
+  if (timeZone === 'Etc/Unknown') {
+    return 'UTC';
+  }
+  return timeZone;
+});
+
 export const browserTimezoneAbbreviation = memoize(() => timezoneAbbreviation(browserTimezone()));
 export const timezoneAbbreviation = memoize((timeZone: string) => {
   const dateString = new Date().toLocaleDateString('en-US', {

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/browserTimezone.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/browserTimezone.ts
@@ -1,8 +1,13 @@
 import memoize from 'lodash/memoize';
 
+// Etc/Unknown states that TZ information cannot be determined based on user's preferences.
+// We can't pass this value to `toLocaleDateString`, so we need to handle it and convert it
+// to a valid value.
+const BROWSER_TZ_UNKNOWN = `Etc/Unknown`;
+
 export const browserTimezone = memoize(() => {
   const {timeZone} = Intl.DateTimeFormat().resolvedOptions();
-  if (timeZone === 'Etc/Unknown') {
+  if (timeZone === BROWSER_TZ_UNKNOWN) {
     return 'UTC';
   }
   return timeZone;


### PR DESCRIPTION
## Summary & Motivation

Resolves issue auto-reported via DD here: https://app.datadoghq.com/rum/error-tracking?query=%40application.id%3A7edc09bb-51d0-4555-90cd-b19ca483d1fe&start=1654881708843&end=1654896108843&paused=false

## How I Tested These Changes

I simulated the `Intl.DateTimeFormat().resolvedOptions()` returning `Etc/Unknown`, and verified that it caused the stack trace seen in the issue. Then changed the logic to prevent this case:

![image](https://github.com/dagster-io/dagster/assets/1037212/c626594e-6599-48cd-8f6a-5701357a9e84)
