### PR TITLE
[upath io manager] if an asset goes from unpartitioned to partitioned, delete the old storage file so the partitioned data can be stored

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -425,6 +425,13 @@ class UPathIOManager(MemoizableIOManager):
 
                 return self._load_multiple_inputs(context)
 
+    def _handle_transition_to_partitioned_asset(self, path: "UPath"):
+        # if the asset was previously non-partitioned, path will be a file, when it should
+        # be a directory for the partitioned asset. Delete the file, so that it can be made
+        # into a directory
+        if path.exists() and path.is_file():
+            path.unlink()
+
     def handle_output(self, context: OutputContext, obj: Any):
         if context.has_asset_partitions:
             paths = self._get_paths_for_partitions(context)
@@ -438,6 +445,7 @@ class UPathIOManager(MemoizableIOManager):
             )
 
             path = next(iter(paths.values()))
+            self._handle_transition_to_partitioned_asset(path.parent)
         else:
             path = self._get_path(context)
         self.make_directory(path.parent)

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -431,9 +431,8 @@ class UPathIOManager(MemoizableIOManager):
         # into a directory
         if path.exists() and path.is_file():
             context.log.warn(
-                f"Non-partitioned asset {context.asset_key} was materialized to"
-                " file {path}. Materializing {context.asset_key} as a partitioned asset,"
-                f" will delete this file, and create a directory, {path} containing partitioned data files."
+                f"Found file at {path} believed to correspond with previously non-partitioned version"
+                f" of {context.asset_key}. Removing {path} and replacing with directory for partitioned data files."
             )
             path.unlink(missing_ok=True)
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -675,3 +675,23 @@ def test_upath_io_manager_async_allow_missing_partitions(
     )
     downstream_asset_data = result.output_for_node("downstream_asset", "result")
     assert len(downstream_asset_data) == 1, "1 partition should be missing"
+
+
+def test_upath_can_transition_from_non_partitioned_to_partitioned(
+    tmp_path: Path, daily: DailyPartitionsDefinition, start: datetime
+):
+    my_io_manager = PickleIOManager(UPath(tmp_path))
+
+    @asset
+    def my_asset():  # type: ignore
+        return 1
+
+    assert materialize([my_asset], resources={"io_manager": my_io_manager}).success
+
+    @asset(partitions_def=daily)
+    def my_asset():
+        return 1
+
+    assert materialize(
+        [my_asset], resources={"io_manager": my_io_manager}, partition_key=start.strftime(daily.fmt)
+    ).success


### PR DESCRIPTION
## Summary & Motivation
The UPath I/O managers store `None` values. This presents a couple problems, but one of the most user facing issues is that if a user transitions an asset from non-partitioned to partitioned, they will get a FileExists error. For new users, especially users who are not introduced to I/O managers, this could be a pretty common experience. 

```python
@asset 
def my_asset():
   # does some work, but returns None
```
if they materialize this asset, the file `$DAGSTER_HOME/storage/my_asset` will be created.
If they later update `my_asset` to be partitioned
```python
@asset(partitions_def=DailyPartitionsDefinition(...))
def my_asset():
   # does some work, but returns None
```
and try to materialize, they will get the error 
```
FileExistsError: [Errno 17] File exists: '$DAGSTER_HOME/storage/my_asset'
```
since the I/O manager wants to store the partitioned data at `$DAGSTER_HOME/storage/my_asset/<partition_key>`.

The solution for this right now is to manually delete the `my_asset` file, or annotate the asset with the `-> None` return type. However, we could detect that the `my_asset` file exists, and delete it for the user in the UPath I/O manager. I think this is a safe thing to do since the user is materializing the asset anyway, so they would be overriding the contents of the file even if they hadn't transitioned it to a partitioned asset.

## How I Tested These Changes
new unit test. Ran it before making code changes and confirmed the FileExists error was raised. Error no longer raised with the new code changes