### PR TITLE
[ui][tweak] add onClick attr to HeaderCell

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
@@ -6,11 +6,8 @@ export const HeaderCell = ({
   children,
   style,
   onClick,
-}: {
-  children?: React.ReactNode;
-  style?: React.CSSProperties;
-  onClick?: React.MouseEventHandler;
-}) => {
+  ...rest
+}: React.ComponentProps<typeof CellBox>) => {
   // no text select
   const clickStyle = onClick ? {cursor: 'pointer', 'user-select': 'none'} : {};
 
@@ -26,6 +23,7 @@ export const HeaderCell = ({
         ...(style || {}),
       }}
       onClick={onClick}
+      {...rest}
     >
       {children}
     </CellBox>

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
@@ -5,18 +5,32 @@ import styled from 'styled-components';
 export const HeaderCell = ({
   children,
   style,
+  onClick,
 }: {
   children?: React.ReactNode;
   style?: React.CSSProperties;
-}) => (
-  <CellBox
-    padding={{vertical: 8, horizontal: 12}}
-    border="right"
-    style={{whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden', ...(style || {})}}
-  >
-    {children}
-  </CellBox>
-);
+  onClick?: React.MouseEventHandler;
+}) => {
+  // no text select
+  const clickStyle = onClick ? {cursor: 'pointer', 'user-select': 'none'} : {};
+
+  return (
+    <CellBox
+      padding={{vertical: 8, horizontal: 12}}
+      border="right"
+      style={{
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
+        overflow: 'hidden',
+        ...clickStyle,
+        ...(style || {}),
+      }}
+      onClick={onClick}
+    >
+      {children}
+    </CellBox>
+  );
+};
 
 export const RowCell = ({
   children,


### PR DESCRIPTION
## Summary

Adds the ability to pass `onClick` to a header cell, which gives it that click behavior and gives it a clickable hover state / no user select style.

Used in https://github.com/dagster-io/internal/pull/8212 (can also just wrap it, as in the temp solution there)