### PR TITLE
Ignore tempdir cleanup warning in test_utils.py

### DIFF
--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -697,6 +697,14 @@ def raise_exception_on_warnings():
     warnings.resetwarnings()
     warnings.filterwarnings("error")
 
+    # This resource warning can sometimes appear (nondeterministically) when ephemeral instances are
+    # used in tests. There seems to be an issue at the intersection of `DagsterInstance` weakrefs
+    # and guaranteeing timely cleanup of the LocalArtifactStorage for the instance
+    # LocalArtifactStorage.
+    warnings.filterwarnings(
+        "ignore", category=ResourceWarning, message=r".*Implicitly cleaning up.*"
+    )
+
     if sys.version_info >= (3, 12):
         # pendulum sometimes raises DeprecationWarning on python3.12
         warnings.filterwarnings("ignore", category=DeprecationWarning, module="pendulum")


### PR DESCRIPTION
## Summary & Motivation

Calling `JobDefinition.execute_in_process()` in certain circumstances can trigger the emission of a `ResourceWarning` concerning a tempdir cleanup, which in turn causes test failure for tests that are wrapped with an "error on warning" fixture.

I'm pretty sure the ultimate solution to this problem is fixing the `LocalArtifactStorage` tempdir cleanup code for ephemeral `DagsterInstance`, which seems to have a bad interaction with instance weakrefs. I'm not sure how to do this immediately, so we are going to just filter out this (practically harmless) warning for now.