### PR TITLE
Fix rendering runs when the user has permission to terminate/delete some runs but not all

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRow.tsx
@@ -35,6 +35,7 @@ import {useRepositoryForRunWithoutSnapshot} from '../workspace/useRepositoryForR
 
 export const RunRow = ({
   run,
+  hasCheckboxColumn,
   canTerminateOrDelete,
   onAddTag,
   checked,
@@ -45,6 +46,7 @@ export const RunRow = ({
   hideCreatedBy,
 }: {
   run: RunTableRunFragment;
+  hasCheckboxColumn: boolean;
   canTerminateOrDelete: boolean;
   onAddTag?: (token: RunFilterToken) => void;
   checked?: boolean;
@@ -141,8 +143,12 @@ export const RunRow = ({
         setIsHovered(false);
       }}
     >
-      {canTerminateOrDelete ? (
-        <td>{onToggleChecked ? <Checkbox checked={!!checked} onChange={onChange} /> : null}</td>
+      {hasCheckboxColumn ? (
+        <td>
+          {canTerminateOrDelete ? (
+            <>{onToggleChecked ? <Checkbox checked={!!checked} onChange={onChange} /> : null}</>
+          ) : null}
+        </td>
       ) : null}
       <td>
         <Link to={`/runs/${run.id}`}>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
@@ -126,6 +126,7 @@ export const RunTable = (props: RunTableProps) => {
           <tbody>
             {runs.map((run) => (
               <RunRow
+                hasCheckboxColumn={canTerminateOrDeleteAny}
                 canTerminateOrDelete={run.hasTerminatePermission || run.hasDeletePermission}
                 run={run}
                 key={run.id}


### PR DESCRIPTION
## Summary & Motivation

Fixes an issue where the columns are off by 1 because the header row renders a checkbox due to the user having permission to terminate/delete one of the runs. But the rows where the user doesn't have permission to terminate a run don't render a checkbox, causing them to be off by 1.

The fix is to update the RunRow component to check `canTerminateOrDeleteAny` to determine whether to render a cell for the checkbox column, same as the header row.


## How I Tested These Changes

locally
