### PR TITLE
feat: support ECS code server replicas (DS-68)

### DIFF
--- a/docs/content/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference.mdx
@@ -41,6 +41,7 @@ locations:
         server_resources: # Resources for code servers launched by the agent for this location
           cpu: 256
           memory: 512
+          replica_count: 1
         run_resources: # Resources for runs launched by the agent for this location
           cpu: 4096
           memory: 16384

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
@@ -186,6 +186,12 @@ ECS_CONTAINER_CONTEXT_SCHEMA = {
                     is_required=False,
                     description="The ephemeral storage, in GiB, to use for the launched task.",
                 ),
+                "replica_count": Field(
+                    int,
+                    default_value=1,
+                    is_required=False,
+                    description="The number of code server instances to launch.",
+                ),
             }
         )
     ),

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -501,6 +501,7 @@ def other_container_context_config(other_configured_secret):
             "server_resources": {
                 "cpu": "2048",
                 "memory": "4096",
+                "replica_count": 2,
             },
             "task_role_arn": "other-task-role",
             "execution_role_arn": "other-fake-execution-role",

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_container_context.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_container_context.py
@@ -87,6 +87,7 @@ def test_merge(
         "cpu": "2048",
         "memory": "4096",
         "ephemeral_storage": 25,
+        "replica_count": 2,
     }
 
     assert merged.server_ecs_tags == [

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -323,7 +323,7 @@ def test_task_definition_registration(
 
 
 @pytest.mark.skip(
-    "This remains occassionally flaky on older versions of Python. See"
+    "This remains occasionally flaky on older versions of Python. See"
     " https://github.com/dagster-io/dagster/pull/11290 "
     "https://linear.app/elementl/issue/CLOUD-2093/re-enable-flaky-ecs-task-registration-race-condition-tests"
 )


### PR DESCRIPTION
## Summary & Motivation

Support the hybrid ECS deployment with code servers/locations replicas.

## How I Tested These Changes

- unit test
- dev ECS cluster against local host cloud