### PR TITLE
(bugfix) handle backcompat resources properly in source assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -89,7 +89,9 @@ def wrap_source_asset_observe_fn_in_op_compute_fn(
 
     def fn(context: OpExecutionContext) -> Output[None]:
         resource_kwarg_keys = [param.name for param in get_resource_args(observe_fn)]
-        resource_kwargs = {key: getattr(context.resources, key) for key in resource_kwarg_keys}
+        resource_kwargs = {
+            key: context.resources.original_resource_dict.get(key) for key in resource_kwarg_keys
+        }
         observe_fn_return_value = (
             observe_fn(context, **resource_kwargs)
             if observe_fn_has_context

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
@@ -209,3 +209,20 @@ def test_observe_pythonic_resource():
 
         observe([foo], instance=instance, resources={"foo": FooResource(foo="bar")})
         assert _get_current_data_version(AssetKey("foo"), instance) == DataVersion("bar-alpha")
+
+
+def test_observe_backcompat_pythonic_resource():
+    class FooResource(ConfigurableResource):
+        foo: str
+
+        def get_object_to_set_on_execution_context(self):
+            raise Exception("Shouldn't get here")
+
+    @observable_source_asset
+    def foo(foo: FooResource) -> DataVersion:
+        return DataVersion(f"{foo.foo}-alpha")
+
+    instance = DagsterInstance.ephemeral()
+
+    observe([foo], instance=instance, resources={"foo": FooResource(foo="bar")})
+    assert _get_current_data_version(AssetKey("foo"), instance) == DataVersion("bar-alpha")


### PR DESCRIPTION
Fixes an issue with observable source assets, where they always default to using the backcompat resource, instead of the pythonic resource. Prior art can be found here: https://github.com/dagster-io/dagster/pull/18349

Adds a test specifically for the backwards-compatible pythonic resource case
