### PR TITLE
Use `fetch_*` instead of `get_event_records`

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -276,20 +276,20 @@ def get_asset_materializations(
     check.opt_mapping_param(tags, "tags", key_type=str, value_type=str)
 
     instance = graphene_info.context.instance
+    records_filter = AssetRecordsFilter(
+        asset_key=asset_key,
+        asset_partitions=partitions,
+        before_timestamp=before_timestamp,
+        after_timestamp=after_timestamp,
+        tags=tags,
+        storage_ids=storage_ids,
+    )
     if limit is None:
         event_records = []
         cursor = None
         while True:
             event_records_result = instance.fetch_materializations(
-                records_filter=AssetRecordsFilter(
-                    asset_key=asset_key,
-                    asset_partitions=partitions,
-                    before_timestamp=before_timestamp,
-                    after_timestamp=after_timestamp,
-                    storage_ids=storage_ids,
-                ),
-                cursor=cursor,
-                limit=get_max_event_records_limit(),
+                records_filter=records_filter, cursor=cursor, limit=get_max_event_records_limit()
             )
             cursor = event_records_result.cursor
             event_records.extend(event_records_result.records)
@@ -297,13 +297,7 @@ def get_asset_materializations(
                 break
     else:
         event_records = instance.fetch_materializations(
-            records_filter=AssetRecordsFilter(
-                asset_key=asset_key,
-                asset_partitions=partitions,
-                before_timestamp=before_timestamp,
-                after_timestamp=after_timestamp,
-            ),
-            limit=limit,
+            records_filter=records_filter, limit=limit
         ).records
 
     return [event_record.event_log_entry for event_record in event_records]
@@ -323,19 +317,18 @@ def get_asset_observations(
     check.opt_float_param(after_timestamp, "after_timestamp")
 
     instance = graphene_info.context.instance
+    records_filter = AssetRecordsFilter(
+        asset_key=asset_key,
+        asset_partitions=partitions,
+        before_timestamp=before_timestamp,
+        after_timestamp=after_timestamp,
+    )
     if limit is None:
         event_records = []
         cursor = None
         while True:
             event_records_result = instance.fetch_observations(
-                records_filter=AssetRecordsFilter(
-                    asset_key=asset_key,
-                    asset_partitions=partitions,
-                    before_timestamp=before_timestamp,
-                    after_timestamp=after_timestamp,
-                ),
-                cursor=cursor,
-                limit=get_max_event_records_limit(),
+                records_filter=records_filter, cursor=cursor, limit=get_max_event_records_limit()
             )
             cursor = event_records_result.cursor
             event_records.extend(event_records_result.records)
@@ -343,13 +336,7 @@ def get_asset_observations(
                 break
     else:
         event_records = instance.fetch_observations(
-            records_filter=AssetRecordsFilter(
-                asset_key=asset_key,
-                asset_partitions=partitions,
-                before_timestamp=before_timestamp,
-                after_timestamp=after_timestamp,
-            ),
-            limit=limit,
+            records_filter=records_filter, limit=limit
         ).records
 
     return [event_record.event_log_entry for event_record in event_records]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1010,19 +1010,40 @@ class GrapheneAssetNode(graphene.ObjectType):
 
         partitions = partitions or self.get_partition_keys()
 
-        events_for_partitions = get_asset_materializations(
-            graphene_info,
-            self._external_asset_node.asset_key,
-            partitions,
-        )
+        if partitions is None or len(partitions) > 1000:
+            # when there are many partitions, it's much more efficient to grab the latest storage
+            # id for all partitions and then query for the materialization events based on those
+            # storage ids
+            latest_storage_ids = sorted(
+                (
+                    graphene_info.context.instance.event_log_storage.get_latest_storage_id_by_partition(
+                        self._external_asset_node.asset_key, DagsterEventType.ASSET_MATERIALIZATION
+                    )
+                ).values()
+            )
+            events_for_partitions = get_asset_materializations(
+                graphene_info,
+                asset_key=self._external_asset_node.asset_key,
+                partitions=partitions,
+                storage_ids=latest_storage_ids,
+            )
+            latest_materialization_by_partition = {
+                get_partition(event): event for event in events_for_partitions
+            }
+        else:
+            events_for_partitions = get_asset_materializations(
+                graphene_info,
+                self._external_asset_node.asset_key,
+                partitions,
+            )
 
-        latest_materialization_by_partition = {}
-        for event in events_for_partitions:  # events are sorted in order of newest to oldest
-            event_partition = get_partition(event)
-            if event_partition not in latest_materialization_by_partition:
-                latest_materialization_by_partition[event_partition] = event
-            if len(latest_materialization_by_partition) == len(partitions):
-                break
+            latest_materialization_by_partition = {}
+            for event in events_for_partitions:  # events are sorted in order of newest to oldest
+                event_partition = get_partition(event)
+                if event_partition not in latest_materialization_by_partition:
+                    latest_materialization_by_partition[event_partition] = event
+                if len(latest_materialization_by_partition) == len(partitions):
+                    break
 
         # return materializations in the same order as the provided partitions, None if
         # materialization does not exist

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1025,7 +1025,6 @@ class GrapheneAssetNode(graphene.ObjectType):
             events_for_partitions = get_asset_materializations(
                 graphene_info,
                 asset_key=self._external_asset_node.asset_key,
-                partitions=partitions,
                 storage_ids=latest_storage_ids,
             )
             latest_materialization_by_partition = {

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1008,9 +1008,10 @@ class GrapheneAssetNode(graphene.ObjectType):
             lambda event: event.dagster_event.step_materialization_data.materialization.partition
         )
 
-        partitions = partitions or self.get_partition_keys()
+        query_all_partitions = partitions is None
+        partitions = self.get_partition_keys() if query_all_partitions else partitions
 
-        if partitions is None or len(partitions) > 1000:
+        if query_all_partitions or len(partitions) > 1000:
             # when there are many partitions, it's much more efficient to grab the latest storage
             # id for all partitions and then query for the materialization events based on those
             # storage ids


### PR DESCRIPTION
## Summary & Motivation

Avoid using get_event_records in this codepath as it is less efficient.

Horrifyingly, the `getLatestMaterializationEventByPartition` callsite actually gets every single record for a given asset, when we theoretically have much more efficient options available. However, fixing this would require adding a new instance method, and this is a much simpler fix.

Side note: I feel like there should be some built-in functionality for fetching all records rather than having to do this while loop business, but oh well.

## How I Tested These Changes

Existing tests, plus set the limit to 1 and ran tests to ensure that the cursoring behavior works as expected.