### PR TITLE
[time-window-partitions] No error on empty time window partitions definition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1648,7 +1648,8 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
         ).get_last_partition_window(current_time=current_time)
 
         if not first_tw or not last_tw:
-            check.failed("No partitions found")
+            # no partitions
+            return []
 
         last_tw_end_timestamp = last_tw.end.timestamp()
         first_tw_start_timestamp = first_tw.start.timestamp()

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1514,3 +1514,13 @@ def test_time_window_partitions_subset_add_partition_to_front():
     assert combined == PartitionKeysTimeWindowPartitionsSubset(
         partitions_def, {"2023-01-01", "2023-01-02"}
     )
+
+
+def test_get_partition_keys_not_in_subset_empty_subset() -> None:
+    # starts in the future
+    partitions_def = DailyPartitionsDefinition("2024-01-01")
+    time_windows_subset = TimeWindowPartitionsSubset(
+        partitions_def, num_partitions=0, included_time_windows=[]
+    )
+    with pendulum.test(create_pendulum_time(2023, 1, 1)):
+        assert time_windows_subset.get_partition_keys_not_in_subset(partitions_def) == []


### PR DESCRIPTION
## Summary & Motivation

No reason to error here, as other partitions definitions handle this gracefully.

## How I Tested These Changes

Added test fails before the change, passes now.