### PR TITLE
test(dbt): divest from the legacy `TEST_PROJECT_DIR`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
@@ -10,7 +10,7 @@ import pytest
 from dagster_dbt.cli.app import app
 from typer.testing import CliRunner
 
-from ..dbt_projects import test_meta_config_path
+from ..dbt_projects import test_jaffle_shop_path
 
 if TYPE_CHECKING:
     from dagster import Definitions
@@ -27,8 +27,8 @@ def disable_openblas_threading_affinity_fixture(monkeypatch: pytest.MonkeyPatch)
 
 @pytest.fixture(name="dbt_project_dir")
 def dbt_project_dir_fixture(tmp_path: Path, disable_openblas_threading_affinity) -> Path:
-    dbt_project_dir = tmp_path.joinpath("test_dagster_meta_config")
-    shutil.copytree(src=test_meta_config_path, dst=dbt_project_dir)
+    dbt_project_dir = tmp_path.joinpath("test_jaffle_shop")
+    shutil.copytree(src=test_jaffle_shop_path, dst=dbt_project_dir)
 
     return dbt_project_dir
 
@@ -84,7 +84,7 @@ def _update_dbt_project_path(
 ) -> Path:
     if use_dbt_project_package_data_dir:
         dbt_project_dir = dagster_project_dir.joinpath("dbt-project")
-        shutil.copytree(src=test_meta_config_path, dst=dbt_project_dir)
+        shutil.copytree(src=test_jaffle_shop_path, dst=dbt_project_dir)
 
     return dbt_project_dir
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 import pytest
 from dagster._utils import file_relative_path, pushd
 from dagster_dbt import DbtCliClientResource, DbtCliResource, dbt_cli_resource
