### PR TITLE
feat(dagster-k8s): wait for all containers within the pod

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -2,7 +2,7 @@ import logging
 import sys
 import time
 from enum import Enum
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, List, Optional, Set, TypeVar
 
 import kubernetes.client
 import kubernetes.client.rest
@@ -30,7 +30,11 @@ DEFAULT_JOB_POD_COUNT = 1  # expect job:pod to be 1:1 by default
 
 class WaitForPodState(Enum):
     Ready = "READY"
+    # Wait for the successful termination of all containers in the pod. Fail upon first failure.
     Terminated = "TERMINATED"
+    # Wait for termination of all containers in the pod. Fail if at least one container was not successful in
+    # terminating.
+    TerminatedAll = "TERMINATED_ALL"
 
 
 class DagsterK8sError(Exception):
@@ -521,6 +525,7 @@ class DagsterKubernetesClient:
         wait_timeout=DEFAULT_WAIT_TIMEOUT,
         wait_time_between_attempts=DEFAULT_WAIT_BETWEEN_ATTEMPTS,
         start_time=None,
+        ignore_containers: Set | None = None,
     ):
         """Wait for a pod to launch and be running, or wait for termination (useful for job pods).
 
@@ -533,6 +538,9 @@ class DagsterKubernetesClient:
                 Defaults to DEFAULT_WAIT_TIMEOUT. Set to 0 to disable.
             wait_time_between_attempts (numeric, optional): Wait time between polling attempts. Defaults
                 to DEFAULT_WAIT_BETWEEN_ATTEMPTS.
+            start_time (numeric, optional): The start time of the wait, used for testing.
+            ignore_containers (set, optional): The container names that we should ignore
+                when waiting for the pod to be ready/terminate.
 
         Raises:
             DagsterK8sError: Raised when wait_timeout is exceeded or an error is encountered
@@ -546,6 +554,11 @@ class DagsterKubernetesClient:
         self.logger('Waiting for pod "%s"' % pod_name)
 
         start = start_time or self.timer()
+
+        # A set of container names that have exited.
+        exited_containers = set()
+        ignore_containers = ignore_containers or set()
+        error_logs = []
 
         while True:
             pods = self.core_api.list_namespaced_pod(
@@ -563,13 +576,28 @@ class DagsterKubernetesClient:
                 self.sleeper(wait_time_between_attempts)
                 continue
 
-            if not pod.status.container_statuses:
-                self.logger("Waiting for pod container status to be set by kubernetes...")
+            if not pod.status.init_container_statuses and not pod.status.container_statuses:
+                self.logger(
+                    "Waiting for pod init_container or container status to be set by kubernetes..."
+                )
                 self.sleeper(wait_time_between_attempts)
                 continue
 
             # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#containerstatus-v1-core
-            container_status = pod.status.container_statuses[0]
+            all_statuses = []
+            all_statuses.extend(pod.status.init_container_statuses or [])
+            all_statuses.extend(pod.status.container_statuses or [])
+
+            # Filter out ignored containers
+            all_statuses = [s for s in all_statuses if s.name not in ignore_containers]
+
+            # Always get the first status from the list, which will first get the
+            # init container (if it exists), then will iterate through the loop
+            # of all containers if we are waiting for termination.
+            #
+            # In case we are waiting for the pod to be ready, we will exit after
+            # the first container in this list is ready.
+            container_status = next(s for s in all_statuses if s.name not in exited_containers)
 
             # State checks below, see:
             # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#containerstate-v1-core
@@ -588,7 +616,9 @@ class DagsterKubernetesClient:
                         break
                 else:
                     check.invariant(
-                        wait_for_state == WaitForPodState.Terminated, "New invalid WaitForPodState"
+                        wait_for_state
+                        in [WaitForPodState.Terminated, WaitForPodState.TerminatedAll],
+                        "New invalid WaitForPodState",
                     )
                     self.sleeper(wait_time_between_attempts)
                     continue
@@ -626,15 +656,37 @@ class DagsterKubernetesClient:
 
             # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#containerstateterminated-v1-core
             elif state.terminated is not None:
-                if not state.terminated.exit_code == 0:
-                    raw_logs = self.retrieve_pod_logs(pod_name, namespace)
+                container_name = container_status.name
+                if state.terminated.exit_code != 0:
+                    raw_logs = self.retrieve_pod_logs(
+                        pod_name, namespace, container_name=container_name
+                    )
                     message = state.terminated.message
-                    raise DagsterK8sError(
-                        f'Pod did not exit successfully. Failed with message: "{message}" '
+                    msg = (
+                        f"Pod {pod_name} did not exit successfully. "
+                        f'Container "{container_name}" failed with message: "{message}" '
                         f'and pod logs: "{raw_logs}"'
                     )
+
+                    if wait_for_state == WaitForPodState.TerminatedAll:
+                        self.logger(msg)
+                        error_logs.append(msg)
+                    else:
+                        raise DagsterK8sError(msg)
                 else:
-                    self.logger(f"Pod {pod_name} exitted successfully")
+                    self.logger(f"Container {container_name} in {pod_name} has exited successfully")
+
+                exited_containers.add(container_name)
+                if len(all_statuses) != len(exited_containers):
+                    continue
+
+                if error_logs:
+                    logs = "\n\n".join(error_logs)
+                    raise DagsterK8sError(
+                        f"Pod {pod_name} has exited but some containers exited with errors: {logs}"
+                    )
+                else:
+                    self.logger(f"Pod {pod_name} exited successfully")
                 break
 
             else:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -525,7 +525,7 @@ class DagsterKubernetesClient:
         wait_timeout=DEFAULT_WAIT_TIMEOUT,
         wait_time_between_attempts=DEFAULT_WAIT_BETWEEN_ATTEMPTS,
         start_time=None,
-        ignore_containers: Set | None = None,
+        ignore_containers: Optional[Set] = None,
     ):
         """Wait for a pod to launch and be running, or wait for termination (useful for job pods).
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -273,7 +273,7 @@ class _PipesK8sClient(PipesClient):
                 client.wait_for_pod(
                     pod_name,
                     namespace,
-                    wait_for_state=WaitForPodState.Terminate,
+                    wait_for_state=WaitForPodState.Terminated,
                     ignore_containers=ignore_containers,
                     wait_time_between_attempts=self.poll_interval,
                 )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -195,7 +195,6 @@ class _PipesK8sClient(PipesClient):
         env: Optional[Mapping[str, str]] = None,
         base_pod_meta: Optional[Mapping[str, Any]] = None,
         base_pod_spec: Optional[Mapping[str, Any]] = None,
