### PR TITLE
feat(dagster-k8s): support auto-detecting the namespace based on kubeconfig on in-cluster secret

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -279,7 +279,7 @@ class _PipesK8sClient(PipesClient):
 
 
 def _detect_current_namespace(
-    kubeconfig_file: str, namespace_secret_path: Path = _NAMESPACE_SECRET_PATH
+    kubeconfig_file: Optional[str], namespace_secret_path: Path = _NAMESPACE_SECRET_PATH
 ) -> Optional[str]:
     """Get the current in-cluster namespace when operating within the cluster.
 
@@ -290,6 +290,9 @@ def _detect_current_namespace(
         with namespace_secret_path.open() as f:
             # We only need to read the first line, this guards us against bad input.
             return f.read().strip()
+
+    if not kubeconfig_file:
+        return None
 
     try:
         _, active_context = kubernetes.config.list_kube_config_contexts(kubeconfig_file)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -3,6 +3,7 @@ import random
 import string
 from contextlib import contextmanager
 from typing import Any, Iterator, Mapping, Optional, Sequence, Union
+from pathlib import Path
 
 import kubernetes
 from dagster import (
@@ -46,6 +47,7 @@ def get_pod_name(run_id: str, op_name: str):
 
 
 DEFAULT_CONTAINER_NAME = "dagster-pipes-execution"
+_NAMESPACE_SECRET_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 
 
 @experimental
@@ -202,7 +204,8 @@ class _PipesK8sClient(PipesClient):
             command (Optional[Union[str, Sequence[str]]]):
                 The command to set the first container in the pod spec to use.
             namespace (Optional[str]):
-                Which kubernetes namespace to use, defaults to "default"
+                Which kubernetes namespace to use, defaults to the current namespace if
+                running inside a kubernetes cluster or falling back to "default".
             env (Optional[Mapping[str,str]]):
                 A mapping of environment variable names to values to set on the first
                 container in the pod spec, on top of those configured on resource.
@@ -234,7 +237,7 @@ class _PipesK8sClient(PipesClient):
             context_injector=self.context_injector,
             message_reader=self.message_reader,
         ) as pipes_session:
-            namespace = namespace or "default"
+            namespace = namespace or _detect_current_namespace(self.kubeconfig_file) or "default"
             pod_name = get_pod_name(context.run_id, context.op.name)
             pod_body = build_pod_body(
                 pod_name=pod_name,
@@ -273,6 +276,24 @@ class _PipesK8sClient(PipesClient):
             finally:
                 client.core_api.delete_namespaced_pod(pod_name, namespace)
         return PipesClientCompletedInvocation(pipes_session)
+
+
+def _detect_current_namespace(kubeconfig_file: str, namespace_secret_path: Path = _NAMESPACE_SECRET_PATH) -> Optional[str]:
+    """Get the current in-cluster namespace when operating within the cluster.
+
+    First attempt to read it from the `serviceaccount` secret or get it from the kubeconfig_file if it is possible.
+    It will attempt to take from the active context if it exists and returns None if it does not exist.
+    """
+    if namespace_secret_path.exists():
+        with namespace_secret_path.open() as f:
+            # We only need to read the first line, this guards us against bad input.
+            return f.read().strip()
+
+    try:
+        _, active_context = kubernetes.config.list_kube_config_contexts(kubeconfig_file)
+        return active_context["context"]["namespace"]
+    except KeyError:
+        return None
 
 
 def build_pod_body(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -2,8 +2,8 @@ import os
 import random
 import string
 from contextlib import contextmanager
-from typing import Any, Iterator, Mapping, Optional, Sequence, Union
 from pathlib import Path
+from typing import Any, Iterator, Mapping, Optional, Sequence, Union
 
 import kubernetes
 from dagster import (
@@ -278,7 +278,9 @@ class _PipesK8sClient(PipesClient):
         return PipesClientCompletedInvocation(pipes_session)
 
 
-def _detect_current_namespace(kubeconfig_file: str, namespace_secret_path: Path = _NAMESPACE_SECRET_PATH) -> Optional[str]:
+def _detect_current_namespace(
+    kubeconfig_file: str, namespace_secret_path: Path = _NAMESPACE_SECRET_PATH
+) -> Optional[str]:
     """Get the current in-cluster namespace when operating within the cluster.
 
     First attempt to read it from the `serviceaccount` secret or get it from the kubeconfig_file if it is possible.

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_pipes.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster_k8s.pipes import build_pod_body, _detect_current_namespace
+from dagster_k8s.pipes import _detect_current_namespace, build_pod_body
 
 
 def test_pod_building():
@@ -190,9 +190,11 @@ def test_pod_building():
             base_pod_meta=None,
         )
 
+
 def _kubeconfig(tmpdir: str, current_context: str) -> str:
     kubeconfig = Path(tmpdir) / "kubeconfig"
-    kubeconfig.write_text("""\
+    kubeconfig.write_text(
+        f"""\
 ---
 apiVersion: v1
 clusters:
@@ -218,24 +220,30 @@ users:
   user:
     client-certificate-data: deadbeef==
     client-key-data: deadbeef==
-""".format(current_context=current_context))
+"""
+    )
     return str(kubeconfig)
+
 
 @pytest.fixture
 def kubeconfig_dummy(tmpdir) -> str:
     return _kubeconfig(tmpdir, "ctx")
 
+
 @pytest.fixture
 def kubeconfig_with_namespace(tmpdir) -> str:
     return _kubeconfig(tmpdir, "ctx-with-namespace")
+
 
 def test_namespace_autodetect_fails(kubeconfig_dummy):
     got = _detect_current_namespace(kubeconfig_dummy)
     assert got is None
 
+
 def test_namespace_autodetect_from_kubeconfig_active_context(kubeconfig_with_namespace):
     got = _detect_current_namespace(kubeconfig_with_namespace)
     assert got == "my-namespace"
+
 
 def test_pipes_client_namespace_autodetection_from_secret(tmpdir, kubeconfig_dummy):
     namespace_secret_path = Path(tmpdir) / "namespace_secret"


### PR DESCRIPTION
## Summary & Motivation

With this change we can successfully detect the current namespace when operating
inside of a cluster or use the active context within a kubeconfig file before
falling back to 'default' as our namespace where we launch a dagster pipes pod.

Note, this may be a breaking change for users running inside of a cluster if
they relied on the default being `default` but since #19459 fixed the loading of
kubeconfig, it should be fine. Likewise, users would now have to select the
correct kubeconfig context when running `dagster dev` locally and using pipes.
If users don't have a namespace in the current context, it should work as
previously.

## How I Tested These Changes

Unit tests.
