### PR TITLE
feat(dbt): execute dbt with a debug log level by default

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -1,4 +1,3 @@
-import contextlib
 import os
 import shutil
 import signal
@@ -98,6 +97,11 @@ class DbtCliEventMessage:
     def __str__(self) -> str:
         return self.raw_event["info"]["msg"]
 
+    @property
+    def log_level(self) -> str:
+        """The log level of the event."""
+        return self.raw_event["info"]["level"]
+
     @public
     def to_default_asset_events(
         self,
@@ -126,7 +130,7 @@ class DbtCliEventMessage:
                 - AssetObservation for dbt test results.
 
         """
-        if self.raw_event["info"]["level"] == "debug":
+        if self.raw_event["info"]["name"] != "NodeFinished":
             return
 
         event_node_info: Dict[str, Any] = self.raw_event["data"].get("node_info")
@@ -147,10 +151,16 @@ class DbtCliEventMessage:
         unique_id: str = event_node_info["unique_id"]
         node_resource_type: str = event_node_info["resource_type"]
         node_status: str = event_node_info["node_status"]
+        node_materialization: str = self.raw_event["data"]["node_info"]["materialized"]
 
+        is_node_ephemeral = node_materialization == "ephemeral"
         is_node_successful = node_status == NodeStatus.Success
         is_node_finished = bool(event_node_info.get("node_finished_at"))
-        if node_resource_type in NodeType.refable() and is_node_successful:
+        if (
+            node_resource_type in NodeType.refable()
+            and is_node_successful
+            and not is_node_ephemeral
+        ):
             started_at = dateutil.parser.isoparse(event_node_info["node_started_at"])
             finished_at = dateutil.parser.isoparse(event_node_info["node_finished_at"])
             duration_seconds = (finished_at - started_at).total_seconds()
@@ -245,10 +255,12 @@ class DbtCliInvocation:
     project_dir: Path
     target_path: Path
     raise_on_error: bool
+    log_level: Literal["info", "debug"]
     context: Optional[OpExecutionContext] = field(default=None, repr=False)
     termination_timeout_seconds: float = field(
         init=False, default=DAGSTER_DBT_TERMINATION_TIMEOUT_SECONDS
     )
+    _stdout: List[str] = field(init=False, default_factory=list)
     _error_messages: List[str] = field(init=False, default_factory=list)
 
     @classmethod
@@ -261,6 +273,7 @@ class DbtCliInvocation:
         project_dir: Path,
         target_path: Path,
         raise_on_error: bool,
+        log_level: Literal["info", "debug"],
         context: Optional[OpExecutionContext],
     ) -> "DbtCliInvocation":
         # Attempt to take advantage of partial parsing. If there is a `partial_parse.msgpack` in
@@ -302,6 +315,7 @@ class DbtCliInvocation:
             project_dir=project_dir,
             target_path=target_path,
             raise_on_error=raise_on_error,
+            log_level=log_level,
             context=context,
         )
         logger.info(f"Running dbt command: `{dbt_cli_invocation.dbt_command}`.")
@@ -347,6 +361,8 @@ class DbtCliInvocation:
                 if dbt_cli_invocation.is_successful():
                     ...
         """
+        self._stdout = list(self._stream_stdout())
+
         return self.process.wait() == 0
 
     @public
@@ -399,37 +415,32 @@ class DbtCliInvocation:
         Returns:
             Iterator[DbtCliEventMessage]: An iterator of events from the dbt CLI process.
         """
-        try:
-            with self.process.stdout or contextlib.nullcontext():
-                for raw_line in self.process.stdout or []:
-                    log: str = raw_line.decode().strip()
-                    try:
-                        event = DbtCliEventMessage.from_log(log=log)
+        for log in self._stdout or self._stream_stdout():
+            try:
+                event = DbtCliEventMessage.from_log(log=log)
 
-                        # Parse the error message from the event, if it exists.
-                        is_error_message = event.raw_event["info"]["level"] == "error"
-                        if is_error_message:
-                            self._error_messages.append(str(event))
+                is_error_message = event.log_level == "error"
+                is_debug_message = event.log_level == "debug"
+                is_debug_user_log_level = self.log_level == "debug"
 
-                        # Re-emit the logs from dbt CLI process into stdout.
-                        sys.stdout.write(str(event) + "\n")
-                        sys.stdout.flush()
+                # Parse the error message from the event, if it exists.
+                if is_error_message:
+                    self._error_messages.append(str(event))
 
-                        yield event
-                    except:
-                        # If we can't parse the log, then just emit it as a raw log.
-                        sys.stdout.write(log + "\n")
-                        sys.stdout.flush()
+                # Only write debug logs to stdout if the user explicitly set
+                # the log level to debug.
+                if not is_debug_message or is_debug_user_log_level:
+                    sys.stdout.write(str(event) + "\n")
+                    sys.stdout.flush()
 
-            # Ensure that the dbt CLI process has completed.
-            self._raise_on_error()
-        except DagsterExecutionInterruptedError:
-            logger.info(f"Forwarding interrupt signal to dbt command: `{self.dbt_command}`.")
+                yield event
+            except:
+                # If we can't parse the log, then just emit it as a raw log.
+                sys.stdout.write(log + "\n")
+                sys.stdout.flush()
 
-            self.process.send_signal(signal.SIGINT)
-            self.process.wait(timeout=self.termination_timeout_seconds)
-
-            raise
+        # Ensure that the dbt CLI process has completed.
+        self._raise_on_error()
 
     @public
     def get_artifact(
@@ -471,6 +482,25 @@ class DbtCliInvocation:
     def dbt_command(self) -> str:
         """The dbt CLI command that was invoked."""
         return " ".join(cast(Sequence[str], self.process.args))
+
+    def _stream_stdout(self) -> Iterator[str]:
+        """Stream the stdout from the dbt CLI process."""
+        try:
+            if not self.process.stdout or self.process.stdout.closed:
+                return
+
+            with self.process.stdout:
+                for raw_line in self.process.stdout or []:
+                    log: str = raw_line.decode().strip()
+
+                    yield log
+        except DagsterExecutionInterruptedError:
+            logger.info(f"Forwarding interrupt signal to dbt command: `{self.dbt_command}`.")
+
+            self.process.send_signal(signal.SIGINT)
+            self.process.wait(timeout=self.termination_timeout_seconds)
+
+            raise
 
     def _format_error_messages(self) -> str:
         """Format the error messages from the dbt CLI process."""
@@ -878,6 +908,9 @@ class DbtCliResource(ConfigurableResource):
             # The DBT_LOG_FORMAT environment variable must be set to `json`. We use this
             # environment variable to ensure that the dbt CLI outputs structured logs.
             "DBT_LOG_FORMAT": "json",
+            # The DBT_DEBUG environment variable must be set to `true`. We use this
+            # environment variable to ensure that the dbt CLI logs have enriched metadata.
+            "DBT_DEBUG": "true",
             # The DBT_TARGET_PATH environment variable is set to a unique value for each dbt
             # invocation so that artifact paths are separated.
             # See https://discourse.getdbt.com/t/multiple-run-results-json-and-manifest-json-files/7555
@@ -892,6 +925,14 @@ class DbtCliResource(ConfigurableResource):
             # for more information.
             **({"DBT_PROFILES_DIR": self.profiles_dir} if self.profiles_dir else {}),
         }
+
+        # Although we always set the dbt log level to debug, we only write those logs to stdout if
+        # the user has explicitly set the log level to debug.
+        log_level = (
+            "debug"
+            if set(["--debug", "-d"]).intersection([*args, *self.global_config_flags])
+            else "info"
+        )
 
         assets_def: Optional[AssetsDefinition] = None
         with suppress(DagsterInvalidPropertyError):
@@ -953,6 +994,7 @@ class DbtCliResource(ConfigurableResource):
             project_dir=project_dir,
             target_path=target_path,
             raise_on_error=raise_on_error,
+            log_level=log_level,
             context=context,
         )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -125,11 +125,11 @@ def test_dbt_cli_subprocess_cleanup(
     with pytest.raises(DagsterExecutionInterruptedError):
         mock_stdout = mocker.patch.object(dbt_cli_invocation_1.process, "stdout")
         mock_stdout.__enter__.side_effect = DagsterExecutionInterruptedError()
+        mock_stdout.closed = False
 
         dbt_cli_invocation_1.wait()
 
     assert "Forwarding interrupt signal to dbt command" in caplog.text
-    assert not dbt_cli_invocation_1.is_successful()
     assert dbt_cli_invocation_1.process.returncode < 0
 
 
@@ -423,6 +423,7 @@ def test_dbt_cli_op_execution() -> None:
         {},
         {
             "node_info": {
+                "materialized": "table",
                 "unique_id": "a.b.c",
                 "resource_type": "model",
                 "node_status": "failure",
@@ -432,6 +433,7 @@ def test_dbt_cli_op_execution() -> None:
         },
         {
             "node_info": {
+                "materialized": "table",
                 "unique_id": "a.b.c",
                 "resource_type": "macro",
                 "node_status": "success",
@@ -441,6 +443,7 @@ def test_dbt_cli_op_execution() -> None:
         },
         {
             "node_info": {
+                "materialized": "table",
                 "unique_id": "a.b.c",
                 "resource_type": "model",
                 "node_status": "failure",
@@ -449,6 +452,7 @@ def test_dbt_cli_op_execution() -> None:
         },
         {
             "node_info": {
+                "materialized": "test",
                 "unique_id": "a.b.c",
                 "resource_type": "test",
                 "node_status": "success",
@@ -468,6 +472,7 @@ def test_no_default_asset_events_emitted(data: dict) -> None:
     asset_events = DbtCliEventMessage(
         raw_event={
             "info": {
+                "name": "NodeFinished",
                 "level": "info",
                 "invocation_id": "1-2-3",
             },
@@ -481,11 +486,13 @@ def test_no_default_asset_events_emitted(data: dict) -> None:
 def test_to_default_asset_output_events() -> None:
     raw_event = {
         "info": {
+            "name": "NodeFinished",
             "level": "info",
             "invocation_id": "1-2-3",
         },
         "data": {
             "node_info": {
+                "materialized": "table",
                 "unique_id": "a.b.c",
                 "resource_type": "model",
                 "node_name": "node_name",
@@ -548,11 +555,13 @@ def test_dbt_tests_to_events(mocker: MockerFixture, is_asset_check: bool) -> Non
     }
     raw_event = {
         "info": {
+            "name": "NodeFinished",
             "level": "info",
             "invocation_id": "1-2-3",
         },
         "data": {
             "node_info": {
+                "materialized": "test",
                 "unique_id": "test.a",
                 "resource_type": "test",
                 "node_name": "node_name.test.a",


### PR DESCRIPTION
## Summary & Motivation
Separating this out since there are behavior changes that I want to call out here.

What we're doing here is always running the dbt CLI in debug mode, regardless if it's set by the user (e.g. through `--debug`, or `--log-level=debug`).

This gives us access to a richer stream of metadata while dbt is executing the command. In the downstream PR, we'll actually parse the metadata, but for now just make it so that all existing behavior still works with this new switch.

### Assumptions

- Even though we are now executing dbt in debug mode, we should only display the debug level information to the user unless they have explicitly added `--debug` or `--log-level=debug` to their dbt command.
- `.stream_raw_events()` will now always include debug level events in the stream. This is a change in current behavior, but I assume it's ok to land since these new events fit the description of "raw events" from dbt.

## How I Tested These Changes
pytest, local
