### PR TITLE
make run dequeuer daemon a bit less spammy

### DIFF
--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -229,10 +229,8 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
                 " Temporarily skipping runs from the following locations due to a user code error: "
                 + ",".join(list(paused_location_names))
             )
-        self._logger.info(
-            "Priority sorting and checking tag concurrency limits for queued runs."
-            + locations_clause
-        )
+
+        logged_this_iteration = False
         # Paginate through our runs list so we don't need to hold every run
         # in memory at once. The maximum number of runs we'll hold in memory is
         # max_runs_to_launch + page_size.
@@ -248,6 +246,13 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
             if not queued_runs:
                 has_more = False
                 return batch
+
+            if not logged_this_iteration:
+                logged_this_iteration = True
+                self._logger.info(
+                    "Priority sorting and checking tag concurrency limits for queued runs."
+                    + locations_clause
+                )
 
             cursor = queued_runs[-1].run_id
 


### PR DESCRIPTION
Summary:
Right now we log this string every iteration even when there are no runs. Blames to https://github.com/dagster-io/dagster/pull/18347/files - before we would do a single fetch, log nothing in the common case where there were no queued runs. Now we always log because it takes longer to know for sure whether there are runs. Defer the log until the first time we know there is at least one queued run.

Test Plan:
Run dagster dev locally with no queued runs, no logspew
Enqueue a run, see one log line per iteration still, as long as there are runs to consider

## Summary & Motivation

## How I Tested These Changes
