### PR TITLE
chore/automount svc account

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -35,6 +35,7 @@ spec:
     spec:
       imagePullSecrets: {{ $.Values.imagePullSecrets | toYaml | nindent 8 }}
       serviceAccountName: {{ include "dagsterUserDeployments.serviceAccountName" $ }}
+      automountServiceAccountToken: true
       securityContext: {{ $deployment.podSecurityContext | toYaml | nindent 8 }}
       {{- if $deployment.initContainers }}
       initContainers:

--- a/helm/dagster/charts/dagster-user-deployments/templates/serviceaccount.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/serviceaccount.yaml
@@ -11,4 +11,5 @@ metadata:
   name: {{ include "dagsterUserDeployments.serviceAccountName" . }}
   labels: {{ include "dagster.labels" . | nindent 4 }}
   annotations: {{- .Values.serviceAccount.annotations | toYaml | nindent 4 }}
+automountServiceAccountToken: false
 {{- end }}

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -473,6 +473,16 @@ def test_webserver_scheduler_name_override(deployment_template: HelmTemplate):
     assert webserver_deployment.spec.template.spec.scheduler_name == "myscheduler"
 
 
+def test_automount_svc_acct_token(deployment_template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(
+        dagsterWebserver=Webserver.construct(
+        )
+    )
+
+    [deployment] = deployment_template.render(helm_values)
+
+    assert deployment.spec.template.spec.automount_service_account_token
+
 def test_webserver_security_context(deployment_template: HelmTemplate):
     security_context = {
         "allowPrivilegeEscalation": False,

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -474,14 +474,12 @@ def test_webserver_scheduler_name_override(deployment_template: HelmTemplate):
 
 
 def test_automount_svc_acct_token(deployment_template: HelmTemplate):
-    helm_values = DagsterHelmValues.construct(
-        dagsterWebserver=Webserver.construct(
-        )
-    )
+    helm_values = DagsterHelmValues.construct(dagsterWebserver=Webserver.construct())
 
     [deployment] = deployment_template.render(helm_values)
 
     assert deployment.spec.template.spec.automount_service_account_token
+
 
 def test_webserver_security_context(deployment_template: HelmTemplate):
     security_context = {

--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -559,6 +559,14 @@ def test_init_container_resources(template: HelmTemplate):
         for container in webserver_deployment.spec.template.spec.init_containers
     )
 
+def test_automount_svc_acct_token(template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(
+        dagsterDaemon=Daemon.construct()
+    )
+
+    [daemon_deployment] = template.render(helm_values)
+
+    assert daemon_deployment.spec.template.spec.automount_service_account_token
 
 def test_env(template: HelmTemplate):
     helm_values = DagsterHelmValues.construct(dagsterDaemon=Daemon.construct())

--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -560,13 +560,12 @@ def test_init_container_resources(template: HelmTemplate):
     )
 
 def test_automount_svc_acct_token(template: HelmTemplate):
-    helm_values = DagsterHelmValues.construct(
-        dagsterDaemon=Daemon.construct()
-    )
+    helm_values = DagsterHelmValues.construct(dagsterDaemon=Daemon.construct())
 
     [daemon_deployment] = template.render(helm_values)
 
     assert daemon_deployment.spec.template.spec.automount_service_account_token
+
 
 def test_env(template: HelmTemplate):
     helm_values = DagsterHelmValues.construct(dagsterDaemon=Daemon.construct())

--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -559,6 +559,7 @@ def test_init_container_resources(template: HelmTemplate):
         for container in webserver_deployment.spec.template.spec.init_containers
     )
 
+
 def test_automount_svc_acct_token(template: HelmTemplate):
     helm_values = DagsterHelmValues.construct(dagsterDaemon=Daemon.construct())
 

--- a/helm/dagster/schema/schema_tests/test_service_account.py
+++ b/helm/dagster/schema/schema_tests/test_service_account.py
@@ -39,6 +39,18 @@ def standalone_subchart_helm_template() -> HelmTemplate:
     )
 
 
