### PR TITLE
add names to the queries used by the Dagster Python GraphQL Client

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
@@ -1,5 +1,5 @@
 CLIENT_SUBMIT_PIPELINE_RUN_MUTATION = """
-mutation($executionParams: ExecutionParams!) {
+mutation GraphQLClientSubmitRun($executionParams: ExecutionParams!) {
   launchPipelineExecution(executionParams: $executionParams) {
     __typename
 
@@ -46,7 +46,7 @@ mutation($executionParams: ExecutionParams!) {
 """
 
 CLIENT_GET_REPO_LOCATIONS_NAMES_AND_PIPELINES_QUERY = """
-query {
+query GraphQLClientGetJobNames {
   repositoriesOrError {
     __typename
     ... on RepositoryConnection {
@@ -68,7 +68,7 @@ query {
 """
 
 RELOAD_REPOSITORY_LOCATION_MUTATION = """
-mutation ($repositoryLocationName: String!) {
+mutation GraphQLClientReloadCodeLocation($repositoryLocationName: String!) {
    reloadRepositoryLocation(repositoryLocationName: $repositoryLocationName) {
       __typename
       ... on WorkspaceLocationEntry {
@@ -97,7 +97,7 @@ mutation ($repositoryLocationName: String!) {
 """
 
 GET_PIPELINE_RUN_STATUS_QUERY = """
-query($runId: ID!) {
+query GraphQLClientGetRunStatus($runId: ID!) {
   pipelineRunOrError(runId: $runId) {
     __typename
     ... on PipelineRun {
@@ -114,7 +114,7 @@ query($runId: ID!) {
 """
 
 SHUTDOWN_REPOSITORY_LOCATION_MUTATION = """
-mutation ($repositoryLocationName: String!) {
+mutation GraphQLClientShutdownCodeLocation($repositoryLocationName: String!) {
    shutdownRepositoryLocation(repositoryLocationName: $repositoryLocationName) {
       __typename
       ... on PythonError {
@@ -128,7 +128,7 @@ mutation ($repositoryLocationName: String!) {
 """
 
 TERMINATE_RUN_JOB_MUTATION = """
-mutation TerminateRun($runId: String!) {
+mutation GraphQLClientTerminateRun($runId: String!) {
   terminateRun(runId: $runId){
     __typename
     ... on TerminateRunSuccess{

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/CLIENT_GET_REPO_LOCATIONS_NAMES_AND_PIPELINES_QUERY/1!0+dev-2024_02_12.graphql
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/CLIENT_GET_REPO_LOCATIONS_NAMES_AND_PIPELINES_QUERY/1!0+dev-2024_02_12.graphql
@@ -1,0 +1,19 @@
+query GraphQLClientGetJobNames {
+  repositoriesOrError {
+    __typename
+    ... on RepositoryConnection {
+      nodes {
+        name
+        location {
+          name
+        }
+        pipelines {
+          name
+        }
+      }
+    }
+    ... on PythonError {
+      message
+    }
+  }
+}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/CLIENT_SUBMIT_PIPELINE_RUN_MUTATION/1!0+dev-2024_02_12.graphql
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/CLIENT_SUBMIT_PIPELINE_RUN_MUTATION/1!0+dev-2024_02_12.graphql
@@ -1,0 +1,43 @@
+mutation GraphQLClientSubmitRun($executionParams: ExecutionParams!) {
+  launchPipelineExecution(executionParams: $executionParams) {
+    __typename
+    ... on InvalidStepError {
+      invalidStepKey
+    }
+    ... on InvalidOutputError {
+      stepKey
+      invalidOutputName
+    }
+    ... on LaunchPipelineRunSuccess {
+      run {
+        runId
+      }
+    }
+    ... on ConflictingExecutionParamsError {
+      message
+    }
+    ... on PresetNotFoundError {
+      message
+    }
+    ... on PipelineRunConflict {
+      message
+    }
+    ... on PipelineConfigValidationInvalid {
+      errors {
+        __typename
+        message
+        path
+        reason
+      }
+    }
+    ... on PipelineNotFoundError {
+      message
+    }
+    ... on PythonError {
+      message
+    }
+    ... on UnauthorizedError {
+      message
+    }
+  }
+}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/GET_PIPELINE_RUN_STATUS_QUERY/1!0+dev-2024_02_12.graphql
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/GET_PIPELINE_RUN_STATUS_QUERY/1!0+dev-2024_02_12.graphql
@@ -1,0 +1,14 @@
+query GraphQLClientGetRunStatus($runId: ID!) {
+  pipelineRunOrError(runId: $runId) {
+    __typename
+    ... on PipelineRun {
+        status
+    }
+    ... on PipelineRunNotFoundError {
+      message
+    }
+    ... on PythonError {
+      message
+    }
+  }
+}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/RELOAD_REPOSITORY_LOCATION_MUTATION/1!0+dev-2024_02_12.graphql
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/RELOAD_REPOSITORY_LOCATION_MUTATION/1!0+dev-2024_02_12.graphql
@@ -1,0 +1,26 @@
+mutation GraphQLClientReloadCodeLocation($repositoryLocationName: String!) {
+   reloadRepositoryLocation(repositoryLocationName: $repositoryLocationName) {
+      __typename
+      ... on WorkspaceLocationEntry {
+        name
+        locationOrLoadError {
+          __typename
+          ... on RepositoryLocation {
+            isReloadSupported
+            repositories {
+                name
+            }
+          }
+          ... on PythonError {
+            message
+          }
+        }
+      }
+      ... on ReloadNotSupported {
+        message
+      }
+      ... on RepositoryLocationNotFound {
+        message
+      }
+   }
+}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/SHUTDOWN_REPOSITORY_LOCATION_MUTATION/1!0+dev-2024_02_12.graphql
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/SHUTDOWN_REPOSITORY_LOCATION_MUTATION/1!0+dev-2024_02_12.graphql
@@ -1,0 +1,11 @@
+mutation GraphQLClientShutdownCodeLocation($repositoryLocationName: String!) {
+   shutdownRepositoryLocation(repositoryLocationName: $repositoryLocationName) {
+      __typename
+      ... on PythonError {
+        message
+      }
+      ... on RepositoryLocationNotFound {
+        message
+      }
+   }
+}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/TERMINATE_RUN_JOB_MUTATION/1!0+dev-2024_02_12.graphql
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/TERMINATE_RUN_JOB_MUTATION/1!0+dev-2024_02_12.graphql
@@ -1,0 +1,20 @@
+mutation GraphQLClientTerminateRun($runId: String!) {
+  terminateRun(runId: $runId){
+    __typename
+    ... on TerminateRunSuccess{
+      run {
+        runId
+      }
+    }
+    ... on TerminateRunFailure {
+      message
+    }
+    ... on RunNotFoundError {
+      runId
+    }
+    ... on PythonError {
+      message
+      stack
+    }
+  }
+}


### PR DESCRIPTION
Summary:
This makes it easy to attribute queries in logs to specific callsites from the python graphql client.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