-        aggregate_termination_errors: bool = False,
         ignore_containers: Optional[Set] = None,
     ) -> PipesClientCompletedInvocation:
         """Publish a kubernetes pod and wait for it to complete, enriched with the pipes protocol.
@@ -225,8 +224,6 @@ class _PipesK8sClient(PipesClient):
                 Override the default ext protocol context injection.
             message_reader (Optional[PipesMessageReader]):
                 Override the default ext protocol message reader.
-            aggregate_termination_errors (bool): Wether to wait for termination for all containers and raise a
-                DagsterK8sError at the end. Defaults to raising the exception on first encountered error.
             ignore_containers (Optional[Set]): Ignore certain containers from waiting for termination. Defaults to
                 None.
 
@@ -276,9 +273,7 @@ class _PipesK8sClient(PipesClient):
                 client.wait_for_pod(
                     pod_name,
                     namespace,
-                    wait_for_state=WaitForPodState.TerminatedAll
-                    if aggregate_termination_errors
-                    else WaitForPodState.Terminated,
+                    wait_for_state=WaitForPodState.Terminate,
                     ignore_containers=ignore_containers,
                     wait_time_between_attempts=self.poll_interval,
                 )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -195,6 +195,7 @@ class _PipesK8sClient(PipesClient):
         env: Optional[Mapping[str, str]] = None,
         base_pod_meta: Optional[Mapping[str, Any]] = None,
         base_pod_spec: Optional[Mapping[str, Any]] = None,
+        wait_for_state: WaitForPodState = WaitForPodState.Terminated,
     ) -> PipesClientCompletedInvocation:
         """Publish a kubernetes pod and wait for it to complete, enriched with the pipes protocol.
 
