### PR TITLE
fix: propagate empty string schema's

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -185,7 +185,7 @@ class DbIOManager(IOManager):
             # schema order of precedence: metadata, I/O manager 'schema' config, key_prefix
             if output_context_metadata.get("schema"):
                 schema = cast(str, output_context_metadata["schema"])
-            elif self._schema:
+            elif self._schema is not None:
                 schema = self._schema
             elif len(asset_key_path) > 1:
                 schema = asset_key_path[-2]

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
@@ -233,7 +233,7 @@ class DeltaLakeDbClient(DbClient):
             **{k: str(v) for k, v in client_options.items() if v is not None},
         }
         table_config = resource_config.get("table_config")
-        
+
         # Ignore schema if None or empty string, useful to set schema = "" which overrides the assetkey
         if table_slice.schema:
             table_uri = f"{root_uri}/{table_slice.schema}/{table_slice.table}"

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
@@ -233,7 +233,12 @@ class DeltaLakeDbClient(DbClient):
             **{k: str(v) for k, v in client_options.items() if v is not None},
         }
         table_config = resource_config.get("table_config")
-        table_uri = f"{root_uri}/{table_slice.schema}/{table_slice.table}"
+        
+        # Ignore schema if None or empty string, useful to set schema = "" which overrides the assetkey
+        if table_slice.schema:
+            table_uri = f"{root_uri}/{table_slice.schema}/{table_slice.table}"
+        else:
+            table_uri = f"{root_uri}/{table_slice.table}"
 
         conn = TableConnection(
             table_uri=table_uri,


### PR DESCRIPTION
## Summary & Motivation
There are some situations where you want to ignore the asset_keys and don't wont to use a schema. To allow passing a `schema=""`, just had to make 2 small modifications to allow propagating them.

This won't change any of the behavior for other use cases but make it a bit more flexible