+from dagster_dbt.core.resources_v2 import DbtCliInvocation
 
 from .dbt_projects import (
     test_asset_checks_path,
@@ -96,50 +97,62 @@ def dbt_build(dbt_executable, dbt_config_dir):
         subprocess.run([dbt_executable, "run", "--profiles-dir", dbt_config_dir], check=True)
 
 
-def _create_dbt_manifest(project_dir: Path) -> Dict[str, Any]:
+def _create_dbt_invocation(project_dir: Path) -> DbtCliInvocation:
     dbt = DbtCliResource(project_dir=os.fspath(project_dir), global_config_flags=["--quiet"])
 
     dbt.cli(["deps"]).wait()
     dbt_invocation = dbt.cli(["compile"]).wait()
 
-    return dbt_invocation.get_artifact("manifest.json")
+    return dbt_invocation
+
+
+@pytest.fixture(name="test_jaffle_shop_invocation", scope="session")
+def test_jaffle_shop_invocation_fixture() -> DbtCliInvocation:
+    return _create_dbt_invocation(test_jaffle_shop_path)
+
+
+@pytest.fixture(name="test_jaffle_shop_manifest_path", scope="session")
+def test_jaffle_shop_manifest_path_fixture(test_jaffle_shop_invocation: DbtCliInvocation) -> Path:
+    return test_jaffle_shop_invocation.target_path.joinpath("manifest.json")
 
 
 @pytest.fixture(name="test_jaffle_shop_manifest", scope="session")
-def test_jaffle_shop_manifest_fixture() -> Dict[str, Any]:
-    return _create_dbt_manifest(test_jaffle_shop_path)
+def test_jaffle_shop_manifest_fixture(
+    test_jaffle_shop_invocation: DbtCliInvocation,
+) -> Dict[str, Any]:
+    return test_jaffle_shop_invocation.get_artifact("manifest.json")
 
 
 @pytest.fixture(name="test_asset_checks_manifest", scope="session")
 def test_asset_checks_manifest_fixture() -> Dict[str, Any]:
-    return _create_dbt_manifest(test_asset_checks_path)
+    return _create_dbt_invocation(test_asset_checks_path).get_artifact("manifest.json")
 
 
 @pytest.fixture(name="test_asset_key_exceptions_manifest", scope="session")
 def test_asset_key_exceptions_manifest_fixture() -> Dict[str, Any]:
-    return _create_dbt_manifest(test_asset_key_exceptions_path)
+    return _create_dbt_invocation(test_asset_key_exceptions_path).get_artifact("manifest.json")
 
 
 @pytest.fixture(name="test_dbt_alias_manifest", scope="session")
 def test_dbt_alias_manifest_fixture() -> Dict[str, Any]:
-    return _create_dbt_manifest(test_dbt_alias_path)
+    return _create_dbt_invocation(test_dbt_alias_path).get_artifact("manifest.json")
 
 
 @pytest.fixture(name="test_dbt_model_versions_manifest", scope="session")
 def test_dbt_model_versions_manifest_fixture() -> Dict[str, Any]:
-    return _create_dbt_manifest(test_dbt_model_versions_path)
+    return _create_dbt_invocation(test_dbt_model_versions_path).get_artifact("manifest.json")
 
 
 @pytest.fixture(name="test_dbt_python_interleaving_manifest", scope="session")
 def test_dbt_python_interleaving_manifest_fixture() -> Dict[str, Any]:
-    return _create_dbt_manifest(test_dbt_python_interleaving_path)
+    return _create_dbt_invocation(test_dbt_python_interleaving_path).get_artifact("manifest.json")
 
 
 @pytest.fixture(name="test_meta_config_manifest", scope="session")
 def test_meta_config_manifest_fixture() -> Dict[str, Any]:
-    return _create_dbt_manifest(test_meta_config_path)
+    return _create_dbt_invocation(test_meta_config_path).get_artifact("manifest.json")
 
 
 @pytest.fixture(name="test_metadata_manifest", scope="session")
 def test_metadata_manifest_fixture() -> Dict[str, Any]:
-    return _create_dbt_manifest(test_metadata_path)
+    return _create_dbt_invocation(test_metadata_path).get_artifact("manifest.json")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
@@ -1,115 +1,149 @@
-import json
 import os
 from pathlib import Path
-from typing import Optional, Set
+from typing import Any, Dict, Optional, Set
 
 import pytest
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.events import AssetKey
 from dagster_dbt import build_dbt_asset_selection
 from dagster_dbt.asset_decorator import dbt_assets
-from dagster_dbt.dbt_manifest import DbtManifestParam
-
-manifest_path = Path(__file__).joinpath("..", "..", "sample_manifest.json").resolve()
-
-with open(manifest_path, "r") as f:
-    manifest = json.load(f)
 
 
 @pytest.mark.parametrize(
-    ["select", "exclude", "expected_asset_names"],
+    ["select", "exclude", "expected_dbt_resource_names"],
     [
         (
-            "fqn:*",
+            None,
             None,
             {
-                "sort_by_calories",
-                "cold_schema/sort_cold_cereals_by_calories",
-                "subdir_schema/least_caloric",
-                "sort_hot_cereals_by_calories",
-                "orders_snapshot",
-                "cereals",
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
             },
         ),
         (
-            "+least_caloric",
-            None,
-            {"sort_by_calories", "subdir_schema/least_caloric", "cereals"},
-        ),
-        (
-            "sort_by_calories least_caloric",
-            None,
-            {"sort_by_calories", "subdir_schema/least_caloric"},
-        ),
-        (
-            "tag:bar+",
+            "raw_customers stg_customers",
             None,
             {
-                "sort_by_calories",
-                "cold_schema/sort_cold_cereals_by_calories",
-                "subdir_schema/least_caloric",
-                "sort_hot_cereals_by_calories",
-                "orders_snapshot",
+                "raw_customers",
+                "stg_customers",
             },
         ),
         (
-            "tag:foo",
+            "raw_customers+",
             None,
-            {"sort_by_calories", "cold_schema/sort_cold_cereals_by_calories"},
-        ),
-        (
-            "tag:foo,tag:bar",
-            None,
-            {"sort_by_calories"},
-        ),
-        (
-            None,
-            "sort_hot_cereals_by_calories",
             {
-                "sort_by_calories",
-                "cold_schema/sort_cold_cereals_by_calories",
-                "subdir_schema/least_caloric",
-                "cereals",
-                "orders_snapshot",
+                "raw_customers",
+                "stg_customers",
+                "customers",
+            },
+        ),
+        (
+            "resource_type:model",
+            None,
+            {
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
+            },
+        ),
+        (
+            "raw_customers+,resource_type:model",
+            None,
+            {
+                "stg_customers",
+                "customers",
             },
         ),
         (
             None,
-            "+least_caloric",
+            "orders",
             {
-                "cold_schema/sort_cold_cereals_by_calories",
-                "sort_hot_cereals_by_calories",
-                "orders_snapshot",
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
             },
         ),
         (
             None,
-            "sort_by_calories least_caloric",
+            "raw_customers+",
             {
-                "cold_schema/sort_cold_cereals_by_calories",
-                "sort_hot_cereals_by_calories",
-                "orders_snapshot",
-                "cereals",
+                "raw_orders",
+                "raw_payments",
+                "stg_orders",
+                "stg_payments",
+                "orders",
             },
         ),
         (
             None,
-            "tag:foo",
+            "raw_customers stg_customers",
             {
-                "subdir_schema/least_caloric",
-                "sort_hot_cereals_by_calories",
-                "orders_snapshot",
-                "cereals",
+                "raw_orders",
+                "raw_payments",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
+            },
+        ),
+        (
+            None,
+            "resource_type:model",
+            {
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+            },
+        ),
+        (
+            None,
+            "tag:does-not-exist",
+            {
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
             },
         ),
     ],
+    ids=[
+        "--select fqn:*",
+        "--select raw_customers stg_customers",
+        "--select raw_customers+",
+        "--select resource_type:model",
+        "--select raw_customers+,resource_type:model",
+        "--exclude orders",
+        "--exclude raw_customers+",
+        "--exclude raw_customers stg_customers",
+        "--exclude resource_type:model",
+        "--exclude tag:does-not-exist",
+    ],
 )
 def test_dbt_asset_selection(
-    select: Optional[str], exclude: Optional[str], expected_asset_names: Set[str]
+    test_jaffle_shop_manifest: Dict[str, Any],
+    select: Optional[str],
+    exclude: Optional[str],
+    expected_dbt_resource_names: Set[str],
 ) -> None:
-    expected_asset_keys = {AssetKey(key.split("/")) for key in expected_asset_names}
+    expected_asset_keys = {AssetKey(key) for key in expected_dbt_resource_names}
 
-    @dbt_assets(manifest=manifest)
+    @dbt_assets(manifest=test_jaffle_shop_manifest)
     def my_dbt_assets():
         ...
 
@@ -124,26 +158,35 @@ def test_dbt_asset_selection(
     assert selected_asset_keys == expected_asset_keys
 
 
-@pytest.mark.parametrize("manifest", [manifest, manifest_path, os.fspath(manifest_path)])
-def test_dbt_asset_selection_manifest_argument(manifest: DbtManifestParam) -> None:
+def test_dbt_asset_selection_manifest_argument(
+    test_jaffle_shop_manifest_path: Path, test_jaffle_shop_manifest: Dict[str, Any]
+) -> None:
     expected_asset_keys = {
-        AssetKey(key.split("/"))
+        AssetKey(key)
         for key in {
-            "sort_by_calories",
-            "cold_schema/sort_cold_cereals_by_calories",
-            "subdir_schema/least_caloric",
-            "sort_hot_cereals_by_calories",
-            "orders_snapshot",
-            "cereals",
+            "raw_customers",
+            "raw_orders",
+            "raw_payments",
+            "stg_customers",
+            "stg_orders",
+            "stg_payments",
+            "customers",
+            "orders",
         }
     }
 
-    @dbt_assets(manifest=manifest)
-    def my_dbt_assets():
-        ...
+    for manifest_param in [
+        test_jaffle_shop_manifest,
+        test_jaffle_shop_manifest_path,
+        os.fspath(test_jaffle_shop_manifest_path),
+    ]:
 
-    asset_graph = AssetGraph.from_assets([my_dbt_assets])
-    asset_selection = build_dbt_asset_selection([my_dbt_assets], dbt_select="fqn:*")
-    selected_asset_keys = asset_selection.resolve(all_assets=asset_graph)
+        @dbt_assets(manifest=manifest_param)
+        def my_dbt_assets():
+            ...
 
-    assert selected_asset_keys == expected_asset_keys
+        asset_graph = AssetGraph.from_assets([my_dbt_assets])
+        asset_selection = build_dbt_asset_selection([my_dbt_assets], dbt_select="fqn:*")
+        selected_asset_keys = asset_selection.resolve(all_assets=asset_graph)
+
+        assert selected_asset_keys == expected_asset_keys

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -1,8 +1,7 @@
-import json
 import os
 import shutil
 from pathlib import Path
-from typing import List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 import pytest
 from dagster import (
@@ -23,25 +22,26 @@ from dagster_dbt.core.resources_v2 import (
     DbtCliEventMessage,
     DbtCliResource,
 )
-from dagster_dbt.dbt_manifest import DbtManifestParam
 from dagster_dbt.errors import DagsterDbtCliRuntimeError
 from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
-from ..conftest import TEST_PROJECT_DIR
-from ..dbt_projects import test_exceptions_path
+from ..dbt_projects import test_exceptions_path, test_jaffle_shop_path
 
-manifest_path = Path(TEST_PROJECT_DIR).joinpath("manifest.json")
-manifest = json.loads(manifest_path.read_bytes())
+
+@pytest.fixture(name="dbt", scope="module")
+def dbt_fixture() -> DbtCliResource:
+    return DbtCliResource(project_dir=os.fspath(test_jaffle_shop_path))
 
 
 @pytest.mark.parametrize("global_config_flags", [[], ["--quiet"]])
-@pytest.mark.parametrize("command", ["run", "parse"])
-def test_dbt_cli(global_config_flags: List[str], command: str) -> None:
-    dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR, global_config_flags=global_config_flags)
-    dbt_cli_invocation = dbt.cli([command])
+def test_dbt_cli(global_config_flags: List[str]) -> None:
+    dbt = DbtCliResource(
+        project_dir=os.fspath(test_jaffle_shop_path), global_config_flags=global_config_flags
+    )
+    dbt_cli_invocation = dbt.cli(["parse"])
 
-    assert dbt_cli_invocation.process.args == ["dbt", *global_config_flags, command]
+    assert dbt_cli_invocation.process.args == ["dbt", *global_config_flags, "parse"]
     assert dbt_cli_invocation.is_successful()
     assert dbt_cli_invocation.process.returncode == 0
     assert dbt_cli_invocation.target_path.joinpath("dbt.log").exists()
@@ -49,31 +49,31 @@ def test_dbt_cli(global_config_flags: List[str], command: str) -> None:
 
 def test_dbt_cli_executable() -> None:
     dbt_executable = cast(str, shutil.which("dbt"))
-    dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR, dbt_executable=dbt_executable)
+    assert (
+        DbtCliResource(project_dir=os.fspath(test_jaffle_shop_path), dbt_executable=dbt_executable)
+        .cli(["parse"])
+        .is_successful()
+    )
 
-    assert dbt.cli(["run"], manifest=manifest).is_successful()
-
-    dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR, dbt_executable=Path(dbt_executable))  # type: ignore
-
-    assert dbt.cli(["run"], manifest=manifest).is_successful()
+    assert (
+        DbtCliResource(
+            project_dir=os.fspath(test_jaffle_shop_path),
+            dbt_executable=Path(dbt_executable),  # type: ignore
+        )
+        .cli(["parse"])
+        .is_successful()
+    )
 
     # dbt executable must exist
     with pytest.raises(ValidationError, match="does not exist"):
