### PR TITLE
[docs] - Rename Enterprise to Pro

### DIFF
--- a/docs/content/dagster-cloud/account/authentication.mdx
+++ b/docs/content/dagster-cloud/account/authentication.mdx
@@ -74,7 +74,7 @@ Role-based access control (RBAC) enables you to grant specific permissions to us
   ></ArticleListItem>
   <ArticleListItem
     href="/dagster-cloud/account/managing-users/managing-teams"
-    title="Managing teams (Enterprise only)"
+    title="Managing teams (Pro only)"
   ></ArticleListItem>
   <ArticleListItem
     href="/dagster-cloud/account/managing-users"

--- a/docs/content/dagster-cloud/account/authentication/okta/saml-sso.mdx
+++ b/docs/content/dagster-cloud/account/authentication/okta/saml-sso.mdx
@@ -3,7 +3,7 @@ title: "Setting up Okta SSO for Dagster Cloud | Dagster Docs"
 
 display_name: "Okta"
 feature_name: "saml_sso_okta"
-pricing_plan: "enterprise"
+pricing_plan: "pro"
 ---
 
 # Setting up Okta SSO for Dagster Cloud
@@ -21,7 +21,7 @@ To complete the steps in this guide, you'll need:
 - **An existing Okta account**
 - **To install the [`dagster-cloud` CLI](/dagster-cloud/managing-deployments/dagster-cloud-cli)**
 - **The following in Dagster Cloud:**
