### PR TITLE
show Target row for sensors with an asset selection

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
@@ -88,6 +88,12 @@ export const SensorDetails = ({
   const [showTestTickDialog, setShowTestTickDialog] = useState(false);
   const running = status === InstigationStatus.RUNNING;
 
+  const assetSelectionResult = selectionQueryResult.data?.sensorOrError;
+
+  const assetSelectionData =
+    assetSelectionResult?.__typename === 'Sensor' ? assetSelectionResult : null;
+  const selectedAssets = assetSelectionData?.assetSelection;
+
   return (
     <>
       <PageHeader
@@ -157,7 +163,7 @@ export const SensorDetails = ({
               </td>
             </tr>
           )}
-          {sensor.targets && sensor.targets.length ? (
+          {(sensor.targets && sensor.targets.length) || selectedAssets ? (
             <tr>
               <td>Target</td>
               <td>

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorTargetList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorTargetList.tsx
@@ -98,6 +98,8 @@ const AssetSelectionLink = ({
     [sortedAssets],
   );
 
+  const assetSelectionString = assetSelection.assetSelectionString || '';
+
   return (
     <>
       <Dialog
@@ -142,7 +144,8 @@ const AssetSelectionLink = ({
           setShowAssetSelection(true);
         }}
       >
-        {assetSelection.assetSelectionString}
+        {assetSelectionString.slice(0, 1).toUpperCase()}
+        {assetSelectionString.slice(1)}
       </ButtonLink>
     </>
   );


### PR DESCRIPTION
Summary:
Auto-materialize sensors may not have target jobs, but they do have asset selections. include their asset selections as well.

Test Plan:
View the sensor page for an auto-materialize sensor and a normal sensor with an asset selection - both display a Target row.

## Summary & Motivation

## How I Tested These Changes
