### PR TITLE
[docs] fix example of running dagster-webserver pointing to non-existant file

### DIFF
--- a/docs/content/community/contributing.mdx
+++ b/docs/content/community/contributing.mdx
@@ -75,7 +75,7 @@ For development, run an instance of the webserver providing GraphQL service on a
 
 ```bash
 cd dagster/examples/docs_snippets/docs_snippets/intro_tutorial/basics/connecting_ops/
-dagster-webserver -p 3333 -f complex_pipeline.py
+dagster-webserver -p 3333 -f complex_job.py
 ```
 
 Keep this running. Then, in another terminal, run the local development (autoreloading, etc.) version of the webapp:


### PR DESCRIPTION
## Summary & Motivation

In example:

```
dagster-webserver -p 3333 -f complex_pipeline.py
```

The `complex_pipeline.py` no longer exists, however `complex_job.py` can be used as an alternative.

```
 > ls examples/docs_snippets/docs_snippets/intro_tutorial/basics/connecting_ops/
total 16
-rw-r--r--  1 -  -     0B Jan 26 11:05 __init__.py
-rwxr-xr-x  1 -  -   757B Jan 26 11:05 complex_job.py
-rwxr-xr-x  1 -  -   483B Jan 26 11:05 serial_job.py
```

```
dagster-webserver -p 3333 -f complex_job.py
```

## How I Tested These Changes

Ran `dagster-webserver` and web UI locally.