### PR TITLE
feat/add init container resources

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -101,6 +101,7 @@ class Daemon(BaseModel):
     schedulerName: Optional[str]
     volumeMounts: Optional[List[kubernetes.VolumeMount]]
     volumes: Optional[List[kubernetes.Volume]]
+    initContainers: Optional[Dict[str, kubernetes.Resources]]
 
     class Config:
         extra = Extra.forbid

--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -101,7 +101,7 @@ class Daemon(BaseModel):
     schedulerName: Optional[str]
     volumeMounts: Optional[List[kubernetes.VolumeMount]]
     volumes: Optional[List[kubernetes.Volume]]
-    initContainerResources: kubernetes.Resources
+    initContainerResources: Optional[kubernetes.Resources]
 
     class Config:
         extra = Extra.forbid

--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -101,7 +101,7 @@ class Daemon(BaseModel):
     schedulerName: Optional[str]
     volumeMounts: Optional[List[kubernetes.VolumeMount]]
     volumes: Optional[List[kubernetes.Volume]]
-    initContainers: Optional[Dict[str, kubernetes.Resources]]
+    initContainerResources: kubernetes.Resources
 
     class Config:
         extra = Extra.forbid

--- a/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
@@ -48,6 +48,7 @@ class Webserver(BaseModel):
     schedulerName: Optional[str]
     volumeMounts: Optional[List[kubernetes.VolumeMount]]
     volumes: Optional[List[kubernetes.Volume]]
+    initContainers: Optional[Dict[str, kubernetes.Resources]]
 
     class Config:
         extra = Extra.forbid

--- a/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
@@ -48,7 +48,7 @@ class Webserver(BaseModel):
     schedulerName: Optional[str]
     volumeMounts: Optional[List[kubernetes.VolumeMount]]
     volumes: Optional[List[kubernetes.Volume]]
-    initContainers: Optional[Dict[str, kubernetes.Resources]]
+    initContainerResources: kubernetes.Resources
 
     class Config:
         extra = Extra.forbid

--- a/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
@@ -48,7 +48,7 @@ class Webserver(BaseModel):
     schedulerName: Optional[str]
     volumeMounts: Optional[List[kubernetes.VolumeMount]]
     volumes: Optional[List[kubernetes.Volume]]
-    initContainerResources: kubernetes.Resources
+    initContainerResources: Optional[kubernetes.Resources]
 
     class Config:
         extra = Extra.forbid

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -503,6 +503,31 @@ def test_webserver_security_context(deployment_template: HelmTemplate):
         for container in webserver_deployment.spec.template.spec.init_containers
     )
 
+def test_init_container_resources(deployment_template: HelmTemplate):
+    init_container_resources = {
+        "limits": {
+            "cpu": "200m"
+        },
+        "requests": {
+            "memory": "1Gi"
+        }
+    }
+    helm_values = DagsterHelmValues.construct(
+        dagsterWebserver=Webserver.construct(initContainerResources=init_container_resources)
+    )
+
+    [webserver_deployment] = deployment_template.render(helm_values)
+
+    assert len(webserver_deployment.spec.template.spec.init_containers) == 2
+
+    assert all(
+        container.resources
+        == k8s_model_from_dict(
+            k8s_client.models.v1_resource_requirements.V1ResourceRequirements,
+            k8s_snake_case_dict(k8s_client.models.v1_resource_requirements.V1ResourceRequirements, init_container_resources),
+        )
+        for container in webserver_deployment.spec.template.spec.init_containers
+    )
 
 def test_env(deployment_template: HelmTemplate):
     helm_values = DagsterHelmValues.construct(dagsterWebserver=Webserver.construct())

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -503,15 +503,9 @@ def test_webserver_security_context(deployment_template: HelmTemplate):
         for container in webserver_deployment.spec.template.spec.init_containers
     )
 
+
 def test_init_container_resources(deployment_template: HelmTemplate):
