### PR TITLE
[external-assets] refactor AssetGraph

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_checks.py
@@ -120,6 +120,10 @@ class AssetChecksDefinition(ResourceAddable, RequiresResources):
         return self._specs_by_output_name.values()
 
     @property
+    def keys(self) -> Iterable[AssetCheckKey]:
+        return self._specs_by_handle.keys()
+
+    @property
     def specs_by_output_name(self) -> Mapping[str, AssetCheckSpec]:
         return self._specs_by_output_name
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -193,7 +193,7 @@ class AssetDaemonContext:
         """
         # convert the legacy AutoMaterializePolicy to an Evaluator
         asset_condition = check.not_none(
-            self.asset_graph.auto_materialize_policies_by_key.get(asset_key)
+            self.asset_graph.get_auto_materialize_policy(asset_key)
         ).to_asset_condition()
 
         asset_cursor = self.cursor.get_previous_evaluation_state(asset_key)

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -231,7 +231,7 @@ def backcompat_deserialize_asset_daemon_cursor_str(
 
     previous_evaluation_state = []
     cursor_keys = (
-        asset_graph.auto_materialize_policies_by_key.keys()
+        asset_graph.materializable_asset_keys
         if asset_graph
         else latest_evaluation_by_asset_key.keys()
     )

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -686,9 +686,10 @@ class GroupsAssetSelection(AssetSelection, frozen=True):
             else asset_graph.materializable_asset_keys
         )
         return {
-            asset_key
-            for asset_key, group in asset_graph.group_names_by_key.items()
-            if group in self.selected_groups and asset_key in base_set
+            key
+            for group in self.selected_groups
+            for key in asset_graph.asset_keys_for_group(group)
+            if key in base_set
         }
 
     def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -533,7 +533,7 @@ class CachingDataTimeResolver:
         asset_key: AssetKey,
         evaluation_time: datetime.datetime,
     ) -> Optional[FreshnessMinutes]:
-        freshness_policy = self.asset_graph.freshness_policies_by_key.get(asset_key)
+        freshness_policy = self.asset_graph.get_freshness_policy(asset_key)
         if freshness_policy is None:
             raise DagsterInvariantViolationError(
                 "Cannot calculate minutes late for asset without a FreshnessPolicy"

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -543,7 +543,7 @@ class Definitions:
 
     def get_assets_def(self, key: CoercibleToAssetKey) -> AssetsDefinition:
         asset_key = AssetKey.from_coercible(key)
-        for assets_def in self.get_asset_graph().assets:
+        for assets_def in self.get_asset_graph().assets_defs:
             if asset_key in assets_def.keys:
                 return assets_def
 

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -8,17 +8,19 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
-    Set,
     Tuple,
 )
 
 import dagster._check as check
+from dagster._core.definitions.asset_check_spec import AssetCheckKey
+from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.assets_job import ASSET_BASE_JOB_PREFIX
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.host_representation.external import ExternalRepository
 from dagster._core.host_representation.handle import RepositoryHandle
 from dagster._core.selector.subset_selector import DependencyGraph
 from dagster._core.workspace.workspace import IWorkspace
+from dagster._utils.cached_method import cached_method
 
 from .asset_graph import AssetGraph, AssetKeyOrCheckKey
 from .backfill_policy import BackfillPolicy
@@ -37,44 +39,13 @@ if TYPE_CHECKING:
 class ExternalAssetGraph(AssetGraph):
     def __init__(
         self,
-        asset_dep_graph: DependencyGraph[AssetKey],
-        source_asset_keys: AbstractSet[AssetKey],
-        partitions_defs_by_key: Mapping[AssetKey, Optional[PartitionsDefinition]],
-        partition_mappings_by_key: Mapping[AssetKey, Optional[Mapping[AssetKey, PartitionMapping]]],
-        group_names_by_key: Mapping[AssetKey, Optional[str]],
-        freshness_policies_by_key: Mapping[AssetKey, Optional[FreshnessPolicy]],
-        auto_materialize_policies_by_key: Mapping[AssetKey, Optional[AutoMaterializePolicy]],
-        backfill_policies_by_key: Mapping[AssetKey, Optional[BackfillPolicy]],
+        asset_nodes_by_key: Mapping[AssetKey, "ExternalAssetNode"],
+        asset_checks_by_key: Mapping[AssetCheckKey, "ExternalAssetCheck"],
         repo_handles_by_key: Mapping[AssetKey, RepositoryHandle],
-        job_names_by_key: Mapping[AssetKey, Sequence[str]],
-        code_versions_by_key: Mapping[AssetKey, Optional[str]],
-        is_observable_by_key: Mapping[AssetKey, bool],
-        auto_observe_interval_minutes_by_key: Mapping[AssetKey, Optional[float]],
-        required_assets_and_checks_by_key: Mapping[
-            AssetKeyOrCheckKey, AbstractSet[AssetKeyOrCheckKey]
-        ],
     ):
-        super().__init__(
-            asset_dep_graph=asset_dep_graph,
-            source_asset_keys=source_asset_keys,
-            partitions_defs_by_key=partitions_defs_by_key,
-            partition_mappings_by_key=partition_mappings_by_key,
-            group_names_by_key=group_names_by_key,
-            freshness_policies_by_key=freshness_policies_by_key,
-            auto_materialize_policies_by_key=auto_materialize_policies_by_key,
-            backfill_policies_by_key=backfill_policies_by_key,
-            code_versions_by_key=code_versions_by_key,
-            is_observable_by_key=is_observable_by_key,
-            auto_observe_interval_minutes_by_key=auto_observe_interval_minutes_by_key,
-            required_assets_and_checks_by_key=required_assets_and_checks_by_key,
-        )
+        self._asset_nodes_by_key = asset_nodes_by_key
+        self._asset_checks_by_key = asset_checks_by_key
         self._repo_handles_by_key = repo_handles_by_key
-        self._materialization_job_names_by_key = job_names_by_key
-
-        self._asset_keys_by_job_name: Mapping[str, List[AssetKey]] = defaultdict(list)
-        for asset_key, job_names in self._materialization_job_names_by_key.items():
-            for job_name in job_names:
-                self._asset_keys_by_job_name[job_name].append(asset_key)
 
     @classmethod
     def from_workspace(cls, context: IWorkspace) -> "ExternalAssetGraph":
@@ -122,106 +93,218 @@ class ExternalAssetGraph(AssetGraph):
         repo_handle_external_asset_nodes: Sequence[Tuple[RepositoryHandle, "ExternalAssetNode"]],
         external_asset_checks: Sequence["ExternalAssetCheck"],
     ) -> "ExternalAssetGraph":
-        upstream: Dict[AssetKey, AbstractSet[AssetKey]] = {}
-        source_asset_keys: Set[AssetKey] = set()
-        partitions_defs_by_key: Dict[AssetKey, Optional[PartitionsDefinition]] = {}
-        partition_mappings_by_key: Dict[AssetKey, Dict[AssetKey, PartitionMapping]] = defaultdict(
-            defaultdict
-        )
-        group_names_by_key = {}
-        freshness_policies_by_key = {}
-        auto_materialize_policies_by_key = {}
-        backfill_policies_by_key = {}
-        keys_by_atomic_execution_unit_id: Dict[str, Set[AssetKeyOrCheckKey]] = defaultdict(set)
         repo_handles_by_key = {
             node.asset_key: repo_handle
             for repo_handle, node in repo_handle_external_asset_nodes
             if not node.is_source or node.is_observable
         }
-        job_names_by_key = {
-            node.asset_key: node.job_names
-            for _, node in repo_handle_external_asset_nodes
-            if not node.is_source or node.is_observable
-        }
-        code_versions_by_key = {
-            node.asset_key: node.code_version
-            for _, node in repo_handle_external_asset_nodes
-            if not node.is_source
-        }
 
-        all_non_source_keys = {
-            node.asset_key for _, node in repo_handle_external_asset_nodes if not node.is_source
-        }
-
-        is_observable_by_key = {}
-        auto_observe_interval_minutes_by_key = {}
-
+        # Split the nodes into materializable, observable, and unexecutable nodes. Observable and
+        # unexecutable `ExternalAssetNode` represent both source and external assets-- the
+        # "External" in "ExternalAssetNode" is unrelated to the "external" in "external asset", this
+        # is just an unfortunate naming collision. `ExternalAssetNode` will be renamed eventually.
+        materializable_node_pairs: List[Tuple[RepositoryHandle, "ExternalAssetNode"]] = []
+        observable_node_pairs: List[Tuple[RepositoryHandle, "ExternalAssetNode"]] = []
+        unexecutable_node_pairs: List[Tuple[RepositoryHandle, "ExternalAssetNode"]] = []
         for repo_handle, node in repo_handle_external_asset_nodes:
-            is_observable_by_key[node.asset_key] = node.is_observable
-            auto_observe_interval_minutes_by_key[
-                node.asset_key
-            ] = node.auto_observe_interval_minutes
-            if node.is_source:
-                if node.asset_key in all_non_source_keys:
-                    # one location's source is another location's non-source
-                    continue
+            if node.is_source and node.is_observable:
+                observable_node_pairs.append((repo_handle, node))
+            elif node.is_source:
+                unexecutable_node_pairs.append((repo_handle, node))
+            else:
+                materializable_node_pairs.append((repo_handle, node))
 
-                source_asset_keys.add(node.asset_key)
+        asset_nodes_by_key = {}
 
-            upstream[node.asset_key] = {dep.upstream_asset_key for dep in node.dependencies}
-            for dep in node.dependencies:
-                if dep.partition_mapping is not None:
-                    partition_mappings_by_key[node.asset_key][
-                        dep.upstream_asset_key
-                    ] = dep.partition_mapping
-            partitions_defs_by_key[node.asset_key] = (
-                node.partitions_def_data.get_partitions_definition()
-                if node.partitions_def_data
-                else None
-            )
-            group_names_by_key[node.asset_key] = node.group_name
-            freshness_policies_by_key[node.asset_key] = node.freshness_policy
-            auto_materialize_policies_by_key[node.asset_key] = node.auto_materialize_policy
-            backfill_policies_by_key[node.asset_key] = node.backfill_policy
+        # It is possible for multiple nodes to exist that share the same key. This is invalid if
+        # more than one node is materializable or if more than one node is observable. It is valid
+        # if there is at most one materializable node and at most one observable node, with all
+        # other nodes unexecutable. The asset graph will receive only a single `ExternalAssetNode`
+        # representing the asset. This will always be the materializable node if one exists; then
+        # the observable node if it exists; then finally the first-encountered unexecutable node.
+        for repo_handle, node in materializable_node_pairs:
+            if node.asset_key in asset_nodes_by_key:
+                check.failed("Found two materialization nodes with the same asset key")
+            asset_nodes_by_key[node.asset_key] = node
 
-            if node.atomic_execution_unit_id is not None:
-                keys_by_atomic_execution_unit_id[node.atomic_execution_unit_id].add(node.asset_key)
+        for repo_handle, node in observable_node_pairs:
+            if node.asset_key in asset_nodes_by_key:
+                current_node = asset_nodes_by_key[node.asset_key]
+                if current_node.is_observable:
+                    check.failed("Found two observable source nodes with the same asset key")
+                asset_nodes_by_key[node.asset_key] = current_node._replace(is_observable=True)
+            else:
+                asset_nodes_by_key[node.asset_key] = node
 
+        for repo_handle, node in unexecutable_node_pairs:
+            if node.asset_key in asset_nodes_by_key:
+                continue
+            asset_nodes_by_key[node.asset_key] = node
+
+        asset_checks_by_key: Dict[AssetCheckKey, "ExternalAssetCheck"] = {}
         for asset_check in external_asset_checks:
-            if asset_check.atomic_execution_unit_id is not None:
-                keys_by_atomic_execution_unit_id[asset_check.atomic_execution_unit_id].add(
-                    asset_check.key
-                )
-
-        downstream: Dict[AssetKey, Set[AssetKey]] = defaultdict(set)
-        for asset_key, upstream_keys in upstream.items():
-            for upstream_key in upstream_keys:
-                downstream[upstream_key].add(asset_key)
-
-        required_assets_and_checks_by_key: Dict[
-            AssetKeyOrCheckKey, AbstractSet[AssetKeyOrCheckKey]
-        ] = {}
-        for keys in keys_by_atomic_execution_unit_id.values():
-            if len(keys) > 1:
-                for key in keys:
-                    required_assets_and_checks_by_key[key] = keys
+            asset_checks_by_key[asset_check.key] = asset_check
 
         return cls(
-            asset_dep_graph={"upstream": upstream, "downstream": downstream},
-            source_asset_keys=source_asset_keys,
-            partitions_defs_by_key=partitions_defs_by_key,
-            partition_mappings_by_key=partition_mappings_by_key,
-            group_names_by_key=group_names_by_key,
-            freshness_policies_by_key=freshness_policies_by_key,
-            auto_materialize_policies_by_key=auto_materialize_policies_by_key,
-            backfill_policies_by_key=backfill_policies_by_key,
+            asset_nodes_by_key,
+            asset_checks_by_key,
             repo_handles_by_key=repo_handles_by_key,
-            job_names_by_key=job_names_by_key,
-            code_versions_by_key=code_versions_by_key,
-            is_observable_by_key=is_observable_by_key,
-            auto_observe_interval_minutes_by_key=auto_observe_interval_minutes_by_key,
-            required_assets_and_checks_by_key=required_assets_and_checks_by_key,
         )
+
+    @property
+    def asset_nodes(self) -> Sequence["ExternalAssetNode"]:
+        return list(self._asset_nodes_by_key.values())
+
+    def get_asset_node(self, asset_key: AssetKey) -> "ExternalAssetNode":
+        return self._asset_nodes_by_key[asset_key]
+
+    def has_asset(self, asset_key: AssetKey) -> bool:
+        return asset_key in self._asset_nodes_by_key
+
+    @property
+    def asset_checks(self) -> Sequence["ExternalAssetCheck"]:
+        return list(self._asset_checks_by_key.values())
+
+    def get_asset_check(self, asset_check_key: AssetCheckKey) -> "ExternalAssetCheck":
+        return self._asset_checks_by_key[asset_check_key]
+
+    @property
+    @cached_method
+    def asset_dep_graph(self) -> DependencyGraph[AssetKey]:
+        upstream = {node.asset_key: set() for node in self.asset_nodes}
+        downstream = {node.asset_key: set() for node in self.asset_nodes}
+        for node in self.asset_nodes:
+            for dep in node.dependencies:
+                upstream[node.asset_key].add(dep.upstream_asset_key)
+                downstream[dep.upstream_asset_key].add(node.asset_key)
+        return {"upstream": upstream, "downstream": downstream}
+
+    @property
+    def all_asset_keys(self) -> AbstractSet[AssetKey]:
+        return {node.asset_key for node in self.asset_nodes}
+
+    @property
+    def source_asset_keys(self) -> AbstractSet[AssetKey]:
+        # If a node exists as a source in one location and a non-source in another, it does not show
+        # up here. This is arguably incorrect but is being kept as is for backcompat.
+        # `source_asset_keys` is slated for removal in any case.
+        return {
+            node.asset_key for node in self.asset_nodes if node.is_source
+        } - self.materializable_asset_keys
+
+    @property
+    def materializable_asset_keys(self) -> AbstractSet[AssetKey]:
+        return {
+            node.asset_key
+            for node in self.asset_nodes
+            if node.execution_type == AssetExecutionType.MATERIALIZATION
+        }
+
+    def is_materializable(self, asset_key: AssetKey) -> bool:
+        return self.get_asset_node(asset_key).execution_type == AssetExecutionType.MATERIALIZATION
+
+    @property
+    def observable_asset_keys(self) -> AbstractSet[AssetKey]:
+        return {
+            node.asset_key
+            for node in self.asset_nodes
+            # check the separate `is_observable` field because `execution_type` will be
+            # `MATERIALIZATION` if there exists a materializable version of the asset
+            if node.is_observable
+        }
+
+    def is_observable(self, asset_key: AssetKey) -> bool:
+        return self.get_asset_node(asset_key).is_observable
+
+    @property
+    def external_asset_keys(self) -> AbstractSet[AssetKey]:
+        return {
+            node.asset_key
+            for node in self.asset_nodes
+            if node.execution_type != AssetExecutionType.MATERIALIZATION
+        }
+
+    def is_external(self, asset_key: AssetKey) -> bool:
+        return self.get_asset_node(asset_key).execution_type != AssetExecutionType.MATERIALIZATION
+
+    @property
+    def executable_asset_keys(self) -> AbstractSet[AssetKey]:
+        return {node.asset_key for node in self.asset_nodes if node.is_executable}
+
+    def is_executable(self, asset_key: AssetKey) -> bool:
+        return self.get_asset_node(asset_key).execution_type != AssetExecutionType.UNEXECUTABLE
+
+    def asset_keys_for_group(self, group_name: str) -> AbstractSet[AssetKey]:
+        return {node.asset_key for node in self.asset_nodes if node.group_name == group_name}
+
+    def asset_keys_for_job(self, job_name: str) -> AbstractSet[AssetKey]:
+        return {node.asset_key for node in self.asset_nodes if job_name in node.job_names}
+
+    def get_required_asset_and_check_keys(
+        self, asset_or_check_key: AssetKeyOrCheckKey
+    ) -> AbstractSet[AssetKeyOrCheckKey]:
+        if isinstance(asset_or_check_key, AssetKey):
+            atomic_execution_unit_id = self.get_asset_node(
+                asset_or_check_key
+            ).atomic_execution_unit_id
+        else:  # AssetCheckKey
+            atomic_execution_unit_id = self.get_asset_check(
+                asset_or_check_key
+            ).atomic_execution_unit_id
+        if atomic_execution_unit_id is None:
+            return set()
+        else:
+            return {
+                *(
+                    node.asset_key
+                    for node in self.asset_nodes
+                    if node.atomic_execution_unit_id == atomic_execution_unit_id
+                ),
+                *(
+                    node.key
+                    for node in self.asset_checks
+                    if node.atomic_execution_unit_id == atomic_execution_unit_id
+                ),
+            }
+
+    def get_required_multi_asset_keys(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
+        return {
+            key
+            for key in self.get_required_asset_and_check_keys(asset_key)
+            if isinstance(key, AssetKey)
+        }
+
+    @property
+    def all_jobs(self) -> AbstractSet[str]:
+        return {job_name for node in self.asset_nodes for job_name in node.job_names}
+
+    def get_partitions_def(self, asset_key: AssetKey) -> Optional[PartitionsDefinition]:
+        external_def = self.get_asset_node(asset_key).partitions_def_data
+        return external_def.get_partitions_definition() if external_def else None
+
+    def get_partition_mappings(
+        self, asset_key: AssetKey
+    ) -> Optional[Mapping[AssetKey, PartitionMapping]]:
+        return {
+            dep.upstream_asset_key: dep.partition_mapping
+            for dep in self.get_asset_node(asset_key).dependencies
+            if dep.partition_mapping is not None
+        }
+
+    def get_freshness_policy(self, asset_key: AssetKey) -> Optional[FreshnessPolicy]:
+        return self.get_asset_node(asset_key).freshness_policy
+
+    def get_auto_materialize_policy(self, asset_key: AssetKey) -> Optional[AutoMaterializePolicy]:
+        return self.get_asset_node(asset_key).auto_materialize_policy
+
+    def get_auto_observe_interval_minutes(self, asset_key: AssetKey) -> Optional[float]:
+        return self.get_asset_node(asset_key).auto_observe_interval_minutes
+
+    def get_backfill_policy(self, asset_key: AssetKey) -> Optional[BackfillPolicy]:
+        return self.get_asset_node(asset_key).backfill_policy
+
+    def get_code_version(self, asset_key: AssetKey) -> Optional[str]:
+        return self.get_asset_node(asset_key).code_version
 
     @property
     def repository_handles_by_key(self) -> Mapping[AssetKey, RepositoryHandle]:
@@ -230,9 +313,9 @@ class ExternalAssetGraph(AssetGraph):
     def get_repository_handle(self, asset_key: AssetKey) -> RepositoryHandle:
         return self._repo_handles_by_key[asset_key]
 
-    def get_materialization_job_names(self, asset_key: AssetKey) -> Iterable[str]:
+    def get_materialization_job_names(self, asset_key: AssetKey) -> Sequence[str]:
         """Returns the names of jobs that materialize this asset."""
-        return self._materialization_job_names_by_key[asset_key]
+        return self.get_asset_node(asset_key).job_names
 
     def get_materialization_asset_keys_for_job(self, job_name: str) -> Sequence[AssetKey]:
         """Returns asset keys that are targeted for materialization in the given job."""
@@ -241,9 +324,6 @@ class ExternalAssetGraph(AssetGraph):
             for k in self.materializable_asset_keys
             if job_name in self.get_materialization_job_names(k)
         ]
-
-    def get_asset_keys_for_job(self, job_name: str) -> Sequence[AssetKey]:
-        return self._asset_keys_by_job_name[job_name]
 
     def get_implicit_job_name_for_assets(
         self,
@@ -284,23 +364,21 @@ class ExternalAssetGraph(AssetGraph):
                     partitions_def_by_job_name[job_name] = None
             # find the job that matches the expected partitions definition
             for job_name, external_partitions_def in partitions_def_by_job_name.items():
+                asset_keys_for_job = self.asset_keys_for_job(job_name)
                 if not job_name.startswith(ASSET_BASE_JOB_PREFIX):
                     continue
                 if (
                     # unpartitioned observable source assets may be materialized in any job
                     target_partitions_def is None
                     or external_partitions_def == target_partitions_def
-                ) and all(
-                    asset_key in self._asset_keys_by_job_name[job_name] for asset_key in asset_keys
-                ):
+                ) and all(asset_key in asset_keys_for_job for asset_key in asset_keys):
                     return job_name
         else:
-            for job_name in sorted(self._asset_keys_by_job_name.keys()):
+            for job_name in self.all_jobs:
+                asset_keys_for_job = self.asset_keys_for_job(job_name)
                 if not job_name.startswith(ASSET_BASE_JOB_PREFIX):
                     continue
-                if all(
-                    asset_key in self._asset_keys_by_job_name[job_name] for asset_key in asset_keys
-                ):
+                if all(asset_key in self.asset_keys_for_job(job_name) for asset_key in asset_keys):
                     return job_name
         return None
 

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -207,7 +207,7 @@ def freshness_evaluation_results_for_asset_key(
         execution_period,
         evaluation_data,
     ) = get_execution_period_and_evaluation_data_for_policies(
-        local_policy=context.asset_graph.freshness_policies_by_key.get(asset_key),
+        local_policy=context.asset_graph.get_freshness_policy(asset_key),
         policies=context.asset_graph.get_downstream_freshness_policies(asset_key=asset_key),
         effective_data_time=effective_data_time,
         current_time=current_time,

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
@@ -258,7 +258,7 @@ class FreshnessPolicySensorDefinition(SensorDefinition):
 
             minutes_late_by_key: Dict[AssetKey, Optional[float]] = {}
             for asset_key in monitored_keys:
-                freshness_policy = asset_graph.freshness_policies_by_key.get(asset_key)
+                freshness_policy = asset_graph.get_freshness_policy(asset_key)
                 if freshness_policy is None:
                     continue
 

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -181,7 +181,7 @@ class UnresolvedAssetJobDefinition(
         resource_defs: Optional[Mapping[str, "ResourceDefinition"]] = None,
     ) -> "JobDefinition":
         """Resolve this UnresolvedAssetJobDefinition into a JobDefinition."""
-        assets = asset_graph.assets
+        assets = asset_graph.assets_defs
         source_assets = asset_graph.source_assets
         selected_asset_keys = self.selection.resolve(asset_graph)
         if asset_graph.includes_materializable_and_source_assets(selected_asset_keys):
@@ -229,7 +229,7 @@ class UnresolvedAssetJobDefinition(
         return build_asset_selection_job(
             name=self.name,
             assets=assets,
-            asset_checks=asset_graph.asset_checks,
+            asset_checks=asset_graph.asset_checks_defs,
             config=self.config,
             source_assets=source_assets,
             description=self.description,

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1438,7 +1438,7 @@ def _get_failed_asset_partitions(
                 )
                 for asset_key in failed_asset_keys:
                     result.extend(
-                        asset_graph.get_asset_partitions_in_range(
+                        asset_graph.get_partitions_in_range(
                             asset_key, partition_range, instance_queryer
                         )
                     )

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -211,14 +211,15 @@ class ExternalRepository:
 
             default_sensor_asset_keys = set()
 
-            for asset_key, policy in asset_graph.auto_materialize_policies_by_key.items():
+            for asset_key in asset_graph.materializable_asset_keys:
+                policy = asset_graph.get_auto_materialize_policy(asset_key)
                 if not policy:
                     continue
 
                 if asset_key not in covered_asset_keys:
                     default_sensor_asset_keys.add(asset_key)
 
-            for asset_key in asset_graph.observable_keys:
+            for asset_key in asset_graph.observable_asset_keys:
                 if asset_graph.get_auto_observe_interval_minutes(asset_key) is None:
                     continue
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -283,7 +283,7 @@ def test_source_asset():
             assert context.resources.subresource == 9
             assert context.upstream_output.resources.subresource == 9
             assert context.upstream_output.asset_key == AssetKey("source1")
-            assert context.upstream_output.metadata == {"a": "b"}
+            assert context.upstream_output.metadata["a"] == "b"
             assert context.upstream_output.resource_config["a"] == 7
             assert context.upstream_output.log is not None
             context.upstream_output.log.info("hullo")

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -675,7 +675,7 @@ def _requested_asset_partitions_in_run_request(
         asset_partitions = []
         for asset_key in asset_keys:
             asset_partitions.extend(
-                asset_graph.get_asset_partitions_in_range(
+                asset_graph.get_partitions_in_range(
                     asset_key=asset_key,
                     partition_key_range=partition_range,
                     dynamic_partitions_store=MagicMock(),

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -405,8 +405,8 @@ class AssetDaemonScenarioState(NamedTuple):
             asset_graph=self.asset_graph,
             auto_materialize_asset_keys={
                 key
-                for key, policy in self.asset_graph.auto_materialize_policies_by_key.items()
-                if policy is not None
+                for key in self.asset_graph.materializable_asset_keys
+                if self.asset_graph.get_auto_materialize_policy(key) is not None
             },
             instance=self.instance,
             materialize_run_tags={},

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_observe.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_observe.py
@@ -64,7 +64,7 @@ def test_single_observable_source_asset_no_prior_observe_requests(
         current_timestamp=1000,
         last_observe_request_timestamp_by_asset_key={},
         run_tags={},
-        auto_observe_asset_keys=single_auto_observe_asset_graph.observable_keys,
+        auto_observe_asset_keys=single_auto_observe_asset_graph.observable_asset_keys,
     )
     assert len(run_requests) == 1
     run_request = run_requests[0]
@@ -81,7 +81,7 @@ def test_single_observable_source_asset_prior_observe_requests(
         current_timestamp=last_timestamp + 30 * 60 + 5,
         last_observe_request_timestamp_by_asset_key={AssetKey("asset1"): last_timestamp},
         run_tags={},
-        auto_observe_asset_keys=single_auto_observe_asset_graph.observable_keys,
+        auto_observe_asset_keys=single_auto_observe_asset_graph.observable_asset_keys,
     )
     assert len(run_requests) == 1
     run_request = run_requests[0]
@@ -98,7 +98,7 @@ def test_single_observable_source_asset_prior_recent_observe_requests(
         current_timestamp=last_timestamp + 30 * 60 - 5,
         last_observe_request_timestamp_by_asset_key={AssetKey("asset1"): last_timestamp},
         run_tags={},
-        auto_observe_asset_keys=single_auto_observe_asset_graph.observable_keys,
+        auto_observe_asset_keys=single_auto_observe_asset_graph.observable_asset_keys,
     )
     assert len(run_requests) == 0
 


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/8339

- Refactor `InternalAssetGraph` and `ExternalAssetGraph` to implement the `AssetGraph` interface by proxying to wrapped `AssetsDefinition`/`ExternalAssetNode` instead of building separate `<property_x>_by_key` dicts.
- Add `AssetGraph` methods to retrieve various subsets of keys (e.g. `executable_asset_keys`)
- Rename a few methods for consistency (e.g. `observable_keys` -> `observable_asset_keys`)
- Standardize property lookup methods to `AssetGraph.get_<property_x>(asset_key)` instead of `AssetGraph.<property_x>_by_key.get(asset_key)`. The previous state is a mix, where some properties are exposed via single-asset-scoped getters and others are exposed as dict properties. This is over-complicated and leads to inconsistency in how lookups for missing asset keys are handled. We standardize on single-key lookup-- if callers need a dict, this can be easily constructed on site with something like:
 
```python
{k: asset_graph.get_x(k) for k in graph.{all,observable,materializable,executable,external}_asset_keys`}
```

- Move `InternalAssetGraph` to its own module.

## Additional notes

`AssetGraph` (a private API) has two variants; `InternalAssetGraph` (for assets scoped to one location) and `ExternalAssetGraph` (for assets scoped to multiple locations). They share a common interface that is based on a large number of `<property_x>_by_key` dicts, e.g. `code_location_by_key`. These dictionaries are constructed from `AssetsDefinition` (for `InternalAssetGraph`) and `ExternalAssetNode` (for `ExternalAssetGraph`) in lengthy `@staticmethod` constructors. This is complex, error-prone, and adds significant friction when making any changes to assets.

This PR eliminates the `<property_x>_by_key` dicts in favor of having `InternalAssetGraph` and `ExternalAssetGraph` wrap `AssetsDefinition` and `ExternalAssetNode` respectively, implementing the common `AssetGraph` interface in terms of lookup operations on these nodes.

In the initial version of this PR I have not added any caching on the methods except for `asset_dep_graph`. We may want to cache various sets of asset keys etc. I'm frankly not sure about the memory/perf tradeoff.

## How I Tested These Changes

Existing test suite.