### PR TITLE
[refactor][AssetCondition] Begin moving AutoMaterializeRule implementations into AssetCondition

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
@@ -3,7 +3,7 @@ import itertools
 from typing import Optional, Sequence, Union
 
 import graphene
-from dagster._core.definitions.asset_condition import AssetConditionEvaluation
+from dagster._core.definitions.asset_condition.asset_condition import AssetConditionEvaluation
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.time_window_partitions import BaseTimeWindowPartitionsSubset

--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -2,7 +2,7 @@ from typing import Optional, Sequence, Tuple
 
 import graphene
 from dagster import PartitionsDefinition
-from dagster._core.definitions.asset_condition import (
+from dagster._core.definitions.asset_condition.asset_condition import (
     AssetConditionEvaluation,
     AssetSubsetWithMetadata,
     RuleCondition,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -5,7 +5,7 @@ from unittest.mock import PropertyMock, patch
 import dagster._check as check
 import pendulum
 from dagster import AssetKey, RunRequest
-from dagster._core.definitions.asset_condition import (
+from dagster._core.definitions.asset_condition.asset_condition import (
     AssetConditionEvaluation,
     AssetConditionEvaluationWithRunIds,
     AssetConditionSnapshot,
@@ -17,13 +17,9 @@ from dagster._core.definitions.auto_materialize_rule_evaluation import (
     deserialize_auto_materialize_asset_evaluation_to_asset_condition_evaluation_with_run_ids,
 )
 from dagster._core.definitions.partition import PartitionsDefinition, StaticPartitionsDefinition
-from dagster._core.definitions.run_request import (
-    InstigatorType,
-)
+from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.sensor_definition import SensorType
-from dagster._core.host_representation.origin import (
-    ExternalInstigatorOrigin,
-)
+from dagster._core.host_representation.origin import ExternalInstigatorOrigin
 from dagster._core.scheduler.instigation import (
     InstigatorState,
     InstigatorStatus,

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
@@ -23,16 +23,13 @@ import dagster._check as check
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataMapping, MetadataValue
 from dagster._core.definitions.partition import AllPartitionsSubset
-from dagster._serdes.serdes import (
-    PackableValue,
-    whitelist_for_serdes,
-)
+from dagster._serdes.serdes import PackableValue, whitelist_for_serdes
 
-from .asset_subset import AssetSubset, ValidAssetSubset
+from ..asset_subset import AssetSubset, ValidAssetSubset
 
 if TYPE_CHECKING:
+    from ..auto_materialize_rule import AutoMaterializeRule
     from .asset_condition_evaluation_context import AssetConditionEvaluationContext
-    from .auto_materialize_rule import AutoMaterializeRule
 
 
 T = TypeVar("T")

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition_evaluation_context.py
@@ -18,7 +18,9 @@ from typing import (
 
 import pendulum
 
-from dagster._core.definitions.asset_condition import HistoricalAllPartitionsSubsetSentinel
+from dagster._core.definitions.asset_condition.asset_condition import (
+    HistoricalAllPartitionsSubsetSentinel,
+)
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.metadata import MetadataValue
@@ -27,17 +29,17 @@ from dagster._core.definitions.partition_mapping import IdentityPartitionMapping
 from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
-from .asset_graph import AssetGraph
-from .asset_subset import AssetSubset, ValidAssetSubset
+from ..asset_graph import AssetGraph
+from ..asset_subset import AssetSubset, ValidAssetSubset
 
 if TYPE_CHECKING:
+    from ..asset_daemon_context import AssetDaemonContext
     from .asset_condition import (
         AssetCondition,
         AssetConditionEvaluation,
         AssetConditionEvaluationState,
         AssetSubsetWithMetadata,
     )
-    from .asset_daemon_context import AssetDaemonContext
 
 T = TypeVar("T")
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/backfill_in_progress_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/backfill_in_progress_condition.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+
+from dagster._core.definitions.asset_condition.asset_condition import AssetConditionResult
+from dagster._core.definitions.asset_condition.asset_condition_evaluation_context import (
+    AssetConditionEvaluationContext,
+)
+from dagster._serdes.serdes import whitelist_for_serdes
+
+from .asset_condition import AssetCondition
+
+
+@whitelist_for_serdes
+@dataclass(frozen=True)
+class BackfillInProgressCondition(AssetCondition):
+    """Determines if an asset partition is part of an in-progress backfill.
+
+    Args:
+        any_partition (bool): If True, the condition will be true for all partitions of the asset
+            if any partition of the asset is part of an in-progress backfill. If False, the
+            condition will only be true for the partitions of the asset that are currently being
+            backfilled. Defaults to False.
+    """
+
+    any_partition: bool = False
+
+    @property
+    def description(self) -> str:
+        if self.any_partition:
+            return "part of an asset targeted by an in-progress backfill"
+        else:
+            return "targeted by an in-progress backfill"
+
+    def evaluate(self, context: AssetConditionEvaluationContext) -> AssetConditionResult:
+        backfilling_subset = (
+            # this backfilling subset is aware of the current partitions definitions, and so will
+            # be valid
+            (context.instance_queryer.get_active_backfill_target_asset_graph_subset())
+            .get_asset_subset(context.asset_key, context.asset_graph)
+            .as_valid(context.partitions_def)
+        )
+
+        if backfilling_subset.size == 0:
+            true_subset = context.empty_subset()
+        elif self.any_partition:
+            true_subset = context.candidate_subset
+        else:
+            true_subset = context.candidate_subset & backfilling_subset
+
+        return AssetConditionResult.create(context, true_subset)

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/required_nonexistent_parents_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/required_nonexistent_parents_condition.py
@@ -1,0 +1,52 @@
+from collections import defaultdict
+from dataclasses import dataclass
+
+from dagster._core.definitions.asset_condition.asset_condition import AssetConditionResult
+from dagster._core.definitions.asset_condition.asset_condition_evaluation_context import (
+    AssetConditionEvaluationContext,
+)
+from dagster._serdes.serdes import whitelist_for_serdes
+
+from .asset_condition import AssetCondition
+
+
+@whitelist_for_serdes
+@dataclass(frozen=True)
+class RequiresNonexistentParentsCondition(AssetCondition):
+    """Determines if an asset partition is downstream of one or more partitions which are required
+    but do not yet exist.
+    """
+
+    @property
+    def description(self) -> str:
+        return "required parent partitions do not exist"
+
+    def evaluate(self, context: AssetConditionEvaluationContext) -> AssetConditionResult:
+        asset_partitions_by_evaluation_data = defaultdict(set)
+
+        subset_to_evaluate = (
+            context.candidates_not_evaluated_on_previous_tick_subset
+            | context.candidate_parent_has_or_will_update_subset
+        )
+        for candidate in subset_to_evaluate.asset_partitions:
+            nonexistent_parent_partitions = context.asset_graph.get_parents_partitions(
+                context.instance_queryer,
+                context.instance_queryer.evaluation_time,
+                candidate.asset_key,
+                candidate.partition_key,
+            ).required_but_nonexistent_parents_partitions
+
+            parents_with_nonexistent_partitions = sorted(
+                {parent.asset_key for parent in nonexistent_parent_partitions}
+            )
+            if parents_with_nonexistent_partitions:
+                metadata = frozenset(
+                    (f"parent_{i+1}", parent)
+                    for i, parent in enumerate(parents_with_nonexistent_partitions)
+                )
+                asset_partitions_by_evaluation_data[metadata].add(candidate)
+
+        true_subset, subsets_with_metadata = context.add_evaluation_data_from_previous_tick(
+            asset_partitions_by_evaluation_data, ignore_subset=subset_to_evaluate
+        )
+        return AssetConditionResult.create(context, true_subset, subsets_with_metadata)

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -34,8 +34,8 @@ from dagster._core.instance import DynamicPartitionsStore
 
 from ... import PartitionKeyRange
 from ..storage.tags import ASSET_PARTITION_RANGE_END_TAG, ASSET_PARTITION_RANGE_START_TAG
-from .asset_condition import AssetConditionEvaluation, AssetConditionEvaluationState
-from .asset_condition_evaluation_context import (
+from .asset_condition.asset_condition import AssetConditionEvaluation, AssetConditionEvaluationState
+from .asset_condition.asset_condition_evaluation_context import (
     AssetConditionEvaluationContext,
 )
 from .asset_daemon_cursor import AssetDaemonCursor

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -28,7 +28,7 @@ from dagster._serdes.serdes import (
 from .asset_graph import AssetGraph
 
 if TYPE_CHECKING:
-    from .asset_condition import (
+    from .asset_condition.asset_condition import (
         AssetConditionEvaluation,
         AssetConditionEvaluationState,
         AssetConditionSnapshot,
@@ -148,7 +148,7 @@ def get_backcompat_asset_condition_evaluation_state(
     handled_root_subset: Optional[AssetSubset],
 ) -> "AssetConditionEvaluationState":
     """Generates an AssetDaemonCursor from information available on the old cursor format."""
-    from dagster._core.definitions.asset_condition import (
+    from dagster._core.definitions.asset_condition.asset_condition import (
         AssetConditionEvaluationState,
         RuleCondition,
     )
@@ -173,7 +173,7 @@ def backcompat_deserialize_asset_daemon_cursor_str(
     """This serves as a backcompat layer for deserializing the old cursor format. Some information
     is impossible to fully recover, this will recover enough to continue operating as normal.
     """
-    from .asset_condition import AssetConditionEvaluation, AssetConditionSnapshot
+    from .asset_condition.asset_condition import AssetConditionEvaluation, AssetConditionSnapshot
     from .auto_materialize_rule_evaluation import (
         deserialize_auto_materialize_asset_evaluation_to_asset_condition_evaluation_with_run_ids,
     )

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -11,7 +11,7 @@ from dagster._serdes.serdes import (
 )
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.asset_condition import AssetCondition
+    from dagster._core.definitions.asset_condition.asset_condition import AssetCondition
     from dagster._core.definitions.auto_materialize_rule import (
         AutoMaterializeRule,
         AutoMaterializeRuleSnapshot,
@@ -281,7 +281,11 @@ class AutoMaterializePolicy(
 
     def to_asset_condition(self) -> "AssetCondition":
         """Converts a set of materialize / skip rules into a single binary expression."""
-        from .asset_condition import AndAssetCondition, NotAssetCondition, OrAssetCondition
+        from .asset_condition.asset_condition import (
+            AndAssetCondition,
+            NotAssetCondition,
+            OrAssetCondition,
+        )
         from .auto_materialize_rule import DiscardOnMaxMaterializationsExceededRule
 
         if self.asset_condition is not None:

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -45,11 +45,14 @@ from dagster._utils.schedules import (
     reverse_cron_string_iterator,
 )
 
-from .asset_condition_evaluation_context import AssetConditionEvaluationContext
+from .asset_condition.asset_condition_evaluation_context import AssetConditionEvaluationContext
 from .asset_graph import sort_key_for_asset_partition
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.asset_condition import AssetCondition, AssetConditionResult
+    from dagster._core.definitions.asset_condition.asset_condition import (
+        AssetCondition,
+        AssetConditionResult,
+    )
 
 
 class AutoMaterializeRule(ABC):
@@ -78,7 +81,7 @@ class AutoMaterializeRule(ABC):
 
     def to_asset_condition(self) -> "AssetCondition":
         """Converts this AutoMaterializeRule into an AssetCondition."""
-        from .asset_condition import RuleCondition
+        from .asset_condition.asset_condition import RuleCondition
 
         return RuleCondition(rule=self)
 
@@ -263,7 +266,7 @@ class MaterializeOnRequiredForFreshnessRule(
     def evaluate_for_asset(
         self, context: AssetConditionEvaluationContext
     ) -> "AssetConditionResult":
-        from .asset_condition import AssetConditionResult
+        from .asset_condition.asset_condition import AssetConditionResult
 
         true_subset, subsets_with_metadata = freshness_evaluation_results_for_asset_key(
             context.root_context
@@ -377,7 +380,7 @@ class MaterializeOnCronRule(
     def evaluate_for_asset(
         self, context: AssetConditionEvaluationContext
     ) -> "AssetConditionResult":
-        from .asset_condition import AssetConditionResult
+        from .asset_condition.asset_condition import AssetConditionResult
 
         new_asset_partitions_to_request = self.get_new_asset_partitions_to_request(context)
         asset_subset_to_request = AssetSubset.from_asset_partitions_set(
@@ -498,7 +501,7 @@ class MaterializeOnParentUpdatedRule(
         """Evaluates the set of asset partitions of this asset whose parents have been updated,
         or will update on this tick.
         """
-        from .asset_condition import AssetConditionResult
+        from .asset_condition.asset_condition import AssetConditionResult
 
         asset_partitions_by_updated_parents: Mapping[
             AssetKeyPartitionKey, Set[AssetKeyPartitionKey]
@@ -619,7 +622,7 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
         """Evaluates the set of asset partitions for this asset which are missing and were not
         previously discarded.
         """
-        from .asset_condition import AssetConditionResult
+        from .asset_condition.asset_condition import AssetConditionResult
 
         if context.asset_key in context.asset_graph.root_materializable_or_observable_asset_keys:
             handled_subset = self.get_handled_subset(context)
@@ -672,7 +675,7 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
     def evaluate_for_asset(
         self, context: AssetConditionEvaluationContext
     ) -> "AssetConditionResult":
-        from .asset_condition import AssetConditionResult
+        from .asset_condition.asset_condition import AssetConditionResult
 
         asset_partitions_by_evaluation_data = defaultdict(set)
 
@@ -719,7 +722,7 @@ class SkipOnParentMissingRule(AutoMaterializeRule, NamedTuple("_SkipOnParentMiss
         self,
         context: AssetConditionEvaluationContext,
     ) -> "AssetConditionResult":
-        from .asset_condition import AssetConditionResult
+        from .asset_condition.asset_condition import AssetConditionResult
 
         asset_partitions_by_evaluation_data = defaultdict(set)
 
@@ -789,7 +792,7 @@ class SkipOnNotAllParentsUpdatedRule(
         self,
         context: AssetConditionEvaluationContext,
     ) -> "AssetConditionResult":
-        from .asset_condition import AssetConditionResult
+        from .asset_condition.asset_condition import AssetConditionResult
 
         asset_partitions_by_evaluation_data = defaultdict(set)
 
@@ -990,7 +993,7 @@ class SkipOnNotAllParentsUpdatedSinceCronRule(
     def evaluate_for_asset(
         self, context: AssetConditionEvaluationContext
     ) -> "AssetConditionResult":
-        from .asset_condition import AssetConditionResult
+        from .asset_condition.asset_condition import AssetConditionResult
 
         passed_time_window = self.passed_time_window(context)
         has_new_passed_time_window = passed_time_window.end.timestamp() > (
@@ -1060,7 +1063,7 @@ class SkipOnRequiredButNonexistentParentsRule(
     def evaluate_for_asset(
         self, context: AssetConditionEvaluationContext
     ) -> "AssetConditionResult":
-        from .asset_condition import AssetConditionResult
+        from .asset_condition.asset_condition import AssetConditionResult
 
         asset_partitions_by_evaluation_data = defaultdict(set)
 
@@ -1109,7 +1112,7 @@ class SkipOnBackfillInProgressRule(
     def evaluate_for_asset(
         self, context: AssetConditionEvaluationContext
     ) -> "AssetConditionResult":
-        from .asset_condition import AssetConditionResult
+        from .asset_condition.asset_condition import AssetConditionResult
 
         backfilling_subset = (
             # this backfilling subset is aware of the current partitions definitions, and so will
@@ -1144,7 +1147,7 @@ class DiscardOnMaxMaterializationsExceededRule(
     def evaluate_for_asset(
         self, context: AssetConditionEvaluationContext
     ) -> "AssetConditionResult":
-        from .asset_condition import AssetConditionResult
+        from .asset_condition.asset_condition import AssetConditionResult
 
         # the set of asset partitions which exceed the limit
         rate_limited_asset_partitions = set(

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -49,7 +49,7 @@ from .asset_condition_evaluation_context import AssetConditionEvaluationContext
 from .asset_graph import sort_key_for_asset_partition
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.asset_condition import AssetConditionResult
+    from dagster._core.definitions.asset_condition import AssetCondition, AssetConditionResult
 
 
 class AutoMaterializeRule(ABC):
@@ -75,6 +75,12 @@ class AutoMaterializeRule(ABC):
         complete the sentence: 'Indicates an asset should be (materialize/skipped) when ____'.
         """
         ...
+
+    def to_asset_condition(self) -> "AssetCondition":
+        """Converts this AutoMaterializeRule into an AssetCondition."""
+        from .asset_condition import RuleCondition
+
+        return RuleCondition(rule=self)
 
     @abstractmethod
     def evaluate_for_asset(

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
@@ -33,12 +33,11 @@ from dagster._serdes.serdes import (
 from .partition import PartitionsDefinition, SerializedPartitionsSubset
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.asset_condition import AssetSubsetWithMetadata
-
-    from .asset_condition import (
+    from .asset_condition.asset_condition import (
         AssetConditionEvaluation,
         AssetConditionEvaluationWithRunIds,
         AssetConditionSnapshot,
+        AssetSubsetWithMetadata,
     )
 
 
@@ -148,7 +147,7 @@ def deserialize_auto_materialize_asset_evaluation_to_asset_condition_evaluation_
     """Provides a backcompat layer to allow deserializing old AutoMaterializeAssetEvaluation
     objects into the new AssetConditionEvaluationWithRunIds objects.
     """
-    from .asset_condition import AssetConditionEvaluationWithRunIds
+    from .asset_condition.asset_condition import AssetConditionEvaluationWithRunIds
 
     class BackcompatDeserializer(BackcompatAutoMaterializeAssetEvaluationSerializer):
         @property
@@ -213,7 +212,7 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
     def _asset_condition_snapshot_from_rule_snapshot(
         self, rule_snapshot: AutoMaterializeRuleSnapshot
     ) -> "AssetConditionSnapshot":
-        from .asset_condition import AssetConditionSnapshot, RuleCondition
+        from .asset_condition.asset_condition import AssetConditionSnapshot, RuleCondition
 
         unique_id_parts = [rule_snapshot.class_name, rule_snapshot.description]
         unique_id = hashlib.md5("".join(unique_id_parts).encode()).hexdigest()
@@ -233,7 +232,7 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
         is_partitioned: bool,
         rule_snapshot: AutoMaterializeRuleSnapshot,
     ) -> "AssetConditionEvaluation":
-        from .asset_condition import (
+        from .asset_condition.asset_condition import (
             AssetConditionEvaluation,
             AssetSubsetWithMetadata,
             HistoricalAllPartitionsSubsetSentinel,
@@ -278,7 +277,7 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
         is_partitioned: bool,
         decision_type: AutoMaterializeDecisionType,
     ) -> Optional["AssetConditionEvaluation"]:
-        from .asset_condition import (
+        from .asset_condition.asset_condition import (
             AssetConditionEvaluation,
             AssetConditionSnapshot,
             HistoricalAllPartitionsSubsetSentinel,
@@ -371,7 +370,7 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
         whitelist_map: WhitelistMap,
         context: UnpackContext,
     ) -> "AssetConditionEvaluationWithRunIds":
-        from .asset_condition import (
+        from .asset_condition.asset_condition import (
             AndAssetCondition,
             AssetConditionEvaluation,
             AssetConditionSnapshot,

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -19,8 +19,8 @@ from dagster._seven.compat.pendulum import (
 from dagster._utils.schedules import cron_string_iterator
 
 if TYPE_CHECKING:
-    from .asset_condition import AssetSubsetWithMetadata
-    from .asset_condition_evaluation_context import AssetConditionEvaluationContext
+    from .asset_condition.asset_condition import AssetSubsetWithMetadata
+    from .asset_condition.asset_condition_evaluation_context import AssetConditionEvaluationContext
     from .auto_materialize_rule_evaluation import TextRuleEvaluationData
 
 
@@ -162,7 +162,7 @@ def freshness_evaluation_results_for_asset_key(
 
     Attempts to minimize the total number of asset executions.
     """
-    from .asset_condition import AssetSubsetWithMetadata
+    from .asset_condition.asset_condition import AssetSubsetWithMetadata
 
     asset_key = context.asset_key
     current_time = context.evaluation_time

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -6,7 +6,7 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._core.definitions import RunRequest
-from dagster._core.definitions.asset_condition import (
+from dagster._core.definitions.asset_condition.asset_condition import (
     AssetConditionEvaluationWithRunIds,
 )
 from dagster._core.definitions.auto_materialize_rule_evaluation import (

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -13,7 +13,9 @@ from dagster import (
     _check as check,
 )
 from dagster._config.config_schema import UserConfigSchema
-from dagster._core.definitions.asset_condition import AssetConditionEvaluationWithRunIds
+from dagster._core.definitions.asset_condition.asset_condition import (
+    AssetConditionEvaluationWithRunIds,
+)
 from dagster._core.definitions.events import AssetKey
 from dagster._core.event_api import EventHandlerFn
 from dagster._core.storage.asset_check_execution_record import (

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -2,7 +2,7 @@ import abc
 from typing import Mapping, Optional, Sequence, Set
 
 from dagster import AssetKey
-from dagster._core.definitions.asset_condition import (
+from dagster._core.definitions.asset_condition.asset_condition import (
     AssetConditionEvaluationWithRunIds,
 )
 from dagster._core.definitions.run_request import InstigatorType

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -20,7 +20,9 @@ import sqlalchemy.exc as db_exc
 from sqlalchemy.engine import Connection
 
 import dagster._check as check
-from dagster._core.definitions.asset_condition import AssetConditionEvaluationWithRunIds
+from dagster._core.definitions.asset_condition.asset_condition import (
+    AssetConditionEvaluationWithRunIds,
+)
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.errors import DagsterInvariantViolationError

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -5,7 +5,7 @@ import pendulum
 import pytest
 
 from dagster import StaticPartitionsDefinition
-from dagster._core.definitions.asset_condition import (
+from dagster._core.definitions.asset_condition.asset_condition import (
     AssetConditionEvaluation,
     AssetConditionSnapshot,
     AssetSubsetWithMetadata,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -39,7 +39,7 @@ from dagster import (
     asset,
     materialize,
 )
-from dagster._core.definitions.asset_condition import (
+from dagster._core.definitions.asset_condition.asset_condition import (
     AssetConditionEvaluation,
     AssetSubsetWithMetadata,
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_materialize_asset_evaluation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_materialize_asset_evaluation.py
@@ -1,7 +1,5 @@
 from dagster import DailyPartitionsDefinition, MetadataValue
-from dagster._core.definitions.asset_condition import (
-    AssetSubsetWithMetadata,
-)
+from dagster._core.definitions.asset_condition.asset_condition import AssetSubsetWithMetadata
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
     deserialize_auto_materialize_asset_evaluation_to_asset_condition_evaluation_with_run_ids,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
@@ -4,6 +4,7 @@ from .asset_daemon_scenario import AssetDaemonScenario
 from .updated_scenarios.basic_scenarios import basic_scenarios
 from .updated_scenarios.cron_scenarios import cron_scenarios
 from .updated_scenarios.cursor_migration_scenarios import cursor_migration_scenarios
+from .updated_scenarios.custom_condition_scenarios import custom_condition_scenarios
 from .updated_scenarios.freshness_policy_scenarios import freshness_policy_scenarios
 from .updated_scenarios.latest_materialization_run_tag_scenarios import (
     latest_materialization_run_tag_scenarios,
@@ -17,6 +18,7 @@ all_scenarios = (
     + partition_scenarios
     + latest_materialization_run_tag_scenarios
     + cursor_migration_scenarios
+    + custom_condition_scenarios
 )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
@@ -1,5 +1,5 @@
 from dagster import AutoMaterializeRule
-from dagster._core.definitions.asset_condition import RuleCondition
+from dagster._core.definitions.asset_condition.asset_condition import RuleCondition
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 
 from ..asset_daemon_scenario import (

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
@@ -1,0 +1,31 @@
+from dagster import AutoMaterializeRule
+from dagster._core.definitions.asset_condition import RuleCondition
+from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+
+from ..asset_daemon_scenario import (
+    AssetDaemonScenario,
+)
+from ..base_scenario import run_request
+from .asset_daemon_scenario_states import (
+    one_asset,
+)
+
+custom_condition_scenarios = [
+    AssetDaemonScenario(
+        id="funky_custom_condition_scenario",
+        initial_state=one_asset.with_asset_properties(
+            auto_materialize_policy=AutoMaterializePolicy.from_asset_condition(
+                # intentionally funky condition
+                # not ((not missing) | (parent_updated)) ->
+                # it starts missing, and with no parents updated, so this evaluates to true
+                ~(
+                    ~RuleCondition(AutoMaterializeRule.materialize_on_missing())
+                    & RuleCondition(AutoMaterializeRule.materialize_on_parent_updated())
+                )
+            )
+        ),
+        execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
+            run_request(asset_keys=["A"])
+        ),
+    ),
+]

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -6,7 +6,7 @@ import sqlalchemy as db
 import sqlalchemy.dialects as db_dialects
 import sqlalchemy.pool as db_pool
 from dagster._config.config_schema import UserConfigSchema
-from dagster._core.definitions.asset_condition import (
+from dagster._core.definitions.asset_condition.asset_condition import (
     AssetConditionEvaluationWithRunIds,
 )
 from dagster._core.storage.config import MySqlStorageConfig, mysql_config

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -6,7 +6,9 @@ import sqlalchemy as db
 import sqlalchemy.dialects as db_dialects
 import sqlalchemy.pool as db_pool
 from dagster._config.config_schema import UserConfigSchema
-from dagster._core.definitions.asset_condition import AssetConditionEvaluationWithRunIds
+from dagster._core.definitions.asset_condition.asset_condition import (
+    AssetConditionEvaluationWithRunIds,
+)
 from dagster._core.scheduler.instigation import InstigatorState
 from dagster._core.storage.config import PostgresStorageConfig, pg_config
 from dagster._core.storage.schedules import ScheduleStorageSqlMetadata, SqlScheduleStorage


### PR DESCRIPTION
## Summary & Motivation

As it says in the title -- this begins the process of shuttling over the implementations of these rules into native AssetCondition objects. There's not particular urgency to move over all of these, but this sets up the pattern going forward.

Other changes may end up leading to the composition of multiple AssetConditions to replace a single rule.

## How I Tested These Changes
