### PR TITLE
[external-assets] Move `AssetGraph.from_assets` to `InternalAssetGraph.from_assets`

### DIFF
--- a/examples/docs_snippets/docs_snippets/integrations/dagstermill/iris_notebook_config.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dagstermill/iris_notebook_config.py
@@ -1,5 +1,6 @@
 from dagster import asset
 from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 
 
 # placeholder so that the test works. this isn't used in the docs
@@ -46,4 +47,4 @@ assets_with_resource = with_resources(
 config_asset_job = define_asset_job(
     name="config_asset_job",
     selection=AssetSelection.assets(iris_kmeans_jupyter_notebook).upstream(),
-).resolve(asset_graph=AssetGraph.from_assets(assets_with_resource))
+).resolve(asset_graph=InternalAssetGraph.from_assets(assets_with_resource))

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -10,8 +10,8 @@ from dagster import (
     asset,
     define_asset_job,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.execution.asset_backfill import (
     AssetBackfillIterationResult,
     execute_asset_backfill_iteration,
@@ -269,7 +269,7 @@ def _mock_asset_backfill_runs(
         return Output(5)
 
     define_asset_job("my_job", [dummy_asset]).resolve(
-        asset_graph=AssetGraph.from_assets([dummy_asset])
+        asset_graph=InternalAssetGraph.from_assets([dummy_asset])
     ).execute_in_process(
         tags={**DagsterRun.tags_for_backfill_id(backfill_id)},
         partition_key=partition_key,

--- a/python_modules/dagster-test/dagster_test/benchmarks/partition_stale_status.py
+++ b/python_modules/dagster-test/dagster_test/benchmarks/partition_stale_status.py
@@ -1,5 +1,4 @@
 # ruff: noqa: T201
-
 import argparse
 from random import randint
 from typing import Sequence, Union
@@ -8,13 +7,13 @@ from dagster import (
     StaticPartitionsDefinition,
     asset,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import (
     SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD,
     CachingStaleStatusResolver,
     StaleStatus,
 )
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance_for_test import instance_for_test
@@ -86,7 +85,7 @@ def get_stale_status_resolver(
 ) -> CachingStaleStatusResolver:
     return CachingStaleStatusResolver(
         instance=instance,
-        asset_graph=AssetGraph.from_assets(assets),
+        asset_graph=InternalAssetGraph.from_assets(assets),
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -22,9 +22,12 @@ from typing import (
 import toposort
 
 import dagster._check as check
+from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.asset_subset import ValidAssetSubset
+from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.selector.subset_selector import (
@@ -35,8 +38,6 @@ from dagster._core.selector.subset_selector import (
 from dagster._utils.cached_method import cached_method
 
 from .asset_check_spec import AssetCheckKey
-from .asset_checks import AssetChecksDefinition
-from .assets import AssetsDefinition
 from .backfill_policy import BackfillPolicy
 from .events import AssetKey, AssetKeyPartitionKey
 from .freshness_policy import FreshnessPolicy
@@ -47,7 +48,6 @@ from .partition_mapping import (
     UpstreamPartitionsResult,
     infer_partition_mapping,
 )
-from .source_asset import SourceAsset
 from .time_window_partitions import (
     get_time_partition_key,
     get_time_partitions_def,

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -11,6 +11,7 @@ from typing_extensions import TypeAlias
 import dagster._check as check
 from dagster._annotations import deprecated, experimental_param, public
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.errors import DagsterInvalidSubsetError
 from dagster._core.selector.subset_selector import (
     fetch_connected,
@@ -29,7 +30,6 @@ from .events import (
     CoercibleToAssetKeyPrefix,
     key_prefix_from_coercible,
 )
-from .internal_asset_graph import InternalAssetGraph
 from .source_asset import SourceAsset
 
 CoercibleToAssetSelection: TypeAlias = Union[
@@ -332,7 +332,7 @@ class AssetSelection(ABC, BaseModel, frozen=True):
             asset_graph = all_assets
         else:
             check.iterable_param(all_assets, "all_assets", (AssetsDefinition, SourceAsset))
-            asset_graph = AssetGraph.from_assets(all_assets)
+            asset_graph = InternalAssetGraph.from_assets(all_assets)
 
         return self.resolve_inner(asset_graph)
 

--- a/python_modules/dagster/dagster/_core/definitions/internal_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/internal_asset_graph.py
@@ -1,8 +1,9 @@
-from typing import AbstractSet, Mapping, Optional, Sequence
+from typing import AbstractSet, Dict, Iterable, List, Mapping, Optional, Sequence, Union
 
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_graph import AssetGraph, AssetKeyOrCheckKey
+from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicy
@@ -11,7 +12,7 @@ from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.source_asset import SourceAsset
-from dagster._core.selector.subset_selector import DependencyGraph
+from dagster._core.selector.subset_selector import DependencyGraph, generate_asset_dep_graph
 
 
 class InternalAssetGraph(AssetGraph):
@@ -59,6 +60,85 @@ class InternalAssetGraph(AssetGraph):
         for asset in assets:
             asset_check_keys.update([spec.key for spec in asset.check_specs])
         self._asset_check_keys = asset_check_keys
+
+    @staticmethod
+    def from_assets(
+        all_assets: Iterable[Union[AssetsDefinition, SourceAsset]],
+        asset_checks: Optional[Sequence[AssetChecksDefinition]] = None,
+    ) -> "InternalAssetGraph":
+        from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
+
+        assets_defs: List[AssetsDefinition] = []
+        source_assets: List[SourceAsset] = []
+        partitions_defs_by_key: Dict[AssetKey, Optional[PartitionsDefinition]] = {}
+        partition_mappings_by_key: Dict[
+            AssetKey, Optional[Mapping[AssetKey, PartitionMapping]]
+        ] = {}
+        group_names_by_key: Dict[AssetKey, Optional[str]] = {}
+        freshness_policies_by_key: Dict[AssetKey, Optional[FreshnessPolicy]] = {}
+        auto_materialize_policies_by_key: Dict[AssetKey, Optional[AutoMaterializePolicy]] = {}
+        backfill_policies_by_key: Dict[AssetKey, Optional[BackfillPolicy]] = {}
+        code_versions_by_key: Dict[AssetKey, Optional[str]] = {}
+        is_observable_by_key: Dict[AssetKey, bool] = {}
+        auto_observe_interval_minutes_by_key: Dict[AssetKey, Optional[float]] = {}
+        required_assets_and_checks_by_key: Dict[
+            AssetKeyOrCheckKey, AbstractSet[AssetKeyOrCheckKey]
+        ] = {}
+
+        for asset in all_assets:
+            if isinstance(asset, SourceAsset):
+                source_assets.append(asset)
+                partitions_defs_by_key[asset.key] = asset.partitions_def
+                group_names_by_key[asset.key] = asset.group_name
+                is_observable_by_key[asset.key] = asset.is_observable
+                auto_observe_interval_minutes_by_key[
+                    asset.key
+                ] = asset.auto_observe_interval_minutes
+            else:  # AssetsDefinition
+                assets_defs.append(asset)
+                partition_mappings_by_key.update(
+                    {key: asset.partition_mappings for key in asset.keys}
+                )
+                partitions_defs_by_key.update({key: asset.partitions_def for key in asset.keys})
+                group_names_by_key.update(asset.group_names_by_key)
+                freshness_policies_by_key.update(asset.freshness_policies_by_key)
+                auto_materialize_policies_by_key.update(asset.auto_materialize_policies_by_key)
+                backfill_policies_by_key.update({key: asset.backfill_policy for key in asset.keys})
+                code_versions_by_key.update(asset.code_versions_by_key)
+
+                is_observable = asset.execution_type == AssetExecutionType.OBSERVATION
+                is_observable_by_key.update({key: is_observable for key in asset.keys})
+
+                # Set auto_observe_interval_minutes for external observable assets
+                # This can be removed when/if we have a a solution for mapping
+                # `auto_observe_interval_minutes` to an AutoMaterialzePolicy
+                auto_observe_interval_minutes_by_key.update(
+                    {key: asset.auto_observe_interval_minutes for key in asset.keys}
+                )
+
+                if not asset.can_subset:
+                    all_required_keys = {*asset.check_keys, *asset.keys}
+                    if len(all_required_keys) > 1:
+                        for key in all_required_keys:
+                            required_assets_and_checks_by_key[key] = all_required_keys
+
+        return InternalAssetGraph(
+            asset_dep_graph=generate_asset_dep_graph(assets_defs, source_assets),
+            source_asset_keys={source_asset.key for source_asset in source_assets},
+            partitions_defs_by_key=partitions_defs_by_key,
+            partition_mappings_by_key=partition_mappings_by_key,
+            group_names_by_key=group_names_by_key,
+            freshness_policies_by_key=freshness_policies_by_key,
+            auto_materialize_policies_by_key=auto_materialize_policies_by_key,
+            backfill_policies_by_key=backfill_policies_by_key,
+            assets=assets_defs,
+            asset_checks=asset_checks or [],
+            source_assets=source_assets,
+            code_versions_by_key=code_versions_by_key,
+            is_observable_by_key=is_observable_by_key,
+            auto_observe_interval_minutes_by_key=auto_observe_interval_minutes_by_key,
+            required_assets_and_checks_by_key=required_assets_and_checks_by_key,
+        )
 
     @property
     def asset_check_keys(self) -> AbstractSet[AssetCheckKey]:

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -262,7 +262,7 @@ def build_caching_repository_data_from_list(
                 schedule_def, coerced_graphs, unresolved_jobs, jobs, target
             )
 
-    asset_graph = AssetGraph.from_assets(
+    asset_graph = InternalAssetGraph.from_assets(
         [*assets_defs, *source_assets], asset_checks=asset_checks_defs
     )
     _validate_auto_materialize_sensors(sensors.values(), asset_graph)
@@ -363,7 +363,7 @@ def build_caching_repository_data_from_dict(
         elif isinstance(raw_job_def, UnresolvedAssetJobDefinition):
             repository_definitions["jobs"][key] = raw_job_def.resolve(
                 # TODO: https://github.com/dagster-io/dagster/issues/8263
-                asset_graph=AssetGraph.from_assets([]),
+                asset_graph=InternalAssetGraph.from_assets([]),
                 default_executor_def=None,
             )
         elif not isinstance(raw_job_def, JobDefinition) and not isfunction(raw_job_def):

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -16,7 +16,6 @@ from typing import (
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.assets_job import (
     ASSET_BASE_JOB_PREFIX,
 )
@@ -387,7 +386,7 @@ class RepositoryDefinition:
 
     @property
     def asset_graph(self) -> InternalAssetGraph:
-        return AssetGraph.from_assets(
+        return InternalAssetGraph.from_assets(
             [*set(self.assets_defs_by_key.values()), *self.source_assets_by_key.values()]
         )
 

--- a/python_modules/dagster/dagster/_utils/test/data_versions.py
+++ b/python_modules/dagster/dagster/_utils/test/data_versions.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union, c
 
 from typing_extensions import Literal
 
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import (
     CODE_VERSION_TAG,
@@ -12,6 +11,7 @@ from dagster._core.definitions.data_version import (
     DataVersion,
 )
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.materialize import materialize
 from dagster._core.definitions.run_config import RunConfig
 from dagster._core.definitions.source_asset import SourceAsset
@@ -216,5 +216,5 @@ def get_stale_status_resolver(
 ) -> CachingStaleStatusResolver:
     return CachingStaleStatusResolver(
         instance=instance,
-        asset_graph=AssetGraph.from_assets(assets),
+        asset_graph=InternalAssetGraph.from_assets(assets),
     )

--- a/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
+++ b/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
@@ -15,8 +15,8 @@ from dagster import (
     schedule,
     usable_as_dagster_type,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.decorators.sensor_decorator import sensor
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.partition import (
     PartitionedConfig,
     StaticPartitionsDefinition,
@@ -203,7 +203,7 @@ def bar_repo():
             "baz": lambda: baz_job,
             "dynamic_job": define_asset_job(
                 "dynamic_job", [dynamic_asset], partitions_def=dynamic_partitions_def
-            ).resolve(asset_graph=AssetGraph.from_assets([dynamic_asset])),
+            ).resolve(asset_graph=InternalAssetGraph.from_assets([dynamic_asset])),
             "fail": fail_job,
             "foo": foo_job,
             "forever": forever_job,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -33,10 +33,10 @@ from dagster import (
     op,
 )
 from dagster._core.definitions.asset_dep import AssetDep
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.partition import (
     DefaultPartitionsSubset,
     DynamicPartitionsDefinition,
@@ -438,7 +438,7 @@ def test_multipartitions_def_partition_mapping_infer_identity():
         assert context.asset_partition_keys_for_input("upstream") == context.partition_keys
         return 1
 
-    asset_graph = AssetGraph.from_assets([upstream, downstream])
+    asset_graph = InternalAssetGraph.from_assets([upstream, downstream])
     assets_job = define_asset_job("foo", [upstream, downstream]).resolve(asset_graph=asset_graph)
 
     assert (
@@ -471,7 +471,7 @@ def test_multipartitions_def_partition_mapping_infer_single_dim_to_multi():
         assert context.partition_keys == [MultiPartitionKey({"abc": "a", "123": "1"})]
         return 1
 
-    asset_graph = AssetGraph.from_assets([upstream, downstream])
+    asset_graph = InternalAssetGraph.from_assets([upstream, downstream])
 
     assert (
         asset_graph.get_partition_mapping(upstream.key, downstream.key)
@@ -526,7 +526,7 @@ def test_multipartitions_def_partition_mapping_infer_multi_to_single_dim():
         assert context.partition_keys == ["a"]
         return 1
 
-    asset_graph = AssetGraph.from_assets([upstream, downstream])
+    asset_graph = InternalAssetGraph.from_assets([upstream, downstream])
 
     assert (
         asset_graph.get_partition_mapping(upstream.key, downstream.key)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -30,6 +30,7 @@ from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.decorators.asset_check_decorator import asset_check
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import UpstreamPartitionsResult
@@ -61,7 +62,7 @@ def to_external_asset_graph(assets, asset_checks=None) -> AssetGraph:
 
 
 @pytest.fixture(
-    name="asset_graph_from_assets", params=[AssetGraph.from_assets, to_external_asset_graph]
+    name="asset_graph_from_assets", params=[InternalAssetGraph.from_assets, to_external_asset_graph]
 )
 def asset_graph_from_assets_fixture(request) -> Callable[[List[AssetsDefinition]], AssetGraph]:
     return request.param
@@ -336,7 +337,7 @@ def test_custom_unsupported_partition_mapping():
         def child(parent):
             ...
 
-    internal_asset_graph = AssetGraph.from_assets([parent, child])
+    internal_asset_graph = InternalAssetGraph.from_assets([parent, child])
     external_asset_graph = to_external_asset_graph([parent, child])
 
     with instance_for_test() as instance:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -41,6 +41,7 @@ from dagster._core.definitions.asset_selection import (
 )
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._serdes import deserialize_value
 from dagster._serdes.serdes import _WHITELIST_MAP
 from pydantic import ValidationError
@@ -552,7 +553,7 @@ def test_to_serializable_asset_selection():
     def check1():
         ...
 
-    asset_graph = AssetGraph.from_assets([asset1, asset2], asset_checks=[check1])
+    asset_graph = InternalAssetGraph.from_assets([asset1, asset2], asset_checks=[check1])
 
     def assert_serializable_same(asset_selection: AssetSelection) -> None:
         assert asset_selection.to_serializable_asset_selection(asset_graph) == asset_selection

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -37,12 +37,12 @@ from dagster import (
 )
 from dagster._check import CheckError
 from dagster._core.definitions import AssetIn, SourceAsset, asset, multi_asset
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.assets import TeamAssetOwner, UserAssetOwner
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.decorators.asset_decorator import graph_asset
 from dagster._core.definitions.events import AssetMaterialization
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.result import MaterializeResult
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
@@ -1054,7 +1054,7 @@ def test_graph_backed_asset_subset():
         return bar.alias("bar_1")(one), bar.alias("bar_2")(one)
 
     asset_job = define_asset_job("yay").resolve(
-        asset_graph=AssetGraph.from_assets(
+        asset_graph=InternalAssetGraph.from_assets(
             [
                 AssetsDefinition.from_graph(my_graph, can_subset=True),
             ]
@@ -1083,7 +1083,7 @@ def test_graph_backed_asset_partial_output_selection():
         return one, two
 
     asset_job = define_asset_job("yay").resolve(
-        asset_graph=AssetGraph.from_assets(
+        asset_graph=InternalAssetGraph.from_assets(
             [
                 AssetsDefinition.from_graph(graph_asset, can_subset=True),
             ]
@@ -1130,7 +1130,7 @@ def test_input_subsetting_graph_backed_asset():
 
     with tempfile.TemporaryDirectory() as tmpdir_path:
         asset_job = define_asset_job("yay").resolve(
-            asset_graph=AssetGraph.from_assets(
+            asset_graph=InternalAssetGraph.from_assets(
                 with_resources(
                     [
                         upstream_1,
@@ -1248,7 +1248,7 @@ def test_graph_backed_asset_subset_context(
         return {"asset_one": out_1, "asset_two": out_2, "asset_three": out_3}
 
     asset_job = define_asset_job("yay").resolve(
-        asset_graph=AssetGraph.from_assets(
+        asset_graph=InternalAssetGraph.from_assets(
             [AssetsDefinition.from_graph(three, can_subset=True)],
         )
     )
@@ -1329,7 +1329,7 @@ def test_graph_backed_asset_subset_context_intermediate_ops(
         }
 
     asset_job = define_asset_job("yay").resolve(
-        asset_graph=AssetGraph.from_assets(
+        asset_graph=InternalAssetGraph.from_assets(
             [AssetsDefinition.from_graph(graph_asset, can_subset=True)],
         )
     )
@@ -1391,7 +1391,7 @@ def test_nested_graph_subset_context(
         return {"a": a, "b": b, "c": c, "d": d}
 
     asset_job = define_asset_job("yay").resolve(
-        asset_graph=AssetGraph.from_assets(
+        asset_graph=InternalAssetGraph.from_assets(
             [AssetsDefinition.from_graph(nested_graph, can_subset=True)],
         )
     )
@@ -1428,7 +1428,7 @@ def test_graph_backed_asset_reused():
 
     with tempfile.TemporaryDirectory() as tmpdir_path:
         asset_job = define_asset_job("yay").resolve(
-            asset_graph=AssetGraph.from_assets(
+            asset_graph=InternalAssetGraph.from_assets(
                 with_resources(
                     [
                         upstream,
@@ -1543,7 +1543,7 @@ def test_context_assets_def():
         return 2
 
     asset_job = define_asset_job("yay", [a, b]).resolve(
-        asset_graph=AssetGraph.from_assets(
+        asset_graph=InternalAssetGraph.from_assets(
             [a, b],
         )
     )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -36,11 +36,11 @@ from dagster import (
 )
 from dagster._config import StringSource
 from dagster._core.definitions import AssetIn, SourceAsset, asset
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_selection import AssetSelection, CoercibleToAssetSelection
 from dagster._core.definitions.assets_job import get_base_asset_jobs
 from dagster._core.definitions.dependency import NodeHandle, NodeInvocation
 from dagster._core.definitions.executor_definition import in_process_executor
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.load_assets_from_modules import prefix_assets
 from dagster._core.errors import DagsterInvalidSubsetError
@@ -1379,7 +1379,7 @@ dbt_asset_def = AssetsDefinition(
 )
 
 my_job = define_asset_job("foo", selection=["a", "b", "c", "d", "e", "f"]).resolve(
-    asset_graph=AssetGraph.from_assets(
+    asset_graph=InternalAssetGraph.from_assets(
         with_resources(
             [dbt_asset_def, fivetran_asset],
             resource_defs={"my_resource": my_resource, "my_resource_2": my_resource_2},
@@ -1444,7 +1444,7 @@ def test_job_preserved_with_asset_subset():
         },
         description="my cool job",
         tags={"yay": 1},
-    ).resolve(asset_graph=AssetGraph.from_assets([asset_one, two, three]))
+    ).resolve(asset_graph=InternalAssetGraph.from_assets([asset_one, two, three]))
 
     result = foo_job.execute_in_process(asset_selection=[AssetKey("one")])
     assert result.success
@@ -1469,7 +1469,7 @@ def test_job_default_config_preserved_with_asset_subset():
         assert context.op_execution_context.op_config["baz"] == 3
 
     foo_job = define_asset_job("foo_job").resolve(
-        asset_graph=AssetGraph.from_assets([asset_one, two, three])
+        asset_graph=InternalAssetGraph.from_assets([asset_one, two, three])
     )
 
     result = foo_job.execute_in_process(asset_selection=[AssetKey("one")])
@@ -1489,7 +1489,7 @@ def test_empty_asset_job():
     assert empty_selection.resolve([a, b]) == set()
 
     empty_job = define_asset_job("empty_job", selection=empty_selection).resolve(
-        asset_graph=AssetGraph.from_assets([a, b])
+        asset_graph=InternalAssetGraph.from_assets([a, b])
     )
     assert empty_job.all_node_defs == []
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -31,9 +31,9 @@ from dagster import (
 )
 from dagster._check import CheckError
 from dagster._core.definitions import asset, multi_asset
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.materialize import materialize_to_memory
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import TimeWindow
@@ -543,7 +543,7 @@ def test_job_config_with_asset_partitions():
         "job",
         partitions_def=daily_partitions_def,
         config={"ops": {"asset1": {"config": {"a": 5}}}},
-    ).resolve(asset_graph=AssetGraph.from_assets([asset1]))
+    ).resolve(asset_graph=InternalAssetGraph.from_assets([asset1]))
 
     assert the_job.execute_in_process(partition_key="2020-01-01").success
     assert (
@@ -566,7 +566,7 @@ def test_job_partitioned_config_with_asset_partitions():
         return {"ops": {"asset1": {"config": {"day_of_month": start.day}}}}
 
     the_job = define_asset_job("job", config=myconfig).resolve(
-        asset_graph=AssetGraph.from_assets([asset1])
+        asset_graph=InternalAssetGraph.from_assets([asset1])
     )
 
     assert the_job.execute_in_process(partition_key="2020-01-01").success
@@ -592,7 +592,7 @@ def test_mismatched_job_partitioned_config_with_asset_partitions():
         ),
     ):
         define_asset_job("job", config=myconfig).resolve(
-            asset_graph=AssetGraph.from_assets([asset1])
+            asset_graph=InternalAssetGraph.from_assets([asset1])
         )
 
 
@@ -619,7 +619,7 @@ def test_partition_range_single_run():
         )
 
     the_job = define_asset_job("job").resolve(
-        asset_graph=AssetGraph.from_assets([upstream_asset, downstream_asset])
+        asset_graph=InternalAssetGraph.from_assets([upstream_asset, downstream_asset])
     )
 
     result = the_job.execute_in_process(
@@ -659,7 +659,7 @@ def test_multipartition_range_single_run():
         assert all(isinstance(key, MultiPartitionKey) for key in context.partition_keys)
 
     the_job = define_asset_job("job").resolve(
-        asset_graph=AssetGraph.from_assets([multipartitioned_asset])
+        asset_graph=InternalAssetGraph.from_assets([multipartitioned_asset])
     )
 
     result = the_job.execute_in_process(
@@ -722,7 +722,7 @@ def test_dynamic_partition_range_single_run():
         assert len(context.partition_keys) == 3
 
     the_job = define_asset_job("job").resolve(
-        asset_graph=AssetGraph.from_assets([dynamicpartitioned_asset])
+        asset_graph=InternalAssetGraph.from_assets([dynamicpartitioned_asset])
     )
 
     instance = DagsterInstance.ephemeral()

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -20,11 +20,11 @@ from dagster import (
 )
 from dagster._check import ParameterCheckError
 from dagster._core.definitions import AssetIn, SourceAsset, asset, multi_asset
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_spec import AssetExecutionType, AssetSpec
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.external_asset import external_assets_from_specs
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.metadata import MetadataValue, TextMetadataValue, normalize_metadata
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.partition import ScheduleType
@@ -348,10 +348,10 @@ def test_assets_excluded_from_subset_not_in_job():
 
     all_assets = [abc, a2, c2]
     as_job = define_asset_job("as_job", selection="a*").resolve(
-        asset_graph=AssetGraph.from_assets(all_assets)
+        asset_graph=InternalAssetGraph.from_assets(all_assets)
     )
     cs_job = define_asset_job("cs_job", selection="*c2").resolve(
-        asset_graph=AssetGraph.from_assets(all_assets)
+        asset_graph=InternalAssetGraph.from_assets(all_assets)
     )
 
     external_asset_nodes = _get_external_asset_nodes_from_definitions(
@@ -608,7 +608,7 @@ def test_inter_op_dependency():
         pass
 
     subset_job = define_asset_job("subset_job", selection="mixed").resolve(
-        asset_graph=AssetGraph.from_assets([in1, in2, assets, downstream]),
+        asset_graph=InternalAssetGraph.from_assets([in1, in2, assets, downstream]),
     )
     all_assets_job = define_asset_job("assets_job", [in1, in2, assets, downstream])
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -17,12 +17,12 @@ from dagster import (
     multi_asset,
     repository,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_layer import build_asset_selection_job
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.data_version import DataVersion
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
 from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.materialize import materialize_to_memory
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition
@@ -106,7 +106,7 @@ def test_calculate_data_time_unpartitioned(ignore_asset_tags, runs_to_expected_d
 
     all_assets = [a, bcd, e, f]
 
-    asset_graph = AssetGraph.from_assets(all_assets)
+    asset_graph = InternalAssetGraph.from_assets(all_assets)
 
     with DagsterInstance.ephemeral() as instance:
         # mapping from asset key to a mapping of materialization timestamp to run index

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -37,7 +37,6 @@ from dagster import (
     repository,
     run_failure_sensor,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.auto_materialize_sensor_definition import (
     AutoMaterializeSensorDefinition,
 )
@@ -45,6 +44,7 @@ from dagster._core.definitions.decorators import op
 from dagster._core.definitions.decorators.job_decorator import job
 from dagster._core.definitions.decorators.sensor_decorator import asset_sensor, sensor
 from dagster._core.definitions.instigation_logger import get_instigation_log_records
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.run_request import InstigatorType, SensorResult
 from dagster._core.definitions.run_status_sensor_definition import run_status_sensor
 from dagster._core.definitions.sensor_definition import (
@@ -719,7 +719,7 @@ def partitioned_asset():
 daily_partitioned_job = define_asset_job(
     "daily_partitioned_job",
     partitions_def=daily_partitions_def,
-).resolve(asset_graph=AssetGraph.from_assets([partitioned_asset]))
+).resolve(asset_graph=InternalAssetGraph.from_assets([partitioned_asset]))
 
 
 @run_status_sensor(run_status=DagsterRunStatus.SUCCESS, monitored_jobs=[daily_partitioned_job])

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -62,6 +62,7 @@ from dagster._core.definitions.auto_materialize_sensor_definition import (
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.events import AssetKeyPartitionKey, CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import in_process_executor
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
@@ -281,7 +282,7 @@ class AssetDaemonScenarioState(NamedTuple):
 
     @property
     def asset_graph(self) -> AssetGraph:
-        return AssetGraph.from_assets(self.assets)
+        return InternalAssetGraph.from_assets(self.assets)
 
     def with_asset_properties(
         self, keys: Optional[Iterable[CoercibleToAssetKey]] = None, **kwargs

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -65,6 +65,7 @@ from dagster._core.definitions.data_version import DataVersionsByPartition
 from dagster._core.definitions.events import CoercibleToAssetKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.partition import (
     PartitionsSubset,
@@ -193,7 +194,7 @@ class AssetReconciliationScenario(
             or isinstance(a, SourceAsset)
             for a in assets
         ):
-            asset_graph = AssetGraph.from_assets(assets, asset_checks=asset_checks)
+            asset_graph = InternalAssetGraph.from_assets(assets, asset_checks=asset_checks)
             auto_materialize_asset_keys = (
                 asset_selection.resolve(asset_graph)
                 if asset_selection is not None

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_cursor.py
@@ -6,7 +6,7 @@ from dagster._core.definitions.asset_daemon_cursor import (
     AssetDaemonCursor,
     backcompat_deserialize_asset_daemon_cursor_str,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._serdes.serdes import deserialize_value, serialize_value
 
 partitions = StaticPartitionsDefinition(partition_keys=["a", "b", "c"])
@@ -29,7 +29,7 @@ def test_asset_reconciliation_cursor_evaluation_id_backcompat() -> None:
         backcompat_serialized, None, 0
     ) == AssetDaemonCursor.empty(20)
 
-    asset_graph = AssetGraph.from_assets([my_asset])
+    asset_graph = InternalAssetGraph.from_assets([my_asset])
     c = backcompat_deserialize_asset_daemon_cursor_str(backcompat_serialized, asset_graph, 0)
 
     assert c == AssetDaemonCursor.empty(20)
@@ -76,6 +76,6 @@ def test_asset_reconciliation_cursor_auto_observe_backcompat() -> None:
     )
 
     cursor = backcompat_deserialize_asset_daemon_cursor_str(
-        serialized, AssetGraph.from_assets([asset1, asset2]), 0
+        serialized, InternalAssetGraph.from_assets([asset1, asset2]), 0
     )
     assert cursor.evaluation_id == 25

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_observe.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_observe.py
@@ -6,8 +6,8 @@ from dagster._core.definitions.asset_daemon_context import (
     get_auto_observe_run_requests,
 )
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.external_asset import create_external_asset_from_source_asset
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from pytest import fixture
 
 
@@ -16,7 +16,7 @@ def test_single_observable_source_asset_no_auto_observe():
     def asset1():
         ...
 
-    asset_graph = AssetGraph.from_assets([asset1])
+    asset_graph = InternalAssetGraph.from_assets([asset1])
 
     assert (
         len(
@@ -52,7 +52,7 @@ def single_auto_observe_asset_graph(request):
         ...
 
     observable = create_external_asset_from_source_asset(asset1) if request.param else asset1
-    asset_graph = AssetGraph.from_assets([observable])
+    asset_graph = InternalAssetGraph.from_assets([observable])
     return asset_graph
 
 
@@ -108,7 +108,7 @@ def test_reconcile():
     def asset1():
         ...
 
-    asset_graph = AssetGraph.from_assets([asset1])
+    asset_graph = InternalAssetGraph.from_assets([asset1])
     instance = DagsterInstance.ephemeral()
 
     run_requests, cursor, _ = AssetDaemonContext(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_default_io_manager.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_default_io_manager.py
@@ -8,7 +8,7 @@ from dagster import (
     op,
     reconstructable,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.errors import DagsterSubprocessError
 from dagster._core.storage.fs_io_manager import PickledObjectFilesystemIOManager
 from dagster._core.test_utils import environ, instance_for_test
@@ -77,7 +77,7 @@ def foo_io_manager_asset(context):
 
 def create_asset_job():
     return define_asset_job(name="foo_io_manager_asset_job").resolve(
-        asset_graph=AssetGraph.from_assets([foo_io_manager_asset])
+        asset_graph=InternalAssetGraph.from_assets([foo_io_manager_asset])
     )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -21,7 +21,7 @@ from dagster import (
     repository,
 )
 from dagster._check import CheckError
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.time_window_partitions import TimeWindow, get_time_partitions_def
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
@@ -485,7 +485,7 @@ def test_dynamic_dimension_in_multipartitioned_asset():
 
     dynamic_multipartitioned_job = define_asset_job(
         "dynamic_multipartitioned_job", [my_asset, asset2], partitions_def=multipartitions_def
-    ).resolve(asset_graph=AssetGraph.from_assets([my_asset, asset2]))
+    ).resolve(asset_graph=InternalAssetGraph.from_assets([my_asset, asset2]))
 
     with instance_for_test() as instance:
         instance.add_dynamic_partitions("dynamic", ["1"])
@@ -538,7 +538,7 @@ def test_context_partition_time_window():
 
     multipartitioned_job = define_asset_job(
         "my_job", [my_asset], partitions_def=partitions_def
-    ).resolve(asset_graph=AssetGraph.from_assets([my_asset]))
+    ).resolve(asset_graph=InternalAssetGraph.from_assets([my_asset]))
     multipartitioned_job.execute_in_process(
         partition_key=MultiPartitionKey({"date": "2020-01-01", "static": "a"})
     )
@@ -558,7 +558,7 @@ def test_context_invalid_partition_time_window():
 
     multipartitioned_job = define_asset_job(
         "my_job", [my_asset], partitions_def=partitions_def
-    ).resolve(asset_graph=AssetGraph.from_assets([my_asset]))
+    ).resolve(asset_graph=InternalAssetGraph.from_assets([my_asset]))
     with pytest.raises(
         DagsterInvariantViolationError,
         match=(

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_reexecute.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_reexecute.py
@@ -17,9 +17,9 @@ from dagster import (
     op,
     reconstructable,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.events import Output
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.output import DynamicOut, Out
 from dagster._core.errors import DagsterExecutionStepNotFoundError
 from dagster._core.instance import DagsterInstance
@@ -574,7 +574,7 @@ def asset_job():
         ),
         executor_def=in_process_executor,
     ).resolve(
-        asset_graph=AssetGraph.from_assets(
+        asset_graph=InternalAssetGraph.from_assets(
             [
                 branching_asset,
                 echo_branching,

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
@@ -32,11 +32,11 @@ from dagster import (
     with_resources,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
     CacheableAssetsDefinition,
 )
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.no_step_launcher import no_step_launcher
@@ -323,7 +323,7 @@ def define_asset_check_job():
         yield AssetCheckResult(passed=True)
 
     return define_asset_job(name="asset_check_job", selection=[asset1]).resolve(
-        asset_graph=AssetGraph.from_assets([asset1])
+        asset_graph=InternalAssetGraph.from_assets([asset1])
     )
 
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
@@ -30,8 +30,8 @@ from dagster import (
     with_resources,
 )
 from dagster._core.definitions import AssetIn, asset, multi_asset
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.partition_mapping import UpstreamPartitionsResult
 from dagster._core.definitions.version_strategy import VersionStrategy
@@ -530,7 +530,7 @@ def test_multipartitions_fs_io_manager():
             return asset1
 
         my_job = define_asset_job("my_job", [asset1, asset2]).resolve(
-            asset_graph=AssetGraph.from_assets([asset1, asset2])
+            asset_graph=InternalAssetGraph.from_assets([asset1, asset2])
         )
 
         result = my_job.execute_in_process(partition_key=MultiPartitionKey({"a": "a", "1": "1"}))
@@ -578,7 +578,7 @@ def test_backcompat_multipartitions_fs_io_manager():
             my_job = define_asset_job(
                 "my_job", [multipartitioned, downstream_of_multipartitioned]
             ).resolve(
-                asset_graph=AssetGraph.from_assets(
+                asset_graph=InternalAssetGraph.from_assets(
                     [multipartitioned, downstream_of_multipartitioned]
                 )
             )
@@ -590,7 +590,9 @@ def test_backcompat_multipartitions_fs_io_manager():
         my_job = define_asset_job(
             "my_job", [multipartitioned, downstream_of_multipartitioned]
         ).resolve(
-            asset_graph=AssetGraph.from_assets([multipartitioned, downstream_of_multipartitioned])
+            asset_graph=InternalAssetGraph.from_assets(
+                [multipartitioned, downstream_of_multipartitioned]
+            )
         )
         result = my_job.execute_in_process(
             partition_key=MultiPartitionKey({"abc": "c", "date": "2020-04-22"}),

--- a/python_modules/dagster/dagster_tests/storage_tests/test_partition_status_cache.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_partition_status_cache.py
@@ -14,7 +14,7 @@ from dagster import (
     asset,
     define_asset_job,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.time_window_partitions import HourlyPartitionsDefinition
 from dagster._core.events import (
     AssetMaterializationPlannedData,
@@ -42,7 +42,7 @@ def test_get_cached_status_unpartitioned():
     def asset1():
         return 1
 
-    asset_graph = AssetGraph.from_assets([asset1])
+    asset_graph = InternalAssetGraph.from_assets([asset1])
     asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     asset_key = AssetKey("asset1")
@@ -86,12 +86,12 @@ def test_get_cached_partition_status_changed_time_partitions():
         return 1
 
     asset_key = AssetKey("asset1")
-    asset_graph = AssetGraph.from_assets([asset1])
+    asset_graph = InternalAssetGraph.from_assets([asset1])
     asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     def _swap_partitions_def(new_partitions_def, asset, asset_graph, asset_job):
         asset._partitions_def = new_partitions_def  # noqa: SLF001
-        asset_graph = AssetGraph.from_assets([asset])
+        asset_graph = InternalAssetGraph.from_assets([asset])
         asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
         return asset, asset_job, asset_graph
 
@@ -135,12 +135,12 @@ def test_get_cached_partition_status_by_asset():
         return 1
 
     asset_key = AssetKey("asset1")
-    asset_graph = AssetGraph.from_assets([asset1])
+    asset_graph = InternalAssetGraph.from_assets([asset1])
     asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     def _swap_partitions_def(new_partitions_def, asset, asset_graph, asset_job):
         asset._partitions_def = new_partitions_def  # noqa: SLF001
-        asset_graph = AssetGraph.from_assets([asset])
+        asset_graph = InternalAssetGraph.from_assets([asset])
         asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
         return asset, asset_job, asset_graph
 
@@ -221,7 +221,7 @@ def test_multipartition_get_cached_partition_status():
         return 1
 
     asset_key = AssetKey("asset1")
-    asset_graph = AssetGraph.from_assets([asset1])
+    asset_graph = InternalAssetGraph.from_assets([asset1])
     asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
@@ -277,7 +277,7 @@ def test_cached_status_on_wipe():
         return 1
 
     asset_key = AssetKey("asset1")
-    asset_graph = AssetGraph.from_assets([asset1])
+    asset_graph = InternalAssetGraph.from_assets([asset1])
     asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
@@ -309,7 +309,7 @@ def test_dynamic_partitions_status_not_cached():
         return 1
 
     asset_key = AssetKey("asset1")
-    asset_graph = AssetGraph.from_assets([asset1])
+    asset_graph = InternalAssetGraph.from_assets([asset1])
     asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
@@ -334,7 +334,7 @@ def test_failure_cache():
             raise Exception()
 
     asset_key = AssetKey("asset1")
-    asset_graph = AssetGraph.from_assets([asset1])
+    asset_graph = InternalAssetGraph.from_assets([asset1])
     asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
@@ -452,7 +452,7 @@ def test_failure_cache_added():
             raise Exception()
 
     asset_key = AssetKey("asset1")
-    asset_graph = AssetGraph.from_assets([asset1])
+    asset_graph = InternalAssetGraph.from_assets([asset1])
     asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
@@ -486,7 +486,7 @@ def test_failure_cache_in_progress_runs():
             raise Exception()
 
     asset_key = AssetKey("asset1")
-    asset_graph = AssetGraph.from_assets([asset1])
+    asset_graph = InternalAssetGraph.from_assets([asset1])
     define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
@@ -580,7 +580,7 @@ def test_cache_cancelled_runs():
             raise Exception()
 
     asset_key = AssetKey("asset1")
-    asset_graph = AssetGraph.from_assets([asset1])
+    asset_graph = InternalAssetGraph.from_assets([asset1])
     define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
@@ -681,7 +681,7 @@ def test_failure_cache_concurrent_materializations():
             raise Exception()
 
     asset_key = AssetKey("asset1")
-    asset_graph = AssetGraph.from_assets([asset1])
+    asset_graph = InternalAssetGraph.from_assets([asset1])
     define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
@@ -757,7 +757,7 @@ def test_failed_partitioned_asset_converted_to_multipartitioned():
         raise Exception("oops")
 
     with instance_for_test() as created_instance:
-        asset_graph = AssetGraph.from_assets([my_asset])
+        asset_graph = InternalAssetGraph.from_assets([my_asset])
         my_job = define_asset_job("asset_job", partitions_def=daily_def).resolve(
             asset_graph=asset_graph
         )
@@ -772,7 +772,7 @@ def test_failed_partitioned_asset_converted_to_multipartitioned():
                 "b": StaticPartitionsDefinition(["a", "b"]),
             }
         )
-        asset_graph = AssetGraph.from_assets([my_asset])
+        asset_graph = InternalAssetGraph.from_assets([my_asset])
         my_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
         asset_key = AssetKey("my_asset")
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
@@ -16,7 +16,7 @@ from dagster import (
     file_relative_path,
 )
 from dagster._config.field_utils import EnvVar
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.test_utils import environ, instance_for_test
 from dagster_dbt import (
     DagsterDbtCloudJobInvariantViolationError,
@@ -184,7 +184,7 @@ def test_load_assets_from_dbt_cloud_job(
     materialize_cereal_assets = define_asset_job(
         name="materialize_cereal_assets",
         selection=AssetSelection.assets(*dbt_cloud_assets),
-    ).resolve(asset_graph=AssetGraph.from_assets(dbt_cloud_assets))
+    ).resolve(asset_graph=InternalAssetGraph.from_assets(dbt_cloud_assets))
 
     with instance_for_test() as instance:
         result = materialize_cereal_assets.execute_in_process(instance=instance)
@@ -298,7 +298,7 @@ def test_load_assets_from_cached_compile_run(
     materialize_cereal_assets = define_asset_job(
         name="materialize_cereal_assets",
         selection=AssetSelection.assets(*dbt_cloud_assets),
-    ).resolve(asset_graph=AssetGraph.from_assets(dbt_cloud_assets))
+    ).resolve(asset_graph=InternalAssetGraph.from_assets(dbt_cloud_assets))
 
     with instance_for_test() as instance:
         result = materialize_cereal_assets.execute_in_process(instance=instance)
@@ -536,7 +536,7 @@ def test_partitions(mocker, dbt_cloud, dbt_cloud_service):
     materialize_cereal_assets = define_asset_job(
         name="materialize_partitioned_cereal_assets",
         selection=AssetSelection.assets(*dbt_cloud_assets),
-    ).resolve(asset_graph=AssetGraph.from_assets(dbt_cloud_assets))
+    ).resolve(asset_graph=InternalAssetGraph.from_assets(dbt_cloud_assets))
 
     with instance_for_test() as instance:
         result = materialize_cereal_assets.execute_in_process(
@@ -631,7 +631,7 @@ def test_subsetting(
     materialize_cereal_assets = define_asset_job(
         name="materialize_cereal_assets",
         selection=asset_selection,
-    ).resolve(asset_graph=AssetGraph.from_assets([*dbt_cloud_assets, hanger1, hanger2]))
+    ).resolve(asset_graph=InternalAssetGraph.from_assets([*dbt_cloud_assets, hanger1, hanger2]))
 
     with instance_for_test() as instance:
         result = materialize_cereal_assets.execute_in_process(instance=instance)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_check_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_check_selection.py
@@ -2,7 +2,6 @@ from typing import Any, Dict
 
 import pytest
 from dagster import AssetCheckKey, AssetKey, AssetsDefinition
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster_dbt import (
     DagsterDbtTranslator,
@@ -30,7 +29,7 @@ def my_dbt_assets_fixture(test_asset_checks_manifest: Dict[str, Any]) -> AssetsD
 
 @pytest.fixture(name="asset_graph", scope="module")
 def asset_graph_fixture(my_dbt_assets: AssetsDefinition) -> InternalAssetGraph:
-    return AssetGraph.from_assets([my_dbt_assets])
+    return InternalAssetGraph.from_assets([my_dbt_assets])
 
 
 ALL_ASSET_KEYS = {

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Set
 
 import pytest
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster_dbt import build_dbt_asset_selection
 from dagster_dbt.asset_decorator import dbt_assets
 
@@ -147,7 +147,7 @@ def test_dbt_asset_selection(
     def my_dbt_assets():
         ...
 
-    asset_graph = AssetGraph.from_assets([my_dbt_assets])
+    asset_graph = InternalAssetGraph.from_assets([my_dbt_assets])
     asset_selection = build_dbt_asset_selection(
         [my_dbt_assets],
         dbt_select=select or "fqn:*",
@@ -185,7 +185,7 @@ def test_dbt_asset_selection_manifest_argument(
         def my_dbt_assets():
             ...
 
-        asset_graph = AssetGraph.from_assets([my_dbt_assets])
+        asset_graph = InternalAssetGraph.from_assets([my_dbt_assets])
         asset_selection = build_dbt_asset_selection([my_dbt_assets], dbt_select="fqn:*")
         selected_asset_keys = asset_selection.resolve(all_assets=asset_graph)
 

--- a/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
+++ b/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
@@ -23,7 +23,7 @@ from dagster import (
     with_resources,
 )
 from dagster._config.pythonic_config import Config
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.utils import DEFAULT_OUTPUT
 from dagster._utils import PICKLE_PROTOCOL, file_relative_path
 
@@ -604,7 +604,7 @@ assets = with_resources(
 def make_resolved_job(asset):
     return define_asset_job(
         name=f"{asset.key.to_user_string()}_job", selection=AssetSelection.assets(asset).upstream()
-    ).resolve(asset_graph=AssetGraph.from_assets(assets))
+    ).resolve(asset_graph=InternalAssetGraph.from_assets(assets))
 
 
 hello_world_asset_job = make_resolved_job(hello_world_asset)


### PR DESCRIPTION
## Summary & Motivation

Move `from_assets` static method for constructing `InternalAssetGraph` from `AssetGraph` to `InternalAssetGraph`. This makes the static method location consistent with `ExternalAssetGraph` (i.e. it lives on the concrete class that it instantiates).

## How I Tested These Changes

Existing test suite.
