### PR TITLE
feat: deltalake `MERGE` support + additional features and bug fixes

### DIFF
--- a/pyright/alt-1/requirements-pinned.txt
+++ b/pyright/alt-1/requirements-pinned.txt
@@ -104,7 +104,7 @@ idna==3.6
 importlib-metadata==6.11.0
 iniconfig==2.0.0
 ipykernel==6.29.0
-ipython==8.21.0
+ipython==8.18.0
 isodate==0.6.1
 isoduration==20.11.0
 isort==5.13.2

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -172,7 +172,7 @@ dbt-extractor==0.4.1
 debugpy==1.8.0
 decorator==5.1.1
 defusedxml==0.7.1
-deltalake==0.15.1
+deltalake==0.15.3
 Deprecated==1.2.14
 -e examples/development_to_production
 dict2css==0.3.0.post1
@@ -259,7 +259,7 @@ importlib-resources==6.1.1
 inflection==0.5.1
 iniconfig==2.0.0
 ipykernel==6.29.0
-ipython==8.21.0
+ipython==8.18.0
 ipython-genutils==0.2.0
 ipywidgets==8.1.1
 iso8601==2.1.0

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -185,7 +185,7 @@ class DbIOManager(IOManager):
             # schema order of precedence: metadata, I/O manager 'schema' config, key_prefix
             if output_context_metadata.get("schema"):
                 schema = cast(str, output_context_metadata["schema"])
-            elif self._schema:
+            elif self._schema is not None:
                 schema = self._schema
             elif len(asset_key_path) > 1:
                 schema = asset_key_path[-2]

--- a/python_modules/libraries/dagster-deltalake-pandas/dagster_deltalake_pandas/deltalake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-deltalake-pandas/dagster_deltalake_pandas/deltalake_pandas_type_handler.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Sequence, Tuple, Type
+from typing import Any, Dict, Optional, Sequence, Tuple, Type, Mapping
 
 import pandas as pd
 import pyarrow as pa
@@ -9,6 +9,7 @@ from dagster_deltalake.handler import (
     DeltalakeBaseArrowTypeHandler,
     DeltaLakePyArrowTypeHandler,
 )
+from dagster import MetadataValue
 from dagster_deltalake.io_manager import DeltaLakeIOManager
 
 
@@ -24,6 +25,10 @@ class DeltaLakePandasTypeHandler(DeltalakeBaseArrowTypeHandler[pd.DataFrame]):
     @property
     def supported_types(self) -> Sequence[Type[object]]:
         return [pd.DataFrame]
