### PR TITLE
[AssetCondition] Add asset_condition to AutoMaterializePolicy

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -49,7 +49,7 @@ from .asset_condition_evaluation_context import AssetConditionEvaluationContext
 from .asset_graph import sort_key_for_asset_partition
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.asset_condition import AssetConditionResult
+    from dagster._core.definitions.asset_condition import AssetCondition, AssetConditionResult
 
 
 class AutoMaterializeRule(ABC):
@@ -75,6 +75,12 @@ class AutoMaterializeRule(ABC):
         complete the sentence: 'Indicates an asset should be (materialize/skipped) when ____'.
         """
         ...
+
+    def to_asset_condition(self) -> "AssetCondition":
+        """Converts this AutoMaterializeRule into an AssetCondition."""
+        from .asset_condition import RuleCondition
+
+        return RuleCondition(rule=self)
 
     @abstractmethod
     def evaluate_for_asset(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
@@ -4,6 +4,7 @@ from .asset_daemon_scenario import AssetDaemonScenario
 from .updated_scenarios.basic_scenarios import basic_scenarios
 from .updated_scenarios.cron_scenarios import cron_scenarios
 from .updated_scenarios.cursor_migration_scenarios import cursor_migration_scenarios
+from .updated_scenarios.custom_condition_scenarios import custom_condition_scenarios
 from .updated_scenarios.freshness_policy_scenarios import freshness_policy_scenarios
 from .updated_scenarios.latest_materialization_run_tag_scenarios import (
     latest_materialization_run_tag_scenarios,
@@ -17,6 +18,7 @@ all_scenarios = (
     + partition_scenarios
     + latest_materialization_run_tag_scenarios
     + cursor_migration_scenarios
+    + custom_condition_scenarios
 )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
@@ -1,0 +1,31 @@
+from dagster import AutoMaterializeRule
+from dagster._core.definitions.asset_condition import RuleCondition
+from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+
+from ..asset_daemon_scenario import (
+    AssetDaemonScenario,
+)
+from ..base_scenario import run_request
+from .asset_daemon_scenario_states import (
+    one_asset,
+)
+
+custom_condition_scenarios = [
+    AssetDaemonScenario(
+        id="funky_custom_condition_scenario",
+        initial_state=one_asset.with_asset_properties(
+            auto_materialize_policy=AutoMaterializePolicy.from_asset_condition(
+                # intentionally funky condition
+                # not ((not missing) | (parent_updated)) ->
+                # it starts missing, and with no parents updated, so this evaluates to true
+                ~(
+                    ~RuleCondition(AutoMaterializeRule.materialize_on_missing())
+                    & RuleCondition(AutoMaterializeRule.materialize_on_parent_updated())
+                )
+            )
+        ),
+        execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
+            run_request(asset_keys=["A"])
+        ),
+    ),
+]


### PR DESCRIPTION
## Summary & Motivation

This allows users to experiment with AssetCondition objects in shapes that are currently not possible with the AutoMaterializeRule system.

In the future, there will be a dedicated argument on the `@asset` decorator and others, but for now this provides a simple entry point.

## How I Tested These Changes
