### PR TITLE
Account for cgroups v2 in container utilization metrics

### DIFF
--- a/python_modules/dagster/dagster/_utils/container.py
+++ b/python_modules/dagster/dagster/_utils/container.py
@@ -1,16 +1,33 @@
 import logging
 import os
+from enum import Enum
 from typing import Optional, TypedDict
 
 import pendulum
 
 
-def cpu_usage_path():
+def cpu_usage_path_cgroup_v1():
     """Path to the cgroup file containing the CPU time in nanoseconds.
 
     We use cgroup files instead of the psutil library because psutil uses the host machine's CPU allocation in virtualized environments like Docker, K8s, ECS, etc.
     """
     return os.getenv("DAGSTER_CPU_USAGE_PATH", "/sys/fs/cgroup/cpuacct/cpuacct.usage")
+
+
+def cpu_stat_path_cgroup_v2():
+    """Path to the cgroup file containing current CPU stats in microseconds.
+
+    We use cgroup files instead of the psutil library because psutil uses the host machine's CPU allocation in virtualized environments like Docker, K8s, ECS, etc.
+    """
+    return os.getenv("DAGSTER_CPU_STAT_PATH", "/sys/fs/cgroup/cpu.stat")
+
+
+def cpu_max_path_cgroup_v2():
+    """Path to the cgroup file containing the maximum CPU quota per period in microseconds.
+
+    We use cgroup files instead of the psutil library because psutil uses the host machine's CPU allocation in virtualized environments like Docker, K8s, ECS, etc.
+    """
+    return os.getenv("DAGSTER_CPU_MAX_PATH", "/sys/fs/cgroup/cpu.max")
 
 
 def cpu_cfs_quota_us_path():
@@ -42,32 +59,54 @@ def cpu_info_path():
     return os.getenv("DAGSTER_CPU_INFO_PATH", "/proc/cpuinfo")
 
 
-def memory_usage_path():
+def memory_usage_path_cgroup_v1():
     """Path to the cgroup file containing the memory usage in bytes.
 
     We use cgroup files instead of the psutil library because psutil uses the host machine's memory allocation in virtualized environments like Docker, K8s, ECS, etc.
     """
-    return os.getenv("DAGSTER_MEMORY_USAGE_PATH", "/sys/fs/cgroup/memory/memory.usage_in_bytes")
+    return os.getenv("DAGSTER_MEMORY_USAGE_PATH_V1", "/sys/fs/cgroup/memory/memory.usage_in_bytes")
 
 
-def memory_limit_path():
+def memory_usage_path_cgroup_v2():
+    """Path to the cgroup file containing the memory usage in bytes.
+
+    We use cgroup files instead of the psutil library because psutil uses the host machine's memory allocation in virtualized environments like Docker, K8s, ECS, etc.
+    """
+    return os.getenv("DAGSTER_MEMORY_USAGE_PATH_V2", "/sys/fs/cgroup/memory.current")
+
+
+def memory_limit_path_cgroup_v1():
     """Path to the cgroup file containing the memory limit in bytes.
 
     We use cgroup files instead of the psutil library because psutil uses the host machine's memory allocation in virtualized environments like Docker, K8s, ECS, etc.
     """
-    return os.getenv("DAGSTER_MEMORY_LIMIT_PATH", "/sys/fs/cgroup/memory/memory.limit_in_bytes")
+    return os.getenv("DAGSTER_MEMORY_LIMIT_PATH_V1", "/sys/fs/cgroup/memory/memory.limit_in_bytes")
+
+
+def memory_limit_path_cgroup_v2():
+    """Path to the cgroup file containing the memory limit in bytes.
+
+    We use cgroup files instead of the psutil library because psutil uses the host machine's memory allocation in virtualized environments like Docker, K8s, ECS, etc.
+    """
+    return os.getenv("DAGSTER_MEMORY_LIMIT_PATH_V2", "/sys/fs/cgroup/memory.max")
+
+
+class CGroupVersion(Enum):
+    V1 = "V1"
+    V2 = "V2"
 
 
 class ContainerUtilizationMetrics(TypedDict):
     num_allocated_cores: Optional[int]
-    cpu_usage: Optional[float]
-    cpu_cfs_quota_us: Optional[float]
-    cpu_cfs_period_us: Optional[float]
-    memory_usage: Optional[float]
-    memory_limit: Optional[int]
+    cpu_usage: Optional[float]  # CPU usage in seconds
+    cpu_cfs_quota_us: Optional[float]  # CPU quota per period in microseconds
+    cpu_cfs_period_us: Optional[float]  # CPU period in microseconds
+    memory_usage: Optional[float]  # Memory usage in bytes
+    memory_limit: Optional[int]  # Memory limit in bytes
     measurement_timestamp: Optional[float]
     previous_cpu_usage: Optional[float]
     previous_measurement_timestamp: Optional[float]
