### PR TITLE
chore: enforce supported Python versions on pip installation

### DIFF
--- a/python_modules/dagit/setup.py
+++ b/python_modules/dagit/setup.py
@@ -42,6 +42,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagit_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster-webserver{pin}",
     ],

--- a/python_modules/dagster-graphql/setup.py
+++ b/python_modules/dagster-graphql/setup.py
@@ -34,6 +34,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_graphql_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         "graphene>=3,<4",

--- a/python_modules/dagster-pipes/setup.py
+++ b/python_modules/dagster-pipes/setup.py
@@ -35,5 +35,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_pipes_tests*"]),
+    python_requires=">=3.8,<3.13",
     zip_safe=False,
 )

--- a/python_modules/dagster-test/setup.py
+++ b/python_modules/dagster-test/setup.py
@@ -16,6 +16,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_test_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         "dagster",
         "pyspark",

--- a/python_modules/dagster-webserver/setup.py
+++ b/python_modules/dagster-webserver/setup.py
@@ -42,6 +42,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_webserver_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         # cli
         "click>=7.0,<9.0",

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -74,6 +74,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         # cli
         "click>=5.0",

--- a/python_modules/libraries/dagster-airbyte/setup.py
+++ b/python_modules/libraries/dagster-airbyte/setup.py
@@ -35,6 +35,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_airbyte_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         "requests",

--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -30,6 +30,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_airflow_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         "docker>=5.0.3,<6.0.0",

--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -34,6 +34,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_aws_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         "boto3",
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-azure/setup.py
+++ b/python_modules/libraries/dagster-azure/setup.py
@@ -34,6 +34,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_azure_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         "azure-core<2.0.0,>=1.7.0",
         "azure-identity<2.0.0,>=1.7.0",

--- a/python_modules/libraries/dagster-celery-docker/setup.py
+++ b/python_modules/libraries/dagster-celery-docker/setup.py
@@ -30,6 +30,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_celery_docker_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         f"dagster-celery{pin}",

--- a/python_modules/libraries/dagster-celery-k8s/setup.py
+++ b/python_modules/libraries/dagster-celery-k8s/setup.py
@@ -30,6 +30,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_celery_k8s_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         f"dagster-k8s{pin}",

--- a/python_modules/libraries/dagster-celery/setup.py
+++ b/python_modules/libraries/dagster-celery/setup.py
@@ -32,6 +32,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_celery_tests*"]),
     entry_points={"console_scripts": ["dagster-celery = dagster_celery.cli:main"]},
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         "celery>=4.3.0",

--- a/python_modules/libraries/dagster-census/setup.py
+++ b/python_modules/libraries/dagster-census/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_census_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-dask/setup.py
+++ b/python_modules/libraries/dagster-dask/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_dask_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         "bokeh",
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-databricks/setup.py
+++ b/python_modules/libraries/dagster-databricks/setup.py
@@ -32,6 +32,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_databricks_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         f"dagster-pipes{pin}",

--- a/python_modules/libraries/dagster-datadog/setup.py
+++ b/python_modules/libraries/dagster-datadog/setup.py
@@ -35,6 +35,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_datadog_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "datadog"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-datahub/setup.py
+++ b/python_modules/libraries/dagster-datahub/setup.py
@@ -36,6 +36,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_datahub_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         "acryl-datahub[datahub-rest, datahub-kafka]",
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -33,6 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_dbt_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         # Follow the version support constraints for dbt Core: https://docs.getdbt.com/docs/dbt-versions/core

--- a/python_modules/libraries/dagster-deltalake-pandas/setup.py
+++ b/python_modules/libraries/dagster-deltalake-pandas/setup.py
@@ -35,6 +35,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_deltalake_pandas_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         f"dagster-deltalake{pin}",

--- a/python_modules/libraries/dagster-deltalake-polars/setup.py
+++ b/python_modules/libraries/dagster-deltalake-polars/setup.py
@@ -35,6 +35,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_deltalake_polars_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         f"dagster-deltalake{pin}",

--- a/python_modules/libraries/dagster-deltalake/setup.py
+++ b/python_modules/libraries/dagster-deltalake/setup.py
@@ -33,6 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_deltalake_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         "deltalake>=0.15",
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-docker/setup.py
+++ b/python_modules/libraries/dagster-docker/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_docker_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "docker", "docker-image-py"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-duckdb-pandas/setup.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/setup.py
@@ -33,6 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_duckdb_pandas_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         f"dagster-duckdb{pin}",

--- a/python_modules/libraries/dagster-duckdb-polars/setup.py
+++ b/python_modules/libraries/dagster-duckdb-polars/setup.py
@@ -33,6 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_duckdb_polars_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         f"dagster-duckdb{pin}",

--- a/python_modules/libraries/dagster-duckdb-pyspark/setup.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/setup.py
@@ -32,6 +32,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_duckdb_pyspark_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         f"dagster-duckdb{pin}",

--- a/python_modules/libraries/dagster-duckdb/setup.py
+++ b/python_modules/libraries/dagster-duckdb/setup.py
@@ -32,6 +32,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_duckdb_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         "duckdb",
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-embedded-elt/setup.py
+++ b/python_modules/libraries/dagster-embedded-elt/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_embedded_elt_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "sling>=1.0.20"],
     zip_safe=False,
     extras_require={},

