### PR TITLE
[rfc] bigquery observable source asset factory

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/observe.py
+++ b/python_modules/dagster/dagster/_core/definitions/observe.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
 
 import dagster._check as check
-from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._utils.warnings import disable_dagster_warnings
 
 from ..instance import DagsterInstance
@@ -47,7 +47,9 @@ def observe(
     resources = check.opt_mapping_param(resources, "resources", key_type=str)
 
     with disable_dagster_warnings():
-        observation_job = build_assets_job("in_process_observation_job", [], source_assets)
+        observation_job = define_asset_job(
+            "in_process_observation_job", [source_asset.key for source_asset in source_assets]
+        )
         defs = Definitions(
             assets=source_assets,
             jobs=[observation_job],

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -86,7 +86,9 @@ def wrap_source_asset_observe_fn_in_op_compute_fn(
 
     def fn(context: OpExecutionContext) -> Output[None]:
         resource_kwarg_keys = [param.name for param in get_resource_args(observe_fn)]
-        resource_kwargs = {key: getattr(context.resources, key) for key in resource_kwarg_keys}
+        resource_kwargs = {
+            key: context.resources.original_resource_dict.get(key) for key in resource_kwarg_keys
+        }
         observe_fn_return_value = (
             observe_fn(context, **resource_kwargs)
             if observe_fn_has_context

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
@@ -178,3 +178,20 @@ def test_observe_pythonic_resource():
 
     observe([foo], instance=instance, resources={"foo": FooResource(foo="bar")})
     assert _get_current_data_version(AssetKey("foo"), instance) == DataVersion("bar-alpha")
+
+
+def test_observe_backcompat_pythonic_resource():
+    class FooResource(ConfigurableResource):
+        foo: str
+
+        def get_object_to_set_on_execution_context(self):
+            raise Exception("Shouldn't get here")
+
+    @observable_source_asset
+    def foo(foo: FooResource) -> DataVersion:
+        return DataVersion(f"{foo.foo}-alpha")
+
+    instance = DagsterInstance.ephemeral()
+
+    observe([foo], instance=instance, resources={"foo": FooResource(foo="bar")})
+    assert _get_current_data_version(AssetKey("foo"), instance) == DataVersion("bar-alpha")

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/assets.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/assets.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from dagster import DataVersion, observable_source_asset
+
+from .resources import BigQueryResource
+
+"""
+Running the following query in bigquery gets you the last updated timestamp:
+select
+  table_id,
+  TIMESTAMP_MILLIS(last_modified_time) AS last_modified
+from
+  `elementl-dev.IRIS.__TABLES__`; (elementl-dev is project_id, IRIS is dataset_id). To narrow this to a particular table, you can add a where clause for table_id.
+"""
+
+
+def observe_table_factory(dataset_id, table_id):
+    @observable_source_asset
+    def observe_table_last_modified_time(context, bigquery: BigQueryResource) -> DataVersion:
+        with bigquery.get_client() as client:
+            query = f"""
+            select
+              table_id,
+              TIMESTAMP_MILLIS(last_modified_time) AS last_modified
+            from
+              `{bigquery.project}.{dataset_id}.__TABLES__`
+            where
+              table_id = '{table_id}'
+            """
+            df = client.query(query).to_dataframe()
+        # context.log.info the last modified time as a UTC timestamp.
+        context.log.info(
+            f"Last modified time for table {table_id}: {df['last_modified'].values[0]}"
+        )
+        timestamp = pd.to_datetime(df["last_modified"].values[0])
+        return DataVersion(str(timestamp))
+
+    return observe_table_last_modified_time

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/conftest.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/conftest.py
@@ -1,0 +1,27 @@
+import os
+import uuid
+from contextlib import contextmanager
+from typing import Iterator
+
+from google.cloud import bigquery
+
+IS_BUILDKITE = os.getenv("BUILDKITE") is not None
+
+SHARED_BUILDKITE_BQ_CONFIG = {
+    "project": os.getenv("GCP_PROJECT_ID"),
+}
+
+
+@contextmanager
+def temporary_bigquery_table(schema_name: str, column_str: str) -> Iterator[str]:
+    bq_client = bigquery.Client(
+        project=SHARED_BUILDKITE_BQ_CONFIG["project"],
+    )
+    table_name = "test_io_manager_" + str(uuid.uuid4()).replace("-", "_")
+    bq_client.query(f"create table {schema_name}.{table_name} ({column_str})").result()
+    try:
+        yield table_name
+    finally:
+        bq_client.query(
+            f"drop table {SHARED_BUILDKITE_BQ_CONFIG['project']}.{schema_name}.{table_name}"
+        ).result()

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_assets.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_assets.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+import pytest
+from dagster import DagsterInstance, EnvVar
+from dagster._core.definitions.observe import observe
+from dagster_gcp.bigquery.assets import observe_table_factory
+from dagster_gcp.bigquery.resources import BigQueryResource
+
+from .conftest import IS_BUILDKITE, temporary_bigquery_table
+
+
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
+@pytest.mark.integration
+def test_observe_table_factory():
+    dataset_name = "BIGQUERY_IO_MANAGER_SCHEMA"
+    with temporary_bigquery_table(schema_name=dataset_name, column_str="FOO string") as table_name:
+        table_src_asset = observe_table_factory(dataset_name, table_name)
+        instance = DagsterInstance.ephemeral()
+        result = observe(
+            [table_src_asset],
+            instance=instance,
+            resources={"bigquery": BigQueryResource(project=EnvVar("GCP_PROJECT_ID"))},
+        )
+        observations = result.asset_observations_for_node(table_src_asset.op.name)
+        assert len(observations) == 1
+        observation = observations[0]
+        assert observation.tags["dagster/data_version"] is not None
+        # Interpret the data version as a timestamp
+        # Convert from a string in the format 2024-02-09 00:41:29.829000 to a timestamp
+        timestamp = datetime.strptime(
+            observation.tags["dagster/data_version"], "%Y-%m-%d %H:%M:%S.%f"
+        )
+        assert timestamp is not None

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_io_manager.py
@@ -1,9 +1,6 @@
 import base64
 import os
-import uuid
-from contextlib import contextmanager
 from datetime import datetime
-from typing import Iterator
 
 import pytest
 from dagster import InputContext, OutputContext, TimeWindow, asset, materialize
@@ -13,28 +10,8 @@ from dagster_gcp.bigquery.io_manager import (
     _get_cleanup_statement,
     build_bigquery_io_manager,
 )
-from google.cloud import bigquery
 
-IS_BUILDKITE = os.getenv("BUILDKITE") is not None
-
-SHARED_BUILDKITE_BQ_CONFIG = {
-    "project": os.getenv("GCP_PROJECT_ID"),
-}
-
-
-@contextmanager
-def temporary_bigquery_table(schema_name: str, column_str: str) -> Iterator[str]:
-    bq_client = bigquery.Client(
-        project=SHARED_BUILDKITE_BQ_CONFIG["project"],
-    )
-    table_name = "test_io_manager_" + str(uuid.uuid4()).replace("-", "_")
-    bq_client.query(f"create table {schema_name}.{table_name} ({column_str})").result()
-    try:
-        yield table_name
-    finally:
-        bq_client.query(
-            f"drop table {SHARED_BUILDKITE_BQ_CONFIG['project']}.{schema_name}.{table_name}"
-        ).result()
+from .conftest import IS_BUILDKITE, SHARED_BUILDKITE_BQ_CONFIG, temporary_bigquery_table
 
 
 def test_get_select_statement():


### PR DESCRIPTION
Initial design concept for a bigquery observable source asset, which tracks the freshness of a provided table. The purpose of this PR is to gather feedback on the method used for retrieval of freshness from bigquery. If we're in agreement here, I'll transform the retrieval step into a method on the bigquery resource

I don't expect this to land for two reasons. One, this information should live in metadata, not the dataversion specifier. Two, any factory should be able to ingest multiple tables at once as opposed to just one.

How I tested this
This PR mainly exists as a proof of concept of the retrieval method of source freshness. To that end, I've added a test which runs against a live ephemeral bigquery table, and retrieves it's freshness.