### PR TITLE
[AssetCondition] Add LatestPartitionsCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
@@ -430,6 +430,18 @@ class AssetCondition(ABC):
             AutoMaterializeRule.skip_on_not_all_parents_updated_since_cron(cron_schedule, timezone)
         )
 
+    @staticmethod
+    def latest_partitions() -> "AssetCondition":
+        """Returns an AssetCondition that is true for the latest asset partition of an asset. For
+        unpartioned assets, this will always be true. For time-partitioned assets and
+        multi-partitioned assets with a time window dimension, this will be true for all partitions
+        in the latest time window. For all other partitions definitions, this will be true for the
+        final partition of the asset.
+        """
+        from .latest_partition_condition import LatestPartitionsCondition
+
+        return LatestPartitionsCondition()
+
 
 class RuleCondition(
     NamedTuple("_RuleCondition", [("rule", "AutoMaterializeRule")]),

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/latest_partition_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/latest_partition_condition.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+
+from dagster._core.definitions.asset_condition.asset_condition_evaluation_context import (
+    AssetConditionEvaluationContext,
+)
+from dagster._core.definitions.asset_subset import AssetSubset
+from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
+from dagster._core.definitions.time_window_partitions import get_time_partitions_def
+
+from .asset_condition import AssetCondition, AssetConditionResult
+
+
+@dataclass(frozen=True)
+class LatestPartitionsCondition(AssetCondition):
+    """AssetCondition which is true for a given asset partition if it is the last partition key
+    for the asset. For unpartitioned assets, this will always be true. For time-partitioned assets
+    and multi-partitioned assets with a time window dimension, this will be true for all partitions
+    in the latest time window. For all other partitions definitions, this will be true for the
+    final partition of the asset.
+    """
+
+    @property
+    def description(self) -> str:
+        return "Is the latest asset partition for this asset"
+
+    def evaluate(self, context: AssetConditionEvaluationContext) -> AssetConditionResult:
+        time_partitions_def = get_time_partitions_def(context.partitions_def)
+
+        if context.partitions_def is None:
+            # unpartitioned, always true
+            true_subset = AssetSubset.all(context.asset_key, None)
+        elif (
+            isinstance(context.partitions_def, MultiPartitionsDefinition)
+            and time_partitions_def is not None
+        ):
+            # multi-partitioned with time dimension, true for all partitions in latest time window
+            latest_time_partition_key = time_partitions_def.get_last_partition_key(
+                current_time=context.evaluation_time,
+                dynamic_partitions_store=context.instance_queryer,
+            )
+            true_subset = AssetSubset.from_asset_partitions_set(
+                context.asset_key,
+                context.partitions_def,
+                {
+                    AssetKeyPartitionKey(context.asset_key, partition_key)
+                    for partition_key in context.partitions_def.get_multipartition_keys_with_dimension_value(
+                        context.partitions_def.time_window_dimension.name,
+                        latest_time_partition_key,
+                        dynamic_partitions_store=context.instance_queryer,
+                    )
+                }
+                if latest_time_partition_key is not None
+                else set(),
+            )
+        else:
+            # other, true for latest partition key
+            latest_partition_key = context.partitions_def.get_last_partition_key(
+                context.evaluation_time, context.instance_queryer
+            )
+            true_subset = AssetSubset.from_asset_partitions_set(
+                context.asset_key,
+                context.partitions_def,
+                {AssetKeyPartitionKey(context.asset_key, latest_partition_key)}
+                if latest_partition_key is not None
+                else set(),
+            )
+
+        return AssetConditionResult.create(context, true_subset=true_subset)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/latest_partition_tests.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/latest_partition_tests.py
@@ -1,0 +1,89 @@
+from dagster._core.definitions.asset_condition.asset_condition import AssetCondition
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+
+from ..utils import multi_partition_key
+from ..utils.asset_condition_scenario import AssetConditionScenarioState
+from ..utils.asset_scenario_states import daily_partitions_def, one_asset, time_multipartitions_def
+
+
+def test_unpartitioned() -> None:
+    state = AssetConditionScenarioState.create_from_state(
+        one_asset, AssetCondition.latest_partitions()
+    )
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+    assert result.true_subset.asset_partitions == {AssetKeyPartitionKey(AssetKey("A"))}
+
+    # still true
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+    assert result.true_subset.asset_partitions == {AssetKeyPartitionKey(AssetKey("A"))}
+
+
+def test_time_partitioned() -> None:
+    state = (
+        AssetConditionScenarioState.create_from_state(one_asset, AssetCondition.latest_partitions())
+        .with_asset_properties(partitions_def=daily_partitions_def)
+        .with_current_time("2024-01-07 11:06:00")
+    )
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+    assert result.true_subset.asset_partitions == {
+        AssetKeyPartitionKey(AssetKey("A"), "2024-01-06")
+    }
+
+    # unchanged
+    state, result = state.evaluate("A")
+    assert result.true_subset.asset_partitions == {
+        AssetKeyPartitionKey(AssetKey("A"), "2024-01-06")
+    }
+
+    # unchanged
+    state, result = state.with_current_time_advanced(days=4).evaluate("A")
+    assert result.true_subset.asset_partitions == {
+        AssetKeyPartitionKey(AssetKey("A"), "2024-01-10")
+    }
+
+    # evaluate from scratch
+    _, result = state.without_previous_evaluation_state().evaluate("A")
+    assert result.true_subset.asset_partitions == {
+        AssetKeyPartitionKey(AssetKey("A"), "2024-01-10")
+    }
+
+
+def test_time_multi_partitioned() -> None:
+    state = (
+        AssetConditionScenarioState.create_from_state(one_asset, AssetCondition.latest_partitions())
+        .with_asset_properties(partitions_def=time_multipartitions_def)
+        .with_current_time("2024-01-07 11:06:00")
+    )
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 2
+    assert result.true_subset.asset_partitions == {
+        AssetKeyPartitionKey(AssetKey("A"), multi_partition_key(time="2024-01-06", static=s))
+        for s in ["1", "2"]
+    }
+
+    # unchanged
+    state, result = state.evaluate("A")
+    assert result.true_subset.asset_partitions == {
+        AssetKeyPartitionKey(AssetKey("A"), multi_partition_key(time="2024-01-06", static=s))
+        for s in ["1", "2"]
+    }
+
+    # unchanged
+    state, result = state.with_current_time_advanced(days=4).evaluate("A")
+    assert result.true_subset.asset_partitions == {
+        AssetKeyPartitionKey(AssetKey("A"), multi_partition_key(time="2024-01-10", static=s))
+        for s in ["1", "2"]
+    }
+
+    # evaluate from scratch
+    _, result = state.without_previous_evaluation_state().evaluate("A")
+    assert result.true_subset.asset_partitions == {
+        AssetKeyPartitionKey(AssetKey("A"), multi_partition_key(time="2024-01-10", static=s))
+        for s in ["1", "2"]
+    }


### PR DESCRIPTION
## Summary & Motivation

In the (near?) future, we should add a "time window lookback" argument to this to allow users to look back over a longer period of time. They'd specify it as some sort of "days=1, hours=3" sort of deal, and we'd then return true for any time partitions within that window.

I originally was imagining a static "n partitions" argument, but upon further reflection:
a) This is actually somewhat annoying perf-wise to implement for time-partitioned assets compared to a static "lookback"
b) I can't imagine that parameter being useful for anything _other_ than partitioned assets (why would anyone care about the last N partitions of a static partitioned asset?)
c) For time-partitioned assets, it's much easier to think in terms of time spans rather than n partitions anyway

## How I Tested These Changes