-    init_container_resources = {
-        "limits": {
-            "cpu": "200m"
-        },
-        "requests": {
-            "memory": "1Gi"
-        }
-    }
+    init_container_resources = {"limits": {"cpu": "200m"}, "requests": {"memory": "1Gi"}}
     helm_values = DagsterHelmValues.construct(
         dagsterWebserver=Webserver.construct(initContainerResources=init_container_resources)
     )
@@ -524,10 +518,14 @@ def test_init_container_resources(deployment_template: HelmTemplate):
         container.resources
         == k8s_model_from_dict(
             k8s_client.models.v1_resource_requirements.V1ResourceRequirements,
-            k8s_snake_case_dict(k8s_client.models.v1_resource_requirements.V1ResourceRequirements, init_container_resources),
+            k8s_snake_case_dict(
+                k8s_client.models.v1_resource_requirements.V1ResourceRequirements,
+                init_container_resources,
+            ),
         )
         for container in webserver_deployment.spec.template.spec.init_containers
     )
+
 
 def test_env(deployment_template: HelmTemplate):
     helm_values = DagsterHelmValues.construct(dagsterWebserver=Webserver.construct())

--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -538,14 +538,7 @@ def test_scheduler_name(template: HelmTemplate):
 
 
 def test_init_container_resources(template: HelmTemplate):
-    init_container_resources = {
-        "limits": {
-            "cpu": "200m"
-        },
-        "requests": {
-            "memory": "1Gi"
-        }
-    }
+    init_container_resources = {"limits": {"cpu": "200m"}, "requests": {"memory": "1Gi"}}
     helm_values = DagsterHelmValues.construct(
         dagsterDaemon=Daemon.construct(initContainerResources=init_container_resources)
     )
@@ -558,10 +551,14 @@ def test_init_container_resources(template: HelmTemplate):
         container.resources
         == k8s_model_from_dict(
             k8s_client.models.v1_resource_requirements.V1ResourceRequirements,
-            k8s_snake_case_dict(k8s_client.models.v1_resource_requirements.V1ResourceRequirements, init_container_resources),
+            k8s_snake_case_dict(
+                k8s_client.models.v1_resource_requirements.V1ResourceRequirements,
+                init_container_resources,
+            ),
         )
         for container in webserver_deployment.spec.template.spec.init_containers
     )
+
 
 def test_env(template: HelmTemplate):
     helm_values = DagsterHelmValues.construct(dagsterDaemon=Daemon.construct())

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -63,8 +63,10 @@ spec:
           command: ['sh', '-c', "until nslookup {{ $deployment.name -}}; do echo waiting for user service; sleep 2; done"]
           securityContext:
             {{- toYaml $.Values.dagsterDaemon.securityContext | nindent 12 }}
+          {{- if $.Values.dagsterDaemon.initContainerResources }}
           resources:
             {{- toYaml $.Values.dagsterDaemon.initContainerResources | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- end }}
       containers:

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -54,6 +54,8 @@ spec:
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" . | squote }}]
           securityContext:
             {{- toYaml .Values.dagsterDaemon.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.dagsterDaemon.initContainers.resources | nindent 12 }}
         {{- if (and $userDeployments.enabled $userDeployments.enableSubchart) }}
         {{- range $deployment := $userDeployments.deployments }}
         - name: "init-user-deployment-{{- $deployment.name -}}"
@@ -61,6 +63,8 @@ spec:
           command: ['sh', '-c', "until nslookup {{ $deployment.name -}}; do echo waiting for user service; sleep 2; done"]
           securityContext:
             {{- toYaml $.Values.dagsterDaemon.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml $.Values.dagsterDaemon.initContainers.resources | nindent 12 }}
         {{- end }}
         {{- end }}
       containers:

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -55,7 +55,7 @@ spec:
           securityContext:
             {{- toYaml .Values.dagsterDaemon.securityContext | nindent 12 }}
           resources:
