### PR TITLE
Switch Buildkite to do a treeless clone

### DIFF
--- a/.buildkite/hooks/pre-checkout
+++ b/.buildkite/hooks/pre-checkout
@@ -1,0 +1,2 @@
+export BUILDKITE_GIT_CLONE_FLAGS="--filter tree:0"
+export BUILDKITE_GIT_CLONE_MIRROR_FLAGS="--filter tree:0"


### PR DESCRIPTION
This has shown some benefit elsewhere where we're using it internally.

https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/