### PR TITLE
update asset selection used by default AMP sensors to be more clear

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -416,6 +416,26 @@ class AssetSelection(ABC, BaseModel, frozen=True):
 
 
 @whitelist_for_serdes
+class AllAutoMaterializableSelection(AssetSelection, frozen=True):
+    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+        return {
+            target_key
+            for target_key in asset_graph.materializable_asset_keys
+            if asset_graph.get_auto_materialize_policy(target_key) is not None
+        }.union(
+            target_key
+            for target_key in asset_graph.source_asset_keys
+            if asset_graph.get_auto_observe_interval_minutes(target_key) is not None
+        )
+
+    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+        return self
+
+    def __str__(self) -> str:
+        return "all auto-materializable assets and auto-observable source assets"
+
+
+@whitelist_for_serdes
 class AllSelection(AssetSelection, frozen=True):
     include_sources: Optional[bool]
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_asset_policy_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_asset_policy_sensors.py
@@ -10,6 +10,7 @@ from dagster import (
     observable_source_asset,
     sensor,
 )
+from dagster._core.definitions.asset_selection import AllAutoMaterializableSelection
 from dagster._core.definitions.automation_policy_sensor_definition import (
     AutomationPolicySensorDefinition,
 )
@@ -124,6 +125,8 @@ def test_default_automation_policy_sensors(instance_with_automation_policy_senso
 
     asset_graph = ExternalAssetGraph.from_external_repository(external_repo)
 
+    assert automation_policy_sensor.asset_selection == AllAutoMaterializableSelection()
+
     assert automation_policy_sensor.asset_selection.resolve(asset_graph) == {
         AssetKey(["auto_materialize_asset"]),
         AssetKey(["auto_observe_asset"]),
@@ -197,6 +200,11 @@ def test_combine_default_sensors_with_non_default_sensors(instance_with_automati
     # default sensor includes the assets that weren't covered by the custom one
 
     default_sensor = external_repo.get_external_sensor("default_automation_policy_sensor")
+
+    assert (
+        default_sensor.asset_selection
+        == AllAutoMaterializableSelection() - automation_policy_sensor.asset_selection
+    )
 
     assert default_sensor.asset_selection.resolve(asset_graph) == {
         AssetKey(["other_auto_materialize_asset"]),


### PR DESCRIPTION
Summary:
Instead of computing all the keys that will be included and making the asset selection a list of all of those keys, use a new asset selection that specifically targets all auto-materializable and auto-observable assets.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
