### PR TITLE
[bugfix] asset owner copying

### DIFF
--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2062,21 +2062,27 @@ def test_asset_owners():
     def my_asset():
         pass
 
-    assert my_asset.owners_by_key == {
-        my_asset.key: [TeamAssetOwner("team1"), UserAssetOwner("claire@dagsterlabs.com")]
-    }
+    owners = [TeamAssetOwner("team1"), UserAssetOwner("claire@dagsterlabs.com")]
+    assert my_asset.owners_by_key == {my_asset.key: owners}
+    assert my_asset.with_attributes().owners_by_key == {my_asset.key: owners}  # copies ok
 
-    @asset(owners=[])
-    def asset_2():
+    @asset(owners=["team:team1", "claire@dagsterlabs.com"])
+    def my_asset_2():
         pass
 
-    assert asset_2.owners_by_key == {}
+    assert my_asset_2.owners_by_key == {my_asset_2.key: owners}
 
-    @asset(owners=None)
+    @asset(owners=[])
     def asset_3():
         pass
 
     assert asset_3.owners_by_key == {}
+
+    @asset(owners=None)
+    def asset_4():
+        pass
+
+    assert asset_4.owners_by_key == {}
 
 
 def test_invalid_asset_owners():


### PR DESCRIPTION
## Summary & Motivation

The recently added `owners_by_key` field on `AssetsDefinition` breaks when copying an `AssetsDefinition`. Calling `with_attributes` on an `AssetDefinition` that had defined assets owners would trigger a runtime error due to performance of string operations on `{Team,User}AssetOwner` objects. Also the type annotation was incorrect for `owners_by_key`. This fixes the bug.

## How I Tested These Changes

Add test for copying owners.
