### PR TITLE
[asset-backfill] Fix run grouping when using BackfillPolicy

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1373,9 +1373,14 @@ def should_backfill_atomic_asset_partitions_unit(
                 (parent in asset_partitions_to_request or parent in candidates_unit)
                 and asset_graph.have_same_partitioning(parent.asset_key, candidate.asset_key)
                 and (
-                    (parent.partition_key == candidate.partition_key and not parent_backfill_policy)
+                    (
+                        # always allow runs to be grouped if there is a simple 1-1 partition mapping
+                        parent.partition_key == candidate.partition_key
+                        and len(parent_partitions_result.parent_partitions) == 1
+                    )
                     # candidate shares a partition key that is already being requested by the parent
-                    # and both candidate and parent have backfill policies and max_partitions_per_run is not 1
+                    # and both candidate and parent have backfill policies and max_partitions_per_run is
+                    # not greater than the number of partitions being requested
                     or has_partition_mapping_safe_backfill_policy
                 )
                 and asset_graph.get_repository_handle(candidate.asset_key)

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
@@ -706,11 +706,14 @@ def test_assets_backfill_with_partition_mapping_without_backfill_policy():
     assert len(result.run_requests) == 2
 
     for run_request in result.run_requests:
+        # b should not be materialized in the same run as a
         if run_request.partition_key == "2023-03-02":
-            assert set(run_request.asset_selection) == {upstream_a.key, downstream_b.key}
-        elif run_request.partition_key == "2023-03-03":
-            # downstream_b's 03-03 partition should be skipped because upstream_a's 03-02 partition is not materialized
             assert set(run_request.asset_selection) == {upstream_a.key}
+        elif run_request.partition_key == "2023-03-03":
+            assert set(run_request.asset_selection) == {upstream_a.key}
+        else:
+            # should only have the above 2 partitions
+            assert False
 
 
 def test_assets_backfill_with_partition_mapping_with_one_partition_multi_run_backfill_policy():


### PR DESCRIPTION
## Summary & Motivation

A previous change made it so that, if more parent partitions than `max_partitions_per_run` were set to materialize in a given tick, then downstream assets could not be grouped together in the same run.

This allows that to happen as long as there is a simple partition mapping between the assets (i.e. an IdentityPartitionMapping)

## How I Tested These Changes
