### PR TITLE
Pass AMP settings dictionary into AssetDaemon constructor rather than always pulling it from the instance

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -357,7 +357,10 @@ class TestAssetConditionEvaluations(ExecutingGraphQLContextTestMatrix):
         assert not results.data["assetNodeOrError"]["currentAutoMaterializeEvaluationId"]
 
         with patch(
-            "dagster._core.instance.DagsterInstance.auto_materialize_use_sensors",
+            graphql_context.instance.__class__.__module__
+            + "."
+            + graphql_context.instance.__class__.__name__
+            + ".auto_materialize_use_sensors",
             new_callable=PropertyMock,
         ) as mock_my_property:
             mock_my_property.return_value = True

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -816,6 +816,9 @@ class DagsterInstance(DynamicPartitionsStore):
     def get_sensor_settings(self) -> Mapping[str, Any]:
         return self.get_settings("sensors")
 
+    def get_auto_materialize_settings(self) -> Mapping[str, Any]:
+        return self.get_settings("auto_materialize")
+
     @property
     def telemetry_enabled(self) -> bool:
         if self.is_ephemeral:

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -353,11 +353,12 @@ def create_daemon_of_type(daemon_type: str, instance: DagsterInstance) -> Dagste
         return EventLogConsumerDaemon()
     elif daemon_type == AssetDaemon.daemon_type():
         return AssetDaemon(
+            settings=instance.get_auto_materialize_settings(),
             pre_sensor_interval_seconds=(
                 instance.auto_materialize_minimum_interval_seconds
                 if instance.auto_materialize_minimum_interval_seconds is not None
                 else DEFAULT_DAEMON_INTERVAL_SECONDS
-            )
+            ),
         )
     else:
         raise Exception(f"Unexpected daemon type {daemon_type}")

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -488,7 +488,8 @@ class AssetDaemonScenarioState(NamedTuple):
 
             list(
                 AssetDaemon(  # noqa: SLF001
-                    pre_sensor_interval_seconds=42
+                    settings=self.instance.get_auto_materialize_settings(),
+                    pre_sensor_interval_seconds=42,
                 )._run_iteration_impl(
                     workspace_context,
                     threadpool_executor=self.threadpool_executor,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -505,7 +505,10 @@ class AssetReconciliationScenario(
 
                 try:
                     list(
-                        AssetDaemon(pre_sensor_interval_seconds=42)._run_iteration_impl(  # noqa: SLF001
+                        AssetDaemon(  # noqa: SLF001
+                            settings=instance.get_auto_materialize_settings(),
+                            pre_sensor_interval_seconds=42,
+                        )._run_iteration_impl(
                             workspace_context,
                             threadpool_executor=None,
                             amp_tick_futures={},


### PR DESCRIPTION
Summary:
This mirrors similar logic in SensorDaemon and makes it possible for us to override threadpool behavior differently in different contexts.

Test Plan :BK

## Summary & Motivation

## How I Tested These Changes