@@ -270,7 +271,7 @@ class _PipesK8sClient(PipesClient):
                 client.wait_for_pod(
                     pod_name,
                     namespace,
-                    wait_for_state=WaitForPodState.Terminated,
+                    wait_for_state=wait_for_state,
                     wait_time_between_attempts=self.poll_interval,
                 )
             finally:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -659,7 +659,7 @@ def test_wait_for_ready_but_terminated_unsuccessfully():
 
     assert (
         str(exc_info.value)
-        == f'Pod {pod_name} did not exit successfully. Container "{container_name}" failed with message: "error_message" '
+        == f'Pod {pod_name} terminated but some containers exited with errors:\nContainer "{container_name}" failed with message: "error_message" '
         'and pod logs: "raw_logs_ret_val"'
     )
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -422,19 +422,30 @@ def test_retrieve_pod_logs():
     assert mock_client.retrieve_pod_logs("pod", "namespace") == "a_string"
 
 
-def _pod_list_for_container_status(container_status):
-    return V1PodList(items=[V1Pod(status=V1PodStatus(container_statuses=[container_status]))])
+def _pod_list_for_container_status(*container_statuses, init_container_statuses=None):
+    return V1PodList(
+        items=[
+            V1Pod(
+                status=V1PodStatus(
+                    container_statuses=container_statuses,
+                    init_container_statuses=init_container_statuses,
+                )
+            )
+        ]
+    )
 
 
-def _ready_running_status():
-    return _create_status(state=V1ContainerState(running=V1ContainerStateRunning()), ready=True)
+def _ready_running_status(name="a_name"):
+    return _create_status(
+        state=V1ContainerState(running=V1ContainerStateRunning()), ready=True, name=name
+    )
 
 
-def _create_status(state, ready):
+def _create_status(state, ready, name="a_name"):
     return V1ContainerStatus(
         image="an_image",
         image_id="an_image_id",
-        name="a_name",
+        name=name,
         restart_count=0,
         state=state,
         ready=ready,
@@ -505,7 +516,7 @@ def test_wait_for_statuses_then_success():
         mock_client.logger,
         [
             'Waiting for pod "%s"' % pod_name,
-            "Waiting for pod container status to be set by kubernetes...",
+            "Waiting for pod init_container or container status to be set by kubernetes...",
             'Pod "%s" is ready, done waiting' % pod_name,
         ],
     )
@@ -582,10 +593,16 @@ def test_running_but_not_ready():
 def test_wait_for_ready_but_terminated():
     mock_client = create_mocked_client()
 
+    ignored_container = _create_status(
+        state=V1ContainerState(terminated=V1ContainerStateTerminated(exit_code=1)),
+        ready=False,
+        name="ignored",
+    )
     single_pod_terminated_successful = _pod_list_for_container_status(
+        ignored_container,
         _create_status(
             state=V1ContainerState(terminated=V1ContainerStateTerminated(exit_code=0)), ready=False
-        )
+        ),
     )
 
     mock_client.core_api.list_namespaced_pod.side_effect = [
@@ -593,14 +610,18 @@ def test_wait_for_ready_but_terminated():
     ]
 
     pod_name = "a_pod"
+    container_name = "a_name"
 
-    mock_client.wait_for_pod(pod_name=pod_name, namespace="namespace")
+    mock_client.wait_for_pod(
+        pod_name=pod_name, namespace="namespace", ignore_containers={"ignored"}
+    )
 
     assert_logger_calls(
         mock_client.logger,
         [
             'Waiting for pod "%s"' % pod_name,
-            f"Pod {pod_name} exitted successfully",
+            f"Container {container_name} in {pod_name} has exited successfully",
+            f"Pod {pod_name} exited successfully",
         ],
     )
 
@@ -631,13 +652,14 @@ def test_wait_for_ready_but_terminated_unsuccessfully():
     mock_client.retrieve_pod_logs = retrieve_pod_logs_mock
 
     pod_name = "a_pod"
+    container_name = "a_name"
 
     with pytest.raises(DagsterK8sError) as exc_info:
         mock_client.wait_for_pod(pod_name=pod_name, namespace="namespace")
 
     assert (
         str(exc_info.value)
-        == 'Pod did not exit successfully. Failed with message: "error_message" '
+        == f'Pod {pod_name} did not exit successfully. Container "{container_name}" failed with message: "error_message" '
         'and pod logs: "raw_logs_ret_val"'
     )
 
@@ -659,6 +681,7 @@ def test_wait_for_termination_ready_then_terminate():
     ]
 
     pod_name = "a_pod"
