### PR TITLE
[fix] - dagster-deltalake: make storage backend options return a string dict

### DIFF
--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/config.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/config.py
@@ -9,7 +9,8 @@ else:
     from typing_extensions import Literal
 
 
-def _to_string_dict(dictionary: Dict) -> Dict[str, str]:
+def _to_str_dict(dictionary: Dict) -> Dict[str, str]:
+    """Filters dict of None values and casts other values to str."""
     return {key: str(value) for key, value in dictionary.items() if value is not None}
 
 
@@ -17,6 +18,10 @@ class LocalConfig(Config):
     """Storage configuration for local object store."""
 
     provider: Literal["local"] = "local"
+
+    def str_dict(self) -> Dict[str, str]:
+        """Storage options as str dict."""
+        return _to_str_dict(self.dict())
 
 
 class AzureConfig(Config):
@@ -63,8 +68,9 @@ class AzureConfig(Config):
     container_name: Optional[str] = None
     """Storage container name"""
 
-    def dict(self) -> Dict[str, str]:
-        return _to_string_dict(super().dict())
+    def str_dict(self) -> Dict[str, str]:
+        """Storage options as str dict."""
+        return _to_str_dict(self.dict())
 
 
 # TODO add documentation and config to handle atomic writes with S3
@@ -73,56 +79,57 @@ class S3Config(Config):
 
     provider: Literal["s3"] = "s3"
 
-    access_key_id: Optional[str]
+    access_key_id: Optional[str] = None
     """AWS access key ID"""
 
-    secret_access_key: Optional[str]
+    secret_access_key: Optional[str] = None
     """AWS access key secret"""
 
-    region: Optional[str]
+    region: Optional[str] = None
     """AWS region"""
 
-    bucket: Optional[str]
+    bucket: Optional[str] = None
     """Storage bucket name"""
 
-    endpoint: Optional[str]
+    endpoint: Optional[str] = None
     """Sets custom endpoint for communicating with S3."""
 
-    token: Optional[str]
+    token: Optional[str] = None
     """Token to use for requests (passed to underlying provider)"""
 
     imdsv1_fallback: bool = False
     """Allow fall back to ImdsV1"""
 
-    virtual_hosted_style_request: Optional[str]
+    virtual_hosted_style_request: Optional[str] = None
     """Bucket is hosted under virtual-hosted-style URL"""
 
-    unsigned_payload: Optional[bool]
+    unsigned_payload: Optional[bool] = None
     """Avoid computing payload checksum when calculating signature."""
 
-    checksum: Optional[str]
+    checksum: Optional[str] = None
     """Set the checksum algorithm for this client."""
 
-    metadata_endpoint: Optional[str]
+    metadata_endpoint: Optional[str] = None
     """Instance metadata endpoint URL for fetching credentials"""
 
-    container_credentials_relative_uri: Optional[str]
+    container_credentials_relative_uri: Optional[str] = None
     """Set the container credentials relative URI
 
     https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
     """
 
-    copy_if_not_exists: Optional[str]
+    copy_if_not_exists: Optional[str] = None
     """Specifiy additional headers passed to strage backend, that enable 'if_not_exists' semantics.
 
     https://docs.rs/object_store/0.7.0/object_store/aws/enum.S3CopyIfNotExists.html#variant.Header
     """
 
-    allow_unsafe_rename: Optional[bool]
+    allow_unsafe_rename: Optional[bool] = None
     """Allows tables writes that may conflict with concurrent writers."""
 
-    def dict(self) -> Dict[str, str]:
-        return _to_string_dict(super().dict())
+    def str_dict(self) -> Dict[str, str]:
+        """Storage options as str dict."""
+        return _to_str_dict(self.dict())
 
 
 class GcsConfig(Config):
@@ -130,29 +137,30 @@ class GcsConfig(Config):
 
     provider: Literal["gcs"] = "gcs"
 
-    service_account: Optional[str]
+    service_account: Optional[str] = None
     """Path to the service account file"""
 
-    service_account_key: Optional[str]
+    service_account_key: Optional[str] = None
     """The serialized service account key."""
 
