### PR TITLE
[asset backfill] Surface backfill launch errors

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -4,7 +4,11 @@ import dagster._check as check
 import pendulum
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.selector import PartitionsByAssetSelector, RepositorySelector
-from dagster._core.errors import DagsterError, DagsterUserCodeProcessError
+from dagster._core.errors import (
+    DagsterError,
+    DagsterInvariantViolationError,
+    DagsterUserCodeProcessError,
+)
 from dagster._core.events import AssetKey
 from dagster._core.execution.asset_backfill import create_asset_backfill_data_from_asset_partitions
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
@@ -98,7 +102,7 @@ def create_and_launch_partition_backfill(
     if (
         asset_selection or backfill_params.get("selector") or backfill_params.get("partitionNames")
     ) and partitions_by_assets:
-        raise DagsterError(
+        raise DagsterInvariantViolationError(
             "partitions_by_assets cannot be used together with asset_selection, selector, or"
             " partitionNames"
         )
@@ -130,7 +134,7 @@ def create_and_launch_partition_backfill(
             return GraphenePartitionSetNotFoundError(partition_set_name)
 
         if len(matches) != 1:
-            raise DagsterError(
+            raise DagsterInvariantViolationError(
                 "Partition set names must be unique: found {num} matches for {partition_set_name}".format(
                     num=len(matches), partition_set_name=partition_set_name
                 )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -95,17 +95,13 @@ def create_and_launch_partition_backfill(
 
     partitions_by_assets = backfill_params.get("partitionsByAssets")
 
-    check.invariant(
-        (
-            asset_selection is None
-            and backfill_params.get("selector") is None
-            and backfill_params.get("partitionNames") is None
-            if partitions_by_assets
-            else True
-        ),
-        "partitions_by_assets cannot be used together with asset_selection, selector, or"
-        " partitionNames",
-    )
+    if (
+        asset_selection or backfill_params.get("selector") or backfill_params.get("partitionNames")
+    ) and partitions_by_assets:
+        raise DagsterError(
+            "partitions_by_assets cannot be used together with asset_selection, selector, or"
+            " partitionNames"
+        )
 
     tags = {t["key"]: t["value"] for t in backfill_params.get("tags", [])}
 
@@ -133,12 +129,12 @@ def create_and_launch_partition_backfill(
         if not matches:
             return GraphenePartitionSetNotFoundError(partition_set_name)
 
-        check.invariant(
-            len(matches) == 1,
-            "Partition set names must be unique: found {num} matches for {partition_set_name}".format(
-                num=len(matches), partition_set_name=partition_set_name
-            ),
-        )
+        if len(matches) != 1:
+            raise DagsterError(
+                "Partition set names must be unique: found {num} matches for {partition_set_name}".format(
+                    num=len(matches), partition_set_name=partition_set_name
+                )
+            )
         external_partition_set = next(iter(matches))
 
         if backfill_params.get("allPartitions"):


### PR DESCRIPTION
Previously these check errors would not be exposed to the user in cloud.

This PR switches the check errors to instead be `DagsterError`s.