### PR TITLE
test(dbt): optimize legacy tests

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/legacy/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/legacy/conftest.py
@@ -69,10 +69,3 @@ def dbt_cli_resource_factory(request):
 def dbt_seed(dbt_executable, dbt_config_dir):
     with pushd(TEST_PROJECT_DIR):
         subprocess.run([dbt_executable, "seed", "--profiles-dir", dbt_config_dir], check=True)
-
-
-@pytest.fixture(scope="session")
-def dbt_build(dbt_executable, dbt_config_dir):
-    with pushd(TEST_PROJECT_DIR):
-        subprocess.run([dbt_executable, "seed", "--profiles-dir", dbt_config_dir], check=True)
-        subprocess.run([dbt_executable, "run", "--profiles-dir", dbt_config_dir], check=True)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/legacy/test_ops.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/legacy/test_ops.py
@@ -45,7 +45,7 @@ def test_run_op(dbt_seed, test_project_dir, dbt_config_dir):
     assert len(dbt_results[-1].value.result["results"]) == 4
 
 
-def test_run_op_with_select(dbt_build, test_project_dir, dbt_config_dir):
+def test_run_op_with_select(dbt_seed, test_project_dir, dbt_config_dir):
     dbt_resource = dbt_cli_resource.configured(
         {"project_dir": test_project_dir, "profiles_dir": dbt_config_dir, "select": "least_caloric"}
     )


### PR DESCRIPTION
## Summary & Motivation
Optimize the legacy tests just enough so that they don't timeout.

Basically amounts to switching over some tests to use `load_assets_from_dbt_manifest`.

While we're at it, remove the reruns for this test suite.

## How I Tested These Changes
bk

- Current: https://buildkite.com/dagster/dagster-dagster/builds/75910/waterfall
<img width="1518" alt="Screenshot 2024-02-15 at 10 54 18 PM" src="https://github.com/dagster-io/dagster/assets/16431325/2fa95bb6-89ee-42e6-9d14-dc0f63c64c36">



- After: https://buildkite.com/dagster/dagster-dagster/builds/75932/waterfall
<img width="1615" alt="Screenshot 2024-02-15 at 11 07 33 PM" src="https://github.com/dagster-io/dagster/assets/16431325/3c06ff10-134b-4bc2-b3bc-eecb02bb5baa">
