### PR TITLE
Add group name for InputContext and OutputContext

### DIFF
--- a/examples/docs_snippets/docs_snippets/concepts/io_management/test_build_io_context.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/test_build_io_context.py
@@ -130,3 +130,16 @@ def test_input_context_partition_key():
 
     context = build_input_context()
     assert not context.has_partition_key
+
+
+def test_input_context_group_name():
+    context = build_input_context(group_name="default")
+    assert context.group_name == "default"
+
+
+    context = build_input_context(group_name="test_group")
+    assert context.group_name == "test_group"
+
+def test_output_context_group_name():
+    context = build_output_context(group_name="test_group")
+    assert context.group_name == "test_group"

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1017,6 +1017,14 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
                 partition_mapping, self._partitions_def, upstream_partitions_def
             )
 
+    def get_group_name_for_asset_key(self, key: AssetKey) -> str:
+        if key in self._group_names_by_key:
+            return self._group_names_by_key[key]
+
+        raise DagsterInvariantViolationError(
+            f"Asset key {key.to_user_string()} not found in AssetsDefinition"
+        )
+
     def get_output_name_for_asset_key(self, key: AssetKey) -> str:
         for output_name, asset_key in self.keys_by_output_name.items():
             if key == asset_key:

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1017,13 +1017,12 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
                 partition_mapping, self._partitions_def, upstream_partitions_def
             )
 
-    def get_group_name_for_asset_key(self, key: AssetKey) -> str:
+    def get_group_name_for_asset_key(self, key: AssetKey, default_group_name: str) -> str:
         if key in self._group_names_by_key:
             return self._group_names_by_key[key]
+        else:
+            return default_group_name
 
-        raise DagsterInvariantViolationError(
-            f"Asset key {key.to_user_string()} not found in AssetsDefinition"
-        )
 
     def get_output_name_for_asset_key(self, key: AssetKey) -> str:
         for output_name, asset_key in self.keys_by_output_name.items():

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -595,7 +595,7 @@ def build_input_context(
     from dagster._core.types.dagster_type import DagsterType
 
     name = check.opt_str_param(name, "name")
-    group_name = check.opt_str_param(name, "group_name")
+    group_name = check.opt_str_param(group_name, "group_name")
     metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
     upstream_output = check.opt_inst_param(upstream_output, "upstream_output", OutputContext)
     dagster_type = check.opt_inst_param(dagster_type, "dagster_type", DagsterType)

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -59,6 +59,7 @@ class InputContext:
         self,
         *,
         name: Optional[str] = None,
+        group_name: Optional[str] = None,
         job_name: Optional[str] = None,
         op_def: Optional["OpDefinition"] = None,
         config: Optional[Any] = None,
@@ -79,6 +80,7 @@ class InputContext:
         from dagster._core.execution.build_resources import build_resources
 
         self._name = name
+        self._group_name = group_name
         self._job_name = job_name
         self._op_def = op_def
         self._config = config
@@ -153,6 +155,18 @@ class InputContext:
             )
 
         return self._name
+
+    @public
+    @property
+    def group_name(self) -> str:
+        """The name of the input that we're loading."""
+        if self._group_name is None:
+            raise DagsterInvariantViolationError(
+                "Attempting to access group_name, "
+                "but it was not provided when constructing the InputContext"
+            )
+
+        return self._group_name
 
     @property
     def job_name(self) -> str:
