### PR TITLE
change leak test names

### DIFF
--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_cached_method.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_cached_method.py
@@ -53,32 +53,32 @@ def test_kwargs_order_irrelevant_and_no_kwargs():
 
 
 def test_does_not_leak():
-    class KeyClass(NamedTuple):
+    class LeakTestKey(NamedTuple):
         attr: str
 
-    class ValueClass(NamedTuple):
+    class LeakTestValue(NamedTuple):
         attr: str
 
-    class MyClass:
+    class LeakTestObj:
         @cached_method
-        def my_method(self, _arg1: KeyClass) -> ValueClass:
-            return ValueClass("abc")
+        def my_method(self, _arg1: LeakTestKey) -> LeakTestValue:
+            return LeakTestValue("abc")
 
-    obj = MyClass()
-    assert objgraph.count("MyClass") == 1
-    assert objgraph.count("KeyClass") == 0
-    assert objgraph.count("ValueClass") == 0
+    obj = LeakTestObj()
+    assert objgraph.count("LeakTestObj") == 1
+    assert objgraph.count("LeakTestKey") == 0
+    assert objgraph.count("LeakTestValue") == 0
 
-    obj.my_method(_arg1=KeyClass("1234"))
-    assert objgraph.count("MyClass") == 1
-    assert objgraph.count("KeyClass") == 1
-    assert objgraph.count("ValueClass") == 1
+    obj.my_method(_arg1=LeakTestKey("1234"))
+    assert objgraph.count("LeakTestObj") == 1
+    assert objgraph.count("LeakTestKey") == 1
+    assert objgraph.count("LeakTestValue") == 1
 
     del obj
     gc.collect()
-    assert objgraph.count("MyClass") == 0
-    assert objgraph.count("KeyClass") == 0
-    assert objgraph.count("ValueClass") == 0
+    assert objgraph.count("LeakTestObj") == 0
+    assert objgraph.count("LeakTestKey") == 0
+    assert objgraph.count("LeakTestValue") == 0
 
 
 def test_collisions():


### PR DESCRIPTION
Observing failures like
https://buildkite.com/dagster/dagster-dagster/builds/76188#018dc7c6-a911-45a2-b150-03655cf2b81c

leads me to believe that we are picking up references to other `MyClass` instances so change the names 

## How I Tested These Changes

ran the test locally