### PR TITLE
fix(pythonic-resources): support nested pythonic resources when specified on a job definition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -14,16 +14,13 @@ from typing import (
 
 import dagster._check as check
 from dagster._annotations import deprecated, experimental, public
-from dagster._config.pythonic_config import (
-    attach_resource_id_to_key_mapping,
-)
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_graph import InternalAssetGraph
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster._core.execution.build_resources import wrap_resources_for_execution
+from dagster._core.execution.build_resources import wrap_resources_for_execution, get_resource_key_mapping
 from dagster._core.execution.with_resources import with_resources
 from dagster._core.executor.base import Executor
 from dagster._core.instance import DagsterInstance
@@ -269,21 +266,7 @@ def _create_repository_using_definitions_args(
         else ExecutorDefinition.hardcoded_executor(executor)
     )
 
-    # Generate a mapping from each top-level resource instance ID to its resource key
-    resource_key_mapping = {id(v): k for k, v in resources.items()} if resources else {}
-
-    # Provide this mapping to each resource instance so that it can be used to resolve
-    # nested resources
-    resources_with_key_mapping = (
-        {
-            k: attach_resource_id_to_key_mapping(v, resource_key_mapping)
-            for k, v in resources.items()
-        }
-        if resources
-        else {}
-    )
-
-    resource_defs = wrap_resources_for_execution(resources_with_key_mapping)
+    resource_defs = wrap_resources_for_execution(resources)
 
     check.opt_mapping_param(loggers, "loggers", key_type=str, value_type=LoggerDefinition)
 
@@ -299,7 +282,7 @@ def _create_repository_using_definitions_args(
         default_executor_def=executor_def,
         default_logger_defs=loggers,
         _top_level_resources=resource_defs,
-        _resource_key_mapping=resource_key_mapping,
+        _resource_key_mapping=get_resource_key_mapping(resources),
     )
     def created_repo():
         return [


### PR DESCRIPTION
## Summary & Motivation
Nested pythonic resources do not work when they are directly passed in to a job definition. This includes both the decorator or the `to_job` method of a `GraphDefinition`. Trying to do so results in the following error:

```
dagster._check.CheckError: Object <dagster._core.execution.context.init.InitResourceContext object at 0x1167d9970> is not a InitResourceContextWithKeyMapping. 
Got <dagster._core.execution.context.init.InitResourceContext object at 0x1167d9970> with type <class 'dagster._core.execution.context.init.InitResourceContext'>. 
This ConfiguredResource contains unresolved partially-specified nested resources, and so can only be initialized using a InitResourceContextWithKeyMapping

```

Upon further investigation I noticed that this is because only the `resources` attribute of the `Definitions` class actually triggers [the code to wrap pythonic resources with the resource/key mapping](https://github.com/dagster-io/dagster/pull/11645/files#diff-b9703e2b8757e40cf8a844844e89ed0b9f7a338dae712c9773113841df79008e). 

In this PR I decided to move the relevant code into the `wrap_resources_for_execution` function which _is_ called everywhere resource definitions enter the Dagster system. I'm happy to adjust this approach based on feedback though. 

## How I Tested These Changes
New unit tests and launching op jobs locally. The definition for the op job is attached below. Note that the asset was materializing fine but the job was not running without errors until the change in this PR was used. 

<details>
<summary> Test Op Job </summary>

```python
class AWSCredentialsResource(ConfigurableResource):
    username: str
    password: str

class S3Resource(ConfigurableResource):
    aws_credentials: ResourceDependency[AWSCredentialsResource]
    bucket_name: str


@asset
def my_asset(s3: S3Resource):
    get_dagster_logger().info(s3)
    assert s3.aws_credentials.username == "foo"
    assert s3.aws_credentials.password == "bar"
    assert s3.bucket_name == "my_bucket"


@op(required_resource_keys={"s3"})
def my_op(context):
    s3 = context.resources.s3
    get_dagster_logger().info(s3)
    assert s3.aws_credentials.username == "foo"
    assert s3.aws_credentials.password == "bar"
    assert s3.bucket_name == "my_bucket"


@graph
def my_graph():
    my_op()

aws_credentials = AWSCredentialsResource.configure_at_launch()
s3 = S3Resource.configure_at_launch(aws_credentials=aws_credentials)

resources = {
    "aws_credentials": aws_credentials,
    "s3": s3,
}

local = Definitions(
    assets=[my_asset],
    jobs=[my_graph.to_job(resource_defs=resources)],
    resources=resources
)
```

</details>