### PR TITLE
[dagster-dbt] update usage of deprecated context methods

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -536,7 +536,7 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
             # Run the dbt Cloud job to rematerialize the assets.
             dbt_cloud_output = dbt_cloud.run_job_and_poll(
                 job_id=job_id,
-                cause=f"Materializing software-defined assets in Dagster run {context.run_id[:8]}",
+                cause=f"Materializing software-defined assets in Dagster run {context.run.run_id[:8]}",
                 steps_override=job_commands,
             )
 


### PR DESCRIPTION
## Summary & Motivation
Some methods in the dbt integration use context methods that were deprecated in https://github.com/dagster-io/dagster/pull/19441 and https://github.com/dagster-io/dagster/pull/17339. The op-specific methods are meant to be replaced by calling `context.op_execution_context.op` rather than `context.op`. However, in some of the dbt methods, we don't know if the context is of type `AssetExecutionContext` or `OpExecutionContext`, so it is unclear if we need to call the underlying `op_execution_context` before op-specific methods. 

This PR adds a check in some methods that will pull the `op_execution_context` from the context if the context is an `AssetExecutionContext` so that we are guaranteed to be working with an `OpExecutionContext` in the rest of the method. 

## How I Tested These Changes
