### PR TITLE
[test-all] Don't create indices immediately on InMemoryRunStorage/InMemoryEventLogStorage creation

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
@@ -39,13 +39,13 @@ class InMemoryEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             alembic_config = get_alembic_config(__file__, "sqlite/alembic/alembic.ini")
             stamp_alembic_rev(alembic_config, self._held_conn)
 
-        self.reindex_events()
-        self.reindex_assets()
-
         if preload:
             for payload in preload:
                 for event in payload.event_list:
                     self.store_event(event)
+
+    def has_secondary_index(self, name: str) -> bool:
+        return True
 
     @contextmanager
     def _connect(self):

--- a/python_modules/dagster/dagster/_core/storage/runs/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/in_memory.py
@@ -39,9 +39,6 @@ class InMemoryRunStorage(SqlRunStorage):
             if "instance_info" not in table_names:
                 InstanceInfo.create(self._held_conn)
 
-        self.migrate()
-        self.optimize()
-
         if preload:
             for payload in preload:
                 self.add_job_snapshot(payload.job_snapshot, payload.dagster_run.job_snapshot_id)
@@ -49,6 +46,9 @@ class InMemoryRunStorage(SqlRunStorage):
                     payload.execution_plan_snapshot, payload.dagster_run.execution_plan_snapshot_id
                 )
                 self.add_run(payload.dagster_run)
+
+    def has_secondary_index(self, name: str) -> bool:
+        return True
 
     @contextmanager
     def connect(self) -> Iterator[Connection]:

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -748,7 +748,9 @@ class TestEventLogStorage:
         assert len(c_stats.attempts_list) == 1
 
     def test_secondary_index(self, storage: EventLogStorage):
-        if not isinstance(storage, SqlEventLogStorage):
+        if not isinstance(storage, SqlEventLogStorage) or isinstance(
+            storage, InMemoryEventLogStorage
+        ):
             pytest.skip("This test is for SQL-backed Event Log behavior")
 
         # test that newly initialized DBs will have the secondary indexes built

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -1235,6 +1235,8 @@ class TestRunStorage:
         assert len(storage.get_backfills(status=BulkActionStatus.REQUESTED)) == 0
 
     def test_secondary_index(self, storage):
+        self._skip_in_memory(storage)
+
         if not isinstance(storage, SqlRunStorage):
             return
 


### PR DESCRIPTION
Summary:
[test-all]
Particularly on python 3.12, the pattern where InMemory run/event storage inserts rows and events immediately on instance creation seems to be causing strange sqlalchemy issues. I think it safe to assume that in memory storage is brand new

Test Plan: BK (a couple trials to make sure there isn't lingering flakiness)

## Summary & Motivation

## How I Tested These Changes
