### PR TITLE
[backfills] Add batch inserts for ranged materialization/observation backfills

### DIFF
--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import sys
+import uuid
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -243,6 +244,12 @@ EVENT_TYPE_TO_PIPELINE_RUN_STATUS = {
 
 PIPELINE_RUN_STATUS_TO_EVENT_TYPE = {v: k for k, v in EVENT_TYPE_TO_PIPELINE_RUN_STATUS.items()}
 
+# These are the only events currently supported in `EventLogStorage.store_event_batch`
+BATCH_WRITABLE_EVENTS = {
+    DagsterEventType.ASSET_MATERIALIZATION,
+    DagsterEventType.ASSET_OBSERVATION,
+}
+
 ASSET_EVENTS = {
     DagsterEventType.ASSET_MATERIALIZATION,
     DagsterEventType.ASSET_OBSERVATION,
@@ -327,7 +334,15 @@ def _validate_event_specific_data(
     return event_specific_data
 
 
-def log_step_event(step_context: IStepContext, event: "DagsterEvent") -> None:
+def generate_event_batch_id():
+    return str(uuid.uuid4())
+
+
+def log_step_event(
+    step_context: IStepContext,
+    event: "DagsterEvent",
+    batch_metadata: Optional["DagsterEventBatchMetadata"],
+) -> None:
     event_type = DagsterEventType(event.event_type_value)
     log_level = logging.ERROR if event_type in FAILURE_EVENTS else logging.DEBUG
 
@@ -335,6 +350,7 @@ def log_step_event(step_context: IStepContext, event: "DagsterEvent") -> None:
         level=log_level,
         msg=event.message or f"{event_type} for step {step_context.step.key}",
         dagster_event=event,
+        batch_metadata=batch_metadata,
     )
 
 
@@ -393,6 +409,11 @@ class DagsterEventSerializer(NamedTupleSerializer["DagsterEvent"]):
         )
 
 
+class DagsterEventBatchMetadata(NamedTuple):
+    id: str
+    is_end: bool
+
+
 @whitelist_for_serdes(
     serializer=DagsterEventSerializer,
     storage_field_names={
@@ -439,6 +460,7 @@ class DagsterEvent(
         step_context: IStepContext,
         event_specific_data: Optional["EventSpecificData"] = None,
         message: Optional[str] = None,
+        batch_metadata: Optional["DagsterEventBatchMetadata"] = None,
     ) -> "DagsterEvent":
         event = DagsterEvent(
             event_type_value=check.inst_param(event_type, "event_type", DagsterEventType).value,
@@ -452,7 +474,7 @@ class DagsterEvent(
             pid=os.getpid(),
         )
 
-        log_step_event(step_context, event)
+        log_step_event(step_context, event, batch_metadata)
 
         return event
 
@@ -982,6 +1004,7 @@ class DagsterEvent(
     def asset_materialization(
         step_context: IStepContext,
         materialization: AssetMaterialization,
+        batch_metadata: Optional[DagsterEventBatchMetadata] = None,
     ) -> "DagsterEvent":
         return DagsterEvent.from_step(
             event_type=DagsterEventType.ASSET_MATERIALIZATION,
@@ -994,16 +1017,20 @@ class DagsterEvent(
                     label_clause=f" {materialization.label}" if materialization.label else ""
                 )
             ),
+            batch_metadata=batch_metadata,
         )
 
     @staticmethod
     def asset_observation(
-        step_context: IStepContext, observation: AssetObservation
+        step_context: IStepContext,
+        observation: AssetObservation,
+        batch_metadata: Optional[DagsterEventBatchMetadata] = None,
     ) -> "DagsterEvent":
         return DagsterEvent.from_step(
             event_type=DagsterEventType.ASSET_OBSERVATION,
             step_context=step_context,
             event_specific_data=AssetObservationData(observation),
+            batch_metadata=batch_metadata,
         )
 
     @staticmethod

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -196,6 +196,10 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
             event (EventLogEntry): The event to store.
         """
 
+    def store_event_batch(self, events: Sequence["EventLogEntry"]) -> None:
+        for event in events:
+            self.store_event(event)
+
     @abstractmethod
     def delete_events(self, run_id: str) -> None:
         """Remove events for a given run id."""

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -263,7 +263,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                     "Cannot store asset event tags for null event id."
                 )
 
-            self.store_asset_event_tags(event, event_id)
+            self.store_asset_event_tags([event], [event_id])
 
         if event.is_dagster_event and event.dagster_event_type in ASSET_CHECK_EVENTS:
             self.store_asset_check_event(event, None)

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
@@ -1,5 +1,6 @@
 import math
-from unittest.mock import MagicMock
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
 
 import pendulum
 import pytest
@@ -14,8 +15,12 @@ from dagster import (
     WeeklyPartitionsDefinition,
     asset,
 )
+from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.errors import DagsterBackfillFailedError
+from dagster._core.event_api import EventRecordsFilter
+from dagster._core.events import DagsterEventType
 from dagster._core.execution.asset_backfill import AssetBackfillData, AssetBackfillStatus
+from dagster._core.instance_for_test import instance_for_test
 from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
     ASSET_PARTITION_RANGE_START_TAG,
@@ -1002,3 +1007,70 @@ def test_run_request_partition_order():
         PartitionKeyRange("2023-10-03", "2023-10-04"),
         PartitionKeyRange("2023-10-05", "2023-10-06"),
     ]
+
+
+# 0 turns off batching
+# 2 will require multiple batches to fulfill the backfill
+# 10 will require a single to fulfill the backfill
+@pytest.mark.parametrize("batch_size", [0, 2, 10])
+@pytest.mark.parametrize("throw_store_event_batch_error", [False, True])
+def test_single_run_backfill_full_execution(
+    batch_size: int, throw_store_event_batch_error: bool, capsys
+):
+    time_now = pendulum.now("UTC")
+
+    partitions_def = StaticPartitionsDefinition(["a", "b", "c", "d"])
+
+    @asset(partitions_def=partitions_def, backfill_policy=BackfillPolicy.single_run())
+    def partitioned_asset():
+        return {"a": 1, "b": 2}
+
+    assets_by_repo_name = {
+        "repo": [
+            partitioned_asset,
+        ]
+    }
+    asset_graph = get_asset_graph(assets_by_repo_name)
+
+    backfill_data = AssetBackfillData.from_asset_partitions(
+        partition_names=None,
+        asset_graph=asset_graph,
+        asset_selection=[
+            partitioned_asset.key,
+        ],
+        dynamic_partitions_store=MagicMock(),
+        all_partitions=True,
+        backfill_start_time=time_now,
+    )
+
+    with instance_for_test() as instance:
+        with ExitStack() as stack:
+            stack.enter_context(patch("dagster._core.instance.EVENT_BATCH_SIZE", new=batch_size))
+            if throw_store_event_batch_error:
+                stack.enter_context(
+                    patch(
+                        "dagster._core.storage.event_log.base.EventLogStorage.store_event_batch",
+                        side_effect=Exception("failed"),
+                    )
+                )
+            run_backfill_to_completion(
+                asset_graph,
+                assets_by_repo_name,
+                backfill_data,
+                [],
+                instance,
+            )
+            events = instance.get_event_records(
+                EventRecordsFilter(
+                    asset_key=partitioned_asset.key,
+                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                )
+            )
+            assert len(events) == 4
+
+            if batch_size > 0 and throw_store_event_batch_error:
+                stderr = capsys.readouterr().err
+                assert "Exception while storing event batch" in stderr
+                assert (
+                    "Falling back to storing multiple single-event storage requests...\n" in stderr
+                )

--- a/python_modules/dagster/dagster_tests/logging_tests/test_python_logging.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_python_logging.py
@@ -403,7 +403,7 @@ def test_failure_logging(managed_loggers, reset_logging):
         orig_handle_new_event = instance.handle_new_event
 
         # run still succeeds even if user-generated logger writes fail
-        def _fake_handle_new_event(event):
+        def _fake_handle_new_event(event, *, batch_metadata=None):
             # fail all user-generated log calls
             if not event.dagster_event:
                 raise Exception("failed writing user-generated event")

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -48,7 +48,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.dependency import NodeHandle
 from dagster._core.definitions.job_base import InMemoryJob
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionKey
-from dagster._core.definitions.partition import PartitionKeyRange
+from dagster._core.definitions.partition import PartitionKeyRange, StaticPartitionsDefinition
 from dagster._core.definitions.time_window_partitions import (
     DailyPartitionsDefinition,
     PartitionKeysTimeWindowPartitionsSubset,
@@ -92,8 +92,13 @@ from dagster._core.storage.event_log.migration import (
 )
 from dagster._core.storage.event_log.schema import SqlEventLogStorageTable
 from dagster._core.storage.event_log.sqlite.sqlite_event_log import SqliteEventLogStorage
+from dagster._core.storage.io_manager import IOManager
 from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 from dagster._core.storage.sqlalchemy_compat import db_select
+from dagster._core.storage.tags import (
+    ASSET_PARTITION_RANGE_END_TAG,
+    ASSET_PARTITION_RANGE_START_TAG,
+)
 from dagster._core.test_utils import create_run_for_test, instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.utils import make_new_run_id
@@ -257,20 +262,31 @@ def _default_loggers(event_callback):
 
 # This exists to create synthetic events to test the store
 def _synthesize_events(
-    ops_fn, run_id=None, check_success=True, instance=None, run_config=None
+    ops_fn_or_assets, run_id=None, check_success=True, instance=None, run_config=None, tags=None
 ) -> Tuple[List[EventLogEntry], JobExecutionResult]:
     events = []
 
     def _append_event(event):
         events.append(event)
 
-    @job(
-        resource_defs=_default_resources(),
-        logger_defs=_default_loggers(_append_event),
-        executor_def=in_process_executor,
-    )
-    def a_job():
-        ops_fn()
+    if isinstance(ops_fn_or_assets, list):  # assets
+        job_def = Definitions(
+            assets=ops_fn_or_assets,
+            loggers=_default_loggers(_append_event),
+            resources=_default_resources(),
+            executor=in_process_executor,
+        ).get_implicit_job_def_for_assets([k for a in ops_fn_or_assets for k in a.keys])
+        assert job_def
+        a_job = job_def
+    else:  # op_fn
+
+        @job(
+            resource_defs=_default_resources(),
+            logger_defs=_default_loggers(_append_event),
+            executor_def=in_process_executor,
+        )
+        def a_job():
+            ops_fn_or_assets()
 
     result = None
 
@@ -283,7 +299,9 @@ def _synthesize_events(
             **(run_config if run_config else {}),
         }
 
-        dagster_run = instance.create_run_for_job(a_job, run_id=run_id, run_config=run_config)
+        dagster_run = instance.create_run_for_job(
+            a_job, run_id=run_id, run_config=run_config, tags=tags
+        )
         result = execute_run(InMemoryJob(a_job), dagster_run, instance)
 
         if check_success:
@@ -1106,6 +1124,38 @@ class TestEventLogStorage:
             assert record.event_log_entry.dagster_event
             assert record.event_log_entry.dagster_event.asset_key == asset_key
             assert result.cursor == EventLogCursor.from_storage_id(record.storage_id).to_string()
+
+    def test_asset_materialization_range(self, storage, test_run_id):
+        partitions_def = StaticPartitionsDefinition(["a", "b"])
+
+        class DummyIOManager(IOManager):
+            def handle_output(self, context, obj):
+                pass
+
+            def load_input(self, context):
+                return 1
+
+        @asset(partitions_def=partitions_def, io_manager_def=DummyIOManager())
+        def foo():
+            return {"a": 1, "b": 2}
+
+        with instance_for_test() as instance:
+            if not storage.has_instance:
+                storage.register_instance(instance)
+
+            events, _ = _synthesize_events(
+                [foo],
+                instance=instance,
+                run_id=test_run_id,
+                tags={ASSET_PARTITION_RANGE_START_TAG: "a", ASSET_PARTITION_RANGE_END_TAG: "b"},
+            )
+            materializations = [
+                e for e in events if e.dagster_event.event_type == "ASSET_MATERIALIZATION"
+            ]
+            storage.store_event_batch(materializations)
+
+            result = storage.fetch_materializations(foo.key, limit=100)
+            assert len(result.records) == 2
 
     def test_asset_materialization_null_key_fails(self):
         with pytest.raises(check.CheckError):


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/8634

See this comment for up-to-date summary: https://github.com/dagster-io/dagster/pull/19862#issuecomment-1962397047

Add batch insert support for asset materializations and observations emitted in a single step. Previously, a ranged backfill that generated N `AssetMaterialization` events would perform N DB inserts. After this PR, it generates only a few inserts (more than 1 because a few tables are hit).

## How it works

- Logged dagster events take the following pathway:
    - `DagsterEvent.<event_type>` (e.g. `DagsterEvent.asset_materialization`)
    - `DagsterEvent.from_step`
    - `log_dagster_event`
    - `DagsterLogManager.log`
    - `DagsterLogManager._log`
    - `DagsterLogHandler.filter`
    - `DagsterLogHandler.emit`
    - `_EventListenerLogHandler` (in `_core/instance/__init__.py`)
    - `DagsterInstance.handle_new_event`
- This pathway has been modified to pass batch metadata, represented in a new `DagsterEventBatchMetadata`  class, along the entire path. `DagsterEventBatchMetadata` has two fields: `id` and `is_end`.
- `DagsterEventBatchMetadata` must be passed in to the static method that creates the event  (`DagsterEvent.<event_type>`). It is then packaged side by side with the event and passed up the call chain. `DagsterEvent` itself is not modified.
- Batching management is done in `DagsterInstance.handle_new_event`, which receives optional `DagsterEventBatchMetadata`. If a call receives batch metadata, the event is buffered under the batch id. The buffer is cleared and a write is performed if (a) the buffer has hit the `EVENT_BATCH_SIZE` threshold (set at 1000, overridable via env var); or (b) `DagsterEventBatchMetadata.is_end` is set.
- The write is implemented via a new method `EventLogStorage.store_event_batch`. The default implementation of this is just to loop over the events in the batch and call `store_event`, i.e. equivalent to the old behavior. In the `EventLogStorage` implementations in cloud and `dagster-postgres`, this method is overridden to perform a batch insert instead.

## How I Tested These Changes

- Add new storage test that performs a single-run partition range materialization. The organization of the storage tests is unfamiliar to me so I'm not sure I put it in the appropriate place.
- Add simple single run backfill test that actually executes the full backfill.