### PR TITLE
Fix issue causing memory to explode on assets page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -58,7 +58,7 @@ export function useAssetsLiveData(
   thread: LiveDataThreadID = 'default',
 ) {
   return factory.useLiveData(
-    assetKeys.map((key) => tokenForAssetKey(key)),
+    React.useMemo(() => assetKeys.map((key) => tokenForAssetKey(key)), [assetKeys]),
     thread,
   );
 }


### PR DESCRIPTION
## Summary & Motivation

This array is used as a dependency to setup a bunch of listeners. Because we're using `.map` we end up creating a new array on every render which causes us to unregister and register a new set of listeners endlessly. If your computer can keep up with the memory swapping then everything seems fine but if it can't your tab quickly grows unbounded.



## How I Tested These Changes

Use the task manager and saw that the "Assets tab" is no longer using 50%+ CPU and that the memory usage isn't changing wildly.

<img width="792" alt="Screenshot 2024-02-14 at 1 49 45 PM" src="https://github.com/dagster-io/dagster/assets/2286579/ef39d3a7-3768-408b-bccc-fa28d2b307ff">

