### PR TITLE
[rfc] snowflake observable source asset factory

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/observe.py
+++ b/python_modules/dagster/dagster/_core/definitions/observe.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
 
 import dagster._check as check
-from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._utils.warnings import disable_dagster_warnings
 
 from ..instance import DagsterInstance
@@ -47,7 +47,9 @@ def observe(
     resources = check.opt_mapping_param(resources, "resources", key_type=str)
 
     with disable_dagster_warnings():
-        observation_job = build_assets_job("in_process_observation_job", [], source_assets)
+        observation_job = define_asset_job(
+            "in_process_observation_job", [source_asset.key for source_asset in source_assets]
+        )
         defs = Definitions(
             assets=source_assets,
             jobs=[observation_job],

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -86,7 +86,9 @@ def wrap_source_asset_observe_fn_in_op_compute_fn(
 
     def fn(context: OpExecutionContext) -> Output[None]:
         resource_kwarg_keys = [param.name for param in get_resource_args(observe_fn)]
-        resource_kwargs = {key: getattr(context.resources, key) for key in resource_kwarg_keys}
+        resource_kwargs = {
+            key: context.resources.original_resource_dict.get(key) for key in resource_kwarg_keys
+        }
         observe_fn_return_value = (
             observe_fn(context, **resource_kwargs)
             if observe_fn_has_context

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
@@ -178,3 +178,20 @@ def test_observe_pythonic_resource():
 
     observe([foo], instance=instance, resources={"foo": FooResource(foo="bar")})
     assert _get_current_data_version(AssetKey("foo"), instance) == DataVersion("bar-alpha")
+
+
+def test_observe_backcompat_pythonic_resource():
+    class FooResource(ConfigurableResource):
+        foo: str
+
+        def get_object_to_set_on_execution_context(self):
+            raise Exception("Shouldn't get here")
+
+    @observable_source_asset
+    def foo(foo: FooResource) -> DataVersion:
+        return DataVersion(f"{foo.foo}-alpha")
+
+    instance = DagsterInstance.ephemeral()
+
+    observe([foo], instance=instance, resources={"foo": FooResource(foo="bar")})
+    assert _get_current_data_version(AssetKey("foo"), instance) == DataVersion("bar-alpha")

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/assets.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/assets.py
@@ -1,0 +1,32 @@
+from dagster import DataVersion, observable_source_asset
+
+from .resources import SnowflakeResource
+
+"""
+Running the following query in snowflake gets you the last updated timestamp:
+SELECT table_name, last_altered
+FROM information_schema.tables
+WHERE table_schema = 'your_schema' AND table_name = 'your_table_name';
+  """
+
+
+def observe_table_factory(schema, table):
+    @observable_source_asset
+    def observe_table_last_modified_time(context, snowflake: SnowflakeResource) -> DataVersion:
+        with snowflake.get_connection() as conn:
+            query = f"""
+            SELECT table_name, last_altered
+            FROM information_schema.tables
+            WHERE table_schema = '{schema}' AND table_name = '{table}';
+            """
+            with conn.cursor() as cursor:
+                result = cursor.execute(query)
+                if not result:
+                    raise ValueError("No results found")
+                results = result.fetchall()
+
+        # context.log.info the last modified time as a UTC timestamp.
+        context.log.info(f"Last modified time for table {table}: {results[0][1]}")
+        return DataVersion(results[0][1].strftime("%Y-%m-%d %H:%M:%S.%f"))
+
+    return observe_table_last_modified_time

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_assets.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_assets.py
@@ -1,0 +1,70 @@
+import os
+import uuid
+from contextlib import contextmanager
+from datetime import datetime
+from typing import Iterator
+
+import pytest
+from dagster import DagsterInstance, build_resources
+from dagster._core.definitions.observe import observe
+from dagster_snowflake.assets import observe_table_factory
+from dagster_snowflake.resources import SnowflakeResource
+
+IS_BUILDKITE = os.getenv("BUILDKITE") is not None
+
+
+@contextmanager
+def temporary_snowflake_table() -> Iterator[str]:
+    with build_resources(
+        {
+            "snowflake": SnowflakeResource(
+                account=os.getenv("SNOWFLAKE_ACCOUNT"),
+                user=os.environ["SNOWFLAKE_USER"],
+                password=os.getenv("SNOWFLAKE_PASSWORD"),
+                database="TESTDB",
+                schema="TESTSCHEMA",
+            )
+        }
+    ) as resources:
+        table_name = f"TEST_TABLE_{str(uuid.uuid4()).replace('-', '_').upper()}"  # Snowflake table names are expected to be capitalized.
+        snowflake: SnowflakeResource = resources.snowflake
+        with snowflake.get_connection() as conn:
+            try:
+                conn.cursor().execute(f"create table {table_name} (foo string)")
+                # Insert one row
+                conn.cursor().execute(f"insert into {table_name} values ('bar')")
+                yield table_name
+            finally:
+                conn.cursor().execute(f"drop table {table_name}")
+
+
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
+@pytest.mark.integration
+def test_observe_table_factory():
+    table_name = "the_table"
+    with temporary_snowflake_table() as table_name:
+        table_src_asset = observe_table_factory("TESTSCHEMA", table_name)
+        instance = DagsterInstance.ephemeral()
+        result = observe(
+            [table_src_asset],
+            instance=instance,
+            resources={
+                "snowflake": SnowflakeResource(
+                    account=os.getenv("SNOWFLAKE_ACCOUNT"),
+                    user=os.environ["SNOWFLAKE_USER"],
+                    password=os.getenv("SNOWFLAKE_PASSWORD"),
+                    database="TESTDB",
+                    schema="TESTSCHEMA",
+                )
+            },
+        )
+        observations = result.asset_observations_for_node(table_src_asset.op.name)
+        assert len(observations) == 1
+        observation = observations[0]
+        assert observation.tags["dagster/data_version"] is not None
+        # Interpret the data version as a timestamp
+        # Convert from a string in the format 2024-02-09 00:41:29.829000 to a timestamp
+        timestamp = datetime.strptime(
+            observation.tags["dagster/data_version"], "%Y-%m-%d %H:%M:%S.%f"
+        )
+        assert timestamp is not None


### PR DESCRIPTION
Adds an observable source asset for snowflake table freshness. Similarly to bigquery PR, goal here is mostly to evaluate the approach taken for retrieving last updated time, and refine into a resource method in a later PR. Starting to think we can introduce a configurable resource subclass for "freshness enabled" stuff, could potentially be a cool avenue.

How I tested this
This takes advantage of existing secrets in the buildkite bucket to test against live snowflake data. To my knowledge we don't do this in other tests. It's a pattern I stole from dagster-bigquery that I found nice, and think we should adopt here.
