### PR TITLE
[auto-materialize] Fix memory leak across multiple ticks 

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -1,5 +1,7 @@
-import functools
+import dataclasses
 import json
+from dataclasses import dataclass
+from functools import cached_property
 from typing import (
     TYPE_CHECKING,
     Mapping,
@@ -66,7 +68,8 @@ class ObserveRequestTimestampSerializer(FieldSerializer):
         "last_observe_request_timestamp_by_asset_key": ObserveRequestTimestampSerializer
     }
 )
-class AssetDaemonCursor(NamedTuple):
+@dataclass(frozen=True)
+class AssetDaemonCursor:
     """State that's stored between daemon evaluations.
 
     Attributes:
@@ -88,8 +91,7 @@ class AssetDaemonCursor(NamedTuple):
             last_observe_request_timestamp_by_asset_key={},
         )
 
-    @property
-    @functools.lru_cache(maxsize=1)
+    @cached_property
     def previous_evaluation_state_by_key(
         self,
     ) -> Mapping[AssetKey, "AssetConditionEvaluationState"]:
@@ -119,7 +121,8 @@ class AssetDaemonCursor(NamedTuple):
         newly_observe_requested_asset_keys: Sequence[AssetKey],
         evaluation_state: Sequence["AssetConditionEvaluationState"],
     ) -> "AssetDaemonCursor":
-        return self._replace(
+        return dataclasses.replace(
+            self,
             evaluation_id=evaluation_id,
             previous_evaluation_state=evaluation_state,
             last_observe_request_timestamp_by_asset_key={

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime
 from contextlib import contextmanager, nullcontext
 from typing import Any, Generator, Mapping, Optional, Sequence, cast
@@ -400,7 +401,9 @@ def test_automation_policy_sensor_transition():
         instance.daemon_cursor_storage.set_cursor_values(
             {
                 _PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY: serialize_value(
-                    AssetDaemonCursor.empty()._replace(evaluation_id=pre_sensor_evaluation_id)
+                    dataclasses.replace(
+                        AssetDaemonCursor.empty(), evaluation_id=pre_sensor_evaluation_id
+                    )
                 )
             }
         )
@@ -465,7 +468,10 @@ def test_automation_policy_sensor_ticks(num_threads):
             instance.daemon_cursor_storage.set_cursor_values(
                 {
                     _PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY: serialize_value(
-                        AssetDaemonCursor.empty()._replace(evaluation_id=pre_sensor_evaluation_id)
+                        dataclasses.replace(
+                            AssetDaemonCursor.empty(),
+                            evaluation_id=pre_sensor_evaluation_id,
+                        )
                     )
                 }
             )


### PR DESCRIPTION
## Summary & Motivation

Somehow, this was causing a memory leak! Use dataclasses instead

## How I Tested These Changes
