### PR TITLE
feat(dbt): add `dagster` dbt package

### DIFF
--- a/python_modules/libraries/dagster-dbt/MANIFEST.in
+++ b/python_modules/libraries/dagster-dbt/MANIFEST.in
@@ -1,3 +1,5 @@
+recursive-exclude dbt_packages *
+
 include LICENSE
 include dagster_dbt/py.typed
 recursive-include dagster_dbt/include *

--- a/python_modules/libraries/dagster-dbt/dbt_packages/dagster/.gitignore
+++ b/python_modules/libraries/dagster-dbt/dbt_packages/dagster/.gitignore
@@ -1,0 +1,3 @@
+target/
+dbt_packages/
+logs/

--- a/python_modules/libraries/dagster-dbt/dbt_packages/dagster/dbt_project.yml
+++ b/python_modules/libraries/dagster-dbt/dbt_packages/dagster/dbt_project.yml
@@ -1,0 +1,9 @@
+name: "dagster"
+version: "0.0.1"
+config-version: 2
+
+require-dbt-version: [">=1.5.0", "<2.0.0"]
+
+macro-paths: ["macros"]
+
+clean-targets: ["target", "dbt_packages"]

--- a/python_modules/libraries/dagster-dbt/dbt_packages/dagster/macros/log_columns_in_relation.sql
+++ b/python_modules/libraries/dagster-dbt/dbt_packages/dagster/macros/log_columns_in_relation.sql
@@ -1,0 +1,11 @@
+{% macro log_columns_in_relation() %}
+    {%- set columns = adapter.get_columns_in_relation(this) -%}
+    {%- set table_schema = {} -%}
+
+    {% for column in columns %}
+        {%- set serializable_column = {column.name: {'data_type': column.data_type}} -%}
+        {%- set _ = table_schema.update(serializable_column) -%}
+    {% endfor %}
+
+    {% do log(tojson(table_schema), info=true) %}
+{% endmacro %}


### PR DESCRIPTION
## Summary & Motivation
Formalize https://github.com/dagster-io/dagster/pull/19548 by pulling the new macro logic into a separate dbt package.

Separated this out into a separate PR since I wanted to discuss where this package should live in the monorepo.

### Assumptions

[Although dbt Hub packages are recommended](https://docs.getdbt.com/docs/build/packages#hub-packages-recommended), I believe we should instead prioritize the [`git` installation experience](https://docs.getdbt.com/docs/build/packages#git-packages). 
  - This will give us a better experience while developing this package. Users will be able to install via revision if we need to push out hotfixes.
  - Users still have the option to install via named tags/revisions (e.g. `1.6.0`)

Note that we will still have the option to formally move to dbt Hub in the future, so this isn't a binding choice.

Here's some examples `dependencies.yml` would look like for a user:

**Named Revision**
```yaml
packages:
  - git: "https://github.com/dagster-io/dagster.git"
    subdirectory: "/python_modules/libraries/dagster-dbt/dbt_packages/dagster"
    revision: 1.6.0
```

**Hash Revision**
```yaml
packages:
  - git: "https://github.com/dagster-io/dagster.git"
    subdirectory: "/python_modules/libraries/dagster-dbt/dbt_packages/dagster"
    revision: fd13563951d76ee5abf8381bb71046efaa6f90bb
```

### Open Questions

We could put this package directory at the top level of our monorepo, just to make `subdirectory` a bit more ergonomic. I don't think it's a big deal since this is one time copy paste anyways.

```yaml
packages:
  - git: "https://github.com/dagster-io/dagster.git"
    subdirectory: "dbt_packages/dagster"
    revision: fd13563951d76ee5abf8381bb71046efaa6f90bb
```

## How I Tested These Changes
follow up PRs
