### PR TITLE
feat(dbt): remove support for `dbt-core==1.4.*`

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -438,16 +438,14 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     PackageSpec(
         "python_modules/libraries/dagster-dbt",
         pytest_tox_factors=[
-            "dbt_14X_legacy",
             "dbt_15X_legacy",
             "dbt_16X_legacy",
             "dbt_17X_legacy",
-            "dbt_14X",
             "dbt_15X",
             "dbt_16X",
             "dbt_17X",
-            "dbt_14X_pydantic1",
-            "dbt_14X_legacy_pydantic1",
+            "dbt_pydantic1",
+            "dbt_legacy_pydantic1",
         ],
     ),
     PackageSpec(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -694,9 +694,9 @@ class DbtCliResource(ConfigurableResource):
     @compat_model_validator(mode="before")
     def validate_dbt_version(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Validate that the dbt version is supported."""
-        if version.parse(dbt_version) < version.parse("1.4.0"):
+        if version.parse(dbt_version) < version.parse("1.5.0"):
             raise ValueError(
-                "To use `dagster_dbt.DbtCliResource`, you must use `dbt-core>=1.4.0`. Currently,"
+                "To use `dagster_dbt.DbtCliResource`, you must use `dbt-core>=1.5.0`. Currently,"
                 f" you are using `dbt-core=={dbt_version}`. Please install a compatible dbt-core"
                 " version."
             )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/utils.py
@@ -41,25 +41,15 @@ class DbtCliEvent(NamedTuple):
             else:
                 # in rare cases, the loaded json line may be a string rather than a dictionary
                 if isinstance(parsed_json_line, dict):
-                    message = parsed_json_line.get(
-                        # Attempt to get the message from the dbt-core==1.3.* format
+                    message = parsed_json_line.get("info", {}).get(
                         "msg",
-                        # Otherwise, try to get the message from the dbt-core==1.4.* format
-                        parsed_json_line.get("info", {}).get(
-                            "msg",
-                            # If all else fails, default to the whole line
-                            line,
-                        ),
+                        # If all else fails, default to the whole line
+                        line,
                     )
-                    log_level = parsed_json_line.get(
-                        # Attempt to get the log level from the dbt-core==1.3.* format
+                    log_level = parsed_json_line.get("info", {}).get(
                         "level",
-                        # Otherwise, try to get the message from the dbt-core==1.4.* format
-                        parsed_json_line.get("info", {}).get(
-                            "level",
-                            # If all else fails, default to the `debug` level
-                            "debug",
-                        ),
+                        # If all else fails, default to the `debug` level
+                        "debug",
                     )
         # attempt to parse log level out of raw line
         elif "Done." not in line:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/setup.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/setup.py.jinja
@@ -15,7 +15,6 @@ setup(
         "dagster",
         "dagster-cloud",
         "dagster-dbt",
-        "dbt-core>=1.4.0",
         {%- for dbt_adapter in dbt_adapter_packages %}
         "{{ dbt_adapter }}",
         {%- endfor %}

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_checks.py
@@ -19,12 +19,7 @@ from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.asset_defs import load_assets_from_dbt_manifest
 from dagster_dbt.core.resources_v2 import DbtCliResource
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, DagsterDbtTranslatorSettings
-from dbt.version import __version__ as dbt_version
-from packaging import version
 from pytest_mock import MockerFixture
-
-is_dbt_1_4 = version.parse("1.4.0") <= version.parse(dbt_version) < version.parse("1.5.0")
-
 
 test_asset_checks_dbt_project_dir = (
     Path(__file__).joinpath("..", "dbt_projects", "test_dagster_asset_checks").resolve()
@@ -255,20 +250,12 @@ def test_materialize_no_selection(dbt_commands: List[List[str]]) -> None:
     assert len(result.get_asset_check_evaluations()) == 22
 
 
-@pytest.mark.xfail(
-    is_dbt_1_4,
-    reason="DBT_INDIRECT_SELECTION=empty is not supported in dbt 1.4",
-)
 def test_materialize_asset_and_checks(dbt_commands: List[List[str]]) -> None:
     result = _materialize_dbt_assets(dbt_commands, AssetSelection.keys(AssetKey(["customers"])))
     assert len(result.get_asset_materialization_events()) == 1
     assert len(result.get_asset_check_evaluations()) == 2
 
 
-@pytest.mark.xfail(
-    is_dbt_1_4,
-    reason="DBT_INDIRECT_SELECTION=empty is not supported in dbt 1.4",
-)
 def test_materialize_asset_no_checks(dbt_commands: List[List[str]]) -> None:
     result = _materialize_dbt_assets(
         dbt_commands, AssetSelection.keys(AssetKey(["customers"])).without_checks()
@@ -369,10 +356,6 @@ def test_asset_checks_are_logged_from_resource(
     )
 
 
-@pytest.mark.xfail(
-    is_dbt_1_4,
-    reason="DBT_INDIRECT_SELECTION=empty is not supported in dbt 1.4",
-)
 @pytest.mark.parametrize(
     "selection",
     [

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         f"dagster{pin}",
         # Follow the version support constraints for dbt Core: https://docs.getdbt.com/docs/dbt-versions/core
-        "dbt-core>=1.4,<1.8",
+        "dbt-core>=1.5,<1.8",
         "Jinja2",
         "networkx",
         "orjson",

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -9,28 +9,24 @@ deps =
   -e ../../dagster-pipes
   -e ../dagster-duckdb
   -e ../dagster-duckdb-pandas
-  dbt_14X: dbt-core==1.4.*
-  dbt_14X: dbt-duckdb==1.4.*
   dbt_15X: dbt-core==1.5.*
   dbt_15X: dbt-duckdb==1.5.*
   dbt_16X: dbt-core==1.6.*
   dbt_16X: dbt-duckdb==1.6.*
   dbt_17X: dbt-core==1.7.*
   dbt_17X: dbt-duckdb==1.7.*
-  dbt_14X_pydantic1:        pydantic!=1.10.7,<2.0.0
-  dbt_14X_legacy_pydantic1: pydantic!=1.10.7,<2.0.0
+  dbt_pydantic1:        pydantic!=1.10.7,<2.0.0
+  dbt_legacy_pydantic1: pydantic!=1.10.7,<2.0.0
   -e .[test]
 allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-  dbt_14X_legacy: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
   dbt_15X_legacy: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
   dbt_16X_legacy: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
   dbt_17X_legacy: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
-  dbt_14X: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy" -vv {posargs}
   dbt_15X: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy" -vv {posargs}
   dbt_16X: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy" -vv {posargs}
   dbt_17X: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy" -vv {posargs}
-  dbt_14X_pydantic1: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy" -vv {posargs}
-  dbt_14X_legacy_pydantic1: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
+  dbt_pydantic1: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy" -vv {posargs}
+  dbt_legacy_pydantic1: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}


### PR DESCRIPTION
## Summary & Motivation
`dbt-core==1.4.*` has been EOL since January 25, 2024: https://docs.getdbt.com/docs/dbt-versions/core.

Also, enforce that dbt-core>=1.5 on installation.

Same rodeo as https://github.com/dagster-io/dagster/pull/18594.

## How I Tested These Changes
pytest