-        DbtCliResource(project_dir=TEST_PROJECT_DIR, dbt_executable="nonexistent")
-
-
-@pytest.mark.parametrize("manifest", [None, manifest, manifest_path, os.fspath(manifest_path)])
-def test_dbt_cli_manifest_argument(manifest: DbtManifestParam) -> None:
-    dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
-
-    assert dbt.cli(["run"], manifest=manifest).is_successful()
+        DbtCliResource(project_dir=os.fspath(test_jaffle_shop_path), dbt_executable="nonexistent")
 
 
 def test_dbt_cli_project_dir_path() -> None:
-    dbt = DbtCliResource(project_dir=Path(TEST_PROJECT_DIR))  # type: ignore
+    dbt = DbtCliResource(project_dir=test_jaffle_shop_path)  # type: ignore
 
     assert Path(dbt.project_dir).is_absolute()
-    assert dbt.cli(["run"]).is_successful()
+    assert dbt.cli(["parse"]).is_successful()
 
     # project directory must exist
     with pytest.raises(ValidationError, match="does not exist"):
@@ -81,7 +81,7 @@ def test_dbt_cli_project_dir_path() -> None:
 
     # project directory must be a valid dbt project
     with pytest.raises(ValidationError, match="specify a valid path to a dbt project"):
-        DbtCliResource(project_dir=f"{TEST_PROJECT_DIR}/models")
+        DbtCliResource(project_dir=f"{os.fspath(test_jaffle_shop_path)}/models")
 
 
 def test_dbt_cli_failure() -> None:
@@ -108,8 +108,8 @@ def test_dbt_cli_failure() -> None:
 def test_dbt_cli_subprocess_cleanup(
     mocker: MockerFixture,
     caplog: pytest.LogCaptureFixture,
+    dbt: DbtCliResource,
 ) -> None:
-    dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
     dbt_cli_invocation_1 = dbt.cli(["run"])
 
     assert dbt_cli_invocation_1.process.returncode is None
@@ -125,13 +125,11 @@ def test_dbt_cli_subprocess_cleanup(
     assert dbt_cli_invocation_1.process.returncode < 0
 
 
-def test_dbt_cli_get_artifact() -> None:
-    dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
-
-    dbt_cli_invocation_1 = dbt.cli(["run"]).wait()
+def test_dbt_cli_get_artifact(dbt: DbtCliResource) -> None:
+    dbt_cli_invocation_1 = dbt.cli(["seed"]).wait()
     dbt_cli_invocation_2 = dbt.cli(["compile"]).wait()
 
-    # `dbt run` produces a manifest.json and run_results.json
+    # `dbt seed` produces a manifest.json and run_results.json
     manifest_json_1 = dbt_cli_invocation_1.get_artifact("manifest.json")
     assert manifest_json_1
     assert dbt_cli_invocation_1.get_artifact("run_results.json")
@@ -147,16 +145,17 @@ def test_dbt_cli_get_artifact() -> None:
 
     # Artifacts are stored in separate paths by manipulating DBT_TARGET_PATH.
     # By default, they are stored in the `target` directory of the DBT project.
-    assert dbt_cli_invocation_1.target_path.parent == Path(TEST_PROJECT_DIR, "target")
+    assert dbt_cli_invocation_1.target_path.parent == test_jaffle_shop_path.joinpath("target")
 
     # As a result, their contents should be different, and newer artifacts
     # should not overwrite older ones.
     assert manifest_json_1 != manifest_json_2
 
 
-def test_dbt_cli_target_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_dbt_cli_target_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, dbt: DbtCliResource
+) -> None:
     monkeypatch.setenv("DBT_TARGET_PATH", os.fspath(tmp_path))
-    dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
 
     dbt_cli_invocation_1 = dbt.cli(["compile"]).wait()
     manifest_st_mtime_1 = dbt_cli_invocation_1.target_path.joinpath("manifest.json").stat().st_mtime
@@ -172,10 +171,11 @@ def test_dbt_cli_target_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
 
 
 @pytest.mark.parametrize("target_path", [Path("tmp"), Path("/tmp")])
-def test_dbt_cli_target_path_env_var(monkeypatch: pytest.MonkeyPatch, target_path: Path) -> None:
-    dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
+def test_dbt_cli_target_path_env_var(
+    monkeypatch: pytest.MonkeyPatch, dbt: DbtCliResource, target_path: Path
+) -> None:
     expected_target_path = (
-        target_path if target_path.is_absolute() else Path(TEST_PROJECT_DIR).joinpath(target_path)
+        target_path if target_path.is_absolute() else test_jaffle_shop_path.joinpath(target_path)
     )
 
     monkeypatch.setenv("DBT_TARGET_PATH", os.fspath(target_path))