@@ -521,6 +535,7 @@ class InputContext:
 
 def build_input_context(
     name: Optional[str] = None,
+    group_name: Optional[str] = None,
     config: Optional[Any] = None,
     metadata: Optional[ArbitraryMetadataMapping] = None,
     upstream_output: Optional["OutputContext"] = None,
@@ -543,6 +558,7 @@ def build_input_context(
 
     Args:
         name (Optional[str]): The name of the input that we're loading.
+        group_name (Optional[str]): The group name of the input that we're loading.
         config (Optional[Any]): The config attached to the input that we're loading.
         metadata (Optional[Dict[str, Any]]): A dict of metadata that is assigned to the
             InputDefinition that we're loading for.
@@ -579,6 +595,7 @@ def build_input_context(
     from dagster._core.types.dagster_type import DagsterType
 
     name = check.opt_str_param(name, "name")
+    group_name = check.opt_str_param(name, "group_name")
     metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
     upstream_output = check.opt_inst_param(upstream_output, "upstream_output", OutputContext)
     dagster_type = check.opt_inst_param(dagster_type, "dagster_type", DagsterType)
@@ -605,6 +622,7 @@ def build_input_context(
 
     return InputContext(
         name=name,
+        group_name=group_name,
         job_name=None,
         config=config,
         metadata=metadata,

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -875,7 +875,7 @@ def build_output_context(
 
     step_key = check.opt_str_param(step_key, "step_key")
     name = check.opt_str_param(name, "name")
-    group_name = check.opt_str_param(name, "group_name")
+    group_name = check.opt_str_param(group_name, "group_name")
     metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
     run_id = check.opt_str_param(run_id, "run_id", default=RUN_ID_PLACEHOLDER)
     mapping_key = check.opt_str_param(mapping_key, "mapping_key")

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -65,6 +65,7 @@ class OutputContext:
 
     _step_key: Optional[str]
     _name: Optional[str]
+    _group_name: Optional[str]
     _job_name: Optional[str]
     _run_id: Optional[str]
     _metadata: ArbitraryMetadataMapping
@@ -90,6 +91,7 @@ class OutputContext:
         self,
         step_key: Optional[str] = None,
         name: Optional[str] = None,
+        group_name: Optional[str] = None,
         job_name: Optional[str] = None,
         run_id: Optional[str] = None,
         metadata: Optional[ArbitraryMetadataMapping] = None,
@@ -111,6 +113,7 @@ class OutputContext:
 
         self._step_key = step_key
         self._name = name
+        self._group_name = group_name
         self._job_name = job_name
         self._run_id = run_id
         self._metadata = metadata or {}
@@ -185,6 +188,18 @@ class OutputContext:
             )
 
         return self._name
+
+    @public
+    @property
+    def group_name(self) -> str:
+        """The name of the output that produced the output."""
+        if self._group_name is None:
+            raise DagsterInvariantViolationError(
+                "Attempting to access group_name, "
+                "but it was not provided when constructing the OutputContext"
+            )
+
+        return self._group_name
 
     @property
     def job_name(self) -> str:
@@ -805,6 +820,7 @@ def step_output_version(
 def build_output_context(
     step_key: Optional[str] = None,
     name: Optional[str] = None,
+    group_name: Optional[str] = None,
     metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     run_id: Optional[str] = None,
     mapping_key: Optional[str] = None,
@@ -826,6 +842,7 @@ def build_output_context(
     Args:
         step_key (Optional[str]): The step_key for the compute step that produced the output.
         name (Optional[str]): The name of the output that produced the output.
+        group_name (Optional[str]): The group name of the output that produced the output.
         metadata (Optional[Mapping[str, Any]]): A dict of the metadata that is assigned to the
             OutputDefinition that produced the output.
         mapping_key (Optional[str]): The key that identifies a unique mapped output. None for regular outputs.
@@ -858,6 +875,7 @@ def build_output_context(
 
     step_key = check.opt_str_param(step_key, "step_key")
     name = check.opt_str_param(name, "name")
+    group_name = check.opt_str_param(name, "group_name")
     metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
     run_id = check.opt_str_param(run_id, "run_id", default=RUN_ID_PLACEHOLDER)
     mapping_key = check.opt_str_param(mapping_key, "mapping_key")
@@ -872,6 +890,7 @@ def build_output_context(
     return OutputContext(
         step_key=step_key,
         name=name,
+        group_name=group_name,
         job_name=None,
         run_id=run_id,
         metadata=metadata,

--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -11,7 +11,7 @@ from dagster._core.definitions.job_definition import (
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.source_asset import SourceAsset
-from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
+from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY, DEFAULT_GROUP_NAME
 from dagster._core.execution.build_resources import build_resources, get_mapped_resource_config
 from dagster._core.execution.context.input import build_input_context
 from dagster._core.execution.context.output import build_output_context
@@ -109,7 +109,7 @@ class AssetValueLoader:
             io_manager_key = assets_def.get_io_manager_key_for_asset_key(asset_key)
             io_manager_def = resource_defs[io_manager_key]
             name = assets_def.get_output_name_for_asset_key(asset_key)
-            group_name = assets_def.get_group_name_for_asset_key(asset_key)
+            group_name = assets_def.get_group_name_for_asset_key(asset_key, DEFAULT_GROUP_NAME)
             output_metadata = assets_def.metadata_by_key[asset_key]
             op_def = assets_def.get_op_def_for_asset_key(asset_key)
             asset_partitions_def = assets_def.partitions_def
@@ -123,6 +123,7 @@ class AssetValueLoader:
             io_manager_key = source_asset.get_io_manager_key()
             io_manager_def = resource_defs[io_manager_key]
             name = asset_key.path[-1]
+            group_name = source_asset.group_name
             output_metadata = source_asset.raw_metadata
             op_def = None
             asset_partitions_def = source_asset.partitions_def

--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -109,6 +109,7 @@ class AssetValueLoader:
             io_manager_key = assets_def.get_io_manager_key_for_asset_key(asset_key)
             io_manager_def = resource_defs[io_manager_key]
             name = assets_def.get_output_name_for_asset_key(asset_key)
+            group_name = assets_def.get_group_name_for_asset_key(asset_key)
             output_metadata = assets_def.metadata_by_key[asset_key]
             op_def = assets_def.get_op_def_for_asset_key(asset_key)
             asset_partitions_def = assets_def.partitions_def
@@ -147,10 +148,12 @@ class AssetValueLoader:
 
         input_context = build_input_context(
             name=None,
+            group_name=group_name,
             asset_key=asset_key,
             dagster_type=resolve_dagster_type(python_type),
             upstream_output=build_output_context(
                 name=name,
+                group_name=group_name,
                 metadata=output_metadata,
                 asset_key=asset_key,
                 op_def=op_def,


### PR DESCRIPTION
## Summary & Motivation

This PR add the `group_name` parameter in the `InputContext` and `OutputContext`, to be accessible by the `IOManager`, without passing information in the metadata (as explained in this issue #13945)

## How I Tested These Changes

I added tests, for the `build_input_context()` and `build_output_context()`, and tests for the `load_asset_value`, to verify the default group is "default"