### PR TITLE
Add flag to run retries to choose whether to retry when the run failed due to a step failure

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
+++ b/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
@@ -3,6 +3,7 @@ import time
 from typing import cast
 
 from dagster import DagsterEvent, DagsterEventType, DagsterInstance, EventLogEntry
+from dagster._core.events import JobFailureData, RunFailureReason
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.snap import snapshot_from_execution_plan
@@ -71,6 +72,45 @@ def test_filter_runs_to_should_retry(instance):
             )
         )
         == 1
+    )
+
+
+def test_filter_runs_no_retry_on_asset_or_op_failure(instance_no_retry_on_asset_or_op_failure):
+    instance = instance_no_retry_on_asset_or_op_failure
+
+    run = create_run(instance, status=DagsterRunStatus.STARTED, tags={MAX_RETRIES_TAG: "2"})
+
+    assert list(filter_runs_to_should_retry([run], instance, 2)) == []
+
+    dagster_event = DagsterEvent(
+        event_type_value=DagsterEventType.PIPELINE_FAILURE.value,
+        job_name=run.job_name,
+        message="oops step failure",
+        event_specific_data=JobFailureData(
+            error=None, failure_reason=RunFailureReason.STEP_FAILURE
+        ),
+    )
+    instance.report_dagster_event(dagster_event, run_id=run.run_id, log_level=logging.ERROR)
+
+    # doesn't retry because its a step failure
+
+    assert (
+        len(
+            list(
+                filter_runs_to_should_retry(
+                    instance.get_runs(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+                    instance,
+                    2,
+                )
+            )
+        )
+        == 0
+    )
+
+    assert any(
+        "Not retrying run since it failed due to a step failure and run retries are configured with retry_on_asset_or_op_failure set to false."
+        in str(event)
+        for event in instance.all_logs(run.run_id)
     )
 
 

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -365,6 +365,17 @@ def dagster_instance_config_schema() -> Mapping[str, Field]:
             {
                 "enabled": Field(bool, is_required=False, default_value=False),
                 "max_retries": Field(int, is_required=False, default_value=0),
+                "retry_on_asset_or_op_failure": Field(
+                    bool,
+                    is_required=False,
+                    default_value=True,
+                    description="Whether to retry runs that failed due to steps in the run failing. "
+                    "Set this to false if you only want to retry failures that occur "
+                    "due to the run worker crashing or unexpectedly terminating, and instead "
+                    "rely on op or asset-level retry policies to retry step failures. Setting this "
+                    "field to false will only change retry behavior for runs on dagster "
+                    "version 1.6.7 or greater.",
+                ),
             }
         ),
         "code_servers": Field(

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -3,11 +3,16 @@ from typing import Iterator, Optional, Sequence, Tuple, cast
 
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.selector import JobSubsetSelector
-from dagster._core.events import EngineEventData
+from dagster._core.events import EngineEventData, RunFailureReason
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunRecord
-from dagster._core.storage.tags import MAX_RETRIES_TAG, RETRY_NUMBER_TAG, RETRY_STRATEGY_TAG
+from dagster._core.storage.tags import (
+    MAX_RETRIES_TAG,
+    RETRY_NUMBER_TAG,
+    RETRY_STRATEGY_TAG,
+    RUN_FAILURE_REASON_TAG,
+)
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._utils.error import serializable_error_info_from_exc_info
 
@@ -56,10 +61,24 @@ def filter_runs_to_should_retry(
         else:
             return 1
 
+    retry_on_asset_or_op_failure = instance.get_settings("run_retries").get(
+        "retry_on_asset_or_op_failure", True
+    )
+
     for run in runs:
         retry_number = get_retry_number(run)
         if retry_number is not None:
-            yield (run, retry_number)
+            if (
+                run.tags.get(RUN_FAILURE_REASON_TAG) == RunFailureReason.STEP_FAILURE.value
+                and not retry_on_asset_or_op_failure
+            ):
+                instance.report_engine_event(
+                    "Not retrying run since it failed due to a step failure and run retries "
+                    "are configured with retry_on_asset_or_op_failure set to false.",
+                    run,
+                )
+            else:
+                yield (run, retry_number)
 
 
 def get_reexecution_strategy(


### PR DESCRIPTION
## Summary & Motivation
Add a flag that allows you to configure both run retries so that they only kick in on unexpected events that kill the run worker, like an unhandled exception or the k8s cluster terminating your run unexpectedly.

## How I Tested These Changes
BK, set this flag locally and verify that retries don't happen on runs that fail on step failures