+    cgroup_version: Optional[str]
 
 
 def retrieve_containerized_utilization_metrics(
@@ -76,24 +115,67 @@ def retrieve_containerized_utilization_metrics(
     previous_cpu_usage: Optional[float],
 ) -> ContainerUtilizationMetrics:
     """Retrieve the CPU and memory utilization metrics from cgroup and proc files."""
+    cgroup_version = _retrieve_cgroup_version(logger)
     return {
         "num_allocated_cores": _retrieve_containerized_num_allocated_cores(logger),
-        "cpu_usage": _retrieve_containerized_cpu_usage(logger),
+        "cpu_usage": _retrieve_containerized_cpu_usage(logger, cgroup_version),
         "previous_cpu_usage": previous_cpu_usage,
         "previous_measurement_timestamp": previous_measurement_timestamp,
-        "cpu_cfs_quota_us": _retrieve_containerized_cpu_cfs_quota_us(logger),
-        "cpu_cfs_period_us": _retrieve_containerized_cpu_cfs_period_us(logger),
-        "memory_usage": _retrieve_containerized_memory_usage(logger),
-        "memory_limit": _retrieve_containerized_memory_limit(logger),
+        "cpu_cfs_quota_us": _retrieve_containerized_cpu_cfs_quota_us(logger, cgroup_version),
+        "cpu_cfs_period_us": _retrieve_containerized_cpu_cfs_period_us(logger, cgroup_version),
+        "memory_usage": _retrieve_containerized_memory_usage(logger, cgroup_version),
+        "memory_limit": _retrieve_containerized_memory_limit(logger, cgroup_version),
         "measurement_timestamp": pendulum.now("UTC").float_timestamp,
+        "cgroup_version": cgroup_version.value if cgroup_version else None,
     }
 
 
-def _retrieve_containerized_cpu_usage(logger: Optional[logging.Logger]) -> Optional[float]:
-    """Retrieve the CPU time in seconds from the cgroup file."""
+def _retrieve_cgroup_version(logger: Optional[logging.Logger]) -> Optional[CGroupVersion]:
     try:
-        with open(cpu_usage_path()) as f:
+        # Run the stat command in a subprocess and read the result.
+        status = os.popen("stat -fc %T /sys/fs/cgroup/").read().strip()
+        if status == "cgroup2fs":
+            return CGroupVersion.V2
+        elif status == "tmpfs":
+            return CGroupVersion.V1
+        else:
+            return None
+    except Exception as e:
+        if logger:
+            logger.info(f"No cgroup version found: {e}")
+        return None
+
+
+def _retrieve_containerized_cpu_usage(
+    logger: Optional[logging.Logger], cgroup_version: Optional[CGroupVersion]
+) -> Optional[float]:
+    """Retrieve the CPU time in seconds from the cgroup file."""
+    if cgroup_version == CGroupVersion.V1:
+        return _retrieve_containerized_cpu_usage_v1(logger)
+    elif cgroup_version == CGroupVersion.V2:
+        return _retrieve_containerized_cpu_usage_v2(logger)
+    else:
+        return None
+
+
+def _retrieve_containerized_cpu_usage_v1(logger: Optional[logging.Logger]) -> Optional[float]:
+    try:
+        with open(cpu_usage_path_cgroup_v1()) as f:
             return float(f.read()) / 1e9  # Cpuacct.usage is in nanoseconds
+    except Exception as e:
+        if logger:
+            logger.error(f"Failed to retrieve CPU time from cgroup: {e}")
+        return None
+
+
+def _retrieve_containerized_cpu_usage_v2(logger: Optional[logging.Logger]) -> Optional[float]:
+    try:
+        with open(cpu_stat_path_cgroup_v2()) as f:
+            lines = f.readlines()
+            for line in lines:
+                if line.startswith("usage_usec"):
+                    return float(line.split()[1]) / 1e6  # Cpu.stat usage_usec is in microseconds
+            return None
     except Exception as e:
         if logger:
             logger.error(f"Failed to retrieve CPU time from cgroup: {e}")
@@ -111,10 +193,21 @@ def _retrieve_containerized_num_allocated_cores(logger: Optional[logging.Logger]
         return None
 
 
-def _retrieve_containerized_memory_usage(logger: Optional[logging.Logger]) -> Optional[int]:
+def _retrieve_containerized_memory_usage(
+    logger: Optional[logging.Logger], cgroup_version: Optional[CGroupVersion]
+) -> Optional[int]:
     """Retrieve the memory usage in bytes from the cgroup file."""
+    if cgroup_version == CGroupVersion.V1:
+        return _retrieve_containerized_memory_usage_v1(logger)
+    elif cgroup_version == CGroupVersion.V2:
+        return _retrieve_containerized_memory_usage_v2(logger)
+    else:
+        return None
+
+
+def _retrieve_containerized_memory_usage_v1(logger: Optional[logging.Logger]) -> Optional[int]:
     try:
-        with open(memory_usage_path()) as f:
+        with open(memory_usage_path_cgroup_v1()) as f:
             return int(f.read())
     except Exception as e:
         if logger:
@@ -122,10 +215,31 @@ def _retrieve_containerized_memory_usage(logger: Optional[logging.Logger]) -> Op
         return None
 
 
-def _retrieve_containerized_memory_limit(logger: Optional[logging.Logger]) -> Optional[int]:
-    """Retrieve the memory limit in bytes from the cgroup file."""
+def _retrieve_containerized_memory_usage_v2(logger: Optional[logging.Logger]) -> Optional[int]:
     try:
-        with open(memory_limit_path()) as f:
+        with open(memory_usage_path_cgroup_v2()) as f:
+            return int(f.read())
+    except Exception as e:
+        if logger:
+            logger.error(f"Failed to retrieve memory usage from cgroup: {e}")
+        return None
+
+
+def _retrieve_containerized_memory_limit(
+    logger: Optional[logging.Logger], cgroup_version: Optional[CGroupVersion]
+) -> Optional[int]:
+    """Retrieve the memory limit in bytes from the cgroup file."""
+    if cgroup_version == CGroupVersion.V1:
+        return _retrieve_containerized_memory_limit_v1(logger)
+    elif cgroup_version == CGroupVersion.V2:
+        return _retrieve_containerized_memory_limit_v2(logger)
+    else:
+        return None
+
+
+def _retrieve_containerized_memory_limit_v1(logger: Optional[logging.Logger]) -> Optional[int]:
+    try:
+        with open(memory_limit_path_cgroup_v1()) as f:
             return int(f.read())
     except:
         if logger:
@@ -133,8 +247,31 @@ def _retrieve_containerized_memory_limit(logger: Optional[logging.Logger]) -> Op
         return None
 
 
-def _retrieve_containerized_cpu_cfs_period_us(logger: Optional[logging.Logger]) -> Optional[float]:
+def _retrieve_containerized_memory_limit_v2(logger: Optional[logging.Logger]) -> Optional[int]:
+    try:
+        with open(memory_limit_path_cgroup_v2()) as f:
+            return int(f.read())
+    except:
+        if logger:
+            logger.exception("Failed to retrieve memory limit from cgroup")
+        return None
+
+
+def _retrieve_containerized_cpu_cfs_period_us(
+    logger: Optional[logging.Logger], cgroup_version: Optional[CGroupVersion]
+) -> Optional[float]:
     """Retrieve the CPU period in microseconds from the cgroup file."""
+    if cgroup_version == CGroupVersion.V1:
+        return _retrieve_containerized_cpu_cfs_period_us_v1(logger)
+    elif cgroup_version == CGroupVersion.V2:
+        return _retrieve_containerized_cpu_cfs_period_us_v2(logger)
+    else:
+        return None
+
+
+def _retrieve_containerized_cpu_cfs_period_us_v1(
+    logger: Optional[logging.Logger],
+) -> Optional[float]:
     try:
         with open(cpu_cfs_period_us_path()) as f:
             return float(f.read())
@@ -144,11 +281,52 @@ def _retrieve_containerized_cpu_cfs_period_us(logger: Optional[logging.Logger]) 
         return None
 
 
-def _retrieve_containerized_cpu_cfs_quota_us(logger: Optional[logging.Logger]) -> Optional[float]:
+def _retrieve_containerized_cpu_cfs_period_us_v2(
+    logger: Optional[logging.Logger],
+) -> Optional[float]:
+    # We can retrieve period information from the cpu.max file. The file is in the format $MAX $PERIOD and is only one line.
+    try:
+        with open(cpu_max_path_cgroup_v2()) as f:
+            line = f.readline()
+            return float(line.split()[1])
+    except:
+        if logger:
+            logger.exception("Failed to retrieve CPU period from cgroup")
+        return None
+
+
+def _retrieve_containerized_cpu_cfs_quota_us(
+    logger: Optional[logging.Logger], cgroup_version: Optional[CGroupVersion]
+) -> Optional[float]:
     """Retrieve the CPU quota in microseconds from the cgroup file."""
+    if cgroup_version == CGroupVersion.V1:
+        return _retrieve_containerized_cpu_cfs_quota_us_v1(logger)
+    elif cgroup_version == CGroupVersion.V2:
+        return _retrieve_containerized_cpu_cfs_quota_us_v2(logger)
+    else:
+        return None
+
+
+def _retrieve_containerized_cpu_cfs_quota_us_v1(
+    logger: Optional[logging.Logger],
+) -> Optional[float]:
     try:
         with open(cpu_cfs_quota_us_path()) as f:
             return float(f.read())
+    except:
+        if logger:
+            logger.exception("Failed to retrieve CPU quota from cgroup")
+        return None
+
+
+def _retrieve_containerized_cpu_cfs_quota_us_v2(
+    logger: Optional[logging.Logger],
+) -> Optional[float]:
+    # We can retrieve quota information from the cpu.max file. The file is in the format $MAX $PERIOD .
+    try:
+        with open(cpu_max_path_cgroup_v2()) as f:
+            line = f.readline()
+            return float(line.split()[0])
     except:
         if logger:
             logger.exception("Failed to retrieve CPU quota from cgroup")

--- a/python_modules/dagster/dagster_tests/utils_tests/test_container_utils.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_container_utils.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 from typing import Optional
 
+import mock
 import pytest
-from dagster._utils.container import retrieve_containerized_utilization_metrics
+from dagster._utils.container import CGroupVersion, retrieve_containerized_utilization_metrics
 from dagster._utils.env import environ
 
 
@@ -14,11 +15,21 @@ def temp_dir(tmp_path: Path):
             "DAGSTER_CPU_INFO_PATH": f"{tmp_path}/cpuinfo",
             "DAGSTER_CPU_CFS_QUOTA_US_PATH": f"{tmp_path}/cpu.cfs_quota_us",
             "DAGSTER_CPU_CFS_PERIOD_US_PATH": f"{tmp_path}/cpu.cfs_period_us",
-            "DAGSTER_MEMORY_USAGE_PATH": f"{tmp_path}/memory.usage_in_bytes",
-            "DAGSTER_MEMORY_LIMIT_PATH": f"{tmp_path}/memory.limit_in_bytes",
+            "DAGSTER_MEMORY_USAGE_PATH_V1": f"{tmp_path}/memory.usage_in_bytes",
+            "DAGSTER_MEMORY_LIMIT_PATH_V1": f"{tmp_path}/memory.limit_in_bytes",
+            "DAGSTER_CPU_STAT_PATH": f"{tmp_path}/cpu.stat",
+            "DAGSTER_CPU_MAX_PATH": f"{tmp_path}/cpu.max",
+            "DAGSTER_MEMORY_USAGE_PATH_V2": f"{tmp_path}/memory.current",
+            "DAGSTER_MEMORY_LIMIT_PATH_V2": f"{tmp_path}/memory.max",
         }
     ):
         yield tmp_path
