### PR TITLE
enforce one output per asset key in AssetsDefinition

### DIFF
--- a/examples/with_airflow/with_airflow/assets_repository.py
+++ b/examples/with_airflow/with_airflow/assets_repository.py
@@ -17,14 +17,9 @@ def new_upstream_asset_2():
 simple_assets = load_assets_from_airflow_dag(
     simple_dag,
     task_ids_by_asset_key={
-        AssetKey("task_instances_0"): {
-            "get_task_instance_0",
-            "get_task_instance_0_0",
-            "get_task_instance_0_1",
-            "get_task_instance_0_2",
-        },
+        AssetKey("task_instances_0"): {"get_task_instance_0"},
         AssetKey("task_instance_2"): {"get_task_instance_2"},
-        AssetKey("new_asset"): {"sink_task_bar", "sink_task_foo"},
+        AssetKey("new_asset"): {"sink_task_bar"},
         AssetKey("task_instances_1"): {"get_task_instance_1"},
         AssetKey("task_instances_1_0"): {"get_task_instance_1_0"},
         AssetKey("task_instances_1_1"): {"get_task_instance_1_1"},

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2119,3 +2119,17 @@ def test_multi_asset_owners():
         AssetKey("out1"): [TeamAssetOwner("team1"), UserAssetOwner("user@dagsterlabs.com")],
         AssetKey("out2"): [UserAssetOwner("user2@dagsterlabs.com")],
     }
+
+
+def test_multiple_output_names_same_asset_key():
+    with pytest.raises(DagsterInvalidDefinitionError, match="both point to the same asset key"):
+
+        @op(out={"out1": Out(), "out2": Out()})
+        def op1():
+            ...
+
+        AssetsDefinition(
+            node_def=op1,
+            keys_by_output_name={"out1": AssetKey("a"), "out2": AssetKey("a")},
+            keys_by_input_name={},
+        )

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_assets.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_assets.py
@@ -65,8 +65,8 @@ def test_load_assets_from_airflow_dag():
         assets = load_assets_from_airflow_dag(
             dag=asset_dag,
             task_ids_by_asset_key={
-                AssetKey("foo_asset"): {"foo", "bar"},
-                AssetKey("biz_asset"): {"biz", "baz"},
+                AssetKey("foo_asset"): {"foo"},
+                AssetKey("biz_asset"): {"biz"},
             },
             upstream_dependencies_by_asset_key={
                 AssetKey("foo_asset"): {

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_assets_airflow_2.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_assets_airflow_2.py
@@ -59,8 +59,8 @@ def test_load_assets_from_airflow_dag():
         assets = load_assets_from_airflow_dag(
             dag=asset_dag,
             task_ids_by_asset_key={
-                AssetKey("foo_asset"): {"foo", "bar"},
-                AssetKey("biz_asset"): {"biz", "baz"},
+                AssetKey("foo_asset"): {"foo"},
+                AssetKey("biz_asset"): {"biz"},
             },
             upstream_dependencies_by_asset_key={
                 AssetKey("foo_asset"): {


### PR DESCRIPTION
## Summary & Motivation

In the constructor of `AssetsDefinition`, raises an error if multiple outputs of the node are assigned to the same asset key.

If multiple outputs target the same asset key, it breaks assumptions that are deeply ingrained but apparently rarely checked. E.g. you can end up with multiple `AssetMaterialization`s for the same asset within the same step.

Concerningly, the `task_ids_by_asset_key` argument to `load_assets_from_airflow_dag` appears to allow this pattern. However, changing that API is outside the scope of this PR.

## How I Tested These Changes

tests
