### PR TITLE
[auto-materialize] Incremental fix for `materialize_on_missing`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -649,7 +649,7 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
                 )
                 previous_last_partition_key = context.partitions_def.get_last_partition_key(
                     current_time=datetime.datetime.fromtimestamp(
-                        context.previous_evaluation_timestamp or 0
+                        context.previous_evaluation_timestamp or 0, tz=datetime.timezone.utc
                     )
                 )
                 if last_partition_key != previous_last_partition_key:

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -635,8 +635,28 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
                 else context.candidate_subset
             )
         else:
-            # to retain compatibility with the previous behavior of this rule, we only count a non-root
-            # asset as missing if at least one of its parents has updated since the previous tick
+            # to avoid causing potential perf issues, we are maintaing the previous behavior of
+            # only marking a non-root asset as missing if at least one of its parents has updated
+            # since the previous tick.
+            # on top of this, we also check the latest time partition of the asset to see if it's
+            # missing on the tick that it pops into existence
+            asset_partitions_to_evaluate = (
+                context.candidate_parent_has_or_will_update_subset.asset_partitions
+            )
+            if isinstance(context.partitions_def, TimeWindowPartitionsDefinition):
+                last_partition_key = context.partitions_def.get_last_partition_key(
+                    current_time=context.evaluation_time
+                )
+                previous_last_partition_key = context.partitions_def.get_last_partition_key(
+                    current_time=datetime.datetime.fromtimestamp(
+                        context.previous_evaluation_timestamp or 0
+                    )
+                )
+                if last_partition_key != previous_last_partition_key:
+                    asset_partitions_to_evaluate |= {
+                        AssetKeyPartitionKey(context.asset_key, last_partition_key)
+                    }
+
             handled_subset = None
             unhandled_candidates = (
                 AssetSubset.from_asset_partitions_set(
@@ -644,7 +664,7 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
                     context.partitions_def,
                     {
                         ap
-                        for ap in context.candidate_parent_has_or_will_update_subset.asset_partitions
+                        for ap in asset_partitions_to_evaluate
                         if not context.instance_queryer.asset_partition_has_materialization_or_observation(
                             ap
                         )


### PR DESCRIPTION
## Summary & Motivation

For non-root assets, we only calculate if an asset is missing if one of its parents has updated since the previous tick. This is essentially a perf optimization, because most of the time you only care if a partition is missing in the case that there's new parent data to work with.

This works in most cases, but sometimes parent data is available before downstream partitions exist, and so new partitions are available to be materialized as soon as they pop into existence.

This change prompts the evaluation logic to check if a new time partition is missing as soon as it pops into existence.

This is only an incremental fix to the underlying problem, as it does not handle non-time-partitioned assets and does not handle partitions that existed before the policy was created.

## How I Tested These Changes
