### PR TITLE
Update config dbt incremental model with partitions

### DIFF
--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -711,7 +711,7 @@ With the variables defined, we can now reference `min_date` and `max_date` in ou
 
 ```sql
 -- Configure the model as incremental
-{{ config(materialized='incremental') }}
+{{ config(materialized='incremental', unique_key='order_date', incremental_strategy="delete+insert") }}
 
 select * from {{ ref('my_model') }}
 

--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -710,7 +710,7 @@ def partitionshop_dbt_assets(context: OpExecutionContext, dbt: DbtCliResource):
 With the variables defined, we can now reference `min_date` and `max_date` in our SQL and configure the dbt model as incremental. Here, we define an incremental run to operate on rows with `order_date` that is between our `min_date` and `max_date`.
 
 ```sql
--- Configure the model as incremental
+-- Configure the model as incremental, use a unique_key and the delete+insert strategy to ensure the pipeline is idempotent.
 {{ config(materialized='incremental', unique_key='order_date', incremental_strategy="delete+insert") }}
 
 select * from {{ ref('my_model') }}


### PR DESCRIPTION
Without the additional config the model wouldn't be idempotent, as the incremental would be append only and rerunning a date would insert those again.

When using `delete+insert`, the `unique_key` doesn't actually need to be unique (in comparison to `merge` that would fail if `unique_key` is not unique)

## Summary & Motivation

Docs update

## How I Tested These Changes

N/A