### PR TITLE
[graph diff] workspace context can get parent deployment workspace context

### DIFF
--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -308,6 +308,9 @@ class BaseWorkspaceRequestContext(IWorkspace):
         code_location = self.get_code_location(code_location_name)
         return code_location.get_external_notebook_data(notebook_path=notebook_path)
 
+    def get_parent_deployment_context(self) -> Optional["BaseWorkspaceRequestContext"]:
+        return None
+
 
 class WorkspaceRequestContext(BaseWorkspaceRequestContext):
     def __init__(


### PR DESCRIPTION
## Summary & Motivation

We need a way to get the parent workspace context from a branch deployment workspace context. This PR adds `get_parent_deployment_context`. For OSS, we always return `None` since there is no concept of a parent deployment 

internal PR https://github.com/dagster-io/internal/pull/8280 that implements `get_parent_deployment_context` for cloud

## How I Tested These Changes
