### PR TITLE
test(dbt): enable `pytest-xdist` for core and cloud tests

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_app.py
@@ -19,14 +19,8 @@ if TYPE_CHECKING:
 runner = CliRunner()
 
 
-@pytest.fixture(name="disable_openblas_threading_affinity")
-def disable_openblas_threading_affinity_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OPENBLAS_MAIN_FREE", "1")
-    monkeypatch.setenv("GOTOBLAS_MAIN_FREE", "1")
-
-
 @pytest.fixture(name="dbt_project_dir")
-def dbt_project_dir_fixture(tmp_path: Path, disable_openblas_threading_affinity) -> Path:
+def dbt_project_dir_fixture(tmp_path: Path) -> Path:
     dbt_project_dir = tmp_path.joinpath("test_jaffle_shop")
     shutil.copytree(src=test_jaffle_shop_path, dst=dbt_project_dir)
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/.gitignore
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/.gitignore
@@ -9,3 +9,4 @@ venv/
 env/
 **/*.duckdb
 **/*.duckdb.wal
+tmp/

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/profiles.yml
@@ -3,5 +3,5 @@ jaffle_shop:
   outputs:
     dev:
       type: duckdb
-      path: "jaffle_shop.duckdb"
+      path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH') }}"
       threads: 24

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_checks/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_checks/profiles.yml
@@ -3,5 +3,5 @@ jaffle_shop:
   outputs:
     dev:
       type: duckdb
-      path: "jaffle_shop.duckdb"
+      path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH') }}"
       threads: 24

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_key_exceptions/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_key_exceptions/profiles.yml
@@ -3,5 +3,5 @@ jaffle_shop:
   outputs:
     dev:
       type: duckdb
-      path: "jaffle_shop.duckdb"
+      path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH') }}"
       threads: 24

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_alias/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_alias/profiles.yml
@@ -3,5 +3,5 @@ jaffle_shop:
   outputs:
     dev:
       type: duckdb
-      path: "jaffle_shop.duckdb"
+      path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH') }}"
       threads: 24

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_model_versions/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_model_versions/profiles.yml
@@ -3,5 +3,5 @@ jaffle_shop:
   outputs:
     dev:
       type: duckdb
-      path: "jaffle_shop.duckdb"
+      path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH') }}"
       threads: 24

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_python_interleaving/models/customers.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_python_interleaving/models/customers.sql
@@ -2,7 +2,7 @@ with customers as (
 
     -- this is a fake table that won't exist, just select from stg_orders
     -- select * from {{ source('dagster', 'python_augmented_customers') }}
-    select * from jaffle_shop.main.stg_customers
+    select * from main.stg_customers
 
 ),
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_python_interleaving/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_python_interleaving/profiles.yml
@@ -3,5 +3,5 @@ jaffle_shop:
   outputs:
     dev:
       type: duckdb
-      path: "jaffle_shop.duckdb"
+      path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH') }}"
       threads: 24

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/profiles.yml
@@ -3,5 +3,5 @@ jaffle_shop:
   outputs:
     dev:
       type: duckdb
-      path: "jaffle_shop.duckdb"
+      path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH') }}"
       threads: 24

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_exceptions/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_exceptions/profiles.yml
@@ -3,10 +3,10 @@ jaffle_shop:
   outputs:
     dev:
       type: duckdb
-      path: "jaffle_shop.duckdb"
+      path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH') }}"
       threads: 24
 
     error_dev:
       type: duckdb
-      path: "jaffle_shop.duckdb"
+      path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH') }}"
       threads: '{{ env_var("DBT_DUCKDB_THREADS")}}'

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_meta_config/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_meta_config/profiles.yml
@@ -7,5 +7,5 @@ jaffle_shop:
   outputs:
     dev:
       type: duckdb
-      path: "jaffle_shop.duckdb"
+      path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH') }}"
       threads: 24

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/profiles.yml
@@ -3,5 +3,5 @@ jaffle_shop:
   outputs:
     dev:
       type: duckdb
-      path: "jaffle_shop.duckdb"
+      path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH') }}"
       threads: 24

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -23,6 +23,6 @@ allowlist_externals =
   /bin/bash
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-  cloud: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
-  core: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "not legacy and not cloud" -vv {posargs}
-  legacy: pytest --reruns 2 --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
+  cloud: pytest --numprocesses 6 --durations 10 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
+  core: pytest --numprocesses 6 --durations 10 -c ../../../pyproject.toml -m "core" -vv {posargs}
+  legacy: pytest --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}


### PR DESCRIPTION
## Summary & Motivation
Distribute test execution across multiple workers using `pytest-xdist`. We can do this by doing the following:

- Ensure session fixtures that operate against disk have unique file paths per worker
- Fix up existing tests by preventing operations that destroy/mutate disk storage across all workers (e.g. `dbt clean`)
- Fix up existing tests that were relying on sequential test execution assumptions

## How I Tested These Changes
pytest, see changes in `cloud` and `core` test suites (another ~3-4 minutes shaved off per suite)

**Current**
https://buildkite.com/dagster/dagster-dagster/builds/76132/waterfall
<img width="1490" alt="Screenshot 2024-02-20 at 8 42 11 AM" src="https://github.com/dagster-io/dagster/assets/16431325/7cbdb8cf-648d-4d0e-8788-b7f4ac1f4815">


**After**
https://buildkite.com/dagster/dagster-dagster/builds/76141/waterfall
<img width="1490" alt="Screenshot 2024-02-20 at 8 42 20 AM" src="https://github.com/dagster-io/dagster/assets/16431325/072888f9-0aba-4b0a-aff2-b6b8823e9e83">
