### PR TITLE
[ui] Quietly ignore CSS xsrf errors when exporting DAG SVGs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graph/makeSVGPortable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/makeSVGPortable.tsx
@@ -129,13 +129,18 @@ export async function makeSVGPortable(svg: SVGElement) {
   const cssSources = Array.from<HTMLStyleElement | HTMLLinkElement>(
     document.querySelectorAll('style,link[rel=stylesheet]'),
   );
-  const fontFaces = cssSources.flatMap((el) =>
-    el.sheet
-      ? Array.from(el.sheet.cssRules)
-          .filter((r) => r instanceof CSSFontFaceRule)
-          .map((r) => r.cssText)
-      : [],
-  );
+  const fontFaces = cssSources.flatMap((el) => {
+    try {
+      return el.sheet
+        ? Array.from(el.sheet.cssRules)
+            .filter((r) => r instanceof CSSFontFaceRule)
+            .map((r) => r.cssText)
+        : [];
+    } catch (err) {
+      // https://stackoverflow.com/questions/49993633/uncaught-domexception-failed-to-read-the-cssrules-property
+      return [];
+    }
+  });
 
   const styleEl = document.createElement('style');
   styleEl.textContent = fontFaces.join('\n\n');

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/makeSVGPortable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/makeSVGPortable.tsx
@@ -130,16 +130,14 @@ export async function makeSVGPortable(svg: SVGElement) {
     document.querySelectorAll('style,link[rel=stylesheet]'),
   );
   const fontFaces = cssSources.flatMap((el) => {
+    let sheetRules: CSSRule[];
     try {
-      return el.sheet
-        ? Array.from(el.sheet.cssRules)
-            .filter((r) => r instanceof CSSFontFaceRule)
-            .map((r) => r.cssText)
-        : [];
+      sheetRules = el.sheet ? Array.from(el.sheet.cssRules) : [];
     } catch (err) {
       // https://stackoverflow.com/questions/49993633/uncaught-domexception-failed-to-read-the-cssrules-property
-      return [];
+      sheetRules = [];
     }
+    return sheetRules.filter((r) => r instanceof CSSFontFaceRule).map((r) => r.cssText);
   });
 
   const styleEl = document.createElement('style');


### PR DESCRIPTION
## Summary & Motivation

This seems like a real edge case, but someone has hit it on dagster.cloud, which suggests it may be possible to do without self-hosting.

If a Chrome extension / something else injects `style` or `link rel="stylesheet"` tags into our DOM which do not match our CSRF policy, they fail to load, but they also break the "download SVG" feautre on the graph. It attempts to read the `cssRules` contained in the style tag and encounters this error:

https://stackoverflow.com/questions/49993633/uncaught-domexception-failed-to-read-the-cssrules-property

I was able to reproduce this happening by adding a cross-site style tag to a dagster.cloud page:


![Screenshot 2024-01-24 at 1 52 53 PM](https://github.com/dagster-io/dagster/assets/1037212/331bfa08-a4d6-4b63-aa7e-a6ec0ff22617)

I think it's safe to try-catch and ignore these errors, since we only want the CSS we're allowed to read.
