### PR TITLE
FreshnessPolicy on source assets with data_time metadata

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -28,6 +28,7 @@ from dagster import (
     Bool,
     DagsterInstance,
     DailyPartitionsDefinition,
+    DataVersion,
     DefaultScheduleStatus,
     DefaultSensorStatus,
     DynamicOut,
@@ -75,6 +76,7 @@ from dagster import (
     logger,
     multi_asset,
     multi_asset_sensor,
+    observable_source_asset,
     op,
     repository,
     resource,
@@ -2037,6 +2039,11 @@ def define_asset_checks():
     ]
 
 
+@observable_source_asset(freshness_policy=FreshnessPolicy(maximum_lag_minutes=30))
+def source_asset_with_freshness():
+    return DataVersion("1")
+
+
 @repository(default_executor_def=in_process_executor)
 def test_repo():
     return [
@@ -2046,6 +2053,7 @@ def test_repo():
         *define_sensors(),
         *define_asset_jobs(),
         *define_asset_checks(),
+        source_asset_with_freshness,
     ]
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_freshness.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_freshness.py
@@ -1,0 +1,109 @@
+import time
+
+from dagster import DagsterEvent, DagsterEventType
+from dagster._core.definitions.data_time import DATA_TIME_METADATA_KEY
+from dagster._core.definitions.events import AssetObservation
+from dagster._core.events import AssetObservationData
+from dagster._core.events.log import EventLogEntry
+from dagster._core.workspace.context import WorkspaceRequestContext
+from dagster_graphql.test.utils import (
+    execute_dagster_graphql,
+)
+
+from .graphql_context_test_suite import GraphQLContextVariant, make_graphql_context_test_suite
+
+GET_FRESHNESS_INFO = """
+    query AssetNodeQuery($assetKeys: [AssetKeyInput!]!) {
+        assetNodes(assetKeys: $assetKeys) {
+            id
+            freshnessInfo {
+                currentMinutesLate
+                latestMaterializationMinutesLate
+            }
+            freshnessPolicy {
+                cronSchedule
+                maximumLagMinutes
+            }
+        }
+    }
+"""
+
+BaseTestSuite = make_graphql_context_test_suite(
+    context_variants=[GraphQLContextVariant.non_launchable_sqlite_instance_multi_location()]
+)
+
+
+class TestAssetFreshness(BaseTestSuite):
+    def test_source_asset_freshness_policy(self, graphql_context: WorkspaceRequestContext):
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_FRESHNESS_INFO,
+            variables={"assetKeys": [{"path": ["source_asset_with_freshness"]}]},
+        )
+        assert result.data
+        assert result.data["assetNodes"][0]["freshnessPolicy"]
+
+    def test_source_asset_freshness_info(self, graphql_context: WorkspaceRequestContext):
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_FRESHNESS_INFO,
+            variables={"assetKeys": [{"path": ["source_asset_with_freshness"]}]},
+        )
+        assert result.data
+        assert result.data["assetNodes"][0]["freshnessInfo"]["currentMinutesLate"] is None
+
+        graphql_context.instance.event_log_storage.store_event(
+            EventLogEntry(
+                error_info=None,
+                level="debug",
+                user_message="",
+                run_id="foo",
+                timestamp=time.time(),
+                dagster_event=DagsterEvent(
+                    DagsterEventType.ASSET_OBSERVATION.value,
+                    "nonce",
+                    event_specific_data=AssetObservationData(
+                        AssetObservation(
+                            asset_key="source_asset_with_freshness",
+                            metadata={DATA_TIME_METADATA_KEY: time.time() - 60 * 60},
+                        )
+                    ),
+                ),
+            )
+        )
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_FRESHNESS_INFO,
+            variables={"assetKeys": [{"path": ["source_asset_with_freshness"]}]},
+        )
+        assert result.data
+        assert result.data["assetNodes"][0]["freshnessInfo"]["currentMinutesLate"] >= 30
+
+        graphql_context.instance.event_log_storage.store_event(
+            EventLogEntry(
+                error_info=None,
+                level="debug",
+                user_message="",
+                run_id="foo",
+                timestamp=time.time(),
+                dagster_event=DagsterEvent(
+                    DagsterEventType.ASSET_OBSERVATION.value,
+                    "nonce",
+                    event_specific_data=AssetObservationData(
+                        AssetObservation(
+                            asset_key="source_asset_with_freshness",
+                            metadata={DATA_TIME_METADATA_KEY: time.time()},
+                        )
+                    ),
+                ),
+            )
+        )
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_FRESHNESS_INFO,
+            variables={"assetKeys": [{"path": ["source_asset_with_freshness"]}]},
+        )
+        assert result.data
+        assert result.data["assetNodes"][0]["freshnessInfo"]["currentMinutesLate"] == 0

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -38,6 +38,8 @@ from dagster._utils import datetime_as_float, make_hashable
 from dagster._utils.cached_method import cached_method
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
+DATA_TIME_METADATA_KEY = "dagster/data_time"
+
 
 class CachingDataTimeResolver:
     _instance_queryer: CachingInstanceQueryer
