### PR TITLE
[asset-subset] Use type system to handle compatibility issues with AssetSubsets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition.py
@@ -197,7 +197,9 @@ class AssetConditionEvaluation(NamedTuple):
         if discarded_subset is None:
             return self.true_subset
         else:
-            return self.true_subset | discarded_subset
+            # the true_subset and discarded_subset were created on the same tick, so they are
+            # guaranteed to be compatible with each other
+            return self.true_subset | discarded_subset.as_valid
 
     def for_child(self, child_condition: "AssetCondition") -> Optional["AssetConditionEvaluation"]:
         """Returns the evaluation of a given child condition by finding the child evaluation that
@@ -428,7 +430,7 @@ class AndAssetCondition(
             child_context = context.for_child(condition=child, candidate_subset=true_subset)
             child_result = child.evaluate(child_context)
             child_results.append(child_result)
-            true_subset &= child_result.true_subset
+            true_subset &= child_result.true_subset.as_valid
         return AssetConditionResult.create_from_children(context, true_subset, child_results)
 
 
@@ -451,7 +453,7 @@ class OrAssetCondition(
             )
             child_result = child.evaluate(child_context)
             child_results.append(child_result)
-            true_subset |= child_result.true_subset
+            true_subset |= child_result.true_subset.as_valid
         return AssetConditionResult.create_from_children(context, true_subset, child_results)
 
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -5,6 +5,7 @@ from typing import (
     AbstractSet,
     Callable,
     NamedTuple,
+    NewType,
     Optional,
     Union,
     cast,
@@ -16,6 +17,9 @@ from dagster._core.definitions.partition import (
     AllPartitionsSubset,
     PartitionsDefinition,
     PartitionsSubset,
+)
+from dagster._core.definitions.time_window_partitions import (
+    BaseTimeWindowPartitionsSubset,
 )
 from dagster._serdes.serdes import NamedTupleSerializer, whitelist_for_serdes
 
@@ -74,15 +78,22 @@ class AssetSubset(NamedTuple):
         else:
             return len(self.subset_value)
 
+    @property
+    def as_valid(self) -> "ValidAssetSubset":
+        """Method to indicate to the type checker that this AssetSubset is valid based on the
+        current PartitionsDefinition of the asset it represents.
+        """
+        return self  # type: ignore
+
     @staticmethod
     def all(
         asset_key: AssetKey,
         partitions_def: Optional[PartitionsDefinition],
         dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
         current_time: Optional[datetime.datetime] = None,
-    ) -> "AssetSubset":
+    ) -> "ValidAssetSubset":
         if partitions_def is None:
-            return AssetSubset(asset_key=asset_key, value=True)
+            return AssetSubset(asset_key=asset_key, value=True).as_valid
         else:
             if dynamic_partitions_store is None or current_time is None:
                 check.failed(
@@ -91,23 +102,25 @@ class AssetSubset(NamedTuple):
             return AssetSubset(
                 asset_key=asset_key,
                 value=AllPartitionsSubset(partitions_def, dynamic_partitions_store, current_time),
-            )
+            ).as_valid
 
     @staticmethod
-    def empty(asset_key: AssetKey, partitions_def: Optional[PartitionsDefinition]) -> "AssetSubset":
+    def empty(
+        asset_key: AssetKey, partitions_def: Optional[PartitionsDefinition]
+    ) -> "ValidAssetSubset":
         if partitions_def is None:
-            return AssetSubset(asset_key=asset_key, value=False)
+            return AssetSubset(asset_key=asset_key, value=False).as_valid
         else:
-            return AssetSubset(asset_key=asset_key, value=partitions_def.empty_subset())
+            return AssetSubset(asset_key=asset_key, value=partitions_def.empty_subset()).as_valid
 
     @staticmethod
     def from_asset_partitions_set(
         asset_key: AssetKey,
         partitions_def: Optional[PartitionsDefinition],
         asset_partitions_set: AbstractSet[AssetKeyPartitionKey],
-    ) -> "AssetSubset":
+    ) -> "ValidAssetSubset":
         if partitions_def is None:
-            return AssetSubset(asset_key=asset_key, value=bool(asset_partitions_set))
+            return AssetSubset(asset_key=asset_key, value=bool(asset_partitions_set)).as_valid
         else:
             return AssetSubset(
                 asset_key=asset_key,
@@ -118,17 +131,17 @@ class AssetSubset(NamedTuple):
                         if ap.partition_key is not None
                     }
                 ),
-            )
+            ).as_valid
 
     def inverse(
         self,
         partitions_def: Optional[PartitionsDefinition],
         current_time: Optional[datetime.datetime] = None,
         dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
-    ) -> "AssetSubset":
+    ) -> "ValidAssetSubset":
         """Returns the AssetSubset containing all asset partitions which are not in this AssetSubset."""
         if partitions_def is None:
-            return self._replace(value=not self.bool_value)
+            return self._replace(value=not self.bool_value).as_valid
         else:
             value = partitions_def.subset_with_partition_keys(
                 self.subset_value.get_partition_keys_not_in_subset(
@@ -137,21 +150,52 @@ class AssetSubset(NamedTuple):
                     dynamic_partitions_store=dynamic_partitions_store,
                 )
             )
-            return self._replace(value=value)
+            return self._replace(value=value).as_valid
 
-    def _oper(self, other: "AssetSubset", oper: Callable) -> "AssetSubset":
+    def _oper(self, other: "ValidAssetSubset", oper: Callable) -> "ValidAssetSubset":
         value = oper(self.value, other.value)
-        return self._replace(value=value)
+        return other._replace(value=value)
 
-    def __sub__(self, other: "AssetSubset") -> "AssetSubset":
+    def __sub__(self, other: "ValidAssetSubset") -> "ValidAssetSubset":
+        """Returns an AssetSubset representing self - other if they are compatible, otherwise
+        returns an empty subset.
+        """
+        if not self.is_compatible_with(other):
+            return other._replace(
+                # unfortunately, this is the best way to get an empty subset of an unknown type
+                # if you don't have access to the partitions definition
+                value=(other.subset_value - other.subset_value) if other.is_partitioned else False
+            )
+
         if not self.is_partitioned:
-            return self._replace(value=self.bool_value and not other.bool_value)
+            return other._replace(value=self.bool_value and not other.bool_value)
         return self._oper(other, operator.sub)
 
-    def __and__(self, other: "AssetSubset") -> "AssetSubset":
+    def __rsub__(self, other: "ValidAssetSubset") -> "ValidAssetSubset":
+        """Returns an AssetSubset representing other - self if they are compatible, otherwise
+        returns other.
+        """
+        if not self.is_compatible_with(other):
+            return other
+
+        if not self.is_partitioned:
+            return other._replace(value=self.bool_value and not other.bool_value)
+        return self._oper(other, operator.sub)
+
+    def __and__(self, other: "ValidAssetSubset") -> "ValidAssetSubset":
+        """Returns the intersection of this AssetSubset and another AssetSubset if they are compatible,
+        otherwise returns the other AssetSubset.
+        """
+        if not self.is_compatible_with(other):
+            return other
         return self._oper(other, operator.and_)
 
-    def __or__(self, other: "AssetSubset") -> "AssetSubset":
+    def __or__(self, other: "ValidAssetSubset") -> "ValidAssetSubset":
+        """Returns the union of this AssetSubset and another AssetSubset if they are compatible,
+        otherwise returns the other AssetSubset.
+        """
+        if not self.is_compatible_with(other):
+            return other
         return self._oper(other, operator.or_)
 
     def __contains__(self, item: AssetKeyPartitionKey) -> bool:
@@ -161,3 +205,22 @@ class AssetSubset(NamedTuple):
             )
         else:
             return item.asset_key == self.asset_key and item.partition_key in self.subset_value
+
+    def is_compatible_with(self, other: "ValidAssetSubset") -> bool:
+        if self.asset_key != other.asset_key:
+            return False
+        elif isinstance(self.value, BaseTimeWindowPartitionsSubset):
+            # for time window partitions, we have access to the underlying partitions definitions so
+            # we can ensure those are identical
+            return (
+                isinstance(other.value, (BaseTimeWindowPartitionsSubset, AllPartitionsSubset))
+                and other.value.partitions_def == self.value.partitions_def
+            )
+        else:
+            # otherwise, we just make sure that the underlying values are of the same type
+            return self.is_partitioned == other.is_partitioned
+
+
+# This type represents an AssetSubset which has been validated by the type checker to be compatible
+# with the current PartitionsDefinition of the asset it represents.
+ValidAssetSubset = NewType("ValidAssetSubset", AssetSubset)

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -580,17 +580,11 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
         previous_handled_subset = (
             context.previous_evaluation_state.get_extra_state(context.condition, AssetSubset)
             if context.previous_evaluation_state
-            else context.instance_queryer.get_materialized_asset_subset(asset_key=context.asset_key)
-        )
-        return (
-            (
-                previous_handled_subset
-                or context.instance_queryer.get_materialized_asset_subset(
-                    asset_key=context.asset_key
-                )
-            )
-            | context.previous_tick_requested_subset
-            | context.materialized_since_previous_tick_subset
+            else None
+        ) or context.instance_queryer.get_materialized_asset_subset(asset_key=context.asset_key)
+
+        return previous_handled_subset | (
+            context.previous_tick_requested_subset | context.materialized_since_previous_tick_subset
         )
 
     def evaluate_for_asset(

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -30,7 +30,6 @@ from dagster._core.definitions.freshness_based_auto_materialize import (
 )
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.time_window_partitions import (
-    TimeWindowPartitionsSubset,
     get_time_partitions_def,
 )
 from dagster._core.storage.dagster_run import RunsFilter
@@ -581,19 +580,8 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
         previous_handled_subset = (
             context.previous_evaluation_state.get_extra_state(context.condition, AssetSubset)
             if context.previous_evaluation_state
-            else None
+            else context.instance_queryer.get_materialized_asset_subset(asset_key=context.asset_key)
         )
-        if previous_handled_subset:
-            # partitioned -> unpartitioned or vice versa
-            if previous_handled_subset.is_partitioned != (context.partitions_def is not None):
-                previous_handled_subset = None
-            # time partitions def changed
-            elif (
-                previous_handled_subset.is_partitioned
-                and isinstance(previous_handled_subset.subset_value, TimeWindowPartitionsSubset)
-                and previous_handled_subset.subset_value.partitions_def != context.partitions_def
-            ):
-                previous_handled_subset = None
         return (
             (
                 previous_handled_subset
@@ -903,8 +891,12 @@ class SkipOnBackfillInProgressRule(
         from .asset_condition import AssetConditionResult
 
         backfilling_subset = (
-            context.instance_queryer.get_active_backfill_target_asset_graph_subset()
-        ).get_asset_subset(context.asset_key, context.asset_graph)
+            # this backfilling subset is aware of the current partitions definitions, and so will
+            # be valid
+            (context.instance_queryer.get_active_backfill_target_asset_graph_subset())
+            .get_asset_subset(context.asset_key, context.asset_graph)
+            .as_valid
+        )
 
         if backfilling_subset.size == 0:
             true_subset = context.empty_subset()

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
@@ -205,7 +205,7 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
         if serialized is None:
             # Confusingly, we used `None` to indicate "all of an unpartitioned asset" in the old
             # serialization scheme
-            return AssetSubset(asset_key, False)
+            return AssetSubset(asset_key, True)
         return deserialize_serialized_partitions_subset_to_asset_subset(
             serialized, asset_key, self.partitions_def
         )


### PR DESCRIPTION
## Summary & Motivation

AssetSubsets can be serialized and persist across ticks. Between serialization time and deserialization time, the PartitionsDefinition of the asset that the AssetSubset references may change. This means that it is possible for us to serialize an AssetSubset when an asset is (e.g.) unpartitioned, then deserialize it at a time when that asset is (e.g.) time-partitioned.

If we then attempt to perform operations between an AssetSubset created in the past and an AssetSubset created on this tick, we'll hit an error.

We could have guards against this situation at every single call site where we do this sort of thing, but considering the rarity of this situation, and the fact that generally the handling would be pretty similar in all of these cases, I thought it would be nicer to bake this into the operators themselves. That is:

```
# The union of a subset with some invalid information is just the original subset
<A : invalid> | <B : valid> = B  

# The intersection of a subset with some invalid information is the empty subset
<A : invalid> & <B : valid> = <empty subset>

# A valid subset minus some invalid information is just the original subset
<A : valid> - <B : invalid> = A

# Some invalid information minus a valid subset is just an empty subset
<A : invalid> - <B : valid> = <empty>
```

In short, "invalid" subsets are treated as the empty subset across all operations.

That introduces a new problem though -- how do we know which subset is the "valid" one? The best way to do that is to reference the current PartitionsDefinition, but this is not something we have access to within these operators.

That's where the type system comes in -- whenever you create an AssetSubset using an explicit PartitionsDefinition, you get a "ValidAssetSubset", i.e. an AssetSubset which is known to reflect the current PartitionsDefinition. This way, we can track this "validity" as it flows through the system. I also included an "escape hatch" to allow AssetSubsets to be manually marked as "valid", but this is used only when necessary.

I found this approach enormously helpful in catching potential bugs.

## How I Tested These Changes
