### PR TITLE
snowflake freshness helper

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -475,6 +475,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             "pydantic1",
             "pydantic2",
         ],
+        env_vars=["SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER", "SNOWFLAKE_PASSWORD"],
     ),
     PackageSpec(
         "python_modules/libraries/dagster-airbyte",

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/__init__.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/__init__.py
@@ -4,6 +4,7 @@ from .ops import snowflake_op_for_query as snowflake_op_for_query
 from .resources import (
     SnowflakeConnection as SnowflakeConnection,
     SnowflakeResource as SnowflakeResource,
+    fetch_last_updated_timestamps as fetch_last_updated_timestamps,
     snowflake_resource as snowflake_resource,
 )
 from .snowflake_io_manager import (

--- a/python_modules/libraries/dagster-snowflake/tox.ini
+++ b/python_modules/libraries/dagster-snowflake/tox.ini
@@ -3,7 +3,7 @@ skipsdist = true
 
 [testenv]
 download = True
-passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE*
+passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE* SNOWFLAKE_ACCOUNT SNOWFLAKE_USER SNOWFLAKE_PASSWORD
 install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]


### PR DESCRIPTION
This PR introduces a standalone method to the dagster-snowflake package that, given a list of tables and a project ID, returns the freshness of each table.

How I tested this
Added a test that creates an observable source asset that attaches freshness as metadata to its observe result, and asserts the information is correct on the resulting observation event.
