### PR TITLE
add run priority awareness to the concurrency context

### DIFF
--- a/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
+++ b/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
@@ -437,6 +437,41 @@ concurrency:
   default_op_concurrency_limit: 1
 ```
 
+#### Setting priority for ops/assets
+
+By default, slots will be allocated to op / asset execution on a first-in-first-out basis. However, steps from high priority runs will take precedence over steps from low priority runs, as determined by the priority tag on the individual run.
+
+```python startafter=start_marker_priority endbefore=end_marker_priority file=/deploying/concurrency_limits/concurrency_limits.py
+@job(tags={"dagster/priority": "3"})
+def important_job():
+    ...
+
+
+@schedule(
+    cron_schedule="* * * * *",
+    job_name="important_job",
+    execution_timezone="US/Central",
+    tags={"dagster/priority": "-1"},
+)
+def less_important_schedule(_):
+    ...
+```
+
+Priority can also be assigned based on the priority tag of the op/asset definition.
+
+```python file=/deploying/concurrency_limits/concurrency_limits.py startafter=start_global_concurrency_priority endbefore=end_global_concurrency_priority
+@op(tags={"dagster/concurrency_key": "foo", "dagster/priority": "3"})
+def my_op():
+    ...
+
+
+@asset(op_tags={"dagster/concurrency_key": "foo", "dagster/priority": "3"})
+def my_asset():
+    ...
+```
+
+When the priority tag is set on both the run and the asset/op definition, the step priority will be the sum of the two values.
+
 #### Freeing concurrency slots
 
 With a global concurrency limit set, it is useful to configure your instance to automatically free slots for canceled/failed runs. Certain execution errors can cause steps to exit without freeing an occupied concurrency slot.

--- a/examples/docs_snippets/docs_snippets/deploying/concurrency_limits/concurrency_limits.py
+++ b/examples/docs_snippets/docs_snippets/deploying/concurrency_limits/concurrency_limits.py
@@ -33,3 +33,17 @@ def my_redshift_table():
 
 
 # end_global_concurrency
+
+
+# start_global_concurrency_priority
+@op(tags={"dagster/concurrency_key": "foo", "dagster/priority": "3"})
+def my_op():
+    ...
+
+
+@asset(op_tags={"dagster/concurrency_key": "foo", "dagster/priority": "3"})
+def my_asset():
+    ...
+
+
+# end_global_concurrency_priority

--- a/python_modules/dagster/dagster/_core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/active.py
@@ -354,12 +354,12 @@ class ActiveExecution:
             step_concurrency_key = step.tags.get(GLOBAL_CONCURRENCY_TAG)
             if step_concurrency_key and self._instance_concurrency_context:
                 try:
-                    priority = int(step.tags.get(PRIORITY_TAG, 0))
+                    step_priority = int(step.tags.get(PRIORITY_TAG, 0))
                 except ValueError:
-                    priority = 0
+                    step_priority = 0
 
                 if not self._instance_concurrency_context.claim(
-                    step_concurrency_key, step.key, priority
+                    step_concurrency_key, step.key, step_priority
                 ):
                     continue
 

--- a/python_modules/dagster/dagster/_core/executor/in_process.py
+++ b/python_modules/dagster/dagster/_core/executor/in_process.py
@@ -10,7 +10,6 @@ from dagster._core.execution.plan.execute_plan import inner_plan_execution_itera
 from dagster._core.execution.plan.instance_concurrency_context import InstanceConcurrencyContext
 from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.execution.retries import RetryMode
-from dagster._core.storage.tags import PRIORITY_TAG
 from dagster._utils.timing import format_duration, time_execution_scope
 
 from .base import Executor
@@ -21,13 +20,8 @@ def inprocess_execution_iterator(
     execution_plan: ExecutionPlan,
     instance_concurrency_context: Optional[InstanceConcurrencyContext] = None,
 ) -> Iterator[DagsterEvent]:
-    try:
-        run_priority = int(job_context.run_tags.get(PRIORITY_TAG, "0"))
-    except ValueError:
-        run_priority = 0
-
     with InstanceConcurrencyContext(
-        job_context.instance, job_context.run_id, run_priority
+        job_context.instance, job_context.dagster_run
     ) as instance_concurrency_context:
         yield from inner_plan_execution_iterator(
             job_context, execution_plan, instance_concurrency_context

--- a/python_modules/dagster/dagster/_core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/_core/executor/multiprocess.py
@@ -29,7 +29,6 @@ from dagster._core.execution.plan.step import ExecutionStep
 from dagster._core.execution.retries import RetryMode
 from dagster._core.executor.base import Executor
 from dagster._core.instance import DagsterInstance
-from dagster._core.storage.tags import PRIORITY_TAG
 from dagster._utils import get_run_crash_explanation, start_termination_thread
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 from dagster._utils.timing import TimerResult, format_duration, time_execution_scope
@@ -188,13 +187,8 @@ class MultiprocessExecutor(Executor):
         with ExitStack() as stack:
             timer_result = stack.enter_context(time_execution_scope())
 
-            try:
-                run_priority = int(plan_context.run_tags.get(PRIORITY_TAG, "0"))
-            except ValueError:
-                run_priority = 0
-
             instance_concurrency_context = stack.enter_context(
-                InstanceConcurrencyContext(plan_context.instance, plan_context.run_id, run_priority)
+                InstanceConcurrencyContext(plan_context.instance, plan_context.dagster_run)
             )
             active_execution = stack.enter_context(
                 ActiveExecution(

--- a/python_modules/dagster/dagster/_core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/_core/executor/multiprocess.py
@@ -29,6 +29,7 @@ from dagster._core.execution.plan.step import ExecutionStep
 from dagster._core.execution.retries import RetryMode
 from dagster._core.executor.base import Executor
 from dagster._core.instance import DagsterInstance
+from dagster._core.storage.tags import PRIORITY_TAG
 from dagster._utils import get_run_crash_explanation, start_termination_thread
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 from dagster._utils.timing import TimerResult, format_duration, time_execution_scope
@@ -186,8 +187,14 @@ class MultiprocessExecutor(Executor):
         timer_result: Optional[TimerResult] = None
         with ExitStack() as stack:
             timer_result = stack.enter_context(time_execution_scope())
+
+            try:
+                run_priority = int(plan_context.run_tags.get(PRIORITY_TAG, "0"))
+            except ValueError:
+                run_priority = 0
+
             instance_concurrency_context = stack.enter_context(
-                InstanceConcurrencyContext(plan_context.instance, plan_context.run_id)
+                InstanceConcurrencyContext(plan_context.instance, plan_context.run_id, run_priority)
             )
             active_execution = stack.enter_context(
                 ActiveExecution(

--- a/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
@@ -16,7 +16,6 @@ from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.execution.retries import RetryMode
 from dagster._core.executor.step_delegating.step_handler.base import StepHandler, StepHandlerContext
 from dagster._core.instance import DagsterInstance
-from dagster._core.storage.tags import PRIORITY_TAG
 from dagster._grpc.types import ExecuteStepArgs
 from dagster._utils.error import serializable_error_info_from_exc_info
 
@@ -118,12 +117,8 @@ class StepDelegatingExecutor(Executor):
             f"Starting execution with step handler {self._step_handler.name}.",
             EngineEventData(),
         )
-        try:
-            run_priority = int(plan_context.run_tags.get(PRIORITY_TAG, "0"))
-        except ValueError:
-            run_priority = 0
         with InstanceConcurrencyContext(
-            plan_context.instance, plan_context.run_id, run_priority
+            plan_context.instance, plan_context.dagster_run
         ) as instance_concurrency_context:
             with ActiveExecution(
                 execution_plan,

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_active.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_active.py
@@ -198,12 +198,13 @@ def test_active_concurrency():
             assert instance.event_log_storage.supports_global_concurrency_limits
 
             instance.event_log_storage.set_concurrency_slots("foo", 1)
+            run = instance.create_run_for_job(foo_job, run_id=run_id)
 
             with pytest.raises(
                 DagsterInvariantViolationError,
                 match="Execution finished without completing the execution plan",
             ):
-                with InstanceConcurrencyContext(instance, run_id) as instance_concurrency_context:
+                with InstanceConcurrencyContext(instance, run) as instance_concurrency_context:
                     with create_execution_plan(foo_job).start(
                         RetryMode.DISABLED,
                         instance_concurrency_context=instance_concurrency_context,

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_instance_concurrency_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_instance_concurrency_context.py
@@ -1,6 +1,7 @@
 import time
 from contextlib import ExitStack
 
+import mock
 import pytest
 from dagster import job, op
 from dagster._core.execution.plan.instance_concurrency_context import (
@@ -190,6 +191,8 @@ def test_zero_concurrency_key(concurrency_instance):
         assert not context.claim("foo", "b")
 
 
+@mock.patch("dagster._core.execution.plan.instance_concurrency_context.INITIAL_INTERVAL_VALUE", 0.1)
+@mock.patch("dagster._core.execution.plan.instance_concurrency_context.STEP_UP_BASE", 1)
 def test_step_priority(concurrency_instance):
     run = concurrency_instance.create_run_for_job(define_foo_job(), run_id=make_new_run_id())
     concurrency_instance.event_log_storage.set_concurrency_slots("foo", 1)
@@ -200,7 +203,7 @@ def test_step_priority(concurrency_instance):
         assert not context.claim("foo", "d", step_priority=-1)
 
         context.free_step("a")
-        time.sleep(1)
+        time.sleep(0.1)
 
         # highest priority step should be able to claim the slot
         assert not context.claim("foo", "b")
@@ -208,6 +211,8 @@ def test_step_priority(concurrency_instance):
         assert not context.claim("foo", "d")
 
 
+@mock.patch("dagster._core.execution.plan.instance_concurrency_context.INITIAL_INTERVAL_VALUE", 0.1)
+@mock.patch("dagster._core.execution.plan.instance_concurrency_context.STEP_UP_BASE", 1)
 def test_run_priority(concurrency_instance):
     low_priority_run = concurrency_instance.create_run_for_job(
         define_foo_job(), run_id=make_new_run_id()
@@ -230,8 +235,62 @@ def test_run_priority(concurrency_instance):
 
         # free the occupied slot
         low_context.free_step("a")
-        time.sleep(1)
+        time.sleep(0.1)
 
         # high priority run should now be able to claim the slot
         assert not low_context.claim("foo", "b")
         assert high_context.claim("foo", "c")
+
+
+@mock.patch("dagster._core.execution.plan.instance_concurrency_context.INITIAL_INTERVAL_VALUE", 0.1)
+@mock.patch("dagster._core.execution.plan.instance_concurrency_context.STEP_UP_BASE", 1)
+def test_run_step_priority(concurrency_instance):
+    low_priority_run = concurrency_instance.create_run_for_job(
+        define_foo_job(), run_id=make_new_run_id()
+    )
+    high_priority_run = concurrency_instance.create_run_for_job(
+        define_foo_job(), run_id=make_new_run_id(), tags={"dagster/priority": "1000"}
+    )
+    concurrency_instance.event_log_storage.set_concurrency_slots("foo", 0)
+
+    with ExitStack() as stack:
+        low_context = stack.enter_context(
+            InstanceConcurrencyContext(concurrency_instance, low_priority_run)
+        )
+        high_context = stack.enter_context(
+            InstanceConcurrencyContext(concurrency_instance, high_priority_run)
+        )
+
+        # at first all steps are blocked
+        assert not low_context.claim("foo", "low_run_low_step", step_priority=-1)  # 0 - 1
+        assert not low_context.claim("foo", "low_run_high_step", step_priority=1000)  # 0 + 1000
+        assert not high_context.claim("foo", "high_run_low_step", step_priority=-1)  # 1000 - 1
+        assert not high_context.claim(
+            "foo", "high_run_high_step", step_priority=1000
+        )  # 1000 + 1000
+
+        concurrency_instance.event_log_storage.set_concurrency_slots("foo", 1)
+        time.sleep(0.1)
+
+        assert not low_context.claim("foo", "low_run_low_step", step_priority=-1)  # 0 - 1
+        assert not low_context.claim("foo", "low_run_high_step", step_priority=1000)  # 0 + 1000
+        assert not high_context.claim("foo", "high_run_low_step", step_priority=-1)  # 1000 - 1
+        assert high_context.claim("foo", "high_run_high_step", step_priority=1000)  # 1000 + 1000
+
+        high_context.free_step("high_run_high_step")
+        time.sleep(0.1)
+
+        assert not low_context.claim("foo", "low_run_low_step", step_priority=-1)  # 0 - 1
+        assert low_context.claim("foo", "low_run_high_step", step_priority=1000)  # 0 + 1000
+        assert not high_context.claim("foo", "high_run_low_step", step_priority=-1)  # 1000 - 1
+
+        low_context.free_step("low_run_high_step")
+        time.sleep(0.1)
+
+        assert not low_context.claim("foo", "low_run_low_step", step_priority=-1)  # 0 - 1
+        assert high_context.claim("foo", "high_run_low_step", step_priority=-1)  # 1000 - 1
+
+        high_context.free_step("high_run_low_step")
+        time.sleep(0.1)
+
+        assert low_context.claim("foo", "low_run_low_step", step_priority=-1)  # 0 - 1

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_instance_concurrency_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_instance_concurrency_context.py
@@ -2,6 +2,7 @@ import time
 from contextlib import ExitStack
 
 import pytest
+from dagster import job, op
 from dagster._core.execution.plan.instance_concurrency_context import (
     INITIAL_INTERVAL_VALUE,
     STEP_UP_BASE,
@@ -12,11 +13,23 @@ from dagster._core.utils import make_new_run_id
 from .conftest import CUSTOM_SLEEP_INTERVAL
 
 
+def define_foo_job():
+    @op
+    def foo_op():
+        pass
+
+    @job
+    def foo_job():
+        foo_op()
+
+    return foo_job
+
+
 def test_global_concurrency(concurrency_instance):
-    run_id = make_new_run_id()
+    run = concurrency_instance.create_run_for_job(define_foo_job(), run_id=make_new_run_id())
     concurrency_instance.event_log_storage.set_concurrency_slots("foo", 2)
 
-    with InstanceConcurrencyContext(concurrency_instance, run_id) as context:
+    with InstanceConcurrencyContext(concurrency_instance, run) as context:
         assert context.claim("foo", "a")
         assert not context.has_pending_claims()
         assert context.claim("foo", "b")
@@ -34,10 +47,10 @@ def test_global_concurrency(concurrency_instance):
 
 
 def test_limitless_context(concurrency_instance):
-    run_id = make_new_run_id()
+    run = concurrency_instance.create_run_for_job(define_foo_job(), run_id=make_new_run_id())
     assert concurrency_instance.event_log_storage.get_concurrency_info("foo").slot_count == 0
 
-    with InstanceConcurrencyContext(concurrency_instance, run_id) as context:
+    with InstanceConcurrencyContext(concurrency_instance, run) as context:
         assert context.claim("foo", "a")
         assert context.claim("foo", "b")
         assert context.claim("foo", "d")
@@ -50,11 +63,11 @@ def test_limitless_context(concurrency_instance):
 
 
 def test_context_error(concurrency_instance):
-    run_id = make_new_run_id()
+    run = concurrency_instance.create_run_for_job(define_foo_job(), run_id=make_new_run_id())
     concurrency_instance.event_log_storage.set_concurrency_slots("foo", 2)
 
     with pytest.raises(Exception, match="uh oh"):
-        with InstanceConcurrencyContext(concurrency_instance, run_id) as context:
+        with InstanceConcurrencyContext(concurrency_instance, run) as context:
             assert context.claim("foo", "a")
             assert not context.has_pending_claims()
             assert context.claim("foo", "b")
@@ -72,10 +85,10 @@ def test_context_error(concurrency_instance):
 
 
 def test_default_interval(concurrency_instance):
-    run_id = make_new_run_id()
+    run = concurrency_instance.create_run_for_job(define_foo_job(), run_id=make_new_run_id())
     concurrency_instance.event_log_storage.set_concurrency_slots("foo", 1)
 
-    with InstanceConcurrencyContext(concurrency_instance, run_id) as context:
+    with InstanceConcurrencyContext(concurrency_instance, run) as context:
         assert context.claim("foo", "a")
         assert not context.claim("foo", "b")
         call_count = concurrency_instance.event_log_storage.get_check_calls("b")
@@ -90,10 +103,10 @@ def test_default_interval(concurrency_instance):
 
 
 def test_backoff_interval(concurrency_instance):
-    run_id = make_new_run_id()
+    run = concurrency_instance.create_run_for_job(define_foo_job(), run_id=make_new_run_id())
     concurrency_instance.event_log_storage.set_concurrency_slots("foo", 1)
 
-    with InstanceConcurrencyContext(concurrency_instance, run_id) as context:
+    with InstanceConcurrencyContext(concurrency_instance, run) as context:
         assert context.claim("foo", "a")
         assert not context.claim("foo", "b")
         call_count = concurrency_instance.event_log_storage.get_check_calls("b")
@@ -116,11 +129,13 @@ def test_backoff_interval(concurrency_instance):
 
 
 def test_custom_interval(concurrency_custom_sleep_instance):
-    run_id = make_new_run_id()
+    run = concurrency_custom_sleep_instance.create_run_for_job(
+        define_foo_job(), run_id=make_new_run_id()
+    )
     storage = concurrency_custom_sleep_instance.event_log_storage
     storage.set_concurrency_slots("foo", 1)
 
-    with InstanceConcurrencyContext(concurrency_custom_sleep_instance, run_id) as context:
+    with InstanceConcurrencyContext(concurrency_custom_sleep_instance, run) as context:
         assert context.claim("foo", "a")
         assert not context.claim("foo", "b")
         call_count = storage.get_check_calls("b")
@@ -142,41 +157,43 @@ def test_custom_interval(concurrency_custom_sleep_instance):
 
 
 def test_unset_concurrency_default(concurrency_instance):
-    run_id = make_new_run_id()
+    run = concurrency_instance.create_run_for_job(define_foo_job(), run_id=make_new_run_id())
 
     assert concurrency_instance.event_log_storage.get_concurrency_keys() == set()
 
-    with InstanceConcurrencyContext(concurrency_instance, run_id) as context:
+    with InstanceConcurrencyContext(concurrency_instance, run) as context:
         assert context.claim("foo", "a")
         assert context.claim("foo", "b")
 
 
 def test_default_concurrency_key(concurrency_instance_with_default_one):
-    run_id = make_new_run_id()
+    run = concurrency_instance_with_default_one.create_run_for_job(
+        define_foo_job(), run_id=make_new_run_id()
+    )
 
     assert concurrency_instance_with_default_one.event_log_storage.get_concurrency_keys() == set()
     assert concurrency_instance_with_default_one.global_op_concurrency_default_limit == 1
 
-    with InstanceConcurrencyContext(concurrency_instance_with_default_one, run_id) as context:
+    with InstanceConcurrencyContext(concurrency_instance_with_default_one, run) as context:
         assert context.claim("foo", "a")
         assert not context.claim("foo", "b")
 
 
 def test_zero_concurrency_key(concurrency_instance):
-    run_id = make_new_run_id()
+    run = concurrency_instance.create_run_for_job(define_foo_job(), run_id=make_new_run_id())
 
     concurrency_instance.event_log_storage.set_concurrency_slots("foo", 0)
     assert concurrency_instance.event_log_storage.get_concurrency_keys() == set(["foo"])
 
-    with InstanceConcurrencyContext(concurrency_instance, run_id) as context:
+    with InstanceConcurrencyContext(concurrency_instance, run) as context:
         assert not context.claim("foo", "a")
         assert not context.claim("foo", "b")
 
 
 def test_step_priority(concurrency_instance):
-    run_id = make_new_run_id()
+    run = concurrency_instance.create_run_for_job(define_foo_job(), run_id=make_new_run_id())
     concurrency_instance.event_log_storage.set_concurrency_slots("foo", 1)
-    with InstanceConcurrencyContext(concurrency_instance, run_id) as context:
+    with InstanceConcurrencyContext(concurrency_instance, run) as context:
         assert context.claim("foo", "a")
         assert not context.claim("foo", "b")
         assert not context.claim("foo", "c", step_priority=1000)
@@ -192,8 +209,12 @@ def test_step_priority(concurrency_instance):
 
 
 def test_run_priority(concurrency_instance):
-    low_priority_run = make_new_run_id()
-    high_priority_run = make_new_run_id()
+    low_priority_run = concurrency_instance.create_run_for_job(
+        define_foo_job(), run_id=make_new_run_id()
+    )
+    high_priority_run = concurrency_instance.create_run_for_job(
+        define_foo_job(), run_id=make_new_run_id(), tags={"dagster/priority": "1000"}
+    )
     concurrency_instance.event_log_storage.set_concurrency_slots("foo", 1)
 
     with ExitStack() as stack:
@@ -201,7 +222,7 @@ def test_run_priority(concurrency_instance):
             InstanceConcurrencyContext(concurrency_instance, low_priority_run)
         )
         high_context = stack.enter_context(
-            InstanceConcurrencyContext(concurrency_instance, high_priority_run, run_priority=1000)
+            InstanceConcurrencyContext(concurrency_instance, high_priority_run)
         )
         assert low_context.claim("foo", "a")
         assert not low_context.claim("foo", "b")


### PR DESCRIPTION
## Summary & Motivation
Currently, we allow steps to grab free concurrency slots using priority assigned at op/asset definition time.  This means that every run that materializes a given asset will have equal priority, and thus earlier runs will claim the slot over later runs.

One use case for priority is to assign an overall priority for asset backfills, such that backfill runs will not claim open slots over regular materializations.  The main way to do this is to use tags assigned to runs, in addition to the asset tags (assigned at definition-time).

The formula for op concurrency slot priority is: <run_priority> + <asset/op def priority>

## How I Tested These Changes
BK