### PR TITLE
docs: fix configuration reference for isolated agents in ECS

### DIFF
--- a/docs/content/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference.mdx
@@ -171,8 +171,9 @@ user_code_launcher:
     run_ecs_tags:
       - key: MyEcsTagKeyWithoutValue
     repository_credentials: MyRepositoryCredentialsSecretArn
-    isolated_agents:
-      enabled: <true|false>
+
+isolated_agents:
+  enabled: <true|false>
 ```
 
 ### dagster_cloud_api properties


### PR DESCRIPTION
## Summary & Motivation

The existing configuration reference points to this configuration field being nested under user_code_launcher/config but it should be at the root of the ECS agent dagster.yaml.


## How I Tested These Changes

- User validation