### PR TITLE
[fix] Set default run_retries_max_retries to 0

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -907,7 +907,7 @@ class DagsterInstance(DynamicPartitionsStore):
 
     @property
     def run_retries_max_retries(self) -> int:
-        return self.get_settings("run_retries").get("max_retries")
+        return self.get_settings("run_retries").get("max_retries", 0)
 
     @property
     def auto_materialize_enabled(self) -> bool:


### PR DESCRIPTION
## Summary & Motivation
Spawned while debugging https://github.com/dagster-io/dagster/issues/19893

We reached a weird edge case, where the daemon crashed randomly. I found the following stack trace:

```  
Error calling event event log consumer handler: consume_new_runs_for_automatic_reexecution
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/dagster/_daemon/auto_run_reexecution/event_log_consumer.py", line 86, in run_iteration
    yield from fn(workspace_process_context, run_records)
  File "/usr/local/lib/python3.10/site-packages/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py", line 168, in consume_new_runs_for_automatic_reexecution
    for run, retry_number in filter_runs_to_should_retry(
  File "/usr/local/lib/python3.10/site-packages/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py", line 60, in filter_runs_to_should_retry
    retry_number = get_retry_number(run)
  File "/usr/local/lib/python3.10/site-packages/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py", line 49, in get_retry_number
    if len(run_group_list) >= max_retries + 1:
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
```

This, as far as I can tell, is because the `default_max_retries` was not actually `int` but `int | None`. An alternative solution would be something like this: https://github.com/dagster-io/dagster/commit/8c5f9ee95fd1687f2fef723ea96561c85c5a108b where instead we allow it to be None, rather than int.   

## How I Tested These Changes
Not sure exactly how to test this, but the typing of the function makes it semi-obvious, however, the function should have a default value. This is also covered in your [documentation here](https://docs.dagster.io/deployment/run-retries#configuration), if this can be tested with a unit test, feel free to provide feedback.
