### PR TITLE
[docs] fix PipesLambdaClient import in Lambda with Dagster Pipes tutorial

### DIFF
--- a/docs/content/guides/dagster-pipes/aws-lambda.mdx
+++ b/docs/content/guides/dagster-pipes/aws-lambda.mdx
@@ -178,7 +178,7 @@ In your Dagster project, create a file named `dagster_lambda_pipes.py` and paste
 
 import boto3
 from dagster import AssetExecutionContext, Definitions, asset
-from dagster_aws import PipesLambdaClient
+from dagster_aws.pipes import PipesLambdaClient
 
 
 @asset
@@ -234,7 +234,7 @@ At this point, `dagster_lambda_pipes.py` should look like the following:
 
 import boto3
 from dagster import AssetExecutionContext, Definitions, asset
-from dagster_aws import PipesLambdaClient
+from dagster_aws.pipes import PipesLambdaClient
 
 
 @asset


### PR DESCRIPTION
## Summary & Motivation

Corrects docs to instruct import of `PipesLambdaClient` to be from `dagster_aws.pipes`.

```
>>> from dagster_aws import PipesLambdaClient
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'PipesLambdaClient' from 'dagster_aws' (/Users/.../.direnv/python-3.11/lib/python3.11/site-packages/dagster_aws/__init__.py)
>>> from dagster_aws.pipes import PipesLambdaClient
```
