### PR TITLE
[ui] In asset graph sidebar, allow clicking whenever hover state is shown

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
@@ -73,12 +73,20 @@ export const AssetSidebarNode = ({
     <>
       <Box ref={elementRef} padding={{left: 8}}>
         <BoxWrapper level={level}>
-          <ItemContainer padding={{right: 12}} flex={{direction: 'row', alignItems: 'center'}}>
+          <ItemContainer
+            padding={{right: 12}}
+            flex={{direction: 'row', alignItems: 'center'}}
+            onClick={selectThisNode}
+            onDoubleClick={(e) => !e.metaKey && toggleOpen()}
+          >
             {showArrow ? (
               <UnstyledButton
                 onClick={(e) => {
                   e.stopPropagation();
                   toggleOpen();
+                }}
+                onDoubleClick={(e) => {
+                  e.stopPropagation();
                 }}
                 onKeyDown={(e) => {
                   if (e.code === 'Space') {
@@ -102,8 +110,6 @@ export const AssetSidebarNode = ({
               <div style={{width: 18}} />
             )}
             <GrayOnHoverBox
-              onClick={selectThisNode}
-              onDoubleClick={(e) => !e.metaKey && toggleOpen()}
               style={{
                 width: '100%',
                 borderRadius: '8px',
@@ -119,9 +125,13 @@ export const AssetSidebarNode = ({
                   alignItems: 'center',
                 }}
               >
-                {isAssetNode ? <StatusDot node={node} /> : null}
-                {isGroupNode ? <Icon name="asset_group" /> : null}
-                {isLocationNode ? <Icon name="folder_open" /> : null}
+                {isAssetNode ? (
+                  <StatusDot node={node} />
+                ) : isGroupNode ? (
+                  <Icon name="asset_group" />
+                ) : isLocationNode ? (
+                  <Icon name="folder_open" />
+                ) : null}
                 <MiddleTruncate text={displayName} />
               </div>
             </GrayOnHoverBox>
@@ -195,7 +205,6 @@ const ExpandMore = styled.div`
 
 const GrayOnHoverBox = styled(UnstyledButton)`
   border-radius: 8px;
-  cursor: pointer;
   user-select: none;
   width: 100%;
   display: flex;
@@ -212,6 +221,7 @@ const GrayOnHoverBox = styled(UnstyledButton)`
 const ItemContainer = styled(Box)`
   height: 32px;
   position: relative;
+  cursor: pointer;
 
   &:hover,
   &:focus-within {


### PR DESCRIPTION
## Summary & Motivation

This is a really small nit, but I keep clicking on assets in the sidebar and having it not do anything. We apply the "hover" appearance when you're inside `ItemContainer`, but the actual clickable target was a box within that with padding and a border radius. 

This moves the click target up to the ItemContainer, so anytime you see a hover state, you can click the item.

Doing this does require that onClick/onDoubleClick inside ItemContainer properly stopPropagation, but that was already the case for click and I added a handler for double click

## How I Tested These Changes

Just manually tested