### PR TITLE
Improve text display of auto-materialize sensors

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -722,7 +722,10 @@ class KeysAssetSelection(AssetSelection, frozen=True):
         return len(self.selected_keys) > 1
 
     def __str__(self) -> str:
-        return f"{' or '.join(k.to_user_string() for k in self.selected_keys)}"
+        if len(self.selected_keys) <= 3:
+            return f"{' or '.join(k.to_user_string() for k in self.selected_keys)}"
+        else:
+            return f"{len(self.selected_keys)} assets"
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -166,9 +166,13 @@ def test_asset_selection_groups(all_assets: _AssetList):
 def test_asset_selection_keys(all_assets: _AssetList):
     sel = AssetSelection.keys(AssetKey("alice"), AssetKey("bob"))
     assert sel.resolve(all_assets) == _asset_keys_of({alice, bob})
+    assert str(sel) == "alice or bob"
 
     sel = AssetSelection.keys("alice", "bob")
     assert sel.resolve(all_assets) == _asset_keys_of({alice, bob})
+
+    sel = AssetSelection.keys("alice", "bob", "carol", "dave")
+    assert str(sel) == "4 assets"
 
 
 def test_asset_selection_key_prefixes(all_assets: _AssetList):

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -10,6 +10,7 @@ from dagster import (
     observable_source_asset,
     sensor,
 )
+from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.auto_materialize_sensor_definition import (
     AutoMaterializeSensorDefinition,
 )
@@ -74,6 +75,14 @@ defs = Definitions(
     sensors=[normal_sensor],
 )
 
+defs_without_observables = Definitions(
+    assets=[
+        auto_materialize_asset,
+        other_auto_materialize_asset,
+        boring_asset,
+    ],
+)
+
 
 @pytest.fixture
 def instance_with_auto_materialize_sensors():
@@ -120,14 +129,38 @@ def test_default_auto_materialize_sensors(instance_with_auto_materialize_sensors
     assert auto_materialize_sensor.name == "default_auto_materialize_sensor"
     assert external_repo.has_external_sensor(auto_materialize_sensor.name)
 
-    asset_graph = ExternalAssetGraph.from_external_repository(external_repo)
+    assert auto_materialize_sensor.asset_selection == AssetSelection.all(include_sources=True)
 
-    assert auto_materialize_sensor.asset_selection.resolve(asset_graph) == {
-        AssetKey(["auto_materialize_asset"]),
-        AssetKey(["auto_observe_asset"]),
-        AssetKey(["other_auto_materialize_asset"]),
-        AssetKey(["other_auto_observe_asset"]),
-    }
+
+def test_default_auto_materialize_sensors_without_observable(
+    instance_with_auto_materialize_sensors,
+):
+    instance = instance_with_auto_materialize_sensors
+
+    repo_handle = MagicMock(spec=RepositoryHandle)
+    repo_handle.get_external_origin.return_value = ExternalRepositoryOrigin(
+        code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
+        repository_name="bar_repo",
+    )
+
+    external_repo = ExternalRepository(
+        external_repository_data_from_def(
+            defs_without_observables.get_repository_def(),
+        ),
+        repository_handle=repo_handle,
+        instance=instance,
+    )
+
+    sensors = external_repo.get_external_sensors()
+
+    assert len(sensors) == 1
+
+    auto_materialize_sensor = sensors[0]
+
+    assert auto_materialize_sensor.name == "default_auto_materialize_sensor"
+    assert external_repo.has_external_sensor(auto_materialize_sensor.name)
+
+    assert auto_materialize_sensor.asset_selection == AssetSelection.all(include_sources=False)
 
 
 def test_no_default_auto_materialize_sensors(instance_without_auto_materialize_sensors):
@@ -192,13 +225,20 @@ def test_combine_default_sensors_with_non_default_sensors(instance_with_auto_mat
 
     asset_graph = ExternalAssetGraph.from_external_repository(external_repo)
 
-    # default sensor includes the assets that weren't covered by the custom one
+    # default sensor includes all assets that weren't covered by the custom one
 
     default_sensor = external_repo.get_external_sensor("default_auto_materialize_sensor")
+
+    assert (
+        str(default_sensor.asset_selection)
+        == "all materializable assets and source assets - (auto_materialize_asset or auto_observe_asset)"
+    )
 
     assert default_sensor.asset_selection.resolve(asset_graph) == {
         AssetKey(["other_auto_materialize_asset"]),
         AssetKey(["other_auto_observe_asset"]),
+        AssetKey(["boring_asset"]),
+        AssetKey(["boring_observable_asset"]),
     }
 
     custom_sensor = external_repo.get_external_sensor("my_custom_policy_sensor")


### PR DESCRIPTION
Summary:
- In the common case where you have a single auto-materialize sensor for the whole code location, make it say "All materializable assets" rather than listing every asset in the code location
- In the less common case where it actually does just use a list of keys, say e.g. "54 assets" instead of listing out all 54 asset keys individually - we now have separate fields in graphql that can be used to enumerate the assets

Test Plan: BK, view AMP sensors in the UI to sanity check

## Summary & Motivation

## How I Tested These Changes
