### PR TITLE
[embedded-elt] revert Decoupling connections from resource allocation (#18270)

### DIFF
--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -428,7 +428,7 @@ pyarrow-hotfix==0.6
 pyasn1==0.5.1
 pyasn1-modules==0.3.0
 pycparser==2.21
-pydantic==1.10.14
+pydantic==2.6.0
 pydata-google-auth==1.8.2
 pyflakes==3.2.0
 Pygments==2.17.2

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/__init__.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/__init__.py
@@ -1,5 +1,5 @@
 from dagster_embedded_elt.sling.asset_decorator import sling_assets
-from dagster_embedded_elt.sling.asset_defs import build_assets_from_sling_stream, build_sling_asset
+from dagster_embedded_elt.sling.asset_defs import build_sling_asset
 from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
 from dagster_embedded_elt.sling.resources import (
     SlingConnectionResource,
@@ -14,7 +14,6 @@ __all__ = [
     "SlingResource",
     "SlingMode",
     "build_sling_asset",
-    "build_assets_from_sling_stream",
     "SlingSourceConnection",
     "SlingTargetConnection",
     "SlingConnectionResource",

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/__init__.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/__init__.py
@@ -1,4 +1,6 @@
+from dagster_embedded_elt.sling.asset_decorator import sling_assets
 from dagster_embedded_elt.sling.asset_defs import build_assets_from_sling_stream, build_sling_asset
+from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
 from dagster_embedded_elt.sling.resources import (
     SlingConnectionResource,
     SlingMode,
@@ -6,6 +8,7 @@ from dagster_embedded_elt.sling.resources import (
     SlingSourceConnection,
     SlingTargetConnection,
 )
+from dagster_embedded_elt.sling.sling_replication import SlingReplicationParam
 
 __all__ = [
     "SlingResource",
@@ -15,4 +18,7 @@ __all__ = [
     "SlingSourceConnection",
     "SlingTargetConnection",
     "SlingConnectionResource",
+    "sling_assets",
+    "DagsterSlingTranslator",
+    "SlingReplicationParam",
 ]

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
@@ -9,6 +9,7 @@ from dagster import (
     multi_asset,
 )
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from sling.translator import DagsterSlingTranslator
 
 from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
 from dagster_embedded_elt.sling.sling_replication import SlingReplicationParam, validate_replication

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
@@ -1,0 +1,135 @@
+from typing import Any, Callable, Iterable, List, Mapping, Optional
+
+from dagster import (
+    AssetsDefinition,
+    AssetSpec,
+    BackfillPolicy,
+    FreshnessPolicy,
+    PartitionsDefinition,
+    multi_asset,
+)
+from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+
+from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
+from dagster_embedded_elt.sling.sling_replication import SlingReplicationParam, validate_replication
+
+
+def get_streams_from_replication(replication_config: Mapping[str, Any]) -> Iterable[str]:
+    """Returns a list of streams from a Sling replication config.
+
+    If an `asset_key` is provided, it will be used instead. For example, below the stream name
+    will be read as `public.foo_users`
+
+
+    .. code-block:: yaml
+
+        streams:
+          public.users:
+            meta:
+              dagster:
+                asset_key: public.foo_users
+
+    Args:
+        replication_config: Mapping[str, Any]: A dictionary of a Sling replication config.
+    """
+    keys = []
+
+    for key, value in replication_config["streams"].items():
+        if isinstance(value, dict):
+            asset_key_config = value.get("meta", {}).get("dagster", {}).get("asset_key", [])
+            keys.append(asset_key_config if asset_key_config else key)
+        else:
+            keys.append(key)
+    return keys
+
+
+def sling_assets(
+    *,
+    replication_config: SlingReplicationParam,
+    dagster_sling_translator: DagsterSlingTranslator = DagsterSlingTranslator(),
+    partitions_def: Optional[PartitionsDefinition] = None,
+    backfill_policy: Optional[BackfillPolicy] = None,
+    op_tags: Optional[Mapping[str, Any]] = None,
+    group_name: Optional[str] = None,
+    code_version: Optional[str] = None,
+    freshness_policy: Optional[FreshnessPolicy] = None,
+    auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
+) -> Callable[..., AssetsDefinition]:
+    """Create a definition for how to materialize a Sling replication stream as a Dagster Asset, as
+    described by a Sling replication config. This will create on Asset for every Sling target stream.
+
+    A Sling Replication config is a configuration that maps sources to destinations. For the full
+    spec and descriptions, see `Sling's Documentation <https://docs.slingdata.io/sling-cli/run/configuration>`_.
+
+    Args:
+        replication_config: SlingReplicationParam: A path to a Sling replication config, or a dictionary of a replication config.
+        dagster_sling_translator: DagsterSlingTranslator: Allows customization of how to map a Sling stream to a Dagster AssetKey.
+        partitions_def: Optional[PartitionsDefinition]: The partitions definition for this asset.
+        backfill_policy: Optional[BackfillPolicy]: The backfill policy for this asset.
+        op_tags: Optional[Mapping[str, Any]]: The tags for this asset.
+        group_name: Optional[str]: The group name for this asset.
+        code_version: Optional[str]: The code version for this asset.
+        freshness_policy: Optional[FreshnessPolicy]: The freshness policy for this asset.
+        auto_materialize_policy: Optional[AutoMaterializePolicy]: The auto materialize policy for this asset.
+
+    Examples:
+        Running a sync by providing a path to a Sling Replication config:
+
+        .. code-block:: python
+
+            from dagster_embedded_elt.sling import sling_assets, SlingResource, SlingConnectionResource
+
+            sling_resource = SlingResource(
+                connections=[
+                    SlingConnectionResource(
+                        name="MY_POSTGRES", type="postgres", connection_string=EnvVar("POSTGRES_URL")
+                    ),
+                    SlingConnectionResource(
+                        name="MY_DUCKDB",
+                        type="duckdb",
+                        connection_string="duckdb:///var/tmp/duckdb.db",
+                    ),
+                ]
+            )
+
+            config_path = "/path/to/replication.yaml"
+            @sling_assets(replication_config=config_path)
+            def my_assets(context, sling: SlingResource):
+                for lines in sling.replicate(
+                    replication_config=config_path,
+                    dagster_sling_translator=DagsterSlingTranslator(),
+                ):
+                    context.log.info(lines)
+
+        Running a sync using a custom translator:
+    """
+    replication_config = validate_replication(replication_config)
+    streams = get_streams_from_replication(replication_config)
+
+    specs: List[AssetSpec] = []
+    for stream in streams:
+        specs.append(
+            AssetSpec(
+                key=dagster_sling_translator.get_asset_key(stream),
+                deps=dagster_sling_translator.get_deps_asset_key(stream),
+                group_name=group_name,
+                code_version=code_version,
+                freshness_policy=freshness_policy,
+                auto_materialize_policy=auto_materialize_policy,
+            )
+        )
+
+    def inner(fn) -> AssetsDefinition:
+        asset_definition = multi_asset(
+            name="sling_asset_definition",
+            compute_kind="sling",
+            partitions_def=partitions_def,
+            can_subset=False,
+            op_tags=op_tags,
+            backfill_policy=backfill_policy,
+            specs=specs,
+        )(fn)
+
+        return asset_definition
+
+    return inner

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_defs.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_defs.py
@@ -10,12 +10,7 @@ from dagster import (
 )
 from dagster._annotations import experimental
 
-from dagster_embedded_elt.sling.resources import (
-    SlingConnectionResource,
-    SlingMode,
-    SlingResource,
-    SlingStreamReplicator,
-)
+from dagster_embedded_elt.sling.resources import SlingMode, SlingResource
 
 
 @experimental
@@ -104,103 +99,3 @@ def build_sling_asset(
         )
 
     return sync
-
-
-@experimental
-def build_assets_from_sling_stream(
-    source: SlingConnectionResource,
-    target: SlingConnectionResource,
-    stream: str,
-    target_object: str = "{{target_schema}}.{{stream_schema}}_{{stream_table}}",
-    mode: SlingMode = SlingMode.FULL_REFRESH,
-    primary_key: Optional[Union[str, List[str]]] = None,
-    update_key: Optional[str] = None,
-    source_options: Optional[Dict[str, Any]] = None,
-    target_options: Optional[Dict[str, Any]] = None,
-) -> AssetsDefinition:
-    """Asset Factory for using Sling to sync data from a source stream to a target object.
-
-    Args:
-        source (SlingConnectionResource): The source SlingConnectionResource to use.
-        target (SlingConnectionResource): The target SlingConnectionResource to use.
-        stream (str): The source stream to sync from. This can be a table, a query, or a path.
-        target_object (str, optional): The target object to sync to. This can be a table, or a path. Defaults to the template of "{{target_schema}}.{{stream_schema}}_{{stream_table}}". See the Sling documentation for more information. https://docs.slingdata.io/sling-cli/replication
-        mode (SlingMode, optional): The sync mode to use when syncing. Defaults to `full-refresh`.
-        primary_key (Optional[Union[str, List[str]]], optional): The optional primary key to use when syncing.
-        update_key (Optional[str], optional): The optional update key to use when syncing.
-        source_options (Optional[Dict[str, Any]], optional): Any optional Sling source options to use when syncing.
-        target_options (Optional[Dict[str, Any]], optional): Any optional target options to use when syncing.
-
-    Examples:
-        Creating a Sling asset that syncs from a database to a data warehouse:
-
-        .. code-block:: python
-
-            source = SlingConnectionResource(
-                type="postgres",
-                host=EnvVar("POSTGRES_HOST"),
-                port=EnvVar("POSTGRES_PORT"),
-                user=EnvVar("POSTGRES_USER"),
-                password=EnvVar("POSTGRES_PASSWORD"),
-                database=EnvVar("POSTGRES_DATABASE"),
-            )
-
-            target = SlingConnectionResource(
-                type="snowflake",
-                account=EnvVar("SNOWFLAKE_ACCOUNT"),
-                user=EnvVar("SNOWFLAKE_USER"),
-                password=EnvVar("SNOWFLAKE_PASSWORD"),
-                database=EnvVar("SNOWFLAKE_DATABASE"),
-                warehouse=EnvVar("SNOWFLAKE_WAREHOUSE"),
-            )
-
-            asset_def = build_assets_from_sling_stream(
-                    source=source,
-                    target=target,
-                    stream="main.orders",
-                    target_object="main.orders",
-                    mode=SlingMode.INCREMENTAL,
-                    primary_key="id"
-            )
-    """
-    if primary_key is not None and not isinstance(primary_key, list):
-        primary_key = [primary_key]
-
-    sling_replicator = SlingStreamReplicator(
-        source_connection=source,
-        target_connection=target,
-    )
-
-    # sanitize the stream name to a valid asset name, matching the regex A-Za-z0-9_
-    asset_name = stream.replace(".", "_")
-
-    if asset_name.startswith("file://"):
-        asset_name = asset_name.split("/")[-1]
-
-    specs = [AssetSpec(asset_name)]
-
-    @multi_asset(name=f"sling_sync__{asset_name}", compute_kind="sling", specs=specs)
-    def _sling_assets(context: AssetExecutionContext) -> MaterializeResult:
-        last_row_count_observed = None
-
-        for stdout_line in sling_replicator.sync(
-            source_stream=stream,
-            target_object=target_object,
-            mode=mode,
-            primary_key=primary_key,
-            update_key=update_key,
-            source_options=source_options,
-            target_options=target_options,
-        ):
-            match = re.search(r"(\d+) rows", stdout_line)
-            if match:
-                last_row_count_observed = int(match.group(1))
-            context.log.info(stdout_line)
-
-        return MaterializeResult(
-            metadata=(
-                {} if last_row_count_observed is None else {"row_count": last_row_count_observed}
-            )
-        )
-
-    return _sling_assets

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any, Mapping
 
 from dagster import AssetKey
 from dagster._annotations import public
@@ -31,11 +32,18 @@ class DagsterSlingTranslator:
 
     @public
     @classmethod
-    def get_asset_key(cls, stream_name: str, target_prefix: str = "target") -> AssetKey:
-        """A function that takes a stream name from a Sling replication config and returns a
+    def get_asset_key(
+        cls, stream_definition: Mapping[str, Any], target_prefix: str = "target"
+    ) -> AssetKey:
+        """A function that takes a stream definition from a Sling replication config and returns a
         Dagster AssetKey.
 
-        By default, this returns concatenates `target_` with the stream name. For example, a stream
+        The stream definition is a dictionary key/value pair where the key is the stream name and
+        the value is a dictionary representing the stream definition. For example:
+
+        stream_definition = {"public.users": {'sql': 'select all_user_id, name from public."all_Users"', 'object': 'public.all_users'}}
+
+        By default, this returns the target_prefix concatenated with the stream name. For example, a stream
         named "public.accounts" will create an AssetKey named "target_public_accounts".
 
         Override this function to customize how to map a Sling stream to a Dagster AssetKey.
@@ -51,8 +59,8 @@ class DagsterSlingTranslator:
                    asset_key: "mydb_users"
 
         Args:
-            stream_name (str): The name of the stream.
-            target_prefix (str): The prefix for the target stream.
+            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition
+            target_prefix (str): The prefix to use when creating the AssetKey
 
         Returns:
             AssetKey: The Dagster AssetKey for the replication stream.
@@ -60,20 +68,29 @@ class DagsterSlingTranslator:
         Examples:
             Using a custom mapping for streams:
 
-            .. code-block:: python
-
-                class CustomSlingTranslator(DagsterSlingTranslator):
-                    @classmethod
-                    def get_asset_key(cls, stream_name: str) -> AssetKey:
-                        map = {"stream1": "asset1", "stream2": "asset2"}
-                        return AssetKey(map[stream_name])
+            class CustomSlingTranslator(DagsterSlingTranslator):
+                @classmethod
+                def get_asset_key_for_target(cls, stream_definition) -> AssetKey:
+                    map = {"stream1": "asset1", "stream2": "asset2"}
+                    return AssetKey(map[stream_name])
         """
+        meta = stream_definition.get("meta", {}).get("dagster", {})
+        asset_key = meta.get("asset_key")
+        if asset_key and cls.sanitize_stream_name(asset_key) != asset_key:
+            raise ValueError(
+                f"Asset key {asset_key} for stream {stream_definition['name']} is not "
+                "sanitized. Please use only alphanumeric characters and underscores."
+            )
+        elif asset_key:
+            return AssetKey(asset_key)
+
+        stream_name = next(iter(stream_definition.keys()))
         components = cls.sanitize_stream_name(stream_name).split(".")
         return AssetKey([target_prefix] + components)
 
     @public
     @classmethod
-    def get_deps_asset_key(cls, stream_name: str) -> AssetKey:
+    def get_deps_asset_key(cls, stream_definition: Mapping[str, Any]) -> AssetKey:
         """A function that takes a stream name from a Sling replication config and returns a
         Dagster AssetKey for the dependencies of the replication stream.
 
@@ -107,5 +124,16 @@ class DagsterSlingTranslator:
 
 
         """
+        meta = stream_definition.get("meta", {}).get("dagster", {})
+        asset_key = meta.get("deps")
+        if asset_key and cls.sanitize_stream_name(asset_key) != asset_key:
+            raise ValueError(
+                f"Asset key {asset_key} for stream {stream_definition['name']} is not "
+                "sanitized. Please use only alphanumeric characters and underscores."
+            )
+        elif asset_key:
+            return AssetKey(asset_key)
+
+        stream_name = next(iter(stream_definition.keys()))
         components = cls.sanitize_stream_name(stream_name).split(".")
         return AssetKey(components)

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
@@ -1,11 +1,24 @@
 import re
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping, Optional
 
-from dagster import AssetKey
+from dagster import (
+    AssetKey,
+    AutoMaterializePolicy,
+    FreshnessPolicy,
+    MetadataValue,
+)
 from dagster._annotations import public
 
 
 class DagsterSlingTranslator:
+    def __init__(self, target_prefix="target"):
+        """A class that allows customization of how to map a Sling stream to a Dagster AssetKey.
+
+        Args:
+            target_prefix (str): The prefix to use when creating the AssetKey
+        """
+        self.target_prefix = target_prefix
+
     @public
     @classmethod
     def sanitize_stream_name(cls, stream_name: str) -> str:
@@ -31,10 +44,7 @@ class DagsterSlingTranslator:
         return re.sub(r"[^a-zA-Z0-9_.]", "_", stream_name.replace('"', ""))
 
     @public
-    @classmethod
-    def get_asset_key(
-        cls, stream_definition: Mapping[str, Any], target_prefix: str = "target"
-    ) -> AssetKey:
+    def get_asset_key(self, stream_definition: Mapping[str, Any]) -> AssetKey:
         """A function that takes a stream definition from a Sling replication config and returns a
         Dagster AssetKey.
 
@@ -43,7 +53,7 @@ class DagsterSlingTranslator:
 
         stream_definition = {"public.users": {'sql': 'select all_user_id, name from public."all_Users"', 'object': 'public.all_users'}}
 
-        By default, this returns the target_prefix concatenated with the stream name. For example, a stream
+        By default, this returns the class's target_prefix paramater concatenated with the stream name. For example, a stream
         named "public.accounts" will create an AssetKey named "target_public_accounts".
 
         Override this function to customize how to map a Sling stream to a Dagster AssetKey.
@@ -60,7 +70,6 @@ class DagsterSlingTranslator:
 
         Args:
             stream_definition (Mapping[str, Any]): A dictionary representing the stream definition
-            target_prefix (str): The prefix to use when creating the AssetKey
 
         Returns:
             AssetKey: The Dagster AssetKey for the replication stream.
@@ -74,23 +83,25 @@ class DagsterSlingTranslator:
                     map = {"stream1": "asset1", "stream2": "asset2"}
                     return AssetKey(map[stream_name])
         """
-        meta = stream_definition.get("meta", {}).get("dagster", {})
-        asset_key = meta.get("asset_key")
-        if asset_key and cls.sanitize_stream_name(asset_key) != asset_key:
-            raise ValueError(
-                f"Asset key {asset_key} for stream {stream_definition['name']} is not "
-                "sanitized. Please use only alphanumeric characters and underscores."
-            )
-        elif asset_key:
-            return AssetKey(asset_key)
+        config = stream_definition.get("config", {}) or {}
+        meta = config.get("meta", {})
+        asset_key = meta.get("dagster", {}).get("asset_key")
 
-        stream_name = next(iter(stream_definition.keys()))
-        components = cls.sanitize_stream_name(stream_name).split(".")
-        return AssetKey([target_prefix] + components)
+        if asset_key:
+            if self.sanitize_stream_name(asset_key) != asset_key:
+                raise ValueError(
+                    f"Asset key {asset_key} for stream {stream_definition['name']} is not "
+                    "sanitized. Please use only alphanumeric characters and underscores."
+                )
+            return AssetKey(asset_key.split("."))
+
+        stream_name = stream_definition["name"]
+        sanitized_components = self.sanitize_stream_name(stream_name).split(".")
+        return AssetKey([self.target_prefix] + sanitized_components)
 
     @public
     @classmethod
-    def get_deps_asset_key(cls, stream_definition: Mapping[str, Any]) -> AssetKey:
+    def get_deps_asset_key(cls, stream_definition: Mapping[str, Any]) -> Iterable[AssetKey]:
         """A function that takes a stream name from a Sling replication config and returns a
         Dagster AssetKey for the dependencies of the replication stream.
 
@@ -124,16 +135,71 @@ class DagsterSlingTranslator:
 
 
         """
-        meta = stream_definition.get("meta", {}).get("dagster", {})
-        asset_key = meta.get("deps")
-        if asset_key and cls.sanitize_stream_name(asset_key) != asset_key:
-            raise ValueError(
-                f"Asset key {asset_key} for stream {stream_definition['name']} is not "
-                "sanitized. Please use only alphanumeric characters and underscores."
-            )
-        elif asset_key:
-            return AssetKey(asset_key)
+        config = stream_definition.get("config", {}) or {}
+        meta = config.get("meta", {})
+        deps = meta.get("dagster", {}).get("deps")
+        deps_out = []
+        if deps and isinstance(deps, str):
+            deps = [deps]
+        if deps:
+            assert isinstance(deps, list)
+            for asset_key in deps:
+                if cls.sanitize_stream_name(asset_key) != asset_key:
+                    raise ValueError(
+                        f"Deps Asset key {asset_key} for stream {stream_definition['name']} is not "
+                        "sanitized. Please use only alphanumeric characters and underscores."
+                    )
+                deps_out.append(AssetKey(asset_key.split(".")))
+            return deps_out
 
-        stream_name = next(iter(stream_definition.keys()))
+        stream_name = stream_definition["name"]
         components = cls.sanitize_stream_name(stream_name).split(".")
-        return AssetKey(components)
+        return [AssetKey(components)]
+
+    @classmethod
+    @public
+    def get_description(cls, stream_definition: Mapping[str, Any]) -> Optional[str]:
+        config = stream_definition.get("config", {}) or {}
+        if "sql" in config:
+            return config["sql"]
+        meta = config.get("meta", {})
+        description = meta.get("dagster", {}).get("description")
+        return description
+
+    @classmethod
+    @public
+    def get_metadata(cls, stream_definition: Mapping[str, Any]) -> Mapping[str, Any]:
+        return {"stream_config": MetadataValue.json(stream_definition.get("config", {}))}
+
+    @classmethod
+    @public
+    def get_group_name(cls, stream_definition: Mapping[str, Any]) -> Optional[str]:
+        config = stream_definition.get("config", {}) or {}
+        meta = config.get("meta", {})
+        return meta.get("dagster", {}).get("group")
+
+    @classmethod
+    @public
+    def get_freshness_policy(
+        cls, stream_definition: Mapping[str, Any]
+    ) -> Optional[FreshnessPolicy]:
+        config = stream_definition.get("config", {}) or {}
+        meta = config.get("meta", {})
+        freshness_policy_config = meta.get("dagster", {}).get("freshness_policy")
+        if freshness_policy_config:
+            return FreshnessPolicy(
+                maximum_lag_minutes=float(freshness_policy_config["maximum_lag_minutes"]),
+                cron_schedule=freshness_policy_config.get("cron_schedule"),
+                cron_schedule_timezone=freshness_policy_config.get("cron_schedule_timezone"),
+            )
+
+    @classmethod
+    @public
+    def get_auto_materialize_policy(
+        cls, stream_definition: Mapping[str, Any]
+    ) -> Optional[AutoMaterializePolicy]:
+        config = stream_definition.get("config", {}) or {}
+        meta = config.get("meta", {})
+        auto_materialize_policy_config = "auto_materialize_policy" in meta.get("dagster", {})
+        if auto_materialize_policy_config:
+            return AutoMaterializePolicy.eager()

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
@@ -1,0 +1,111 @@
+import re
+
+from dagster import AssetKey
+from dagster._annotations import public
+
+
+class DagsterSlingTranslator:
+    @public
+    @classmethod
+    def sanitize_stream_name(cls, stream_name: str) -> str:
+        """A function that takes a stream name from a Sling replication config and returns a
+        sanitized name for the stream.
+
+        By default, this removes any non-alphanumeric characters from the stream name and replaces
+        them with underscores, while removing any double quotes.
+
+        Args:
+            stream_name (str): The name of the stream.
+
+        Examples:
+            Using a custom stream name sanitizer:
+
+            .. code-block:: python
+
+                class CustomSlingTranslator(DagsterSlingTranslator):
+                    @classmethod
+                    def sanitize_stream_name(cls, stream_name: str) -> str:
+                        return stream_name.replace(".", "")
+        """
+        return re.sub(r"[^a-zA-Z0-9_.]", "_", stream_name.replace('"', ""))
+
+    @public
+    @classmethod
+    def get_asset_key(cls, stream_name: str, target_prefix: str = "target") -> AssetKey:
+        """A function that takes a stream name from a Sling replication config and returns a
+        Dagster AssetKey.
+
+        By default, this returns concatenates `target_` with the stream name. For example, a stream
+        named "public.accounts" will create an AssetKey named "target_public_accounts".
+
+        Override this function to customize how to map a Sling stream to a Dagster AssetKey.
+
+        Alternatively, you can provide metadata in your Sling replication config to specify the
+        Dagster AssetKey for a stream as follows:
+
+        .. code-block:: yaml
+
+            public.users:
+               meta:
+                 dagster:
+                   asset_key: "mydb_users"
+
+        Args:
+            stream_name (str): The name of the stream.
+            target_prefix (str): The prefix for the target stream.
+
+        Returns:
+            AssetKey: The Dagster AssetKey for the replication stream.
+
+        Examples:
+            Using a custom mapping for streams:
+
+            .. code-block:: python
+
+                class CustomSlingTranslator(DagsterSlingTranslator):
+                    @classmethod
+                    def get_asset_key(cls, stream_name: str) -> AssetKey:
+                        map = {"stream1": "asset1", "stream2": "asset2"}
+                        return AssetKey(map[stream_name])
+        """
+        components = cls.sanitize_stream_name(stream_name).split(".")
+        return AssetKey([target_prefix] + components)
+
+    @public
+    @classmethod
+    def get_deps_asset_key(cls, stream_name: str) -> AssetKey:
+        """A function that takes a stream name from a Sling replication config and returns a
+        Dagster AssetKey for the dependencies of the replication stream.
+
+        By default, this returns the stream name. For example, a stream
+        named "public.accounts" will create an AssetKey named "target_public_accounts" and a
+        dependency named "public_accounts".
+
+        Override this function to customize how to map a Sling stream to a Dagster depenency.
+        Alternatively, you can provide metadata in your Sling replication config to specify the
+        Dagster AssetKey for a stream as follows:
+
+        public.users:
+           meta:
+             dagster:
+               deps: "sourcedb_users"
+
+        Args:
+            stream_name (str): The name of the stream.
+
+        Returns:
+            AssetKey: The Dagster AssetKey dependency for the replication stream.
+
+        Examples:
+            Using a custom mapping for streams:
+
+            class CustomSlingTranslator(DagsterSlingTranslator):
+                @classmethod
+                def get_deps_asset_key(cls, stream_name: str) -> AssetKey:
+                    map = {"stream1": "asset1", "stream2": "asset2"}
+                    return AssetKey(map[stream_name])
+
+
+        """
+        components = cls.sanitize_stream_name(stream_name).split(".")
+        return AssetKey(components)

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -8,7 +8,6 @@ from typing import IO, Any, AnyStr, Dict, Generator, Iterator, List, Optional
 
 from dagster import (
     ConfigurableResource,
-    MaterializeResult,
     PermissiveConfig,
     get_dagster_logger,
 )
@@ -17,8 +16,6 @@ from dagster._config.field_utils import EnvVar
 from dagster._utils.env import environ
 from pydantic import ConfigDict, Extra, Field
 from sling import Sling
-
-from dagster_embedded_elt.sling.asset_decorator import DagsterSlingTranslator
 
 logger = get_dagster_logger()
 
@@ -131,7 +128,6 @@ class _SlingSyncBase:
     def replicate(
         self,
         *,
-        dagster_sling_translator: DagsterSlingTranslator,
         source_stream: str,
         target_object: str,
         mode: SlingMode,
@@ -153,9 +149,6 @@ class _SlingSyncBase:
             logger.info(line)
             logs += line
             # TODO: capture actual metadata here
-
-        output_name = dagster_sling_translator.get_asset_key(target_object)
-        yield MaterializeResult(asset_key=output_name, metadata={"logs": logs})
 
     def sync(
         self,

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -1,31 +1,52 @@
 import contextlib
 import json
-import os
 import re
-import tempfile
-import uuid
 from enum import Enum
 from subprocess import PIPE, STDOUT, Popen
 from typing import IO, Any, AnyStr, Dict, Generator, Iterator, List, Optional
 
-import sling
-from dagster import (
-    ConfigurableResource,
-    MaterializeResult,
-    PermissiveConfig,
-    get_dagster_logger,
-)
+from dagster import ConfigurableResource, PermissiveConfig, get_dagster_logger
+from dagster._annotations import experimental
+from dagster._config.field_utils import EnvVar
+from enum import Enum
+from subprocess import PIPE, STDOUT, Popen
+from typing import IO, Any, AnyStr, Dict, Generator, Iterator, List, Optional
+
+from dagster import ConfigurableResource, PermissiveConfig, get_dagster_logger
 from dagster._annotations import experimental
 from dagster._config.field_utils import EnvVar
 from dagster._utils.env import environ
-from pydantic import ConfigDict, Field
+from pydantic import Field
+from sling import Sling
 
-from dagster_embedded_elt.sling.asset_decorator import get_streams_from_replication
-from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
-from dagster_embedded_elt.sling.sling_replication import (
-    SlingReplicationParam,
-    validate_replication,
-)
+logger = get_dagster_logger()
+
+
+class SlingMode(str, Enum):
+    """The mode to use when syncing.
+
+    See the Sling docs for more information: https://docs.slingdata.io/sling-cli/running-tasks#modes.
+    """
+
+from dagster._annotations import experimental
+from dagster._config.field_utils import EnvVar
+from dagster._utils.env import environ
+from pydantic import Field
+from sling import Sling
+
+logger = get_dagster_logger()
+
+
+class SlingMode(str, Enum):
+    """The mode to use when syncing.
+
+    See the Sling docs for more information: https://docs.slingdata.io/sling-cli/running-tasks#modes.
+    """
+
+    INCREMENTAL = "incremental"
+    TRUNCATE = "truncate"
+    FULL_REFRESH = "full-refresh"
+    SNAPSHOT = "snapshot"
 
 logger = get_dagster_logger()
 
@@ -111,96 +132,86 @@ class SlingTargetConnection(PermissiveConfig):
     )
 
 
-class SlingConnectionResource(PermissiveConfig):
-    """A representation a connection to a database or file to be used by Sling. This resource can be used as a source or a target for a Sling sync.
-
-    Each resource must have a name which corresponds to the name of the resource in the sling replication.yaml file, and a type which defines
-    the type of connection used, e.g. file, postgres, snowflake.
+@experimental
+class SlingResource(ConfigurableResource):
+    """Resource for interacting with the Sling package.
 
     Examples:
-        Creating a Sling Connection using a connection string:
-
         .. code-block:: python
 
-            source = SlingConnectionResource(name="MY_POSTGRES", type="postgres", connection_string=EnvVar("POSTGRES_CONNECTION_STRING"))
-            source = SlingConnectionResource(name="MY_MYSQL", type="mysql", connection_string="mysql://user:password@host:port/schema")
+            from dagster_etl.sling import SlingResource
+            sling_resource = SlingResource(
+                source_connection=SlingSourceConnection(
+                    type="postgres", connection_string=EnvVar("POSTGRES_CONNECTION_STRING")
+                ),
+                target_connection=SlingTargetConnection(
+                    type="snowflake",
+                    host="host",
+                    user="user",
+                    database="database",
+                    password="password",
+                    role="role",
+                ),
+            )
 
-        Create a Sling Connection for a Postgres or Snowflake database, using keyword arguments, as described here:
-        https://docs.slingdata.io/connections/database-connections/postgres
-
-        .. code-block:: python
-
-            source = SlingConnectionResource(name="MY_POSTGRES", type="postgres", host="host", user="hunter42", password=EnvVar("POSTGRES_PASSWORD"))
-            source = SlingConnectionResource(name="MY_SNOWFLAKE", type="snowflake", host=EnvVar("SNOWFLAKE_HOST"), user=EnvVar("SNOWFLAKE_USER"), database=EnvVar("SNOWFLAKE_DATABASE"), password=EnvVar("SNOWFLAKE_PASSWORD"), role=EnvVar("SNOWFLAKE_ROLE"))
     """
 
-    model_config = ConfigDict(extra="allow")
-    name: str = Field(description="The name of the connection.")
-    type: str = Field(description="Type of the source connection. Use 'file' for local storage.")
-    connection_string: Optional[str] = Field(
-        description="The connection string for the source database.",
-        default=None,
-    )
+    source_connection: SlingSourceConnection
+    target_connection: SlingTargetConnection
 
+    @contextlib.contextmanager
+    def _setup_config(self) -> Generator[None, None, None]:
+        """Uses environment variables to set the Sling source and target connections."""
+        sling_source = _process_env_vars(dict(self.source_connection))
+        sling_target = _process_env_vars(dict(self.target_connection))
 
 @experimental
 class SlingResource(ConfigurableResource):
     """Resource for interacting with the Sling package.
 
     Examples:
-            .. code-block:: python
+        .. code-block:: python
 
-                from dagster_etl.sling import SlingResource
-                sling_resource = SlingResource(
-                    source_connection=SlingSourceConnection(
-                        type="postgres", connection_string=EnvVar("POSTGRES_CONNECTION_STRING")
-                    ),
-                    target_connection=SlingTargetConnection(
-                        type="snowflake",
-                        host="host",
-                        user="user",
-                        database="database",
-                        password="password",
-                        role="role",
-                    ),
-                )
+            from dagster_etl.sling import SlingResource
+            sling_resource = SlingResource(
+                source_connection=SlingSourceConnection(
+                    type="postgres", connection_string=EnvVar("POSTGRES_CONNECTION_STRING")
+                ),
+                target_connection=SlingTargetConnection(
+                    type="snowflake",
+                    host="host",
+                    user="user",
+                    database="database",
+                    password="password",
+                    role="role",
+                ),
+            )
 
     """
 
-    source_connection: Optional[SlingSourceConnection] = None
-    target_connection: Optional[SlingTargetConnection] = None
-    connections: List[SlingConnectionResource] = []
+    source_connection: SlingSourceConnection
+    target_connection: SlingTargetConnection
 
     @contextlib.contextmanager
     def _setup_config(self) -> Generator[None, None, None]:
         """Uses environment variables to set the Sling source and target connections."""
-        sling_source = None
-        sling_target = None
-        if self.source_connection:
-            sling_source = _process_env_vars(dict(self.source_connection))
-            if self.source_connection.connection_string:
-                sling_source["url"] = self.source_connection.connection_string
-        if self.target_connection:
-            sling_target = _process_env_vars(dict(self.target_connection))
-            if self.target_connection.connection_string:
-                sling_target["url"] = self.target_connection.connection_string
+        sling_source = _process_env_vars(dict(self.source_connection))
+        sling_target = _process_env_vars(dict(self.target_connection))
 
-        sling_connections: dict[str, Dict[str, Any]] = {
-            conn.name: {
-                "url" if k == "connection_string" else k: v
-                for k, v in _process_env_vars(dict(conn)).items()
-            }
-            for conn in self.connections
-        }
+        if self.source_connection.connection_string:
+            sling_source["url"] = self.source_connection.connection_string
+        if self.target_connection.connection_string:
+            sling_target["url"] = self.target_connection.connection_string
+        with environ(
 
+        if self.source_connection.connection_string:
+            sling_source["url"] = self.source_connection.connection_string
+        if self.target_connection.connection_string:
+            sling_target["url"] = self.target_connection.connection_string
         with environ(
             {
                 "SLING_SOURCE": json.dumps(sling_source),
                 "SLING_TARGET": json.dumps(sling_target),
-                **{
-                    f"{conn.name}": json.dumps(sling_connections[conn.name])
-                    for conn in self.connections
-                },
             }
         ):
             yield
@@ -240,18 +251,10 @@ class SlingResource(ConfigurableResource):
         """Runs a Sling sync from the given source table to the given destination table. Generates
         output lines from the Sling CLI.
         """
-        if (
-            self.source_connection
-            and self.source_connection.type == "file"
-            and not source_stream.startswith("file://")
-        ):
+        if self.source_connection.type == "file" and not source_stream.startswith("file://"):
             source_stream = "file://" + source_stream
 
-        if (
-            self.target_connection
-            and self.target_connection.type == "file"
-            and not target_object.startswith("file://")
-        ):
+        if self.target_connection.type == "file" and not target_object.startswith("file://"):
             target_object = "file://" + target_object
 
         with self._setup_config():
@@ -273,73 +276,50 @@ class SlingResource(ConfigurableResource):
             config["source"] = {k: v for k, v in config["source"].items() if v is not None}
             config["target"] = {k: v for k, v in config["target"].items() if v is not None}
 
-            sling_cli = sling.Sling(**config)
+            sling_cli = Sling(**config)
             logger.info("Starting Sling sync with mode: %s", mode)
             cmd = sling_cli._prep_cmd()  # noqa: SLF001
 
             yield from self._exec_sling_cmd(cmd, encoding=encoding)
 
-    def replicate(
-        self,
-        *,
-        replication_config: SlingReplicationParam,
-        dagster_sling_translator: DagsterSlingTranslator,
-        debug: bool = False,
-    ):
-        replication_config = validate_replication(replication_config)
-        stream_definition = get_streams_from_replication(replication_config)
+
+def _process_env_vars(config: Dict[str, Any]) -> Dict[str, Any]:
+    out = {}
+    for key, value in config.items():
+        if isinstance(value, dict) and len(value) == 1 and next(iter(value.keys())) == "env":
+            out[key] = EnvVar(next(iter(value.values()))).get_value()
+        else:
+            out[key] = value
+    return out
+            source_stream = "file://" + source_stream
+
+        if self.target_connection.type == "file" and not target_object.startswith("file://"):
+            target_object = "file://" + target_object
 
         with self._setup_config():
-            uid = uuid.uuid4()
-            temp_dir = tempfile.gettempdir()
-            temp_file = os.path.join(temp_dir, f"sling-replication-{uid}.json")
-            env = os.environ.copy()
+            config = {
+                "mode": mode,
+                "source": {
+                    "conn": "SLING_SOURCE",
+                    "stream": source_stream,
+                    "primary_key": primary_key,
+                    "update_key": update_key,
+                    "options": source_options,
+                },
+                "target": {
+                    "conn": "SLING_TARGET",
+                    "object": target_object,
+                    "options": target_options,
+                },
+            }
+            config["source"] = {k: v for k, v in config["source"].items() if v is not None}
+            config["target"] = {k: v for k, v in config["target"].items() if v is not None}
 
-            with open(temp_file, "w") as file:
-                json.dump(replication_config, file, cls=sling.JsonEncoder)
+            sling_cli = Sling(**config)
+            logger.info("Starting Sling sync with mode: %s", mode)
+            cmd = sling_cli._prep_cmd()  # noqa: SLF001
 
-            logger.debug(f"Replication config: {replication_config}")
-
-            debug_str = "-d" if debug else ""
-
-            cmd = f"{sling.SLING_BIN} run {debug_str} -r {temp_file}"
-
-            logger.debug(f"Running Sling replication with command: {cmd}")
-
-            results = sling._run(  # noqa
-                cmd=cmd,
-                temp_file=temp_file,
-                return_output=True,
-                env=env,
-            )
-
-        logger.info(results)
-        for stream in stream_definition:
-            output_name = dagster_sling_translator.get_asset_key(stream)
-            yield MaterializeResult(asset_key=output_name)
-
-            with open(temp_file, "w") as file:
-                json.dump(replication_config, file, cls=sling.JsonEncoder)
-
-            logger.debug(f"Replication config: {replication_config}")
-
-            debug_str = "-d" if debug else ""
-
-            cmd = f"{sling.SLING_BIN} run {debug_str} -r {temp_file}"
-
-            logger.debug(f"Running Sling replication with command: {cmd}")
-
-            results = sling._run(  # noqa
-                cmd=cmd,
-                temp_file=temp_file,
-                return_output=True,
-                env=env,
-            )
-
-        logger.info(results)
-        for stream in stream_definition:
-            output_name = dagster_sling_translator.get_asset_key(stream)
-            yield MaterializeResult(asset_key=output_name)
+            yield from self._exec_sling_cmd(cmd, encoding=encoding)
 
 
 def _process_env_vars(config: Dict[str, Any]) -> Dict[str, Any]:

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -6,12 +6,19 @@ from enum import Enum
 from subprocess import PIPE, STDOUT, Popen
 from typing import IO, Any, AnyStr, Dict, Generator, Iterator, List, Optional
 
-from dagster import ConfigurableResource, PermissiveConfig, get_dagster_logger
+from dagster import (
+    ConfigurableResource,
+    MaterializeResult,
+    PermissiveConfig,
+    get_dagster_logger,
+)
 from dagster._annotations import experimental
 from dagster._config.field_utils import EnvVar
 from dagster._utils.env import environ
 from pydantic import ConfigDict, Extra, Field
 from sling import Sling
+
+from dagster_embedded_elt.sling.asset_decorator import DagsterSlingTranslator
 
 logger = get_dagster_logger()
 
@@ -120,6 +127,35 @@ class _SlingSyncBase:
             proc.wait()
             if proc.returncode != 0:
                 raise Exception("Sling command failed with error code %s", proc.returncode)
+
+    def replicate(
+        self,
+        *,
+        dagster_sling_translator: DagsterSlingTranslator,
+        source_stream: str,
+        target_object: str,
+        mode: SlingMode,
+        primary_key: Optional[List[str]] = None,
+        update_key: Optional[str] = None,
+        source_options: Optional[Dict[str, Any]] = None,
+        target_options: Optional[Dict[str, Any]] = None,
+    ):
+        logs = ""
+        for line in self.sync(
+            source_stream,
+            target_object,
+            mode,
+            primary_key,
+            update_key,
+            source_options,
+            target_options,
+        ):
+            logger.info(line)
+            logs += line
+            # TODO: capture actual metadata here
+
+        output_name = dagster_sling_translator.get_asset_key(target_object)
+        yield MaterializeResult(asset_key=output_name, metadata={"logs": logs})
 
     def sync(
         self,

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -1,23 +1,20 @@
 import contextlib
 import json
 import re
-from abc import abstractmethod
 from enum import Enum
 from subprocess import PIPE, STDOUT, Popen
 from typing import IO, Any, AnyStr, Dict, Generator, Iterator, List, Optional
 
-from dagster import (
-    ConfigurableResource,
-    PermissiveConfig,
-    get_dagster_logger,
-)
+from dagster import ConfigurableResource, MaterializeResult, PermissiveConfig, get_dagster_logger
 from dagster._annotations import experimental
 from dagster._config.field_utils import EnvVar
 from dagster._utils.env import environ
-from pydantic import ConfigDict, Extra, Field
+from pydantic import ConfigDict, Field
 from sling import Sling
 
 logger = get_dagster_logger()
+
+from dagster_embedded_elt.sling import DagsterSlingTranslator
 
 
 class SlingMode(str, Enum):
@@ -101,154 +98,40 @@ class SlingTargetConnection(PermissiveConfig):
     )
 
 
-class _SlingSyncBase:
-    """Base class for Sling syncs. Handles the execution of the Sling CLI and processing of the output. Classes that inherit from this class must implement how to sync themselves ,but can use the `_exec_sling_cmd` and `process_stdout` methods to handle the execution and processing of the output."""
+class SlingConnectionResource(PermissiveConfig):
+    """A representation a connection to a database or file to be used by Sling. This resource can be used as a source or a target for a Sling sync.
 
-    def process_stdout(self, stdout: IO[AnyStr], encoding="utf8") -> Iterator[str]:
-        """Process stdout from the Sling CLI."""
-        ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
-        for line in stdout:
-            assert isinstance(line, bytes)
-            fmt_line = bytes.decode(line, encoding=encoding, errors="replace")
-            clean_line: str = ansi_escape.sub("", fmt_line).replace("INF", "")
-            yield clean_line
+    Each resource must have a name which corresponds to the name of the resource in the sling replication.yaml file, and a type which defines
+    the type of connection used, e.g. file, postgres, snowflake.
 
-    def _exec_sling_cmd(
-        self, cmd, stdin=None, stdout=PIPE, stderr=STDOUT, encoding="utf8"
-    ) -> Generator[str, None, None]:
-        with Popen(cmd, shell=True, stdin=stdin, stdout=stdout, stderr=stderr) as proc:
-            if proc.stdout:
-                for line in self.process_stdout(proc.stdout, encoding=encoding):
-                    yield line
+    Examples:
+        Creating a Sling Connection using a connection string:
 
-            proc.wait()
-            if proc.returncode != 0:
-                raise Exception("Sling command failed with error code %s", proc.returncode)
+        .. code-block:: python
 
-    def replicate(
-        self,
-        *,
-        source_stream: str,
-        target_object: str,
-        mode: SlingMode,
-        primary_key: Optional[List[str]] = None,
-        update_key: Optional[str] = None,
-        source_options: Optional[Dict[str, Any]] = None,
-        target_options: Optional[Dict[str, Any]] = None,
-    ):
-        logs = ""
-        for line in self.sync(
-            source_stream,
-            target_object,
-            mode,
-            primary_key,
-            update_key,
-            source_options,
-            target_options,
-        ):
-            logger.info(line)
-            logs += line
-            # TODO: capture actual metadata here
+            source = SlingConnectionResource(name="MY_POSTGRES", type="postgres", connection_string=EnvVar("POSTGRES_CONNECTION_STRING"))
+            source = SlingConnectionResource(name="MY_MYSQL", type="mysql", connection_string="mysql://user:password@host:port/schema")
 
-    def sync(
-        self,
-        source_stream: str,
-        target_object: str,
-        mode: SlingMode,
-        primary_key: Optional[List[str]] = None,
-        update_key: Optional[str] = None,
-        source_options: Optional[Dict[str, Any]] = None,
-        target_options: Optional[Dict[str, Any]] = None,
-    ) -> Generator[str, None, None]:
-        """Initiate a Sling Sync between a source stream and a target object.
+        Create a Sling Connection for a Postgres or Snowflake database, using keyword arguments, as described here:
+        https://docs.slingdata.io/connections/database-connections/postgres
 
-        Args:
-            source_stream (str):  The source stream to read from. For database sources, the source stream can be either
-                a table name, a SQL statement or a path to a SQL file e.g. `TABLE1` or `SCHEMA1.TABLE2` or
-                `SELECT * FROM TABLE`. For file sources, the source stream is a path or an url to a file.
-                For file targets, the target object is a path or a url to a file, e.g. file:///tmp/file.csv or
-                s3://my_bucket/my_folder/file.csv
-            target_object (str): The target object to write into. For database targets, the target object is a table
-                name, e.g. TABLE1, SCHEMA1.TABLE2. For file targets, the target object is a path or an url to a file.
-            mode (SlingMode): The Sling mode to use when syncing, i.e. incremental, full-refresh
-                See the Sling docs for more information: https://docs.slingdata.io/sling-cli/running-tasks#modes.
-            primary_key (List[str]): For incremental syncs, a primary key is used during merge statements to update
-                existing rows.
-            update_key (str): For incremental syncs, an update key is used to stream records after max(update_key)
-            source_options (Dict[str, Any]): Other source options to pass to Sling,
-                see https://docs.slingdata.io/sling-cli/running-tasks#source-options-src-options-flag-source.options-key
-                for details
-            target_options (Dict[str, Any[): Other target options to pass to Sling,
-                see https://docs.slingdata.io/sling-cli/running-tasks#target-options-tgt-options-flag-target.options-key
-                for details
+        .. code-block:: python
 
-        Examples:
-            Sync from a source file to a sqlite database:
+            source = SlingConnectionResource(name="MY_POSTGRES", type="postgres", host="host", user="hunter42", password=EnvVar("POSTGRES_PASSWORD"))
+            source = SlingConnectionResource(name="MY_SNOWFLAKE", type="snowflake", host=EnvVar("SNOWFLAKE_HOST"), user=EnvVar("SNOWFLAKE_USER"), database=EnvVar("SNOWFLAKE_DATABASE"), password=EnvVar("SNOWFLAKE_PASSWORD"), role=EnvVar("SNOWFLAKE_ROLE"))
+    """
 
-            .. code-block:: python
-
-                sqllite_path = "/path/to/sqlite.db"
-                csv_path = "/path/to/file.csv"
-
-                @asset
-                def run_sync(context, sling: SlingResource):
-                    res = sling.sync(
-                        source_stream=csv_path,
-                        target_object="events",
-                        mode=SlingMode.FULL_REFRESH,
-                    )
-                    for stdout in res:
-                        context.log.debug(stdout)
-                    counts = sqlite3.connect(sqllitepath).execute("SELECT count(1) FROM events").fetchone()
-                    assert counts[0] == 3
-
-                source = SlingSourceConnection(
-                    type="file",
-                )
-                target = SlingTargetConnection(type="sqlite", instance=sqllitepath)
-
-                materialize(
-                    [run_sync],
-                    resources={
-                        "sling": SlingResource(
-                            source_connection=source,
-                            target_connection=target,
-                            mode=SlingMode.TRUNCATE,
-                        )
-                    },
-                )
-
-        """
-        yield from self._sync(
-            source_stream=source_stream,
-            target_object=target_object,
-            mode=mode,
-            primary_key=primary_key,
-            update_key=update_key,
-            source_options=source_options,
-            target_options=target_options,
-        )
-
-    @abstractmethod
-    def _sync(
-        self,
-        source_stream: str,
-        target_object: str,
-        mode: SlingMode = SlingMode.FULL_REFRESH,
-        primary_key: Optional[List[str]] = None,
-        update_key: Optional[str] = None,
-        source_options: Optional[Dict[str, Any]] = None,
-        target_options: Optional[Dict[str, Any]] = None,
-        encoding: str = "utf8",
-    ) -> Generator[str, None, None]:
-        """Runs a Sling sync from the given source table to the given destination table. Generates
-        output lines from the Sling CLI.
-        """
-        raise NotImplementedError()
+    model_config = ConfigDict(extra="allow")
+    name: str = Field(description="The name of the connection.")
+    type: str = Field(description="Type of the source connection. Use 'file' for local storage.")
+    connection_string: Optional[str] = Field(
+        description="The connection string for the source database.",
+        default=None,
+    )
 
 
 @experimental
-class SlingResource(ConfigurableResource, _SlingSyncBase):
+class SlingResource(ConfigurableResource):
     """Resource for interacting with the Sling package.
 
     Examples:
@@ -292,7 +175,28 @@ class SlingResource(ConfigurableResource, _SlingSyncBase):
         ):
             yield
 
-    def _sync(
+    def process_stdout(self, stdout: IO[AnyStr], encoding="utf8") -> Iterator[str]:
+        """Process stdout from the Sling CLI."""
+        ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+        for line in stdout:
+            assert isinstance(line, bytes)
+            fmt_line = bytes.decode(line, encoding=encoding, errors="replace")
+            clean_line: str = ansi_escape.sub("", fmt_line).replace("INF", "")
+            yield clean_line
+
+    def _exec_sling_cmd(
+        self, cmd, stdin=None, stdout=PIPE, stderr=STDOUT, encoding="utf8"
+    ) -> Generator[str, None, None]:
+        with Popen(cmd, shell=True, stdin=stdin, stdout=stdout, stderr=stderr) as proc:
+            if proc.stdout:
+                for line in self.process_stdout(proc.stdout, encoding=encoding):
+                    yield line
+
+            proc.wait()
+            if proc.returncode != 0:
+                raise Exception("Sling command failed with error code %s", proc.returncode)
+
+    def sync(
         self,
         source_stream: str,
         target_object: str,
@@ -337,42 +241,34 @@ class SlingResource(ConfigurableResource, _SlingSyncBase):
 
             yield from self._exec_sling_cmd(cmd, encoding=encoding)
 
+    def replicate(
+        self,
+        *,
+        dagster_sling_translator: DagsterSlingTranslator,
+        source_stream: str,
+        target_object: str,
+        mode: SlingMode,
+        primary_key: Optional[List[str]] = None,
+        update_key: Optional[str] = None,
+        source_options: Optional[Dict[str, Any]] = None,
+        target_options: Optional[Dict[str, Any]] = None,
+    ):
+        logs = ""
+        for line in self.sync(
+            source_stream,
+            target_object,
+            mode,
+            primary_key,
+            update_key,
+            source_options,
+            target_options,
+        ):
+            logger.info(line)
+            logs += line
+            # TODO: capture actual metadata here
 
-class SlingConnectionResource(ConfigurableResource):
-    """A representation a connection to a database or file to be used by Sling. This resource can be used as a source or a target for a Sling sync.
-
-    This resource is responsible for the managing how Sling connects to a resource. To manage how Sling uses this connection (as a source or target), see the specific source_options or target_options in the `build_assets_from_sling_stream` function.
-
-    Examples:
-        Creating a Sling Connection for a file, such as CSV or JSON:
-
-        .. code-block:: python
-
-             source = SlingConnectionResource(type="file")
-
-        Create a Sling Connection for a Postgres database, using a connection string:
-
-        .. code-block:: python
-
-            source = SlingConnectionResource(type="postgres", connection_string=EnvVar("POSTGRES_CONNECTION_STRING"))
-            source = SlingConnectionResource(type="mysql", connection_string="mysql://user:password@host:port/schema")
-
-        Create a Sling Connection for a Postgres or Snowflake database, using keyword arguments, as described here:
-        https://docs.slingdata.io/connections/database-connections/postgres
-
-        .. code-block::python
-
-            source = SlingConnectionResource(type="postgres", host="host", user="hunter42", password=EnvVar("POSTGRES_PASSWORD"))
-            source = SlingConnectionResource(type="snowflake", host=EnvVar("SNOWFLAKE_HOST"), user=EnvVar("SNOWFLAKE_USER"), database=EnvVar("SNOWFLAKE_DATABASE"), password=EnvVar("SNOWFLAKE_PASSWORD"), role=EnvVar("SNOWFLAKE_ROLE"))
-    """
-
-    model_config = ConfigDict(extra=Extra.allow)
-
-    type: str = Field(description="Type of the source connection. Use 'file' for local storage.")
-    connection_string: Optional[str] = Field(
-        description="The connection string for the source database.",
-        default=None,
-    )
+        output_name = dagster_sling_translator.get_asset_key(target_object)
+        yield MaterializeResult(asset_key=output_name, metadata={"logs": logs})
 
 
 def _process_env_vars(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -383,83 +279,3 @@ def _process_env_vars(config: Dict[str, Any]) -> Dict[str, Any]:
         else:
             out[key] = value
     return out
-
-
-class SlingStreamReplicator(_SlingSyncBase):
-    """A utility class for running a Sling sync from outside of a Dagster resource to enable parity between the SlingResource and SlingStreamSync.
-
-    Inherits from :py:class:`~dagster_elt.sling._SlingSyncBase` and implements `_sync` to run a sync using 2 SlingConnectionResources and no SlingResource.
-    """
-
-    def __init__(
-        self,
-        source_connection: SlingConnectionResource,
-        target_connection: SlingConnectionResource,
-    ):
-        self.source_connection = source_connection
-        self.target_connection = target_connection
-
-    def _sync(
-        self,
-        source_stream: str,
-        target_object: str,
-        mode: SlingMode = SlingMode.FULL_REFRESH,
-        primary_key: Optional[List[str]] = None,
-        update_key: Optional[str] = None,
-        source_options: Optional[Dict[str, Any]] = None,
-        target_options: Optional[Dict[str, Any]] = None,
-        encoding: str = "utf8",
-    ) -> Generator[str, None, None]:
-        """Runs a Sling sync from the given source table to the given destination table. Generates
-        output lines from the Sling CLI.
-        """
-        if self.source_connection.type == "file" and not source_stream.startswith("file://"):
-            source_stream = "file://" + source_stream
-
-        if self.target_connection.type == "file" and not target_object.startswith("file://"):
-            target_object = "file://" + target_object
-
-        sling_source = self.source_connection.dict()
-        sling_target = self.target_connection.dict()
-
-        sling_source = _process_env_vars(sling_source)
-        sling_target = _process_env_vars(sling_target)
-
-        if self.source_connection.connection_string:
-            sling_source["url"] = self.source_connection.connection_string
-        if self.target_connection.connection_string:
-            sling_target["url"] = self.target_connection.connection_string
-        with environ(
-            {
-                "SLING_SOURCE": json.dumps(sling_source),
-                "SLING_TARGET": json.dumps(sling_target),
-            }
-        ):
-            config = {
-                "mode": mode,
-                "source": {
-                    "conn": "SLING_SOURCE",
-                    "stream": source_stream,
-                    "primary_key": primary_key,
-                    "update_key": update_key,
-                    "options": source_options,
-                },
-                "target": {
-                    "conn": "SLING_TARGET",
-                    "object": target_object,
-                    "options": target_options,
-                },
-            }
-            config["source"] = {k: v for k, v in config["source"].items() if v is not None}
-            config["target"] = {k: v for k, v in config["target"].items() if v is not None}
-
-            sling_cli = Sling(**config)
-            logger.info("Starting Sling sync with mode: %s", mode)
-            cmd = sling_cli._prep_cmd()  # noqa: SLF001
-
-            # `_prep_cmd` only works with the Single Task command, so we need to replace it with the Replication command
-            # TODO: Unfortunately, _prep_cmd doesn't expose a way to add streams, so we'll need to override it ourselves
-            # We'll also need to parse the logs differently, since the output is different
-            # cmd = cmd.replace(" -c ", " -r ")
-
-            yield from self._exec_sling_cmd(cmd, encoding=encoding)

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_replication.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_replication.py
@@ -1,0 +1,31 @@
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Mapping, Union, cast
+
+import dagster._check as check
+import yaml
+
+SlingReplicationParam = Union[Mapping[str, Any], str, Path]
+
+
+@lru_cache(maxsize=None)
+def read_replication_path(replication_path: Path) -> Mapping[str, Any]:
+    """Reads a Sling replication config from a path and returns a dict.
+
+    This function is cached to ensure that we don't read the same path multiple times, which
+    creates multiple copies of the parsed manifest in memory.
+    """
+    return cast(Mapping[str, Any], yaml.safe_load(replication_path.read_bytes()))
+
+
+def validate_replication(replication: SlingReplicationParam) -> Mapping[str, Any]:
+    check.inst_param(replication, "manifest", (Path, str, dict))
+
+    if isinstance(replication, str):
+        replication = Path(replication)
+
+    if isinstance(replication, Path):
+        # Resolve the path to ensure a consistent key for the cache
+        replication = read_replication_path(replication.resolve())
+
+    return replication

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/conftest.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/conftest.py
@@ -5,6 +5,7 @@ import tempfile
 import pytest
 from dagster import file_relative_path
 from dagster_embedded_elt.sling import (
+    SlingConnectionResource,
     SlingResource,
     SlingSourceConnection,
     SlingTargetConnection,
@@ -35,4 +36,26 @@ def sling_sqlite_resource(temp_db):
         target_connection=SlingTargetConnection(
             type="sqlite", connection_string=f"sqlite://{temp_db}"
         ),
+    )
+
+
+@pytest.fixture
+def sling_file_connection():
+    return SlingConnectionResource(name="SLING_FILE", type="file")
+
+
+@pytest.fixture
+def sling_sqlite_connection(temp_db):
+    return SlingConnectionResource(
+        name="SLING_SQLITE", type="sqlite", connection_string=f"sqlite://{temp_db}"
+    )
+
+
+@pytest.fixture()
+def sling_csv_sqlite_resource(sling_file_connection, sling_sqlite_connection):
+    return SlingResource(
+        connections=[
+            sling_file_connection,
+            sling_sqlite_connection,
+        ]
     )

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/conftest.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/conftest.py
@@ -1,0 +1,38 @@
+import os
+import sqlite3
+import tempfile
+
+import pytest
+from dagster import file_relative_path
+from dagster_embedded_elt.sling import (
+    SlingResource,
+    SlingSourceConnection,
+    SlingTargetConnection,
+)
+
+
+@pytest.fixture
+def test_csv():
+    return os.path.abspath(file_relative_path(__file__, "test.csv"))
+
+
+@pytest.fixture
+def sqlite_connection(temp_db):
+    yield sqlite3.connect(temp_db)
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir_path:
+        dbpath = os.path.join(tmpdir_path, "sqlite.db")
+        yield dbpath
+
+
+@pytest.fixture
+def sling_sqlite_resource(temp_db):
+    return SlingResource(
+        source_connection=SlingSourceConnection(type="file"),
+        target_connection=SlingTargetConnection(
+            type="sqlite", connection_string=f"sqlite://{temp_db}"
+        ),
+    )

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_replication.yaml
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_replication.yaml
@@ -16,7 +16,11 @@ streams:
     object: "departments" # overwrite default object
     source_options:
       empty_as_null: false
-
+    meta:
+      dagster:
+        deps:
+          - foo_one
+          - foo_two
   public."Transactions":
     mode: incremental # overwrite default mode
     primary_key: id

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_replication.yaml
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_replication.yaml
@@ -1,0 +1,33 @@
+source: MY_SOURCE
+target: MY_TARGET
+
+defaults:
+  mode: full-refresh
+  object: "{stream_schema}_{stream_table}"
+
+streams:
+  public.accounts:
+  public.users:
+    disabled: true
+    meta:
+      dagster:
+        asset_key: public.foo_users
+  public.finance_departments_old:
+    object: "departments" # overwrite default object
+    source_options:
+      empty_as_null: false
+
+  public."Transactions":
+    mode: incremental # overwrite default mode
+    primary_key: id
+    update_key: last_updated_at
+
+  public.all_users:
+    sql: |
+      select all_user_id, name 
+      from public."all_Users"
+    object: public.all_users # need to add 'object' key for custom SQL
+
+env:
+  SLING_LOADED_AT_COLUMN: true # adds the _sling_loaded_at timestamp column
+  SLING_STREAM_URL_COLUMN: true # if source is file, adds a _sling_stream_url column with file path / url

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sqlite_replication.yaml
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sqlite_replication.yaml
@@ -1,0 +1,7 @@
+source: "file://test.csv"
+target: "sqlite://tmp_db.db"
+
+streams:
+  file://test.csv:
+    object: "main.tbl"
+

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/staging_test.csv
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/staging_test.csv
@@ -1,5 +1,0 @@
-SPECIES_CODE,SPECIES_NAME,UPDATED_AT
-youtube,domestic short hair,1
-ferngully,scottish fold,2
-landbeforetime,an orange one,2
-an-american-tail,abyssinian,2

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
@@ -1,0 +1,46 @@
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+from dagster import AssetKey
+from dagster_embedded_elt.sling import (
+    SlingReplicationParam,
+    sling_assets,
+)
+from dagster_embedded_elt.sling.asset_decorator import get_streams_from_replication
+
+replication_path = Path(__file__).joinpath("..", "sling_replication.yaml").resolve()
+with replication_path.open("r") as f:
+    replication = yaml.safe_load(f)
+
+
+@pytest.mark.parametrize(
+    "replication", [replication, replication_path, os.fspath(replication_path)]
+)
+def test_replication_argument(replication: SlingReplicationParam):
+    @sling_assets(replication_config=replication)
+    def my_sling_assets():
+        ...
+
+    assert my_sling_assets.keys == {
+        AssetKey.from_user_string(key)
+        for key in [
+            "target/public/accounts",
+            "target/public/foo_users",
+            "target/public/Transactions",
+            "target/public/all_users",
+            "target/public/finance_departments_old",
+        ]
+    }
+
+
+def test_streams_from_replication():
+    streams = get_streams_from_replication(replication)
+    assert set(streams) == {
+        "public.accounts",
+        "public.foo_users",
+        'public."Transactions"',
+        "public.all_users",
+        "public.finance_departments_old",
+    }

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_assets.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_assets.py
@@ -1,70 +1,14 @@
 import io
-import os
 import sqlite3
-import tempfile
 
 import pytest
-from dagster import AssetSpec, Definitions, file_relative_path
-from dagster._core.definitions.materialize import materialize
+from dagster import AssetSpec, Definitions
+from dagster._core.definitions import build_assets_job
 from dagster_embedded_elt.sling import (
     SlingMode,
     SlingResource,
-    build_assets_from_sling_stream,
     build_sling_asset,
 )
-from dagster_embedded_elt.sling.resources import (
-    SlingConnectionResource,
-    SlingSourceConnection,
-    SlingTargetConnection,
-)
-
-
-@pytest.fixture
-def test_csv():
-    return os.path.abspath(file_relative_path(__file__, "test.csv"))
-
-
-@pytest.fixture
-def test_staging_csv():
-    return os.path.abspath(file_relative_path(__file__, "staging_test.csv"))
-
-
-@pytest.fixture
-def temp_db():
-    with tempfile.TemporaryDirectory() as tmpdir_path:
-        dbpath = os.path.join(tmpdir_path, "sqlite.db")
-        yield dbpath
-
-
-@pytest.fixture
-def sling_sqlite_resource(temp_db):
-    return SlingResource(
-        source_connection=SlingSourceConnection(type="file"),
-        target_connection=SlingTargetConnection(
-            type="sqlite", connection_string=f"sqlite://{temp_db}"
-        ),
-    )
-
-
-@pytest.fixture
-def sling_file_connection():
-    return SlingConnectionResource(type="file")
-
-
-@pytest.fixture
-def sling_staging_file_connection():
-    return SlingConnectionResource(type="file")
-
-
-@pytest.fixture
-def sling_sqlite_connection(temp_db):
-    return SlingConnectionResource(type="sqlite", connection_string=f"sqlite://{temp_db}")
-
-
-@pytest.fixture
-def sqlite_connection(temp_db):
-    yield sqlite3.connect(temp_db)
-
 
 ASSET_SPEC = AssetSpec(
     key=["main", "tbl"],
@@ -96,10 +40,7 @@ def test_build_sling_asset(
 
     counts = None
     for _ in range(runs):
-        res = materialize(
-            [asset_def],
-            resources={"sling_resource": sling_sqlite_resource},
-        )
+        res = sling_job.execute_in_process()
         assert res.success
         counts = sqlite_connection.execute("SELECT count(1) FROM main.tbl").fetchone()[0]
     assert counts == expected
@@ -162,10 +103,10 @@ def test_update_mode(
         sling_resource_key="sling_resource",
     )
 
-    # First run should have 3 new rows
-    res = materialize(
+    sling_job_base = build_assets_job(
+        "sling_job",
         [asset_def_base],
-        resources={"sling_resource": sling_sqlite_resource},
+        resource_defs={"sling_resource": sling_sqlite_resource},
     )
     assert res.success
     assert sqlite_connection.execute("SELECT count(1) FROM main.tbl").fetchone()[0] == 3
@@ -175,7 +116,8 @@ def test_update_mode(
     cur.execute("UPDATE main.tbl set UPDATED_AT=999")
     sqlite_connection.commit()
 
-    res = materialize(
+    sling_job_update = build_assets_job(
+        "sling_job_update",
         [asset_def_update],
         resources={"sling_resource": sling_sqlite_resource},
     )
@@ -193,134 +135,3 @@ def test_update_mode(
 def test_non_unicode_stdout(text, encoding, expected, sling_sqlite_resource: SlingResource):
     lines = sling_sqlite_resource.process_stdout(text, encoding)
     assert list(lines) == expected
-
-
-@pytest.mark.parametrize(
-    "mode,runs,expected", [(SlingMode.INCREMENTAL, 1, 3), (SlingMode.SNAPSHOT, 2, 6)]
-)
-def test_build_assets_from_sling_stream(
-    test_csv: str,
-    sling_file_connection: SlingConnectionResource,
-    sling_sqlite_connection: SlingConnectionResource,
-    mode: SlingMode,
-    runs: int,
-    expected: int,
-    sqlite_connection: sqlite3.Connection,
-):
-    asset_def = build_assets_from_sling_stream(
-        sling_file_connection,
-        sling_sqlite_connection,
-        stream=f"file://{test_csv}",
-        target_object="main.tbl",
-        mode=mode,
-        primary_key="SPECIES_CODE",
-    )
-
-    counts = None
-    for _ in range(runs):
-        res = materialize(
-            [asset_def],
-            resources={
-                "sling_file_connection": sling_file_connection,
-                "sling_sqlite_connection": sling_sqlite_connection,
-            },
-        )
-        assert res.success
-        counts = sqlite_connection.execute("SELECT count(1) FROM main.tbl").fetchone()[0]
-    assert counts == expected
-
-
-def test_reuse_sling_connection_resource(
-    test_csv: str,
-    test_staging_csv: str,
-    sling_file_connection: SlingConnectionResource,
-    sling_staging_file_connection: SlingConnectionResource,
-    sling_sqlite_connection: SlingConnectionResource,
-    sqlite_connection: sqlite3.Connection,
-):
-    """Create two assets that target the same SlingConnectionResource."""
-    asset_def = build_assets_from_sling_stream(
-        sling_file_connection,
-        sling_sqlite_connection,
-        stream=f"file://{test_csv}",
-        target_object="main.tbl",
-        mode=SlingMode.FULL_REFRESH,
-        primary_key="SPECIES_CODE",
-    )
-
-    asset_def_two = build_assets_from_sling_stream(
-        sling_staging_file_connection,
-        sling_sqlite_connection,
-        stream=f"file://{test_staging_csv}",
-        target_object="main.staging_tbl",
-        mode=SlingMode.FULL_REFRESH,
-        primary_key="SPECIES_CODE",
-    )
-
-    res = materialize(
-        [asset_def, asset_def_two],
-        resources={
-            "sling_file_connection": sling_file_connection,
-            "sling_staging_file_connection": sling_staging_file_connection,
-            "sling_sqlite_connection": sling_sqlite_connection,
-        },
-    )
-
-    assert res.success
-    assert sqlite_connection.execute("SELECT count(1) FROM main.tbl").fetchone()[0] == 3
-    assert sqlite_connection.execute("SELECT count(1) FROM main.staging_tbl").fetchone()[0] == 4
-
-
-def test_update_mode_from_stream(
-    test_csv: str,
-    sling_file_connection: SlingConnectionResource,
-    sling_sqlite_connection: SlingConnectionResource,
-    sqlite_connection: sqlite3.Connection,
-):
-    """Creates a Sling sync using Full Refresh, manually increments the UPDATE KEY to be a higher value,
-    which should cause the next run not to append new rows.
-    """
-    asset_def_base = build_assets_from_sling_stream(
-        sling_file_connection,
-        sling_sqlite_connection,
-        stream=f"file://{test_csv}",
-        target_object="main.tbl",
-        mode=SlingMode.FULL_REFRESH,
-    )
-
-    asset_def_update = build_assets_from_sling_stream(
-        sling_file_connection,
-        sling_sqlite_connection,
-        stream=f"file://{test_csv}",
-        target_object="main.tbl",
-        mode=SlingMode.INCREMENTAL,
-        primary_key="SPECIES_NAME",
-        update_key="UPDATED_AT",
-    )
-
-    res = materialize(
-        [asset_def_base],
-        resources={
-            "sling_file_connection": sling_file_connection,
-            "sling_sqlite_connection": sling_sqlite_connection,
-        },
-    )
-
-    # First run should have 3 new rows
-    assert res.success
-    assert sqlite_connection.execute("SELECT count(1) FROM main.tbl").fetchone()[0] == 3
-
-    # Next, manually set the UPDATED_AT to a higher value, this should prevent an append job from adding new rows.
-    cur = sqlite_connection.cursor()
-    cur.execute("UPDATE main.tbl set UPDATED_AT=999")
-    sqlite_connection.commit()
-
-    res = materialize(
-        [asset_def_update],
-        resources={
-            "sling_file_connection": sling_file_connection,
-            "sling_sqlite_connection": sling_sqlite_connection,
-        },
-    )
-    assert res.success
-    assert sqlite_connection.execute("SELECT count(1) FROM main.tbl").fetchone()[0] == 3

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_dagster_sling_translator.py
@@ -1,0 +1,150 @@
+import pytest
+from dagster import AssetKey, AutoMaterializePolicy, FreshnessPolicy, JsonMetadataValue
+from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
+
+
+@pytest.mark.parametrize(
+    "test,expected",
+    [
+        ("foo", "foo"),
+        ("foo.bar", "foo.bar"),
+        ("foo.$bar$", "foo._bar_"),
+    ],
+)
+def test_sling_translator_sanitize(test, expected):
+    translator = DagsterSlingTranslator()
+
+    assert translator.sanitize_stream_name(test) == expected
+
+
+@pytest.mark.parametrize(
+    "stream,expected",
+    [
+        ({"name": "foo"}, "target/foo"),
+        ({"name": "public.foo"}, "target/public/foo"),
+        (
+            {"name": "foo", "config": {"meta": {"dagster": {"asset_key": "foo.bar"}}}},
+            "foo/bar",
+        ),
+    ],
+)
+def test_get_asset_key(stream, expected):
+    translator = DagsterSlingTranslator()
+    assert translator.get_asset_key(stream) == AssetKey.from_user_string(expected)
+
+
+def test_get_asset_key_error():
+    stream_definition = {"name": "foo", "config": {"meta": {"dagster": {"asset_key": "foo$bar"}}}}
+    translator = DagsterSlingTranslator()
+    with pytest.raises(ValueError):
+        translator.get_asset_key(stream_definition)
+
+
+@pytest.mark.parametrize(
+    "stream,expected",
+    [
+        ({"name": "foo"}, ["foo"]),
+        ({"name": "public.foo"}, ["public/foo"]),
+        (
+            {"name": "foo", "config": {"meta": {"dagster": {"deps": "foo.bar"}}}},
+            ["foo/bar"],
+        ),
+        (
+            {"name": "foo", "config": {"meta": {"dagster": {"deps": ["foo_one", "foo_two"]}}}},
+            ["foo_one", "foo_two"],
+        ),
+    ],
+)
+def test_get_deps_asset_key(stream, expected):
+    translator = DagsterSlingTranslator()
+    assert translator.get_deps_asset_key(stream) == [AssetKey.from_user_string(e) for e in expected]
+
+
+def test_get_deps_asset_key_error():
+    stream_definition = {"name": "foo", "config": {"meta": {"dagster": {"deps": "foo$bar"}}}}
+    translator = DagsterSlingTranslator()
+    with pytest.raises(ValueError):
+        translator.get_deps_asset_key(stream_definition)
+
+
+@pytest.mark.parametrize(
+    "stream,expected",
+    [
+        ({"name": "foo"}, None),
+        ({"name": "public.foo"}, None),
+        (
+            {"name": "foo", "config": {"meta": {"dagster": {"description": "foo.bar"}}}},
+            "foo.bar",
+        ),
+    ],
+)
+def test_get_description(stream, expected):
+    translator = DagsterSlingTranslator()
+    assert translator.get_description(stream) == expected
+
+
+@pytest.mark.parametrize(
+    "stream,expected",
+    [
+        ({"name": "foo"}, None),
+        (
+            {"name": "foo", "config": {"meta": {"dagster": {"description": "foo.bar"}}}},
+            "foo.bar",
+        ),
+    ],
+)
+def test_get_metadata(stream, expected):
+    translator = DagsterSlingTranslator()
+    stream = {"name": "foo", "config": {"foo": "bar"}}
+    assert translator.get_metadata(stream) == {"stream_config": JsonMetadataValue(stream["config"])}
+
+
+@pytest.mark.parametrize(
+    "stream,expected",
+    [
+        ({"name": "foo"}, None),
+        (
+            {"name": "foo", "config": {"meta": {"dagster": {"group": "foo.bar"}}}},
+            "foo.bar",
+        ),
+    ],
+)
+def test_get_group_name(stream, expected):
+    translator = DagsterSlingTranslator()
+    assert translator.get_group_name(stream) == expected
+
+
+@pytest.mark.parametrize(
+    "stream,expected",
+    [
+        ({"name": "foo"}, None),
+        (
+            {
+                "name": "foo",
+                "config": {"meta": {"dagster": {"freshness_policy": {"maximum_lag_minutes": 5}}}},
+            },
+            FreshnessPolicy(maximum_lag_minutes=5),
+        ),
+    ],
+)
+def test_get_freshness_policy(stream, expected):
+    translator = DagsterSlingTranslator()
+    assert translator.get_freshness_policy(stream) == expected
+
+
+@pytest.mark.parametrize(
+    "stream,expected",
+    [
+        ({"name": "foo"}, None),
+        (
+            {
+                "name": "foo",
+                "config": {"meta": {"dagster": {"auto_materialize_policy": {}}}},
+            },
+            AutoMaterializePolicy.eager(),
+        ),
+    ],
+)
+def test_get_auto_materialize_policy(stream, expected):
+    translator = DagsterSlingTranslator()
+    assert translator.get_auto_materialize_policy(stream) == expected

--- a/python_modules/libraries/dagster-embedded-elt/setup.py
+++ b/python_modules/libraries/dagster-embedded-elt/setup.py
@@ -33,7 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_embedded_elt_tests*"]),
-    install_requires=[f"dagster{pin}", "sling>=1.0.20"],
+    install_requires=[f"dagster{pin}", "sling>=1.1.5"],
     zip_safe=False,
     extras_require={},
 )


### PR DESCRIPTION
## Summary & Motivation

This reverts most of the changes that introduced abstract base classes as well as the old replication stream classes and methods introduced in PR #18270. These methods were not documented or completed, the initial plan was to build off these to complete the sling replication changes. 

However, after moving to a decorator-based approach, we're no longer going to use the builder pattern, 
and newer version of Sling have introuced a Python API for replication. 

## How I Tested These Changes

pytest
