### PR TITLE
[test-all][NO_SKIP] Do tox builds in editable_mode=compat

### DIFF
--- a/docs/tox.ini
+++ b/docs/tox.ini
@@ -7,6 +7,7 @@ passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUIL
 usedevelop = False
 allowlist_externals =
   make
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 
 [testenv:sphinx]
 deps =

--- a/examples/assets_dbt_python/tox.ini
+++ b/examples/assets_dbt_python/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 ; note: "source" does not work at this time due to dagster-cloud source access
 deps =
   source: -e ../../python_modules/dagster[test]

--- a/examples/assets_dynamic_partitions/tox.ini
+++ b/examples/assets_dynamic_partitions/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/examples/assets_modern_data_stack/tox.ini
+++ b/examples/assets_modern_data_stack/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 ; note: "source" does not work at this time due to dagster-cloud source access
 deps =
   source: -e ../../python_modules/dagster[test]

--- a/examples/assets_pandas_pyspark/tox.ini
+++ b/examples/assets_pandas_pyspark/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/examples/assets_pandas_type_metadata/tox.ini
+++ b/examples/assets_pandas_type_metadata/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/examples/assets_smoke_test/tox.ini
+++ b/examples/assets_smoke_test/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/examples/deploy_docker/tox.ini
+++ b/examples/deploy_docker/tox.ini
@@ -4,6 +4,7 @@ skipsdist = True
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* DEPLOY_DOCKER_WEBSERVER_HOST
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/examples/deploy_ecs/tox.ini
+++ b/examples/deploy_ecs/tox.ini
@@ -4,6 +4,7 @@ skipsdist = True
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* DEPLOY_DOCKER_WEBSERVER_HOST
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/examples/deploy_k8s/tox.ini
+++ b/examples/deploy_k8s/tox.ini
@@ -4,6 +4,7 @@ skipsdist = True
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/examples/development_to_production/tox.ini
+++ b/examples/development_to_production/tox.ini
@@ -4,6 +4,7 @@ skipsdist = True
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN POSTGRES_TEST_DB_HOST BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/examples/experimental/assets_yaml_dsl/tox.ini
+++ b/examples/experimental/assets_yaml_dsl/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../../python_modules/dagster[test]
   -e ../../../python_modules/dagster-pipes

--- a/examples/feature_graph_backed_assets/tox.ini
+++ b/examples/feature_graph_backed_assets/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/examples/project_fully_featured/tox.ini
+++ b/examples/project_fully_featured/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* SNOWFLAKE_ACCOUNT SNOWFLAKE_USER SNOWFLAKE_PASSWORD
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/examples/quickstart_aws/tox.ini
+++ b/examples/quickstart_aws/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 ; note: "source" does not work at this time due to dagster-cloud source access
 deps =
   source: -e ../../python_modules/dagster[test]

--- a/examples/quickstart_etl/tox.ini
+++ b/examples/quickstart_etl/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 ; note: "source" does not work at this time due to dagster-cloud source access
 deps =
   source: -e ../../python_modules/dagster[test]

--- a/examples/quickstart_gcp/tox.ini
+++ b/examples/quickstart_gcp/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 ; note: "source" does not work at this time due to dagster-cloud source access
 deps =
   source: -e ../../python_modules/dagster[test]

--- a/examples/quickstart_snowflake/tox.ini
+++ b/examples/quickstart_snowflake/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 ; note: "source" does not work at this time due to dagster-cloud source access
 deps =
   source: -e ../../python_modules/dagster[test]

--- a/examples/with_airflow/tox.ini
+++ b/examples/with_airflow/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/examples/with_great_expectations/tox.ini
+++ b/examples/with_great_expectations/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/examples/with_pyspark/tox.ini
+++ b/examples/with_pyspark/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/examples/with_pyspark_emr/tox.ini
+++ b/examples/with_pyspark_emr/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/examples/with_wandb/tox.ini
+++ b/examples/with_wandb/tox.ini
@@ -4,6 +4,7 @@
 usedevelop = true
 download = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/helm/dagster/schema/tox.ini
+++ b/helm/dagster/schema/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../../python_modules/dagster[test]
   -e ../../../python_modules/dagster-pipes

--- a/integration_tests/python_modules/dagster-k8s-test-infra/tox.ini
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../../python_modules/dagster[test]
   -e ../../../python_modules/dagster-pipes