--- a/python_modules/libraries/dagster-fivetran/setup.py
+++ b/python_modules/libraries/dagster-fivetran/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_fivetran_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}"],
     zip_safe=False,
     entry_points={

--- a/python_modules/libraries/dagster-gcp-pandas/setup.py
+++ b/python_modules/libraries/dagster-gcp-pandas/setup.py
@@ -34,6 +34,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_gcp_pandas_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         f"dagster-gcp{pin}",

--- a/python_modules/libraries/dagster-gcp-pyspark/setup.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/setup.py
@@ -34,6 +34,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_gcp_pyspark_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         f"dagster-gcp{pin}",

--- a/python_modules/libraries/dagster-gcp/setup.py
+++ b/python_modules/libraries/dagster-gcp/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_gcp_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         f"dagster_pandas{pin}",

--- a/python_modules/libraries/dagster-ge/setup.py
+++ b/python_modules/libraries/dagster-ge/setup.py
@@ -30,6 +30,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_ge_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         f"dagster-pandas{pin}",

--- a/python_modules/libraries/dagster-github/setup.py
+++ b/python_modules/libraries/dagster-github/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_github_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         # Using a Github app requires signing your own JWT :(

--- a/python_modules/libraries/dagster-k8s/setup.py
+++ b/python_modules/libraries/dagster-k8s/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_k8s_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         "kubernetes",

--- a/python_modules/libraries/dagster-managed-elements/setup.py
+++ b/python_modules/libraries/dagster-managed-elements/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_managed_elements_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "requests", "click_spinner"],
     zip_safe=False,
     entry_points={

--- a/python_modules/libraries/dagster-mlflow/setup.py
+++ b/python_modules/libraries/dagster-mlflow/setup.py
@@ -31,6 +31,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_mlflow_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "mlflow", "pandas"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-msteams/setup.py
+++ b/python_modules/libraries/dagster-msteams/setup.py
@@ -34,6 +34,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_msteams_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         "requests>=2,<3",

--- a/python_modules/libraries/dagster-mysql/setup.py
+++ b/python_modules/libraries/dagster-mysql/setup.py
@@ -36,6 +36,7 @@ setup(
         ]
     },
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "mysql-connector-python"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-pagerduty/setup.py
+++ b/python_modules/libraries/dagster-pagerduty/setup.py
@@ -31,6 +31,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_pagerduty_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "pypd"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-pandas/setup.py
+++ b/python_modules/libraries/dagster-pandas/setup.py
@@ -46,5 +46,6 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_pandas_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "pandas"],
 )

--- a/python_modules/libraries/dagster-pandera/setup.py
+++ b/python_modules/libraries/dagster-pandera/setup.py
@@ -34,6 +34,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_pandera_tests*"]),
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "pandas", "pandera>=0.14.2"],
     extras_require={
         "test": [

--- a/python_modules/libraries/dagster-papertrail/setup.py
+++ b/python_modules/libraries/dagster-papertrail/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_papertrail_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-polars/setup.py
+++ b/python_modules/libraries/dagster-polars/setup.py
@@ -34,6 +34,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_polars_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         "polars>=0.20.0",

--- a/python_modules/libraries/dagster-postgres/setup.py
+++ b/python_modules/libraries/dagster-postgres/setup.py
@@ -39,6 +39,7 @@ setup(
         ]
     },
     include_package_data=True,
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "psycopg2-binary"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-prometheus/setup.py
+++ b/python_modules/libraries/dagster-prometheus/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_prometheus_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "prometheus_client"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-pyspark/setup.py
+++ b/python_modules/libraries/dagster-pyspark/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_pyspark_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         f"dagster_spark{pin}",

--- a/python_modules/libraries/dagster-shell/setup.py
+++ b/python_modules/libraries/dagster-shell/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_shell_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}"],
     extras_require={"test": ["psutil"]},
     zip_safe=False,

--- a/python_modules/libraries/dagster-slack/setup.py
+++ b/python_modules/libraries/dagster-slack/setup.py
@@ -32,6 +32,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_slack_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         "slack_sdk",

--- a/python_modules/libraries/dagster-snowflake-pandas/setup.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/setup.py
@@ -34,6 +34,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_snowflake_pandas_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         f"dagster-snowflake{pin}",

--- a/python_modules/libraries/dagster-snowflake-pyspark/setup.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_snowflake_pyspark_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         f"dagster-snowflake{pin}",

--- a/python_modules/libraries/dagster-snowflake/setup.py
+++ b/python_modules/libraries/dagster-snowflake/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_snowflake_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         "snowflake-connector-python>=2.1.0",

--- a/python_modules/libraries/dagster-spark/setup.py
+++ b/python_modules/libraries/dagster-spark/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_spark_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-ssh/setup.py
+++ b/python_modules/libraries/dagster-ssh/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_ssh_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "sshtunnel", "paramiko"],
     extras_require={"test": ["cryptography==2.6.1", "pytest-sftpserver==1.2.0"]},
     zip_safe=False,

--- a/python_modules/libraries/dagster-twilio/setup.py
+++ b/python_modules/libraries/dagster-twilio/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_twilio_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "twilio"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-wandb/setup.py
+++ b/python_modules/libraries/dagster-wandb/setup.py
@@ -32,6 +32,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_wandb_tests*"]),
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         "wandb>=0.13.5,<0.15.5",

--- a/python_modules/libraries/dagstermill/setup.py
+++ b/python_modules/libraries/dagstermill/setup.py
@@ -31,6 +31,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
+    python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
         # ipykernel 5.4.0 and 5.4.1 broke papermill


### PR DESCRIPTION
## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/17933.

## How I Tested These Changes
- Create a virtualenv of Python 3.12, see installation fail.
- Create a virtualenv of Python 3.7, see installation fail.
- Create a virtualenv of Python 3.8, see installation succeed.
- See Buildkite still succeed.
