### PR TITLE
[test-all] pin pendulum back to version 2 on python 3.8

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -393,7 +393,11 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
                         "cli_tests",  # test suite prone to hangs on unpinned grpcio version due to https://github.com/grpc/grpc/issues/31885
                     }
                 )
-                else []
+                else (
+                    [AvailablePythonVersion.V3_8]  # pendulum 3 not supported on python 3.8
+                    if tox_factor in {"scheduler_tests", "definitions_tests"}
+                    else []
+                )
             )
         ),
     ),

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -86,7 +86,8 @@ setup(
         f"grpcio>={GRPC_VERSION_FLOOR}",
         f"grpcio-health-checking>={GRPC_VERSION_FLOOR}",
         "packaging>=20.9",
-        "pendulum>=0.7.0,<4",
+        "pendulum>=0.7.0,<4; python_version>='3.9'",
+        "pendulum>=0.7.0,<3; python_version<'3.9'",  # https://github.com/dagster-io/dagster/issues/19500
         "protobuf>=3.20.0,<5",  # min protobuf version to be compatible with both protobuf 3 and 4
         "python-dateutil",
         "python-dotenv",


### PR DESCRIPTION
Summary:
[test-all]
pendulum 3 is causing mysterious SIGABRTS on python 3.8, and only python 3.8, in our CI/CD. Eliminate that version from the pin removal for now, since the primary goal of pendulum 3 is to unlock python 3.12 support anyways.

Test Plan:

## Summary & Motivation

## How I Tested These Changes
