### PR TITLE
[ui] FE-178 - Make asset nodes wider, allow long group names

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -205,7 +205,7 @@ export const AssetNodeMinimal = ({
 
   return (
     <AssetInsetForHoverEffect>
-      <MinimalAssetNodeContainer $selected={selected} style={{paddingTop: (height - 64) / 2}}>
+      <MinimalAssetNodeContainer $selected={selected} style={{paddingTop: height / 2 - 50}}>
         <TooltipStyled
           content={displayName}
           canShow={displayName.length > 14}
@@ -221,8 +221,8 @@ export const AssetNodeMinimal = ({
             <AssetNodeSpinnerContainer>
               <AssetLatestRunSpinner liveData={liveData} purpose="section" />
             </AssetNodeSpinnerContainer>
-            <MinimalName style={{fontSize: 30}} $isSource={isSource}>
-              {withMiddleTruncation(displayName, {maxLength: 14})}
+            <MinimalName style={{fontSize: 28}} $isSource={isSource}>
+              {withMiddleTruncation(displayName, {maxLength: 20})}
             </MinimalName>
           </MinimalAssetNodeBox>
         </TooltipStyled>
@@ -303,7 +303,7 @@ const AssetNodeBox = styled.div<{$isSource: boolean; $selected: boolean}>`
 
 /** Keep in sync with DISPLAY_NAME_PX_PER_CHAR */
 const NameCSS: CSSObject = {
-  padding: '3px 6px',
+  padding: '3px 0 3px 6px',
   color: Colors.textDefault(),
   fontFamily: FontFamily.monospace,
   fontWeight: 600,
@@ -361,7 +361,7 @@ const MinimalAssetNodeBox = styled.div<{
 
   border-radius: 16px;
   position: relative;
-  padding: 4px;
+  padding: 2px;
   height: 100%;
   min-height: 86px;
   &:hover {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
@@ -26,7 +26,10 @@ import {AssetKey} from '../assets/types';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 
 export const GroupNodeNameAndRepo = ({group, minimal}: {minimal: boolean; group: GroupLayout}) => {
-  const name = `${group.groupName} `;
+  const name = group.groupName;
+  const nameWidth = group.bounds.width - 36; // padding and icon
+  const maxLengthAtFontSize = (fontSize: number) => Math.floor(nameWidth / (fontSize * 0.53));
+
   const location = repoAddressAsHumanString({
     name: group.repositoryName,
     location: group.repositoryLocationName,
@@ -40,7 +43,7 @@ export const GroupNodeNameAndRepo = ({group, minimal}: {minimal: boolean; group:
           data-tooltip-style={GroupNameTooltipStyle}
           style={{fontSize: 30, fontWeight: 600, lineHeight: '30px'}}
         >
-          {withMiddleTruncation(name, {maxLength: 14})}
+          {withMiddleTruncation(name, {maxLength: maxLengthAtFontSize(30)})}
         </div>
       </Box>
     );
@@ -53,11 +56,11 @@ export const GroupNodeNameAndRepo = ({group, minimal}: {minimal: boolean; group:
           data-tooltip-style={GroupNameTooltipStyle}
           style={{fontSize: 20, fontWeight: 600, lineHeight: '1.1em'}}
         >
-          {withMiddleTruncation(name, {maxLength: 22})}
+          {withMiddleTruncation(name, {maxLength: maxLengthAtFontSize(20)})}
         </div>
       </Box>
-      <Box style={{lineHeight: '1em', color: Colors.textLight()}}>
-        {withMiddleTruncation(location, {maxLength: 31})}
+      <Box style={{fontSize: 14, lineHeight: '1em', color: Colors.textLight()}}>
+        {withMiddleTruncation(location, {maxLength: maxLengthAtFontSize(14)})}
       </Box>
     </Box>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ForeignNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ForeignNode.tsx
@@ -21,8 +21,8 @@ export const AssetNodeLink = memo(({assetKey}: {assetKey: {path: string[]}}) => 
 
 const AssetNodeLinkContainer = styled.div`
   display: flex;
-  padding: 4px 8px 6px;
-  margin-top: 26px;
+  padding: 4px 0 6px 8px;
+  margin-top: 6px;
   line-height: 30px;
   font-family: ${FontFamily.monospace};
   color: ${Colors.linkDefault()};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -95,7 +95,7 @@ export const layoutAssetGraph = (
       if (expandedGroups.includes(groupId)) {
         g.setNode(groupId, {}); // sized based on it's children
       } else {
-        g.setNode(groupId, {width: 270, height: 110});
+        g.setNode(groupId, {width: 320, height: 110});
       }
     });
   }
@@ -245,12 +245,12 @@ export const layoutAssetGraph = (
   };
 };
 
-export const ASSET_LINK_NAME_MAX_LENGTH = 10;
+export const ASSET_LINK_NAME_MAX_LENGTH = 30;
 
 export const getAssetLinkDimensions = (label: string, opts: LayoutAssetGraphOptions) => {
   return opts.horizontalDAGs
-    ? {width: 32 + 8 * Math.min(ASSET_LINK_NAME_MAX_LENGTH, label.length), height: 90}
-    : {width: 106, height: 90};
+    ? {width: 32 + 7.1 * Math.min(ASSET_LINK_NAME_MAX_LENGTH, label.length), height: 50}
+    : {width: 106, height: 50};
 };
 
 export const padBounds = (a: IBounds, padding: {x: number; top: number; bottom: number}) => {
@@ -270,7 +270,7 @@ export const extendBounds = (a: IBounds, b: IBounds) => {
   return {x: xmin, y: ymin, width: xmax - xmin, height: ymax - ymin};
 };
 
-export const ASSET_NODE_NAME_MAX_LENGTH = 28;
+export const ASSET_NODE_NAME_MAX_LENGTH = 38;
 
 export const getAssetNodeDimensions = (def: {
   assetKey: {path: string[]};
@@ -282,7 +282,7 @@ export const getAssetNodeDimensions = (def: {
   description?: string | null;
   computeKind: string | null;
 }) => {
-  const width = 265;
+  const width = 320;
 
   let height = 100; // top tags area + name + description
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -61,6 +61,7 @@ const _assetLayoutCacheKey = (graphData: GraphData, opts: LayoutAssetGraphOption
   }
 
   return `${JSON.stringify(opts)}${JSON.stringify({
+    version: 1,
     downstream: recreateObjectWithKeysSorted(graphData.downstream),
     upstream: recreateObjectWithKeysSorted(graphData.upstream),
     nodes: Object.keys(graphData.nodes).sort(),


### PR DESCRIPTION
## Summary & Motivation

Also addresses FE-179

- Expands asset graph nodes from 270 => 320px (20% increase). The name bar now fits 38 chars instead of 28 chars in zoomed in mode, and 20 chars instead of 14 in mini mode. I also changed padding and slightly shrank the minimal font size to get every possible character in.

- External asset nodes are now 30 chars instead of 10 (FE-38). Now that we display the graph horizontally, I think having these wide but very thin (vertically) nodes won't disrupt layout too much. 

- Instead of capping the length of the asset group title bar, its now based on the available size (note: this is still px-to-monospace-font math, we can't use MiddleTruncation because the measurement changes based on SVG scale). 

- I fixed a bug that was causing zoomed out asset nodes to not align with the arrows.

- To ensure everyone sees these new widths, I added a version number to the asset cache key and incremented it to version 1.

AFTER: 

<img width="485" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/10773bfb-59d4-4bd4-a9c8-8093f82871ad">
<img width="923" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/333508f3-757d-4147-93bd-a92fb99352f8">
<img width="684" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/95e64789-d503-41ed-8181-a38b246e89f2">

BEFORE (for reference):

<img width="362" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/0ed87aef-705d-42fa-9d15-9537e70e8391">
<img width="743" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/dd824e77-bc42-4f54-a444-55a4c016cffb">
<img width="538" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/93fdf18b-d6f3-4d8b-ad65-185934b60c53">
