### PR TITLE
Support moto >= 5

### DIFF
--- a/examples/docs_snippets/setup.py
+++ b/examples/docs_snippets/setup.py
@@ -50,7 +50,7 @@ setup(
             # "'NoneType' object has no attribute 'canvas'" errors in the tests that involve
             # Jupyter notebooks
             "matplotlib-inline<=0.1.3",
-            "moto",
+            "moto>=5",
             "numpy",
             "pandas",
             "pandera",

--- a/examples/docs_snippets/setup.py
+++ b/examples/docs_snippets/setup.py
@@ -50,7 +50,7 @@ setup(
             # "'NoneType' object has no attribute 'canvas'" errors in the tests that involve
             # Jupyter notebooks
             "matplotlib-inline<=0.1.3",
-            "moto<5.0",
+            "moto",
             "numpy",
             "pandas",
             "pandera",

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/athena_tests/test_resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/athena_tests/test_resources.py
@@ -22,7 +22,7 @@ class TestAthenaClientResource(ResourceWithAthenaConfig):
 
 @pytest.fixture
 def mock_athena_client(mock_s3_resource):
-    with mock_athena():
+    with mock_aws():
         yield boto3.client("athena", region_name="us-east-1")
 
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/cloudwatch_tests/test_loggers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/cloudwatch_tests/test_loggers.py
@@ -4,7 +4,7 @@ import boto3
 import pytest
 from dagster import job, op
 from dagster_aws.cloudwatch import cloudwatch_logger
-from moto import mock_logs
+from moto import mock_aws
 
 
 @op
@@ -25,7 +25,7 @@ def region():
 
 @pytest.fixture
 def cloudwatch_client(region):
-    with mock_logs():
+    with mock_aws():
         yield boto3.client("logs", region_name=region)
 
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/conftest.py
@@ -1,6 +1,6 @@
 import boto3
 import pytest
-from moto import mock_s3, mock_secretsmanager, mock_ssm
+from moto import mock_aws
 
 
 # Make sure unit tests never connect to real AWS
@@ -12,7 +12,7 @@ def fake_aws_credentials(monkeypatch):
 
 @pytest.fixture
 def mock_s3_resource():
-    with mock_s3():
+    with mock_aws():
         yield boto3.resource("s3", region_name="us-east-1")
 
 
@@ -23,11 +23,11 @@ def mock_s3_bucket(mock_s3_resource):
 
 @pytest.fixture
 def mock_secretsmanager_resource():
-    with mock_secretsmanager():
+    with mock_aws():
         yield boto3.client("secretsmanager")
 
 
 @pytest.fixture
 def mock_ssm_client():
-    with mock_ssm():
+    with mock_aws():
         yield boto3.client("ssm")

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/conftest.py
@@ -17,7 +17,7 @@ def ecs(region):
 
 @pytest.fixture
 def ec2(region):
-    with moto.mock_ec2():
+    with moto.mock_aws():
         yield boto3.resource("ec2", region_name=region)
 
 
@@ -38,5 +38,5 @@ def security_group(vpc):
 
 @pytest.fixture
 def secrets_manager(region):
-    with moto.mock_secretsmanager():
+    with moto.mock_aws():
         yield boto3.client("secretsmanager", region_name=region)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -28,7 +28,7 @@ def ignore_dagster_warnings() -> Iterator[None]:
 
 @pytest.fixture
 def cloudwatch_client(region: str):
-    with moto.mock_logs():
+    with moto.mock_aws():
         yield boto3.client("logs", region_name=region)
 
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/emr_tests/test_emr.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/emr_tests/test_emr.py
@@ -9,12 +9,12 @@ import pytest
 from dagster._utils.test import create_test_pipeline_execution_context
 from dagster_aws.emr import EmrClusterState, EmrError, EmrJobRunner
 from dagster_aws.utils.mrjob.utils import _boto3_now
-from moto import mock_emr
+from moto import mock_aws
 
 REGION = "us-west-1"
 
 
-@mock_emr
+@mock_aws
 def test_emr_create_cluster(emr_cluster_config):
     context = create_test_pipeline_execution_context()
     cluster = EmrJobRunner(region=REGION)
@@ -22,7 +22,7 @@ def test_emr_create_cluster(emr_cluster_config):
     assert cluster_id.startswith("j-")
 
 
-@mock_emr
+@mock_aws
 def test_emr_add_tags_and_describe_cluster(emr_cluster_config):
     context = create_test_pipeline_execution_context()
     emr = EmrJobRunner(region=REGION)
@@ -37,7 +37,7 @@ def test_emr_add_tags_and_describe_cluster(emr_cluster_config):
     assert {"Key": "foobar", "Value": "v1"} in tags
 
 
-@mock_emr
+@mock_aws
 def test_emr_describe_cluster(emr_cluster_config):
     context = create_test_pipeline_execution_context()
     cluster = EmrJobRunner(region=REGION)
@@ -47,7 +47,7 @@ def test_emr_describe_cluster(emr_cluster_config):
     assert EmrClusterState(cluster_info["Status"]["State"]) == EmrClusterState.Waiting
 
 
-@mock_emr
+@mock_aws
 def test_emr_id_from_name(emr_cluster_config):
     context = create_test_pipeline_execution_context()
     cluster = EmrJobRunner(region=REGION)
@@ -78,7 +78,7 @@ def test_emr_construct_step_dict():
     }
 
 
-@mock_emr
+@mock_aws
 def test_emr_log_location_for_cluster(emr_cluster_config, mock_s3_bucket):
     context = create_test_pipeline_execution_context()
     emr = EmrJobRunner(region=REGION)
@@ -95,7 +95,7 @@ def test_emr_log_location_for_cluster(emr_cluster_config, mock_s3_bucket):
     assert "Log URI not specified, cannot retrieve step execution logs" in str(exc_info.value)
 
 
-@mock_emr
+@mock_aws
 def test_emr_retrieve_logs(emr_cluster_config, mock_s3_bucket):
     context = create_test_pipeline_execution_context()
     emr = EmrJobRunner(region=REGION)
@@ -159,7 +159,7 @@ def test_wait_for_log(mock_s3_bucket):
     assert "EMR log file did not appear on S3 after waiting" in str(exc_info.value)
 
 
-@mock_emr
+@mock_aws
 def test_is_emr_step_complete(emr_cluster_config):
     context = create_test_pipeline_execution_context()
     emr = EmrJobRunner(region=REGION, check_cluster_every=1)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/emr_tests/test_pyspark.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/emr_tests/test_pyspark.py
@@ -20,7 +20,7 @@ from dagster_aws.emr import EmrError, EmrJobRunner
 from dagster_aws.emr.pyspark_step_launcher import EmrPySparkStepLauncher, emr_pyspark_step_launcher
 from dagster_aws.s3 import s3_resource
 from dagster_pyspark import DataFrame, pyspark_resource
-from moto import mock_emr
+from moto import mock_aws
 from pyspark.sql import Row
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
@@ -115,7 +115,7 @@ def test_local():
     assert result.success
 
 
-@mock_emr
+@mock_aws
 @mock.patch("dagster_aws.emr.pyspark_step_launcher.EmrPySparkStepLauncher.read_events")
 @mock.patch("dagster_aws.emr.emr.EmrJobRunner.is_emr_step_complete")
 @pytest.mark.skipif(sys.version_info >= (3, 11), reason="no pyspark support on 3.11")

--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -44,7 +44,7 @@ setup(
         "pyspark": ["dagster-pyspark"],
         "test": [
             "botocore!=1.32.1",
-            "moto[s3,server]>=2.2.8",
+            "moto>=5",
             "requests-mock",
             "xmltodict==0.12.0",  # pinned until moto>=3.1.9 (https://github.com/spulec/moto/issues/5112)
         ],

--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -44,7 +44,7 @@ setup(
         "pyspark": ["dagster-pyspark"],
         "test": [
             "botocore!=1.32.1",
-            "moto[s3,server]>=2.2.8,<5.0",
+            "moto[s3,server]>=2.2.8",
             "requests-mock",
             "xmltodict==0.12.0",  # pinned until moto>=3.1.9 (https://github.com/spulec/moto/issues/5112)
         ],


### PR DESCRIPTION
Moto 5 changes its public API away from individual service mocks and
toward a generalized `mock_aws` decorator/context manager.

https://github.com/getmoto/moto/issues/7198