### PR TITLE
when a run was launched by an AMP sensor, show the sensor in the launched by

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/CreatedByTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/CreatedByTag.tsx
@@ -32,6 +32,7 @@ type TagType =
   | {type: 'manual'};
 
 const pluckTagFromList = (tags: RunTagsFragment[]): TagType => {
+  // Prefer user/schedule/sensor
   for (const tag of tags) {
     const {key} = tag;
     switch (key) {
@@ -41,6 +42,13 @@ const pluckTagFromList = (tags: RunTagsFragment[]): TagType => {
         return {type: 'schedule', tag};
       case DagsterTag.SensorName:
         return {type: 'sensor', tag};
+    }
+  }
+
+  // If none of those, check for AMP
+  for (const tag of tags) {
+    const {key} = tag;
+    switch (key) {
       case DagsterTag.Automaterialize:
         return {type: 'auto-materialize', tag};
       case DagsterTag.CreatedBy: {


### PR DESCRIPTION
Summary:
an AMP sensor run has both the sensor tag and the AMP tag - prefer the sensor name tag, even if it is later in the tag list

Test Plan:
Load runs that were launched by amp sensors in the UI, see they have the expected tag now

## Summary & Motivation

## How I Tested These Changes