+
+
+@pytest.fixture
+def cgroup_version_mock():
+    with mock.patch("dagster._utils.container._retrieve_cgroup_version") as mock_cgroup_version:
+        yield mock_cgroup_version
 
 
 @pytest.mark.parametrize("cpu_usage_val", [1.0, None], ids=["cpu-set", "cpu-not-set"])
@@ -43,7 +54,7 @@ def temp_dir(tmp_path: Path):
     [True, False],
     ids=["previous-timestamp-set", "previous-timestamp-not-set"],
 )
-def test_containerized_utilization_metrics(
+def test_containerized_utilization_metrics_cgroup_v1(
     temp_dir: str,
     cpu_usage_val: Optional[float],
     cpu_cores_val: Optional[int],
@@ -53,7 +64,10 @@ def test_containerized_utilization_metrics(
     memory_limit_val: Optional[int],
     was_cpu_previously_retrieved: bool,
     was_previous_timestamp_previously_set: bool,
+    cgroup_version_mock: mock.Mock,
 ):
+    cgroup_version_mock.return_value = CGroupVersion.V1
+
     if cpu_usage_val:
         with open(f"{temp_dir}/cpuacct.usage", "w") as f:
             f.write(str(cpu_usage_val * 1e9))
@@ -87,8 +101,86 @@ def test_containerized_utilization_metrics(
     )
     assert utilization_metrics["cpu_usage"] == (1.0 if cpu_usage_val else None)
     assert utilization_metrics["num_allocated_cores"] == (1 if cpu_cores_val else None)
+
     assert utilization_metrics["cpu_cfs_quota_us"] == (1.0 if cpu_quota_val else None)
     assert utilization_metrics["cpu_cfs_period_us"] == (1.0 if cpu_period_val else None)
+
+    assert utilization_metrics["memory_usage"] == (1 if memory_usage_val else None)
+    assert utilization_metrics["memory_limit"] == (1 if memory_limit_val else None)
+    assert utilization_metrics["previous_cpu_usage"] == (
+        1.0 if was_cpu_previously_retrieved else None
+    )
+    assert utilization_metrics["previous_measurement_timestamp"] == (
+        1.0 if was_previous_timestamp_previously_set else None
+    )
+
+
+@pytest.mark.parametrize("cpu_usage_val", [1.0, None], ids=["cpu-set", "cpu-not-set"])
+@pytest.mark.parametrize("cpu_cores_val", [1, None], ids=["cpu-cores-set", "cpu-cores-not-set"])
+@pytest.mark.parametrize(
+    "cpu_quota_and_period_val", ["1 1", None], ids=["cpu-max-set", "cpu-max-not-set"]
+)
+@pytest.mark.parametrize(
+    "memory_usage_val", [1, None], ids=["memory-usage-set", "memory-usage-not-set"]
+)
+@pytest.mark.parametrize(
+    "memory_limit_val", [1, None], ids=["memory-limit-set", "memory-limit-not-set"]
+)
+@pytest.mark.parametrize(
+    "was_cpu_previously_retrieved",
+    [True, False],
+    ids=["last-cpu-time-retrieved", "last-cpu-time-not-retrieved"],
+)
+@pytest.mark.parametrize(
+    "was_previous_timestamp_previously_set",
+    [True, False],
+    ids=["previous-timestamp-set", "previous-timestamp-not-set"],
+)
+def test_containerized_utilization_metrics_cgroup_v2(
+    temp_dir: str,
+    cpu_usage_val: Optional[float],
+    cpu_cores_val: Optional[int],
+    cpu_quota_and_period_val: Optional[str],
+    memory_usage_val: Optional[int],
+    memory_limit_val: Optional[int],
+    was_cpu_previously_retrieved: bool,
+    was_previous_timestamp_previously_set: bool,
+    cgroup_version_mock: mock.Mock,
+):
+    if cpu_usage_val:
+        with open(f"{temp_dir}/cpu.stat", "w") as f:
+            f.write(f"usage_usec {int(cpu_usage_val * 1e6)}")
+
+    if cpu_cores_val:
+        with open(f"{temp_dir}/cpuinfo", "w") as f:
+            f.write("\n".join([f"processor : {i}" for i in range(cpu_cores_val)]))
+
+    if cpu_quota_and_period_val:
+        with open(f"{temp_dir}/cpu.max", "w") as f:
+            f.write(str(cpu_quota_and_period_val))
+
+    if memory_usage_val:
+        with open(f"{temp_dir}/memory.current", "w") as f:
+            f.write(str(memory_usage_val))
+
+    if memory_limit_val:
+        with open(f"{temp_dir}/memory.max", "w") as f:
+            f.write(str(memory_limit_val))
+
+    cgroup_version_mock.return_value = CGroupVersion.V2
+
+    previous_cpu_usage = 1.0 if was_cpu_previously_retrieved else None
+    previous_measurement_timestamp = 1.0 if was_previous_timestamp_previously_set else None
+    utilization_metrics = retrieve_containerized_utilization_metrics(
+        logger=None,
+        previous_measurement_timestamp=previous_measurement_timestamp,
+        previous_cpu_usage=previous_cpu_usage,
+    )
+    assert utilization_metrics["cpu_usage"] == (1.0 if cpu_usage_val else None)
+    assert utilization_metrics["num_allocated_cores"] == (1 if cpu_cores_val else None)
+
+    assert utilization_metrics["cpu_cfs_quota_us"] == (1.0 if cpu_quota_and_period_val else None)
+    assert utilization_metrics["cpu_cfs_period_us"] == (1.0 if cpu_quota_and_period_val else None)
 
     assert utilization_metrics["memory_usage"] == (1 if memory_usage_val else None)
     assert utilization_metrics["memory_limit"] == (1 if memory_limit_val else None)


### PR DESCRIPTION
Previously, we only accounted for cgroups v1 when retrieving containerized metrics. This corrects to also retrieve cgroup v2 metrics, and also telling us which is being used.
Test plan: 
I tested the retrieval of all of these metrics via terminal commands in a cgroupsv2 enabled container on ec2.
Unit tests for the translation of these metrics.
To view the documentation of cgroupsv2 which describes the existence of the various files used here, see https://docs.kernel.org/admin-guide/cgroup-v2.html