### PR TITLE
remove schedule_state_lock

### DIFF
--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -1,6 +1,5 @@
 import random
 import string
-import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack, contextmanager
@@ -817,7 +816,6 @@ def test_grpc_server_down(instance: DagsterInstance, executor: ThreadPoolExecuto
                     get_default_daemon_logger("SchedulerDaemon"),
                     external_schedule,
                     schedule_state,
-                    threading.Lock(),
                     pendulum.now("UTC"),
                     max_catchup_runs=0,
                     max_tick_retries=0,


### PR DESCRIPTION
Summary:
Much like the corresponding change for sensors and the asset daemon - this lock provides no value and only slows things down when many schedules are executing concurrently.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
