### PR TITLE
Move automount_service_account_token configuration to helm chart configuration

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -135,15 +135,14 @@ DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP: "{{ template "dagster.fullname" . }}-pip
     {{- if and (.env) (kindIs "slice" .env) }}
     env: {{- .env | toYaml | nindent 6 }}
     {{- end }}
-    {{- if or .sidecarContainers .initContainers }}
     run_k8s_config:
       pod_spec_config:
+        automount_service_account_token: true
         {{- if .sidecarContainers }}
         containers: {{- toYaml .sidecarContainers | nindent 10 }}
         {{- end }}
         {{- if .initContainers }}
         init_containers: {{- toYaml .initContainers | nindent 10 }}
         {{- end }}
-    {{- end }}
   {{- end }}
 {{- end -}}

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -659,6 +659,11 @@ def test_user_deployment_include_config_in_launched_runs(template: HelmTemplate)
             "env_config_maps": ["release-name-dagster-user-deployments-foo-user-env"],
             "namespace": "default",
             "service_account_name": "release-name-dagster-user-deployments-user-deployments",
+            "run_k8s_config": {
+                "pod_spec_config": {
+                    "automount_service_account_token": True,
+                }
+            },
         }
     }
 
@@ -751,6 +756,11 @@ def test_user_deployment_volumes(template: HelmTemplate, include_config_in_launc
                 "volumes": volumes,
                 "namespace": "default",
                 "service_account_name": "release-name-dagster-user-deployments-user-deployments",
+                "run_k8s_config": {
+                    "pod_spec_config": {
+                        "automount_service_account_token": True,
+                    }
+                },
             }
         }
     else:
@@ -807,6 +817,11 @@ def test_user_deployment_secrets_and_configmaps(
                 ],
                 "namespace": "default",
                 "service_account_name": "release-name-dagster-user-deployments-user-deployments",
+                "run_k8s_config": {
+                    "pod_spec_config": {
+                        "automount_service_account_token": True,
+                    }
+                },
             }
         }
     else:
@@ -854,6 +869,11 @@ def test_user_deployment_labels(template: HelmTemplate, include_config_in_launch
                 "labels": labels,
                 "namespace": "default",
                 "service_account_name": "release-name-dagster-user-deployments-user-deployments",
+                "run_k8s_config": {
+                    "pod_spec_config": {
+                        "automount_service_account_token": True,
+                    }
+                },
             }
         }
     else:
@@ -902,6 +922,11 @@ def test_user_deployment_resources(template: HelmTemplate, include_config_in_lau
                 "resources": resources,
                 "namespace": "default",
                 "service_account_name": "release-name-dagster-user-deployments-user-deployments",
+                "run_k8s_config": {
+                    "pod_spec_config": {
+                        "automount_service_account_token": True,
+                    }
+                },
             }
         }
     else:
@@ -982,6 +1007,7 @@ def test_user_deployment_sidecar(template: HelmTemplate, include_config_in_launc
                     "pod_spec_config": {
                         "init_containers": init_containers,
                         "containers": sidecars,
+                        "automount_service_account_token": True,
                     },
                 },
             }
@@ -1025,6 +1051,11 @@ def test_subchart_image_pull_secrets(
                 "image_pull_secrets": image_pull_secrets,
                 "namespace": "default",
                 "service_account_name": "release-name-dagster-user-deployments-user-deployments",
+                "run_k8s_config": {
+                    "pod_spec_config": {
+                        "automount_service_account_token": True,
+                    }
+                },
             }
         }
     else:
@@ -1196,6 +1227,11 @@ def test_code_server_cli(template: HelmTemplate, user_deployment_configmap_templ
             "env_config_maps": ["release-name-dagster-user-deployments-foo-user-env"],
             "namespace": "default",
             "service_account_name": "release-name-dagster-user-deployments-user-deployments",
+            "run_k8s_config": {
+                "pod_spec_config": {
+                    "automount_service_account_token": True,
+                },
+            },
         }
     }
 
@@ -1231,6 +1267,11 @@ def test_env_container_context(template: HelmTemplate, user_deployment_configmap
             "namespace": "default",
             "service_account_name": "release-name-dagster-user-deployments-user-deployments",
             "env": [{"name": "test_env", "value": "test_value"}],
+            "run_k8s_config": {
+                "pod_spec_config": {
+                    "automount_service_account_token": True,
+                }
+            },
         }
     }
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -853,6 +853,8 @@ def construct_dagster_k8s_job(
 
     scheduler_name = pod_spec_config.pop("scheduler_name", job_config.scheduler_name)
 
+    automount_service_account_token = pod_spec_config.pop("automount_service_account_token", True)
+
     user_defined_containers = pod_spec_config.pop("containers", [])
 
     template = {
@@ -871,7 +873,7 @@ def construct_dagster_k8s_job(
             {
                 "image_pull_secrets": job_config.image_pull_secrets,
                 "service_account_name": service_account_name,
-                "automount_service_account_token": True,
+                "automount_service_account_token": automount_service_account_token,
                 "containers": [container_config] + user_defined_containers,
                 "volumes": volumes,
             },


### PR DESCRIPTION
Summary:
The configuration in https://github.com/dagster-io/dagster/pull/19217/files changed the service account to no longer mount the service token by default to comply with security policies.

To ensure that any jobs launched by dagster still mount the token, the Python code that launches jobs applied the config to still mount the service token.

However, this breaks if you are on an older version of dagster and using the k8s_job_executor to launch your runs.

So in addition to setting it in Python, set it in run_k8s_config in the Helm chart, so that it will be automatically threaded through to the k8s_job_executor, even if its running an older version of Dagster.

Test Plan: BK - verified that making the Python change without making the helm change causes tests to fail due to being unable to spin up jobs

## Summary & Motivation

## How I Tested These Changes