-            {{- toYaml .Values.dagsterDaemon.initContainers.resources | nindent 12 }}
+            {{- toYaml .Values.dagsterDaemon.initContainerResources | nindent 12 }}
         {{- if (and $userDeployments.enabled $userDeployments.enableSubchart) }}
         {{- range $deployment := $userDeployments.deployments }}
         - name: "init-user-deployment-{{- $deployment.name -}}"
@@ -64,7 +64,7 @@ spec:
           securityContext:
             {{- toYaml $.Values.dagsterDaemon.securityContext | nindent 12 }}
           resources:
-            {{- toYaml $.Values.dagsterDaemon.initContainers.resources | nindent 12 }}
+            {{- toYaml $.Values.dagsterDaemon.initContainerResources | nindent 12 }}
         {{- end }}
         {{- end }}
       containers:

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -52,6 +52,8 @@ spec:
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" . | squote }}]
           securityContext:
             {{- toYaml $_.Values.dagsterWebserver.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml $_.Values.dagsterWebserver.initContainers.resources | nindent 12 }}
         {{- if (and $userDeployments.enabled $userDeployments.enableSubchart) }}
         {{- range $deployment := $userDeployments.deployments }}
         - name: "init-user-deployment-{{- $deployment.name -}}"
@@ -59,6 +61,8 @@ spec:
           command: ['sh', '-c', "until nslookup {{ $deployment.name -}}; do echo waiting for user service; sleep 2; done"]
           securityContext:
             {{- toYaml $_.Values.dagsterWebserver.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml $_.Values.dagsterWebserver.initContainers.resources | nindent 12 }}
         {{- end }}
         {{- end }}
       containers:

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -52,8 +52,10 @@ spec:
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" . | squote }}]
           securityContext:
             {{- toYaml $_.Values.dagsterWebserver.securityContext | nindent 12 }}
+          {{- if $_.Values.dagsterWebserver.initContainerResources }}
           resources:
             {{- toYaml $_.Values.dagsterWebserver.initContainerResources | nindent 12 }}
+          {{- end }}
         {{- if (and $userDeployments.enabled $userDeployments.enableSubchart) }}
         {{- range $deployment := $userDeployments.deployments }}
         - name: "init-user-deployment-{{- $deployment.name -}}"
@@ -61,8 +63,10 @@ spec:
           command: ['sh', '-c', "until nslookup {{ $deployment.name -}}; do echo waiting for user service; sleep 2; done"]
           securityContext:
             {{- toYaml $_.Values.dagsterWebserver.securityContext | nindent 12 }}
+          {{- if $_.Values.dagsterWebserver.initContainerResources }}
           resources:
             {{- toYaml $_.Values.dagsterWebserver.initContainerResources | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- end }}
       containers:

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -53,7 +53,7 @@ spec:
           securityContext:
             {{- toYaml $_.Values.dagsterWebserver.securityContext | nindent 12 }}
           resources:
-            {{- toYaml $_.Values.dagsterWebserver.initContainers.resources | nindent 12 }}
+            {{- toYaml $_.Values.dagsterWebserver.initContainerResources | nindent 12 }}
         {{- if (and $userDeployments.enabled $userDeployments.enableSubchart) }}
         {{- range $deployment := $userDeployments.deployments }}
         - name: "init-user-deployment-{{- $deployment.name -}}"
@@ -62,7 +62,7 @@ spec:
           securityContext:
             {{- toYaml $_.Values.dagsterWebserver.securityContext | nindent 12 }}
           resources:
