### PR TITLE
[typing] Convert bare Callable to Callable[..., Any]

### DIFF
--- a/python_modules/automation/automation/docker/dagster_docker.py
+++ b/python_modules/automation/automation/docker/dagster_docker.py
@@ -1,6 +1,6 @@
 import contextlib
 import os
-from typing import Callable, Dict, Iterator, List, NamedTuple, Optional
+from typing import Any, Callable, Dict, Iterator, List, NamedTuple, Optional
 
 import dagster._check as check
 import yaml
@@ -60,7 +60,7 @@ class DagsterDockerImage(
         cls,
         image: str,
         images_path: Optional[str] = None,
-        build_cm: Callable = do_nothing,
+        build_cm: Callable[..., Any] = do_nothing,
     ):
         return super(DagsterDockerImage, cls).__new__(
             cls,

--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -1781,8 +1781,8 @@ def _check_mapping_entries(
     obj: W,
     key_type: Optional[TypeOrTupleOfTypes] = None,
     value_type: Optional[TypeOrTupleOfTypes] = None,
-    key_check: Callable = isinstance,
-    value_check: Callable = isinstance,
+    key_check: Callable[..., Any] = isinstance,
+    value_check: Callable[..., Any] = isinstance,
     mapping_type: Type = collections.abc.Mapping,
 ) -> W:
     """Enforces that the keys/values conform to the types specified by key_type, value_type."""

--- a/python_modules/dagster/dagster/_core/decorator_utils.py
+++ b/python_modules/dagster/dagster/_core/decorator_utils.py
@@ -73,7 +73,7 @@ def get_function_params(fn: Callable[..., Any]) -> Sequence[Parameter]:
     return list(signature(fn).parameters.values())
 
 
-def get_type_hints(fn: Callable) -> Mapping[str, Any]:
+def get_type_hints(fn: Callable[..., Any]) -> Mapping[str, Any]:
     if isinstance(fn, functools.partial):
         target = fn.func
     elif inspect.isfunction(fn):
@@ -128,7 +128,7 @@ def param_is_var_keyword(param: Parameter) -> bool:
     return param.kind == Parameter.VAR_KEYWORD
 
 
-def format_docstring_for_description(fn: Callable) -> Optional[str]:
+def format_docstring_for_description(fn: Callable[..., Any]) -> Optional[str]:
     if fn.__doc__ is not None:
         docstring = fn.__doc__
         if len(docstring) > 0 and docstring[0].isspace():
@@ -225,7 +225,7 @@ def _wrap_with_context_manager(
     return cast(T_Callable, wrapped_with_context_manager_fn)
 
 
-def _update_decoratable(decoratable: T_Decoratable, new_fn: Callable) -> T_Decoratable:
+def _update_decoratable(decoratable: T_Decoratable, new_fn: Callable[..., Any]) -> T_Decoratable:
     """Update a property with a new `fget` function.
 
     `property` objects are immutable, so if we want to apply a decorator to the underlying `fget`,

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -165,7 +165,7 @@ class AssetGraphSubset(NamedTuple):
             ],
         }
 
-    def _oper(self, other: "AssetGraphSubset", oper: Callable) -> "AssetGraphSubset":
+    def _oper(self, other: "AssetGraphSubset", oper: Callable[..., Any]) -> "AssetGraphSubset":
         """Returns the AssetGraphSubset that results from applying the given operator to the set of
         asset partitions in self and other.
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
@@ -24,7 +24,7 @@ class AssetSensorParamNames(NamedTuple):
     event_log_entry_param_name: Optional[str]
 
 
-def get_asset_sensor_param_names(fn: Callable) -> AssetSensorParamNames:
+def get_asset_sensor_param_names(fn: Callable[..., Any]) -> AssetSensorParamNames:
     """Determines the names of the context and event log entry parameters for an asset sensor function.
     These are assumed to be the first two non-resource params, in order (context param before event log entry).
     """

--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -3,6 +3,7 @@ import operator
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
+    Any,
     Callable,
     NamedTuple,
     Optional,
@@ -201,7 +202,7 @@ class ValidAssetSubset(AssetSubset):
             )
             return self._replace(value=value)
 
-    def _oper(self, other: "ValidAssetSubset", oper: Callable) -> "ValidAssetSubset":
+    def _oper(self, other: "ValidAssetSubset", oper: Callable[..., Any]) -> "ValidAssetSubset":
         value = oper(self.value, other.value)
         return self._replace(value=value)
 

--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -964,7 +964,7 @@ def composite_mapping_from_output(
 def do_composition(
     decorator_name: str,
     graph_name: str,
-    fn: Callable,
+    fn: Callable[..., Any],
     provided_input_defs: Sequence[InputDefinition],
     provided_output_defs: Optional[Sequence[OutputDefinition]],
     config_mapping: Optional[ConfigMapping],

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -37,7 +37,7 @@ AssetCheckFunction: TypeAlias = Callable[..., AssetCheckFunctionReturn]
 def _build_asset_check_input(
     name: str,
     asset_key: AssetKey,
-    fn: Callable,
+    fn: Callable[..., Any],
     additional_ins: Mapping[str, AssetIn],
     additional_deps: Optional[AbstractSet[AssetKey]],
 ) -> Mapping[AssetKey, Tuple[str, In]]:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -56,7 +56,7 @@ from ..utils import DEFAULT_IO_MANAGER_KEY, DEFAULT_OUTPUT, NoValueSentinel
 
 @overload
 def asset(
-    compute_fn: Callable,
+    compute_fn: Callable[..., Any],
 ) -> AssetsDefinition:
     ...
 
@@ -350,7 +350,7 @@ class _Asset:
         self.key = key
         self.owners = owners
 
-    def __call__(self, fn: Callable) -> AssetsDefinition:
+    def __call__(self, fn: Callable[..., Any]) -> AssetsDefinition:
         from dagster._config.pythonic_config import (
             validate_resource_annotated_function,
         )
@@ -903,7 +903,9 @@ def multi_asset(
     return inner
 
 
-def get_function_params_without_context_or_config_or_resources(fn: Callable) -> List[Parameter]:
+def get_function_params_without_context_or_config_or_resources(
+    fn: Callable[..., Any],
+) -> List[Parameter]:
     params = get_function_params(fn)
     is_context_provided = len(params) > 0 and params[0].name in get_valid_name_permutations(
         "context"
@@ -925,7 +927,7 @@ def stringify_asset_key_to_input_name(asset_key: AssetKey) -> str:
 
 
 def build_asset_ins(
-    fn: Callable,
+    fn: Callable[..., Any],
     asset_ins: Mapping[str, AssetIn],
     deps: Optional[AbstractSet[AssetKey]],
 ) -> Mapping[AssetKey, Tuple[str, In]]:
@@ -1013,7 +1015,7 @@ def build_subsettable_asset_ins(
 
 @overload
 def graph_asset(
-    compose_fn: Callable,
+    compose_fn: Callable[..., Any],
 ) -> AssetsDefinition:
     ...
 
@@ -1156,7 +1158,7 @@ def graph_asset(
 
 def graph_asset_no_defaults(
     *,
-    compose_fn: Callable,
+    compose_fn: Callable[..., Any],
     name: Optional[str],
     description: Optional[str],
     ins: Optional[Mapping[str, AssetIn]],
@@ -1276,7 +1278,7 @@ def graph_multi_asset(
                 from the underlying nodes).
     """
 
-    def inner(fn: Callable) -> AssetsDefinition:
+    def inner(fn: Callable[..., Any]) -> AssetsDefinition:
         partition_mappings = {
             input_name: asset_in.partition_mapping
             for input_name, asset_in in (ins or {}).items()

--- a/python_modules/dagster/dagster/_core/definitions/decorators/graph_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/graph_decorator.py
@@ -103,7 +103,7 @@ class _Graph:
 
 
 @overload
-def graph(compose_fn: Callable) -> GraphDefinition:
+def graph(compose_fn: Callable[..., Any]) -> GraphDefinition:
     ...
 
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/hook_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/hook_decorator.py
@@ -70,7 +70,7 @@ class _Hook:
 
 @overload
 def event_list_hook(
-    hook_fn: Callable,
+    hook_fn: Callable[..., Any],
 ) -> HookDefinition:
     pass
 

--- a/python_modules/dagster/dagster/_core/definitions/inference.py
+++ b/python_modules/dagster/dagster/_core/definitions/inference.py
@@ -32,7 +32,7 @@ class InferredOutputProps(NamedTuple):
     description: Optional[str]
 
 
-def _infer_input_description_from_docstring(fn: Callable) -> Mapping[str, Optional[str]]:
+def _infer_input_description_from_docstring(fn: Callable[..., Any]) -> Mapping[str, Optional[str]]:
     doc_str = fn.__doc__
     if not IS_DOCSTRING_PARSER_AVAILABLE or doc_str is None:
         return {}
@@ -46,7 +46,7 @@ def _infer_input_description_from_docstring(fn: Callable) -> Mapping[str, Option
         return {}
 
 
-def _infer_output_description_from_docstring(fn: Callable) -> Optional[str]:
+def _infer_output_description_from_docstring(fn: Callable[..., Any]) -> Optional[str]:
     doc_str = fn.__doc__
     if not IS_DOCSTRING_PARSER_AVAILABLE or doc_str is None:
         return None
@@ -62,7 +62,7 @@ def _infer_output_description_from_docstring(fn: Callable) -> Optional[str]:
         return None
 
 
-def infer_output_props(fn: Callable) -> InferredOutputProps:
+def infer_output_props(fn: Callable[..., Any]) -> InferredOutputProps:
     type_hints = get_type_hints(fn)
     annotation = (
         type_hints["return"]
@@ -76,7 +76,7 @@ def infer_output_props(fn: Callable) -> InferredOutputProps:
     )
 
 
-def has_explicit_return_type(fn: Callable) -> bool:
+def has_explicit_return_type(fn: Callable[..., Any]) -> bool:
     sig = signature(fn)
     return sig.return_annotation is not Signature.empty
 
@@ -108,7 +108,9 @@ def _infer_inputs_from_params(
     return input_defs
 
 
-def infer_input_props(fn: Callable, context_arg_provided: bool) -> Sequence[InferredInputProps]:
+def infer_input_props(
+    fn: Callable[..., Any], context_arg_provided: bool
+) -> Sequence[InferredInputProps]:
     sig = signature(fn)
     params = list(sig.parameters.values())
     type_hints = get_type_hints(fn)

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -309,7 +309,7 @@ class MetadataValue(ABC, Generic[T_Packable]):
 
     @public
     @staticmethod
-    def python_artifact(python_artifact: Callable) -> "PythonArtifactMetadataValue":
+    def python_artifact(python_artifact: Callable[..., Any]) -> "PythonArtifactMetadataValue":
         """Static constructor for a metadata value wrapping a python artifact as
         :py:class:`PythonArtifactMetadataValue`. Can be used as the value type for the
         `metadata` parameter for supported events.

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -84,7 +84,7 @@ class DefaultScheduleStatus(Enum):
 
 
 def get_or_create_schedule_context(
-    fn: Callable, *args: Any, **kwargs: Any
+    fn: Callable[..., Any], *args: Any, **kwargs: Any
 ) -> "ScheduleEvaluationContext":
     """Based on the passed resource function and the arguments passed to it, returns the
     user-passed ScheduleEvaluationContext or creates one if it is not passed.

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -451,7 +451,7 @@ SensorEvaluationFunction: TypeAlias = Callable[
 ]
 
 
-def get_context_param_name(fn: Callable) -> Optional[str]:
+def get_context_param_name(fn: Callable[..., Any]) -> Optional[str]:
     """Determines the sensor's context parameter name by excluding all resource parameters."""
     resource_params = {param.name for param in get_resource_args(fn)}
 
@@ -1188,7 +1188,7 @@ T = TypeVar("T")
 
 
 def get_sensor_context_from_args_or_kwargs(
-    fn: Callable,
+    fn: Callable[..., Any],
     args: Tuple[Any, ...],
     kwargs: Dict[str, Any],
     context_type: Type[T],
@@ -1232,7 +1232,7 @@ def get_sensor_context_from_args_or_kwargs(
 
 
 def get_or_create_sensor_context(
-    fn: Callable,
+    fn: Callable[..., Any],
     *args: Any,
     context_type: Type = SensorEvaluationContext,
     **kwargs: Any,

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -103,7 +103,7 @@ async def _coerce_async_op_to_async_gen(
 
 
 def invoke_compute_fn(
-    fn: Callable,
+    fn: Callable[..., Any],
     context: OpExecutionContext,
     kwargs: Mapping[str, Any],
     context_arg_provided: bool,

--- a/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 import sqlalchemy as db
 from sqlalchemy.pool import NullPool
@@ -91,10 +91,10 @@ class InMemoryEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             except Exception:
                 logging.exception("Exception in callback for event watch on run %s.", event.run_id)
 
-    def watch(self, run_id: str, cursor: str, callback: Callable):
+    def watch(self, run_id: str, cursor: str, callback: Callable[..., Any]):
         self._handlers[run_id].add(callback)
 
-    def end_watch(self, run_id: str, handler: Callable):
+    def end_watch(self, run_id: str, handler: Callable[..., Any]):
         if handler in self._handlers[run_id]:
             self._handlers[run_id].remove(handler)
 

--- a/python_modules/dagster/dagster/_core/storage/migration/bigint_migration.py
+++ b/python_modules/dagster/dagster/_core/storage/migration/bigint_migration.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Any, Callable
 
 import sqlalchemy as db
 
@@ -103,7 +103,7 @@ def _migrate_storage(conn, tables_to_migrate, print_fn):
             _restore_asset_event_tags_foreign_key(conn, print_fn)
 
 
-def run_bigint_migration(instance: DagsterInstance, print_fn: Callable = print):
+def run_bigint_migration(instance: DagsterInstance, print_fn: Callable[..., Any] = print):
     if isinstance(instance.event_log_storage, SqliteEventLogStorage):
         print_fn("Sqlite does not support bigint types, no need to migrate event log storage.")
     elif isinstance(instance.event_log_storage, SqlEventLogStorage):

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -682,7 +682,7 @@ class BlockingThreadPoolExecutor(ThreadPoolExecutor):
 def ignore_warning(message_substr: str):
     """Ignores warnings within the decorated function that contain the given string."""
 
-    def decorator(func: Callable):
+    def decorator(func: Callable[..., Any]):
         def wrapper(*args, **kwargs):
             warnings.filterwarnings("ignore", message=message_substr)
             return func(*args, **kwargs)

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -184,7 +184,7 @@ def _set_request_count(api_name: str, value: Any) -> None:
 
 def retrieve_metrics():
     class _MetricsRetriever:
-        def __call__(self, fn: Callable) -> Callable:
+        def __call__(self, fn: Callable[..., Any]) -> Callable:
             api_call = fn.__name__
             METRICS_RETRIEVAL_FUNCTIONS.add(api_call)
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_subset.py
@@ -1,6 +1,6 @@
 import datetime
 import operator
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 import pytest
 from dagster import (
@@ -73,7 +73,7 @@ def test_all_subset(partitions_def: Optional[PartitionsDefinition]) -> None:
 @pytest.mark.parametrize("second_all", [True, False])
 def test_operations(
     partitions_def: Optional[PartitionsDefinition],
-    operation: Callable,
+    operation: Callable[..., Any],
     first_all: bool,
     second_all: bool,
 ) -> None:


### PR DESCRIPTION
## Summary & Motivation

Change all bare `Callable` type annotations to `Callable[..., Any]` so no one ever sees `pyright` complain in strict mode about these. Will prevent issues like: https://github.com/dagster-io/dagster/issues/19612

## How I Tested These Changes

BK