### PR TITLE
Add ObserveResult support for observable source asset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -37,6 +37,7 @@ from dagster._core.definitions.resource_requirement import (
     ensure_requirements_satisfied,
     get_resource_key_conflicts,
 )
+from dagster._core.definitions.result import ObserveResult
 from dagster._core.definitions.utils import (
     DEFAULT_GROUP_NAME,
     DEFAULT_IO_MANAGER_KEY,
@@ -93,19 +94,32 @@ def wrap_source_asset_observe_fn_in_op_compute_fn(
             else observe_fn(**resource_kwargs)
         )
 
-        if isinstance(observe_fn_return_value, DataVersion):
+        if isinstance(observe_fn_return_value, (DataVersion, ObserveResult)):
             if source_asset.partitions_def is not None:
                 raise DagsterInvalidObservationError(
-                    f"{source_asset.key} is partitioned, so its observe function should return a"
-                    " DataVersionsByPartition, not a DataVersion"
+                    f"{source_asset.key} is partitioned. Returning `{observe_fn_return_value.__class__}` not supported"
+                    " for partitioned assets. Return `DataVersionsByPartition` instead."
                 )
+
+            if isinstance(observe_fn_return_value, ObserveResult):
+                data_version = check.not_none(
+                    observe_fn_return_value.data_version,
+                    "ObserveResult returned from an observable_source_asset must have a data version",
+                )
+                data_version_str = data_version.value
+                metadata = observe_fn_return_value.metadata
+            else:  # DataVersion
+                data_version_str = observe_fn_return_value.value
+                metadata = {}
 
             context.log_event(
                 AssetObservation(
                     asset_key=source_asset.key,
-                    tags={DATA_VERSION_TAG: observe_fn_return_value.value},
+                    tags={DATA_VERSION_TAG: data_version_str},
+                    metadata=metadata,
                 )
             )
+
         elif isinstance(observe_fn_return_value, DataVersionsByPartition):
             if source_asset.partitions_def is None:
                 raise DagsterInvalidObservationError(


### PR DESCRIPTION
## Summary & Motivation

Adds the ability to return `ObserveResult` from an `@observable_source_asset`. This allows you to attach metadata. Currently we require a `DataVersion` on the `ObserveResult` to be conservative wrt the previous behavior of observable sources, but it's possible this restriction can be removed.

The more principled solution here is to actually send `ObserveResult` down the pipes instead of turning it into a logged `AssetObservation`, but that works is pending broader refactors.

## How I Tested These Changes

New unit tests.
