### PR TITLE
Fix word splitting in github actions

### DIFF
--- a/.github/workflows/build-dagster-university.yml
+++ b/.github/workflows/build-dagster-university.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get branch preview subdomain
         if: github.event_name == 'pull_request'
         run: |
-          BRANCH_PREVIEW_SUBDOMAIN=$(echo "${{ github.head_ref || github.ref_name }}" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/^-*//' | sed 's/-*$//')
+          BRANCH_PREVIEW_SUBDOMAIN=$(echo "${GITHUB_HEAD_REF:=$GITHUB_REF_NAME}" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/^-*//' | sed 's/-*$//')
           echo "$BRANCH_PREVIEW_SUBDOMAIN"
           echo "BRANCH_PREVIEW_SUBDOMAIN=$BRANCH_PREVIEW_SUBDOMAIN" >> "${GITHUB_ENV}"
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -24,7 +24,7 @@ jobs:
           github.event_name == 'pull_request' || 
           (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-')))
         run: |
-          BRANCH_PREVIEW_SUBDOMAIN=$(echo "${{ github.head_ref || github.ref_name }}" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/^-*//' | sed 's/-*$//')
+          BRANCH_PREVIEW_SUBDOMAIN=$(echo "${GITHUB_HEAD_REF:=$GITHUB_REF_NAME}" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/^-*//' | sed 's/-*$//')
           echo "$BRANCH_PREVIEW_SUBDOMAIN"
           echo "BRANCH_PREVIEW_SUBDOMAIN=$BRANCH_PREVIEW_SUBDOMAIN" >> "${GITHUB_ENV}"
 

--- a/.github/workflows/build-storybook-core.yml
+++ b/.github/workflows/build-storybook-core.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Get branch preview subdomain
         if: github.event_name == 'pull_request'
         run: |
-          BRANCH_PREVIEW_SUBDOMAIN=$(echo "${{ github.head_ref || github.ref_name }}" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/^-*//' | sed 's/-*$//')
+          BRANCH_PREVIEW_SUBDOMAIN=$(echo "${GITHUB_HEAD_REF:=$GITHUB_REF_NAME}" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/^-*//' | sed 's/-*$//')
           echo "$BRANCH_PREVIEW_SUBDOMAIN"
           echo "BRANCH_PREVIEW_SUBDOMAIN=$BRANCH_PREVIEW_SUBDOMAIN" >> "${GITHUB_ENV}"
       - uses: actions/checkout@v3

--- a/.github/workflows/build-storybook-ui.yml
+++ b/.github/workflows/build-storybook-ui.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Get branch preview subdomain
         if: github.event_name == 'pull_request'
         run: |
-          BRANCH_PREVIEW_SUBDOMAIN=$(echo "${{ github.head_ref || github.ref_name }}" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/^-*//' | sed 's/-*$//')
+          BRANCH_PREVIEW_SUBDOMAIN=$(echo "${GITHUB_HEAD_REF:=$GITHUB_REF_NAME}" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/^-*//' | sed 's/-*$//')
           echo "$BRANCH_PREVIEW_SUBDOMAIN"
           echo "BRANCH_PREVIEW_SUBDOMAIN=$BRANCH_PREVIEW_SUBDOMAIN" >> "${GITHUB_ENV}"
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary & Motivation

Even though we don't run github actions on a contributors first PR we're still slightly vulnerable to missing a word splitting attack in a branch name and letting the github actions run uneditted. 

This PR will use the env vars instead of the variables. The env vars are expanded in typical bash fashion so double quoting limits word splitting attacks.

## How I Tested These Changes