+    container_name = "a_name"
 
     mock_client.wait_for_pod(
         pod_name=pod_name, namespace="namespace", wait_for_state=WaitForPodState.Terminated
@@ -668,7 +691,8 @@ def test_wait_for_termination_ready_then_terminate():
         mock_client.logger,
         [
             'Waiting for pod "%s"' % pod_name,
-            f"Pod {pod_name} exitted successfully",
+            f"Container {container_name} in {pod_name} has exited successfully",
+            f"Pod {pod_name} exited successfully",
         ],
     )
 
@@ -687,6 +711,92 @@ def test_waiting_for_pod_initialize():
         )
     )
     single_ready_running_pod = _pod_list_for_container_status(_ready_running_status())
+
+    mock_client.core_api.list_namespaced_pod.side_effect = [
+        single_waiting_pod,
+        single_ready_running_pod,
+    ]
+
+    pod_name = "a_pod"
+    mock_client.wait_for_pod(pod_name=pod_name, namespace="namespace")
+
+    assert_logger_calls(
+        mock_client.logger,
+        [
+            'Waiting for pod "%s"' % pod_name,
+            'Waiting for pod "%s" to initialize...' % pod_name,
+            'Pod "%s" is ready, done waiting' % pod_name,
+        ],
+    )
+    # slept only once
+    assert len(mock_client.sleeper.mock_calls) == 1
+
+
+def test_waiting_for_pod_initialize_with_ignored_containers():
+    mock_client = create_mocked_client(timer=create_timing_out_timer(num_good_ticks=3))
+    ignored_waiting_container_status = _create_status(
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.PodInitializing)
+        ),
+        ready=False,
+        name="ignored",
+    )
+    ignored_ready = _ready_running_status(name="ignored")
+    waiting_container_status = _create_status(
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.PodInitializing)
+        ),
+        ready=False,
+    )
+    ready = _ready_running_status()
+
+    mock_client.core_api.list_namespaced_pod.side_effect = [
+        _pod_list_for_container_status(
+            ignored_waiting_container_status,
+            waiting_container_status,
+        ),
+        _pod_list_for_container_status(
+            ignored_ready,
+            waiting_container_status,
+        ),
+        _pod_list_for_container_status(
+            ignored_ready,
+            ready,
+        ),
+    ]
+
+    pod_name = "a_pod"
+    mock_client.wait_for_pod(
+        pod_name=pod_name, namespace="namespace", ignore_containers={"ignored"}
+    )
+
+    assert_logger_calls(
+        mock_client.logger,
+        [
+            'Waiting for pod "%s"' % pod_name,
+            'Waiting for pod "%s" to initialize...' % pod_name,
+            'Waiting for pod "%s" to initialize...' % pod_name,
+            'Pod "%s" is ready, done waiting' % pod_name,
+        ],
+    )
+    # slept only once
+    assert len(mock_client.sleeper.mock_calls) == 2
+
+
+def test_waiting_for_pod_initialize_with_init_container():
+    mock_client = create_mocked_client(timer=create_timing_out_timer(num_good_ticks=2))
+    waiting_container_status = _create_status(
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.PodInitializing)
+        ),
+        ready=False,
+    )
+    single_waiting_pod = _pod_list_for_container_status(
+        waiting_container_status, init_container_statuses=[waiting_container_status]
+    )
+    single_ready_running_pod = _pod_list_for_container_status(
+        waiting_container_status, init_container_statuses=[_ready_running_status()]
+    )
 
     mock_client.core_api.list_namespaced_pod.side_effect = [
         single_waiting_pod,


### PR DESCRIPTION
## Summary & Motivation

This modifies the k8s client so that it correctly does the following:
* wait for an init container to be ready so that we can start reading
  logs as early as possible.
* wait for all containers to get terminated, so that we don't delete
  the pod before any other containers have exited successfully.
* report errors if containers other than main have exited with non-zero
  status.
* allow waiting for all containers to terminate and only then report
  success or failure, which allows for the containers to send diagnostic
  information back to Dagster or S3.
* Support ignoring certain containers (e.g. istio service mesh container
  never exits without being told `/quitquitquit` and it is better to
  ignore its status when terminating).
* Use the container name when getting logs in the failure case so that
  the kubernetes API does not return bad request errors. It requires the
  container name to be set if there are multiple containers in the pod.

## How I Tested These Changes

Unit tests.

Fixes #19163 
