### PR TITLE
fix: deltalake string partition dimension str_values

### DIFF
--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
@@ -212,7 +212,7 @@ def partition_dimensions_to_dnf(
                 )
                 parts.append(filter_)
             elif field.type.type == "string":
-                parts.append(_value_dnf(partition_dimension, field.type.type, str_values))
+                parts.append(_value_dnf(partition_dimension, field.type.type, str_values=True))
             else:
                 raise ValueError(f"Unsupported partition type {field.type.type}")
         else:

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_type_handler.py
@@ -317,6 +317,30 @@ def test_static_partitioned_asset(tmp_path, io_manager):
 
 
 @asset(
+    partitions_def=StaticPartitionsDefinition(["red", "yellow", "blue"]),
+    key_prefix=["my_schema"],
+    metadata={"partition_expr": "color"},
+)
+def load_partitioned_static(context, static_partitioned: pa.Table) -> pa.Table:
+    return static_partitioned
+
+
+def test_load_static_partitioned_asset(tmp_path, io_manager):
+    resource_defs = {"io_manager": io_manager}
+
+    res = materialize(
+        [static_partitioned, load_partitioned_static],
+        partition_key="red",
+        resources=resource_defs,
+        run_config={"ops": {"my_schema__static_partitioned": {"config": {"value": "1"}}}},
+    )
+
+    assert res.success
+    table = res.asset_value(["my_schema", "load_partitioned_static"])
+    assert table.shape[0] == 3
+
+
+@asset(
     partitions_def=MultiPartitionsDefinition(
         {
             "time": DailyPartitionsDefinition(start_date="2022-01-01"),


### PR DESCRIPTION
## Summary & Motivation

A missing flag causes an error when loading an asset with deltalake io manager when it is partitionned with a string-valued column. This case was not covered in the original unit tests.

Without this flag, the following error appears : 

```
pyarrow.lib.ArrowNotImplementedError: Function 'equal' has no kernel matching input types (string, list<item: string>)
```

## How I Tested These Changes

Wrote a new unit test
