### PR TITLE
Add underlying AMP rule to AssetConditionSnapshot

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -514,7 +514,7 @@ class TestAssetConditionEvaluations(ExecutingGraphQLContextTestMatrix):
     ) -> AssetConditionEvaluation:
         return AssetConditionEvaluation(
             condition_snapshot=AssetConditionSnapshot(
-                "...", description, str(random.randint(0, 100000000))
+                "...", description, str(random.randint(0, 100000000)), None
             ),
             true_subset=AssetSubset(
                 asset_key=asset_key,

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -238,7 +238,7 @@ def backcompat_deserialize_asset_daemon_cursor_str(
         if not latest_evaluation_result:
             partitions_def = asset_graph.get_partitions_def(asset_key) if asset_graph else None
             latest_evaluation_result = AssetConditionEvaluation(
-                condition_snapshot=AssetConditionSnapshot("", "", ""),
+                condition_snapshot=AssetConditionSnapshot("", "", "", None),
                 true_subset=AssetSubset.empty(asset_key, partitions_def),
                 candidate_subset=AssetSubset.empty(asset_key, partitions_def),
                 start_timestamp=None,

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
@@ -222,6 +222,7 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
             class_name=RuleCondition.__name__,
             description=rule_snapshot.description,
             unique_id=unique_id,
+            underlying_auto_materialize_rule=rule_snapshot,
         )
 
     def _get_child_rule_evaluation(
@@ -316,7 +317,10 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
             ]
             unique_id = hashlib.md5("".join(unique_id_parts).encode()).hexdigest()
             decision_type_snapshot = AssetConditionSnapshot(
-                class_name=OrAssetCondition.__name__, description="Any of", unique_id=unique_id
+                class_name=OrAssetCondition.__name__,
+                description="Any of",
+                unique_id=unique_id,
+                underlying_auto_materialize_rule=None,
             )
             true_subset = AssetSubset.empty(asset_key, self.partitions_def)
             for e in child_evaluations:
@@ -354,7 +358,10 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
             )
         return AssetConditionEvaluation(
             condition_snapshot=AssetConditionSnapshot(
-                class_name=NotAssetCondition.__name__, description="Not", unique_id=unique_id
+                class_name=NotAssetCondition.__name__,
+                description="Not",
+                unique_id=unique_id,
+                underlying_auto_materialize_rule=None,
             ),
             true_subset=true_subset,
             candidate_subset=HistoricalAllPartitionsSubsetSentinel()
@@ -434,7 +441,10 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
         ]
         unique_id = hashlib.md5("".join(unique_id_parts).encode()).hexdigest()
         condition_snapshot = AssetConditionSnapshot(
-            class_name=AndAssetCondition.__name__, description="All of", unique_id=unique_id
+            class_name=AndAssetCondition.__name__,
+            description="All of",
+            unique_id=unique_id,
+            underlying_auto_materialize_rule=None,
         )
 
         # all AssetSubsets generated here are created using the current partitions_def, so they

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -31,6 +31,10 @@ from dagster._seven.compat.pendulum import pendulum_freeze_time
 from dagster._utils.error import SerializableErrorInfo
 
 
+def dummy_condition_snapshot() -> AssetConditionSnapshot:
+    return AssetConditionSnapshot("foo", "bar", "", None)
+
+
 class TestScheduleStorage:
     """You can extend this class to easily run these set of tests on any schedule storage. When extending,
     you simply need to override the `schedule_storage` fixture and return your implementation of
@@ -519,7 +523,12 @@ class TestScheduleStorage:
             storage.add_instigator_state(state)
 
     def build_sensor_tick(
-        self, current_time, status=TickStatus.STARTED, run_id=None, error=None, name="my_sensor"
+        self,
+        current_time,
+        status=TickStatus.STARTED,
+        run_id=None,
+        error=None,
+        name="my_sensor",
     ):
         return TickData(
             name,
@@ -664,7 +673,10 @@ class TestScheduleStorage:
         assert latest_tick.tick_id == one_minute_tick.tick_id
 
         storage.purge_ticks(
-            "my_sensor", "my_sensor", now.subtract(minutes=2).timestamp(), [TickStatus.SKIPPED]
+            "my_sensor",
+            "my_sensor",
+            now.subtract(minutes=2).timestamp(),
+            [TickStatus.SKIPPED],
         )
 
         ticks = storage.get_ticks("my_sensor", "my_sensor")
@@ -732,7 +744,7 @@ class TestScheduleStorage:
         if not self.can_store_auto_materialize_asset_evaluations():
             pytest.skip("Storage cannot store auto materialize asset evaluations")
 
-        condition_snapshot = AssetConditionSnapshot("foo", "bar", "")
+        condition_snapshot = dummy_condition_snapshot()
 
         for _ in range(2):  # test idempotency
             storage.add_auto_materialize_asset_evaluations(
@@ -836,7 +848,7 @@ class TestScheduleStorage:
         # add a mix of keys - one that already is using the unique index and one that is not
 
         eval_one = AssetConditionEvaluation(
-            condition_snapshot=AssetConditionSnapshot("foo", "bar", ""),
+            condition_snapshot=dummy_condition_snapshot(),
             start_timestamp=0,
             end_timestamp=1,
             true_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=True),
@@ -846,7 +858,7 @@ class TestScheduleStorage:
         ).with_run_ids(set())
 
         eval_asset_three = AssetConditionEvaluation(
-            condition_snapshot=AssetConditionSnapshot("foo", "bar", ""),
+            condition_snapshot=dummy_condition_snapshot(),
             start_timestamp=0,
             end_timestamp=1,
             true_subset=AssetSubset(asset_key=AssetKey("asset_three"), value=True),
@@ -887,14 +899,17 @@ class TestScheduleStorage:
         asset_subset = AssetSubset(asset_key=AssetKey("asset_two"), value=subset)
         asset_subset_with_metadata = AssetSubsetWithMetadata(
             asset_subset,
-            {"foo": MetadataValue.text("bar"), "baz": MetadataValue.asset(AssetKey("asset_one"))},
+            {
+                "foo": MetadataValue.text("bar"),
+                "baz": MetadataValue.asset(AssetKey("asset_one")),
+            },
         )
 
         storage.add_auto_materialize_asset_evaluations(
             evaluation_id=10,
             asset_evaluations=[
                 AssetConditionEvaluation(
-                    condition_snapshot=AssetConditionSnapshot("foo", "bar", ""),
+                    condition_snapshot=dummy_condition_snapshot(),
                     start_timestamp=0,
                     end_timestamp=1,
                     true_subset=asset_subset,
@@ -928,7 +943,7 @@ class TestScheduleStorage:
             evaluation_id=11,
             asset_evaluations=[
                 AssetConditionEvaluation(
-                    condition_snapshot=AssetConditionSnapshot("foo", "bar", ""),
+                    condition_snapshot=dummy_condition_snapshot(),
                     start_timestamp=0,
                     end_timestamp=1,
                     true_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=True),


### PR DESCRIPTION
## Summary & Motivation

This adds an AutoMaterializeRuleSnapshot to AssetConditionSubset in order to preserve the true provenance of a RuleCondition.

This was useful in later in this stack for testing purposes, but I imagine this will also be useful for debugging and displaying
UI in backwards compat settings

## How I Tested These Changes

TODO
