### PR TITLE
[external-assets] Move InternalAssetGraph to its own module

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -55,6 +55,7 @@ from .time_window_partitions import (
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+    from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 
 AssetKeyOrCheckKey = Union[AssetKey, AssetCheckKey]
 
@@ -164,6 +165,8 @@ class AssetGraph:
         all_assets: Iterable[Union[AssetsDefinition, SourceAsset]],
         asset_checks: Optional[Sequence[AssetChecksDefinition]] = None,
     ) -> "InternalAssetGraph":
+        from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
+
         assets_defs: List[AssetsDefinition] = []
         source_assets: List[SourceAsset] = []
         partitions_defs_by_key: Dict[AssetKey, Optional[PartitionsDefinition]] = {}
@@ -777,77 +780,6 @@ class AssetGraph:
 
     def __eq__(self, other: object) -> bool:
         return self is other
-
-
-class InternalAssetGraph(AssetGraph):
-    def __init__(
-        self,
-        asset_dep_graph: DependencyGraph[AssetKey],
-        source_asset_keys: AbstractSet[AssetKey],
-        partitions_defs_by_key: Mapping[AssetKey, Optional[PartitionsDefinition]],
-        partition_mappings_by_key: Mapping[AssetKey, Optional[Mapping[AssetKey, PartitionMapping]]],
-        group_names_by_key: Mapping[AssetKey, Optional[str]],
-        freshness_policies_by_key: Mapping[AssetKey, Optional[FreshnessPolicy]],
-        auto_materialize_policies_by_key: Mapping[AssetKey, Optional[AutoMaterializePolicy]],
-        backfill_policies_by_key: Mapping[AssetKey, Optional[BackfillPolicy]],
-        assets: Sequence[AssetsDefinition],
-        source_assets: Sequence[SourceAsset],
-        asset_checks: Sequence[AssetChecksDefinition],
-        code_versions_by_key: Mapping[AssetKey, Optional[str]],
-        is_observable_by_key: Mapping[AssetKey, bool],
-        auto_observe_interval_minutes_by_key: Mapping[AssetKey, Optional[float]],
-        required_assets_and_checks_by_key: Mapping[
-            AssetKeyOrCheckKey, AbstractSet[AssetKeyOrCheckKey]
-        ],
-    ):
-        super().__init__(
-            asset_dep_graph=asset_dep_graph,
-            source_asset_keys=source_asset_keys,
-            partitions_defs_by_key=partitions_defs_by_key,
-            partition_mappings_by_key=partition_mappings_by_key,
-            group_names_by_key=group_names_by_key,
-            freshness_policies_by_key=freshness_policies_by_key,
-            auto_materialize_policies_by_key=auto_materialize_policies_by_key,
-            backfill_policies_by_key=backfill_policies_by_key,
-            code_versions_by_key=code_versions_by_key,
-            is_observable_by_key=is_observable_by_key,
-            auto_observe_interval_minutes_by_key=auto_observe_interval_minutes_by_key,
-            required_assets_and_checks_by_key=required_assets_and_checks_by_key,
-        )
-        self._assets = assets
-        self._source_assets = source_assets
-        self._asset_checks = asset_checks
-
-        asset_check_keys = set()
-        for asset_check in asset_checks:
-            asset_check_keys.update([spec.key for spec in asset_check.specs])
-        for asset in assets:
-            asset_check_keys.update([spec.key for spec in asset.check_specs])
-        self._asset_check_keys = asset_check_keys
-
-    @property
-    def asset_check_keys(self) -> AbstractSet[AssetCheckKey]:
-        return self._asset_check_keys
-
-    @property
-    def assets(self) -> Sequence[AssetsDefinition]:
-        return self._assets
-
-    @property
-    def source_assets(self) -> Sequence[SourceAsset]:
-        return self._source_assets
-
-    @property
-    def asset_checks(self) -> Sequence[AssetChecksDefinition]:
-        return self._asset_checks
-
-    def includes_materializable_and_source_assets(self, asset_keys: AbstractSet[AssetKey]) -> bool:
-        """Returns true if the given asset keys contains at least one materializable asset and
-        at least one source asset.
-        """
-        selected_source_assets = self.source_asset_keys & asset_keys
-        selected_regular_assets = asset_keys - self.source_asset_keys
-        return len(selected_source_assets) > 0 and len(selected_regular_assets) > 0
 
 
 def sort_key_for_asset_partition(

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -21,7 +21,7 @@ from dagster._core.selector.subset_selector import (
 from dagster._serdes.serdes import whitelist_for_serdes
 
 from .asset_check_spec import AssetCheckKey
-from .asset_graph import AssetGraph, InternalAssetGraph
+from .asset_graph import AssetGraph
 from .assets import AssetsDefinition
 from .events import (
     AssetKey,
@@ -29,6 +29,7 @@ from .events import (
     CoercibleToAssetKeyPrefix,
     key_prefix_from_coercible,
 )
+from .internal_asset_graph import InternalAssetGraph
 from .source_asset import SourceAsset
 
 CoercibleToAssetSelection: TypeAlias = Union[

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -18,9 +18,9 @@ from dagster._config.pythonic_config import (
     attach_resource_id_to_key_mapping,
 )
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
-from dagster._core.definitions.asset_graph import InternalAssetGraph
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import ExecutorDefinition
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.build_resources import wrap_resources_for_execution

--- a/python_modules/dagster/dagster/_core/definitions/internal_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/internal_asset_graph.py
@@ -1,0 +1,85 @@
+from typing import AbstractSet, Mapping, Optional, Sequence
+
+from dagster._core.definitions.asset_check_spec import AssetCheckKey
+from dagster._core.definitions.asset_checks import AssetChecksDefinition
+from dagster._core.definitions.asset_graph import AssetGraph, AssetKeyOrCheckKey
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from dagster._core.definitions.backfill_policy import BackfillPolicy
+from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.partition import PartitionsDefinition
+from dagster._core.definitions.partition_mapping import PartitionMapping
+from dagster._core.definitions.source_asset import SourceAsset
+from dagster._core.selector.subset_selector import DependencyGraph
+
+
+class InternalAssetGraph(AssetGraph):
+    def __init__(
+        self,
+        asset_dep_graph: DependencyGraph[AssetKey],
+        source_asset_keys: AbstractSet[AssetKey],
+        partitions_defs_by_key: Mapping[AssetKey, Optional[PartitionsDefinition]],
+        partition_mappings_by_key: Mapping[AssetKey, Optional[Mapping[AssetKey, PartitionMapping]]],
+        group_names_by_key: Mapping[AssetKey, Optional[str]],
+        freshness_policies_by_key: Mapping[AssetKey, Optional[FreshnessPolicy]],
+        auto_materialize_policies_by_key: Mapping[AssetKey, Optional[AutoMaterializePolicy]],
+        backfill_policies_by_key: Mapping[AssetKey, Optional[BackfillPolicy]],
+        assets: Sequence[AssetsDefinition],
+        source_assets: Sequence[SourceAsset],
+        asset_checks: Sequence[AssetChecksDefinition],
+        code_versions_by_key: Mapping[AssetKey, Optional[str]],
+        is_observable_by_key: Mapping[AssetKey, bool],
+        auto_observe_interval_minutes_by_key: Mapping[AssetKey, Optional[float]],
+        required_assets_and_checks_by_key: Mapping[
+            AssetKeyOrCheckKey, AbstractSet[AssetKeyOrCheckKey]
+        ],
+    ):
+        super().__init__(
+            asset_dep_graph=asset_dep_graph,
+            source_asset_keys=source_asset_keys,
+            partitions_defs_by_key=partitions_defs_by_key,
+            partition_mappings_by_key=partition_mappings_by_key,
+            group_names_by_key=group_names_by_key,
+            freshness_policies_by_key=freshness_policies_by_key,
+            auto_materialize_policies_by_key=auto_materialize_policies_by_key,
+            backfill_policies_by_key=backfill_policies_by_key,
+            code_versions_by_key=code_versions_by_key,
+            is_observable_by_key=is_observable_by_key,
+            auto_observe_interval_minutes_by_key=auto_observe_interval_minutes_by_key,
+            required_assets_and_checks_by_key=required_assets_and_checks_by_key,
+        )
+        self._assets = assets
+        self._source_assets = source_assets
+        self._asset_checks = asset_checks
+
+        asset_check_keys = set()
+        for asset_check in asset_checks:
+            asset_check_keys.update([spec.key for spec in asset_check.specs])
+        for asset in assets:
+            asset_check_keys.update([spec.key for spec in asset.check_specs])
+        self._asset_check_keys = asset_check_keys
+
+    @property
+    def asset_check_keys(self) -> AbstractSet[AssetCheckKey]:
+        return self._asset_check_keys
+
+    @property
+    def assets(self) -> Sequence[AssetsDefinition]:
+        return self._assets
+
+    @property
+    def source_assets(self) -> Sequence[SourceAsset]:
+        return self._source_assets
+
+    @property
+    def asset_checks(self) -> Sequence[AssetChecksDefinition]:
+        return self._asset_checks
+
+    def includes_materializable_and_source_assets(self, asset_keys: AbstractSet[AssetKey]) -> bool:
+        """Returns true if the given asset keys contains at least one materializable asset and
+        at least one source asset.
+        """
+        selected_source_assets = self.source_asset_keys & asset_keys
+        selected_regular_assets = asset_keys - self.source_asset_keys
+        return len(selected_source_assets) > 0 and len(selected_regular_assets) > 0

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -23,7 +23,7 @@ from dagster._config.pythonic_config import (
     ResourceWithKeyMapping,
 )
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
-from dagster._core.definitions.asset_graph import AssetGraph, InternalAssetGraph
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.assets_job import (
     get_base_asset_jobs,
     is_base_asset_job_name,
@@ -33,6 +33,7 @@ from dagster._core.definitions.auto_materialize_sensor_definition import (
 )
 from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.graph_definition import GraphDefinition
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.definitions.partitioned_schedule import (

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -16,13 +16,14 @@ from typing import (
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
-from dagster._core.definitions.asset_graph import AssetGraph, InternalAssetGraph
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.assets_job import (
     ASSET_BASE_JOB_PREFIX,
 )
 from dagster._core.definitions.cacheable_assets import AssetsDefinitionCacheableData
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import ExecutorDefinition
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.definitions.metadata import MetadataMapping

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
         PartitionsDefinition,
         ResourceDefinition,
     )
-    from dagster._core.definitions.asset_graph import InternalAssetGraph
     from dagster._core.definitions.asset_selection import CoercibleToAssetSelection
+    from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
     from dagster._core.definitions.run_config import RunConfig
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_check_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_check_selection.py
@@ -2,7 +2,8 @@ from typing import Any, Dict
 
 import pytest
 from dagster import AssetCheckKey, AssetKey, AssetsDefinition
-from dagster._core.definitions.asset_graph import AssetGraph, InternalAssetGraph
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster_dbt import (
     DagsterDbtTranslator,
     DagsterDbtTranslatorSettings,


### PR DESCRIPTION
## Summary & Motivation

Move `InternalAssetGraph` to its own module (out of asset_graph.py) to match external_asset_graph.py.

## How I Tested These Changes

Existing test suite.