### PR TITLE
feat(dbt): allow dbt projects with semantic models

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -578,14 +578,15 @@ def default_code_version_fn(dbt_resource_props: Mapping[str, Any]) -> str:
 def is_non_asset_node(dbt_resource_props: Mapping[str, Any]):
     # some nodes exist inside the dbt graph but are not assets
     resource_type = dbt_resource_props["resource_type"]
-    if resource_type == "metric":
-        return True
-    if (
-        resource_type == "model"
-        and dbt_resource_props.get("config", {}).get("materialized") == "ephemeral"
-    ):
-        return True
-    return False
+
+    return any(
+        [
+            resource_type == "metric",
+            resource_type == "semantic_model",
+            resource_type == "model"
+            and dbt_resource_props.get("config", {}).get("materialized") == "ephemeral",
+        ]
+    )
 
 
 def get_deps(
@@ -602,7 +603,7 @@ def get_deps(
         dbt_resource_props = dbt_nodes[unique_id]
         node_resource_type = dbt_resource_props["resource_type"]
 
-        # skip non-assets, such as metrics, tests, and ephemeral models
+        # skip non-assets, such as semantic models, metrics, tests, and ephemeral models
         if is_non_asset_node(dbt_resource_props) or node_resource_type not in asset_resource_types:
             continue
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -269,4 +269,5 @@ def get_dbt_resource_props_by_dbt_unique_id_from_manifest(
         **manifest["sources"],
         **manifest["exposures"],
         **manifest["metrics"],
+        **manifest.get("semantic_models", {}),
     }

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
@@ -12,6 +12,7 @@ from .dbt_projects import (
     test_dbt_alias_path,
     test_dbt_model_versions_path,
     test_dbt_python_interleaving_path,
+    test_dbt_semantic_models_path,
     test_jaffle_shop_path,
     test_meta_config_path,
     test_metadata_path,
@@ -78,6 +79,11 @@ def test_dbt_model_versions_manifest_fixture() -> Dict[str, Any]:
 @pytest.fixture(name="test_dbt_python_interleaving_manifest", scope="session")
 def test_dbt_python_interleaving_manifest_fixture() -> Dict[str, Any]:
     return _create_dbt_invocation(test_dbt_python_interleaving_path).get_artifact("manifest.json")
+
+
+@pytest.fixture(name="test_dbt_semantic_models_manifest", scope="session")
+def test_dbt_semantic_models_manifest_fixture() -> Dict[str, Any]:
+    return _create_dbt_invocation(test_dbt_semantic_models_path).get_artifact("manifest.json")
 
 
 @pytest.fixture(name="test_meta_config_manifest", scope="session")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -32,6 +32,7 @@ from ..dbt_projects import (
     test_dbt_alias_path,
     test_dbt_model_versions_path,
     test_dbt_python_interleaving_path,
+    test_dbt_semantic_models_path,
     test_meta_config_path,
 )
 
@@ -784,6 +785,18 @@ def test_dbt_with_python_interleaving(
         },
     }
     result = subset_job.execute_in_process()
+    assert result.success
+
+
+def test_dbt_with_semantic_models(test_dbt_semantic_models_manifest: Dict[str, Any]) -> None:
+    @dbt_assets(manifest=test_dbt_semantic_models_manifest)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        yield from dbt.cli(["build"], context=context).stream()
+
+    result = materialize(
+        [my_dbt_assets],
+        resources={"dbt": DbtCliResource(project_dir=os.fspath(test_dbt_semantic_models_path))},
+    )
     assert result.success
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/__init__.py
@@ -8,6 +8,7 @@ test_asset_key_exceptions_path = projects_path.joinpath("test_dagster_asset_key_
 test_dbt_alias_path = projects_path.joinpath("test_dagster_dbt_alias")
 test_dbt_model_versions_path = projects_path.joinpath("test_dagster_dbt_model_versions")
 test_dbt_python_interleaving_path = projects_path.joinpath("test_dagster_dbt_python_interleaving")
+test_dbt_semantic_models_path = projects_path.joinpath("test_dagster_dbt_semantic_models")
 test_exceptions_path = projects_path.joinpath("test_dagster_exceptions")
 test_meta_config_path = projects_path.joinpath("test_dagster_meta_config")
 test_metadata_path = projects_path.joinpath("test_dagster_metadata")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/.gitignore
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/.gitignore
@@ -9,3 +9,4 @@ venv/
 env/
 **/*.duckdb
 **/*.duckdb.wal
+package-lock.yml

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/dbt_project.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/dbt_project.yml
@@ -19,6 +19,9 @@ clean-targets:
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 
+vars:
+  "dbt_date:time_zone": "America/New_York"
+
 models:
   test_dagster_dbt_semantic_models:
     materialized: table

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/models/metricflow_time_spine.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/models/metricflow_time_spine.sql
@@ -1,0 +1,21 @@
+
+-- metricflow_time_spine.sql
+with
+
+days as (
+
+    --for BQ adapters use "DATE('01/01/2000','mm/dd/yyyy')"
+    {{ dbt_date.get_base_dates(n_dateparts=365*10, datepart="day") }}
+
+),
+
+cast_to_date as (
+
+    select
+        cast(date_day as date) as date_day
+
+    from days
+
+)
+
+select * from cast_to_date

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/models/schema.yml
@@ -81,3 +81,19 @@ models:
         description: Amount of the order (AUD) paid for by gift card
         tests:
           - not_null
+
+semantic_models:
+  - name: customers
+    description: Customer grain mart.
+    model: ref('customers')
+    entities:
+      - name: customer
+        expr: customer_id
+        type: primary
+    measures:
+      - name: total_order_amount
+        description: Total count of orders per customer.
+        agg: sum
+      - name: total_order_amount
+        agg: sum
+        description: Gross customer lifetime spend inclusive of taxes.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/packages.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/packages.yml
@@ -1,0 +1,5 @@
+# We keep use `packages.yml` for compatability with `dbt-core==1.5.*`.
+# Once we remove support for that version, we should rename this file to `dependencies.yml`
+packages:
+  - package: calogica/dbt_date
+    version: [">=0.8.0", "<0.9.0"]


### PR DESCRIPTION
## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/17471.

Similar to dbt metrics, don't represent semantic models as Dagster assets. This allows dbt projects with semantic models to render their asset graphs in Dagster.

## How I Tested These Changes
Added new dbt project with semantic models, execute `@dbt_assets` against it and see it succeed.
