### PR TITLE
Add `working_directory` as an option for the `[tool.dagster]` section…

### DIFF
--- a/python_modules/dagster/dagster/_core/workspace/load_target.py
+++ b/python_modules/dagster/dagster/_core/workspace/load_target.py
@@ -52,7 +52,7 @@ def get_origins_from_toml(path: str) -> Sequence[ManagedGrpcPythonEnvCodeLocatio
             return ModuleTarget(
                 module_name=dagster_block["module_name"],
                 attribute=None,
-                working_directory=os.getcwd(),
+                working_directory=dagster_block["working_directory"] or os.getcwd(),
                 location_name=dagster_block.get("code_location_name"),
             ).create_origins()
         return []


### PR DESCRIPTION
## Summary & Motivation

The `working_directory` CLI argument can't be used in the `[tool.dagster]` section of pyproject.toml. This PR shows a method to add that.

I use a monorepo where dagster is one folder, and we have a complicated folder structure so all devs would need to run `dagster dev` with a `--working-directory` arg, I'd like if we could avoid that by adding it in the `pyproject.toml`.

## How I Tested These Changes

I didn't - please test it