### PR TITLE
[external-assets] External asset renames

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -15,8 +15,8 @@ from dagster._core.definitions.resolved_asset_deps import resolve_similar_asset_
 from dagster._core.errors import DagsterInvalidSubsetError
 from dagster._core.selector.subset_selector import (
     fetch_connected,
+    fetch_roots,
     fetch_sinks,
-    fetch_sources,
     parse_clause,
 )
 from dagster._core.storage.tags import TAG_NO_VALUE
@@ -748,7 +748,7 @@ class RootsAssetSelection(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         selection = self.child.resolve_inner(asset_graph, allow_missing=allow_missing)
-        return fetch_sources(asset_graph.asset_dep_graph, selection)
+        return fetch_roots(asset_graph.asset_dep_graph, selection)
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return self.replace(child=self.child.to_serializable_asset_selection(asset_graph))

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -243,10 +243,10 @@ def fetch_sinks(
     return sinks
 
 
-def fetch_sources(
+def fetch_roots(
     graph: DependencyGraph[T_Hashable], within_selection: AbstractSet[T_Hashable]
 ) -> AbstractSet[T_Hashable]:
-    """A source is a node that has no upstream dependencies within the provided selection.
+    """A root is a node that has no upstream dependencies within the provided selection.
     It can have other dependencies outside of the selection.
     """
     dp: Dict[T_Hashable, bool] = {}


### PR DESCRIPTION
## Summary & Motivation

Renames of internal methods using "source" or "non_source" to their respective "external" and "materializable" equivalents. In some cases "source" was also renamed to "root", when "source" was used not to mean `SourceAsset` but rather "root of an asset selection" (we already use "root" terminology in `AssetSelection`).

## How I Tested These Changes

Existing test suite.