### PR TITLE
Update partitioning-assets.mdx

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
@@ -100,6 +100,7 @@ from dagster import (
     AssetExecutionContext,
     DailyPartitionsDefinition,
     MultiPartitionsDefinition,
+    MultiPartitionKey,
     StaticPartitionsDefinition,
     asset,
 )

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/multipartitions_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/multipartitions_asset.py
@@ -3,6 +3,7 @@ from dagster import (
     AssetExecutionContext,
     DailyPartitionsDefinition,
     MultiPartitionsDefinition,
+    MultiPartitionKey,
     StaticPartitionsDefinition,
     asset,
 )

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/multipartitions_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/multipartitions_asset.py
@@ -2,8 +2,8 @@
 from dagster import (
     AssetExecutionContext,
     DailyPartitionsDefinition,
-    MultiPartitionsDefinition,
     MultiPartitionKey,
+    MultiPartitionsDefinition,
     StaticPartitionsDefinition,
     asset,
 )


### PR DESCRIPTION
Add missing import to "Multi-dimensionally partitioned assets" example code

## How I Tested These Changes
I didn't see a way to test, because the example code seems to be taken out of
context. That's probably why the missing import slipped in.