### PR TITLE
[partitions] allow range selection for multi-partitioned assets (#15599)

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -224,7 +224,7 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
         self,
         partition_key_range: PartitionKeyRange,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
-    ) -> list[str]:
+    ) -> Sequence[str]:
         start: MultiPartitionKey = self.get_partition_key_from_str(partition_key_range.start)
         end: MultiPartitionKey = self.get_partition_key_from_str(partition_key_range.end)
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -654,3 +654,26 @@ def test_context_returns_multipartition_keys():
         assert isinstance(output.end, MultiPartitionKey)
 
     materialize([upstream, downstream], partition_key="1|a")
+
+
+def test_multipartitions_range_cartesian():
+    from dagster import PartitionKeyRange
+
+    partitions_def = MultiPartitionsDefinition(
+        {
+            "a": DailyPartitionsDefinition(start_date="2024-01-01"),
+            "b": StaticPartitionsDefinition(["a", "b", "c"]),
+        }
+    )
+
+    partition_range = partitions_def.get_partition_keys_in_range(
+        PartitionKeyRange(
+            MultiPartitionKey({"a": "2024-01-01", "b": "a"}),
+            MultiPartitionKey({"a": "2024-01-02", "b": "a"}),
+        )
+    )
+
+    assert partition_range == [
+        MultiPartitionKey({"a": "2024-01-01", "b": "a"}),
+        MultiPartitionKey({"a": "2024-01-02", "b": "a"}),
+    ]


### PR DESCRIPTION
This PR overrides `get_partition_keys_in_range` for MutliPartitionDefinitino to build a cartesian product of the ranges for each of the dimensions instead of lexicographically determining the range on the serialized MultiPartitionKey string.

## Summary & Motivation
See issue #15599

A Multi-Partitioned Job Run with a Partition Range uses the range of the serialized MultiPartitionKey. This leads makes the resulting partition range depending on the order of the dimensions. E.g with a Partition Definition

```
    partitions_def = MultiPartitionsDefinition(
        {
            "a": DailyPartitionsDefinition(start_date="2024-01-01"),
            "b": StaticPartitionsDefinition(["a", "b", "c"]),
        }
    )
```

when requesting a partition Range from `2024-01-01|a` to `2024-01-03|a`, this would lead to including all static partitions `a`, `b` and `c`:

```
['2024-01-01|a', '2024-01-01|b', '2024-01-01|c', '2024-01-02|a', '2024-01-02|b', '2024-01-02|c', '2024-01-03|a']
```

where the intent was to run the range only for static partition `a`:

```
['2024-01-01|a', '2024-01-02|a', '2024-01-03|a]
```

## How I Tested These Changes
- Added unit test `dagster/dagster_tests/definitions_tests/test_multi_partitions.py:654 (test_multipartitions_range_cartesian)`