-  - An Enterprise plan
+  - A Pro plan
   - [Access to a user token](/dagster-cloud/account/managing-user-agent-tokens#managing-user-tokens)
   - [Organization Admin permissions](/dagster-cloud/account/managing-users/managing-user-roles-permissions#user-permissions-reference) in your organization
 

--- a/docs/content/dagster-cloud/account/authentication/okta/scim-provisioning.mdx
+++ b/docs/content/dagster-cloud/account/authentication/okta/scim-provisioning.mdx
@@ -3,7 +3,7 @@ title: "Setting up Okta SCIM provisioning for Dagster Cloud | Dagster Docs"
 
 display_name: "Okta"
 feature_name: "scim_okta"
-pricing_plan: "enterprise"
+pricing_plan: "pro"
 ---
 
 # Setting up Okta SCIM provisioning for Dagster Cloud
@@ -51,7 +51,7 @@ To complete the steps in this guide, you'll need:
 - **To have set up Okta SSO for Dagster Cloud.** Refer to the [Okta SSO setup guide](/dagster-cloud/account/authentication/okta/saml-sso) for more info.
 - **Permissions in Okta that allow you to configure applications.**
 - **The following in Dagster Cloud:**
-  - An Enterprise plan
+  - A Pro plan
   - [Organization Admin permissions](/dagster-cloud/account/managing-users/managing-user-roles-permissions#user-permissions-reference) in your organization
 
 ---

--- a/docs/content/dagster-cloud/account/authentication/setting-up-azure-ad-saml-sso.mdx
+++ b/docs/content/dagster-cloud/account/authentication/setting-up-azure-ad-saml-sso.mdx
@@ -4,7 +4,7 @@ title: "Setting up Azure Active Directory SSO for Dagster Cloud | Dagster Docs"
 platform_type: "cloud"
 display_name: "Azure AD"
 feature_name: "saml_sso_azure"
-pricing_plan: "enterprise"
+pricing_plan: "pro"
 ---
 
 # Setting up Azure Active Directory SSO for Dagster Cloud
@@ -22,6 +22,7 @@ To complete the steps in this guide, you'll need:
 - **An existing Azure AD account**
 - **To install the [`dagster-cloud` CLI](/dagster-cloud/managing-deployments/dagster-cloud-cli)**
 - **The following in Dagster Cloud:**
+  - A Pro plan
   - [Access to a user token](/dagster-cloud/account/managing-user-agent-tokens#managing-user-tokens)
   - [Organization Admin permissions](/dagster-cloud/account/managing-users/managing-user-roles-permissions#user-permissions-reference) in your organization
 

--- a/docs/content/dagster-cloud/account/authentication/setting-up-google-workspace-saml-sso.mdx
+++ b/docs/content/dagster-cloud/account/authentication/setting-up-google-workspace-saml-sso.mdx
@@ -4,7 +4,7 @@ title: "Setting up Google Workspace SSO for Dagster Cloud | Dagster Docs"
 platform_type: "cloud"
 display_name: "Google Workspace"
 feature_name: "saml_sso_google"
-pricing_plan: "enterprise"
+pricing_plan: "pro"
 ---
 
 # Setting up Google Workspace SSO for Dagster Cloud
@@ -24,6 +24,7 @@ To complete the steps in this guide, you'll need:
   - [Workspace Admin permissions](https://support.google.com/a/answer/6365252?hl=en\&ref_topic=4388346)
 - **To install the [`dagster-cloud` CLI](/dagster-cloud/managing-deployments/dagster-cloud-cli)**
 - **The following in Dagster Cloud:**
+  - A Pro plan
   - [Access to a user token](/dagster-cloud/account/managing-user-agent-tokens#managing-user-tokens)
   - [Organization Admin permissions](/dagster-cloud/account/managing-users/managing-user-roles-permissions#user-permissions-reference) in your organization
 

--- a/docs/content/dagster-cloud/account/authentication/setting-up-onelogin-saml-sso.mdx
+++ b/docs/content/dagster-cloud/account/authentication/setting-up-onelogin-saml-sso.mdx
@@ -4,7 +4,7 @@ title: "Setting up OneLogin SSO for Dagster Cloud | Dagster Docs"
 platform_type: "cloud"
 display_name: "OneLogin"
 feature_name: "saml_sso_onelogin"
-pricing_plan: "enterprise"
+pricing_plan: "pro"
 ---
 
 # Setting up OneLogin SSO for Dagster Cloud
@@ -24,6 +24,7 @@ To complete the steps in this guide, you'll need:
   - Admin permissions
 - **To install the [`dagster-cloud` CLI](/dagster-cloud/managing-deployments/dagster-cloud-cli)**
 - **The following in Dagster Cloud:**
+  - A Pro plan
   - [Access to a user token](/dagster-cloud/account/managing-user-agent-tokens#managing-user-tokens)
   - [Organization Admin permissions](/dagster-cloud/account/managing-users/managing-user-roles-permissions#user-permissions-reference) in your organization
 

--- a/docs/content/dagster-cloud/account/authentication/setting-up-pingone-saml-sso.mdx
+++ b/docs/content/dagster-cloud/account/authentication/setting-up-pingone-saml-sso.mdx
@@ -3,7 +3,7 @@ title: "Setting up PingOne SSO for Dagster Cloud | Dagster Docs"
 
 display_name: "PingOne"
 feature_name: "saml_sso_pingone"
-pricing_plan: "enterprise"
+pricing_plan: "pro"
 ---
 
 # Setting up PingOne SSO for Dagster Cloud
@@ -23,6 +23,7 @@ To complete the steps in this guide, you'll need:
   - Organization admin permissions
 - **To install the [`dagster-cloud` CLI](/dagster-cloud/managing-deployments/dagster-cloud-cli)**
 - **The following in Dagster Cloud:**
+  - A Pro plan
   - [Access to a user token](/dagster-cloud/account/managing-user-agent-tokens#managing-user-tokens)
   - [Organization Admin permissions](/dagster-cloud/account/managing-users/managing-user-roles-permissions#user-permissions-reference) in your organization
 

--- a/docs/content/dagster-cloud/account/authentication/utilizing-scim-provisioning.mdx
+++ b/docs/content/dagster-cloud/account/authentication/utilizing-scim-provisioning.mdx
@@ -3,7 +3,7 @@ title: "Utilizing SCIM provisioning in Dagster Cloud | Dagster Docs"
 
 display_name: "SCIM"
 feature_name: "scim"
-pricing_plan: "enterprise"
+pricing_plan: "pro"
 ---
 
 # Utilizing SCIM provisioning in Dagster Cloud
@@ -59,7 +59,7 @@ User groups in your IdP can be mapped to Dagster Cloud teams, allowing you to ce
 
 To use SCIM provisioning, you'll need:
 
-- A Dagster Cloud Enterprise plan
+- A Dagster Cloud Pro plan
 - [An IdP for which Dagster Cloud supports SSO and SCIM provisioning](#supported-identity-providers)
 - Permissions in your IdP that allow you to configure SSO and SCIM provisioning
 

--- a/docs/content/dagster-cloud/account/managing-users.mdx
+++ b/docs/content/dagster-cloud/account/managing-users.mdx
@@ -58,7 +58,7 @@ height={1474}
 
 ### Adding users to teams
 
-<Note>Teams are a Dagster Cloud Enterprise feature.</Note>
+<Note>Teams are a Dagster Cloud Pro feature.</Note>
 
 Using the **Teams** field, you can add users to one or more teams. This is useful for centralizing permission sets for different types of users. Refer to the [Managing teams](/dagster-cloud/account/managing-users/managing-teams) guide for more info about creating and managing teams.
 
@@ -80,7 +80,7 @@ In the **Roles** section, you can assign the select the appropriate [user role](
 1. Next to a deployment, click **Edit user role**.
 2. Select the user role for the deployment. This [user role](/dagster-cloud/account/managing-users/managing-user-roles-permissions) will be used as the default for all code locations in the deployment.
 3. Click **Save**.
-4. **Enterprise only**: To set permissions for individual [code locations](/dagster-cloud/account/managing-users/managing-user-roles-permissions#code-locations) in a deployment:
+4. **Pro only**: To set permissions for individual [code locations](/dagster-cloud/account/managing-users/managing-user-roles-permissions#code-locations) in a deployment:
    1. Click the toggle to the left of the deployment to open a list of code locations.
    2. Next to a code location, click **Edit user role**.
    3. Select the user role for the code location.

--- a/docs/content/dagster-cloud/account/managing-users/managing-teams.mdx
+++ b/docs/content/dagster-cloud/account/managing-users/managing-teams.mdx
@@ -4,7 +4,7 @@ title: Managing teams in Dagster Cloud | Dagster Docs
 
 # Managing teams in Dagster Cloud
 
-<Note>This guide is applicable to Dagster Cloud Enterprise.</Note>
+<Note>This guide is applicable to Dagster Cloud Pro.</Note>
 
 As part of our [role-based access control (RBAC) feature](/dagster-cloud/account/managing-users/managing-user-roles-permissions), Dagster Cloud supports the ability to assign users to teams. A team is a group of users with a set of default deployment, code location, and Branch Deployment user roles.
 
@@ -14,7 +14,7 @@ In this guide, we'll cover how to add, manage, and remove teams in Dagster Cloud
 
 ## Prerequisites
 
-To use this feature, you'll need a **Dagster Cloud Enterprise plan.**
+To use this feature, you'll need a **Dagster Cloud Pro plan.**
 
 ---
 

--- a/docs/content/dagster-cloud/account/managing-users/managing-user-roles-permissions.mdx
+++ b/docs/content/dagster-cloud/account/managing-users/managing-user-roles-permissions.mdx
@@ -19,8 +19,8 @@ Dagster Cloud uses a hierarchical model for RBAC, meaning that the most permissi
 - Organization Admin
 - Admin
 - Editor
-- Launcher (Enterprise plans only)
-- Viewer (Enterprise plans only)
+- Launcher (Pro plans only)
+- Viewer
 
 For example, the **Admin** user role includes permissions specific to this role and all permissions in the **Editor**, **Launcher**, and **Viewer** user roles. Refer to the [User permissions reference](#user-permissions-reference) for the full list of user permissions in Dagster Cloud.
 
@@ -30,7 +30,7 @@ All user roles are enforced both in Dagster Cloud and the [GraphQL API](/concept
 
 ### Teams
 
-Dagster Cloud Enterprise users can create teams of users and assign default permission sets. Refer to the [Managing teams in Dagster Cloud](/dagster-cloud/account/managing-users/managing-teams) guide for more info.
+Dagster Cloud Pro users can create teams of users and assign default permission sets. Refer to the [Managing teams in Dagster Cloud](/dagster-cloud/account/managing-users/managing-teams) guide for more info.
 
 ---
 
@@ -67,12 +67,12 @@ Organization Admins have access to the entire organization, including all [full 
     </tr>
     <tr>
       <td>Code location</td>
-      <td>Enterprise</td>
+      <td>Pro</td>
       <td>
         Defines the level of access for a given code location in a deployment.
         <br />
         <br />
-        Dagster Cloud Enterprise users can <a href="#code-locations">
+        Dagster Cloud Pro users can <a href="#code-locations">
           override the default deployment-level role for individual code
           locations
         </a>. For example, if the <strong>Deployment</strong> role is <strong>
@@ -81,8 +81,8 @@ Organization Admins have access to the entire organization, including all [full 
         as <strong>Editor</strong> or <strong>Admin</strong>.
         <br />
         <br />
-        For non-Enterprise users, users will have the same level of access for
-        all code locations in a deployment.
+        For non-Pro users, users will have the same level of access for all code
+        locations in a deployment.
       </td>
     </tr>
     <tr>
@@ -98,7 +98,7 @@ Organization Admins have access to the entire organization, including all [full 
 
 ### Applying role overrides
 
-<Note>This section is applicable to Dagster Cloud Enterprise.</Note>
+<Note>This section is applicable to Dagster Cloud Pro plans.</Note>
 
 As previously mentioned, you can define individual user roles for users in your organization. You can also apply permission overrides to grant specific exceptions.
 

--- a/docs/content/dagster-cloud/deployment/agents/running-multiple-agents.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/running-multiple-agents.mdx
@@ -134,7 +134,7 @@ The `isolated_agents` option can be set as per-deployment configuration on the `
 
 ## Routing requests to specific agents
 
-<Note>Agent queues are a Dagster Cloud Enterprise feature.</Note>
+<Note>Agent queues are a Dagster Cloud Pro feature.</Note>
 
 Every Dagster Cloud agent serves requests from one or more queues. By default, requests for each code location are placed on a default queue and your agent will read requests only from that default queue.
 

--- a/docs/content/dagster-cloud/deployment/serverless.mdx
+++ b/docs/content/dagster-cloud/deployment/serverless.mdx
@@ -33,7 +33,7 @@ Serverless is subject to the following limitations:
 - Sensors receive 0.25 vCPU cores and 1 GB of RAM
 - All Serverless jobs run in the United States
 
-Enterprise customers may request a quota increase by [contacting Sales](mailto:sales@dagsterlabs.com).
+Pro customers may request a quota increase by [contacting Sales](mailto:sales@dagsterlabs.com).
 
 ---
 

--- a/docs/content/dagster-cloud/insights/integrating-external-metrics.mdx
+++ b/docs/content/dagster-cloud/insights/integrating-external-metrics.mdx
@@ -19,7 +19,7 @@ External metrics, such as Snowflake credits, can be integrated into the Dagster 
 
 Before you start, note that:
 
-- This is a Dagster Cloud Enterprise feature
+- This is a Dagster Cloud Pro feature
 - Up to two million individual data points may be added to Insights, per month
 - External metrics data will only be retained for 90 days
 

--- a/docs/content/dagster-cloud/insights/integrating-snowflake-and-dbt.mdx
+++ b/docs/content/dagster-cloud/insights/integrating-snowflake-and-dbt.mdx
@@ -21,7 +21,7 @@ If you use dbt to materialize tables in Snowflake, use this guide to integrate S
 
 To complete the steps in this guide, you'll need:
 
-- A Dagster Cloud account on the Enterprise plan
+- A Dagster Cloud account on the Pro plan
 - Access to the [Dagster Cloud Insights feature](/dagster-cloud/insights)
 - Snowflake credentials which have access to the `snowflake.account_usage.query_history` table. For more information on granting access to this table, see the [Snowflake documentation](https://docs.snowflake.com/en/sql-reference/account-usage#enabling-the-snowflake-database-usage-for-other-roles).
 - To install the following libraries:

--- a/docs/content/dagster-cloud/insights/integrating-snowflake.mdx
+++ b/docs/content/dagster-cloud/insights/integrating-snowflake.mdx
@@ -21,7 +21,7 @@ If you use the [Snowflake Resource](/\_apidocs/libraries/dagster-snowflake) to q
 
 To complete the steps in this guide, you'll need:
 
-- A Dagster Cloud account on the Enterprise plan
+- A Dagster Cloud account on the Pro plan
 - Access to the [Dagster Cloud Insights feature](/dagster-cloud/insights)
 - Snowflake credentials which have access to the `snowflake.account_usage.query_history` table. For more information on granting access to this table, see the [Snowflake documentation](https://docs.snowflake.com/en/sql-reference/account-usage#enabling-the-snowflake-database-usage-for-other-roles).
 - To install the following libraries:

--- a/docs/content/dagster-cloud/managing-deployments/managing-deployments.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/managing-deployments.mdx
@@ -20,7 +20,7 @@ This guide will focus on **full deployments**, hereafter referred to simply as d
 
 Deployments are standalone environments, allowing you to operate independent instances of Dagster with separately managed permissions.
 
-When a Dagster Cloud organization is created, a single deployment named `prod` will also be created. To create additional deployments, an [Enterprise plan](https://dagster.io/pricing) is required.
+When a Dagster Cloud organization is created, a single deployment named `prod` will also be created. To create additional deployments, a [Pro plan](https://dagster.io/pricing) is required.
 
 Each deployment can have one or multiple [code locations](/dagster-cloud/managing-deployments/code-locations).
 
@@ -54,7 +54,7 @@ To view all deployments, click **View all deployments**.
   are required to create deployments. Additionally, note that creating multiple
   deployments requires an{" "}
   <a href="https://dagster.io/pricing" target="new">
-    Enterprise plan
+    Pro plan
   </a>
   .
 </Note>


### PR DESCRIPTION
## Summary & Motivation

This PR replaces instances of the Dagster Cloud Enterprise plan in the docs with its new moniker, `Pro`.

**Note**: There is one outstanding page (Insights) that will be addressed in #19552 

## How I Tested These Changes

👀 