### PR TITLE
Upgrade configuration for Ruff v0.2.0

### DIFF
--- a/examples/docs_snippets/pyproject.toml
+++ b/examples/docs_snippets/pyproject.toml
@@ -6,6 +6,8 @@ extend = "../pyproject.toml"
 # Shorter line length for docs snippets for better browser formatting.
 line-length = 88
 
+[tool.ruff.lint]
+
 # Use extend-ignore so that we ignore all the same codes ignored in root.
 extend-ignore = [
 
@@ -26,7 +28,7 @@ extend-ignore = [
   "TCH",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 
 # Ensures ruff classifies imports from `dagster` as first-party. Keeps snippet imports relatively
 # compressed.

--- a/examples/project_analytics/pyproject.toml
+++ b/examples/project_analytics/pyproject.toml
@@ -8,10 +8,12 @@ module_name = "dagster_pypi"
 [tool.ruff]
 # Extend root configuration.
 extend = "../../pyproject.toml"
+
+src = ["dagster_pypi"]
+
+[tool.ruff.lint]
 # Use extend-ignore so that we ignore all the same codes ignored in root.
 extend-ignore = [
   # (print found): Allow prints for demo purposes.
   "T201",
 ]
-
-src = ["dagster_pypi"]

--- a/examples/project_dagster_university_start/pyproject.toml
+++ b/examples/project_dagster_university_start/pyproject.toml
@@ -8,8 +8,8 @@ module_name = "dagster_university"
 [tool.ruff]
 extend = "../../pyproject.toml"
 
+[tool.ruff.lint]
 extend-ignore = [
-
   # (Unused import): We stub some files with just imports to help people get started
   "F401",    
   # (Import block is un-sorted or un-formatted): It's more important that we introduce the imports in the order they're used rather than alphabetically.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,15 @@ extend-exclude = [
   "*/snapshots/*",
 ]
 
+# Codebase-wide default line length. Override in package-specific pyproject.toml where a different
+# length is desired.
+line-length = 100
+
+# Fail if Ruff is not running this version.
+required-version = "0.1.7"
+
+[tool.ruff.lint]
+
 ignore = [
 
   # (missing public docstrings) These work off of the Python sense of "public", rather than our
@@ -164,10 +173,6 @@ ignore = [
   "PERF401", # (manual-list-comprehension)
   "PERF402", # (manual-list-copy)
 ]
-
-# Codebase-wide default line length. Override in package-specific pyproject.toml where a different
-# length is desired.
-line-length = 100
 
 # By default, ruff only uses all "E" (pycodestyle) and "F" (pyflakes) rules.
 # Here we append to the defaults.
@@ -230,19 +235,16 @@ select = [
   "W605",
 ]
 
-# Fail if Ruff is not running this version.
-required-version = "0.1.7"
-
-[tool.ruff.flake8-builtins]
+[tool.ruff.lint.flake8-builtins]
 
 # We use `id` in many places and almost never want to use the python builtin.
 builtins-ignorelist = ["id"]
 
-[tool.ruff.flake8-tidy-imports.banned-api]
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
 
 "__future__.annotations".msg = "Directly quote annotations instead."
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 
 # Combine multiple `from foo import bar as baz` statements with the same source
 # (`foo`) into a single statement.
@@ -252,12 +254,12 @@ combine-as-imports = true
 # per line. Useful for __init__.py files that just re-export symbols.
 force-wrap-aliases = true
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 
 # Don't format docstrings in alembic migrations.
 "**/alembic/versions/*.py" = ["D"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 
 # Enforce google-style docstrings. This is equivalent to ignoring a large number of pydocstyle (D)
 # rules incompatible with google-style docstrings. See:

--- a/python_modules/libraries/dagster-celery/dagster_celery/cli.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/cli.py
@@ -75,17 +75,17 @@ def get_config_dir(config_yaml=None):
 
     validated_config = get_validated_config(config_yaml)
     with open(config_path, "w", encoding="utf8") as fd:
-        if "broker" in validated_config and validated_config["broker"]:
+        if validated_config.get("broker"):
             fd.write(
                 "broker_url = '{broker_url}'\n".format(broker_url=str(validated_config["broker"]))
             )
-        if "backend" in validated_config and validated_config["backend"]:
+        if validated_config.get("backend"):
             fd.write(
                 "result_backend = '{result_backend}'\n".format(
                     result_backend=str(validated_config["backend"])
                 )
             )
-        if "config_source" in validated_config and validated_config["config_source"]:
+        if validated_config.get("config_source"):
             for key, value in validated_config["config_source"].items():
                 fd.write(f"{key} = {value!r}\n")
 


### PR DESCRIPTION
This PR upgrades Dagster's configuration to avoid deprecation warnings that will appear after upgrading to Ruff's upcoming v0.2.0 release. (All these changes work with v0.1.7 as-is.)
