### PR TITLE
fix: ipython version in pyright requirements

### DIFF
--- a/pyright/alt-1/requirements-pinned.txt
+++ b/pyright/alt-1/requirements-pinned.txt
@@ -104,7 +104,7 @@ idna==3.6
 importlib-metadata==6.11.0
 iniconfig==2.0.0
 ipykernel==6.29.0
-ipython==8.21.0
+ipython==8.18.0
 isodate==0.6.1
 isoduration==20.11.0
 isort==5.13.2

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -259,7 +259,7 @@ importlib-resources==6.1.1
 inflection==0.5.1
 iniconfig==2.0.0
 ipykernel==6.29.0
-ipython==8.21.0
+ipython==8.18.0
 ipython-genutils==0.2.0
 ipywidgets==8.1.1
 iso8601==2.1.0


### PR DESCRIPTION
## Summary & Motivation
8.21.0 is incompatible with python 3.9.16, it's only 3.10+. According to the contributing guide, the required python version is 3.9.16.