### PR TITLE
fix(instigator-tick-logs): serialize and display `exc_info`

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1189,6 +1189,12 @@ def define_sensors():
     @sensor(job_name="no_config_job")
     def logging_sensor(context):
         context.log.info("hello hello")
+
+        try:
+            raise Exception("hi hi")
+        except Exception:
+            context.log.exception("goodbye goodbye")
+
         return SkipReason()
 
     @sensor(asset_selection=AssetSelection.all())

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -1355,8 +1355,11 @@ def test_sensor_tick_logs(graphql_context: WorkspaceRequestContext):
     assert len(result.data["sensorOrError"]["sensorState"]["ticks"]) == 1
     tick = result.data["sensorOrError"]["sensorState"]["ticks"][0]
     log_messages = tick["logEvents"]["events"]
-    assert len(log_messages) == 1
+    assert len(log_messages) == 2
     assert log_messages[0]["message"] == "hello hello"
+    assert log_messages[1]["message"].startswith("goodbye goodbye")
+    assert "Traceback" in log_messages[1]["message"]
+    assert "Exception: hi hi" in log_messages[1]["message"]
 
 
 def test_sensor_dynamic_partitions_request_results(graphql_context: WorkspaceRequestContext):

--- a/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
+++ b/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import threading
+import traceback
 from contextlib import ExitStack
 from typing import IO, Any, List, Mapping, Optional, Sequence
 
@@ -60,7 +61,13 @@ class CapturedLogHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord):
         self._has_logged = True
-        self._write_stream.write(_seven.json.dumps(record.__dict__) + "\n")
+
+        record_dict = record.__dict__
+        exc_info = record_dict.get("exc_info")
+        if exc_info:
+            record_dict["exc_info"] = "".join(traceback.format_exception(*exc_info))
+
+        self._write_stream.write(_seven.json.dumps(record_dict) + "\n")
 
 
 class InstigationLogger(logging.Logger):

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -585,6 +585,12 @@ def logging_sensor(context):
     context.log.addHandler(handler)
     context.log.info("hello %s", "hello")
     context.log.info(handler.message)
+
+    try:
+        raise Exception("hi hi")
+    except Exception:
+        context.log.exception("goodbye goodbye")
+
     context.log.removeHandler(handler)
 
     return SkipReason()
@@ -2980,9 +2986,12 @@ def test_sensor_logging(executor, instance, workspace_context, external_repo):
     ]
     assert tick.status == TickStatus.SKIPPED
     records = get_instigation_log_records(instance, tick.log_key)
-    assert len(records) == 2
+    assert len(records) == 3
     assert records[0][DAGSTER_META_KEY]["orig_message"] == "hello hello"
     assert records[1][DAGSTER_META_KEY]["orig_message"].endswith("hello hello")
+    assert records[2][DAGSTER_META_KEY]["orig_message"] == ("goodbye goodbye")
+    assert records[2]["exc_info"].startswith("Traceback")
+    assert "Exception: hi hi" in records[2]["exc_info"]
     instance.compute_log_manager.delete_logs(log_key=tick.log_key)
 
 


### PR DESCRIPTION
## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/19655.

Calling `logger.exception(...)` in an `except` block populates the logging record with `exc_info: sys.exc_info()`, which is an exception tuple. Currently, this is not serialized out-of-the-box, so attempting to forward the record to compute log storage causes an error. Fix that by serializing the exception tuple using [`traceback.format_exception`](https://docs.python.org/3/library/traceback.html#traceback.format_exception).

## How I Tested These Changes
pytest, local

### Example
<img width="1341" alt="Screenshot 2024-02-07 at 11 47 31 AM" src="https://github.com/dagster-io/dagster/assets/16431325/9b119a27-28a1-4a59-af1f-cc0c43d73d30">

