### PR TITLE
[docs] fixes reference to Sling documentation in embedded-elt docs

### DIFF
--- a/docs/content/integrations/embedded-elt.mdx
+++ b/docs/content/integrations/embedded-elt.mdx
@@ -24,7 +24,7 @@ We plan on adding additional embedded ELT tool integrations in the future.
 
 ## Getting started
 
-To get started with `dagster-embedded-elt` and Sling, familiarize yourself with <a href="https://docs.slingdata.io/sling-cli/running-tasks">Sling</a> by reading their docs which describe how sources and targets are configured.
+To get started with `dagster-embedded-elt` and Sling, familiarize yourself with <a href="https://docs.slingdata.io/sling-cli/run">Sling</a> by reading their docs which describe how sources and targets are configured.
 
 The typical pattern for building an ELT pipeline with Sling has three steps:
 


### PR DESCRIPTION
## Summary & Motivation

Resolves https://github.com/dagster-io/dagster/issues/19508

Fixes broken link to Sling documentation in the `embedded-elt` docs.

## How I Tested These Changes
