### PR TITLE
use uv in make dev_install

### DIFF
--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -104,7 +104,6 @@ def main(
 
     if sys.version_info > (3, 7):
         install_targets += [
-            "-e python_modules/libraries/dagster-dbt",
             "-e python_modules/libraries/dagster-pandera",
             "-e python_modules/libraries/dagster-snowflake",
             "-e python_modules/libraries/dagster-snowflake-pandas",
@@ -130,10 +129,13 @@ def main(
     # if sys.version_info >= (3, 7) and os.name != "nt":
     #     install_targets += ["-e python_modules/libraries/dagster-ge"]
 
+    # Ensure uv is installed which we use for faster package resolution
+    subprocess.run(["pip", "install", "-U", "uv"], check=True)
+
     # NOTE: These need to be installed as one long pip install command, otherwise pip will install
     # conflicting dependencies, which will break pip freeze snapshot creation during the integration
     # image build!
-    cmd = ["pip", "install"] + install_targets
+    cmd = ["uv", "pip", "install"] + install_targets
 
     if quiet is not None:
         cmd.append(f'-{"q" * quiet}')


### PR DESCRIPTION
zoom fast pip
https://github.com/astral-sh/uv
https://astral.sh/blog/uv

## How I Tested These Changes
before
```
time python scripts/install_dev_python_modules.py
...
real	1m26.179s
user	0m59.539s
sys	0m23.994s
```

after, first run cold cache
```
(py311) ~/dagster:master$ python scripts/install_dev_python_modules.py
...
Built 57 editables in 3.95s
Resolved 437 packages in 84ms
Downloaded 149 packages in 13.51s
Installed 206 packages in 520ms
```

after, second run w/ cache
```
(py311) ~/dagster:master$ python scripts/install_dev_python_modules.py
...
Audited 57 packages in 29ms
```