+def test_service_account_automount(template: HelmTemplate):
+    service_account_name = "service-account-name"
+    service_account_values = DagsterHelmValues.construct(
+        serviceAccount=ServiceAccount.construct(name=service_account_name, create=True)
+    )
+
+    service_account_templates = template.render(service_account_values)
+
+    service_account_template = service_account_templates[0]
+
+    assert not service_account_template.automount_service_account_token
+
 def test_service_account_name(template: HelmTemplate):
     service_account_name = "service-account-name"
     service_account_values = DagsterHelmValues.construct(

--- a/helm/dagster/schema/schema_tests/test_service_account.py
+++ b/helm/dagster/schema/schema_tests/test_service_account.py
@@ -51,6 +51,7 @@ def test_service_account_automount(template: HelmTemplate):
 
     assert not service_account_template.automount_service_account_token
 
+
 def test_service_account_name(template: HelmTemplate):
     service_account_name = "service-account-name"
     service_account_values = DagsterHelmValues.construct(

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -1130,6 +1130,13 @@ def test_scheduler_name(template: HelmTemplate):
     assert dagster_user_deployment.spec.template.spec.scheduler_name == "myscheduler"
 
 
+def test_automount_svc_acct_token(template: HelmTemplate):
+    helm_values = UserDeployment.construct()
+
+    [daemon_deployment] = template.render(helm_values)
+
+    assert daemon_deployment.spec.template.spec.automount_service_account_token
+
 def test_env(template: HelmTemplate, user_deployment_configmap_template):
     # new env: list. Gets written to container
     deployment = UserDeployment.construct(

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -1137,6 +1137,7 @@ def test_automount_svc_acct_token(template: HelmTemplate):
 
     assert daemon_deployment.spec.template.spec.automount_service_account_token
 
+
 def test_env(template: HelmTemplate, user_deployment_configmap_template):
     # new env: list. Gets written to container
     deployment = UserDeployment.construct(

--- a/helm/dagster/templates/deployment-celery-queues.yaml
+++ b/helm/dagster/templates/deployment-celery-queues.yaml
@@ -36,6 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "dagster.serviceAccountName" $ }}
+      automountServiceAccountToken: true
       securityContext:
         {{- toYaml $celeryK8sRunLauncherConfig.podSecurityContext | nindent 8 }}
       initContainers:

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -45,6 +45,7 @@ spec:
       imagePullSecrets:
         {{- toYaml $.Values.imagePullSecrets | nindent 8 }}
       serviceAccountName: {{ include "dagster.serviceAccountName" $ }}
+      automountServiceAccountToken: true
       securityContext:
         {{- toYaml .Values.dagsterDaemon.podSecurityContext | nindent 8 }}
       initContainers:

--- a/helm/dagster/templates/deployment-flower.yaml
+++ b/helm/dagster/templates/deployment-flower.yaml
@@ -32,6 +32,7 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "dagster.serviceAccountName" . }}
+      automountServiceAccountToken: true
       securityContext:
       {{- toYaml .Values.flower.podSecurityContext | nindent 8 }}
       initContainers:

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -43,6 +43,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "dagster.serviceAccountName" . }}
+      automountServiceAccountToken: true
       securityContext:
         {{- toYaml $_.Values.dagsterWebserver.podSecurityContext | nindent 8 }}
       initContainers:

--- a/helm/dagster/templates/job-instance-migrate.yaml
+++ b/helm/dagster/templates/job-instance-migrate.yaml
@@ -19,6 +19,7 @@ spec:
     spec:
       imagePullSecrets: {{ .Values.imagePullSecrets | toYaml | nindent 8 }}
       serviceAccountName: {{ include "dagster.serviceAccountName" . }}
+      automountServiceAccountToken: true
       securityContext: {{ $_.Values.dagsterWebserver.podSecurityContext | toYaml | nindent 8 }}
       restartPolicy: Never
       containers:

--- a/helm/dagster/templates/serviceaccount.yaml
+++ b/helm/dagster/templates/serviceaccount.yaml
@@ -5,4 +5,5 @@ metadata:
   name: {{ include "dagster.serviceAccountName" . }}
   labels: {{ include "dagster.labels" . | nindent 4 }}
   annotations: {{- .Values.serviceAccount.annotations | toYaml | nindent 4 }}
+automountServiceAccountToken: false
 {{- end -}}

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -871,6 +871,7 @@ def construct_dagster_k8s_job(
             {
                 "image_pull_secrets": job_config.image_pull_secrets,
                 "service_account_name": service_account_name,
+                "automount_service_account_token": True,
                 "containers": [container_config] + user_defined_containers,
                 "volumes": volumes,
             },

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
@@ -488,6 +488,7 @@ def test_step_handler(kubeconfig_file, k8s_instance):
     method_name, _args, kwargs = mock_method_calls[0]
     assert method_name == "create_namespaced_job"
     assert kwargs["body"].spec.template.spec.containers[0].image == "bizbuz"
+    assert kwargs["body"].spec.template.spec.automount_service_account_token
 
     # appropriate labels applied
     labels = kwargs["body"].spec.template.metadata.labels

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
@@ -70,6 +70,7 @@ def test_construct_dagster_k8s_job():
     assert job["kind"] == "Job"
     assert job["metadata"]["name"] == "job123"
     assert job["spec"]["template"]["spec"]["containers"][0]["image"] == "test/foo:latest"
+    assert job["spec"]["template"]["spec"]["automount_service_account_token"]
     assert DAGSTER_PG_PASSWORD_ENV_VAR in [
         env["name"] for env in job["spec"]["template"]["spec"]["containers"][0]["env"]
     ]


### PR DESCRIPTION
- feat: Use automountServiceAccountToken false
- feat: Add tests
- feat: More tests
- chore: Ruff formatting
- feat: Add automountServiceAccountToken to other Helm templates
- exp: Add automount token to the job.py for spawned pods
- chore: Add tests to pod spec
- chore: Ruff linting

## Summary & Motivation

## How I Tested These Changes