-            {{- toYaml $_.Values.dagsterWebserver.initContainers.resources | nindent 12 }}
+            {{- toYaml $_.Values.dagsterWebserver.initContainerResources | nindent 12 }}
         {{- end }}
         {{- end }}
       containers:

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -518,7 +518,15 @@
                     ]
                 },
                 "initContainerResources": {
-                    "$ref": "#/definitions/Resources"
+                    "title": "Resources",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Resources"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [
@@ -542,8 +550,7 @@
                 "livenessProbe",
                 "startupProbe",
                 "annotations",
-                "enableReadOnly",
-                "initContainerResources"
+                "enableReadOnly"
             ],
             "additionalProperties": false
         },
@@ -2897,7 +2904,15 @@
                     ]
                 },
                 "initContainerResources": {
-                    "$ref": "#/definitions/Resources"
+                    "title": "Resources",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Resources"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [
@@ -2923,8 +2938,7 @@
                 "runMonitoring",
                 "runRetries",
                 "sensors",
-                "schedules",
-                "initContainerResources"
+                "schedules"
             ],
             "additionalProperties": false
         },

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -516,6 +516,20 @@
                             "type": "null"
                         }
                     ]
+                },
+                "initContainers": {
+                    "title": "Initcontainers",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/Resources"
+                    },
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [
@@ -2886,6 +2900,20 @@
                     "anyOf": [
                         {
                             "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "initContainers": {
+                    "title": "Initcontainers",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/Resources"
+                    },
+                    "anyOf": [
+                        {
+                            "type": "object"
                         },
                         {
                             "type": "null"

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -517,19 +517,8 @@
                         }
                     ]
                 },
-                "initContainers": {
-                    "title": "Initcontainers",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/Resources"
-                    },
-                    "anyOf": [
-                        {
-                            "type": "object"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                "initContainerResources": {
+                    "$ref": "#/definitions/Resources"
                 }
             },
             "required": [
@@ -553,7 +542,8 @@
                 "livenessProbe",
                 "startupProbe",
                 "annotations",
-                "enableReadOnly"
+                "enableReadOnly",
+                "initContainerResources"
             ],
             "additionalProperties": false
         },
@@ -2906,19 +2896,8 @@
                         }
                     ]
                 },
-                "initContainers": {
-                    "title": "Initcontainers",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/Resources"
-                    },
-                    "anyOf": [
-                        {
-                            "type": "object"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                "initContainerResources": {
+                    "$ref": "#/definitions/Resources"
                 }
             },
             "required": [
@@ -2944,7 +2923,8 @@
                 "runMonitoring",
                 "runRetries",
                 "sensors",
-                "schedules"
+                "schedules",
+                "initContainerResources"
             ],
             "additionalProperties": false
         },

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -163,6 +163,10 @@ dagsterWebserver:
   securityContext: {}
   resources: {}
 
+  # Configure initContainer resources separately from main container
+  initContainers:
+    resources: {}
+
   # Override the default K8s scheduler
   # schedulerName: ~
 
@@ -1214,6 +1218,10 @@ dagsterDaemon:
   podSecurityContext: {}
   securityContext: {}
   resources: {}
+
+  # Configure initContainer resources separately from main container
+  initContainers:
+    resources: {}
 
   # Override the default K8s scheduler
   # schedulerName: ~

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -164,9 +164,7 @@ dagsterWebserver:
   resources: {}
 
   # Configure initContainer resources separately from main container
-  initContainers:
-    resources: {}
-
+  initContainerResources: {}
   # Override the default K8s scheduler
   # schedulerName: ~
 
@@ -1220,9 +1218,7 @@ dagsterDaemon:
   resources: {}
 
   # Configure initContainer resources separately from main container
-  initContainers:
-    resources: {}
-
+  initContainerResources: {}
   # Override the default K8s scheduler
   # schedulerName: ~
 


### PR DESCRIPTION
Summary:
Moved https://github.com/dagster-io/dagster/pull/19212/files by [MattyKuzyk](https://github.com/MattyKuzyk) into a PR against the main dagster repo so that the helm schema would regenerate cleanly. Only change from the linked PR is the latest commit, which makes the field optional in the Pydantic schema

Test Plan: Buildkite