@@ -502,6 +504,29 @@ class CachingDataTimeResolver:
 
         return min(cast(AbstractSet[datetime.datetime], data_times), default=None)
 
+    def _get_source_data_time(
+        self, asset_key: AssetKey, current_time: datetime.datetime
+    ) -> Optional[datetime.datetime]:
+        latest_record = self.instance_queryer.get_latest_materialization_or_observation_record(
+            AssetKeyPartitionKey(asset_key)
+        )
+        if latest_record is None:
+            return None
+        if latest_record.asset_observation is None:
+            raise DagsterInvariantViolationError(
+                "Cannot calculate data time for source asset with materialization"
+            )
+
+        data_time = latest_record.event_log_entry.dagster_event.event_specific_data.asset_observation.metadata.get(
+            DATA_TIME_METADATA_KEY
+        )
+        if data_time is None:
+            return None
+        else:
+            return datetime.datetime.utcfromtimestamp(data_time.value).replace(
+                tzinfo=datetime.timezone.utc
+            )
+
     def get_minutes_overdue(
         self,
         asset_key: AssetKey,
@@ -513,7 +538,12 @@ class CachingDataTimeResolver:
                 "Cannot calculate minutes late for asset without a FreshnessPolicy"
             )
 
+        if self.asset_graph.is_source(asset_key):
+            current_data_time = self._get_source_data_time(asset_key, current_time=evaluation_time)
+        else:
+            current_data_time = self.get_current_data_time(asset_key, current_time=evaluation_time)
+
         return freshness_policy.minutes_overdue(
-            data_time=self.get_current_data_time(asset_key, current_time=evaluation_time),
+            data_time=current_data_time,
             evaluation_time=evaluation_time,
         )

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -9,6 +9,7 @@ from dagster._core.definitions.events import (
     CoercibleToAssetKey,
     CoercibleToAssetKeyPrefix,
 )
+from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.metadata import (
     MetadataUserInput,
 )
@@ -38,6 +39,7 @@ def observable_source_asset(
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
     auto_observe_interval_minutes: Optional[float] = None,
+    freshness_policy: Optional[FreshnessPolicy] = None,
 ) -> "_ObservableSourceAsset":
     ...
 
@@ -58,6 +60,7 @@ def observable_source_asset(
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
     auto_observe_interval_minutes: Optional[float] = None,
+    freshness_policy: Optional[FreshnessPolicy] = None,
 ) -> Union[SourceAsset, "_ObservableSourceAsset"]:
     """Create a `SourceAsset` with an associated observation function.
 
@@ -91,6 +94,8 @@ def observable_source_asset(
         auto_observe_interval_minutes (Optional[float]): While the asset daemon is turned on, a run
             of the observation function for this asset will be launched at this interval.
         observe_fn (Optional[SourceAssetObserveFunction]) Observation function for the source asset.
+        freshness_policy (FreshnessPolicy): A constraint specifying how often this asset is expected
+            to observe new data.
     """
     if observe_fn is not None:
         return _ObservableSourceAsset()(observe_fn)
@@ -108,6 +113,7 @@ def observable_source_asset(
         resource_defs,
         partitions_def,
         auto_observe_interval_minutes,
+        freshness_policy,
     )
 
 
@@ -126,6 +132,7 @@ class _ObservableSourceAsset:
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
         auto_observe_interval_minutes: Optional[float] = None,
+        freshness_policy: Optional[FreshnessPolicy] = None,
     ):
         self.key = key
         self.name = name
@@ -143,6 +150,7 @@ class _ObservableSourceAsset:
         self.resource_defs = resource_defs
         self.partitions_def = partitions_def
         self.auto_observe_interval_minutes = auto_observe_interval_minutes
+        self.freshness_policy = freshness_policy
 
     def __call__(self, observe_fn: SourceAssetObserveFunction) -> SourceAsset:
         source_asset_key, source_asset_name = resolve_asset_key_and_name_for_decorator(
@@ -174,4 +182,5 @@ class _ObservableSourceAsset:
             observe_fn=observe_fn,
             partitions_def=self.partitions_def,
             auto_observe_interval_minutes=self.auto_observe_interval_minutes,
+            freshness_policy=self.freshness_policy,
         )

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1659,6 +1659,7 @@ def external_asset_nodes_from_defs(
                         if source_asset.partitions_def
                         else None
                     ),
+                    freshness_policy=source_asset.freshness_policy,
                 )
             )
 


### PR DESCRIPTION
Rough draft:
- set FreshnessPolicy on source assets
- freshness is calculated based on a `data_time` timestamp set in the AssetObservation metadata. There's currently no way to set that with an `@observable_source_asset`, so tested with logging raw events. Once we can use `ObserveResult` we'll be able to set it