### PR TITLE
[graph diff] Add ParentAssetGraphDiffer to GQL

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -647,6 +647,7 @@ type AssetNode {
     limit: Int
   ): [ObservationEvent!]!
   backfillPolicy: BackfillPolicy
+  changedReasons: [ChangeReason!]!
   computeKind: String
   configField: ConfigTypeField
   dataVersion(partition: String): String
@@ -710,6 +711,12 @@ type BackfillPolicy {
 enum BackfillPolicyType {
   SINGLE_RUN
   MULTI_RUN
+}
+
+enum ChangeReason {
+  NEW
+  CODE_VERSION
+  INPUTS
 }
 
 type AssetDependency {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -410,6 +410,7 @@ export type AssetNode = {
   assetPartitionStatuses: AssetPartitionStatuses;
   autoMaterializePolicy: Maybe<AutoMaterializePolicy>;
   backfillPolicy: Maybe<BackfillPolicy>;
+  changedReasons: Array<ChangeReason>;
   computeKind: Maybe<Scalars['String']>;
   configField: Maybe<ConfigTypeField>;
   currentAutoMaterializeEvaluationId: Maybe<Scalars['Int']>;
@@ -726,6 +727,12 @@ export type CapturedLogsMetadata = {
   stdoutDownloadUrl: Maybe<Scalars['String']>;
   stdoutLocation: Maybe<Scalars['String']>;
 };
+
+export enum ChangeReason {
+  CODE_VERSION = 'CODE_VERSION',
+  INPUTS = 'INPUTS',
+  NEW = 'NEW',
+}
 
 export type ClaimedConcurrencySlot = {
   __typename: 'ClaimedConcurrencySlot';
@@ -6144,6 +6151,8 @@ export const buildAssetNode = (
         : relationshipsToOmit.has('BackfillPolicy')
         ? ({} as BackfillPolicy)
         : buildBackfillPolicy({}, relationshipsToOmit),
+    changedReasons:
+      overrides && overrides.hasOwnProperty('changedReasons') ? overrides.changedReasons! : [],
     computeKind:
       overrides && overrides.hasOwnProperty('computeKind') ? overrides.computeKind! : 'quasi',
     configField:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -212,7 +212,7 @@ def get_asset_nodes_by_asset_key(
         context=graphene_info.context,
         asset_keys=asset_nodes_by_asset_key.keys(),
     )
-    parent_deployment_context = graphene_info.context.get_parent_deployment_context()
+    base_deployment_context = graphene_info.context.get_base_deployment_context()
 
     return {
         external_asset_node.asset_key: GrapheneAssetNode(
@@ -223,14 +223,14 @@ def get_asset_nodes_by_asset_key(
             depended_by_loader=depended_by_loader,
             stale_status_loader=stale_status_loader,
             dynamic_partitions_loader=dynamic_partitions_loader,
-            # parent_deployment_context will be None if we are not in a branch deployment
+            # base_deployment_context will be None if we are not in a branch deployment
             asset_graph_differ=AssetGraphDiffer.from_external_repositories(
                 code_location_name=repo_loc.name,
                 repository_name=repo.name,
                 branch_workspace=graphene_info.context,
-                parent_workspace=parent_deployment_context,
+                base_workspace=base_deployment_context,
             )
-            if parent_deployment_context is not None
+            if base_deployment_context is not None
             else None,
         )
         for repo_loc, repo, external_asset_node in asset_nodes_by_asset_key.values()

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -23,6 +23,7 @@ from dagster import (
     MultiPartitionsDefinition,
     _check as check,
 )
+from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition import (
@@ -211,6 +212,7 @@ def get_asset_nodes_by_asset_key(
         context=graphene_info.context,
         asset_keys=asset_nodes_by_asset_key.keys(),
     )
+    parent_deployment_context = graphene_info.context.get_parent_deployment_context()
 
     return {
         external_asset_node.asset_key: GrapheneAssetNode(
@@ -221,6 +223,15 @@ def get_asset_nodes_by_asset_key(
             depended_by_loader=depended_by_loader,
             stale_status_loader=stale_status_loader,
             dynamic_partitions_loader=dynamic_partitions_loader,
+            # parent_deployment_context will be None if we are not in a branch deployment
+            asset_graph_differ=AssetGraphDiffer.from_external_repositories(
+                code_location_name=repo_loc.name,
+                repository_name=repo.name,
+                branch_workspace=graphene_info.context,
+                parent_workspace=parent_deployment_context,
+            )
+            if parent_deployment_context is not None
+            else None,
         )
         for repo_loc, repo, external_asset_node in asset_nodes_by_asset_key.values()
     }

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -5,6 +5,7 @@ from dagster import (
     AssetKey,
     _check as check,
 )
+from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer, ChangeReason
 from dagster._core.definitions.assets_job import ASSET_BASE_JOB_PREFIX
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.data_version import (
@@ -108,6 +109,8 @@ GrapheneAssetStaleStatus = graphene.Enum.from_enum(StaleStatus, name="StaleStatu
 GrapheneAssetStaleCauseCategory = graphene.Enum.from_enum(
     StaleCauseCategory, name="StaleCauseCategory"
 )
+
+GrapheneAssetChangedReason = graphene.Enum.from_enum(ChangeReason, name="ChangeReason")
 
 
 class GrapheneUserAssetOwner(graphene.ObjectType):
@@ -245,6 +248,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     _latest_materialization_loader: Optional[BatchMaterializationLoader]
     _stale_status_loader: Optional[StaleStatusLoader]
     _asset_checks_loader: AssetChecksLoader
+    _asset_graph_differ: Optional[AssetGraphDiffer]
 
     # NOTE: properties/resolvers are listed alphabetically
     assetKey = graphene.NonNull(GrapheneAssetKey)
@@ -265,6 +269,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         limit=graphene.Int(),
     )
     backfillPolicy = graphene.Field(GrapheneBackfillPolicy)
+    changedReasons = graphene.Field(non_null_list(GrapheneAssetChangedReason))
     computeKind = graphene.String()
     configField = graphene.Field(GrapheneConfigTypeField)
     dataVersion = graphene.Field(graphene.String(), partition=graphene.String())
@@ -349,6 +354,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         depended_by_loader: Optional[CrossRepoAssetDependedByLoader] = None,
         stale_status_loader: Optional[StaleStatusLoader] = None,
         dynamic_partitions_loader: Optional[CachingDynamicPartitionsLoader] = None,
+        asset_graph_differ: Optional[AssetGraphDiffer] = None,
     ):
         from ..implementation.fetch_assets import get_unique_asset_id
 
@@ -379,6 +385,9 @@ class GrapheneAssetNode(graphene.ObjectType):
         )
         self._asset_checks_loader = check.inst_param(
             asset_checks_loader, "asset_checks_loader", AssetChecksLoader
+        )
+        self._asset_graph_differ = check.opt_inst_param(
+            asset_graph_differ, "asset_graph_differ", AssetGraphDiffer
         )
         self._external_job = None  # lazily loaded
         self._node_definition_snap = None  # lazily loaded
@@ -419,6 +428,10 @@ class GrapheneAssetNode(graphene.ObjectType):
             "stale_status_loader must exist in order to access data versioning information",
         )
         return loader
+
+    @property
+    def asset_graph_differ(self) -> Optional[AssetGraphDiffer]:
+        return self._asset_graph_differ
 
     def get_external_job(self) -> ExternalJob:
         if self._external_job is None:
@@ -673,6 +686,14 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     def resolve_computeKind(self, _graphene_info: ResolveInfo) -> Optional[str]:
         return self._external_asset_node.compute_kind
+
+    def resolve_changedReasons(
+        self, graphene_info: ResolveInfo
+    ) -> Sequence[Any]:  # Sequence[GrapheneAssetChangedReason]
+        if self.asset_graph_differ is None:
+            # asset_graph_differ is None when not in a branch deployment
+            return []
+        return self.asset_graph_differ.get_changes_for_asset(self._external_asset_node.asset_key)
 
     def resolve_staleStatus(
         self, graphene_info: ResolveInfo, partition: Optional[str] = None

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -272,14 +272,14 @@ class GrapheneRepository(graphene.ObjectType):
         self._dynamic_partitions_loader = CachingDynamicPartitionsLoader(instance)
 
         self._asset_graph_differ = None
-        parent_deployment_context = workspace_context.get_parent_deployment_context()
-        if parent_deployment_context is not None:
+        base_deployment_context = workspace_context.get_base_deployment_context()
+        if base_deployment_context is not None:
             # then we are in a branch deployment
             self._asset_graph_differ = AssetGraphDiffer.from_external_repositories(
                 code_location_name=self._repository_location.name,
                 repository_name=self._repository.name,
                 branch_workspace=workspace_context,
-                parent_workspace=parent_deployment_context,
+                base_workspace=base_deployment_context,
             )
         super().__init__(name=repository.name)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -6,6 +6,7 @@ from dagster import (
     DagsterInstance,
     _check as check,
 )
+from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
 from dagster._core.host_representation import (
@@ -269,6 +270,17 @@ class GrapheneRepository(graphene.ObjectType):
             asset_graph=lambda: ExternalAssetGraph.from_external_repository(repository),
         )
         self._dynamic_partitions_loader = CachingDynamicPartitionsLoader(instance)
+
+        self._asset_graph_differ = None
+        parent_deployment_context = workspace_context.get_parent_deployment_context()
+        if parent_deployment_context is not None:
+            # then we are in a branch deployment
+            self._asset_graph_differ = AssetGraphDiffer.from_external_repositories(
+                code_location_name=self._repository_location.name,
+                repository_name=self._repository.name,
+                branch_workspace=workspace_context,
+                parent_workspace=parent_deployment_context,
+            )
         super().__init__(name=repository.name)
 
     def resolve_id(self, _graphene_info: ResolveInfo):
@@ -357,6 +369,7 @@ class GrapheneRepository(graphene.ObjectType):
                 asset_checks_loader=asset_checks_loader,
                 stale_status_loader=self._stale_status_loader,
                 dynamic_partitions_loader=self._dynamic_partitions_loader,
+                asset_graph_differ=self._asset_graph_differ,
             )
             for external_asset_node in self._repository.get_external_asset_nodes()
         ]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -953,7 +953,7 @@ class GrapheneQuery(graphene.ObjectType):
             asset_graph=load_asset_graph,
         )
 
-        parent_deployment_context = graphene_info.context.get_parent_deployment_context()
+        base_deployment_context = graphene_info.context.get_base_deployment_context()
 
         nodes = [
             GrapheneAssetNode(
@@ -965,14 +965,14 @@ class GrapheneQuery(graphene.ObjectType):
                 depended_by_loader=depended_by_loader,
                 stale_status_loader=stale_status_loader,
                 dynamic_partitions_loader=dynamic_partitions_loader,
-                # parent_deployment_context will be None if we are not in a branch deployment
+                # base_deployment_context will be None if we are not in a branch deployment
                 asset_graph_differ=AssetGraphDiffer.from_external_repositories(
                     code_location_name=node.repository_location.name,
                     repository_name=node.external_repository.name,
                     branch_workspace=graphene_info.context,
-                    parent_workspace=parent_deployment_context,
+                    base_workspace=base_deployment_context,
                 )
-                if parent_deployment_context is not None
+                if base_deployment_context is not None
                 else None,
             )
             for node in results

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, cast
 import dagster._check as check
 import graphene
 from dagster import AssetCheckKey
+from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
@@ -952,6 +953,8 @@ class GrapheneQuery(graphene.ObjectType):
             asset_graph=load_asset_graph,
         )
 
+        parent_deployment_context = graphene_info.context.get_parent_deployment_context()
+
         nodes = [
             GrapheneAssetNode(
                 node.repository_location,
@@ -962,6 +965,15 @@ class GrapheneQuery(graphene.ObjectType):
                 depended_by_loader=depended_by_loader,
                 stale_status_loader=stale_status_loader,
                 dynamic_partitions_loader=dynamic_partitions_loader,
+                # parent_deployment_context will be None if we are not in a branch deployment
+                asset_graph_differ=AssetGraphDiffer.from_external_repositories(
+                    code_location_name=node.repository_location.name,
+                    repository_name=node.external_repository.name,
+                    branch_workspace=graphene_info.context,
+                    parent_workspace=parent_deployment_context,
+                )
+                if parent_deployment_context is not None
+                else None,
             )
             for node in results
         ]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -437,7 +437,7 @@ class ISolidDefinitionMixin:
                 context=graphene_info.context, asset_keys=[node.asset_key for node in nodes]
             )
 
-            parent_deployment_context = graphene_info.context.get_parent_deployment_context()
+            base_deployment_context = graphene_info.context.get_base_deployment_context()
 
             return [
                 GrapheneAssetNode(
@@ -445,14 +445,14 @@ class ISolidDefinitionMixin:
                     ext_repo,
                     node,
                     asset_checks_loader=asset_checks_loader,
-                    # parent_deployment_context will be None if we are not in a branch deployment
+                    # base_deployment_context will be None if we are not in a branch deployment
                     asset_graph_differ=AssetGraphDiffer.from_external_repositories(
                         code_location_name=location.name,
                         repository_name=ext_repo.name,
                         branch_workspace=graphene_info.context,
-                        parent_workspace=parent_deployment_context,
+                        base_workspace=base_deployment_context,
                     )
-                    if parent_deployment_context is not None
+                    if base_deployment_context is not None
                     else None,
                 )
                 for node in nodes

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence, Union
 import dagster._check as check
 import graphene
 from dagster._core.definitions import NodeHandle
+from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.host_representation import RepresentedJob
 from dagster._core.host_representation.external import ExternalJob
 from dagster._core.host_representation.historical import HistoricalJob
@@ -435,8 +436,25 @@ class ISolidDefinitionMixin:
             asset_checks_loader = AssetChecksLoader(
                 context=graphene_info.context, asset_keys=[node.asset_key for node in nodes]
             )
+
+            parent_deployment_context = graphene_info.context.get_parent_deployment_context()
+
             return [
-                GrapheneAssetNode(location, ext_repo, node, asset_checks_loader=asset_checks_loader)
+                GrapheneAssetNode(
+                    location,
+                    ext_repo,
+                    node,
+                    asset_checks_loader=asset_checks_loader,
+                    # parent_deployment_context will be None if we are not in a branch deployment
+                    asset_graph_differ=AssetGraphDiffer.from_external_repositories(
+                        code_location_name=location.name,
+                        repository_name=ext_repo.name,
+                        branch_workspace=graphene_info.context,
+                        parent_workspace=parent_deployment_context,
+                    )
+                    if parent_deployment_context is not None
+                    else None,
+                )
                 for node in nodes
             ]
 


### PR DESCRIPTION
## Summary & Motivation
Instantiates a `ParentAssetGraphDiffer` for each repository, and pipes it through to each `GrapheneAssetNode` so each node can get their "changed status" and reasons. 

If the current deployment is not a branch deployment, `parent_deployment_context` will be `None` so `ParentAssetGraphDiffer` will return no changes for all assets. 

I think there's a pretty clear opportunity for some optimizations here, but i'm not quite sure how to do them. We init the `ParentAssetGraphDiffer` from the workspace contexts of both the branch deployment and parent deployment. I think we should just be able to do this once per deployment, not once per repository, I'm not sure what the right Graphene class to put this in is though

## How I Tested These Changes
