### PR TITLE
[ui] Correctly handle errors in assetOrError graphQL response in AssetView

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -375,10 +375,18 @@ const useAssetViewAssetDefinition = (assetKey: AssetKey) => {
   );
   const {assetOrError} = result.data || result.previousData || {};
   const asset = assetOrError && assetOrError.__typename === 'Asset' ? assetOrError : null;
+  if (!asset) {
+    return {
+      definitionQueryResult: result,
+      definition: null,
+      lastMaterialization: null,
+    };
+  }
+
   return {
     definitionQueryResult: result,
-    definition: asset?.definition || null,
-    lastMaterialization: asset?.assetMaterializations[0],
+    definition: asset.definition,
+    lastMaterialization: asset.assetMaterializations[0],
   };
 };
 


### PR DESCRIPTION
This page correctly displays an error message (thanks to the top level query failing), but one of the subqueries on the page was crashing when the result was an Error and not an Asset:

https://app.datadoghq.com/rum/error-tracking/issue/af9b8f14-84d8-11ee-92e7-da7ad0900002?query=%40application.id%3A7edc09bb-51d0-4555-90cd-b19ca483d1fe&refresh_mode=sliding&view=spans&from_ts=1704915008912&to_ts=1706124608746&live=true

## Summary & Motivation

## How I Tested These Changes
