### PR TITLE
[external-assets] Remove SourceAsset from asset jobs

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -913,11 +913,6 @@ def _log_materialization_or_observation_events_for_asset(
             execution_type = AssetExecutionType.MATERIALIZATION
 
         check.invariant(
-            execution_type != AssetExecutionType.UNEXECUTABLE,
-            "There should never be unexecutable assets here",
-        )
-
-        check.invariant(
             execution_type in {AssetExecutionType.MATERIALIZATION, AssetExecutionType.OBSERVATION},
             f"Unexpected asset execution type {execution_type}",
         )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_external_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_external_assets.py
@@ -232,8 +232,6 @@ def test_how_partitioned_source_assets_are_backwards_compatible() -> None:
 
     result_two = job_def_with_shim.execute_in_process(
         instance=instance,
-        # currently we have to explicitly select the asset to exclude the source from execution
-        asset_selection=[AssetKey("an_asset")],
         partition_key="2021-01-03",
     )
 
@@ -284,9 +282,9 @@ def test_external_assets_with_dependencies_manual_construction() -> None:
     defs = Definitions(assets=[_upstream_def, _downstream_asset])
     assert defs
 
-    assert defs.get_implicit_global_asset_job_def().asset_layer.asset_deps[
-        AssetKey("downstream_asset")
-    ] == {AssetKey("upstream_asset")}
+    assert defs.get_asset_graph().asset_dep_graph["upstream"][AssetKey("downstream_asset")] == {
+        AssetKey("upstream_asset")
+    }
 
 
 def test_external_asset_multi_asset() -> None:


### PR DESCRIPTION
## Summary & Motivation

This removes `SourceAsset` from many internal pathways and sets the stage for the deletion of much code. I am doing the majority of deletions in an upstack PR because this is already large and complicated due to the need to introduce various tweaks to internal pathways to handle using external assets instead of source asset.

- Consolidate/rename/add assorted (private) asset graph and asset layer methods for selection of assets by execution type.
- Expunge source assets from the `AssetsLayer`
- Convert all `SourceAsset` to `AssetsDefinition` in `build_assets_job`, which is a path that all assets jobs pass through.
- Convert all `SourceAsset` to `AssetsDefinition` in `CachingRepositoryData`. `SourceAsset` objects are retained so that they can be returning by `RepositoryDefinition` public methods, but are not passed down into our system (their converted external asset counterparts are).
- Add an "unexecutable" system tag that gets attached to the ops associated with unexecutable external assets. This can be discarded when we support a `None` op value (instead of attaching an op that immediately errors) to unexecutable assets.

## How I Tested These Changes

Existing test suite.