### PR TITLE
[WIP] Add support for pendulum 3

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -10,11 +10,10 @@
 import datetime
 from typing import TYPE_CHECKING, AbstractSet, Optional, Sequence, Tuple
 
-import pendulum
-
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._seven.compat.pendulum import Period
 from dagster._utils.schedules import cron_string_iterator
 
 if TYPE_CHECKING:
@@ -27,7 +26,7 @@ def get_execution_period_for_policy(
     freshness_policy: FreshnessPolicy,
     effective_data_time: Optional[datetime.datetime],
     current_time: datetime.datetime,
-) -> pendulum.Period:
+) -> Period:
     if freshness_policy.cron_schedule:
         tick_iterator = cron_string_iterator(
             start_timestamp=current_time.timestamp(),
@@ -41,18 +40,18 @@ def get_execution_period_for_policy(
             tick = next(tick_iterator)
             required_data_time = tick - freshness_policy.maximum_lag_delta
             if effective_data_time is None or effective_data_time < required_data_time:
-                return pendulum.Period(start=required_data_time, end=tick)
+                return Period(start=required_data_time, end=tick)
 
     else:
         # occurs when asset is missing
         if effective_data_time is None:
-            return pendulum.Period(
+            return Period(
                 # require data from at most maximum_lag_delta ago
                 start=current_time - freshness_policy.maximum_lag_delta,
                 # this data should be available as soon as possible
                 end=current_time,
             )
-        return pendulum.Period(
+        return Period(
             # we don't want to execute this too frequently
             start=effective_data_time + 0.9 * freshness_policy.maximum_lag_delta,
             end=max(effective_data_time + freshness_policy.maximum_lag_delta, current_time),
@@ -64,7 +63,7 @@ def get_execution_period_and_evaluation_data_for_policies(
     policies: AbstractSet[FreshnessPolicy],
     effective_data_time: Optional[datetime.datetime],
     current_time: datetime.datetime,
-) -> Tuple[Optional[pendulum.Period], Optional["TextRuleEvaluationData"]]:
+) -> Tuple[Optional[Period], Optional["TextRuleEvaluationData"]]:
     """Determines a range of times for which you can kick off an execution of this asset to solve
     the most pressing constraint, alongside a maximum number of additional constraints.
     """
@@ -84,7 +83,7 @@ def get_execution_period_and_evaluation_data_for_policies(
         if merged_period is None:
             merged_period = period
         elif period.start <= merged_period.end:
-            merged_period = pendulum.Period(
+            merged_period = Period(
                 start=max(period.start, merged_period.start),
                 end=period.end,
             )

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -1,12 +1,11 @@
 import datetime
 from typing import AbstractSet, NamedTuple, Optional
 
-import pendulum
-
 import dagster._check as check
 from dagster._annotations import experimental
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._serdes import whitelist_for_serdes
+from dagster._seven.compat.pendulum import create_pendulum_timezone
 from dagster._utils.schedules import (
     is_valid_cron_schedule,
     reverse_cron_string_iterator,
@@ -122,7 +121,7 @@ class FreshnessPolicy(
             )
             try:
                 # Verify that the timezone can be loaded
-                pendulum.tz.timezone(cron_schedule_timezone)  # type: ignore
+                create_pendulum_timezone(cron_schedule_timezone)  # type: ignore
             except Exception as e:
                 raise DagsterInvalidDefinitionError(
                     "Invalid cron schedule timezone '{cron_schedule_timezone}'.   "

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -20,7 +20,6 @@ from typing import (
     cast,
 )
 
-import pendulum
 from typing_extensions import TypeAlias
 
 import dagster._check as check
@@ -29,6 +28,7 @@ from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.scoped_resources_builder import Resources, ScopedResourcesBuilder
 from dagster._serdes import whitelist_for_serdes
+from dagster._seven.compat.pendulum import create_pendulum_timezone
 from dagster._utils import IHasInternalInit, ensure_gen
 from dagster._utils.merger import merge_dicts
 from dagster._utils.schedules import is_valid_cron_schedule
@@ -692,7 +692,7 @@ class ScheduleDefinition(IHasInternalInit):
         if self._execution_timezone:
             try:
                 # Verify that the timezone can be loaded
-                pendulum.tz.timezone(self._execution_timezone)  # type: ignore
+                create_pendulum_timezone(self._execution_timezone)  # type: ignore
             except Exception as e:
                 raise DagsterInvalidDefinitionError(
                     f"Invalid execution timezone {self._execution_timezone} for {name}"

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -43,10 +43,10 @@ from dagster._serdes.serdes import (
 )
 from dagster._seven.compat.pendulum import (
     _IS_PENDULUM_2_OR_NEWER,
+    PRE_TRANSITION,
     PendulumDateTime,
     create_pendulum_time,
     to_timezone,
-    PRE_TRANSITION,
 )
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
 from dagster._utils.schedules import (

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -42,7 +42,7 @@ from dagster._serdes.serdes import (
     unpack_value,
 )
 from dagster._seven.compat.pendulum import (
-    _IS_PENDULUM_2,
+    _IS_PENDULUM_2_OR_NEWER,
     PendulumDateTime,
     create_pendulum_time,
     to_timezone,
@@ -146,7 +146,7 @@ def dst_safe_strptime(date_string: str, tz: str, fmt: str) -> PendulumDateTime:
         # Pendulum 1.x erroneously believes that there are two instances of the *second* hour after
         # a datetime transition, so to work around this we calculate the timestamp of the next
         # microsecond of the given datetime.
-        dt_microsecond = dt.microsecond + 1 if not _IS_PENDULUM_2 else dt.microsecond
+        dt_microsecond = dt.microsecond + 1 if not _IS_PENDULUM_2_OR_NEWER else dt.microsecond
         dt = create_pendulum_time(
             dt.year,
             dt.month,
@@ -158,7 +158,7 @@ def dst_safe_strptime(date_string: str, tz: str, fmt: str) -> PendulumDateTime:
             tz=tz,
             dst_rule=pendulum.PRE_TRANSITION,
         )
-        if not _IS_PENDULUM_2:
+        if not _IS_PENDULUM_2_OR_NEWER:
             dt = dt.add(microseconds=-1)
         return dt
 

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -46,6 +46,7 @@ from dagster._seven.compat.pendulum import (
     PendulumDateTime,
     create_pendulum_time,
     to_timezone,
+    PRE_TRANSITION,
 )
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
 from dagster._utils.schedules import (
@@ -156,7 +157,7 @@ def dst_safe_strptime(date_string: str, tz: str, fmt: str) -> PendulumDateTime:
             dt.second,
             dt_microsecond,
             tz=tz,
-            dst_rule=pendulum.PRE_TRANSITION,
+            dst_rule=PRE_TRANSITION,
         )
         if not _IS_PENDULUM_2_OR_NEWER:
             dt = dt.add(microseconds=-1)

--- a/python_modules/dagster/dagster/_seven/compat/pendulum.py
+++ b/python_modules/dagster/dagster/_seven/compat/pendulum.py
@@ -17,8 +17,12 @@ _IS_PENDULUM_3_OR_NEWER = (
 
 
 PRE_TRANSITION = pendulum.tz.PRE_TRANSITION if _IS_PENDULUM_3_OR_NEWER else pendulum.PRE_TRANSITION
-POST_TRANSITION = pendulum.tz.POST_TRANSITION if _IS_PENDULUM_3_OR_NEWER else pendulum.POST_TRANSITION
-TRANSITION_ERROR = pendulum.tz.TRANSITION_ERROR if _IS_PENDULUM_3_OR_NEWER else pendulum.TRANSITION_ERROR
+POST_TRANSITION = (
+    pendulum.tz.POST_TRANSITION if _IS_PENDULUM_3_OR_NEWER else pendulum.POST_TRANSITION
+)
+TRANSITION_ERROR = (
+    pendulum.tz.TRANSITION_ERROR if _IS_PENDULUM_3_OR_NEWER else pendulum.TRANSITION_ERROR
+)
 
 
 @contextmanager
@@ -70,7 +74,7 @@ def create_pendulum_time(year, month, day, *args, **kwargs):
 
         if "dst_rule" in kwargs:
             dst_rule = kwargs.pop("dst_rule")
-            raise_on_unknown_times = (dst_rule == TRANSITION_ERROR)
+            raise_on_unknown_times = dst_rule == TRANSITION_ERROR
             if dst_rule == PRE_TRANSITION:
                 fold = 0
             elif dst_rule == POST_TRANSITION:

--- a/python_modules/dagster/dagster/_seven/compat/pendulum.py
+++ b/python_modules/dagster/dagster/_seven/compat/pendulum.py
@@ -31,6 +31,16 @@ def mock_pendulum_timezone(override_timezone):
             yield
 
 
+@contextmanager
+def pendulum_test(mock):
+    if _IS_PENDULUM_3_OR_NEWER:
+        with pendulum.travel_to(mock, freeze=True):
+            yield
+    else:
+        with pendulum.test(mock):
+            yield
+
+
 def create_pendulum_time(year, month, day, *args, **kwargs):
     # pendulum <2.0
     if not _IS_PENDULUM_2_OR_NEWER:

--- a/python_modules/dagster/dagster/_seven/compat/pendulum.py
+++ b/python_modules/dagster/dagster/_seven/compat/pendulum.py
@@ -10,6 +10,11 @@ _IS_PENDULUM_2_OR_NEWER = (
     and getattr(packaging.version.parse(getattr(pendulum, "__version__")), "major") >= 2
 )
 
+_IS_PENDULUM_3_OR_NEWER = (
+    hasattr(pendulum, "__version__")
+    and getattr(packaging.version.parse(getattr(pendulum, "__version__")), "major") >= 3
+)
+
 
 @contextmanager
 def mock_pendulum_timezone(override_timezone):
@@ -49,6 +54,8 @@ def create_pendulum_time(year, month, day, *args, **kwargs):
 PendulumDateTime: TypeAlias = (
     pendulum.DateTime if _IS_PENDULUM_2_OR_NEWER else pendulum.Pendulum  # type: ignore[attr-defined]
 )
+
+Period: TypeAlias = pendulum.Interval if _IS_PENDULUM_3_OR_NEWER else pendulum.Period  # type: ignore[attr-defined]
 
 
 # Workaround for issue with .in_tz() in pendulum:

--- a/python_modules/dagster/dagster/_seven/compat/pendulum.py
+++ b/python_modules/dagster/dagster/_seven/compat/pendulum.py
@@ -5,15 +5,15 @@ import packaging.version
 import pendulum
 from typing_extensions import TypeAlias
 
-_IS_PENDULUM_2 = (
+_IS_PENDULUM_2_OR_NEWER = (
     hasattr(pendulum, "__version__")
-    and getattr(packaging.version.parse(getattr(pendulum, "__version__")), "major") == 2
+    and getattr(packaging.version.parse(getattr(pendulum, "__version__")), "major") >= 2
 )
 
 
 @contextmanager
 def mock_pendulum_timezone(override_timezone):
-    if _IS_PENDULUM_2:
+    if _IS_PENDULUM_2_OR_NEWER:
         with pendulum.tz.test_local_timezone(pendulum.tz.timezone(override_timezone)):
             yield
     else:
@@ -22,7 +22,7 @@ def mock_pendulum_timezone(override_timezone):
 
 
 def create_pendulum_time(year, month, day, *args, **kwargs):
-    if "tz" in kwargs and "dst_rule" in kwargs and not _IS_PENDULUM_2:
+    if "tz" in kwargs and "dst_rule" in kwargs and not _IS_PENDULUM_2_OR_NEWER:
         tz = pendulum.timezone(kwargs.pop("tz"))
         dst_rule = kwargs.pop("dst_rule")
 
@@ -41,13 +41,13 @@ def create_pendulum_time(year, month, day, *args, **kwargs):
 
     return (
         pendulum.datetime(year, month, day, *args, **kwargs)
-        if _IS_PENDULUM_2
+        if _IS_PENDULUM_2_OR_NEWER
         else pendulum.create(year, month, day, *args, **kwargs)
     )
 
 
 PendulumDateTime: TypeAlias = (
-    pendulum.DateTime if _IS_PENDULUM_2 else pendulum.Pendulum  # type: ignore[attr-defined]
+    pendulum.DateTime if _IS_PENDULUM_2_OR_NEWER else pendulum.Pendulum  # type: ignore[attr-defined]
 )
 
 

--- a/python_modules/dagster/dagster/_seven/compat/pendulum.py
+++ b/python_modules/dagster/dagster/_seven/compat/pendulum.py
@@ -81,6 +81,13 @@ def create_pendulum_time(year, month, day, *args, **kwargs):
         return pendulum.datetime(year, month, day, *args, **kwargs)
 
 
+def create_pendulum_timezone(*args, **kwargs):
+    if _IS_PENDULUM_3_OR_NEWER:
+        return pendulum.timezone(*args, **kwargs)
+    else:
+        return pendulum.tz.timezone(*args, **kwargs)
+
+
 PendulumDateTime: TypeAlias = (
     pendulum.DateTime if _IS_PENDULUM_2_OR_NEWER else pendulum.Pendulum  # type: ignore[attr-defined]
 )

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -10,11 +10,11 @@ from croniter import croniter as _croniter
 import dagster._check as check
 from dagster._core.definitions.partition import ScheduleType
 from dagster._seven.compat.pendulum import (
+    POST_TRANSITION,
+    PRE_TRANSITION,
+    TRANSITION_ERROR,
     PendulumDateTime,
     create_pendulum_time,
-    PRE_TRANSITION,
-    POST_TRANSITION,
-    TRANSITION_ERROR,
 )
 
 # Monthly schedules with 29-31 won't reliably run every month

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -294,7 +294,7 @@ def _find_weekly_schedule_time(
         )
 
         # Move to the correct day of the week
-        current_day_of_week = new_time.day_of_week
+        current_day_of_week = new_time.isoweekday() % 7
         if day_of_week != current_day_of_week:
             if ascending:
                 new_time = new_time.add(days=(day_of_week - current_day_of_week) % 7)

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -9,7 +9,13 @@ from croniter import croniter as _croniter
 
 import dagster._check as check
 from dagster._core.definitions.partition import ScheduleType
-from dagster._seven.compat.pendulum import PendulumDateTime, create_pendulum_time
+from dagster._seven.compat.pendulum import (
+    PendulumDateTime,
+    create_pendulum_time,
+    PRE_TRANSITION,
+    POST_TRANSITION,
+    TRANSITION_ERROR,
+)
 
 # Monthly schedules with 29-31 won't reliably run every month
 MAX_DAY_OF_MONTH_WITH_GUARANTEED_MONTHLY_INTERVAL = 28
@@ -99,7 +105,7 @@ def _replace_date_fields(
             0,
             0,
             tz=pendulum_date.timezone_name,
-            dst_rule=pendulum.TRANSITION_ERROR,
+            dst_rule=TRANSITION_ERROR,
         )
     except pendulum.tz.exceptions.NonExistingTime:  # type: ignore
         # If we fall on a non-existant time (e.g. between 2 and 3AM during a DST transition)
@@ -114,7 +120,7 @@ def _replace_date_fields(
             0,
             0,
             tz=pendulum_date.timezone_name,
-            dst_rule=pendulum.TRANSITION_ERROR,
+            dst_rule=TRANSITION_ERROR,
         )
     except pendulum.tz.exceptions.AmbiguousTime:  # type: ignore
         # For consistency, always choose the latter of the two possible times during a fall DST
@@ -129,7 +135,7 @@ def _replace_date_fields(
             0,
             0,
             tz=pendulum_date.timezone_name,
-            dst_rule=pendulum.POST_TRANSITION,
+            dst_rule=POST_TRANSITION,
         )
 
     return new_time
@@ -436,7 +442,7 @@ def _get_dates_to_consider_after_ambigious_time(
         next_date.second,
         next_date.microsecond,
         tz=timezone_str,
-        dst_rule=pendulum.POST_TRANSITION,
+        dst_rule=POST_TRANSITION,
     )
 
     dates_to_consider = [post_transition_time]
@@ -458,7 +464,7 @@ def _get_dates_to_consider_after_ambigious_time(
         next_date.second,
         next_date.microsecond,
         tz=timezone_str,
-        dst_rule=pendulum.PRE_TRANSITION,
+        dst_rule=PRE_TRANSITION,
     )
     dates_to_consider.append(pre_transition_time)
 
@@ -493,7 +499,7 @@ def _get_dates_to_consider_after_ambigious_time(
             next_date.second,
             next_date.microsecond,
             tz=timezone_str,
-            dst_rule=pendulum.PRE_TRANSITION,
+            dst_rule=PRE_TRANSITION,
         )
         dates_to_consider.append(curr_pre_transition_time)
 
@@ -506,7 +512,7 @@ def _get_dates_to_consider_after_ambigious_time(
             next_date.second,
             next_date.microsecond,
             tz=timezone_str,
-            dst_rule=pendulum.POST_TRANSITION,
+            dst_rule=POST_TRANSITION,
         )
         dates_to_consider.append(curr_post_transition_time)
 
@@ -590,7 +596,7 @@ def _timezone_aware_cron_iter(
                     next_date.second,
                     next_date.microsecond,
                     tz=timezone_str,
-                    dst_rule=pendulum.TRANSITION_ERROR,
+                    dst_rule=TRANSITION_ERROR,
                 )
             ]
         except pendulum.tz.exceptions.NonExistingTime:  # type:ignore
@@ -610,7 +616,7 @@ def _timezone_aware_cron_iter(
                         0,
                         0,
                         tz=timezone_str,
-                        dst_rule=pendulum.TRANSITION_ERROR,
+                        dst_rule=TRANSITION_ERROR,
                     )
                 ]
         except pendulum.tz.exceptions.AmbiguousTime:  # type: ignore

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -27,6 +27,7 @@ from dagster._core.scheduler.instigation import (
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._seven import get_current_datetime_in_utc
+from dagster._seven.compat.pendulum import pendulum_test
 from dagster._utils.error import SerializableErrorInfo
 
 
@@ -327,7 +328,7 @@ class TestScheduleStorage:
 
         freeze_datetime = pendulum.now("UTC")
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             updated_tick = tick.with_status(TickStatus.SUCCESS).with_run_info(run_id="1234")
             assert updated_tick.status == TickStatus.SUCCESS
             assert updated_tick.end_timestamp == freeze_datetime.timestamp()

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -42,7 +42,7 @@ from dagster._core.host_representation.external_data import (
 )
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.test_utils import instance_for_test
-from dagster._seven.compat.pendulum import create_pendulum_time
+from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test
 
 
 def to_external_asset_graph(assets, asset_checks=None) -> AssetGraph:
@@ -195,7 +195,7 @@ def test_get_parent_partitions_non_default_partition_mapping(asset_graph_from_as
 
     asset_graph = asset_graph_from_assets([parent, child])
 
-    with pendulum.test(create_pendulum_time(year=2022, month=1, day=3, hour=4)):
+    with pendulum_test(create_pendulum_time(year=2022, month=1, day=3, hour=4)):
         with instance_for_test() as instance:
             current_time = pendulum.now("UTC")
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -39,7 +39,7 @@ from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_START_TAG,
 )
 from dagster._core.test_utils import assert_namedtuple_lists_equal
-from dagster._seven.compat.pendulum import create_pendulum_time
+from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test
 
 
 @pytest.fixture(autouse=True)
@@ -725,7 +725,7 @@ def test_error_on_nonexistent_upstream_partition():
     def downstream_asset(context, upstream_asset):
         return upstream_asset + 1
 
-    with pendulum.test(create_pendulum_time(2020, 1, 2, 10, 0)):
+    with pendulum_test(create_pendulum_time(2020, 1, 2, 10, 0)):
         with pytest.raises(
             DagsterInvariantViolationError,
             match="invalid partition keys",

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -16,7 +16,7 @@ from dagster._core.definitions.time_window_partitions import (
 )
 from dagster._core.errors import DagsterInvalidDeserializationVersionError
 from dagster._serdes import deserialize_value, serialize_value
-from dagster._seven.compat.pendulum import create_pendulum_time
+from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test
 
 
 def test_default_subset_cannot_deserialize_invalid_version():
@@ -165,7 +165,7 @@ def test_all_partitions_subset_static_partitions_def() -> None:
 
 
 def test_all_partitions_subset_time_window_partitions_def() -> None:
-    with pendulum.test(create_pendulum_time(2020, 1, 6, hour=10)):
+    with pendulum_test(create_pendulum_time(2020, 1, 6, hour=10)):
         time_window_partitions_def = DailyPartitionsDefinition(start_date="2020-01-01")
         all_subset = AllPartitionsSubset(time_window_partitions_def, Mock(), pendulum.now("UTC"))
         assert len(all_subset) == 5

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -63,7 +63,7 @@ from dagster._core.storage.tags import (
 )
 from dagster._core.test_utils import environ, instance_for_test
 from dagster._serdes import deserialize_value, serialize_value
-from dagster._seven.compat.pendulum import create_pendulum_time
+from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test
 from dagster._utils import Counter, traced_counter
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
@@ -285,7 +285,7 @@ def test_scenario_to_completion(scenario: AssetBackfillScenario, failures: str, 
     ):
         instance.add_dynamic_partitions("foo", ["a", "b"])
 
-        with pendulum.test(scenario.evaluation_time):
+        with pendulum_test(scenario.evaluation_time):
             assets_by_repo_name = scenario.assets_by_repo_name
 
             asset_graph = get_asset_graph(assets_by_repo_name)

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -27,7 +27,7 @@ from dagster._core.definitions.materialize import materialize_to_memory
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition
 from dagster._core.event_api import EventRecordsFilter
-from dagster._seven.compat.pendulum import create_pendulum_time
+from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 
@@ -276,7 +276,7 @@ scenarios = {
 
 @pytest.mark.parametrize("scenario", list(scenarios.values()), ids=list(scenarios.keys()))
 def test_partitioned_data_time(scenario):
-    with DagsterInstance.ephemeral() as instance, pendulum.test(create_pendulum_time(2023, 1, 7)):
+    with DagsterInstance.ephemeral() as instance, pendulum_test(create_pendulum_time(2023, 1, 7)):
         _materialize_partitions(instance, scenario.before_partitions)
         record = _get_record(instance=instance)
         _materialize_partitions(instance, scenario.after_partitions)

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_asset_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_asset_sensor_run.py
@@ -1,7 +1,7 @@
 import pendulum
 from dagster import materialize
 from dagster._core.scheduler.instigation import TickStatus
-from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
+from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test, to_timezone
 
 from .test_run_status_sensors import (
     instance_with_single_code_location_multiple_repos_with_sensors,
@@ -25,7 +25,7 @@ def test_monitor_source_asset_sensor(executor):
         repos,
     ):
         asset_sensor_repo = repos["asset_sensor_repo"]
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             the_sensor = asset_sensor_repo.get_external_sensor("monitor_source_asset_sensor")
             instance.start_sensor(the_sensor)
 
@@ -41,7 +41,7 @@ def test_monitor_source_asset_sensor(executor):
             )
 
             freeze_datetime = freeze_datetime.add(seconds=60)
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             materialize([a_source_asset], instance=instance)
 
             evaluate_sensors(workspace_ctx, executor)

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_asset_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_asset_sensor_run.py
@@ -1,4 +1,3 @@
-import pendulum
 from dagster import materialize
 from dagster._core.scheduler.instigation import TickStatus
 from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test, to_timezone

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
@@ -3,7 +3,6 @@ import sys
 from contextlib import contextmanager
 from typing import Iterator, Optional
 
-import pendulum
 import pytest
 from dagster import (
     AssetKey,

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
@@ -51,7 +51,7 @@ from dagster._core.test_utils import (
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import ModuleTarget
-from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
+from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test, to_timezone
 
 from .test_sensor_run import evaluate_sensors, validate_tick, wait_for_all_runs_to_start
 
@@ -430,7 +430,7 @@ def test_resources(
         "US/Central",
     )
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         base_run_count = 0
         if "asset" in sensor_name:
             the_job.execute_in_process(instance=instance)
@@ -499,7 +499,7 @@ def test_resources_freshness_policy_sensor(
     )
     original_time = freeze_datetime
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
         instance.add_instigator_state(
             InstigatorState(
@@ -515,15 +515,15 @@ def test_resources_freshness_policy_sensor(
 
     # We have to do two ticks because the first tick will be skipped due to the freshness policy
     # sensor initializing its cursor
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context_struct_resources, None)
         wait_for_all_runs_to_start(instance)
     freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context_struct_resources, None)
         wait_for_all_runs_to_start(instance)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         ticks = instance.get_ticks(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
         )
@@ -575,7 +575,7 @@ def test_resources_run_status_sensor(
     )
     original_time = freeze_datetime
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
         instance.add_instigator_state(
             InstigatorState(
@@ -591,16 +591,16 @@ def test_resources_run_status_sensor(
 
     # We have to do two ticks because the first tick will be skipped due to the run status
     # sensor initializing its cursor
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context_struct_resources, None)
         wait_for_all_runs_to_start(instance)
     the_job.execute_in_process(instance=instance)
     freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context_struct_resources, None)
         wait_for_all_runs_to_start(instance)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         ticks = instance.get_ticks(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
         )
@@ -657,7 +657,7 @@ def test_resources_run_failure_sensor(
     )
     original_time = freeze_datetime
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
         instance.add_instigator_state(
             InstigatorState(
@@ -673,16 +673,16 @@ def test_resources_run_failure_sensor(
 
     # We have to do two ticks because the first tick will be skipped due to the run status
     # sensor initializing its cursor
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context_struct_resources, None)
         wait_for_all_runs_to_start(instance)
     the_failure_job.execute_in_process(instance=instance, raise_on_error=False)
     freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context_struct_resources, None)
         wait_for_all_runs_to_start(instance)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         ticks = instance.get_ticks(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
         )

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -25,6 +25,7 @@ from dagster._core.storage.event_log.base import EventRecordsFilter
 from dagster._core.test_utils import create_test_daemon_workspace_context, instance_for_test
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import WorkspaceFileTarget, WorkspaceLoadTarget
+from dagster._seven.compat.pendulum import pendulum_test
 
 from .conftest import create_workspace_load_target
 from .test_sensor_run import (
@@ -129,7 +130,7 @@ def test_run_status_sensor(
     external_repo: ExternalRepository,
 ):
     freeze_datetime = pendulum.now()
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         success_sensor = external_repo.get_external_sensor("my_job_success_sensor")
         instance.start_sensor(success_sensor)
 
@@ -160,7 +161,7 @@ def test_run_status_sensor(
         freeze_datetime = freeze_datetime.add(seconds=60)
         time.sleep(1)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_job = external_repo.get_full_external_job("failure_job")
         run = instance.create_run_for_job(
             failure_job,
@@ -173,7 +174,7 @@ def test_run_status_sensor(
         assert run.status == DagsterRunStatus.FAILURE
         freeze_datetime = freeze_datetime.add(seconds=60)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should not fire the success sensor, should fire the started sensro
         evaluate_sensors(workspace_context, executor)
 
@@ -199,7 +200,7 @@ def test_run_status_sensor(
             TickStatus.SUCCESS,
         )
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_job = external_repo.get_full_external_job("foo_job")
         run = instance.create_run_for_job(
             foo_job,
@@ -214,7 +215,7 @@ def test_run_status_sensor(
 
     caplog.clear()
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should fire the success sensor and the started sensor
         evaluate_sensors(workspace_context, executor)
 
@@ -251,7 +252,7 @@ def test_run_failure_sensor(
     external_repo: ExternalRepository,
 ):
     freeze_datetime = pendulum.now()
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         failure_sensor = external_repo.get_external_sensor("my_run_failure_sensor")
         instance.start_sensor(failure_sensor)
 
@@ -271,7 +272,7 @@ def test_run_failure_sensor(
         freeze_datetime = freeze_datetime.add(seconds=60)
         time.sleep(1)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_job = external_repo.get_full_external_job("failure_job")
         run = instance.create_run_for_job(
             failure_job,
@@ -284,7 +285,7 @@ def test_run_failure_sensor(
         assert run.status == DagsterRunStatus.FAILURE
         freeze_datetime = freeze_datetime.add(seconds=60)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should fire the failure sensor
         evaluate_sensors(workspace_context, executor)
 
@@ -307,7 +308,7 @@ def test_run_failure_sensor_that_fails(
     external_repo: ExternalRepository,
 ):
     freeze_datetime = pendulum.now()
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         failure_sensor = external_repo.get_external_sensor(
             "my_run_failure_sensor_that_itself_fails"
         )
@@ -329,7 +330,7 @@ def test_run_failure_sensor_that_fails(
         freeze_datetime = freeze_datetime.add(seconds=60)
         time.sleep(1)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_job = external_repo.get_full_external_job("failure_job")
         run = instance.create_run_for_job(
             failure_job,
@@ -342,7 +343,7 @@ def test_run_failure_sensor_that_fails(
         assert run.status == DagsterRunStatus.FAILURE
         freeze_datetime = freeze_datetime.add(seconds=60)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should fire the failure sensor and fail
         evaluate_sensors(workspace_context, executor)
 
@@ -360,7 +361,7 @@ def test_run_failure_sensor_that_fails(
 
     # Next tick skips again
     freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should fire the failure sensor and fail
         evaluate_sensors(workspace_context, executor)
 
@@ -383,7 +384,7 @@ def test_run_failure_sensor_filtered(
     external_repo: ExternalRepository,
 ):
     freeze_datetime = pendulum.now()
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         failure_sensor = external_repo.get_external_sensor("my_run_failure_sensor_filtered")
         instance.start_sensor(failure_sensor)
 
@@ -403,7 +404,7 @@ def test_run_failure_sensor_filtered(
         freeze_datetime = freeze_datetime.add(seconds=60)
         time.sleep(1)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_job = external_repo.get_full_external_job("failure_job_2")
         run = instance.create_run_for_job(
             failure_job_2,
@@ -416,7 +417,7 @@ def test_run_failure_sensor_filtered(
         assert run.status == DagsterRunStatus.FAILURE
         freeze_datetime = freeze_datetime.add(seconds=60)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should not fire the failure sensor (filtered to failure job)
         evaluate_sensors(workspace_context, executor)
 
@@ -434,7 +435,7 @@ def test_run_failure_sensor_filtered(
         freeze_datetime = freeze_datetime.add(seconds=60)
         time.sleep(1)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_job = external_repo.get_full_external_job("failure_job")
         run = instance.create_run_for_job(
             failure_job,
@@ -448,7 +449,7 @@ def test_run_failure_sensor_filtered(
 
         freeze_datetime = freeze_datetime.add(seconds=60)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should not fire the failure sensor (filtered to failure job)
         evaluate_sensors(workspace_context, executor)
 
@@ -508,7 +509,7 @@ def test_run_status_sensor_interleave(storage_config_fn, executor: Optional[Thre
             external_repo,
         ):
             # start sensor
-            with pendulum.test(freeze_datetime):
+            with pendulum_test(freeze_datetime):
                 failure_sensor = external_repo.get_external_sensor("my_run_failure_sensor")
                 instance.start_sensor(failure_sensor)
 
@@ -528,7 +529,7 @@ def test_run_status_sensor_interleave(storage_config_fn, executor: Optional[Thre
                 freeze_datetime = freeze_datetime.add(seconds=60)
                 time.sleep(1)
 
-            with pendulum.test(freeze_datetime):
+            with pendulum_test(freeze_datetime):
                 external_job = external_repo.get_full_external_job("hanging_job")
                 # start run 1
                 run1 = instance.create_run_for_job(
@@ -554,7 +555,7 @@ def test_run_status_sensor_interleave(storage_config_fn, executor: Optional[Thre
                 assert run.run_id == run2.run_id
 
             # check sensor
-            with pendulum.test(freeze_datetime):
+            with pendulum_test(freeze_datetime):
                 # should fire for run 2
                 evaluate_sensors(workspace_context, executor)
 
@@ -572,14 +573,14 @@ def test_run_status_sensor_interleave(storage_config_fn, executor: Optional[Thre
                 assert ticks[0].origin_run_ids[0] == run2.run_id
 
             # fail run 1
-            with pendulum.test(freeze_datetime):
+            with pendulum_test(freeze_datetime):
                 # fail run 2
                 instance.report_run_failed(run1)
                 freeze_datetime = freeze_datetime.add(seconds=60)
                 time.sleep(1)
 
             # check sensor
-            with pendulum.test(freeze_datetime):
+            with pendulum_test(freeze_datetime):
                 # should fire for run 1
                 evaluate_sensors(workspace_context, executor)
 
@@ -608,7 +609,7 @@ def test_run_failure_sensor_empty_run_records(
             workspace_context,
             external_repo,
         ):
-            with pendulum.test(freeze_datetime):
+            with pendulum_test(freeze_datetime):
                 failure_sensor = external_repo.get_external_sensor("my_run_failure_sensor")
                 instance.start_sensor(failure_sensor)
 
@@ -628,7 +629,7 @@ def test_run_failure_sensor_empty_run_records(
                 freeze_datetime = freeze_datetime.add(seconds=60)
                 time.sleep(1)
 
-            with pendulum.test(freeze_datetime):
+            with pendulum_test(freeze_datetime):
                 # create a mismatch between event storage and run storage
                 instance.event_log_storage.store_event(
                     EventLogEntry(
@@ -651,7 +652,7 @@ def test_run_failure_sensor_empty_run_records(
                 assert len(failure_events) == 1
                 freeze_datetime = freeze_datetime.add(seconds=60)
 
-            with pendulum.test(freeze_datetime):
+            with pendulum_test(freeze_datetime):
                 # shouldn't fire the failure sensor due to the mismatch
                 evaluate_sensors(workspace_context, executor)
 
@@ -703,7 +704,7 @@ def test_cross_code_location_run_status_sensor(executor: Optional[ThreadPoolExec
         workspace_context = daemon_sensor_defs_location_info.context
 
         # This remainder is largely copied from test_cross_repo_run_status_sensor
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             success_sensor = sensor_repo.get_external_sensor("success_sensor")
             instance.start_sensor(success_sensor)
 
@@ -725,7 +726,7 @@ def test_cross_code_location_run_status_sensor(executor: Optional[ThreadPoolExec
             freeze_datetime = freeze_datetime.add(seconds=60)
             time.sleep(1)
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             external_success_job = job_repo.get_full_external_job("success_job")
 
             # this unfortunate API (create_run_for_job) requires the importation
@@ -745,7 +746,7 @@ def test_cross_code_location_run_status_sensor(executor: Optional[ThreadPoolExec
             assert dagster_run.status == DagsterRunStatus.SUCCESS
             freeze_datetime = freeze_datetime.add(seconds=60)
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             evaluate_sensors(workspace_context, executor)
 
             ticks = [
@@ -800,7 +801,7 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
         workspace_context = daemon_sensor_defs_location_info.context
 
         # This remainder is largely copied from test_cross_repo_run_status_sensor
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             success_sensor = sensor_repo.get_external_sensor("success_of_another_job_sensor")
             instance.start_sensor(success_sensor)
 
@@ -822,7 +823,7 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
             freeze_datetime = freeze_datetime.add(seconds=60)
             time.sleep(1)
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             external_success_job = job_repo.get_full_external_job("success_job")
 
             # this unfortunate API (create_run_for_job) requires the importation
@@ -842,7 +843,7 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
             assert dagster_run.status == DagsterRunStatus.SUCCESS
             freeze_datetime = freeze_datetime.add(seconds=60)
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             evaluate_sensors(workspace_context, executor)
 
             ticks = [
@@ -869,7 +870,7 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
 
         # now launch the run that is actually being listened to
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             external_another_success_job = job_repo.get_full_external_job("another_success_job")
 
             # this unfortunate API (create_run_for_job) requires the importation
@@ -889,7 +890,7 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
             assert dagster_run.status == DagsterRunStatus.SUCCESS
             freeze_datetime = freeze_datetime.add(seconds=60)
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             evaluate_sensors(workspace_context, executor)
 
             ticks = [
@@ -921,7 +922,7 @@ def test_cross_repo_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
         the_repo = repos["the_repo"]
         the_other_repo = repos["the_other_repo"]
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             cross_repo_sensor = the_repo.get_external_sensor("cross_repo_sensor")
             instance.start_sensor(cross_repo_sensor)
 
@@ -941,7 +942,7 @@ def test_cross_repo_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
             freeze_datetime = freeze_datetime.add(seconds=60)
             time.sleep(1)
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             external_job = the_other_repo.get_full_external_job("the_job")
             run = instance.create_run_for_job(
                 the_job,
@@ -954,7 +955,7 @@ def test_cross_repo_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
             assert run.status == DagsterRunStatus.SUCCESS
             freeze_datetime = freeze_datetime.add(seconds=60)
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             evaluate_sensors(workspace_context, executor)
 
             ticks = instance.get_ticks(
@@ -979,7 +980,7 @@ def test_cross_repo_job_run_status_sensor(executor: Optional[ThreadPoolExecutor]
         the_repo = repos["the_repo"]
         the_other_repo = repos["the_other_repo"]
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             cross_repo_sensor = the_repo.get_external_sensor("cross_repo_job_sensor")
             instance.start_sensor(cross_repo_sensor)
 
@@ -1003,7 +1004,7 @@ def test_cross_repo_job_run_status_sensor(executor: Optional[ThreadPoolExecutor]
             freeze_datetime = freeze_datetime.add(seconds=60)
             time.sleep(1)
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             external_job = the_other_repo.get_full_external_job("the_job")
             run = instance.create_run_for_job(
                 the_job,
@@ -1017,7 +1018,7 @@ def test_cross_repo_job_run_status_sensor(executor: Optional[ThreadPoolExecutor]
             assert run.status == DagsterRunStatus.SUCCESS
             freeze_datetime = freeze_datetime.add(seconds=60)
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             evaluate_sensors(workspace_context, executor)
             wait_for_all_runs_to_finish(instance)
 
@@ -1037,7 +1038,7 @@ def test_cross_repo_job_run_status_sensor(executor: Optional[ThreadPoolExecutor]
             assert run_request_runs[0].status == DagsterRunStatus.SUCCESS
             freeze_datetime = freeze_datetime.add(seconds=60)
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             # ensure that the success of the run launched by the sensor doesn't trigger the sensor
             evaluate_sensors(workspace_context, executor)
             wait_for_all_runs_to_finish(instance)
@@ -1064,7 +1065,7 @@ def test_partitioned_job_run_status_sensor(
     external_repo: ExternalRepository,
 ):
     freeze_datetime = pendulum.now()
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         success_sensor = external_repo.get_external_sensor("partitioned_pipeline_success_sensor")
         instance.start_sensor(success_sensor)
 
@@ -1086,7 +1087,7 @@ def test_partitioned_job_run_status_sensor(
         freeze_datetime = freeze_datetime.add(seconds=60)
         time.sleep(1)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_job = external_repo.get_full_external_job("daily_partitioned_job")
         run = instance.create_run_for_job(
             daily_partitioned_job,
@@ -1103,7 +1104,7 @@ def test_partitioned_job_run_status_sensor(
 
     caplog.clear()
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should fire the success sensor
         evaluate_sensors(workspace_context, executor)
 
@@ -1135,7 +1136,7 @@ def test_different_instance_run_status_sensor(executor: Optional[ThreadPoolExecu
             the_other_workspace_context,
             the_other_repo,
         ):
-            with pendulum.test(freeze_datetime):
+            with pendulum_test(freeze_datetime):
                 cross_repo_sensor = the_repo.get_external_sensor("cross_repo_sensor")
                 instance.start_sensor(cross_repo_sensor)
 
@@ -1155,7 +1156,7 @@ def test_different_instance_run_status_sensor(executor: Optional[ThreadPoolExecu
                 freeze_datetime = freeze_datetime.add(seconds=60)
                 time.sleep(1)
 
-            with pendulum.test(freeze_datetime):
+            with pendulum_test(freeze_datetime):
                 external_job = the_other_repo.get_full_external_job("the_job")
                 run = the_other_instance.create_run_for_job(
                     the_job,
@@ -1170,7 +1171,7 @@ def test_different_instance_run_status_sensor(executor: Optional[ThreadPoolExecu
                 assert run.status == DagsterRunStatus.SUCCESS
                 freeze_datetime = freeze_datetime.add(seconds=60)
 
-            with pendulum.test(freeze_datetime):
+            with pendulum_test(freeze_datetime):
                 evaluate_sensors(workspace_context, executor)
 
                 ticks = instance.get_ticks(
@@ -1196,7 +1197,7 @@ def test_instance_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
         the_repo = repos["the_repo"]
         the_other_repo = repos["the_other_repo"]
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             instance_sensor = the_repo.get_external_sensor("instance_sensor")
             instance.start_sensor(instance_sensor)
 
@@ -1216,7 +1217,7 @@ def test_instance_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
             freeze_datetime = freeze_datetime.add(seconds=60)
             time.sleep(1)
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             external_job = the_other_repo.get_full_external_job("the_job")
             run = instance.create_run_for_job(
                 the_job,
@@ -1229,7 +1230,7 @@ def test_instance_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
             assert run.status == DagsterRunStatus.SUCCESS
             freeze_datetime = freeze_datetime.add(seconds=60)
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             evaluate_sensors(workspace_context, executor)
 
             ticks = instance.get_ticks(
@@ -1251,7 +1252,7 @@ def test_logging_run_status_sensor(
     external_repo: ExternalRepository,
 ):
     freeze_datetime = pendulum.now()
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         success_sensor = external_repo.get_external_sensor("logging_status_sensor")
         instance.start_sensor(success_sensor)
 
@@ -1270,7 +1271,7 @@ def test_logging_run_status_sensor(
 
         freeze_datetime = freeze_datetime.add(seconds=60)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_job = external_repo.get_full_external_job("foo_job")
         run = instance.create_run_for_job(
             foo_job,
@@ -1283,7 +1284,7 @@ def test_logging_run_status_sensor(
         assert run.status == DagsterRunStatus.SUCCESS
         freeze_datetime = freeze_datetime.add(seconds=60)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should fire the success sensor and the started sensor
         evaluate_sensors(workspace_context, executor)
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_failure_recovery.py
@@ -1,6 +1,5 @@
 import multiprocessing
 
-import pendulum
 import pytest
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.instance import DagsterInstance

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_failure_recovery.py
@@ -17,7 +17,7 @@ from dagster._core.test_utils import (
 from dagster._daemon import get_default_daemon_logger
 from dagster._daemon.sensor import execute_sensor_iteration
 from dagster._seven import IS_WINDOWS
-from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
+from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test, to_timezone
 
 from .test_sensor_run import create_workspace_load_target, wait_for_all_runs_to_start
 
@@ -27,7 +27,7 @@ spawn_ctx = multiprocessing.get_context("spawn")
 def _test_launch_sensor_runs_in_subprocess(instance_ref, execution_datetime, debug_crash_flags):
     with DagsterInstance.from_ref(instance_ref) as instance:
         try:
-            with pendulum.test(execution_datetime), create_test_daemon_workspace_context(
+            with pendulum_test(execution_datetime), create_test_daemon_workspace_context(
                 workspace_load_target=create_workspace_load_target(),
                 instance=instance,
             ) as workspace_context:
@@ -60,7 +60,7 @@ def test_failure_before_run_created(crash_location, crash_signal, instance, exte
         "US/Central",
     )
 
-    with pendulum.test(frozen_datetime):
+    with pendulum_test(frozen_datetime):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -135,7 +135,7 @@ def test_failure_after_run_created_before_run_launched(
         create_pendulum_time(year=2019, month=2, day=28, hour=0, minute=0, second=0, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(frozen_datetime):
+    with pendulum_test(frozen_datetime):
         external_sensor = external_repo.get_external_sensor("run_key_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -208,7 +208,7 @@ def test_failure_after_run_launched(crash_location, crash_signal, instance, exte
         ),
         "US/Central",
     )
-    with pendulum.test(frozen_datetime):
+    with pendulum_test(frozen_datetime):
         external_sensor = external_repo.get_external_sensor("run_key_sensor")
         instance.add_instigator_state(
             InstigatorState(

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -84,7 +84,7 @@ from dagster._core.test_utils import (
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._daemon import get_default_daemon_logger
 from dagster._daemon.sensor import execute_sensor_iteration, execute_sensor_iteration_loop
-from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
+from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test, to_timezone
 
 from .conftest import create_workspace_load_target
 
@@ -1013,7 +1013,7 @@ def test_ignore_automation_policy_sensor(instance, workspace_context, external_r
         "US/Central",
     )
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("my_automation_policy_sensor")
         assert external_sensor
         instance.add_instigator_state(
@@ -1040,7 +1040,7 @@ def test_simple_sensor(instance, workspace_context, external_repo, executor):
         "US/Central",
     )
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -1071,7 +1071,7 @@ def test_simple_sensor(instance, workspace_context, external_repo, executor):
 
         freeze_datetime = freeze_datetime.add(seconds=30)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         wait_for_all_runs_to_start(instance)
         assert instance.get_runs_count() == 1
@@ -1105,7 +1105,7 @@ def test_sensors_keyed_on_selector_not_origin(
         "US/Central",
     )
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
 
         existing_origin = external_sensor.get_external_origin()
@@ -1154,7 +1154,7 @@ def test_bad_load_sensor_repository(
         "US/Central",
     )
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
 
         valid_origin = external_sensor.get_external_origin()
@@ -1194,7 +1194,7 @@ def test_bad_load_sensor(caplog, executor, instance, workspace_context, external
         "US/Central",
     )
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
 
         valid_origin = external_sensor.get_external_origin()
@@ -1227,7 +1227,7 @@ def test_error_sensor(caplog, executor, instance, workspace_context, external_re
         create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("error_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -1290,7 +1290,7 @@ def test_wrong_config_sensor(caplog, executor, instance, workspace_context, exte
         ),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("wrong_config_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -1325,7 +1325,7 @@ def test_wrong_config_sensor(caplog, executor, instance, workspace_context, exte
 
     freeze_datetime = freeze_datetime.add(seconds=60)
     caplog.clear()
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # Error repeats on subsequent ticks
 
         evaluate_sensors(workspace_context, executor)
@@ -1360,7 +1360,7 @@ def test_launch_failure(caplog, executor, workspace_context, external_repo):
             },
         },
     ) as instance:
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             exploding_workspace_context = workspace_context.copy_for_test_instance(instance)
             external_sensor = external_repo.get_external_sensor("always_on_sensor")
             instance.add_instigator_state(
@@ -1411,7 +1411,7 @@ def test_launch_once(caplog, executor, instance, workspace_context, external_rep
         "US/Central",
     )
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("run_key_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -1445,7 +1445,7 @@ def test_launch_once(caplog, executor, instance, workspace_context, external_rep
 
     # run again (after 30 seconds), to ensure that the run key maintains idempotence
     freeze_datetime = freeze_datetime.add(seconds=30)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         assert instance.get_runs_count() == 1
         ticks = instance.get_ticks(
@@ -1478,7 +1478,7 @@ def test_launch_once(caplog, executor, instance, workspace_context, external_rep
 
         # Sensor loop still executes
     freeze_datetime = freeze_datetime.add(seconds=30)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
@@ -1497,7 +1497,7 @@ def test_custom_interval_sensor(executor, instance, workspace_context, external_
     freeze_datetime = to_timezone(
         create_pendulum_time(year=2019, month=2, day=28, tz="UTC"), "US/Central"
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("custom_interval_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -1520,7 +1520,7 @@ def test_custom_interval_sensor(executor, instance, workspace_context, external_
 
         freeze_datetime = freeze_datetime.add(seconds=30)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
@@ -1530,7 +1530,7 @@ def test_custom_interval_sensor(executor, instance, workspace_context, external_
 
         freeze_datetime = freeze_datetime.add(seconds=30)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
@@ -1559,7 +1559,7 @@ def test_custom_interval_sensor_with_offset(
     shutdown_event = mock.MagicMock()
     shutdown_event.wait.side_effect = fake_sleep
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # 60 second custom interval
         external_sensor = external_repo.get_external_sensor("custom_interval_sensor")
 
@@ -1610,7 +1610,7 @@ def test_sensor_start_stop(executor, instance, workspace_context, external_repo)
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("always_on_sensor")
         external_origin_id = external_sensor.get_external_origin_id()
         instance.start_sensor(external_sensor)
@@ -1635,7 +1635,7 @@ def test_sensor_start_stop(executor, instance, workspace_context, external_repo)
 
         freeze_datetime = freeze_datetime.add(seconds=15)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         # no new ticks, no new runs, we are below the 30 second min interval
         assert instance.get_runs_count() == 1
@@ -1654,7 +1654,7 @@ def test_sensor_start_stop(executor, instance, workspace_context, external_repo)
 
         freeze_datetime = freeze_datetime.add(seconds=16)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         # should have new tick, new run, we are after the 30 second min interval
         assert instance.get_runs_count() == 2
@@ -1667,7 +1667,7 @@ def test_large_sensor(executor, instance, workspace_context, external_repo):
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("large_sensor")
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor, timeout=300)
@@ -1688,7 +1688,7 @@ def test_many_request_sensor(executor, submit_executor, instance, workspace_cont
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("many_request_sensor")
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor, submit_executor=submit_executor)
@@ -1709,7 +1709,7 @@ def test_cursor_sensor(executor, instance, workspace_context, external_repo):
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         skip_sensor = external_repo.get_external_sensor("skip_cursor_sensor")
         run_sensor = external_repo.get_external_sensor("run_cursor_sensor")
         instance.start_sensor(skip_sensor)
@@ -1739,7 +1739,7 @@ def test_cursor_sensor(executor, instance, workspace_context, external_repo):
         assert run_ticks[0].cursor == "1"
 
     freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
 
         skip_ticks = instance.get_ticks(
@@ -1770,7 +1770,7 @@ def test_run_request_asset_selection_sensor(executor, instance, workspace_contex
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("run_request_asset_selection_sensor")
         external_origin_id = external_sensor.get_external_origin_id()
         instance.start_sensor(external_sensor)
@@ -1810,7 +1810,7 @@ def test_run_request_stale_asset_selection_sensor_never_materialized(
         "US/Central",
     )
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("run_request_stale_asset_sensor")
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor)
@@ -1829,7 +1829,7 @@ def test_run_request_stale_asset_selection_sensor_empty(
 
     materialize([a, b, c], instance=instance)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("run_request_stale_asset_sensor")
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor)
@@ -1847,7 +1847,7 @@ def test_run_request_stale_asset_selection_sensor_subset(
 
     materialize([a], instance=instance)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("run_request_stale_asset_sensor")
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor)
@@ -1861,7 +1861,7 @@ def test_targets_asset_selection_sensor(executor, instance, workspace_context, e
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("targets_asset_selection_sensor")
         external_origin_id = external_sensor.get_external_origin_id()
         instance.start_sensor(external_sensor)
@@ -1909,7 +1909,7 @@ def test_partitioned_asset_selection_sensor(executor, instance, workspace_contex
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("partitioned_asset_selection_sensor")
         external_origin_id = external_sensor.get_external_origin_id()
         instance.start_sensor(external_sensor)
@@ -1948,7 +1948,7 @@ def test_asset_sensor(executor, instance, workspace_context, external_repo):
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         foo_sensor = external_repo.get_external_sensor("asset_foo_sensor")
         instance.start_sensor(foo_sensor)
 
@@ -1964,7 +1964,7 @@ def test_asset_sensor(executor, instance, workspace_context, external_repo):
         )
 
         freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should generate the foo asset
         foo_job.execute_in_process(instance=instance)
 
@@ -1989,7 +1989,7 @@ def test_asset_job_sensor(executor, instance, workspace_context, external_repo):
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         job_sensor = external_repo.get_external_sensor("asset_job_sensor")
         instance.start_sensor(job_sensor)
 
@@ -2006,7 +2006,7 @@ def test_asset_job_sensor(executor, instance, workspace_context, external_repo):
         assert "No new materialization events" in ticks[0].tick_data.skip_reason
 
         freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should generate the foo asset
         foo_job.execute_in_process(instance=instance)
 
@@ -2033,7 +2033,7 @@ def test_asset_sensor_not_triggered_on_observation(
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         foo_sensor = external_repo.get_external_sensor("asset_foo_sensor")
         instance.start_sensor(foo_sensor)
 
@@ -2053,7 +2053,7 @@ def test_asset_sensor_not_triggered_on_observation(
         )
 
         freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should generate the foo asset
         foo_job.execute_in_process(instance=instance)
 
@@ -2078,7 +2078,7 @@ def test_multi_asset_sensor(executor, instance, workspace_context, external_repo
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         a_and_b_sensor = external_repo.get_external_sensor("asset_a_and_b_sensor")
         instance.start_sensor(a_and_b_sensor)
 
@@ -2096,7 +2096,7 @@ def test_multi_asset_sensor(executor, instance, workspace_context, external_repo
         )
 
         freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should generate asset_a
         materialize([asset_a], instance=instance)
 
@@ -2116,7 +2116,7 @@ def test_multi_asset_sensor(executor, instance, workspace_context, external_repo
 
         freeze_datetime = freeze_datetime.add(seconds=60)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should generate asset_b
         materialize([asset_b], instance=instance)
 
@@ -2143,7 +2143,7 @@ def test_asset_selection_sensor(executor, instance, workspace_context, external_
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         asset_selection_sensor = external_repo.get_external_sensor("asset_selection_sensor")
         instance.start_sensor(asset_selection_sensor)
 
@@ -2168,7 +2168,7 @@ def test_multi_asset_sensor_targets_asset_selection(
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         multi_asset_sensor_targets_asset_selection = external_repo.get_external_sensor(
             "multi_asset_sensor_targets_asset_selection"
         )
@@ -2189,7 +2189,7 @@ def test_multi_asset_sensor_targets_asset_selection(
         )
 
         freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should generate asset_a
         materialize([asset_a], instance=instance)
 
@@ -2210,7 +2210,7 @@ def test_multi_asset_sensor_targets_asset_selection(
 
         freeze_datetime = freeze_datetime.add(seconds=60)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should generate asset_b
         materialize([asset_b], instance=instance)
 
@@ -2239,7 +2239,7 @@ def test_multi_asset_sensor_w_many_events(executor, instance, workspace_context,
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         backlog_sensor = external_repo.get_external_sensor("backlog_sensor")
         instance.start_sensor(backlog_sensor)
 
@@ -2257,7 +2257,7 @@ def test_multi_asset_sensor_w_many_events(executor, instance, workspace_context,
         )
 
         freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should generate asset_a
         materialize([asset_a], instance=instance)
 
@@ -2276,7 +2276,7 @@ def test_multi_asset_sensor_w_many_events(executor, instance, workspace_context,
 
         freeze_datetime = freeze_datetime.add(seconds=60)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should generate asset_a
         materialize([asset_a], instance=instance)
 
@@ -2305,7 +2305,7 @@ def test_multi_asset_sensor_w_no_cursor_update(
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         cursor_sensor = external_repo.get_external_sensor("doesnt_update_cursor_sensor")
         instance.start_sensor(cursor_sensor)
 
@@ -2323,7 +2323,7 @@ def test_multi_asset_sensor_w_no_cursor_update(
         )
 
         freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should generate asset_a
         materialize([asset_a], instance=instance)
 
@@ -2345,7 +2345,7 @@ def test_multi_asset_sensor_hourly_to_weekly(executor, instance, workspace_conte
         create_pendulum_time(year=2022, month=8, day=2, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         materialize([hourly_asset], instance=instance, partition_key="2022-08-01-00:00")
         cursor_sensor = external_repo.get_external_sensor("multi_asset_sensor_hourly_to_weekly")
         instance.start_sensor(cursor_sensor)
@@ -2374,7 +2374,7 @@ def test_multi_asset_sensor_hourly_to_hourly(executor, instance, workspace_conte
         create_pendulum_time(year=2022, month=8, day=3, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         materialize([hourly_asset], instance=instance, partition_key="2022-08-02-00:00")
         cursor_sensor = external_repo.get_external_sensor("multi_asset_sensor_hourly_to_hourly")
         instance.start_sensor(cursor_sensor)
@@ -2400,7 +2400,7 @@ def test_multi_asset_sensor_hourly_to_hourly(executor, instance, workspace_conte
 
         freeze_datetime = freeze_datetime.add(seconds=30)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         cursor_sensor = external_repo.get_external_sensor("multi_asset_sensor_hourly_to_hourly")
         instance.start_sensor(cursor_sensor)
 
@@ -2418,7 +2418,7 @@ def test_sensor_result_multi_asset_sensor(executor, instance, workspace_context,
         create_pendulum_time(year=2022, month=8, day=3, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         cursor_sensor = external_repo.get_external_sensor("sensor_result_multi_asset_sensor")
         instance.start_sensor(cursor_sensor)
 
@@ -2443,7 +2443,7 @@ def test_cursor_update_sensor_result_multi_asset_sensor(
         create_pendulum_time(year=2022, month=8, day=3, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         cursor_sensor = external_repo.get_external_sensor("cursor_sensor_result_multi_asset_sensor")
         instance.start_sensor(cursor_sensor)
 
@@ -2467,7 +2467,7 @@ def test_multi_job_sensor(executor, instance, workspace_context, external_repo):
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         job_sensor = external_repo.get_external_sensor("two_job_sensor")
         instance.start_sensor(job_sensor)
 
@@ -2488,7 +2488,7 @@ def test_multi_job_sensor(executor, instance, workspace_context, external_repo):
         assert run.job_name == "the_job"
 
         freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # should fire the asset sensor
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(job_sensor.get_external_origin_id(), job_sensor.selector_id)
@@ -2511,7 +2511,7 @@ def test_bad_run_request_untargeted(executor, instance, workspace_context, exter
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         job_sensor = external_repo.get_external_sensor("bad_request_untargeted")
         instance.start_sensor(job_sensor)
 
@@ -2536,7 +2536,7 @@ def test_bad_run_request_mismatch(executor, instance, workspace_context, externa
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         job_sensor = external_repo.get_external_sensor("bad_request_mismatch")
         instance.start_sensor(job_sensor)
 
@@ -2560,7 +2560,7 @@ def test_bad_run_request_unspecified(executor, instance, workspace_context, exte
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         job_sensor = external_repo.get_external_sensor("bad_request_unspecified")
         instance.start_sensor(job_sensor)
 
@@ -2593,7 +2593,7 @@ def test_status_in_code_sensor(executor, instance):
             iter(workspace_context.create_request_context().get_workspace_snapshot().values())
         ).code_location.get_repository("the_status_in_code_repo")
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             running_sensor = external_repo.get_external_sensor("always_running_sensor")
             not_running_sensor = external_repo.get_external_sensor("never_running_sensor")
 
@@ -2683,7 +2683,7 @@ def test_status_in_code_sensor(executor, instance):
             evaluate_sensors(workspace_context, executor)
 
         freeze_datetime = freeze_datetime.add(seconds=30)
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             evaluate_sensors(workspace_context, executor)
             wait_for_all_runs_to_start(instance)
             assert instance.get_runs_count() == 1
@@ -2721,7 +2721,7 @@ def test_run_request_list_sensor(executor, instance, workspace_context, external
         create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("request_list_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -2750,7 +2750,7 @@ def test_sensor_purge(executor, instance, workspace_context, external_repo):
         create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -2773,7 +2773,7 @@ def test_sensor_purge(executor, instance, workspace_context, external_repo):
         assert len(ticks) == 1
         freeze_datetime = freeze_datetime.add(days=6)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # create another tick
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
@@ -2783,7 +2783,7 @@ def test_sensor_purge(executor, instance, workspace_context, external_repo):
 
         freeze_datetime = freeze_datetime.add(days=2)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # create another tick, but the first tick should be purged
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
@@ -2804,7 +2804,7 @@ def test_sensor_custom_purge(executor, workspace_context, external_repo):
         },
     ) as instance:
         purge_ws_ctx = workspace_context.copy_for_test_instance(instance)
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             external_sensor = external_repo.get_external_sensor("simple_sensor")
             instance.add_instigator_state(
                 InstigatorState(
@@ -2827,7 +2827,7 @@ def test_sensor_custom_purge(executor, workspace_context, external_repo):
             assert len(ticks) == 1
             freeze_datetime = freeze_datetime.add(days=8)
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             # create another tick, and the first tick should not be purged despite the fact that the
             # default purge day offset is 7
             evaluate_sensors(purge_ws_ctx, executor)
@@ -2838,7 +2838,7 @@ def test_sensor_custom_purge(executor, workspace_context, external_repo):
 
             freeze_datetime = freeze_datetime.add(days=7)
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             # create another tick, but the first tick should be purged
             evaluate_sensors(purge_ws_ctx, executor)
             ticks = instance.get_ticks(
@@ -2885,7 +2885,7 @@ def test_repository_namespacing(executor):
         external_sensor = external_repo.get_external_sensor("run_key_sensor")
         other_sensor = other_repo.get_external_sensor("run_key_sensor")
 
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             instance.start_sensor(external_sensor)
             assert instance.get_runs_count() == 0
             ticks = instance.get_ticks(
@@ -2919,7 +2919,7 @@ def test_repository_namespacing(executor):
 
         # run again (after 30 seconds), to ensure that the run key maintains idempotence
         freeze_datetime = freeze_datetime.add(seconds=30)
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             evaluate_sensors(full_workspace_context, executor)
             assert instance.get_runs_count() == 2  # still 2
             ticks = instance.get_ticks(
@@ -3090,7 +3090,7 @@ def test_add_delete_skip_dynamic_partitions(
         "US/Central",
     )
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
@@ -3124,7 +3124,7 @@ def test_add_delete_skip_dynamic_partitions(
         assert run.tags.get("dagster/partition") == "1"
 
     freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
@@ -3297,7 +3297,7 @@ def test_stale_request_context(instance, workspace_context, external_repo):
     executor = ThreadPoolExecutor()
     blocking_executor = BlockingThreadPoolExecutor()
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -3340,7 +3340,7 @@ def test_stale_request_context(instance, workspace_context, external_repo):
     blocking_executor.block()
     freeze_datetime = freeze_datetime.add(seconds=30)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         futures = {}
         list(
             execute_sensor_iteration(
@@ -3389,7 +3389,7 @@ def test_start_tick_sensor(executor, instance, workspace_context, external_repo)
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
         "US/Central",
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         start_skip_sensor = external_repo.get_external_sensor("start_skip_sensor")
         instance.start_sensor(start_skip_sensor)
         evaluate_sensors(workspace_context, executor)
@@ -3401,7 +3401,7 @@ def test_start_tick_sensor(executor, instance, workspace_context, external_repo)
         )
 
     freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         validate_tick(
             _get_last_tick(instance, start_skip_sensor),
@@ -3411,7 +3411,7 @@ def test_start_tick_sensor(executor, instance, workspace_context, external_repo)
         )
 
     freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         instance.stop_sensor(
             start_skip_sensor.get_external_origin_id(),
             start_skip_sensor.selector_id,
@@ -3427,7 +3427,7 @@ def test_start_tick_sensor(executor, instance, workspace_context, external_repo)
         )
 
     freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         validate_tick(
             _get_last_tick(instance, start_skip_sensor),

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
@@ -16,7 +16,7 @@ from dagster._core.test_utils import (
 from dagster._daemon import get_default_daemon_logger
 from dagster._daemon.backfill import execute_backfill_iteration
 from dagster._seven import IS_WINDOWS
-from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
+from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test, to_timezone
 
 from .conftest import workspace_load_target
 
@@ -34,7 +34,7 @@ def _test_backfill_in_subprocess(instance_ref, debug_crash_flags):
     )
     with DagsterInstance.from_ref(instance_ref) as instance:
         try:
-            with pendulum.test(execution_datetime), create_test_daemon_workspace_context(
+            with pendulum_test(execution_datetime), create_test_daemon_workspace_context(
                 workspace_load_target=workspace_load_target(), instance=instance
             ) as workspace_context:
                 list(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_concurrency_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_concurrency_daemon.py
@@ -14,7 +14,7 @@ from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import EmptyWorkspaceTarget
 from dagster._daemon import get_default_daemon_logger
 from dagster._daemon.monitoring.concurrency import execute_concurrency_slots_iteration
-from dagster._seven.compat.pendulum import create_pendulum_time
+from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test
 
 
 @pytest.fixture
@@ -59,7 +59,7 @@ def test_global_concurrency_release(
         tz="UTC",
     )
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         run = create_run_for_test(instance, job_name="my_job", status=DagsterRunStatus.STARTING)
         instance.event_log_storage.claim_concurrency_slot("foo", run.run_id, "my_step")
         key_info = instance.event_log_storage.get_concurrency_info("foo")
@@ -68,14 +68,14 @@ def test_global_concurrency_release(
         instance.report_run_canceled(run)
 
         freeze_datetime = freeze_datetime.add(seconds=59)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         list(execute_concurrency_slots_iteration(workspace_context, logger))
         key_info = instance.event_log_storage.get_concurrency_info("foo")
         assert key_info.slot_count == 1
         assert key_info.active_slot_count == 1
 
         freeze_datetime = freeze_datetime.add(seconds=2)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         list(execute_concurrency_slots_iteration(workspace_context, logger))
         key_info = instance.event_log_storage.get_concurrency_info("foo")
         assert key_info.slot_count == 1

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_concurrency_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_concurrency_daemon.py
@@ -1,7 +1,6 @@
 import tempfile
 from logging import Logger
 
-import pendulum
 import pytest
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRunStatus

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
@@ -29,6 +29,7 @@ from dagster._daemon.monitoring.run_monitoring import (
 )
 from dagster._serdes import ConfigurableClass
 from dagster._serdes.config_class import ConfigurableClassData
+from dagster._seven.compat.pendulum import pendulum_test
 from typing_extensions import Self
 
 
@@ -285,7 +286,7 @@ def test_long_running_termination(
 ):
     with environ({"DAGSTER_TEST_RUN_HEALTH_CHECK_RESULT": "healthy"}):
         initial = pendulum.datetime(2021, 1, 1, tz="UTC")
-        with pendulum.test(initial):
+        with pendulum_test(initial):
             too_long_run = create_run_for_test(
                 instance,
                 job_name="foo",
@@ -302,7 +303,7 @@ def test_long_running_termination(
                 instance, job_name="foo", status=DagsterRunStatus.STARTING
             )
         started_time = initial.add(seconds=1)
-        with pendulum.test(started_time):
+        with pendulum_test(started_time):
             report_started_event(instance, too_long_run, started_time.timestamp())
             report_started_event(instance, okay_run, started_time.timestamp())
             report_started_event(instance, run_no_tag, started_time.timestamp())
@@ -326,7 +327,7 @@ def test_long_running_termination(
         run_launcher = cast(TestRunLauncher, instance.run_launcher)
 
         eval_time = started_time.add(seconds=501)
-        with pendulum.test(eval_time):
+        with pendulum_test(eval_time):
             # run_no_tag has no maximum run tag set, so no termination event should be
             # triggered.
             monitor_started_run(instance, workspace, no_tag_record, logger)
@@ -373,7 +374,7 @@ def test_long_running_termination_failure(
         else:
             instance.run_launcher.should_except_termination = True  # type: ignore
         initial = pendulum.datetime(2021, 1, 1, tz="UTC")
-        with pendulum.test(initial):
+        with pendulum_test(initial):
             too_long_run = create_run_for_test(
                 instance,
                 job_name="foo",
@@ -381,7 +382,7 @@ def test_long_running_termination_failure(
                 tags={MAX_RUNTIME_SECONDS_TAG: "500"},
             )
         started_time = initial.add(seconds=1)
-        with pendulum.test(started_time):
+        with pendulum_test(started_time):
             report_started_event(instance, too_long_run, started_time.timestamp())
 
         too_long_record = instance.get_run_record_by_id(too_long_run.run_id)
@@ -393,7 +394,7 @@ def test_long_running_termination_failure(
         run_launcher = cast(TestRunLauncher, instance.run_launcher)
 
         eval_time = started_time.add(seconds=501)
-        with pendulum.test(eval_time):
+        with pendulum_test(eval_time):
             # Enough runtime has elapsed for too_long_run to hit its maximum runtime so a
             # termination event should be triggered.
             monitor_started_run(instance, workspace, too_long_record, logger)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -92,7 +92,7 @@ from dagster._daemon.asset_daemon import (
     get_current_evaluation_id,
 )
 from dagster._serdes.serdes import serialize_value
-from  dagster._seven.compat.pendulum import pendulum_test
+from dagster._seven.compat.pendulum import pendulum_test
 
 from .base_scenario import FAIL_TAG, run_request
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -92,6 +92,7 @@ from dagster._daemon.asset_daemon import (
     get_current_evaluation_id,
 )
 from dagster._serdes.serdes import serialize_value
+from  dagster._seven.compat.pendulum import pendulum_test
 
 from .base_scenario import FAIL_TAG, run_request
 
@@ -348,7 +349,7 @@ class AssetDaemonScenarioState(NamedTuple):
             # fake current_time on the scenario state
             return (self.current_time + (datetime.datetime.now() - start)).timestamp()
 
-        with pendulum.test(self.current_time), mock.patch("time.time", new=test_time_fn):
+        with pendulum_test(self.current_time), mock.patch("time.time", new=test_time_fn):
             for rr in run_requests:
                 materialize(
                     assets=self.assets,
@@ -541,7 +542,7 @@ class AssetDaemonScenarioState(NamedTuple):
         self.logger.critical("********************************")
         self.logger.critical(f"EVALUATING TICK {label or self.tick_index}")
         self.logger.critical("********************************")
-        with pendulum.test(self.current_time):
+        with pendulum_test(self.current_time):
             if self.is_daemon:
                 (
                     new_run_requests,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -86,6 +86,7 @@ from dagster._daemon.asset_daemon import (
     asset_daemon_cursor_from_pre_sensor_auto_materialize_serialized_cursor,
 )
 from dagster._serdes.serdes import serialize_value
+from dagster._seven.compat.pendulum import pendulum_test
 from dagster._utils import SingleInstigatorDebugCrashFlags
 
 
@@ -262,7 +263,7 @@ class AssetReconciliationScenario(
 
         test_time = self.current_time or pendulum.now()
 
-        with pendulum.test(test_time):
+        with pendulum_test(test_time):
 
             @repository
             def repo():
@@ -362,7 +363,7 @@ class AssetReconciliationScenario(
             if self.between_runs_delta is not None:
                 test_time += self.between_runs_delta
 
-            with pendulum.test(test_time), mock.patch("time.time", new=test_time_fn):
+            with pendulum_test(test_time), mock.patch("time.time", new=test_time_fn):
                 if run.is_observation:
                     observe(
                         instance=instance,
@@ -383,7 +384,7 @@ class AssetReconciliationScenario(
 
         if self.evaluation_delta is not None:
             test_time += self.evaluation_delta
-        with pendulum.test(test_time):
+        with pendulum_test(test_time):
             # get asset_graph
             if not with_external_asset_graph:
                 asset_graph = repo.asset_graph
@@ -446,7 +447,7 @@ class AssetReconciliationScenario(
 
         test_time = self.current_time or pendulum.now()
 
-        with pendulum.test(test_time) if self.current_time else contextlib.nullcontext():
+        with pendulum_test(test_time) if self.current_time else contextlib.nullcontext():
             if self.cursor_from is not None:
                 self.cursor_from.do_daemon_scenario(
                     instance,
@@ -462,7 +463,7 @@ class AssetReconciliationScenario(
             if self.between_runs_delta is not None:
                 test_time += self.between_runs_delta
 
-            with pendulum.test(test_time), mock.patch("time.time", new=test_time_fn):
+            with pendulum_test(test_time), mock.patch("time.time", new=test_time_fn):
                 assert not run.is_observation, "Observations not supported for daemon tests"
                 if self.assets:
                     do_run(
@@ -488,7 +489,7 @@ class AssetReconciliationScenario(
 
         if self.evaluation_delta is not None:
             test_time += self.evaluation_delta
-        with pendulum.test(test_time):
+        with pendulum_test(test_time):
             assert scenario_name is not None, "scenario_name must be provided for daemon runs"
 
             if self.code_locations:

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_failure_recovery.py
@@ -1,7 +1,6 @@
 import multiprocessing
 from typing import TYPE_CHECKING
 
-import pendulum
 import pytest
 from dagster import AssetKey
 from dagster._core.errors import DagsterUserCodeUnreachableError

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_failure_recovery.py
@@ -23,6 +23,7 @@ from dagster._daemon.asset_daemon import (
     set_auto_materialize_paused,
 )
 from dagster._utils import SingleInstigatorDebugCrashFlags, get_terminate_signal
+from dagster.seven.compat.pendulum import pendulum_test
 
 from .scenarios.auto_materialize_policy_scenarios import auto_materialize_policy_scenarios
 from .scenarios.auto_observe_scenarios import auto_observe_scenarios
@@ -91,7 +92,7 @@ def test_old_tick_not_resumed(daemon_not_paused_instance):
 
     debug_crash_flags = {"RUN_CREATED": Exception("OOPS")}
 
-    with pendulum.test(execution_time):
+    with pendulum_test(execution_time):
         with pytest.raises(Exception, match="OOPS"):
             error_asset_scenario.do_daemon_scenario(
                 instance,
@@ -110,7 +111,7 @@ def test_old_tick_not_resumed(daemon_not_paused_instance):
 
     # advancing past MAX_TIME_TO_RESUME_TICK_SECONDS gives up and advances to a new evaluation
     execution_time = execution_time.add(seconds=MAX_TIME_TO_RESUME_TICK_SECONDS + 1)
-    with pendulum.test(execution_time):
+    with pendulum_test(execution_time):
         with pytest.raises(Exception, match="OOPS"):
             error_asset_scenario.do_daemon_scenario(
                 instance,
@@ -128,7 +129,7 @@ def test_old_tick_not_resumed(daemon_not_paused_instance):
 
     # advancing less than that retries the same tick
     execution_time = execution_time.add(seconds=MAX_TIME_TO_RESUME_TICK_SECONDS - 1)
-    with pendulum.test(execution_time):
+    with pendulum_test(execution_time):
         with pytest.raises(Exception, match="OOPS"):
             error_asset_scenario.do_daemon_scenario(
                 instance,
@@ -162,7 +163,7 @@ def test_error_loop_before_cursor_written(daemon_not_paused_instance, crash_loca
 
     for trial_num in range(3):
         test_time = execution_time.add(seconds=15 * trial_num)
-        with pendulum.test(test_time):
+        with pendulum_test(test_time):
             debug_crash_flags = {crash_location: Exception(f"Oops {trial_num}")}
 
             with pytest.raises(Exception, match=f"Oops {trial_num}"):
@@ -200,7 +201,7 @@ def test_error_loop_before_cursor_written(daemon_not_paused_instance, crash_loca
             assert not cursor
 
     test_time = test_time.add(seconds=45)
-    with pendulum.test(test_time):
+    with pendulum_test(test_time):
         # Next successful tick recovers
         error_asset_scenario.do_daemon_scenario(
             instance,
@@ -245,7 +246,7 @@ def test_error_loop_after_cursor_written(daemon_not_paused_instance, crash_locat
 
     # User code error retries but does not increment the retry count
     test_time = execution_time.add(seconds=15)
-    with pendulum.test(test_time):
+    with pendulum_test(test_time):
         debug_crash_flags = {crash_location: DagsterUserCodeUnreachableError("WHERE IS THE CODE")}
 
         with pytest.raises(
@@ -289,7 +290,7 @@ def test_error_loop_after_cursor_written(daemon_not_paused_instance, crash_locat
 
     for trial_num in range(3):
         test_time = test_time.add(seconds=15)
-        with pendulum.test(test_time):
+        with pendulum_test(test_time):
             debug_crash_flags = {crash_location: Exception(f"Oops {trial_num}")}
 
             with pytest.raises(Exception, match=f"Oops {trial_num}"):
@@ -329,7 +330,7 @@ def test_error_loop_after_cursor_written(daemon_not_paused_instance, crash_locat
     # Next tick moves on to use the new cursor / evaluation ID since we have passed the maximum
     # number of retries
     test_time = test_time.add(seconds=45)
-    with pendulum.test(test_time):
+    with pendulum_test(test_time):
         debug_crash_flags = {"RUN_IDS_ADDED_TO_EVALUATIONS": Exception("Oops new tick")}
         with pytest.raises(Exception, match="Oops new tick"):
             error_asset_scenario.do_daemon_scenario(
@@ -358,7 +359,7 @@ def test_error_loop_after_cursor_written(daemon_not_paused_instance, crash_locat
         assert moved_on_cursor != last_cursor
 
     test_time = test_time.add(seconds=45)
-    with pendulum.test(test_time):
+    with pendulum_test(test_time):
         # Next successful tick recovers
         error_asset_scenario.do_daemon_scenario(
             instance,

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_partitioned_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_partitioned_schedule.py
@@ -27,6 +27,7 @@ from dagster._core.definitions.time_window_partitions import (
     monthly_partitioned_config,
     weekly_partitioned_config,
 )
+from dagster_seven.compat.pendulum import pendulum_test
 
 DATE_FORMAT = "%Y-%m-%d"
 
@@ -390,7 +391,7 @@ def test_empty_partitions():
 
 
 def test_future_tick():
-    with pendulum.test(pendulum.parse("2022-02-28")):
+    with pendulum_test(pendulum.parse("2022-02-28")):
 
         @daily_partitioned_config(start_date="2021-05-05")
         def my_partitioned_config(start, end):

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_partitioned_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_partitioned_schedule.py
@@ -27,7 +27,7 @@ from dagster._core.definitions.time_window_partitions import (
     monthly_partitioned_config,
     weekly_partitioned_config,
 )
-from dagster_seven.compat.pendulum import pendulum_test
+from dagster._seven.compat.pendulum import pendulum_test
 
 DATE_FORMAT = "%Y-%m-%d"
 
@@ -60,7 +60,7 @@ def schedule_for_partitioned_config(
 def test_daily_schedule():
     @daily_partitioned_config(start_date="2021-05-05")
     def my_partitioned_config(start, end):
-        return {"start": str(start), "end": str(end)}
+        return {"start": start.isoformat("T"), "end": end.isoformat("T")}
 
     keys = my_partitioned_config.get_partition_keys()
 
@@ -102,7 +102,7 @@ def test_daily_schedule():
 def test_daily_schedule_with_offsets():
     @daily_partitioned_config(start_date="2021-05-05", minute_offset=15, hour_offset=2)
     def my_partitioned_config(start, end):
-        return {"start": str(start), "end": str(end)}
+        return {"start": start.isoformat("T"), "end": end.isoformat("T")}
 
     keys = my_partitioned_config.get_partition_keys()
     assert keys[0] == "2021-05-05"
@@ -140,7 +140,7 @@ def test_daily_schedule_with_offsets():
 def test_hourly_schedule():
     @hourly_partitioned_config(start_date=datetime(2021, 5, 5))
     def my_partitioned_config(start, end):
-        return {"start": str(start), "end": str(end)}
+        return {"start": start.isoformat("T"), "end": end.isoformat("T")}
 
     keys = my_partitioned_config.get_partition_keys()
     assert keys[0] == "2021-05-05-00:00"
@@ -178,7 +178,7 @@ def test_hourly_schedule():
 def test_hourly_schedule_with_offsets():
     @hourly_partitioned_config(start_date=datetime(2021, 5, 5), minute_offset=20)
     def my_partitioned_config(start, end):
-        return {"start": str(start), "end": str(end)}
+        return {"start": start.isoformat("T"), "end": end.isoformat("T")}
 
     keys = my_partitioned_config.get_partition_keys()
     assert keys[0] == "2021-05-05-00:20"
@@ -212,7 +212,7 @@ def test_hourly_schedule_with_offsets():
 def test_weekly_schedule():
     @weekly_partitioned_config(start_date="2021-05-05")
     def my_partitioned_config(start, end):
-        return {"start": str(start), "end": str(end)}
+        return {"start": start.isoformat("T"), "end": end.isoformat("T")}
 
     keys = my_partitioned_config.get_partition_keys()
     assert keys[0] == "2021-05-09"
@@ -250,7 +250,7 @@ def test_weekly_schedule_with_offsets():
         start_date="2021-05-05", minute_offset=10, hour_offset=13, day_offset=3
     )
     def my_partitioned_config(start, end):
-        return {"start": str(start), "end": str(end)}
+        return {"start": start.isoformat("T"), "end": end.isoformat("T")}
 
     keys = my_partitioned_config.get_partition_keys()
     assert keys[0] == "2021-05-05"
@@ -286,7 +286,7 @@ def test_weekly_schedule_with_offsets():
 def test_monthly_schedule():
     @monthly_partitioned_config(start_date="2021-05-05")
     def my_partitioned_config(start, end):
-        return {"start": str(start), "end": str(end)}
+        return {"start": start.isoformat("T"), "end": end.isoformat("T")}
 
     keys = my_partitioned_config.get_partition_keys()
     assert keys[0] == "2021-06-01"
@@ -324,7 +324,7 @@ def test_monthly_schedule_late_in_month():
         start_date="2021-05-05", minute_offset=15, hour_offset=16, day_offset=31
     )
     def my_partitioned_config(start, end):
-        return {"start": str(start), "end": str(end)}
+        return {"start": start.isoformat("T"), "end": end.isoformat("T")}
 
     keys = my_partitioned_config.get_partition_keys()
     assert keys[0] == "2021-05-31"
@@ -336,7 +336,7 @@ def test_monthly_schedule_with_offsets():
         start_date="2021-05-05", minute_offset=15, hour_offset=16, day_offset=12
     )
     def my_partitioned_config(start, end):
-        return {"start": str(start), "end": str(end)}
+        return {"start": start.isoformat("T"), "end": end.isoformat("T")}
 
     keys = my_partitioned_config.get_partition_keys()
     assert keys[0] == "2021-05-12"
@@ -395,7 +395,7 @@ def test_future_tick():
 
         @daily_partitioned_config(start_date="2021-05-05")
         def my_partitioned_config(start, end):
-            return {"start": str(start), "end": str(end)}
+            return {"start": start.isoformat("T"), "end": end.isoformat("T")}
 
         my_schedule = schedule_for_partitioned_config(my_partitioned_config)
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -29,7 +29,7 @@ from dagster._core.definitions.time_window_partitions import (
 )
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._serdes import deserialize_value, serialize_value, whitelist_for_serdes
-from dagster._seven.compat.pendulum import create_pendulum_time
+from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test
 from dagster._utils import utc_datetime_from_timestamp
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
 
@@ -1522,5 +1522,5 @@ def test_get_partition_keys_not_in_subset_empty_subset() -> None:
     time_windows_subset = TimeWindowPartitionsSubset(
         partitions_def, num_partitions=0, included_time_windows=[]
     )
-    with pendulum.test(create_pendulum_time(2023, 1, 1)):
+    with pendulum_test(create_pendulum_time(2023, 1, 1)):
         assert time_windows_subset.get_partition_keys_not_in_subset(partitions_def) == []

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
@@ -2,7 +2,13 @@ import calendar
 
 import pendulum
 import pytest
-from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
+from dagster._seven.compat.pendulum import (
+    create_pendulum_time,
+    to_timezone,
+    POST_TRANSITION,
+    PRE_TRANSITION,
+    TRANSITION_ERROR,
+)
 from dagster._utils.schedules import (
     _croniter_string_iterator,
     cron_string_iterator,
@@ -77,7 +83,7 @@ DST_PARAMS = [
             create_pendulum_time(2023, 10, 27, 2, 0, 0, tz="Europe/Berlin"),  # +2:00
             create_pendulum_time(2023, 10, 28, 2, 0, 0, tz="Europe/Berlin"),  # +2:00
             create_pendulum_time(
-                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),  # +1:00
             create_pendulum_time(2023, 10, 30, 2, 0, 0, tz="Europe/Berlin"),  # +1:00
             create_pendulum_time(2023, 10, 31, 2, 0, 0, tz="Europe/Berlin"),  # +1:00
@@ -89,22 +95,22 @@ DST_PARAMS = [
         "30 2 * * *",
         [
             create_pendulum_time(
-                2023, 10, 27, 2, 30, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 27, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 28, 2, 30, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 28, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 29, 2, 30, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 29, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 30, 2, 30, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 30, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 31, 2, 30, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 31, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 11, 1, 2, 30, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 11, 1, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
         ],
     ),
@@ -128,10 +134,10 @@ DST_PARAMS = [
             create_pendulum_time(2023, 10, 29, 0, 45, 0, tz="Europe/Berlin"),
             create_pendulum_time(2023, 10, 29, 1, 45, 0, tz="Europe/Berlin"),
             create_pendulum_time(
-                2023, 10, 29, 2, 45, 0, tz="Europe/Berlin", dst_rule=pendulum.PRE_TRANSITION
+                2023, 10, 29, 2, 45, 0, tz="Europe/Berlin", dst_rule=PRE_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 29, 2, 45, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 29, 2, 45, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(2023, 10, 29, 3, 45, 0, tz="Europe/Berlin"),
         ],
@@ -143,10 +149,10 @@ DST_PARAMS = [
             create_pendulum_time(2023, 10, 29, 0, 0, 0, tz="Europe/Berlin"),
             create_pendulum_time(2023, 10, 29, 1, 0, 0, tz="Europe/Berlin"),
             create_pendulum_time(
-                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=pendulum.PRE_TRANSITION
+                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=PRE_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(2023, 10, 29, 3, 0, 0, tz="Europe/Berlin"),
         ],
@@ -169,22 +175,22 @@ DST_PARAMS = [
         "0 2 * * 0",  # Every sunday at 2 AM
         [
             create_pendulum_time(
-                2023, 10, 15, 2, 0, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 15, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 22, 2, 0, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 22, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 11, 5, 2, 0, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 11, 5, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 11, 12, 2, 0, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 11, 12, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 11, 19, 2, 0, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 11, 19, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
         ],
     ),
@@ -193,22 +199,22 @@ DST_PARAMS = [
         "30 2 * * 0",  # Every sunday at 2:30 AM
         [
             create_pendulum_time(
-                2023, 10, 15, 2, 30, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 15, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 22, 2, 30, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 22, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 29, 2, 30, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 29, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 11, 5, 2, 30, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 11, 5, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 11, 12, 2, 30, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 11, 12, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 11, 19, 2, 30, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 11, 19, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
         ],
     ),
@@ -241,19 +247,19 @@ DST_PARAMS = [
         "0 1 5 * *",  # 5th of each month at 1AM
         [
             create_pendulum_time(
-                2023, 9, 5, 1, 0, 0, tz="US/Central", dst_rule=pendulum.POST_TRANSITION
+                2023, 9, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 5, 1, 0, 0, tz="US/Central", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 11, 5, 1, 0, 0, tz="US/Central", dst_rule=pendulum.POST_TRANSITION
+                2023, 11, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 12, 5, 1, 0, 0, tz="US/Central", dst_rule=pendulum.POST_TRANSITION
+                2023, 12, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2024, 1, 5, 1, 0, 0, tz="US/Central", dst_rule=pendulum.POST_TRANSITION
+                2024, 1, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
             ),
         ],
     ),
@@ -262,19 +268,19 @@ DST_PARAMS = [
         "30 1 5 * *",  # 5th of each month at 130AM
         [
             create_pendulum_time(
-                2023, 9, 5, 1, 30, 0, tz="US/Central", dst_rule=pendulum.POST_TRANSITION
+                2023, 9, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 5, 1, 30, 0, tz="US/Central", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 11, 5, 1, 30, 0, tz="US/Central", dst_rule=pendulum.POST_TRANSITION
+                2023, 11, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 12, 5, 1, 30, 0, tz="US/Central", dst_rule=pendulum.POST_TRANSITION
+                2023, 12, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2024, 1, 5, 1, 30, 0, tz="US/Central", dst_rule=pendulum.POST_TRANSITION
+                2024, 1, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION
             ),
         ],
     ),
@@ -283,19 +289,19 @@ DST_PARAMS = [
         "0 2 5 * *",  # 5th of each month at 2AM
         [
             create_pendulum_time(
-                2023, 9, 5, 2, 0, 0, tz="US/Central", dst_rule=pendulum.POST_TRANSITION
+                2023, 9, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 5, 2, 0, 0, tz="US/Central", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 11, 5, 2, 0, 0, tz="US/Central", dst_rule=pendulum.POST_TRANSITION
+                2023, 11, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 12, 5, 2, 0, 0, tz="US/Central", dst_rule=pendulum.POST_TRANSITION
+                2023, 12, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2024, 1, 5, 2, 0, 0, tz="US/Central", dst_rule=pendulum.POST_TRANSITION
+                2024, 1, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
             ),
         ],
     ),
@@ -507,28 +513,28 @@ DST_PARAMS = [
             create_pendulum_time(2023, 10, 29, 1, 30, 0, tz="Europe/Berlin"),
             create_pendulum_time(2023, 10, 29, 1, 45, 0, tz="Europe/Berlin"),
             create_pendulum_time(
-                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=pendulum.PRE_TRANSITION
+                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=PRE_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 29, 2, 15, 0, tz="Europe/Berlin", dst_rule=pendulum.PRE_TRANSITION
+                2023, 10, 29, 2, 15, 0, tz="Europe/Berlin", dst_rule=PRE_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 29, 2, 30, 0, tz="Europe/Berlin", dst_rule=pendulum.PRE_TRANSITION
+                2023, 10, 29, 2, 30, 0, tz="Europe/Berlin", dst_rule=PRE_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 29, 2, 45, 0, tz="Europe/Berlin", dst_rule=pendulum.PRE_TRANSITION
+                2023, 10, 29, 2, 45, 0, tz="Europe/Berlin", dst_rule=PRE_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 29, 2, 15, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 29, 2, 15, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 29, 2, 30, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 29, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(
-                2023, 10, 29, 2, 45, 0, tz="Europe/Berlin", dst_rule=pendulum.POST_TRANSITION
+                2023, 10, 29, 2, 45, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
             ),
             create_pendulum_time(2023, 10, 29, 3, 0, 0, tz="Europe/Berlin"),
             create_pendulum_time(2023, 10, 29, 3, 15, 0, tz="Europe/Berlin"),

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
@@ -3,11 +3,10 @@ import calendar
 import pendulum
 import pytest
 from dagster._seven.compat.pendulum import (
-    create_pendulum_time,
-    to_timezone,
     POST_TRANSITION,
     PRE_TRANSITION,
-    TRANSITION_ERROR,
+    create_pendulum_time,
+    to_timezone,
 )
 from dagster._utils.schedules import (
     _croniter_string_iterator,
@@ -246,63 +245,33 @@ DST_PARAMS = [
         "US/Central",
         "0 1 5 * *",  # 5th of each month at 1AM
         [
-            create_pendulum_time(
-                2023, 9, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 11, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 12, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2024, 1, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
-            ),
+            create_pendulum_time(2023, 9, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
+            create_pendulum_time(2023, 10, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
+            create_pendulum_time(2023, 11, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
+            create_pendulum_time(2023, 12, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
+            create_pendulum_time(2024, 1, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
         ],
     ),
     (
         "US/Central",
         "30 1 5 * *",  # 5th of each month at 130AM
         [
-            create_pendulum_time(
-                2023, 9, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 11, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 12, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2024, 1, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION
-            ),
+            create_pendulum_time(2023, 9, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION),
+            create_pendulum_time(2023, 10, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION),
+            create_pendulum_time(2023, 11, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION),
+            create_pendulum_time(2023, 12, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION),
+            create_pendulum_time(2024, 1, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION),
         ],
     ),
     (
         "US/Central",
         "0 2 5 * *",  # 5th of each month at 2AM
         [
-            create_pendulum_time(
-                2023, 9, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 11, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 12, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2024, 1, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION
-            ),
+            create_pendulum_time(2023, 9, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
+            create_pendulum_time(2023, 10, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
+            create_pendulum_time(2023, 11, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
+            create_pendulum_time(2023, 12, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
+            create_pendulum_time(2024, 1, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
         ],
     ),
     # Daily / spring forward

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_pythonic_resources.py
@@ -29,7 +29,7 @@ from dagster._core.test_utils import (
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import ModuleTarget
-from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
+from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test, to_timezone
 
 from .test_scheduler_run import evaluate_schedules, validate_tick, wait_for_all_runs_to_start
 
@@ -190,7 +190,7 @@ def test_resources(
         "US/Central",
     )
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_schedule = external_repo_struct_resources.get_external_schedule(schedule_name)
         instance.start_schedule(external_schedule)
 
@@ -201,7 +201,7 @@ def test_resources(
         assert len(ticks) == 0
     freeze_datetime = freeze_datetime.add(seconds=30)
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_schedules(workspace_context_struct_resources, None, pendulum.now("UTC"))
         wait_for_all_runs_to_start(instance)
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
@@ -18,7 +18,7 @@ from dagster._core.test_utils import (
     get_crash_signals,
 )
 from dagster._seven import IS_WINDOWS
-from dagster._seven.compat.pendulum import create_pendulum_time
+from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test
 from dagster._utils import DebugCrashFlags, get_terminate_signal
 
 from .conftest import workspace_load_target
@@ -61,7 +61,7 @@ def _test_launch_scheduled_runs_in_subprocess(
             with create_test_daemon_workspace_context(
                 workspace_load_target(), instance
             ) as workspace_context:
-                with pendulum.test(execution_datetime):
+                with pendulum_test(execution_datetime):
                     evaluate_schedules(
                         workspace_context,
                         executor,
@@ -91,7 +91,7 @@ def test_failure_recovery_before_run_created(
     freeze_datetime = initial_datetime.add()
 
     external_schedule = external_repo.get_external_schedule("simple_schedule")
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         instance.start_schedule(external_schedule)
 
         debug_crash_flags = {external_schedule.name: {crash_location: crash_signal}}
@@ -114,7 +114,7 @@ def test_failure_recovery_before_run_created(
         assert instance.get_runs_count() == 0
 
     freeze_datetime = freeze_datetime.add(minutes=5)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         scheduler_process = spawn_ctx.Process(
             target=_test_launch_scheduled_runs_in_subprocess,
             args=[instance.get_ref(), freeze_datetime, None, executor],
@@ -161,7 +161,7 @@ def test_failure_recovery_after_run_created(
     initial_datetime = create_pendulum_time(year=2019, month=2, day=27, hour=0, minute=0, second=0)
     freeze_datetime = initial_datetime.add()
     external_schedule = external_repo.get_external_schedule("simple_schedule")
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         instance.start_schedule(external_schedule)
 
         debug_crash_flags = {external_schedule.name: {crash_location: crash_signal}}
@@ -205,7 +205,7 @@ def test_failure_recovery_after_run_created(
             validate_run_exists(instance.get_runs()[0], freeze_datetime)
 
     freeze_datetime = freeze_datetime.add(minutes=5)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # Running again just launches the existing run and marks the tick as success
         scheduler_process = spawn_ctx.Process(
             target=_test_launch_scheduled_runs_in_subprocess,
@@ -248,7 +248,7 @@ def test_failure_recovery_after_tick_success(
     initial_datetime = create_pendulum_time(year=2019, month=2, day=27, hour=0, minute=0, second=0)
     freeze_datetime = initial_datetime.add()
     external_schedule = external_repo.get_external_schedule("simple_schedule")
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         instance.start_schedule(external_schedule)
 
         debug_crash_flags = {external_schedule.name: {crash_location: crash_signal}}
@@ -289,7 +289,7 @@ def test_failure_recovery_after_tick_success(
         )
 
     freeze_datetime = freeze_datetime.add(minutes=1)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # Running again just marks the tick as success since the run has already started
         scheduler_process = spawn_ctx.Process(
             target=_test_launch_scheduled_runs_in_subprocess,
@@ -331,7 +331,7 @@ def test_failure_recovery_between_multi_runs(
     initial_datetime = create_pendulum_time(year=2019, month=2, day=28, hour=0, minute=0, second=0)
     freeze_datetime = initial_datetime.add()
     external_schedule = external_repo.get_external_schedule("multi_run_schedule")
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         instance.start_schedule(external_schedule)
 
         debug_crash_flags = {external_schedule.name: {crash_location: crash_signal}}
@@ -355,7 +355,7 @@ def test_failure_recovery_between_multi_runs(
         assert len(ticks) == 1
 
     freeze_datetime = freeze_datetime.add(minutes=1)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         scheduler_process = spawn_ctx.Process(
             target=_test_launch_scheduled_runs_in_subprocess,
             args=[instance.get_ref(), freeze_datetime, None, executor],

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
@@ -6,7 +6,7 @@ from dagster._core.host_representation.external import ExternalRepository
 from dagster._core.instance import DagsterInstance
 from dagster._core.scheduler.instigation import TickStatus
 from dagster._core.workspace.context import WorkspaceProcessContext
-from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
+from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test, to_timezone
 
 from .test_scheduler_run import (
     evaluate_schedules,
@@ -28,7 +28,7 @@ def test_non_utc_timezone_run(
     freeze_datetime = to_timezone(
         create_pendulum_time(2019, 2, 27, 23, 59, 59, tz="US/Central"), "US/Pacific"
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
 
         schedule_origin = external_schedule.get_external_origin()
@@ -46,7 +46,7 @@ def test_non_utc_timezone_run(
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(seconds=2)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
         assert instance.get_runs_count() == 1
@@ -91,7 +91,7 @@ def test_differing_timezones(
     freeze_datetime = to_timezone(
         create_pendulum_time(2019, 2, 27, 23, 59, 59, tz="US/Eastern"), "US/Pacific"
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
         external_eastern_schedule = external_repo.get_external_schedule(
             "daily_eastern_time_schedule"
@@ -120,7 +120,7 @@ def test_differing_timezones(
 
     # Past midnight eastern time, the eastern timezone schedule will run, but not the central timezone
     freeze_datetime = freeze_datetime.add(minutes=1)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
         assert instance.get_runs_count() == 1
@@ -151,7 +151,7 @@ def test_differing_timezones(
 
     # Past midnight central time, the central timezone schedule will now run
     freeze_datetime = freeze_datetime.add(hours=1)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
         assert instance.get_runs_count() == 2
@@ -204,7 +204,7 @@ def test_different_days_in_different_timezones(
     freeze_datetime = to_timezone(
         create_pendulum_time(2019, 2, 27, 22, 59, 59, tz="US/Central"), "US/Pacific"
     )
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         # Runs every day at 11PM (CST)
         external_schedule = external_repo.get_external_schedule("daily_late_schedule")
         schedule_origin = external_schedule.get_external_origin()
@@ -220,7 +220,7 @@ def test_different_days_in_different_timezones(
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(seconds=2)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
         assert instance.get_runs_count() == 1
@@ -269,7 +269,7 @@ def test_hourly_dst_spring_forward(
 
     external_schedule = external_repo.get_external_schedule("hourly_central_time_schedule")
     schedule_origin = external_schedule.get_external_origin()
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         instance.start_schedule(external_schedule)
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
@@ -278,13 +278,13 @@ def test_hourly_dst_spring_forward(
         assert len(ticks) == 1
 
     freeze_datetime = freeze_datetime.add(hours=1)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
     # DST has now happened, 2 hours later it is 4AM CST
     # Should be 3 runs: 1AM CST, 3AM CST, 4AM CST
     freeze_datetime = freeze_datetime.add(hours=1)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
         wait_for_all_runs_to_start(instance)
@@ -336,7 +336,7 @@ def test_hourly_dst_fall_back(
 
     external_schedule = external_repo.get_external_schedule("hourly_central_time_schedule")
     schedule_origin = external_schedule.get_external_origin()
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         instance.start_schedule(external_schedule)
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
@@ -346,13 +346,13 @@ def test_hourly_dst_fall_back(
 
     for _ in range(3):
         freeze_datetime = freeze_datetime.add(hours=1)
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
     # DST has now happened, 4 hours later it is 3:30AM CST
     # Should be 4 runs: 1AM CDT, 2AM CDT, 2AM CST, 3AM CST
     freeze_datetime = freeze_datetime.add(hours=1)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
         wait_for_all_runs_to_start(instance)
@@ -417,7 +417,7 @@ def test_daily_dst_spring_forward(
 
     external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
     schedule_origin = external_schedule.get_external_origin()
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         instance.start_schedule(external_schedule)
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
@@ -426,11 +426,11 @@ def test_daily_dst_spring_forward(
         assert len(ticks) == 1
 
     freeze_datetime = freeze_datetime.add(days=1)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
     freeze_datetime = freeze_datetime.add(days=1)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
         wait_for_all_runs_to_start(instance)
@@ -482,7 +482,7 @@ def test_daily_dst_fall_back(
         create_pendulum_time(2019, 11, 3, 0, 0, 0, tz="US/Central"), "US/Pacific"
     )
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
         schedule_origin = external_schedule.get_external_origin()
         instance.start_schedule(external_schedule)
@@ -493,11 +493,11 @@ def test_daily_dst_fall_back(
         assert len(ticks) == 1
 
     freeze_datetime = freeze_datetime.add(days=1)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
     freeze_datetime = freeze_datetime.add(days=1)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
         wait_for_all_runs_to_start(instance)
@@ -550,7 +550,7 @@ def test_execute_during_dst_transition_spring_forward(
         create_pendulum_time(2019, 3, 9, 0, 0, 0, tz="US/Central"), "US/Pacific"
     )
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_schedule = external_repo.get_external_schedule(
             "daily_dst_transition_schedule_skipped_time"
         )
@@ -564,11 +564,11 @@ def test_execute_during_dst_transition_spring_forward(
 
     for _ in range(4):
         freeze_datetime = freeze_datetime.add(days=1)
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
     freeze_datetime = freeze_datetime.add(days=1)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
         wait_for_all_runs_to_start(instance)
@@ -620,7 +620,7 @@ def test_execute_during_dst_transition_fall_back(
         create_pendulum_time(2019, 11, 2, 0, 0, 0, tz="US/Central"), "US/Pacific"
     )
 
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         external_schedule = external_repo.get_external_schedule(
             "daily_dst_transition_schedule_doubled_time"
         )
@@ -634,11 +634,11 @@ def test_execute_during_dst_transition_fall_back(
 
     for _ in range(2):
         freeze_datetime = freeze_datetime.add(days=1)
-        with pendulum.test(freeze_datetime):
+        with pendulum_test(freeze_datetime):
             evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
     freeze_datetime = freeze_datetime.add(days=1)
-    with pendulum.test(freeze_datetime):
+    with pendulum_test(freeze_datetime):
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
 
         wait_for_all_runs_to_start(instance)

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -46,7 +46,7 @@ from dagster._core.utils import make_new_run_id
 from dagster._daemon.daemon import SensorDaemon
 from dagster._daemon.types import DaemonHeartbeat
 from dagster._serdes import serialize_pp
-from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
+from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_test, to_timezone
 
 win_py36 = _seven.IS_WINDOWS and sys.version_info[0] == 3 and sys.version_info[1] == 6
 
@@ -1395,7 +1395,7 @@ class TestRunStorage:
                 create_pendulum_time(2019, 11, 2, 0, 0, 0, tz="US/Central"), "US/Pacific"
             )
 
-            with pendulum.test(freeze_datetime):
+            with pendulum_test(freeze_datetime):
                 result = my_job.execute_in_process(instance=instance)
                 records = instance.get_run_records(filters=RunsFilter(run_ids=[result.run_id]))
                 assert len(records) == 1

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -86,7 +86,7 @@ setup(
         f"grpcio>={GRPC_VERSION_FLOOR}",
         f"grpcio-health-checking>={GRPC_VERSION_FLOOR}",
         "packaging>=20.9",
-        "pendulum>=0.7.0,<3",
+        "pendulum>=0.7.0,<4",
         "protobuf>=3.20.0,<5",  # min protobuf version to be compatible with both protobuf 3 and 4
         "python-dateutil",
         "python-dotenv",

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -11,6 +11,8 @@ passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUIL
 deps =
   scheduler_tests_old_pendulum: pendulum<2
   definitions_tests_old_pendulum: pendulum<2
+  scheduler_tests_pendulum_2: pendulum<3
+  definitions_tests_pendulum_2: pendulum<3
   storage_tests_sqlalchemy_1_3: sqlalchemy<1.4
   storage_tests_sqlalchemy_1_4: sqlalchemy<2
   general_tests_old_protobuf: protobuf<4
@@ -33,6 +35,7 @@ commands =
   storage_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/storage_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   definitions_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/definitions_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   definitions_tests_old_pendulum: pytest -c ../../pyproject.toml -vv ./dagster_tests/definitions_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
+  definitions_tests_pendulum_2: pytest -c ../../pyproject.toml -vv ./dagster_tests/definitions_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   asset_defs_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/asset_defs_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   storage_tests_sqlalchemy_1_3: pytest -c ../../pyproject.toml -vv ./dagster_tests/storage_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   storage_tests_sqlalchemy_1_4: pytest -c ../../pyproject.toml -vv ./dagster_tests/storage_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
@@ -40,6 +43,7 @@ commands =
   daemon_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/daemon_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   scheduler_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/scheduler_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   scheduler_tests_old_pendulum: pytest -c ../../pyproject.toml -vv ./dagster_tests/scheduler_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
+  scheduler_tests_pendulum_2: pytest -c ../../pyproject.toml -vv ./dagster_tests/scheduler_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
   general_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/general_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
   general_tests_old_protobuf: pytest -c ../../pyproject.toml -vv ./dagster_tests/general_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
   execution_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}


### PR DESCRIPTION
## Summary & Motivation
I was interested in running dagster on python 3.12. There are two blockers that I am aware of:
* pendulum 2.1 failing to install on 3.12 (https://github.com/sdispater/pendulum/issues/696)
* universal_pathlib broken by internal changes in python's pathlib (https://github.com/fsspec/universal_pathlib/pull/152)

This PR is a WIP attempt to solve the first, by allowing pendulum 3.0, which is compatible with python 3.12. Unfortunately, the rabbit hole was much deeper than I thought initially due to the many breaking changes in pendulum 3.0. At this point I don't have more time to spend on this for a while.

Since, I think @gibsondan was also looking into this, I am opening this WIP PR in case it may be of help (otherwise feel free to close it). I am currently stuck on some scheduler unit test failures.

## How I Tested These Changes
Run unit tests locally