--- a/integration_tests/test_suites/backcompat-test-suite/tox.ini
+++ b/integration_tests/test_suites/backcompat-test-suite/tox.ini
@@ -5,6 +5,7 @@ skipsdist = True
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* BACKCOMPAT_TESTS_WEBSERVER_HOST EARLIEST_TESTED_RELEASE
 
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../../python_modules/dagster-pipes
   -e ../../../python_modules/dagster[test]

--- a/integration_tests/test_suites/celery-k8s-test-suite/tox.ini
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tox.ini
@@ -4,6 +4,7 @@ skipsdist = True
 [testenv]
 download = True
 passenv = HOME AIRFLOW_HOME AWS_* BUILDKITE* CI_* COVERALLS_REPO_TOKEN DAGSTER_* DOCKER_* GOOGLE_* KUBECONFIG
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../../python_modules/dagster[test]
   -e ../../../python_modules/dagster-pipes

--- a/integration_tests/test_suites/daemon-test-suite/tox.ini
+++ b/integration_tests/test_suites/daemon-test-suite/tox.ini
@@ -4,6 +4,7 @@ skipsdist = True
 [testenv]
 download = True
 passenv = HOME AIRFLOW_HOME AWS_* BUILDKITE* CI_* COVERALLS_REPO_TOKEN DAGSTER_* DOCKER_* GOOGLE_* KUBECONFIG POSTGRES_TEST_DB_HOST
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   objgraph
   -e ../../../python_modules/dagster[test]

--- a/integration_tests/test_suites/k8s-test-suite/tox.ini
+++ b/integration_tests/test_suites/k8s-test-suite/tox.ini
@@ -4,6 +4,7 @@ skipsdist = True
 [testenv]
 download = True
 passenv = HOME AIRFLOW_HOME AWS_* BUILDKITE* CI_* COVERALLS_REPO_TOKEN DAGSTER_* DOCKER_* GOOGLE_* KUBECONFIG
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../../python_modules/dagster[test]
   -e ../../../python_modules/dagster-graphql

--- a/js_modules/dagster-ui/tox.ini
+++ b/js_modules/dagster-ui/tox.ini
@@ -6,6 +6,7 @@ download = True
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE*
 setenv =
     STRICT_GRPC_SERVER_PROCESS_WAIT = "1"
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-pipes

--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_PULL_REQUEST COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../dagster[test]
   -e ../dagster-pipes

--- a/python_modules/dagit/tox.ini
+++ b/python_modules/dagit/tox.ini
@@ -6,6 +6,7 @@ download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 setenv =
   STRICT_GRPC_SERVER_PROCESS_WAIT = "1"
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   objgraph
   -e ../dagster[test]

--- a/python_modules/dagster-graphql/tox.ini
+++ b/python_modules/dagster-graphql/tox.ini
@@ -6,6 +6,7 @@ download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* POSTGRES_TEST_DB_HOST
 setenv =
   STRICT_GRPC_SERVER_PROCESS_WAIT = "1"
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../dagster[test]
   -e ../dagster-pipes

--- a/python_modules/dagster-pipes/tox.ini
+++ b/python_modules/dagster-pipes/tox.ini
@@ -2,6 +2,7 @@
 
 [testenv]
 usedevelop = true
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e .
   -e ../dagster[test]

--- a/python_modules/dagster-test/tox.ini
+++ b/python_modules/dagster-test/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../dagster[test]
   -e ../dagster-pipes

--- a/python_modules/dagster-webserver/tox.ini
+++ b/python_modules/dagster-webserver/tox.ini
@@ -7,6 +7,7 @@ download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 setenv =
   STRICT_GRPC_SERVER_PROCESS_WAIT = "1"
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   objgraph
   -e ../dagster[test]

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -8,6 +8,7 @@ setenv =
   windows: COVERAGE_ARGS =
   STRICT_GRPC_SERVER_PROCESS_WAIT = "1"
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE* DAGSTER_DOCKER_* GRPC_SERVER_HOST
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   scheduler_tests_pendulum_1: pendulum<2
   scheduler_tests_pendulum_2: pendulum>1,<3

--- a/python_modules/libraries/dagster-airbyte/tox.ini
+++ b/python_modules/libraries/dagster-airbyte/tox.ini
@@ -2,7 +2,9 @@
 skipsdist = true
 
 [testenv]
