### PR TITLE
[daggy-u] update usage of `context.add_output_metadata` with `MaterializeResult`

### DIFF
--- a/docs/dagster-university/pages/dagster-essentials/extra-credit/asset-metadata-as-markdown.md
+++ b/docs/dagster-university/pages/dagster-essentials/extra-credit/asset-metadata-as-markdown.md
@@ -108,7 +108,11 @@ In Lesson 9, you created the `adhoc_request` asset. During materialization, the 
    ```python
    base64_data = base64.b64encode(image_data).decode('utf-8')
    md_content = f"![Image](data:image/jpeg;base64,{base64_data})"
+   ```
 
+6. Finally, we'll return a `MaterializeResult` object with the metadata specified as a parameter:
+
+   ```python
    return MaterializeResult(
        metadata={
            "preview": MetadataValue.md(md_content)
@@ -122,7 +126,7 @@ In Lesson 9, you created the `adhoc_request` asset. During materialization, the 
    2. `base64.b64encode` encodes the image’s binary data (`image_data`) into base64 format.
    3. Next, the encoded image data is converted to a UTF-8 encoded string using the `decode` function.
    4. Next, a variable named `md_content` is created. The value of this variable is a Markdown-formatted string containing a JPEG image, where the base64 representation of the image is inserted.
-   5. We are able to include the metadata on the asset by returning a `MaterializeResult` instance with the image is passed in as metadata. The metadata will have a `preview` label in the Dagster UI.
+   5. We are able to include the metadata on the asset by returning a `MaterializeResult` instance with the image passed in as metadata. The metadata will have a `preview` label in the Dagster UI.
    6. Using `MetadataValue.md`, the `md_content` is typed as Markdown. This ensures Dagster will correctly render the chart.
 
 At this point, the code for the `adhoc_request` asset should look like this:

--- a/docs/dagster-university/pages/dagster-essentials/extra-credit/asset-metadata-as-markdown.md
+++ b/docs/dagster-university/pages/dagster-essentials/extra-credit/asset-metadata-as-markdown.md
@@ -126,7 +126,7 @@ In Lesson 9, you created the `adhoc_request` asset. During materialization, the 
    2. `base64.b64encode` encodes the image’s binary data (`image_data`) into base64 format.
    3. Next, the encoded image data is converted to a UTF-8 encoded string using the `decode` function.
    4. Next, a variable named `md_content` is created. The value of this variable is a Markdown-formatted string containing a JPEG image, where the base64 representation of the image is inserted.
-   5. We are able to include the metadata on the asset by returning a `MaterializeResult` instance with the image passed in as metadata. The metadata will have a `preview` label in the Dagster UI.
+   5. To include the metadata on the asset, we returned a `MaterializeResult` instance with the image passed in as metadata. The metadata will have a `preview` label in the Dagster UI.
    6. Using `MetadataValue.md`, the `md_content` is typed as Markdown. This ensures Dagster will correctly render the chart.
 
 At this point, the code for the `adhoc_request` asset should look like this:

--- a/docs/dagster-university/pages/dagster-essentials/extra-credit/asset-metadata-as-markdown.md
+++ b/docs/dagster-university/pages/dagster-essentials/extra-credit/asset-metadata-as-markdown.md
@@ -89,7 +89,7 @@ In Lesson 9, you created the `adhoc_request` asset. During materialization, the 
      pio.write_image(fig, file_path)
    ```
 
-3. Add the following to the import to the top of the file:
+3. Add the `base64` and `MaterializeResult` imports to the top of the file:
 
    ```python
    import base64

--- a/docs/dagster-university/pages/dagster-essentials/extra-credit/coding-practice-metadata-taxi-zones-file.md
+++ b/docs/dagster-university/pages/dagster-essentials/extra-credit/coding-practice-metadata-taxi-zones-file.md
@@ -15,6 +15,9 @@ To practice what you’ve learned, add the record counts to the metadata for `ta
 The metadata you built should look similar to the code contained in the **View answer** toggle. Click to open it.
 
 ```python {% obfuscated="true" %}
+from dagster import MaterializeResult
+
+
 @asset(
     group_name="raw_files",
 )

--- a/docs/dagster-university/pages/dagster-essentials/extra-credit/coding-practice-metadata-taxi-zones-file.md
+++ b/docs/dagster-university/pages/dagster-essentials/extra-credit/coding-practice-metadata-taxi-zones-file.md
@@ -18,7 +18,7 @@ The metadata you built should look similar to the code contained in the **View a
 @asset(
     group_name="raw_files",
 )
-def taxi_zones_file(context):
+def taxi_zones_file():
   """
     The raw CSV file for the taxi zones dataset. Sourced from the NYC Open Data portal.
   """
@@ -29,5 +29,10 @@ def taxi_zones_file(context):
   with open(constants.TAXI_ZONES_FILE_PATH, "wb") as output_file:
     output_file.write(raw_taxi_zones.content)
   num_rows = MetadataValue.int(len(pd.read_csv(constants.TAXI_ZONES_FILE_PATH)))
-  context.add_output_metadata({'Number of records': num_rows})
+
+  return MaterializeResult(
+      metadata={
+          'Number of records': MetadataValue.int(num_rows)
+      }
+  )
 ```

--- a/docs/dagster-university/pages/dagster-essentials/extra-credit/materialization-metadata.md
+++ b/docs/dagster-university/pages/dagster-essentials/extra-credit/materialization-metadata.md
@@ -58,11 +58,11 @@ Let’s add metadata to the `taxi_trips_file` asset to demonstrate further. This
 4. Next, we’ll add the metadata with the specified type:
 
    ```python
-    return MaterializeResult(
-        metadata={
-            'Number of records': MetadataValue.int(num_rows)
-        }
-    )
+   return MaterializeResult(
+       metadata={
+           'Number of records': MetadataValue.int(num_rows)
+       }
+   )
    ```
 
    Let’s break down what’s happening here:

--- a/docs/dagster-university/pages/dagster-essentials/extra-credit/materialization-metadata.md
+++ b/docs/dagster-university/pages/dagster-essentials/extra-credit/materialization-metadata.md
@@ -14,8 +14,8 @@ Now that we’ve covered definition metadata, let’s dive into the other type o
 
 To add metadata to an asset, you need to do two things:
 
+- Return a `MaterializeResult` object with the `metadata` parameter from your asset
 - Use the `MetadataValue` utility class to wrap the data, ensuring it displays correctly in the UI
-- Return a `MaterializeResult` instance with the `metadata` parameter from your asset
 
 Let’s add metadata to the `taxi_trips_file` asset to demonstrate further. This will add the count of records to the asset’s materialization metadata.
 

--- a/examples/project_dagster_university_start/setup.py
+++ b/examples/project_dagster_university_start/setup.py
@@ -4,7 +4,7 @@ setup(
     name="dagster_university",
     packages=find_packages(exclude=["dagster_university_tests"]),
     install_requires=[
-        "dagster==1.5.*",
+        "dagster==1.6.*",
         "dagster-cloud",
         "dagster-duckdb",
         "geopandas",


### PR DESCRIPTION
## Summary & Motivation

With Dagster University being upgraded to v1.6, we should update our usage of `context.add_output_metadata` to returning a `MaterializeResult` with the `metadata` defined as a parameter.

The corresponding changes to `project-dagster-university` can be found here:

https://github.com/dagster-io/project-dagster-university/pull/8

## How I Tested These Changes
