### PR TITLE
replace datetime.utcnow with datetime.now(timezone.utc)

### DIFF
--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -64,7 +64,9 @@ class DagsterMessageProps(
             log_timestamp=check.opt_str_param(
                 log_timestamp,
                 "log_timestamp",
-                default=datetime.datetime.utcnow().isoformat(),
+                default=(
+                    datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat()
+                ),
             ),
             dagster_event=dagster_event,
         )

--- a/python_modules/libraries/dagster-ge/dagster_ge/factory.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge/factory.py
@@ -120,7 +120,7 @@ def ge_validation_op_factory(
         batch = data_context.get_batch(final_batch_kwargs, suite)
         run_id = {
             "run_name": datasource_name + " run",
-            "run_time": datetime.datetime.utcnow(),
+            "run_time": datetime.datetime.now(datetime.timezone.utc),
         }
         results = data_context.run_validation_operator(
             validation_operator, assets_to_validate=[batch], run_id=run_id
@@ -225,7 +225,7 @@ def ge_validation_op_factory_v3(
 
         run_id = {
             "run_name": datasource_name + " run",
-            "run_time": datetime.datetime.utcnow(),
+            "run_time": datetime.datetime.now(datetime.timezone.utc),
         }
         results = validator.validate(run_id=run_id)
 


### PR DESCRIPTION
Summary:
This generates warnings starting in python 3.12, replace with the blessed replacement

Technically this replaces a naive timezone with a tz-aware one but I would be surprised if that caused problems here?

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
