### PR TITLE
[external-assets] Allow asset jobs to combine materializations and observations

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -183,17 +183,6 @@ class UnresolvedAssetJobDefinition(
         """Resolve this UnresolvedAssetJobDefinition into a JobDefinition."""
         assets = asset_graph.assets_defs
         selected_asset_keys = self.selection.resolve(asset_graph)
-
-        if (
-            len(selected_asset_keys & asset_graph.materializable_asset_keys) > 0
-            and len(selected_asset_keys & asset_graph.external_asset_keys) > 0
-        ):
-            raise DagsterInvalidDefinitionError(
-                f"Asset selection for job '{self.name}' specified both regular assets and external "
-                "assets. This is not currently supported. Selections must be all regular "
-                "assets or all source assets.",
-            )
-
         selected_asset_checks = self.selection.resolve_checks(asset_graph)
 
         asset_keys_by_partitions_def = defaultdict(set)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
@@ -92,24 +92,6 @@ def test_partitioned_observable_source_asset():
         )
 
 
-def test_mixed_source_asset_observation_job():
-    @observable_source_asset
-    def foo(_context) -> DataVersion:
-        return DataVersion("alpha")
-
-    @asset(deps=["foo"])
-    def bar(context):
-        return 1
-
-    with pytest.raises(
-        DagsterInvalidDefinitionError, match=r"specified both regular assets and external assets"
-    ):
-        Definitions(
-            assets=[foo, bar],
-            jobs=[define_asset_job("mixed_job", [foo, bar])],
-        ).get_all_job_defs()
-
-
 @pytest.mark.parametrize(
     "is_valid,resource_defs",
     [(True, {"bar": ResourceDefinition.hardcoded_resource("bar")}), (False, {})],

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
@@ -7,7 +7,6 @@ from dagster import (
     AssetsDefinition,
     DagsterInvalidDefinitionError,
     DailyPartitionsDefinition,
-    Definitions,
     GraphDefinition,
     IOManager,
     JobDefinition,
@@ -1482,23 +1481,3 @@ def test_auto_materialize_sensors_conflict():
                 AutoMaterializeSensorDefinition("a", asset_selection=[asset1]),
                 AutoMaterializeSensorDefinition("b", asset_selection=[asset1, asset2]),
             ]
-
-
-def test_invalid_asset_selection():
-    source_asset = SourceAsset("source_asset")
-
-    @asset
-    def asset1(): ...
-
-    @sensor(asset_selection=[source_asset, asset1])
-    def sensor1(): ...
-
-    Definitions(assets=[source_asset, asset1], sensors=[sensor1])
-
-    with pytest.raises(
-        DagsterInvalidDefinitionError, match="specified both regular assets and external"
-    ):
-        Definitions(
-            assets=[source_asset, asset1],
-            jobs=[define_asset_job("foo", selection=[source_asset, asset1])],
-        ).get_all_job_defs()


### PR DESCRIPTION
## Summary & Motivation

Lift the restriction that asset jobs cannot contain both observations and materializations. This does _not_ change existing user-constructed jobs using public `define_asset_job`-- it just lifts the restriction so that it is now _possible_ to construct jobs that contain both observations and materializations. This will facilitate ongoing asset job refactoring. I don't think we should encourage/advertise this functionality yet because the result of an observation still cannot be used to determine whether to skip downstream steps within a run.

## How I Tested These Changes

Updated "mixed asset job" test which previously checked for an error, now checks that it successfully executes with correct results.