### PR TITLE
[daggy-u] bump project_dagster_university_start to 1.6.*

### DIFF
--- a/examples/project_dagster_university_start/setup.py
+++ b/examples/project_dagster_university_start/setup.py
@@ -4,7 +4,7 @@ setup(
     name="dagster_university",
     packages=find_packages(exclude=["dagster_university_tests"]),
     install_requires=[
-        "dagster==1.5.*",
+        "dagster==1.6.*",
         "dagster-cloud",
         "dagster-duckdb",
         "geopandas",


### PR DESCRIPTION
## Summary & Motivation

Dagster University training material is in the process of being updated to v1.6.* -- to
prepare for that, the start project needs to be on this version.

## How I Tested These Changes

Ran the project locally, and confirmed no errors were present:

```bash
pip install -e ".[dev]"
```

Duplicate the `.env.example` file and rename it to `.env`.

Then, start the Dagster UI web server:

```bash
dagster dev
```