@@ -187,42 +187,51 @@ def test_dbt_cli_target_path_env_var(monkeypatch: pytest.MonkeyPatch, target_pat
 
 
 def test_dbt_profile_configuration() -> None:
-    dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR, profile="duckdb", target="dev")
-
-    dbt_cli_invocation = dbt.cli(["parse"]).wait()
+    dbt_cli_invocation = (
+        DbtCliResource(
+            project_dir=os.fspath(test_jaffle_shop_path), profile="jaffle_shop", target="dev"
+        )
+        .cli(["parse"])
+        .wait()
+    )
 
     assert dbt_cli_invocation.process.args == [
         "dbt",
         "parse",
         "--profile",
-        "duckdb",
+        "jaffle_shop",
         "--target",
         "dev",
     ]
     assert dbt_cli_invocation.is_successful()
 
 
-@pytest.mark.parametrize("profiles_dir", [None, TEST_PROJECT_DIR, Path(TEST_PROJECT_DIR)])
+@pytest.mark.parametrize(
+    "profiles_dir", [None, test_jaffle_shop_path, os.fspath(test_jaffle_shop_path)]
+)
 def test_dbt_profiles_dir_configuration(profiles_dir: Union[str, Path]) -> None:
-    dbt = DbtCliResource(
-        project_dir=TEST_PROJECT_DIR,
-        profiles_dir=profiles_dir,  # type: ignore
+    assert (
+        DbtCliResource(
+            project_dir=os.fspath(test_jaffle_shop_path),
+            profiles_dir=profiles_dir,  # type: ignore
+        )
+        .cli(["parse"])
+        .is_successful()
     )
-
-    assert dbt.cli(["parse"]).is_successful()
 
     # profiles directory must exist
     with pytest.raises(ValidationError, match="does not exist"):
-        DbtCliResource(project_dir=TEST_PROJECT_DIR, profiles_dir="nonexistent")
+        DbtCliResource(project_dir=os.fspath(test_jaffle_shop_path), profiles_dir="nonexistent")
 
     # profiles directory must contain profile configuration
     with pytest.raises(ValidationError, match="specify a valid path to a dbt profile directory"):
-        DbtCliResource(project_dir=TEST_PROJECT_DIR, profiles_dir=f"{TEST_PROJECT_DIR}/models")
+        DbtCliResource(
+            project_dir=os.fspath(test_jaffle_shop_path),
+            profiles_dir=f"{os.fspath(test_jaffle_shop_path)}/models",
+        )
 
 
-def test_dbt_without_partial_parse() -> None:
-    dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
-
+def test_dbt_without_partial_parse(dbt: DbtCliResource) -> None:
     dbt.cli(["clean"]).wait()
 
     dbt_cli_compile_without_partial_parse_invocation = dbt.cli(["compile"])
@@ -234,19 +243,18 @@ def test_dbt_without_partial_parse() -> None:
     )
 
 
-def test_dbt_with_partial_parse() -> None:
-    dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
-
+def test_dbt_with_partial_parse(dbt: DbtCliResource) -> None:
     dbt.cli(["clean"]).wait()
 
     # Run `dbt compile` to generate the partial parse file
     dbt_cli_compile_invocation = dbt.cli(["compile"]).wait()
 
     # Copy the partial parse file to the target directory
-    partial_parse_file_path = Path(
-        TEST_PROJECT_DIR, dbt_cli_compile_invocation.target_path, PARTIAL_PARSE_FILE_NAME
+    partial_parse_file_path = test_jaffle_shop_path.joinpath(
+        dbt_cli_compile_invocation.target_path,
+        PARTIAL_PARSE_FILE_NAME,
     )
-    original_target_path = Path(TEST_PROJECT_DIR, "target", PARTIAL_PARSE_FILE_NAME)
+    original_target_path = test_jaffle_shop_path.joinpath("target", PARTIAL_PARSE_FILE_NAME)
 
     original_target_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy(partial_parse_file_path, original_target_path)
@@ -285,22 +293,21 @@ def test_dbt_with_partial_parse() -> None:
     )
 
 
