### PR TITLE
[ui] Correctly handle errors in assetOrError graphQL response in AssetView (Round 2)

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -386,7 +386,7 @@ const useAssetViewAssetDefinition = (assetKey: AssetKey) => {
   return {
     definitionQueryResult: result,
     definition: asset.definition,
-    lastMaterialization: asset.assetMaterializations[0],
+    lastMaterialization: asset.assetMaterializations ? asset.assetMaterializations[0] : null,
   };
 };
 


### PR DESCRIPTION
This error resurfaced in Datadog after the last release. I attempted to fix it originally here: https://github.com/dagster-io/dagster/pull/19393

I can’t figure out how this is happening.

- The asset.assetMaterializations field is a non-nullable array. If you edit the backend code to return `None`, a backend exception occurs, so the backend could not have sent undefined.

- The early return above this code catches and handles the `asset is null` and `asset is an error` cases.

I think that this must be caused by Apollo’s cache containing the whole object, minus this field, and Apollo yielding the result anyway. We’ve had problems with this in the past and I’ll try to put together a repro case. In the meantime, this should definitively fix the problem…

## Summary & Motivation

## How I Tested These Changes
