### PR TITLE
bigquery freshness helper

### DIFF
--- a/python_modules/libraries/dagster-gcp/dagster_gcp/__init__.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/__init__.py
@@ -15,6 +15,7 @@ from .bigquery.ops import (
 from .bigquery.resources import (
     BigQueryResource as BigQueryResource,
     bigquery_resource as bigquery_resource,
+    fetch_last_updated_timestamps as fetch_last_updated_timestamps,
 )
 from .bigquery.types import BigQueryError as BigQueryError
 from .dataproc.ops import (

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/conftest.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/conftest.py
@@ -1,0 +1,27 @@
+import os
+import uuid
+from contextlib import contextmanager
+from typing import Iterator
+
+from google.cloud import bigquery
+
+IS_BUILDKITE = os.getenv("BUILDKITE") is not None
+
+SHARED_BUILDKITE_BQ_CONFIG = {
+    "project": os.getenv("GCP_PROJECT_ID"),
+}
+
+
+@contextmanager
+def temporary_bigquery_table(schema_name: str, column_str: str) -> Iterator[str]:
+    bq_client = bigquery.Client(
+        project=SHARED_BUILDKITE_BQ_CONFIG["project"],
+    )
+    table_name = "test_io_manager_" + str(uuid.uuid4()).replace("-", "_")
+    bq_client.query(f"create table {schema_name}.{table_name} ({column_str})").result()
+    try:
+        yield table_name
+    finally:
+        bq_client.query(
+            f"drop table {SHARED_BUILDKITE_BQ_CONFIG['project']}.{schema_name}.{table_name}"
+        ).result()

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_io_manager.py
@@ -1,9 +1,6 @@
 import base64
 import os
-import uuid
-from contextlib import contextmanager
 from datetime import datetime
-from typing import Iterator
 
 import pytest
 from dagster import InputContext, OutputContext, TimeWindow, asset, materialize
@@ -13,28 +10,8 @@ from dagster_gcp.bigquery.io_manager import (
     _get_cleanup_statement,
     build_bigquery_io_manager,
 )
-from google.cloud import bigquery
 
-IS_BUILDKITE = os.getenv("BUILDKITE") is not None
-
-SHARED_BUILDKITE_BQ_CONFIG = {
-    "project": os.getenv("GCP_PROJECT_ID"),
-}
-
-
-@contextmanager
-def temporary_bigquery_table(schema_name: str, column_str: str) -> Iterator[str]:
-    bq_client = bigquery.Client(
-        project=SHARED_BUILDKITE_BQ_CONFIG["project"],
-    )
-    table_name = "test_io_manager_" + str(uuid.uuid4()).replace("-", "_")
-    bq_client.query(f"create table {schema_name}.{table_name} ({column_str})").result()
-    try:
-        yield table_name
-    finally:
-        bq_client.query(
-            f"drop table {SHARED_BUILDKITE_BQ_CONFIG['project']}.{schema_name}.{table_name}"
-        ).result()
+from .conftest import IS_BUILDKITE, SHARED_BUILDKITE_BQ_CONFIG, temporary_bigquery_table
 
 
 def test_get_select_statement():


### PR DESCRIPTION
This PR introduces a standalone method to the dagster-bigquery package that, given a single table and a project ID, returns the freshness of each table.

I tried to keep the core function as simple as possible, and use public bigquery APIs rather than rely on raw queries of properties. This method feels a bit more blessed. A previous version that tried to retrieve for multiple tables felt weird to me because (a) there's no super convenient bulk table retrieval method in bigquery and (b) requires us to make a decision around how to handle exceptions for the user when only some of the tables are causing exceptions.

How I tested this
Added a test that creates an observable source asset that attaches freshness as metadata to its observe result, and asserts the information is correct on the resulting observation event.
