### PR TITLE
Fix colors on daggy u popover

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Popover.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Popover.tsx
@@ -77,6 +77,17 @@ export const GlobalPopoverStyle = createGlobalStyle`
     fill-opacity: 0.7;
   }
 
+  .dagster-popover.bp4-dark .bp4-popover2-arrow {
+    z-index: 9;
+    &:before {
+      display: none;
+    }
+  }
+
+  .dagster-popover.bp4-dark a {
+    color: inherit;
+  }
+
   .dagster-popover .bp4-popover2.bp4-dark .bp4-popover2-content,
   .bp4-dark .dagster-popover .bp4-popover2 .bp4-popover2-content {
     background-color: ${Colors.tooltipBackground()};


### PR DESCRIPTION
## Summary & Motivation

Fix colors on dagster university product tour.

Blueprint's dark theme was overriding the link color in the popover and blueprints arrow was on a layer below the popover which made it look a different color due to the box shadow overlaying on it before.

## How I Tested These Changes
<img width="327" alt="Screenshot 2024-02-16 at 12 36 16 AM" src="https://github.com/dagster-io/dagster/assets/2286579/c64afdaf-42a5-45ea-bc33-412aba6e8110">
