### PR TITLE
Add "assets" resolver to GrapheneAssetSelection

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2906,6 +2906,7 @@ enum SensorType {
 type AssetSelection {
   assetSelectionString: String
   assetKeys: [AssetKey!]!
+  assets: [Asset!]!
 }
 
 union SensorOrError = Sensor | SensorNotFoundError | UnauthorizedError | PythonError

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -568,6 +568,7 @@ export type AssetSelection = {
   __typename: 'AssetSelection';
   assetKeys: Array<AssetKey>;
   assetSelectionString: Maybe<Scalars['String']>;
+  assets: Array<Asset>;
 };
 
 export type AssetSubset = {
@@ -6373,6 +6374,7 @@ export const buildAssetSelection = (
       overrides && overrides.hasOwnProperty('assetSelectionString')
         ? overrides.assetSelectionString!
         : 'dolores',
+    assets: overrides && overrides.hasOwnProperty('assets') ? overrides.assets! : [],
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_selections.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_selections.py
@@ -3,6 +3,7 @@ from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.host_representation.external import ExternalRepository
 
+from ..implementation.fetch_assets import get_asset_nodes_by_asset_key
 from .asset_key import GrapheneAssetKey
 from .util import non_null_list
 
@@ -10,6 +11,7 @@ from .util import non_null_list
 class GrapheneAssetSelection(graphene.ObjectType):
     assetSelectionString = graphene.String()
     assetKeys = non_null_list(GrapheneAssetKey)
+    assets = non_null_list("dagster_graphql.schema.pipelines.pipeline.GrapheneAsset")
 
     def __init__(self, asset_selection: AssetSelection, external_repository: ExternalRepository):
         self._asset_selection = asset_selection
@@ -22,6 +24,17 @@ class GrapheneAssetSelection(graphene.ObjectType):
         asset_graph = ExternalAssetGraph.from_external_repository(self._external_repository)
         return [
             GrapheneAssetKey(path=asset_key.path)
+            for asset_key in self._asset_selection.resolve(asset_graph)
+        ]
+
+    def resolve_assets(self, graphene_info):
+        from dagster_graphql.schema.pipelines.pipeline import GrapheneAsset
+
+        asset_graph = ExternalAssetGraph.from_external_repository(self._external_repository)
+        asset_nodes_by_asset_key = get_asset_nodes_by_asset_key(graphene_info)
+
+        return [
+            GrapheneAsset(key=asset_key, definition=asset_nodes_by_asset_key.get(asset_key))
             for asset_key in self._asset_selection.resolve(asset_graph)
         ]
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -155,6 +155,16 @@ query SensorQuery($sensorSelector: SensorSelector!) {
         assetKeys {
           path
         }
+        assets {
+          key {
+            path
+          }
+          definition {
+            assetKey {
+              path
+            }
+          }
+        }
       }
     }
   }
@@ -1419,4 +1429,10 @@ def test_asset_selection(graphql_context):
     )
     assert result.data["sensorOrError"]["assetSelection"]["assetKeys"] == [
         {"path": ["fresh_diamond_bottom"]}
+    ]
+    assert result.data["sensorOrError"]["assetSelection"]["assets"] == [
+        {
+            "key": {"path": ["fresh_diamond_bottom"]},
+            "definition": {"assetKey": {"path": ["fresh_diamond_bottom"]}},
+        }
     ]


### PR DESCRIPTION
Summary:
Will allow us to break out the list of asset keys in the sensor view by whether or not they have an AMP policy.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
