### PR TITLE
[AssetSubset] Make ValidAssetSubset a real class

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.22.21.cjs

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,0 @@
-yarnPath: .yarn/releases/yarn-1.22.21.cjs

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition.py
@@ -28,7 +28,7 @@ from dagster._serdes.serdes import (
     whitelist_for_serdes,
 )
 
-from .asset_subset import AssetSubset
+from .asset_subset import AssetSubset, ValidAssetSubset
 
 if TYPE_CHECKING:
     from .asset_condition_evaluation_context import AssetConditionEvaluationContext
@@ -199,7 +199,7 @@ class AssetConditionEvaluation(NamedTuple):
         else:
             # the true_subset and discarded_subset were created on the same tick, so they are
             # guaranteed to be compatible with each other
-            return self.true_subset | discarded_subset.as_valid
+            return ValidAssetSubset(*self.true_subset) | discarded_subset
 
     def for_child(self, child_condition: "AssetCondition") -> Optional["AssetConditionEvaluation"]:
         """Returns the evaluation of a given child condition by finding the child evaluation that
@@ -430,7 +430,7 @@ class AndAssetCondition(
             child_context = context.for_child(condition=child, candidate_subset=true_subset)
             child_result = child.evaluate(child_context)
             child_results.append(child_result)
-            true_subset &= child_result.true_subset.as_valid
+            true_subset &= child_result.true_subset
         return AssetConditionResult.create_from_children(context, true_subset, child_results)
 
 
@@ -453,7 +453,7 @@ class OrAssetCondition(
             )
             child_result = child.evaluate(child_context)
             child_results.append(child_result)
-            true_subset |= child_result.true_subset.as_valid
+            true_subset |= child_result.true_subset
         return AssetConditionResult.create_from_children(context, true_subset, child_results)
 
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -20,7 +20,10 @@ from dagster._core.definitions.partition import (
 from dagster._core.definitions.time_window_partitions import (
     BaseTimeWindowPartitionsSubset,
 )
-from dagster._serdes.serdes import NamedTupleSerializer, whitelist_for_serdes
+from dagster._serdes.serdes import (
+    NamedTupleSerializer,
+    whitelist_for_serdes,
+)
 
 if TYPE_CHECKING:
     from dagster._core.instance import DynamicPartitionsStore
@@ -28,6 +31,10 @@ if TYPE_CHECKING:
 
 class AssetSubsetSerializer(NamedTupleSerializer):
     """Ensures that the inner PartitionsSubset is converted to a serializable form if necessary."""
+
+    def get_storage_name(self) -> str:
+        # override this method so all ValidAssetSubsets are serialzied as AssetSubsets
+        return "AssetSubset"
 
     def before_pack(self, value: "AssetSubset") -> "AssetSubset":
         if value.is_partitioned:
@@ -154,7 +161,7 @@ class AssetSubset(NamedTuple):
             )
 
 
-@whitelist_for_serdes(serializer=AssetSubsetSerializer, storage_name="AssetSubset")
+@whitelist_for_serdes(serializer=AssetSubsetSerializer)
 class ValidAssetSubset(AssetSubset):
     """Represents an AssetSubset which is known to be compatible with the current
     PartitionsDefinition of the asset represents.

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
@@ -252,9 +252,8 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
 
         true_subset = AssetSubset.empty(asset_key, self.partitions_def)
         for _, serialized in partition_subsets_by_condition:
-            true_subset = (
-                self.deserialize_serialized_partitions_subset_or_none(asset_key, serialized)
-                | true_subset
+            true_subset |= self.deserialize_serialized_partitions_subset_or_none(
+                asset_key, serialized
             )
 
         return AssetConditionEvaluation(
@@ -320,7 +319,7 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
             )
             true_subset = AssetSubset.empty(asset_key, self.partitions_def)
             for e in child_evaluations:
-                true_subset = e.true_subset | true_subset
+                true_subset |= e.true_subset
             evaluation = AssetConditionEvaluation(
                 condition_snapshot=decision_type_snapshot,
                 true_subset=true_subset,
@@ -439,7 +438,7 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
 
         # all AssetSubsets generated here are created using the current partitions_def, so they
         # will be valid
-        true_subset = materialize_evaluation.true_subset.as_valid
+        true_subset = materialize_evaluation.true_subset.as_valid(self.partitions_def)
         if not_skip_evaluation:
             true_subset -= not_skip_evaluation.child_evaluations[0].true_subset
         if not_discard_evaluation:


### PR DESCRIPTION
## Summary & Motivation

Previously, this was just a hint for the type system. This makes it a real subclass of the AssetSubset class.

You can no longer use any of the overloaded operators on the base AssetSubset class (because we can't be sure that their underlying values will be identical).

You _are_ able to do ValidAssetSubset | AssetSubset, in which case the ValidAssetSubset will validate if the other subset is compatible. If it is, it just does the normal operation, and if it's not, it converts the other subset into the empty subset and goes from there.

## How I Tested These Changes
