### PR TITLE
[rfc] deltalake observable source asset factory

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/observe.py
+++ b/python_modules/dagster/dagster/_core/definitions/observe.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
 
 import dagster._check as check
-from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._utils.warnings import disable_dagster_warnings
 
 from ..instance import DagsterInstance
@@ -47,7 +47,9 @@ def observe(
     resources = check.opt_mapping_param(resources, "resources", key_type=str)
 
     with disable_dagster_warnings():
-        observation_job = build_assets_job("in_process_observation_job", [], source_assets)
+        observation_job = define_asset_job(
+            "in_process_observation_job", [source_asset.key for source_asset in source_assets]
+        )
         defs = Definitions(
             assets=source_assets,
             jobs=[observation_job],

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -86,7 +86,9 @@ def wrap_source_asset_observe_fn_in_op_compute_fn(
 
     def fn(context: OpExecutionContext) -> Output[None]:
         resource_kwarg_keys = [param.name for param in get_resource_args(observe_fn)]
-        resource_kwargs = {key: getattr(context.resources, key) for key in resource_kwarg_keys}
+        resource_kwargs = {
+            key: context.resources.original_resource_dict.get(key) for key in resource_kwarg_keys
+        }
         observe_fn_return_value = (
             observe_fn(context, **resource_kwargs)
             if observe_fn_has_context

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
@@ -178,3 +178,20 @@ def test_observe_pythonic_resource():
 
     observe([foo], instance=instance, resources={"foo": FooResource(foo="bar")})
     assert _get_current_data_version(AssetKey("foo"), instance) == DataVersion("bar-alpha")
+
+
+def test_observe_backcompat_pythonic_resource():
+    class FooResource(ConfigurableResource):
+        foo: str
+
+        def get_object_to_set_on_execution_context(self):
+            raise Exception("Shouldn't get here")
+
+    @observable_source_asset
+    def foo(foo: FooResource) -> DataVersion:
+        return DataVersion(f"{foo.foo}-alpha")
+
+    instance = DagsterInstance.ephemeral()
+
+    observe([foo], instance=instance, resources={"foo": FooResource(foo="bar")})
+    assert _get_current_data_version(AssetKey("foo"), instance) == DataVersion("bar-alpha")

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/asset.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/asset.py
@@ -1,0 +1,17 @@
+from dagster import DataVersion, observable_source_asset
+
+from .resource import DeltaTableResource
+
+"""
+Running the following code on an existing delta table gets you the last updated timestamp:
+deltaTable.history(1).select("timestamp").collect()[0][0]
+"""
+
+
+@observable_source_asset
+def observe_table_last_modified_time(context, delta_table: DeltaTableResource) -> DataVersion:
+    table = delta_table.load()
+    timestamp = table.history(1)[0]["timestamp"]
+    # context.log.info the last modified time as a UTC timestamp.
+    context.log.info(f"Last modified time for table {table}: {timestamp}")
+    return DataVersion(str(timestamp))

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_assets.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_assets.py
@@ -1,0 +1,70 @@
+import os
+import uuid
+
+# import contextmanager
+from contextlib import contextmanager
+
+import pyarrow as pa
+from dagster import DagsterInstance, build_resources
+from dagster._core.definitions.observe import observe
+from dagster_deltalake import DeltaTableResource
+from dagster_deltalake.asset import observe_table_last_modified_time
+from dagster_deltalake.config import LocalConfig
+from deltalake import write_deltalake
+
+
+@contextmanager
+def ephemeral_deltalake_table(tmp_path: str):
+    table_name = "test_table_" + str(uuid.uuid4()).replace("-", "_").lower()
+    table_path = os.path.join(tmp_path, table_name)
+    with build_resources(
+        {"delta_table": DeltaTableResource(url=table_path, storage_options=LocalConfig())}
+    ) as resources:
+        write_deltalake(
+            table_path,
+            pa.table({"a": [1, 2, 3], "b": [5, 6, 7]}),
+            storage_options=resources.delta_table.storage_options.dict(),
+        )
+        # Add a few rows to the table.
+        for i in range(3):
+            write_deltalake(
+                table_path,
+                pa.table({"a": [4], "b": [8]}),
+                storage_options=resources.delta_table.storage_options.dict(),
+                mode="append",
+            )
+        yield table_name, table_path
+
+
+def test_observe_table(tmp_path: str):
+    with ephemeral_deltalake_table(tmp_path) as (table_name, table_path):
+        instance = DagsterInstance.ephemeral()
+        result = observe(
+            [observe_table_last_modified_time],
+            instance=instance,
+            resources={
+                "delta_table": DeltaTableResource(url=table_path, storage_options=LocalConfig())
+            },
+        )
+        observations = result.asset_observations_for_node(observe_table_last_modified_time.op.name)
+        assert len(observations) == 1
+        observation = observations[0]
+        assert observation.tags["dagster/data_version"] is not None
+        # Interpret the data version as a timestamp
+        # Convert from a string in the format 2024-02-09 00:41:29.829000 to a timestamp
+        timestamp = float(observation.tags["dagster/data_version"])
+        assert timestamp is not None
+        all_timestamps = [timestamp]
+        # Check the other available timestamps
+        with build_resources(
+            resources={
+                "delta_table": DeltaTableResource(url=table_path, storage_options=LocalConfig())
+            }
+        ) as resources:
+            table = resources.delta_table.load()
+            history = table.history()
+            for entry in history:
+                all_timestamps.append(entry["timestamp"])
+
+        # Ensure we retrieved the last available timestamp
+        assert max(all_timestamps) == timestamp


### PR DESCRIPTION
Proof of concept to retrieve last updated time from deltalake tables. This one is a bit weirder, the documentation doesn't describe this process exactly, and I have at least slight signal that the implementation can vary based on the backend: https://stackoverflow.com/questions/74097691/how-can-i-get-last-modified-date-of-a-delta-table-in-pyspark. Although that example uses a different package. 
I guess my question is, do we have any level of confidence that the format returned by using the local storage option is representative of that of the cloud providers? Or do I need to do more validation there. Fwiw, does feel like it would be a weird outcome for the implementation of `history` to change depending on the backend. But couldn't find much about this online, ultimately.
