### PR TITLE
fix(dbt): test legacy against matrix of `dbt-core` versions

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -460,14 +460,9 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     PackageSpec(
         "python_modules/libraries/dagster-dbt",
         pytest_tox_factors=[
-            "dbt_15X_legacy",
-            "dbt_16X_legacy",
-            "dbt_17X_legacy",
-            "dbt_15X",
-            "dbt_16X",
-            "dbt_17X",
-            "dbt_pydantic1",
-            "dbt_legacy_pydantic1",
+            f"{deps_factor}-{command_factor}"
+            for deps_factor in ["dbt15", "dbt16", "dbt17", "pydantic1"]
+            for command_factor in ["legacy", "core"]
         ],
         unsupported_python_versions=[
             # duckdb

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -10,25 +10,18 @@ deps =
   -e ../../dagster-pipes
   -e ../dagster-duckdb
   -e ../dagster-duckdb-pandas
-  dbt_15X: dbt-core==1.5.*
-  dbt_15X: dbt-duckdb==1.5.*
-  dbt_15X: duckdb<0.10.0
-  dbt_16X: dbt-core==1.6.*
-  dbt_16X: dbt-duckdb==1.6.*
-  dbt_17X: dbt-core==1.7.*
-  dbt_17X: dbt-duckdb==1.7.*
-  dbt_pydantic1:        pydantic!=1.10.7,<2.0.0
-  dbt_legacy_pydantic1: pydantic!=1.10.7,<2.0.0
+  dbt15: dbt-core==1.5.*
+  dbt15: dbt-duckdb==1.5.*
+  dbt15: duckdb<0.10.0
+  dbt16: dbt-core==1.6.*
+  dbt16: dbt-duckdb==1.6.*
+  dbt17: dbt-core==1.7.*
+  dbt17: dbt-duckdb==1.7.*
+  pydantic1: pydantic!=1.10.7,<2.0.0
   -e .[test]
 allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-  dbt_15X_legacy: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
-  dbt_16X_legacy: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
-  dbt_17X_legacy: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
-  dbt_15X: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy" -vv {posargs}
-  dbt_16X: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy" -vv {posargs}
-  dbt_17X: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy" -vv {posargs}
-  dbt_pydantic1: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy" -vv {posargs}
-  dbt_legacy_pydantic1: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
+  legacy: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
+  core: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy" -vv {posargs}


### PR DESCRIPTION
## Summary & Motivation
Looks like I didn't understand tox environments the first time around.

Make the `dagster-dbt` tests for legacy marked tests actually enforce the `dbt-core` version constraint.

## How I Tested These Changes
- local tox
- see [bk build for legacy](https://buildkite.com/dagster/dagster-dagster/builds/75924#018dafa0-260f-4d66-bf10-46b45da64793/318-340), see constraint applied