-def test_dbt_cli_debug_execution() -> None:
-    @dbt_assets(manifest=manifest)
+def test_dbt_cli_debug_execution(
+    test_jaffle_shop_manifest: Dict[str, Any], dbt: DbtCliResource
+) -> None:
+    @dbt_assets(manifest=test_jaffle_shop_manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        yield from dbt.cli(["--debug", "run"], context=context).stream()
+        yield from dbt.cli(["--debug", "build"], context=context).stream()
 
-    result = materialize(
-        [my_dbt_assets],
-        resources={
-            "dbt": DbtCliResource(project_dir=TEST_PROJECT_DIR),
-        },
-    )
+    result = materialize([my_dbt_assets], resources={"dbt": dbt})
     assert result.success
 
 
-def test_dbt_cli_adapter_metadata() -> None:
-    @dbt_assets(manifest=manifest)
+def test_dbt_cli_adapter_metadata(
+    test_jaffle_shop_manifest: Dict[str, Any], dbt: DbtCliResource
+) -> None:
+    @dbt_assets(manifest=test_jaffle_shop_manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
         # For `dbt-duckdb`, the `rows_affected` metadata is only emitted for seed files.
         for event in dbt.cli(["seed"], context=context).stream():
@@ -308,77 +315,68 @@ def test_dbt_cli_adapter_metadata() -> None:
 
             yield event
 
-    result = materialize(
-        [my_dbt_assets],
-        resources={
-            "dbt": DbtCliResource(project_dir=TEST_PROJECT_DIR),
-        },
-    )
+    result = materialize([my_dbt_assets], resources={"dbt": dbt})
     assert result.success
 
 
-def test_dbt_cli_subsetted_execution() -> None:
+def test_dbt_cli_asset_selection(
+    test_jaffle_shop_manifest: Dict[str, Any], dbt: DbtCliResource
+) -> None:
     dbt_select = " ".join(
         [
-            "fqn:dagster_dbt_test_project.subdir.least_caloric",
-            "fqn:dagster_dbt_test_project.sort_by_calories",
+            "fqn:jaffle_shop.raw_customers",
+            "fqn:jaffle_shop.staging.stg_customers",
         ]
     )
 
-    @dbt_assets(manifest=manifest, select=dbt_select)
+    @dbt_assets(manifest=test_jaffle_shop_manifest, select=dbt_select)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        dbt_cli_invocation = dbt.cli(["run"], context=context)
+        dbt_cli_invocation = dbt.cli(["build"], context=context)
 
-        assert dbt_cli_invocation.process.args == ["dbt", "run", "--select", dbt_select]
+        assert dbt_cli_invocation.process.args == ["dbt", "build", "--select", dbt_select]
 
         yield from dbt_cli_invocation.stream()
 
-    result = materialize(
-        [my_dbt_assets],
-        resources={
-            "dbt": DbtCliResource(project_dir=TEST_PROJECT_DIR),
-        },
-    )
+    result = materialize([my_dbt_assets], resources={"dbt": dbt})
     assert result.success
 
 
-def test_dbt_cli_asset_selection() -> None:
+def test_dbt_cli_subsetted_execution(
+    test_jaffle_shop_manifest: Dict[str, Any], dbt: DbtCliResource
+) -> None:
     dbt_select = [
-        "fqn:dagster_dbt_test_project.subdir.least_caloric",
-        "fqn:dagster_dbt_test_project.sort_by_calories",
+        "fqn:jaffle_shop.raw_customers",
+        "fqn:jaffle_shop.staging.stg_customers",
     ]
 
-    @dbt_assets(manifest=manifest)
+    @dbt_assets(manifest=test_jaffle_shop_manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        dbt_cli_invocation = dbt.cli(["run"], context=context)
+        dbt_cli_invocation = dbt.cli(["build"], context=context)
 
         dbt_cli_args: List[str] = list(dbt_cli_invocation.process.args)  # type: ignore
         *dbt_args, dbt_select_args = dbt_cli_args
 
-        assert dbt_args == ["dbt", "run", "--select"]
+        assert dbt_args == ["dbt", "build", "--select"]
         assert set(dbt_select_args.split()) == set(dbt_select)
 
         yield from dbt_cli_invocation.stream()
 
     result = materialize(
         [my_dbt_assets],
-        resources={
-            "dbt": DbtCliResource(project_dir=TEST_PROJECT_DIR),
-        },
+        resources={"dbt": dbt},
         selection=build_dbt_asset_selection(
             [my_dbt_assets],
-            dbt_select=(
-                "fqn:dagster_dbt_test_project.subdir.least_caloric"
-                " fqn:dagster_dbt_test_project.sort_by_calories"
-            ),
+            dbt_select=" ".join(dbt_select),
         ),
     )
     assert result.success
 
 
-@pytest.mark.parametrize("exclude", [None, "fqn:dagster_dbt_test_project.subdir.least_caloric"])
-def test_dbt_cli_default_selection(exclude: Optional[str]) -> None:
-    @dbt_assets(manifest=manifest, exclude=exclude)
+@pytest.mark.parametrize("exclude", [None, "fqn:test_jaffle_shop.customers"])
+def test_dbt_cli_default_selection(
+    test_jaffle_shop_manifest: Dict[str, Any], dbt: DbtCliResource, exclude: Optional[str]
+) -> None:
+    @dbt_assets(manifest=test_jaffle_shop_manifest, exclude=exclude)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
         dbt_cli_invocation = dbt.cli(["run"], context=context)
 
@@ -390,40 +388,22 @@ def test_dbt_cli_default_selection(exclude: Optional[str]) -> None:
 
         yield from dbt_cli_invocation.stream()
 
-    result = materialize(
-        [my_dbt_assets],
-        resources={
-            "dbt": DbtCliResource(project_dir=TEST_PROJECT_DIR),
-        },
-    )
+    result = materialize([my_dbt_assets], resources={"dbt": dbt})
     assert result.success
 
 
-def test_dbt_cli_op_execution() -> None:
-    dbt = DbtCliResource(project_dir=TEST_PROJECT_DIR)
-
-    @op
-    def my_dbt_op(dbt: DbtCliResource):
-        dbt.cli(["run"]).wait()
-
-    @job
-    def my_dbt_job():
-        my_dbt_op()
-
-    result = my_dbt_job.execute_in_process(resources={"dbt": dbt})
-
-    assert result.success
-
+def test_dbt_cli_op_execution(
+    test_jaffle_shop_manifest: Dict[str, Any], dbt: DbtCliResource
+) -> None:
     @op(out={})
     def my_dbt_op_yield_events(context: OpExecutionContext, dbt: DbtCliResource):
-        yield from dbt.cli(["build"], manifest=manifest, context=context).stream()
+        yield from dbt.cli(["build"], manifest=test_jaffle_shop_manifest, context=context).stream()
 
     @job
     def my_dbt_job_yield_events():
         my_dbt_op_yield_events()
 
     result = my_dbt_job_yield_events.execute_in_process(resources={"dbt": dbt})
-
     assert result.success
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_schedules.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_schedules.py
@@ -1,15 +1,9 @@
-import json
-from pathlib import Path
-from typing import Mapping, Optional
+from typing import Any, Dict, Mapping, Optional
 
 import pytest
 from dagster import DefaultScheduleStatus, RunConfig
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 from dagster_dbt import DbtManifestAssetSelection, build_schedule_from_dbt_selection, dbt_assets
-
-manifest_path = Path(__file__).joinpath("..", "..", "sample_manifest.json").resolve()
-with open(manifest_path, "r") as f:
-    manifest = json.load(f)
 
 
 @pytest.mark.parametrize(
@@ -47,6 +41,7 @@ with open(manifest_path, "r") as f:
     ],
 )
 def test_dbt_build_schedule(
+    test_jaffle_shop_manifest: Dict[str, Any],
     job_name: str,
     cron_schedule: str,
     dbt_select: str,
@@ -56,7 +51,7 @@ def test_dbt_build_schedule(
     execution_timezone: Optional[str],
     default_status: DefaultScheduleStatus,
 ) -> None:
-    @dbt_assets(manifest=manifest)
+    @dbt_assets(manifest=test_jaffle_shop_manifest)
     def my_dbt_assets():
         ...
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -1,7 +1,6 @@
-import json
 import os
 from pathlib import Path
-from typing import AbstractSet, Any, Dict, Mapping, Optional
+from typing import Any, Dict, Mapping, Optional, Set
 
 import pytest
 from dagster import (
@@ -28,7 +27,6 @@ from dagster._core.types.dagster_type import DagsterType
 from dagster_dbt.asset_decorator import DUPLICATE_ASSET_KEY_ERROR_MESSAGE, dbt_assets
 from dagster_dbt.core.resources_v2 import DbtCliResource
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
-from dagster_dbt.dbt_manifest import DbtManifestParam
 
 from .dbt_projects import (
     test_dbt_alias_path,
@@ -37,151 +35,187 @@ from .dbt_projects import (
     test_meta_config_path,
 )
 
-manifest_path = Path(__file__).joinpath("..", "sample_manifest.json").resolve()
-manifest = json.loads(manifest_path.read_bytes())
 
+def test_manifest_argument(
+    test_jaffle_shop_manifest_path: Path, test_jaffle_shop_manifest: Dict[str, Any]
+) -> None:
+    for manifest_param in [
+        test_jaffle_shop_manifest,
+        test_jaffle_shop_manifest_path,
+        os.fspath(test_jaffle_shop_manifest_path),
+    ]:
 
-@pytest.mark.parametrize("manifest", [manifest, manifest_path, os.fspath(manifest_path)])
-def test_manifest_argument(manifest: DbtManifestParam):
-    @dbt_assets(manifest=manifest)
-    def my_dbt_assets():
-        ...
+        @dbt_assets(manifest=manifest_param)
+        def my_dbt_assets():
+            ...
 
-    assert my_dbt_assets.keys == {
-        AssetKey.from_user_string(key)
-        for key in [
-            "sort_by_calories",
-            "cold_schema/sort_cold_cereals_by_calories",
-            "subdir_schema/least_caloric",
-            "sort_hot_cereals_by_calories",
-            "orders_snapshot",
-            "cereals",
-        ]
-    }
+        assert my_dbt_assets.keys == {
+            AssetKey(key)
+            for key in {
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
+            }
+        }
 
 
 @pytest.mark.parametrize(
-    "select,exclude,expected_asset_names",
+    ["select", "exclude", "expected_dbt_resource_names"],
     [
         (
-            "*",
+            None,
             None,
             {
-                "sort_by_calories",
-                "cold_schema/sort_cold_cereals_by_calories",
-                "subdir_schema/least_caloric",
-                "sort_hot_cereals_by_calories",
-                "orders_snapshot",
-                "cereals",
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
             },
         ),
         (
-            "+least_caloric",
-            None,
-            {"sort_by_calories", "subdir_schema/least_caloric", "cereals"},
-        ),
-        (
-            "sort_by_calories least_caloric",
-            None,
-            {"sort_by_calories", "subdir_schema/least_caloric"},
-        ),
-        (
-            "tag:bar+",
+            "raw_customers stg_customers",
             None,
             {
-                "sort_by_calories",
-                "cold_schema/sort_cold_cereals_by_calories",
-                "subdir_schema/least_caloric",
-                "sort_hot_cereals_by_calories",
-                "orders_snapshot",
+                "raw_customers",
+                "stg_customers",
             },
         ),
         (
-            "tag:foo",
+            "raw_customers+",
             None,
-            {"sort_by_calories", "cold_schema/sort_cold_cereals_by_calories"},
-        ),
-        (
-            "tag:foo,tag:bar",
-            None,
-            {"sort_by_calories"},
-        ),
-        (
-            None,
-            "sort_hot_cereals_by_calories",
             {
-                "sort_by_calories",
-                "cold_schema/sort_cold_cereals_by_calories",
-                "subdir_schema/least_caloric",
-                "cereals",
-                "orders_snapshot",
+                "raw_customers",
+                "stg_customers",
+                "customers",
+            },
+        ),
+        (
+            "resource_type:model",
+            None,
+            {
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
+            },
+        ),
+        (
+            "raw_customers+,resource_type:model",
+            None,
+            {
+                "stg_customers",
+                "customers",
             },
         ),
         (
             None,
-            "+least_caloric",
+            "orders",
             {
-                "cold_schema/sort_cold_cereals_by_calories",
-                "sort_hot_cereals_by_calories",
-                "orders_snapshot",
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
             },
         ),
         (
             None,
-            "sort_by_calories least_caloric",
+            "raw_customers+",
             {
-                "cold_schema/sort_cold_cereals_by_calories",
-                "sort_hot_cereals_by_calories",
-                "orders_snapshot",
-                "cereals",
+                "raw_orders",
+                "raw_payments",
+                "stg_orders",
+                "stg_payments",
+                "orders",
             },
         ),
         (
             None,
-            "tag:foo",
+            "raw_customers stg_customers",
             {
-                "subdir_schema/least_caloric",
-                "sort_hot_cereals_by_calories",
-                "orders_snapshot",
-                "cereals",
+                "raw_orders",
+                "raw_payments",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
             },
         ),
         (
-            "*",
+            None,
+            "resource_type:model",
+            {
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+            },
+        ),
+        (
+            None,
             "tag:does-not-exist",
             {
-                "sort_by_calories",
-                "cold_schema/sort_cold_cereals_by_calories",
-                "subdir_schema/least_caloric",
-                "sort_hot_cereals_by_calories",
-                "orders_snapshot",
-                "cereals",
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
             },
         ),
     ],
+    ids=[
+        "--select fqn:*",
+        "--select raw_customers stg_customers",
+        "--select raw_customers+",
+        "--select resource_type:model",
+        "--select raw_customers+,resource_type:model",
+        "--exclude orders",
+        "--exclude raw_customers+",
+        "--exclude raw_customers stg_customers",
+        "--exclude resource_type:model",
+        "--exclude tag:does-not-exist",
+    ],
 )
 def test_selections(
-    select: Optional[str], exclude: Optional[str], expected_asset_names: AbstractSet[str]
+    test_jaffle_shop_manifest: Dict[str, Any],
+    select: Optional[str],
+    exclude: Optional[str],
+    expected_dbt_resource_names: Set[str],
 ) -> None:
+    select = select or "fqn:*"
+
     @dbt_assets(
-        manifest=manifest,
-        select=select or "fqn:*",
+        manifest=test_jaffle_shop_manifest,
+        select=select,
         exclude=exclude,
     )
     def my_dbt_assets():
         ...
 
-    expected_asset_keys = {AssetKey(key.split("/")) for key in expected_asset_names}
-    assert my_dbt_assets.keys == expected_asset_keys
+    expected_asset_keys = {AssetKey(key) for key in expected_dbt_resource_names}
 
-    expected_select_tag = "fqn:*" if select is None else select
-    assert my_dbt_assets.op.tags.get("dagster-dbt/select") == expected_select_tag
+    assert my_dbt_assets.keys == expected_asset_keys
+    assert my_dbt_assets.op.tags.get("dagster-dbt/select") == select
     assert my_dbt_assets.op.tags.get("dagster-dbt/exclude") == exclude
 
 
 @pytest.mark.parametrize("name", [None, "custom"])
-def test_with_custom_name(name: Optional[str]) -> None:
-    @dbt_assets(manifest=manifest, name=name)
+def test_with_custom_name(test_jaffle_shop_manifest: Dict[str, Any], name: Optional[str]) -> None:
+    @dbt_assets(manifest=test_jaffle_shop_manifest, name=name)
     def my_dbt_assets():
         ...
 
@@ -193,8 +227,10 @@ def test_with_custom_name(name: Optional[str]) -> None:
 @pytest.mark.parametrize(
     "partitions_def", [None, DailyPartitionsDefinition(start_date="2023-01-01")]
 )
-def test_partitions_def(partitions_def: Optional[PartitionsDefinition]) -> None:
-    @dbt_assets(manifest=manifest, partitions_def=partitions_def)
+def test_partitions_def(
+    test_jaffle_shop_manifest: Dict[str, Any], partitions_def: Optional[PartitionsDefinition]
+) -> None:
+    @dbt_assets(manifest=test_jaffle_shop_manifest, partitions_def=partitions_def)
     def my_dbt_assets():
         ...
 
@@ -202,8 +238,10 @@ def test_partitions_def(partitions_def: Optional[PartitionsDefinition]) -> None:
 
 
 @pytest.mark.parametrize("io_manager_key", [None, "my_io_manager_key"])
-def test_io_manager_key(io_manager_key: Optional[str]) -> None:
-    @dbt_assets(manifest=manifest, io_manager_key=io_manager_key)
+def test_io_manager_key(
+    test_jaffle_shop_manifest: Dict[str, Any], io_manager_key: Optional[str]
+) -> None:
+    @dbt_assets(manifest=test_jaffle_shop_manifest, io_manager_key=io_manager_key)
     def my_dbt_assets():
         ...
 
@@ -245,6 +283,7 @@ def test_io_manager_key(io_manager_key: Optional[str]) -> None:
     ],
 )
 def test_backfill_policy(
+    test_jaffle_shop_manifest: Dict[str, Any],
     partitions_def: PartitionsDefinition,
     backfill_policy: BackfillPolicy,
     expected_backfill_policy: BackfillPolicy,
@@ -256,7 +295,7 @@ def test_backfill_policy(
             return None
 
     @dbt_assets(
-        manifest=manifest,
+        manifest=test_jaffle_shop_manifest,
         partitions_def=partitions_def,
         backfill_policy=backfill_policy,
         dagster_dbt_translator=CustomDagsterDbtTranslator(),
@@ -267,56 +306,54 @@ def test_backfill_policy(
     assert my_dbt_assets.backfill_policy == expected_backfill_policy
 
 
-def test_op_tags():
-    @dbt_assets(manifest=manifest, op_tags={"a": "b", "c": "d"})
+def test_op_tags(test_jaffle_shop_manifest: Dict[str, Any]):
+    op_tags = {"a": "b", "c": "d"}
+
+    @dbt_assets(manifest=test_jaffle_shop_manifest, op_tags=op_tags)
     def my_dbt_assets():
         ...
 
     assert my_dbt_assets.op.tags == {
-        "a": "b",
-        "c": "d",
+        **op_tags,
         "kind": "dbt",
         "dagster-dbt/select": "fqn:*",
     }
 
-    @dbt_assets(manifest=manifest, op_tags={"a": "b", "c": "d"}, select="+least_caloric")
+    @dbt_assets(manifest=test_jaffle_shop_manifest, op_tags=op_tags, select="raw_customers+")
     def my_dbt_assets_with_select():
         ...
 
     assert my_dbt_assets_with_select.op.tags == {
-        "a": "b",
-        "c": "d",
+        **op_tags,
         "kind": "dbt",
-        "dagster-dbt/select": "+least_caloric",
+        "dagster-dbt/select": "raw_customers+",
     }
 
-    @dbt_assets(manifest=manifest, op_tags={"a": "b", "c": "d"}, exclude="+least_caloric")
+    @dbt_assets(manifest=test_jaffle_shop_manifest, op_tags=op_tags, exclude="raw_customers+")
     def my_dbt_assets_with_exclude():
         ...
 
     assert my_dbt_assets_with_exclude.op.tags == {
-        "a": "b",
-        "c": "d",
+        **op_tags,
         "kind": "dbt",
-        "dagster-dbt/exclude": "+least_caloric",
         "dagster-dbt/select": "fqn:*",
+        "dagster-dbt/exclude": "raw_customers+",
     }
 
     @dbt_assets(
-        manifest=manifest,
-        op_tags={"a": "b", "c": "d"},
-        select="+least_caloric",
-        exclude="least_caloric",
+        manifest=test_jaffle_shop_manifest,
+        op_tags=op_tags,
+        select="raw_customers+",
+        exclude="customers",
     )
     def my_dbt_assets_with_select_and_exclude():
         ...
 
     assert my_dbt_assets_with_select_and_exclude.op.tags == {
-        "a": "b",
-        "c": "d",
+        **op_tags,
         "kind": "dbt",
-        "dagster-dbt/select": "+least_caloric",
-        "dagster-dbt/exclude": "least_caloric",
+        "dagster-dbt/select": "raw_customers+",
+        "dagster-dbt/exclude": "customers",
     }
 
     with pytest.raises(
@@ -328,12 +365,8 @@ def test_op_tags():
     ):
 
         @dbt_assets(
-            manifest=manifest,
-            op_tags={
-                "a": "b",
-                "c": "d",
-                "dagster-dbt/select": "+least_caloric",
-            },
+            manifest=test_jaffle_shop_manifest,
+            op_tags={"dagster-dbt/select": "raw_customers+"},
         )
         def select_tag():
             ...
@@ -347,40 +380,42 @@ def test_op_tags():
     ):
 
         @dbt_assets(
-            manifest=manifest,
-            op_tags={
-                "a": "b",
-                "c": "d",
-                "dagster-dbt/exclude": "+least_caloric",
-            },
+            manifest=test_jaffle_shop_manifest,
+            op_tags={"dagster-dbt/exclude": "raw_customers+"},
         )
         def exclude_tag():
             ...
 
 
-def test_with_asset_key_replacements() -> None:
+def test_with_asset_key_replacements(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
     class CustomizedDagsterDbtTranslator(DagsterDbtTranslator):
         @classmethod
         def get_asset_key(cls, dbt_resource_props: Mapping[str, Any]) -> AssetKey:
-            return AssetKey(["prefix", *super().get_asset_key(dbt_resource_props).path])
+            return super().get_asset_key(dbt_resource_props).with_prefix("prefix")
 
-    @dbt_assets(manifest=manifest, dagster_dbt_translator=CustomizedDagsterDbtTranslator())
+    @dbt_assets(
+        manifest=test_jaffle_shop_manifest, dagster_dbt_translator=CustomizedDagsterDbtTranslator()
+    )
     def my_dbt_assets():
         ...
 
     assert my_dbt_assets.keys_by_input_name == {
-        "__subset_input__seed_dagster_dbt_test_project_cereals": AssetKey(["prefix", "cereals"]),
-        "__subset_input__model_dagster_dbt_test_project_sort_by_calories": AssetKey(
-            ["prefix", "sort_by_calories"]
-        ),
+        "__subset_input__model_jaffle_shop_stg_customers": AssetKey(["prefix", "stg_customers"]),
+        "__subset_input__model_jaffle_shop_stg_orders": AssetKey(["prefix", "stg_orders"]),
+        "__subset_input__model_jaffle_shop_stg_payments": AssetKey(["prefix", "stg_payments"]),
+        "__subset_input__seed_jaffle_shop_raw_customers": AssetKey(["prefix", "raw_customers"]),
+        "__subset_input__seed_jaffle_shop_raw_orders": AssetKey(["prefix", "raw_orders"]),
+        "__subset_input__seed_jaffle_shop_raw_payments": AssetKey(["prefix", "raw_payments"]),
     }
     assert set(my_dbt_assets.keys_by_output_name.values()) == {
-        AssetKey(["prefix", "cereals"]),
-        AssetKey(["prefix", "cold_schema", "sort_cold_cereals_by_calories"]),
-        AssetKey(["prefix", "subdir_schema", "least_caloric"]),
-        AssetKey(["prefix", "orders_snapshot"]),
-        AssetKey(["prefix", "sort_hot_cereals_by_calories"]),
-        AssetKey(["prefix", "sort_by_calories"]),
+        AssetKey(["prefix", "raw_customers"]),
+        AssetKey(["prefix", "raw_orders"]),
+        AssetKey(["prefix", "raw_payments"]),
+        AssetKey(["prefix", "stg_customers"]),
+        AssetKey(["prefix", "stg_orders"]),
+        AssetKey(["prefix", "stg_payments"]),
+        AssetKey(["prefix", "customers"]),
+        AssetKey(["prefix", "orders"]),
     }
 
 
@@ -439,7 +474,7 @@ def test_with_partition_mappings(
         )
 
 
-def test_with_description_replacements() -> None:
+def test_with_description_replacements(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
     expected_description = "customized description"
 
     class CustomizedDagsterDbtTranslator(DagsterDbtTranslator):
@@ -447,7 +482,9 @@ def test_with_description_replacements() -> None:
         def get_description(cls, dbt_resource_props: Mapping[str, Any]) -> str:
             return expected_description
 
-    @dbt_assets(manifest=manifest, dagster_dbt_translator=CustomizedDagsterDbtTranslator())
+    @dbt_assets(
+        manifest=test_jaffle_shop_manifest, dagster_dbt_translator=CustomizedDagsterDbtTranslator()
+    )
     def my_dbt_assets():
         ...
 
@@ -455,7 +492,7 @@ def test_with_description_replacements() -> None:
         assert description == expected_description
 
 
-def test_with_metadata_replacements() -> None:
+def test_with_metadata_replacements(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
     expected_metadata = {"customized": "metadata"}
 
     class CustomizedDagsterDbtTranslator(DagsterDbtTranslator):
@@ -463,7 +500,9 @@ def test_with_metadata_replacements() -> None:
         def get_metadata(cls, dbt_resource_props: Mapping[str, Any]) -> Mapping[str, Any]:
             return expected_metadata
 
-    @dbt_assets(manifest=manifest, dagster_dbt_translator=CustomizedDagsterDbtTranslator())
+    @dbt_assets(
+        manifest=test_jaffle_shop_manifest, dagster_dbt_translator=CustomizedDagsterDbtTranslator()
+    )
     def my_dbt_assets():
         ...
 
@@ -471,7 +510,7 @@ def test_with_metadata_replacements() -> None:
         assert metadata["customized"] == "metadata"
 
 
-def test_with_group_replacements() -> None:
+def test_with_group_replacements(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
     expected_group = "customized_group"
 
     class CustomizedDagsterDbtTranslator(DagsterDbtTranslator):
@@ -479,7 +518,9 @@ def test_with_group_replacements() -> None:
         def get_group_name(cls, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:
             return expected_group
 
-    @dbt_assets(manifest=manifest, dagster_dbt_translator=CustomizedDagsterDbtTranslator())
+    @dbt_assets(
+        manifest=test_jaffle_shop_manifest, dagster_dbt_translator=CustomizedDagsterDbtTranslator()
+    )
     def my_dbt_assets():
         ...
 
@@ -487,7 +528,7 @@ def test_with_group_replacements() -> None:
         assert group == expected_group
 
 
-def test_with_freshness_policy_replacements() -> None:
+def test_with_freshness_policy_replacements(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
     expected_freshness_policy = FreshnessPolicy(maximum_lag_minutes=60)
 
     class CustomizedDagsterDbtTranslator(DagsterDbtTranslator):
@@ -497,7 +538,9 @@ def test_with_freshness_policy_replacements() -> None:
         ) -> Optional[FreshnessPolicy]:
             return expected_freshness_policy
 
-    @dbt_assets(manifest=manifest, dagster_dbt_translator=CustomizedDagsterDbtTranslator())
+    @dbt_assets(
+        manifest=test_jaffle_shop_manifest, dagster_dbt_translator=CustomizedDagsterDbtTranslator()
+    )
     def my_dbt_assets():
         ...
 
@@ -505,7 +548,9 @@ def test_with_freshness_policy_replacements() -> None:
         assert freshness_policy == expected_freshness_policy
 
 
-def test_with_auto_materialize_policy_replacements() -> None:
+def test_with_auto_materialize_policy_replacements(
+    test_jaffle_shop_manifest: Dict[str, Any],
+) -> None:
     expected_auto_materialize_policy = AutoMaterializePolicy.eager()
 
     class CustomizedDagsterDbtTranslator(DagsterDbtTranslator):
@@ -515,7 +560,9 @@ def test_with_auto_materialize_policy_replacements() -> None:
         ) -> Optional[AutoMaterializePolicy]:
             return expected_auto_materialize_policy
 
-    @dbt_assets(manifest=manifest, dagster_dbt_translator=CustomizedDagsterDbtTranslator())
+    @dbt_assets(
+        manifest=test_jaffle_shop_manifest, dagster_dbt_translator=CustomizedDagsterDbtTranslator()
+    )
     def my_dbt_assets():
         ...
 
@@ -652,12 +699,10 @@ def test_dbt_with_model_versions(test_dbt_model_versions_manifest: Dict[str, Any
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
         yield from dbt.cli(["build"], context=context).stream()
 
-    assert set(
-        [
-            AssetKey(["stg_customers_v1"]),
-            AssetKey(["stg_customers_v2"]),
-        ]
-    ).issubset(my_dbt_assets.keys)
+    assert {
+        AssetKey(["stg_customers_v1"]),
+        AssetKey(["stg_customers_v2"]),
+    }.issubset(my_dbt_assets.keys)
 
     result = materialize(
         [my_dbt_assets],


### PR DESCRIPTION
## Summary & Motivation
We're making way for marking all the `dagster-dbt` legacy code to be contained in its own directory so that we can separate out pytest better.

Here, we divest from references to `TEST_PROJECT_DIR` in favor of the new `jaffle_shop` directory introduced in #19767.

## How I Tested These Changes
update tests, bk
