### PR TITLE
Sensor error tweak

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -976,10 +976,11 @@ class SensorDefinition(IHasInternalInit):
     @property
     def job_name(self) -> Optional[str]:
         """Optional[str]: The name of the job that is targeted by this sensor."""
-        if len(self._targets) > 1:
-            raise DagsterInvalidInvocationError(
-                f"Cannot use `job_name` property for sensor {self.name}, which targets multiple"
-                " jobs."
+        if len(self._targets) == 0:
+            raise DagsterInvalidDefinitionError("No job was provided to SensorDefinition.")
+        elif len(self._targets) > 1:
+            raise DagsterInvalidDefinitionError(
+                "job_name property not available when SensorDefinition has multiple jobs."
             )
         return self._targets[0].job_name
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor.py
@@ -13,23 +13,26 @@ def test_jobs_attr():
 
     sensor = SensorDefinition(evaluation_fn=eval_fn, job=my_graph)
     assert sensor.job.name == my_graph.name
+    assert sensor.job_name == my_graph.name
 
-    sensor = SensorDefinition(evaluation_fn=eval_fn, job_name="my_pipeline")
-    with pytest.raises(
-        DagsterInvalidDefinitionError, match="No job was provided to SensorDefinition."
-    ):
-        sensor.job  # noqa: B018
+    sensor = SensorDefinition(evaluation_fn=eval_fn, asset_selection=["foo"])
+    for attr in ["job", "job_name"]:
+        with pytest.raises(
+            DagsterInvalidDefinitionError, match="No job was provided to SensorDefinition."
+        ):
+            getattr(sensor, attr)
 
     @graph
     def my_second_graph():
         pass
 
     sensor = SensorDefinition(evaluation_fn=eval_fn, jobs=[my_graph, my_second_graph])
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match="Job property not available when SensorDefinition has multiple jobs.",
-    ):
-        sensor.job  # noqa: B018
+    for attr in ["job", "job_name"]:
+        with pytest.raises(
+            DagsterInvalidDefinitionError,
+            match="property not available when SensorDefinition has multiple jobs.",
+        ):
+            getattr(sensor, attr)
 
 
 def test_direct_sensor_definition_instantiation():


### PR DESCRIPTION
## Summary & Motivation

- Make `SensorDefinition.job_name` throw error for sensor that doesn't target job (previously would throw an uncaught `IndexError`)
- Make error type consistent for invalid `job`, `job_name` access (`DagsterInvalidDefinitionError`)

Note: this is motivated by https://github.com/dagster-io/dagster/pull/19879, which surfaced an unexpected `IndexError` when standardizing the test GQL repo.

## How I Tested These Changes

Modified existing unit tests.