-    bucket: Optional[str]
+    bucket: Optional[str] = None
     """Bucket name"""
 
-    application_credentials: Optional[str]
+    application_credentials: Optional[str] = None
     """Application credentials path"""
 
-    def dict(self) -> Dict[str, str]:
-        return _to_string_dict(super().dict())
+    def str_dict(self) -> Dict[str, str]:
+        """Storage options as str dict."""
+        return _to_str_dict(self.dict())
 
 
 class ClientConfig(Config):
     """Configuration for http client interacting with storage APIs."""
 
-    allow_http: Optional[bool]
+    allow_http: Optional[bool] = None
     """Allow non-TLS, i.e. non-HTTPS connections"""
 
-    allow_invalid_certificates: Optional[bool]
+    allow_invalid_certificates: Optional[bool] = None
     """Skip certificate validation on https connections.
 
     ## Warning
@@ -163,47 +171,48 @@ class ClientConfig(Config):
     and should only be used as a last resort or for testing
     """
 
-    connect_timeout: Optional[int]
+    connect_timeout: Optional[int] = None
     """Timeout for only the connect phase of a Client"""
 
-    default_content_type: Optional[str]
+    default_content_type: Optional[str] = None
     """default CONTENT_TYPE for uploads"""
 
-    http1_only: Optional[bool]
+    http1_only: Optional[bool] = None
     """Only use http1 connections"""
 
-    http2_keep_alive_interval: Optional[int]
+    http2_keep_alive_interval: Optional[int] = None
     """Interval for HTTP2 Ping frames should be sent to keep a connection alive."""
 
-    http2_keep_alive_timeout: Optional[int]
+    http2_keep_alive_timeout: Optional[int] = None
     """Timeout for receiving an acknowledgement of the keep-alive ping."""
 
-    http2_keep_alive_while_idle: Optional[int]
+    http2_keep_alive_while_idle: Optional[int] = None
     """Enable HTTP2 keep alive pings for idle connections"""
 
-    http2_only: Optional[bool]
+    http2_only: Optional[bool] = None
     """Only use http2 connections"""
 
-    pool_idle_timeout: Optional[int]
+    pool_idle_timeout: Optional[int] = None
     """The pool max idle timeout
 
     This is the length of time an idle connection will be kept alive
     """
 
-    pool_max_idle_per_host: Optional[int]
+    pool_max_idle_per_host: Optional[int] = None
     """maximum number of idle connections per host"""
 
-    proxy_url: Optional[str]
+    proxy_url: Optional[str] = None
     """HTTP proxy to use for requests"""
 
-    timeout: Optional[int]
+    timeout: Optional[int] = None
     """Request timeout
 
     The timeout is applied from when the request starts connecting until the response body has finished
     """
 
-    user_agent: Optional[str]
+    user_agent: Optional[str] = None
     """User-Agent header to be used by this client"""
 
-    def dict(self) -> Dict[str, str]:
-        return _to_string_dict(super().dict())
+    def str_dict(self) -> Dict[str, str]:
+        """Storage options as str dict."""
+        return _to_str_dict(self.dict())

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/config.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/config.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Optional
+from typing import Dict, Optional
 
 from dagster import Config
 
@@ -7,6 +7,10 @@ if sys.version_info >= (3, 8):
     from typing import Literal
 else:
     from typing_extensions import Literal
+
+
+def _to_string_dict(dictionary: Dict) -> Dict[str, str]:
+    return {key: str(value) for key, value in dictionary.items() if value is not None}
 
 
 class LocalConfig(Config):
@@ -58,6 +62,9 @@ class AzureConfig(Config):
 
     container_name: Optional[str] = None
     """Storage container name"""
+
+    def dict(self) -> Dict[str, str]:
+        return _to_string_dict(super().dict())
 
 
 # TODO add documentation and config to handle atomic writes with S3
@@ -114,6 +121,9 @@ class S3Config(Config):
     allow_unsafe_rename: Optional[bool]
     """Allows tables writes that may conflict with concurrent writers."""
 
+    def dict(self) -> Dict[str, str]:
+        return _to_string_dict(super().dict())
+
 
 class GcsConfig(Config):
     """Storage configuration for Google Cloud Storage object store."""
