### PR TITLE
test(dbt-cloud): apply `pytest` legacy marker to split test execution

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/conftest.py
@@ -1,0 +1,60 @@
+from typing import Any
+
+import pytest
+from dagster import build_init_resource_context
+from dagster_dbt.cloud.resources import DbtCloudClientResource, dbt_cloud_resource
+
+from .utils import DBT_CLOUD_ACCOUNT_ID, DBT_CLOUD_API_TOKEN
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("legacy", marks=pytest.mark.legacy),
+        pytest.param("pythonic"),
+    ],
+)
+def resource_type(request):
+    return request.param
+
+
+@pytest.fixture(name="dbt_cloud")
+def dbt_cloud_fixture(resource_type) -> Any:
+    if resource_type == "pythonic":
+        yield DbtCloudClientResource(
+            auth_token=DBT_CLOUD_API_TOKEN, account_id=DBT_CLOUD_ACCOUNT_ID
+        )
+    else:
+        yield dbt_cloud_resource.configured(
+            {
+                "auth_token": DBT_CLOUD_API_TOKEN,
+                "account_id": DBT_CLOUD_ACCOUNT_ID,
+            }
+        )
+
+
+@pytest.fixture(name="get_dbt_cloud_resource")
+def get_dbt_cloud_resource_fixture(resource_type) -> Any:
+    if resource_type == "pythonic":
+        return (
+            lambda **kwargs: DbtCloudClientResource(
+                auth_token=DBT_CLOUD_API_TOKEN, account_id=DBT_CLOUD_ACCOUNT_ID, **kwargs
+            )
+            .with_replaced_resource_context(build_init_resource_context())
+            .get_dbt_client()
+        )
+
+    else:
+        return lambda **kwargs: dbt_cloud_resource(
+            build_init_resource_context(
+                config={
+                    "auth_token": DBT_CLOUD_API_TOKEN,
+                    "account_id": DBT_CLOUD_ACCOUNT_ID,
+                    **kwargs,
+                }
+            )
+        )
+
+
+@pytest.fixture(name="dbt_cloud_service")
+def dbt_cloud_service_fixture(get_dbt_cloud_resource) -> Any:
+    return get_dbt_cloud_resource()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_cli.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_cli.py
@@ -4,9 +4,9 @@ from dagster_dbt.cloud.cli import DAGSTER_DBT_COMPILE_RUN_ID_ENV_VAR, app
 from typer.testing import CliRunner
 
 from .utils import (
+    DBT_CLOUD_ACCOUNT_ID,
     DBT_CLOUD_EMEA_HOST,
     DBT_CLOUD_US_HOST,
-    SAMPLE_ACCOUNT_ID,
     SAMPLE_API_PREFIX,
     SAMPLE_API_V3_PREFIX,
     SAMPLE_EMEA_API_PREFIX,
@@ -34,7 +34,7 @@ def test_cache_compile_references(
     monkeypatch: pytest.MonkeyPatch, host: str, api_prefix: str, api_v3_prefix: str
 ) -> None:
     monkeypatch.setenv("DBT_CLOUD_API_KEY", "test")
-    monkeypatch.setenv("DBT_CLOUD_ACCOUNT_ID", str(SAMPLE_ACCOUNT_ID))
+    monkeypatch.setenv("DBT_CLOUD_ACCOUNT_ID", str(DBT_CLOUD_ACCOUNT_ID))
     monkeypatch.setenv("DBT_CLOUD_PROJECT_ID", str(SAMPLE_PROJECT_ID))
     monkeypatch.setenv("DBT_CLOUD_HOST", str(host))
     compile_run_environment_variable_id = 3
@@ -66,7 +66,7 @@ def test_cache_compile_references(
 @responses.activate(assert_all_requests_are_fired=True)
 def test_skip_cache_compile_references(monkeypatch):
     monkeypatch.setenv("DBT_CLOUD_API_KEY", "test")
-    monkeypatch.setenv("DBT_CLOUD_ACCOUNT_ID", SAMPLE_ACCOUNT_ID)
+    monkeypatch.setenv("DBT_CLOUD_ACCOUNT_ID", DBT_CLOUD_ACCOUNT_ID)
     monkeypatch.setenv("DBT_CLOUD_PROJECT_ID", SAMPLE_PROJECT_ID)
 
     responses.get(f"{SAMPLE_API_PREFIX}/jobs", json=sample_list_job_details())

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_ops.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_ops.py
@@ -1,13 +1,10 @@
-from typing import Any
-
 import pytest
 import responses
 from dagster import Failure, job
 from dagster._check import CheckError
-from dagster_dbt import DbtCloudClientResource, dbt_cloud_resource, dbt_cloud_run_op
+from dagster_dbt import dbt_cloud_run_op
 
 from .utils import (
-    SAMPLE_ACCOUNT_ID,
     SAMPLE_API_PREFIX,
     SAMPLE_JOB_ID,
     SAMPLE_RUN_ID,
@@ -15,16 +12,6 @@ from .utils import (
     sample_run_details,
     sample_run_results,
 )
-
-
-@pytest.fixture(name="dbt_cloud", params=["pythonic", "legacy"])
-def dbt_cloud_fixture(request) -> Any:
-    if request.param == "pythonic":
-        yield DbtCloudClientResource(auth_token="some_auth_token", account_id=SAMPLE_ACCOUNT_ID)
-    else:
-        yield dbt_cloud_resource.configured(
-            {"auth_token": "some_auth_token", "account_id": SAMPLE_ACCOUNT_ID}
-        )
 
 
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_resources.py
@@ -1,14 +1,11 @@
 import re
-from typing import Any
 
 import pytest
 import responses
-from dagster import Failure, build_init_resource_context
+from dagster import Failure
 from dagster._check import CheckError
-from dagster_dbt import DbtCloudClientResource, dbt_cloud_resource
 
 from .utils import (
-    SAMPLE_ACCOUNT_ID,
     SAMPLE_API_PREFIX,
     SAMPLE_API_V3_PREFIX,
     SAMPLE_JOB_ID,
@@ -23,25 +20,6 @@ from .utils import (
     sample_runs_details,
     sample_set_environment_variable,
 )
-
-
-@pytest.fixture(name="get_dbt_cloud_resource", params=["pythonic", "legacy"])
-def get_dbt_cloud_resource_fixture(request) -> Any:
-    if request.param == "pythonic":
-        return (
-            lambda **kwargs: DbtCloudClientResource(
-                auth_token="some_auth_token", account_id=SAMPLE_ACCOUNT_ID, **kwargs
-            )
-            .with_replaced_resource_context(build_init_resource_context())
-            .get_dbt_client()
-        )
-
-    else:
-        return lambda **kwargs: dbt_cloud_resource(
-            build_init_resource_context(
-                config={"auth_token": "some_auth_token", "account_id": SAMPLE_ACCOUNT_ID, **kwargs}
-            )
-        )
 
 
 @responses.activate

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/utils.py
@@ -1,18 +1,19 @@
 from dagster._utils.merger import deep_merge_dicts
 
-SAMPLE_ACCOUNT_ID = 30000
 SAMPLE_PROJECT_ID = 35000
 SAMPLE_JOB_ID = 40000
 SAMPLE_RUN_ID = 5000000
 
+DBT_CLOUD_API_TOKEN = "abc"
+DBT_CLOUD_ACCOUNT_ID = 30000
 DBT_CLOUD_US_HOST = "https://cloud.getdbt.com/"
 DBT_CLOUD_EMEA_HOST = "https://emea.dbt.com/"
 
-SAMPLE_API_PREFIX = f"{DBT_CLOUD_US_HOST}api/v2/accounts/{SAMPLE_ACCOUNT_ID}"
-SAMPLE_API_V3_PREFIX = f"{DBT_CLOUD_US_HOST}api/v3/accounts/{SAMPLE_ACCOUNT_ID}"
+SAMPLE_API_PREFIX = f"{DBT_CLOUD_US_HOST}api/v2/accounts/{DBT_CLOUD_ACCOUNT_ID}"
+SAMPLE_API_V3_PREFIX = f"{DBT_CLOUD_US_HOST}api/v3/accounts/{DBT_CLOUD_ACCOUNT_ID}"
 
-SAMPLE_EMEA_API_PREFIX = f"{DBT_CLOUD_EMEA_HOST}api/v2/accounts/{SAMPLE_ACCOUNT_ID}"
-SAMPLE_EMEA_API_V3_PREFIX = f"{DBT_CLOUD_EMEA_HOST}api/v3/accounts/{SAMPLE_ACCOUNT_ID}"
+SAMPLE_EMEA_API_PREFIX = f"{DBT_CLOUD_EMEA_HOST}api/v2/accounts/{DBT_CLOUD_ACCOUNT_ID}"
+SAMPLE_EMEA_API_V3_PREFIX = f"{DBT_CLOUD_EMEA_HOST}api/v3/accounts/{DBT_CLOUD_ACCOUNT_ID}"
 
 
 def job_details_data(job_id: int):
@@ -21,7 +22,7 @@ def job_details_data(job_id: int):
         "generate_docs": False,
         "run_generate_sources": False,
         "id": job_id,
-        "account_id": SAMPLE_ACCOUNT_ID,
+        "account_id": DBT_CLOUD_ACCOUNT_ID,
         "project_id": 50000,
         "environment_id": 47000,
         "name": "MyCoolJob",
@@ -85,7 +86,7 @@ def sample_runs_details(include_related=None, **kwargs):
                 "dbt_project_subdirectory": None,
                 "project_id": 50000,
                 "id": 47000,
-                "account_id": SAMPLE_ACCOUNT_ID,
+                "account_id": DBT_CLOUD_ACCOUNT_ID,
                 "connection_id": 56000,
                 "repository_id": 58000,
                 "credentials_id": 52000,
@@ -113,7 +114,7 @@ def sample_run_details(include_related=None, **kwargs):
     base_data = {
         "id": SAMPLE_RUN_ID,
         "trigger_id": 33000000,
-        "account_id": SAMPLE_ACCOUNT_ID,
+        "account_id": DBT_CLOUD_ACCOUNT_ID,
         "environment_id": 47000,
         "project_id": 50000,
         "job_definition_id": SAMPLE_JOB_ID,
@@ -188,7 +189,7 @@ def sample_run_details(include_related=None, **kwargs):
                 "generate_docs": False,
                 "run_generate_sources": False,
                 "id": SAMPLE_JOB_ID,
-                "account_id": SAMPLE_ACCOUNT_ID,
+                "account_id": DBT_CLOUD_ACCOUNT_ID,
                 "project_id": 50000,
                 "environment_id": 47071,
                 "name": "MyCoolJob",
@@ -348,7 +349,7 @@ def sample_set_environment_variable(environment_variable_id: int, name: str, val
             "developer_message": "",
         },
         "data": {
-            "account_id": SAMPLE_ACCOUNT_ID,
+            "account_id": DBT_CLOUD_ACCOUNT_ID,
             "project_id": SAMPLE_PROJECT_ID,
             "name": name,
             "type": "job",


### PR DESCRIPTION
## Summary & Motivation
We weren't actually applying the `pytest` legacy mark properly in our tests with dbt Cloud. Fix that.

Our tox suite test is the following:

```
  dbt_15X_legacy: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
  dbt_16X_legacy: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
  dbt_17X_legacy: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
  dbt_15X: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy" -vv {posargs}
  dbt_16X: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy" -vv {posargs}
  dbt_17X: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy" -vv {posargs}
  dbt_pydantic1: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy" -vv {posargs}
  dbt_legacy_pydantic1: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}

```

This change ensures our `dbt_XXX_legacy` tests execute the legacy tests for dbt cloud, and that our `dbt_XXX` tests don't execute both the legacy and non-legacy tests.

## How I Tested These Changes
pytest
