### PR TITLE
[ui] Handle edge case where use presses arrow key before layout

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graph/common.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/common.ts
@@ -42,7 +42,11 @@ export const closestNodeInDirection = (
     return;
   }
 
-  const current = layout.nodes[selectedNodeKey]!;
+  const current = layout.nodes[selectedNodeKey];
+  if (!current) {
+    return;
+  }
+
   const center = (op: OpLayout | AssetLayout): {x: number; y: number} => ({
     x: op.bounds.x + op.bounds.width / 2,
     y: op.bounds.y + op.bounds.height / 2,


### PR DESCRIPTION
## Summary & Motivation

This error surfaced in Datadog here: https://app.datadoghq.com/rum/error-tracking?query=%40application.id%3A7edc09bb-51d0-4555-90cd-b19ca483d1fe&issueId=9023ccb6-b988-11ee-aeda-da7ad0900002&view=spans&from_ts=1705521590974&to_ts=1706126390974&live=true

I believe this scenario happens if the user has a selected asset (selectedNodeKey in this code) but the current rendered layout is empty or does not contain that node. I was not able to repro this, but given we update the layout asynchronously, I think it's reasonable to have a selected node that is not onscreen yet. 

This removes a `!` that was not a safe assumption and replaces it with an early return, which just makes the keyboard shortcut do nothing. ( I verified all the callers of this method handle the empty return case)

