### PR TITLE
Include entire asset node data in asset graph layout cache key

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -63,7 +63,9 @@ const _assetLayoutCacheKey = (graphData: GraphData, opts: LayoutAssetGraphOption
   return `${JSON.stringify(opts)}${JSON.stringify({
     downstream: recreateObjectWithKeysSorted(graphData.downstream),
     upstream: recreateObjectWithKeysSorted(graphData.upstream),
-    nodes: Object.keys(graphData.nodes).sort(),
+    nodes: Object.keys(graphData.nodes)
+      .sort()
+      .map((key) => graphData.nodes[key]),
     expandedGroups: graphData.expandedGroups,
   })}`;
 };


### PR DESCRIPTION
## Summary & Motivation

Currently we only include the asset node names in the cache key, we want to also include the group each asset belongs to in order for the graph to update if that changes. That information is part of the definition of the asset which we are now including in the cache key.

## How I Tested These Changes

Loaded the asset graph, changed the group an asset was part of, loaded the asset graph again and saw the node switch groups.