### PR TITLE
[from failure] improve interrupted steps handling

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/state.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/state.py
@@ -225,6 +225,7 @@ def _derive_state_of_past_run(
     parent_run_logs = instance.all_logs(
         parent_run_id,
         of_type={
+            DagsterEventType.STEP_START,
             DagsterEventType.STEP_FAILURE,
             DagsterEventType.STEP_SUCCESS,
             DagsterEventType.STEP_OUTPUT,


### PR DESCRIPTION
When https://github.com/dagster-io/dagster/pull/8030 filtered down the steps fetched to calculate retry from failure, it did not include an event that would allow the `all_steps_in_parent_run_logs` to get steps that never hit one of the terminal states that were fetched. This means that interrupted steps calculations were not working, with most non-dynamic interrupts getting caught by the "missing steps" checks. 

Fix this by fetching step_start so we observe what steps started but never finished. 

resolves https://github.com/dagster-io/dagster/issues/19490

## How I Tested These Changes

added test case
