### PR TITLE
Handle merging materialized_requested_or_discarded_subset for a mix of unpartitioned and partitioned assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -56,10 +56,19 @@ class AssetDaemonAssetCursor(NamedTuple):
             asset_graph.get_partitions_def(self.asset_key),
             newly_materialized_requested_or_discarded_asset_partitions,
         )
-        return self._replace(
-            materialized_requested_or_discarded_subset=self.materialized_requested_or_discarded_subset
-            | newly_materialized_requested_or_discarded_subset
-        )
+
+        if (
+            self.materialized_requested_or_discarded_subset.is_partitioned
+            != newly_materialized_requested_or_discarded_subset.is_partitioned
+        ):
+            return self._replace(
+                materialized_requested_or_discarded_subset=newly_materialized_requested_or_discarded_subset
+            )
+        else:
+            return self._replace(
+                materialized_requested_or_discarded_subset=self.materialized_requested_or_discarded_subset
+                | newly_materialized_requested_or_discarded_subset
+            )
 
 
 class AssetDaemonCursor(NamedTuple):

--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -139,11 +139,8 @@ class AssetSubset(NamedTuple):
             return self._replace(value=value)
 
     def _oper(self, other: "AssetSubset", oper: Callable) -> "AssetSubset":
-        if self.is_partitioned == other.is_partitioned:
-            value = oper(self.value, other.value)
-            return self._replace(value=value)
-        else:
-            return self
+        value = oper(self.value, other.value)
+        return self._replace(value=value)
 
     def __sub__(self, other: "AssetSubset") -> "AssetSubset":
         if not self.is_partitioned:


### PR DESCRIPTION
Summary:
Instead of handling it at the operator level, handle it at the callsite.

## Summary & Motivation

## How I Tested These Changes