@@ -131,6 +141,9 @@ class GcsConfig(Config):
 
     application_credentials: Optional[str]
     """Application credentials path"""
+
+    def dict(self) -> Dict[str, str]:
+        return _to_string_dict(super().dict())
 
 
 class ClientConfig(Config):
@@ -191,3 +204,6 @@ class ClientConfig(Config):
 
     user_agent: Optional[str]
     """User-Agent header to be used by this client"""
+
+    def dict(self) -> Dict[str, str]:
+        return _to_string_dict(super().dict())

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/resource.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/resource.py
@@ -45,8 +45,8 @@ class DeltaTableResource(ConfigurableResource):
     version: Optional[int] = Field(default=None, description="Version to load delta table.")
 
     def load(self) -> DeltaTable:
-        storage_options = self.storage_options.dict() if self.storage_options else {}
-        client_options = self.client_options.dict() if self.client_options else {}
+        storage_options = self.storage_options.str_dict() if self.storage_options else {}
+        client_options = self.client_options.str_dict() if self.client_options else {}
         options = {**storage_options, **client_options}
         table = DeltaTable(table_uri=self.url, storage_options=options, version=self.version)
         return table

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_delta_table_resource.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_delta_table_resource.py
@@ -18,7 +18,9 @@ def test_resource(tmp_path):
 
     @asset
     def create_table(delta_table: DeltaTableResource):
-        write_deltalake(delta_table.url, data, storage_options=delta_table.storage_options.dict())
+        write_deltalake(
+            delta_table.url, data, storage_options=delta_table.storage_options.str_dict()
+        )
 
     @asset
     def read_table(delta_table: DeltaTableResource):
@@ -45,9 +47,14 @@ def test_resource_versioned(tmp_path):
 
     @asset
     def create_table(delta_table: DeltaTableResource):
-        write_deltalake(delta_table.url, data, storage_options=delta_table.storage_options.dict())
         write_deltalake(
-            delta_table.url, data, storage_options=delta_table.storage_options.dict(), mode="append"
+            delta_table.url, data, storage_options=delta_table.storage_options.str_dict()
+        )
+        write_deltalake(
+            delta_table.url,
+            data,
+            storage_options=delta_table.storage_options.str_dict(),
+            mode="append",
         )
 
     @asset
@@ -75,12 +82,15 @@ def test_resource_versioned(tmp_path):
         ClientConfig(timeout=1),
     ],
 )
-def test_resource_storage_options(tmp_path, config):
+def test_config_classes_are_string_dicts(tmp_path, config):
     data = pa.table(
         {
             "a": pa.array([1, 2, 3], type=pa.int32()),
             "b": pa.array([5, 6, 7], type=pa.int32()),
         }
     )
-
-    write_deltalake(os.path.join(tmp_path, "table"), data, storage_options=config.dict())
+    config_dict = config.str_dict()
+    assert all([isinstance(val, str) for val in config_dict.values()])
+    # passing the config_dict to write_deltalake validates that all dict values are str.
+    # it will throw an exception if there are other value types
+    write_deltalake(os.path.join(tmp_path, "table"), data, storage_options=config_dict)


### PR DESCRIPTION
## Summary & Motivation
The current way that `DeltaTableResource` passes configuration values to the `DeltaTable` constructor breaks when passing a dict that have valuetypes other than str (e.g. int, bool or None) with the error:
```python
E       TypeError: argument 'storage_options': 'NoneType' object cannot be converted to 'PyString'
```
This happens even when the user does not pass any of those value types, because there are default values of these types.

To replicate, try:
```python
import pyarrow as pa
from deltalake import write_deltalake
from dagster_deltalake.config import AzureConfig
data = pa.table(
    {
        "a": pa.array([1, 2, 3], type=pa.int32()),
        "b": pa.array([5, 6, 7], type=pa.int32()),
    }
)
write_deltalake("table", data, storage_options=AzureConfig(account_name="test").dict())
```

This PR adds a `str_dict()` method to the config classes to make sure they return string values.

## How I Tested These Changes
Added unit tests in `python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_delta_table_resource.py`
