### PR TITLE
docs(dbt): remove leading slash when installing `dagster` dbt package

### DIFF
--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -543,7 +543,7 @@ To collect this metadata for your dbt project, specify the `dagster` dbt package
 ```yaml
 packages:
   - git: "https://github.com/dagster-io/dagster.git"
-    subdirectory: "/python_modules/libraries/dagster-dbt/dbt_packages/dagster"
+    subdirectory: "python_modules/libraries/dagster-dbt/dbt_packages/dagster"
     revision: DAGSTER_VERSION # replace with the version of `dagster` you are using.
 ```
 


### PR DESCRIPTION
## Summary & Motivation
The `subdirectory` should not have a leading slash.

## How I Tested These Changes
Run `dbt deps`, see it actually succeed.
