### PR TITLE
fix asset checks + step launchers

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -931,9 +931,9 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
     @property
     def is_asset_check_step(self) -> bool:
         """Whether this step corresponds to an asset check."""
-        node_handle = self.node_handle
         return (
-            self.job_def.asset_layer.asset_checks_defs_by_node_handle.get(node_handle) is not None
+            self.job_def.asset_layer.asset_checks_defs_by_node_handle.get(self.node_handle)
+            is not None
         )
 
     def set_data_version(self, asset_key: AssetKey, data_version: "DataVersion") -> None:


### PR DESCRIPTION
https://dagsterlabs.slack.com/archives/C058314NT5H/p1705693260012779

Populate step launched instances with ASSET_CHECK_EVALUATION_PLANNED events. The alternative would be to raise the restriction that ASSET_CHECK_EVALUATION events are preceded by planned events, either globally or just for step launcher instances. I think this approach is workable.