### PR TITLE
[docs] Document recommended partition limits

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
@@ -214,9 +214,7 @@ def my_daily_partitioned_asset(context: AssetExecutionContext) -> pd.DataFrame:
 
 If using the default I/O manager, materializing partition `2022-07-23` of this asset would store the output `DataFrame` in a pickle file at a path like `my_daily_partitioned_asset/2022-07-23`.
 
----
-
-## Recommended partition limits
+### Recommended partition limits
 
 We recommend limiting the number of partitions for each asset to 25,000 or fewer. Assets with partition counts exceeding this limit will likely have slower load times in the UI.
 

--- a/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
@@ -218,7 +218,7 @@ If using the default I/O manager, materializing partition `2022-07-23` of this a
 
 ## Recommended partition limits
 
-We recommended limiting partition counts for each asset to 25,000 partitions or fewer. Assets with partition counts exceeding this limit will likely have slower load times in the UI.
+We recommend limiting the number of partitions for each asset to 25,000 or fewer. Assets with partition counts exceeding this limit will likely have slower load times in the UI.
 
 ---
 

--- a/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
@@ -216,6 +216,12 @@ If using the default I/O manager, materializing partition `2022-07-23` of this a
 
 ---
 
+## Recommended partition limits
+
+We recommended limiting partition counts for each asset to 25,000 partitions or fewer. Assets with partition counts exceeding this limit will likely have slower load times in the UI.
+
+---
+
 ## Defining partition dependencies
 
 Partitioned assets can depend on other partitioned assets. In this case, each partition in the downstream asset will depend on a partition or multiple partitions in the upstream asset.

--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -179,6 +179,8 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
     2020-01-02|b
     ...
 
+    We recommended limiting partition counts for each asset to 25,000 partitions or fewer.
+
     Args:
         partitions_defs (Mapping[str, PartitionsDefinition]):
             A mapping of dimension name to partitions definition. The total set of partitions will

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -306,6 +306,8 @@ def raise_error_on_duplicate_partition_keys(partition_keys: Sequence[str]) -> No
 class StaticPartitionsDefinition(PartitionsDefinition[str]):
     """A statically-defined set of partitions.
 
+    We recommended limiting partition counts for each asset to 25,000 partitions or fewer.
+
     Example:
         .. code-block:: python
 
@@ -417,6 +419,8 @@ class DynamicPartitionsDefinition(
 
     Partitions can be added and removed using `instance.add_dynamic_partitions` and
     `instance.delete_dynamic_partition` methods.
+
+    We recommended limiting partition counts for each asset to 25,000 partitions or fewer.
 
     Args:
         name (Optional[str]): The name of the partitions definition.

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -387,7 +387,9 @@ class SensorResult(
         dynamic_partitions_requests (Optional[Sequence[Union[DeleteDynamicPartitionsRequest,
             AddDynamicPartitionsRequest]]]): A list of dynamic partition requests to request dynamic
             partition addition and deletion. Run requests will be evaluated using the state of the
-            partitions with these changes applied.
+            partitions with these changes applied. We recommend limiting partition additions
+            and deletions to a maximum of 25K partitions per sensor evaluation, as this is the maximum
+            recommended partition limit per asset.
         asset_events (Optional[Sequence[Union[AssetObservation, AssetMaterialization, AssetCheckEvaluation]]]):  (Experimental) A
             list of materializations, observations, and asset check evaluations that the system
             will persist on your behalf at the end of sensor evaluation. These events will be not

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -266,6 +266,8 @@ class TimeWindowPartitionsDefinition(
     or after the given start datetime. The last partition in the set will end before the current
     time, unless the end_offset argument is set to a positive number.
 
+    We recommended limiting partition counts for each asset to 25,000 partitions or fewer.
+
     Args:
         cron_schedule (str): Determines the bounds of the time windows.
         start (datetime): The first partition in the set will start on at the first cron_schedule


### PR DESCRIPTION
Adds partition limit recommendation (25K) to docs and apidocs.

Also considered throwing warnings when partition counts exceed 25K, but this seems excessively noisy.