### PR TITLE
docs infra: fix apidocs layout

### DIFF
--- a/docs/next/pages/_app.tsx
+++ b/docs/next/pages/_app.tsx
@@ -84,6 +84,9 @@ const Layout = ({asPath, children, pageProps}: Props) => {
     }
   }
 
+  // handle API docs pages (they are HTML pages generated from Sphinx, not Markdown pages)
+  const isHTMLPage = pageProps?.type === 'HTML';
+
   return (
     <>
       <div
@@ -105,16 +108,23 @@ const Layout = ({asPath, children, pageProps}: Props) => {
             />
             <FeedbackModal isOpen={isFeedbackOpen} closeFeedback={closeFeedback} />
             <div className="lg:pl-80 flex w-full">
-              <VersionedContentLayout asPath={asPath}>
-                <div className="DocSearch-content prose dark:prose-dark max-w-none">{children}</div>
-              </VersionedContentLayout>
-
-              <RightSidebar
-                markdownHeadings={markdownHeadings}
-                navigationItemsForMDX={navigationItems}
-                githubLink={githubLink}
-                toggleFeedback={toggleFeedback}
-              />
+              {isHTMLPage ? (
+                children
+              ) : (
+                <>
+                  <VersionedContentLayout asPath={asPath}>
+                    <div className="DocSearch-content prose dark:prose-dark max-w-none">
+                      {children}
+                    </div>
+                  </VersionedContentLayout>
+                  <RightSidebar
+                    markdownHeadings={markdownHeadings}
+                    navigationItemsForMDX={navigationItems}
+                    githubLink={githubLink}
+                    toggleFeedback={toggleFeedback}
+                  />
+                </>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary & Motivation
oversight from https://github.com/dagster-io/dagster/pull/19093
![image](https://github.com/dagster-io/dagster/assets/4531914/13d4ed5f-73fb-470d-8199-b8e8058b1475)

this PR handles the HTML page rendering properly, as the HTML pages render themselves through sphinx data instead of markdoc data.
 
## How I Tested These Changes
https://02-02-docs-infra-fix-apidocs-layout.dagster.dagster-docs.io/_apidocs/config renders fine