+download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-airflow/tox.ini
+++ b/python_modules/libraries/dagster-airflow/tox.ini
@@ -6,6 +6,7 @@ download = True
 setenv =
   SLUGIFY_USES_TEXT_UNIDECODE = yes
 passenv = HOME AIRFLOW_HOME AWS_* BUILDKITE* CI_* COVERALLS_REPO_TOKEN DAGSTER_* DOCKER_* GOOGLE_* KUBECONFIG, POSTGRES_TEST_DB_HOST
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-aws/tox.ini
+++ b/python_modules/libraries/dagster-aws/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_* BUILDKITE* SSH_*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-azure/tox.ini
+++ b/python_modules/libraries/dagster-azure/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN AZURE_* BUILDKITE* SSH_*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-celery-docker/tox.ini
+++ b/python_modules/libraries/dagster-celery-docker/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN GOOGLE_APPLICATION_CREDENTIALS BUILDKITE* AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID DAGSTER_DOCKER_* POSTGRES_TEST_DB_HOST
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-celery-k8s/tox.ini
+++ b/python_modules/libraries/dagster-celery-k8s/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-celery/tox.ini
+++ b/python_modules/libraries/dagster-celery/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = HOME CI_PULL_REQUEST COVERALLS_REPO_TOKEN DASK_ADDRESS AWS_* BUILDKITE* DAGSTER_*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-census/tox.ini
+++ b/python_modules/libraries/dagster-census/tox.ini
@@ -2,7 +2,9 @@
 skipsdist = true
 
 [testenv]