+
+    def get_output_stats(self, obj: pd.DataFrame) -> Mapping[str, MetadataValue]:
+        stats = {"source_num_rows": MetadataValue.int(obj.shape[0])}
+        return stats
 
 
 class DeltaLakePandasIOManager(DeltaLakeIOManager):

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/__init__.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/__init__.py
@@ -5,7 +5,10 @@ from dagster._core.storage.db_io_manager import DbTypeHandler
 
 from .config import (
     AzureConfig as AzureConfig,
+    ClientConfig as ClientConfig,
     LocalConfig as LocalConfig,
+    MergeConfig as MergeConfig,
+    MergeType as MergeType,
     S3Config as S3Config,
 )
 from .handler import (

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/config.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/config.py
@@ -1,6 +1,9 @@
 import sys
 from typing import Optional
 
+from enum import Enum
+
+
 from dagster import Config
 
 if sys.version_info >= (3, 8):
@@ -66,52 +69,52 @@ class S3Config(Config):
 
     provider: Literal["s3"] = "s3"
 
-    access_key_id: Optional[str]
+    access_key_id: Optional[str] = None
     """AWS access key ID"""
 
-    secret_access_key: Optional[str]
+    secret_access_key: Optional[str] = None
     """AWS access key secret"""
 
-    region: Optional[str]
+    region: Optional[str] = None
     """AWS region"""
 
-    bucket: Optional[str]
+    bucket: Optional[str] = None
     """Storage bucket name"""
 
-    endpoint: Optional[str]
+    endpoint: Optional[str] = None
     """Sets custom endpoint for communicating with S3."""
 
-    token: Optional[str]
+    token: Optional[str] = None
     """Token to use for requests (passed to underlying provider)"""
 
     imdsv1_fallback: bool = False
     """Allow fall back to ImdsV1"""
 
-    virtual_hosted_style_request: Optional[str]
+    virtual_hosted_style_request: Optional[str] = None
     """Bucket is hosted under virtual-hosted-style URL"""
 
-    unsigned_payload: Optional[bool]
+    unsigned_payload: Optional[bool] = None
     """Avoid computing payload checksum when calculating signature."""
 
-    checksum: Optional[str]
+    checksum: Optional[str] = None
     """Set the checksum algorithm for this client."""
 
-    metadata_endpoint: Optional[str]
+    metadata_endpoint: Optional[str] = None
     """Instance metadata endpoint URL for fetching credentials"""
 
-    container_credentials_relative_uri: Optional[str]
+    container_credentials_relative_uri: Optional[str] = None
     """Set the container credentials relative URI
 
     https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
     """
 
-    copy_if_not_exists: Optional[str]
+    copy_if_not_exists: Optional[str] = None
     """Specifiy additional headers passed to strage backend, that enable 'if_not_exists' semantics.
 
     https://docs.rs/object_store/0.7.0/object_store/aws/enum.S3CopyIfNotExists.html#variant.Header
     """
 
-    allow_unsafe_rename: Optional[bool]
+    AWS_S3_ALLOW_UNSAFE_RENAME: Optional[bool] = None
     """Allows tables writes that may conflict with concurrent writers."""
 
 
@@ -120,26 +123,26 @@ class GcsConfig(Config):
 
     provider: Literal["gcs"] = "gcs"
 
-    service_account: Optional[str]
+    service_account: Optional[str] = None
     """Path to the service account file"""
 
-    service_account_key: Optional[str]
+    service_account_key: Optional[str] = None
     """The serialized service account key."""
 
-    bucket: Optional[str]
+    bucket: Optional[str] = None
     """Bucket name"""
 
-    application_credentials: Optional[str]
+    application_credentials: Optional[str] = None
     """Application credentials path"""
 
 
 class ClientConfig(Config):
     """Configuration for http client interacting with storage APIs."""
 
-    allow_http: Optional[bool]
+    allow_http: Optional[bool] = None
     """Allow non-TLS, i.e. non-HTTPS connections"""
 
-    allow_invalid_certificates: Optional[bool]
+    allow_invalid_certificates: Optional[bool] = None
     """Skip certificate validation on https connections.
 
     ## Warning
@@ -150,44 +153,70 @@ class ClientConfig(Config):
     and should only be used as a last resort or for testing
     """
 
-    connect_timeout: Optional[int]
+    connect_timeout: Optional[int] = None
     """Timeout for only the connect phase of a Client"""
 
-    default_content_type: Optional[str]
+    default_content_type: Optional[str] = None
     """default CONTENT_TYPE for uploads"""
 
-    http1_only: Optional[bool]
+    http1_only: Optional[bool] = None
     """Only use http1 connections"""
 
-    http2_keep_alive_interval: Optional[int]
+    http2_keep_alive_interval: Optional[int] = None
     """Interval for HTTP2 Ping frames should be sent to keep a connection alive."""
 
-    http2_keep_alive_timeout: Optional[int]
+    http2_keep_alive_timeout: Optional[int] = None
     """Timeout for receiving an acknowledgement of the keep-alive ping."""
 
-    http2_keep_alive_while_idle: Optional[int]
+    http2_keep_alive_while_idle: Optional[int] = None
     """Enable HTTP2 keep alive pings for idle connections"""
 
-    http2_only: Optional[bool]
+    http2_only: Optional[bool] = None
     """Only use http2 connections"""
 
-    pool_idle_timeout: Optional[int]
+    pool_idle_timeout: Optional[int] = None
     """The pool max idle timeout
 
     This is the length of time an idle connection will be kept alive
     """
 
-    pool_max_idle_per_host: Optional[int]
+    pool_max_idle_per_host: Optional[int] = None
     """maximum number of idle connections per host"""
 
-    proxy_url: Optional[str]
+    proxy_url: Optional[str] = None
     """HTTP proxy to use for requests"""
 
-    timeout: Optional[int]
+    timeout: Optional[int] = None
     """Request timeout
 
     The timeout is applied from when the request starts connecting until the response body has finished
     """
 
-    user_agent: Optional[str]
+    user_agent: Optional[str] = None
     """User-Agent header to be used by this client"""
+
+
+class MergeType(str, Enum):
+    deduplicate_insert = "deduplicate_insert"  # Deduplicates on write
+    update_only = "update_only"  # updates only the records
+    upsert = "upsert"  # updates and inserts
+    replace_delete_unmatched = "replace_and_delete_unmatched"
+
+
+class MergeConfig(Config):
+    """Configuration for the MERGE operation."""
+
+    merge_type: MergeType
+    """The type of MERGE to execute."""
+
+    predicate: str
+    """SQL like predicate on how to merge, passed into DeltaTable.merge()"""
+
+    source_alias: Optional[str] = None
+    """Alias for the source table"""
+
+    target_alias: Optional[str] = None
+    """Alias for the target table"""
+
+    error_on_type_mismatch: bool = True
+    """specify if merge will return error if data types are mismatching"""

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
@@ -281,7 +281,7 @@ def _value_dnf(table_partition: TablePartitionDimension, data_type: str, str_val
     # ", ".join(f"'{partition}'" for partition in table_partition.partitions)
     partition = cast(Sequence[str], table_partition.partitions)
     if len(partition) > 1:
-        raise ValueError(f"Array partition values are not yet supported: {data_type} / {partition}")
+        return (table_partition.partition_expr, "in", table_partition.partitions)
     if str_values:
         return (table_partition.partition_expr, "=", table_partition.partitions[0])
 

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
@@ -268,7 +268,7 @@ def partition_dimensions_to_dnf(
                 )
                 parts.append(filter_)
             elif field.type.type == "string":
-                parts.append(_value_dnf(partition_dimension, field.type.type, str_values))
+                parts.append(_value_dnf(partition_dimension))
             else:
                 raise ValueError(f"Unsupported partition type {field.type.type}")
         else:
@@ -277,15 +277,13 @@ def partition_dimensions_to_dnf(
     return parts if len(parts) > 0 else None
 
 
-def _value_dnf(table_partition: TablePartitionDimension, data_type: str, str_values: bool):
+def _value_dnf(table_partition: TablePartitionDimension):
     # ", ".join(f"'{partition}'" for partition in table_partition.partitions)
     partition = cast(Sequence[str], table_partition.partitions)
     if len(partition) > 1:
         return (table_partition.partition_expr, "in", table_partition.partitions)
-    if str_values:
+    else:
         return (table_partition.partition_expr, "=", table_partition.partitions[0])
-
-    return (table_partition.partition_expr, "=", table_partition.partitions)
 
 
 def _time_window_partition_dnf(

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
@@ -233,7 +233,7 @@ class DeltaLakeDbClient(DbClient):
             **{k: str(v) for k, v in client_options.items() if v is not None},
         }
         table_config = resource_config.get("table_config")
-        
+
         # Ignore schema if None or empty string, useful to set schema = "" which overrides the assetkey
         if table_slice.schema:
             table_uri = f"{root_uri}/{table_slice.schema}/{table_slice.table}"

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
@@ -233,7 +233,12 @@ class DeltaLakeDbClient(DbClient):
             **{k: str(v) for k, v in client_options.items() if v is not None},
         }
         table_config = resource_config.get("table_config")
-        table_uri = f"{root_uri}/{table_slice.schema}/{table_slice.table}"
+        
+        # Ignore schema if None or empty string, useful to set schema = "" which overrides the assetkey
+        if table_slice.schema:
+            table_uri = f"{root_uri}/{table_slice.schema}/{table_slice.table}"
+        else:
+            table_uri = f"{root_uri}/{table_slice.table}"
 
         conn = TableConnection(
             table_uri=table_uri,

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_type_handler.py
@@ -451,7 +451,7 @@ def test_dynamic_partition(tmp_path, io_manager):
         assert sorted(out_df["a"].to_pylist()) == ["2", "2", "2", "3", "3", "3"]
 
 
-@pytest.mark.skip("handle creating empty tables - hopw to get schema a-priory?")
+@pytest.mark.skip("handle creating empty tables - how to get schema a-priory?")
 def test_self_dependent_asset(tmp_path, io_manager):
     daily_partitions = DailyPartitionsDefinition(start_date="2023-01-01")
 

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_type_handler_merge.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_type_handler_merge.py
@@ -27,14 +27,15 @@ def add_one_to_dataframe():
     add_one(a_df())
 
 
-def test_deltalake_io_manager_with_ops_rust_writer(tmp_path):
+@pytest.mark.parametrize("merge_type", [MergeType.deduplicate_insert, MergeType.upsert])
+def test_deltalake_io_manager_with_ops_rust_writer(tmp_path, merge_type: MergeType):
     resource_defs = {
         "io_manager": DeltaLakePyarrowIOManager(
             root_uri=str(tmp_path),
             storage_options=LocalConfig(),
             mode=WriteMode.merge,
             merge_config=MergeConfig(
-                merge_type=MergeType.deduplicate_insert,
+                merge_type=merge_type,
                 predicate="s.a = t.a",
                 source_alias="s",
                 target_alias="t",

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_type_handler_merge.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_type_handler_merge.py
@@ -1,0 +1,59 @@
+import os
+
+import pyarrow as pa
+import pytest
+from dagster import (
+    Out,
+    graph,
+    op,
+)
+from dagster_deltalake import DeltaLakePyarrowIOManager, LocalConfig, WriterEngine, WriteMode
+from dagster_deltalake import MergeConfig, MergeType
+from deltalake import DeltaTable
+
+
+@op(out=Out(metadata={"schema": "a_df"}))
+def a_df() -> pa.Table:
+    return pa.Table.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+
+@op(out=Out(metadata={"schema": "add_one"}))
+def add_one(df: pa.Table):
+    return df.set_column(0, "a", pa.array([2, 3, 4]))
+
+
+@graph
+def add_one_to_dataframe():
+    add_one(a_df())
+
+
+def test_deltalake_io_manager_with_ops_rust_writer(tmp_path):
+    resource_defs = {
+        "io_manager": DeltaLakePyarrowIOManager(
+            root_uri=str(tmp_path),
+            storage_options=LocalConfig(),
+            mode=WriteMode.merge,
+            merge_config=MergeConfig(
+                merge_type=MergeType.deduplicate_insert,
+                predicate="s.a = t.a",
+                source_alias="s",
+                target_alias="t",
+            ),
+        )
+    }
+
+    job = add_one_to_dataframe.to_job(resource_defs=resource_defs)
+
+    # run the job twice to ensure that tables get properly deleted
+    for _ in range(2):
+        res = job.execute_in_process()
+
+        assert res.success
+
+        dt = DeltaTable(os.path.join(tmp_path, "a_df/result"))
+        out_df = dt.to_pyarrow_table()
+        assert list(sorted(out_df["a"].to_pylist())) == [1, 2, 3]
+
+        dt = DeltaTable(os.path.join(tmp_path, "add_one/result"))
+        out_df = dt.to_pyarrow_table()
+        assert list(sorted(out_df["a"].to_pylist())) == [2, 3, 4]


### PR DESCRIPTION
## Summary & Motivation

## New features
- Adds `MERGE` operation with couple flavors of it
- Adds get_output_stats to collect stats, can be extended per TypeHandler
- Adds support for reading array of partitions from upstream partitioned dataset

## Bug fixes
- Fixes config defaults, they weren't set before (made static type checker fail)
- Load input from upstream partitioned dataset would incorrectly always use start_dt, while if the asset that is being materialized is non-partitioned it should be the range
