### PR TITLE
[docs][insights] add note about running pipeline in single code location

### DIFF
--- a/docs/content/dagster-cloud/insights/integrating-snowflake-and-dbt.mdx
+++ b/docs/content/dagster-cloud/insights/integrating-snowflake-and-dbt.mdx
@@ -107,6 +107,8 @@ This allows you to add a comment to every query recorded in Snowflake's `query_h
 
 The last step is to create a Dagster pipeline that joins asset observation events with the Snowflake query history and calls the Dagster Cloud ingestion API. Snowflake usage information is available at a delay, so this pipeline will run on a schedule to ingest Snowflake usage information from the previous hour.
 
+Note that you only need to create this pipeline in a single code location per deployment, even if you have instrumented dbt assets in multiple code locations.
+
 To do this, you'll need a Snowflake resource (<PyObject module="dagster_snowflake" object="SnowflakeResource" />) that can query the `snowflake.account_usage.query_history` table. You can set up the ingestion pipeline like the following:
 
 ```python
@@ -136,7 +138,7 @@ defs = Definitions(
 )
 ```
 
-In this example, the `snowflake_resource_key` is a <PyObject module="dagster_snowflake" object="SnowflakeResource" /> that has access to the `query_history` table. Note that you only need to create this pipeline in a single code location per deployment, even if you have instrumented dbt assets in multiple code locations.
+In this example, the `snowflake_resource_key` is a <PyObject module="dagster_snowflake" object="SnowflakeResource" /> that has access to the `query_history` table.
 
 Once the pipeline runs, Snowflake credits will be visible in the **Insights** tab in the Dagster UI:
 

--- a/docs/content/dagster-cloud/insights/integrating-snowflake-and-dbt.mdx
+++ b/docs/content/dagster-cloud/insights/integrating-snowflake-and-dbt.mdx
@@ -136,7 +136,7 @@ defs = Definitions(
 )
 ```
 
-In this example, the `snowflake_resource_key` is a <PyObject module="dagster_snowflake" object="SnowflakeResource" /> that has access to the `query_history` table.
+In this example, the `snowflake_resource_key` is a <PyObject module="dagster_snowflake" object="SnowflakeResource" /> that has access to the `query_history` table. Note that you only need to create this pipeline in a single code location per deployment, even if you have instrumented dbt assets in multiple code locations.
 
 Once the pipeline runs, Snowflake credits will be visible in the **Insights** tab in the Dagster UI:
 

--- a/docs/content/dagster-cloud/insights/integrating-snowflake.mdx
+++ b/docs/content/dagster-cloud/insights/integrating-snowflake.mdx
@@ -87,7 +87,7 @@ defs = Definitions(
 )
 ```
 
-In this example, the `snowflake_resource_key` is a <PyObject module="dagster_snowflake" object="SnowflakeResource" /> that has access to the `query_history` table.
+In this example, the `snowflake_resource_key` is a <PyObject module="dagster_snowflake" object="SnowflakeResource" /> that has access to the `query_history` table. Note that you only need to create this pipeline in a single code location per deployment, even if you have instrumented dbt assets in multiple code locations.
 
 Once the pipeline runs, Snowflake credits will be visible in the **Insights** tab in the Dagster UI:
 

--- a/docs/content/dagster-cloud/insights/integrating-snowflake.mdx
+++ b/docs/content/dagster-cloud/insights/integrating-snowflake.mdx
@@ -58,6 +58,8 @@ defs = Definitions(
 
 The second step is to create a Dagster pipeline that joins asset observation events with the Snowflake query history and calls the Dagster Cloud ingestion API. Snowflake usage information is available at a delay, so this pipeline will run on a schedule to ingest Snowflake usage information from the previous hour.
 
+Note that you only need to create this pipeline in a single code location per deployment, even if you have instrumented dbt assets in multiple code locations.
+
 To do this, you'll need a Snowflake resource (<PyObject module="dagster_snowflake" object="InsightsSnowflakeResource" />) that can query the `snowflake.account_usage.query_history` table. You can set up the ingestion pipeline like the following:
 
 ```python
@@ -87,7 +89,7 @@ defs = Definitions(
 )
 ```
 
-In this example, the `snowflake_resource_key` is a <PyObject module="dagster_snowflake" object="SnowflakeResource" /> that has access to the `query_history` table. Note that you only need to create this pipeline in a single code location per deployment, even if you have instrumented dbt assets in multiple code locations.
+In this example, the `snowflake_resource_key` is a <PyObject module="dagster_snowflake" object="SnowflakeResource" /> that has access to the `query_history` table.
 
 Once the pipeline runs, Snowflake credits will be visible in the **Insights** tab in the Dagster UI:
 


### PR DESCRIPTION
## Summary

Adds a brief note to the insights docs pages which mention that you only need to run the deferred pipeline in a single code locaiton.
