### PR TITLE
[AssetCondition] Static constructors for AssetConditions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
@@ -382,6 +382,54 @@ class AssetCondition(ABC):
             unique_id=self.unique_id,
         )
 
+    @staticmethod
+    def parent_newer() -> "AssetCondition":
+        """Returns an AssetCondition that is true for an asset partition when at least one parent
+        asset partition is newer than it.
+        """
+        from ..auto_materialize_rule import AutoMaterializeRule
+
+        return RuleCondition(AutoMaterializeRule.materialize_on_parent_updated())
+
+    @staticmethod
+    def missing() -> "AssetCondition":
+        """Returns an AssetCondition that is true for an asset partition when it has never been
+        materialized.
+        """
+        from ..auto_materialize_rule import AutoMaterializeRule
+
+        return RuleCondition(AutoMaterializeRule.materialize_on_missing())
+
+    @staticmethod
+    def parent_missing() -> "AssetCondition":
+        """Returns an AssetCondition that is true for an asset partition when at least one parent
+        asset partition has never been materialized or observed.
+        """
+        from ..auto_materialize_rule import AutoMaterializeRule
+
+        return RuleCondition(AutoMaterializeRule.skip_on_parent_missing())
+
+    @staticmethod
+    def updated_since_cron(cron_schedule: str, timezone: str = "UTC") -> "AssetCondition":
+        """Returns an AssetCondition that is true for an asset partition when it has been updated
+        since the latest tick of the given cron schedule. For partitioned assets with a time
+        component, this can only be true for the the most recent partition.
+        """
+        from ..auto_materialize_rule import AutoMaterializeRule
+
+        return ~RuleCondition(AutoMaterializeRule.materialize_on_cron(cron_schedule, timezone))
+
+    @staticmethod
+    def parents_updated_since_cron(cron_schedule: str, timezone: str = "UTC") -> "AssetCondition":
+        """Returns an AssetCondition that is true for an asset partition when all parent asset
+        partitions have been updated more recently than the latest tick of the given cron schedule.
+        """
+        from ..auto_materialize_rule import AutoMaterializeRule
+
+        return ~RuleCondition(
+            AutoMaterializeRule.skip_on_not_all_parents_updated_since_cron(cron_schedule, timezone)
+        )
+
 
 class RuleCondition(
     NamedTuple("_RuleCondition", [("rule", "AutoMaterializeRule")]),

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition_evaluation_context.py
@@ -267,13 +267,18 @@ class AssetConditionEvaluationContext:
         return storage_id
 
     @property
+    def parent_has_or_will_update_subset(self) -> ValidAssetSubset:
+        """Returns the set of asset partitions whose parents have updated since the last time this
+        condition was evaluated, or will update on this tick.
+        """
+        return self.parent_has_updated_subset | self.root_context.parent_will_update_subset
+
+    @property
     def candidate_parent_has_or_will_update_subset(self) -> ValidAssetSubset:
         """Returns the set of candidates for this tick which have parents that have updated since
         the previous tick, or will update on this tick.
         """
-        return self.candidate_subset & (
-            self.parent_has_updated_subset | self.root_context.parent_will_update_subset
-        )
+        return self.candidate_subset & self.parent_has_or_will_update_subset
 
     @property
     def candidates_not_evaluated_on_previous_tick_subset(self) -> ValidAssetSubset:

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -510,7 +510,7 @@ class MaterializeOnParentUpdatedRule(
             AssetKeyPartitionKey, Set[AssetKeyPartitionKey]
         ] = defaultdict(set)
 
-        subset_to_evaluate = context.candidate_parent_has_or_will_update_subset
+        subset_to_evaluate = context.parent_has_or_will_update_subset
         for asset_partition in subset_to_evaluate.asset_partitions:
             parent_asset_partitions = context.asset_graph.get_parents_partitions(
                 dynamic_partitions_store=context.instance_queryer,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
@@ -1,14 +1,12 @@
 from dagster import AutoMaterializeRule
-from dagster._core.definitions.asset_condition.asset_condition import RuleCondition
+from dagster._core.definitions.asset_condition.asset_condition import AssetCondition, RuleCondition
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 
 from ..asset_daemon_scenario import (
     AssetDaemonScenario,
 )
 from ..base_scenario import run_request
-from .asset_daemon_scenario_states import (
-    one_asset,
-)
+from .asset_daemon_scenario_states import one_asset, two_assets_in_sequence
 
 custom_condition_scenarios = [
     AssetDaemonScenario(
@@ -27,5 +25,40 @@ custom_condition_scenarios = [
         execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
             run_request(asset_keys=["A"])
         ),
+    ),
+    AssetDaemonScenario(
+        id="funky_custom_condition_static_constructor_scenario",
+        initial_state=one_asset.with_asset_properties(
+            auto_materialize_policy=AutoMaterializePolicy.from_asset_condition(
+                # same as above, but with static constructor
+                ~(~AssetCondition.missing() & AssetCondition.parent_newer())
+            )
+        ),
+        execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
+            run_request(asset_keys=["A"])
+        ),
+    ),
+    AssetDaemonScenario(
+        id="parent_newer_and_not_updated_since_cron_scenario",
+        initial_state=two_assets_in_sequence.with_asset_properties(
+            "B",
+            auto_materialize_policy=AutoMaterializePolicy.from_asset_condition(
+                ~AssetCondition.updated_since_cron("@daily") & AssetCondition.parent_newer()
+            ),
+        ).with_current_time("2024-01-01 00:01:00"),
+        execution_fn=lambda state: state.evaluate_tick()
+        .assert_requested_runs()
+        .with_runs(run_request("A"))
+        # has not been updated since cron, and parent is newer
+        .evaluate_tick()
+        .assert_requested_runs(run_request("B"))
+        .with_runs(run_request("A"))
+        # parent is newer, but has been updated since cron
+        .evaluate_tick()
+        .assert_requested_runs()
+        .with_current_time_advanced(days=1)
+        # parent is newer, and has not been updated since cron
+        .evaluate_tick()
+        .assert_requested_runs(run_request("B")),
     ),
 ]


### PR DESCRIPTION
## Summary & Motivation

Opens up a subset of the existing AutoMaterializeRules to being constructed directly as AssetConditions.

Note a small change in the definition of the `parent_newer` rule, as it was designed under the assumption that its candidate_subset would always be all asset partitions of the asset. This is no longer the case, so I've slightly updated the implementation.

In essence, it works by tracking incremental changes in the state of the asset between ticks, and so if it ignores updates to a certain partition on a tick because that partition is not in the candidate set, then it will never know about that update. Instead, we let it track updates across all asset partitions even if they are not in the candidate subset.

## How I Tested These Changes
