### PR TITLE
[graph diff] GrapheneRepository initialized with workspace context

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -111,7 +111,7 @@ def fetch_repositories(graphene_info: "ResolveInfo") -> "GrapheneRepositoryConne
     return GrapheneRepositoryConnection(
         nodes=[
             GrapheneRepository(
-                instance=graphene_info.context.instance,
+                workspace_context=graphene_info.context,
                 repository=repository,
                 repository_location=location,
             )
@@ -133,7 +133,7 @@ def fetch_repository(
         repo_loc = graphene_info.context.get_code_location(repository_selector.location_name)
         if repo_loc.has_repository(repository_selector.repository_name):
             return GrapheneRepository(
-                instance=graphene_info.context.instance,
+                workspace_context=graphene_info.context,
                 repository=repo_loc.get_repository(repository_selector.repository_name),
                 repository_location=repo_loc,
             )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -157,7 +157,7 @@ def get_asset_node_definition_collisions(
                 continue
             repos[external_asset_node.asset_key].append(
                 GrapheneRepository(
-                    instance=graphene_info.context.instance,
+                    workspace_context=graphene_info.context,
                     repository=repo,
                     repository_location=repo_loc,
                 )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1224,7 +1224,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     def resolve_repository(self, graphene_info: ResolveInfo) -> "GrapheneRepository":
         return external.GrapheneRepository(
-            graphene_info.context.instance, self._external_repository, self._repository_location
+            graphene_info.context, self._external_repository, self._repository_location
         )
 
     def resolve_required_resources(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -21,6 +21,7 @@ from dagster._core.host_representation.grpc_server_state_subscriber import (
     LocationStateSubscriber,
 )
 from dagster._core.workspace.context import (
+    BaseWorkspaceRequestContext,
     WorkspaceProcessContext,
 )
 from dagster._core.workspace.workspace import (
@@ -115,7 +116,7 @@ class GrapheneRepositoryLocation(graphene.ObjectType):
 
     def resolve_repositories(self, graphene_info: ResolveInfo):
         return [
-            GrapheneRepository(graphene_info.context.instance, repository, self._location)
+            GrapheneRepository(graphene_info.context, repository, self._location)
             for repository in self._location.get_repositories().values()
         ]
 
@@ -252,10 +253,11 @@ class GrapheneRepository(graphene.ObjectType):
 
     def __init__(
         self,
-        instance: DagsterInstance,
+        workspace_context: BaseWorkspaceRequestContext,
         repository: ExternalRepository,
         repository_location: CodeLocation,
     ):
+        instance = workspace_context.instance
         self._repository = check.inst_param(repository, "repository", ExternalRepository)
         self._repository_location = check.inst_param(
             repository_location, "repository_location", CodeLocation

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -904,7 +904,7 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
         handle = self._external_job.repository_handle
         location = graphene_info.context.get_code_location(handle.location_name)
         return GrapheneRepository(
-            graphene_info.context.instance,
+            graphene_info.context,
             location.get_repository(handle.repository_name),
             location,
         )


### PR DESCRIPTION
## Summary & Motivation

Sets us up so that we can initialize a `ParentAssetGraphDiffer` for each GrapheneRepository. To do that we'll need access to the workspace context, so update `GrapheneRepository` to take a workspace context rather than an instance. 

## How I Tested These Changes
