### PR TITLE
[docs] instruct user to click Dagster icon to navigate to status page

### DIFF
--- a/docs/content/dagster-cloud/deployment/agents/docker/configuring-running-docker-agent.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/docker/configuring-running-docker-agent.mdx
@@ -91,7 +91,7 @@ This command:
 - Starts the agent with your local `dagster.yaml` mounted as a volume
 - Starts the system Docker socket mounted as a volume, allowing the agent to launch containers.
 
-To view the agent in Dagster Cloud, navigate to the **Status** page and click the **Agents** tab. You should see the agent running in the **Agent statuses** section:
+To view the agent in Dagster Cloud, click the Dagster icon in the top left to navigate to the **Status** page and click the **Agents** tab. You should see the agent running in the **Agent statuses** section:
 
 <Image
 alt="Instance Status"

--- a/docs/content/dagster-cloud/deployment/agents/local.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/local.mdx
@@ -82,7 +82,7 @@ Next, run the process agent by pointing at the home directory you created:
 dagster-cloud agent run ~/dagster_home/
 ```
 
-To view the agent in Dagster Cloud, navigate to the **Status** page and click the **Agents** tab. You should see the agent running in the **Agent statuses** section:
+To view the agent in Dagster Cloud, click the Dagster icon in the top left to navigate to the **Status** page and click the **Agents** tab. You should see the agent running in the **Agent statuses** section:
 
 <Image
 alt="Instance Status"


### PR DESCRIPTION
## Summary & Motivation

Resolves: https://github.com/dagster-io/dagster/issues/19562

It was unclear how to navigate to the status page in onboarding a Docker agent; this explicitly instructs the user to click the Dagster icon.

## How I Tested These Changes
