### PR TITLE
Strong production warning for dagster dev

### DIFF
--- a/docs/content/guides/running-dagster-locally.mdx
+++ b/docs/content/guides/running-dagster-locally.mdx
@@ -58,7 +58,7 @@ For the full list of options that can be set in the `dagster.yaml` file, refer t
 
 ## Moving to production
 
-`dagster dev` is primarily useful for running Dagster for local development and testing, but isn't suitable for the demands of most production deployments. For example, in a production deployment, you might want to run multiple webserver replicas, have zero downtime continuous deployment of your code, or set up your Dagster daemon to automatically restart if it crashes.
+`dagster dev` is primarily useful for running Dagster for local development and testing. It isn't suitable for the demands of most production deployments. Most importantly, `dagster dev` does not include authentication or web security. Additionally, in a production deployment, you might want to run multiple webserver replicas, have zero downtime continuous deployment of your code, or set up your Dagster daemon to automatically restart if it crashes.
 
 For information about deploying Dagster in production, refer to the [Deploying Dagster guides](/deployment/open-source#deploying-dagster).
 


### PR DESCRIPTION
## Summary & Motivation

@PinkDraconian pointed the lack of protection against CSRF and other web vulnerabilities in the development server. As a follow up, we're being more clear that `dagster dev` isn't intended to production use. 
