### PR TITLE
[daggy-u] - Update Slack support channel

### DIFF
--- a/docs/dagster-university/pages/dagster-essentials/capstone.md
+++ b/docs/dagster-university/pages/dagster-essentials/capstone.md
@@ -42,7 +42,7 @@ When building your own project, it should:
 
 If you get stuck or have questions, you can:
 
-- Join the [Dagster Slack](https://dagster.io/community) community and ask a question in our `#dagster-support` channel
+- Join the [Dagster Slack](https://dagster.io/community) community and ask a question in our `#ask-community` channel
 - Find solutions and patterns in our [GitHub discussions](https://github.com/dagster-io/dagster/discussions)
 - Check out the [Dagster Docs](https://docs.dagster.io)
 


### PR DESCRIPTION
## Summary & Motivation

This PR updates the Dagster support Slack channel to its new moniker, `#ask-community`

## How I Tested These Changes

👀 
