### PR TITLE
remove duckdb pin

### DIFF
--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -12,6 +12,7 @@ deps =
   -e ../dagster-duckdb-pandas
   dbt_15X: dbt-core==1.5.*
   dbt_15X: dbt-duckdb==1.5.*
+  dbt_15X: duckdb<0.10.0
   dbt_16X: dbt-core==1.6.*
   dbt_16X: dbt-duckdb==1.6.*
   dbt_17X: dbt-core==1.7.*

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -324,7 +324,7 @@ def test_static_partitioned_asset(tmp_path, io_managers):
         }
     ),
     key_prefix=["my_schema"],
-    metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
+    metadata={"partition_expr": {"time": "CAST(time as DATE)", "color": "color"}},
     config_schema={"value": str},
 )
 def multi_partitioned(context) -> pd.DataFrame:

--- a/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars_tests/test_type_handler.py
@@ -340,7 +340,7 @@ def test_static_partitioned_asset(tmp_path, io_managers):
         }
     ),
     key_prefix=["my_schema"],
-    metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
+    metadata={"partition_expr": {"time": "CAST(time as DATE)", "color": "color"}},
     config_schema={"value": str},
 )
 def multi_partitioned(context) -> pl.DataFrame:

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark_tests/test_type_handler.py
@@ -309,7 +309,7 @@ def test_static_partitioned_asset(tmp_path, io_managers):
         }
     ),
     key_prefix=["my_schema"],
-    metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
+    metadata={"partition_expr": {"time": "CAST(time as DATE)", "color": "color"}},
     config_schema={"value": str},
 )
 def multi_partitioned(context) -> SparkDF:

--- a/python_modules/libraries/dagster-duckdb/setup.py
+++ b/python_modules/libraries/dagster-duckdb/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=find_packages(exclude=["dagster_duckdb_tests*"]),
     include_package_data=True,
     install_requires=[
-        "duckdb<0.10.0",
+        "duckdb",
         f"dagster{pin}",
     ],
     extras_require={


### PR DESCRIPTION
## Summary & Motivation
duckdb release version 0.10.0 and our tests broke. It looks like it's the test code itself that is the problem and not the io manager. I can't find a duckdb PR that directly explains the  issue we ran into in our tests, but it seems that the type conversion from VARCHAR to TIMESTAMP and then comparing with other timestamps to determine which section of the table to delete was returning the incorrect section of table. I think this could be because the granularity of the timestamps differed (ie comparing a date level timestamp to a minute level timestamp). Switching to casting to a DATE fixed the issue. 


## How I Tested These Changes