+download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-dask/tox.ini
+++ b/python_modules/libraries/dagster-dask/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_PULL_REQUEST COVERALLS_REPO_TOKEN DASK_ADDRESS AWS_* BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-databricks/tox.ini
+++ b/python_modules/libraries/dagster-databricks/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN DATABRICKS_* BUILDKITE* SSH_*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-datadog/tox.ini
+++ b/python_modules/libraries/dagster-datadog/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-datahub/tox.ini
+++ b/python_modules/libraries/dagster-datahub/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_* BUILDKITE* SSH_*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-deltalake-pandas/tox.ini
+++ b/python_modules/libraries/dagster-deltalake-pandas/tox.ini
@@ -5,6 +5,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN AZURE_* BUILDKITE* SSH_*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-deltalake-polars/tox.ini
+++ b/python_modules/libraries/dagster-deltalake-polars/tox.ini
@@ -5,6 +5,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN AZURE_* BUILDKITE* SSH_*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-deltalake/tox.ini
+++ b/python_modules/libraries/dagster-deltalake/tox.ini
@@ -5,6 +5,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN AZURE_* BUILDKITE* SSH_*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-docker/tox.ini
+++ b/python_modules/libraries/dagster-docker/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = HOME CI_* COVERALLS_REPO_TOKEN BUILDKITE* AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID DAGSTER_DOCKER_* DOCKER_* GOOGLE_* POSTGRES_TEST_DB_HOST
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-duckdb-pandas/tox.ini
+++ b/python_modules/libraries/dagster-duckdb-pandas/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN AZURE_* BUILDKITE* SSH_*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-duckdb-polars/tox.ini
+++ b/python_modules/libraries/dagster-duckdb-polars/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN AZURE_* BUILDKITE* SSH_*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[mypy,test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-duckdb-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-duckdb-pyspark/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN AZURE_* BUILDKITE* SSH_*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-duckdb/tox.ini
+++ b/python_modules/libraries/dagster-duckdb/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN AZURE_* BUILDKITE* SSH_*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-embedded-elt/tox.ini
+++ b/python_modules/libraries/dagster-embedded-elt/tox.ini
@@ -2,7 +2,9 @@
 skipsdist = true
 
 [testenv]
+download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-fivetran/tox.ini
+++ b/python_modules/libraries/dagster-fivetran/tox.ini
@@ -2,7 +2,9 @@
 skipsdist = true
 
 [testenv]
+download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-gcp-pandas/tox.ini
+++ b/python_modules/libraries/dagster-gcp-pandas/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN AZURE_* BUILDKITE* SSH_* GOOGLE_APPLICATION_CREDENTIALS GCP_PROJECT_ID
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[mypy,test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-gcp-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-gcp-pyspark/tox.ini
@@ -9,6 +9,7 @@ setenv =
   !windows: COVERAGE_ARGS = --cov=dagster --cov-append --cov-report term:skip-covered --cov-report html --cov-report xml
   windows: COVERAGE_ARGS =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* AZURE_* SSH_* GOOGLE_APPLICATION_CREDENTIALS GCP_PROJECT_ID
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-gcp/tox.ini
+++ b/python_modules/libraries/dagster-gcp/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN GOOGLE_APPLICATION_CREDENTIALS GCP_PROJECT_ID BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-ge/tox.ini
+++ b/python_modules/libraries/dagster-ge/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN GOOGLE_APPLICATION_CREDENTIALS GCP_PROJECT_ID BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-github/tox.ini
+++ b/python_modules/libraries/dagster-github/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-k8s/tox.ini
+++ b/python_modules/libraries/dagster-k8s/tox.ini
@@ -5,6 +5,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = HOME AWS_* BUILDKITE* CI_* COVERALLS_REPO_TOKEN DAGSTER_* DOCKER_* GOOGLE_* KUBECONFIG
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   old_kubernetes: kubernetes==12.0.0
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-managed-elements/tox.ini
+++ b/python_modules/libraries/dagster-managed-elements/tox.ini
@@ -2,7 +2,9 @@
 skipsdist = true
 
 [testenv]
+download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-mlflow/tox.ini
+++ b/python_modules/libraries/dagster-mlflow/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-msteams/tox.ini
+++ b/python_modules/libraries/dagster-msteams/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-mysql/tox.ini
+++ b/python_modules/libraries/dagster-mysql/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN MYSQL_TEST_* BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   storage_tests_sqlalchemy_1_3: sqlalchemy<1.4
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-pagerduty/tox.ini
+++ b/python_modules/libraries/dagster-pagerduty/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-pandas/tox.ini
+++ b/python_modules/libraries/dagster-pandas/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-pandera/tox.ini
+++ b/python_modules/libraries/dagster-pandera/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-papertrail/tox.ini
+++ b/python_modules/libraries/dagster-papertrail/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-postgres/tox.ini
+++ b/python_modules/libraries/dagster-postgres/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN POSTGRES_TEST_* BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   storage_tests_sqlalchemy_1_3: sqlalchemy<1.4
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-prometheus/tox.ini
+++ b/python_modules/libraries/dagster-prometheus/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-pyspark/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-shell/tox.ini
+++ b/python_modules/libraries/dagster-shell/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-slack/tox.ini
+++ b/python_modules/libraries/dagster-slack/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-snowflake-pandas/tox.ini
+++ b/python_modules/libraries/dagster-snowflake-pandas/tox.ini
@@ -2,7 +2,9 @@
 skipsdist = true
 
 [testenv]
+download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* SNOWFLAKE_BUILDKITE_PASSWORD SNOWFLAKE_ACCOUNT
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-snowflake-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-snowflake-pyspark/tox.ini
@@ -2,7 +2,9 @@
 skipsdist = true
 
 [testenv]
+download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* SNOWFLAKE_BUILDKITE_PASSWORD SNOWFLAKE_ACCOUNT
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-snowflake/tox.ini
+++ b/python_modules/libraries/dagster-snowflake/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-spark/tox.ini
+++ b/python_modules/libraries/dagster-spark/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-ssh/tox.ini
+++ b/python_modules/libraries/dagster-ssh/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-twilio/tox.ini
+++ b/python_modules/libraries/dagster-twilio/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN TWILIO_* BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e ../../dagster-pipes

--- a/python_modules/libraries/dagster-wandb/tox.ini
+++ b/python_modules/libraries/dagster-wandb/tox.ini
@@ -9,6 +9,7 @@ setenv =
   !windows: COVERAGE_ARGS = --cov=dagster --cov-append --cov-report term:skip-covered --cov-report html --cov-report xml
   windows: COVERAGE_ARGS =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../dagster-wandb[dev]
   -e ../../dagster[test]

--- a/python_modules/libraries/dagstermill/tox.ini
+++ b/python_modules/libraries/dagstermill/tox.ini
@@ -5,6 +5,7 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   papermill1: papermill<2.0.0
   papermill1: jupyter-client<6.1.13

--- a/scripts/templates_create_dagster_package/tox.ini.tmpl
+++ b/scripts/templates_create_dagster_package/tox.ini.tmpl
@@ -1,12 +1,12 @@
 [tox]
 
 [testenv]
-usedevelop = true
 download = True
 setenv =
   !windows: COVERAGE_ARGS = --cov=dagster --cov-append --cov-report term:skip-covered --cov-report html --cov-report xml
   windows: COVERAGE_ARGS =
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* # TODO add additional env var requirements and add them to .buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+install_command = python -m pip install {opts} {packages} --config-settings editable_mode=compat
 deps =
   -e ../../dagster[test]
   -e .


### PR DESCRIPTION
Summary:
This is needed in order for our tox suite to pass when running in python 3.12 due to changes in how editable installs are handled by default in that version - we now fall back to PEP 660 pyproject.toml based installs by default instead of setup.py develop installs.

Test Plan: BK (including a 3.12 build on the next PR)

## Summary & Motivation

## How I Tested These Changes
