### PR TITLE
test(dbt): split test execution by cloud/legacy/core markers

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -462,7 +462,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         pytest_tox_factors=[
             f"{deps_factor}-{command_factor}"
             for deps_factor in ["dbt15", "dbt16", "dbt17", "pydantic1"]
-            for command_factor in ["legacy", "core"]
+            for command_factor in ["cloud", "core", "legacy"]
         ],
         unsupported_python_versions=[
             # duckdb

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/conftest.py
@@ -7,19 +7,14 @@ from dagster_dbt.cloud.resources import DbtCloudClientResource, dbt_cloud_resour
 from .utils import DBT_CLOUD_ACCOUNT_ID, DBT_CLOUD_API_TOKEN
 
 
-@pytest.fixture(
-    params=[
-        pytest.param("legacy", marks=pytest.mark.legacy),
-        pytest.param("pythonic"),
-    ],
-)
+@pytest.fixture(params=["dbt_cloud_resource", "DbtCloudClientResource"])
 def resource_type(request):
     return request.param
 
 
 @pytest.fixture(name="dbt_cloud")
 def dbt_cloud_fixture(resource_type) -> Any:
-    if resource_type == "pythonic":
+    if resource_type == "DbtCloudClientResource":
         yield DbtCloudClientResource(
             auth_token=DBT_CLOUD_API_TOKEN, account_id=DBT_CLOUD_ACCOUNT_ID
         )
@@ -34,7 +29,7 @@ def dbt_cloud_fixture(resource_type) -> Any:
 
 @pytest.fixture(name="get_dbt_cloud_resource")
 def get_dbt_cloud_resource_fixture(resource_type) -> Any:
-    if resource_type == "pythonic":
+    if resource_type == "DbtCloudClientResource":
         return (
             lambda **kwargs: DbtCloudClientResource(
                 auth_token=DBT_CLOUD_API_TOKEN, account_id=DBT_CLOUD_ACCOUNT_ID, **kwargs

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import pytest
 from dagster_dbt import DbtCliResource
@@ -16,6 +16,17 @@ from .dbt_projects import (
     test_meta_config_path,
     test_metadata_path,
 )
+
+
+def pytest_collection_modifyitems(items: List[pytest.Item]):
+    """Mark tests in the `cloud` and `legacy` directories. Mark other tests as `core`."""
+    for item in items:
+        if "cloud" in item.path.parts:
+            item.add_marker(pytest.mark.cloud)
+        elif "legacy" in item.path.parts:
+            item.add_marker(pytest.mark.legacy)
+        else:
+            item.add_marker(pytest.mark.core)
 
 
 def _create_dbt_invocation(project_dir: Path) -> DbtCliInvocation:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/legacy/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/legacy/conftest.py
@@ -48,11 +48,7 @@ def dbt_python_config_dir():
 
 @pytest.fixture(
     scope="session",
-    params=[
-        pytest.param("legacy", marks=pytest.mark.legacy),
-        pytest.param("DbtCliClientResource", marks=pytest.mark.legacy),
-        pytest.param("DbtCliResource"),
-    ],
+    params=["dbt_cli_resource", "DbtCliClientResource", "DbtCliResource"],
 )
 def dbt_cli_resource_factory(request):
     if request.param == "DbtCliClientResource":

--- a/python_modules/libraries/dagster-dbt/pytest.ini
+++ b/python_modules/libraries/dagster-dbt/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 markers =
-    legacy: marks tests that uses non-DbtCliResource and @dbt_assets APIs.
+    cloud: marks tests that use dbt Cloud APIs
+    core: marks tests that use `dagster-dbt>=0.20.0` APIs
+    legacy: marks tests that use `dagster-dbt<0.20.0` APIs

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -23,5 +23,6 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
+  cloud: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
+  core: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy and not cloud" -vv {posargs}
   legacy: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
-  core: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy" -vv {posargs}


### PR DESCRIPTION
## Summary & Motivation
Mark the `dagster-dbt` tests in the following manner:

- Mark `legacy/` with `legacy`
- Mark `cloud/` with `cloud`
- Mark everything else with `core`

Then, split up tox test execution to select by the new markers.

## How I Tested These Changes
bk
