### PR TITLE
dagster dev env var

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/repo.py
+++ b/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/repo.py
@@ -1,3 +1,5 @@
+import os
+
 from bar import foo_op  # requires working_directory
 from dagster import DefaultSensorStatus, RunRequest, job, repository, sensor
 
@@ -25,3 +27,7 @@ def example_repo():
 @repository
 def other_example_repo():
     return [other_foo_job]
+
+
+if os.getenv("CHECK_DAGSTER_DEV") and not os.getenv("DAGSTER_IS_DEV_CLI"):
+    raise Exception("DAGSTER_DEV env var not set")

--- a/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
+++ b/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
@@ -62,7 +62,12 @@ def test_dagster_dev_command_workspace():
 # and waits for a schedule run to launch
 def test_dagster_dev_command_no_dagster_home():
     with tempfile.TemporaryDirectory() as tempdir:
-        with environ({"DAGSTER_HOME": ""}):
+        with environ(
+            {
+                "DAGSTER_HOME": "",  # unset dagster home
+                "CHECK_DAGSTER_DEV": "1",  # trigger target user code to check for DAGSTER_DEV env var
+            }
+        ):
             with new_cwd(tempdir):
                 dagster_yaml = {
                     "run_coordinator": {
@@ -172,7 +177,6 @@ def test_dagster_dev_command_grpc_port():
 
             client = DagsterGrpcClient(port=grpc_port, host="localhost")
             wait_for_grpc_server(grpc_process, client, subprocess_args)
-
             dev_process = subprocess.Popen(
                 [
                     "dagster",

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -118,6 +118,8 @@ def dev_command(
             ' running "pip install dagster-webserver" in your Python environment.'
         )
 
+    os.environ["DAGSTER_IS_DEV_CLI"] = "1"
+
     configure_loggers(formatter=log_format, log_level=log_level.upper())
     logger = logging.getLogger("dagster")
 


### PR DESCRIPTION
Set an env var in `dagster dev` which can be used to control behavior which should only run during local development. Similar to how one might use `DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT` / `DAGSTER_CLOUD_DEPLOYMENT_NAME`.


## How I Tested These Changes

updated e2e test to include a check 