### PR TITLE
fix(ui/instance): correct padding when display warning unsupported run coordinator

### DIFF
--- a/docs/content/community/contributing.mdx
+++ b/docs/content/community/contributing.mdx
@@ -75,7 +75,7 @@ For development, run an instance of the webserver providing GraphQL service on a
 
 ```bash
 cd dagster/examples/docs_snippets/docs_snippets/intro_tutorial/basics/connecting_ops/
-dagster-webserver -p 3333 -f complex_pipeline.py
+dagster-webserver -p 3333 -f complex_job.py
 ```
 
 Keep this running. Then, in another terminal, run the local development (autoreloading, etc.) version of the webapp:

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
@@ -141,7 +141,7 @@ export const RunConcurrencyContent = ({
         <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
           <Subheading>Run concurrency</Subheading>
         </Box>
-        <div>
+        <Box padding={{vertical: 16, horizontal: 24}}>
           Run concurrency is not supported with this run coordinator. To enable run concurrency
           limits, configure your instance to use the <Mono>QueuedRunCoordinator</Mono> in your{' '}
           <Mono>dagster.yaml</Mono>. See the{' '}
@@ -153,7 +153,7 @@ export const RunConcurrencyContent = ({
             QueuedRunCoordinator documentation
           </a>{' '}
           for more information.
-        </div>
+        </Box>
       </>
     );
   }


### PR DESCRIPTION
## Summary & Motivation
- Fix a layout issue when Dagster displays warning of unsupported run coordinator.
- Update a reference to obsolete job script name in `contributing.mdx`

## How I Tested These Changes
Before
![image](https://github.com/dagster-io/dagster/assets/41283691/a67206a1-e6c7-4928-a052-9b4dfbe53845)


After 
![image](https://github.com/dagster-io/dagster/assets/41283691/a0a7f58b-2965-4cfe-9a1a-f1ce12c2e954)
