### PR TITLE
Disable airflow tests that were making the release branch red

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -269,6 +269,7 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     PackageSpec(
         "examples/with_airflow",
         unsupported_python_versions=[
+            AvailablePythonVersion.V3_8,
             AvailablePythonVersion.V3_9,
             AvailablePythonVersion.V3_10,
             AvailablePythonVersion.V3_11,
@@ -463,8 +464,10 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     ),
     PackageSpec(
         "python_modules/libraries/dagster-airflow",
-        # omit python 3.10 until we add support
+        # Airflow back-compat test issues
         unsupported_python_versions=[
+            AvailablePythonVersion.V3_8,
+            AvailablePythonVersion.V3_9,
             AvailablePythonVersion.V3_10,
             AvailablePythonVersion.V3_11,
         ],


### PR DESCRIPTION
Summary:
These don't run in the version we actually test on, lets not run them on the versions that we don't either.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
