### PR TITLE
[docs] introduce script to find missing pyobject sphinx references

### DIFF
--- a/docs/scripts/find-missing-pyobject-sphinx-references.py
+++ b/docs/scripts/find-missing-pyobject-sphinx-references.py
@@ -1,0 +1,60 @@
+"""Identify missing Sphinx references for `.mdx` docs.
+
+
+PREREQUISITES
+
+    make apidoc-build
+
+USAGE
+
+    python scripts/find-missing-pyobject-sphinx-references.py
+
+
+"""
+import json
+import re
+from glob import glob
+from typing import Dict, List
+
+# Location of Sphinx index; requires building Sphinx docs beforehand
+SPHINX_INDEX_PATH = "sphinx/_build/json/searchindex.json"
+
+# Extract `object` and `module` from `PyObject` components in `.mdx` files
+PYOBJECT_PATTERN = r'<PyObject (?:object="([\w\d]+)"\s*)?(?:module="([\w\d]+)"\s*)?/>'
+
+
+def extract_pyobject_object_and_module() -> Dict[str, List[dict]]:
+    """Finds all <PyObject> components in MDX files and return mapping of file to object/module."""
+    mdx_files = glob("**/*.mdx", recursive=True)
+    references = {}
+    for f in mdx_files:
+        content = open(f, "r").read().replace("\n", " ")
+        matches = [
+            {"object": m.group(1), "module": m.group(2)}
+            for m in re.finditer(PYOBJECT_PATTERN, content)
+        ]
+        if matches:
+            references[f] = matches
+    return references
+
+
+def get_sphinx_search_index() -> Dict:
+    """Loads Sphinx JSON search index."""
+    return json.load(open(SPHINX_INDEX_PATH))
+
+
+if __name__ == "__main__":
+    references = extract_pyobject_object_and_module()
+
+    sphinx_index = get_sphinx_search_index()
+
+    for file, pyobjects in references.items():
+        for pyobj in pyobjects:
+            _object = pyobj["object"]
+            _module = pyobj["module"] if pyobj["module"] else "dagster"
+            sphinx_module = sphinx_index["objects"][_module]
+            sphinx_module_objects = [
+                o[4] for o in sphinx_module
+            ]  # Example object entry: [[74, 0, 1, '', 'AddDynamicPartitionsRequest'], ...]
+            if _object not in [o[4] for o in sphinx_module]:
+                print(f"{_module:<20} {_object:<25} {file}")  # noqa: T201

--- a/docs/scripts/validate-pyobjects.py
+++ b/docs/scripts/validate-pyobjects.py
@@ -7,7 +7,7 @@ PREREQUISITES
 
 USAGE
 
-    python scripts/find-missing-pyobject-sphinx-references.py
+    python scripts/validate-pyobjects.py
 
 
 """


### PR DESCRIPTION
## Summary & Motivation

We have a need to determine that all `PyObject` references existing in the Sphinx search index. This script is a bit of a workaround, but finds all `PyObject` component instances in our `.mdx` files, and verifies that those `module` / `object` references exist in the Sphinx search index.

Presently, there are quite a few objects that are missing -- this results in an `href="#"` in our docs.

```
dagster              EnvVar                    content/integrations/dbt-cloud.mdx
dagster              EnvVar                    content/integrations/airbyte-cloud.mdx
dagster              DataVersion               content/guides/dagster/asset-versioning-and-caching.mdx
dagster              EnvVar                    content/guides/dagster/transitioning-data-pipelines-from-development-to-production.mdx
dagster_databricks   PipesDbfsLogReader        content/guides/dagster-pipes/databricks.mdx
dagster              PipesContextLoader        content/guides/dagster-pipes/databricks.mdx
dagster              PipesMessageWriter        content/guides/dagster-pipes/databricks.mdx
dagster              EnvVar                    content/guides/dagster-pipes/subprocess/reference.mdx
dagster              DefaultRunLauncher        content/deployment/run-launcher.mdx
dagster              DefaultRunLauncher        content/deployment/run-monitoring.mdx
dagster              ResourceParam             content/concepts/resources.mdx
dagster              EnvVar                    content/concepts/resources.mdx
dagster              ResourceParam             content/concepts/resources.mdx
dagster              FilesytemIOManager        content/concepts/io-management/io-managers.mdx
dagster              EnvVar                    content/concepts/configuration/config-schema.mdx
dagster              AssetObservation          content/concepts/ops-jobs-graphs/op-events.mdx
dagster              EventMetadata             content/concepts/ops-jobs-graphs/op-events.mdx
dagster              AssetObservation          content/concepts/ops-jobs-graphs/op-events.mdx
dagster              AssetObservation          content/concepts/ops-jobs-graphs/op-events.mdx
dagster              AssetObservation          content/concepts/assets/asset-observations.mdx
dagster              AssetObservation          content/concepts/assets/asset-observations.mdx
dagster              AssetObservation          content/concepts/assets/asset-observations.mdx
dagster              DataVersion               content/concepts/assets/asset-observations.mdx
dagster              AssetObservation          content/concepts/assets/asset-observations.mdx
dagster              json_console_logger       content/concepts/logging/custom-loggers.mdx
dagster              SensorEvaluationContext   content/concepts/partitions-schedules-sensors/asset-sensors.mdx
dagster              SensorEvaluationContext   content/concepts/partitions-schedules-sensors/sensors.mdx
dagster              SensorEvaluationContext   content/concepts/partitions-schedules-sensors/sensors.mdx
dagster              SensorEvaluationContext   content/concepts/partitions-schedules-sensors/sensors.mdx
dagster              SensorEvaluationContext   content/concepts/partitions-schedules-sensors/sensors.mdx
dagster              SensorEvaluationContext   content/concepts/partitions-schedules-sensors/sensors.mdx
dagster              CodeLocationSelector      content/concepts/partitions-schedules-sensors/sensors.mdx
```

## How I Tested These Changes

- Ran script locally
- Confirmed that missing references do in fact map to `href="#"` occurrences

Related - https://github.com/dagster-io/dagster/issues/2939