### PR TITLE
[dagster-postgres] psycopg2-binary -> psycopg2

### DIFF
--- a/python_modules/libraries/dagster-postgres/setup.py
+++ b/python_modules/libraries/dagster-postgres/setup.py
@@ -38,6 +38,9 @@ setup(
         ]
     },
     include_package_data=True,
-    install_requires=[f"dagster{pin}", "psycopg2-binary"],
+    install_requires=[
+        f"dagster{pin}",
+        "psycopg2",
+    ],
     zip_safe=False,
 )


### PR DESCRIPTION
As cited in https://github.com/dagster-io/dagster/issues/19426 `psycopg-binary` is not recommended for production use:

https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary

resolves https://github.com/dagster-io/dagster/issues/19426

## How I Tested These Changes

existing test suite

