### PR TITLE
[refactor] Split AssetDaemonScenarioState

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -98,7 +98,7 @@ daemon_scenarios = [*basic_scenarios, *partition_scenarios]
 auto_materialize_sensor_scenarios = [
     AssetDaemonScenario(
         id="basic_hourly_cron_unpartitioned",
-        initial_state=one_asset.with_asset_properties(
+        initial_graph=one_asset.with_asset_properties(
             auto_materialize_policy=get_cron_policy(basic_hourly_cron_schedule)
         ).with_current_time("2020-01-01T00:05"),
         execution_fn=lambda state: state.evaluate_tick()
@@ -120,7 +120,7 @@ auto_materialize_sensor_scenarios = [
     ),
     AssetDaemonScenario(
         id="sensor_interval_respected",
-        initial_state=two_assets_in_sequence.with_all_eager(),
+        initial_graph=two_assets_in_sequence.with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(["A", "B"]))
         .evaluate_tick()
         .assert_requested_runs()  # No runs initially
@@ -136,7 +136,7 @@ auto_materialize_sensor_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_asset_never_materialized",
-        initial_state=one_asset.with_all_eager(),
+        initial_graph=one_asset.with_all_eager(),
         execution_fn=lambda state: state.evaluate_tick()
         .assert_requested_runs(run_request(asset_keys=["A"]))
         .assert_evaluation(
@@ -145,7 +145,7 @@ auto_materialize_sensor_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_asset_already_launched",
-        initial_state=one_asset.with_all_eager(),
+        initial_graph=one_asset.with_all_eager(),
         execution_fn=lambda state: state.evaluate_tick()
         .assert_requested_runs(run_request(asset_keys=["A"]))
         .with_current_time_advanced(seconds=30)
@@ -233,7 +233,7 @@ def _create_tick(instance: DagsterInstance, status: TickStatus, timestamp: float
 # valid at the start may not be valid when repeated.
 daemon_scenario = AssetDaemonScenario(
     id="simple_daemon_scenario",
-    initial_state=two_assets_in_sequence.with_asset_properties(
+    initial_graph=two_assets_in_sequence.with_asset_properties(
         partitions_def=two_partitions_def
     ).with_all_eager(2),
     execution_fn=lambda state: state.evaluate_tick(),
@@ -279,7 +279,7 @@ three_assets = AssetDaemonScenarioState(
 
 daemon_sensor_scenario = AssetDaemonScenario(
     id="simple_daemon_scenario",
-    initial_state=three_assets.with_auto_materialize_sensors(
+    initial_graph=three_assets.with_auto_materialize_sensors(
         [
             AutoMaterializeSensorDefinition(
                 name="auto_materialize_sensor_a",
@@ -683,7 +683,7 @@ def test_auto_materialize_sensor_ticks(num_threads):
 
 def test_default_purge() -> None:
     with get_daemon_instance() as instance:
-        scenario_time = daemon_scenario.initial_state.current_time
+        scenario_time = daemon_scenario.initial_graph.current_time
         _create_tick(
             instance, TickStatus.SKIPPED, (scenario_time - datetime.timedelta(days=8)).timestamp()
         )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario_states.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario_states.py
@@ -1,3 +1,6 @@
+import datetime
+from typing import Final
+
 import pendulum
 from dagster import AssetSpec, StaticPartitionsDefinition
 from dagster._core.definitions.asset_dep import AssetDep
@@ -10,7 +13,7 @@ from dagster._core.definitions.time_window_partitions import (
     HourlyPartitionsDefinition,
 )
 
-from ..asset_daemon_scenario import AssetDaemonScenarioState, MultiAssetSpec
+from ..asset_daemon_scenario import AssetGraphSpec, MultiAssetSpec
 
 ############
 # PARTITIONS
@@ -21,7 +24,7 @@ two_partitions_def = StaticPartitionsDefinition(["1", "2"])
 three_partitions_def = StaticPartitionsDefinition(["1", "2", "3"])
 
 time_partitions_start_str = "2013-01-05"
-time_partitions_start_datetime = pendulum.parse(time_partitions_start_str)
+time_partitions_start_datetime: Final[datetime.datetime] = pendulum.parse(time_partitions_start_str)
 hourly_partitions_def = HourlyPartitionsDefinition(start_date=time_partitions_start_str + "-00:00")
 daily_partitions_def = DailyPartitionsDefinition(start_date=time_partitions_start_str)
 time_multipartitions_def = MultiPartitionsDefinition(
@@ -36,25 +39,25 @@ self_partition_mapping = TimeWindowPartitionMapping(start_offset=-1, end_offset=
 ##############
 # BASIC STATES
 ##############
-one_asset = AssetDaemonScenarioState(asset_specs=[AssetSpec("A")])
+one_asset = AssetGraphSpec(asset_specs=[AssetSpec("A")])
 
-two_assets_in_sequence = AssetDaemonScenarioState(
+two_assets_in_sequence = AssetGraphSpec(
     asset_specs=[AssetSpec("A"), AssetSpec("B", deps=["A"])],
 )
 
-three_assets_in_sequence = AssetDaemonScenarioState(
+three_assets_in_sequence = AssetGraphSpec(
     asset_specs=[AssetSpec("A"), AssetSpec("B", deps=["A"]), AssetSpec("C", deps=["B"])],
 )
 
-two_assets_depend_on_one = AssetDaemonScenarioState(
+two_assets_depend_on_one = AssetGraphSpec(
     asset_specs=[AssetSpec("A"), AssetSpec("B", deps=["A"]), AssetSpec("C", deps=["A"])]
 )
 
-one_asset_depends_on_two = AssetDaemonScenarioState(
+one_asset_depends_on_two = AssetGraphSpec(
     asset_specs=[AssetSpec("A"), AssetSpec("B"), AssetSpec("C", deps=["A", "B"])]
 )
 
-diamond = AssetDaemonScenarioState(
+diamond = AssetGraphSpec(
     asset_specs=[
         AssetSpec(key="A"),
         AssetSpec(key="B", deps=["A"]),
@@ -63,7 +66,7 @@ diamond = AssetDaemonScenarioState(
     ]
 )
 
-three_assets_not_subsettable = AssetDaemonScenarioState(
+three_assets_not_subsettable = AssetGraphSpec(
     asset_specs=[
         MultiAssetSpec(
             specs=[AssetSpec("A"), AssetSpec("B"), AssetSpec("C")],

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
@@ -11,7 +11,7 @@ from .asset_daemon_scenario_states import one_asset, two_assets_in_sequence
 custom_condition_scenarios = [
     AssetDaemonScenario(
         id="funky_custom_condition_scenario",
-        initial_state=one_asset.with_asset_properties(
+        initial_graph=one_asset.with_asset_properties(
             auto_materialize_policy=AutoMaterializePolicy.from_asset_condition(
                 # intentionally funky condition
                 # not ((not missing) | (parent_updated)) ->
@@ -28,7 +28,7 @@ custom_condition_scenarios = [
     ),
     AssetDaemonScenario(
         id="funky_custom_condition_static_constructor_scenario",
-        initial_state=one_asset.with_asset_properties(
+        initial_graph=one_asset.with_asset_properties(
             auto_materialize_policy=AutoMaterializePolicy.from_asset_condition(
                 # same as above, but with static constructor
                 ~(~AssetCondition.missing() & AssetCondition.parent_newer())
@@ -40,13 +40,14 @@ custom_condition_scenarios = [
     ),
     AssetDaemonScenario(
         id="parent_newer_and_not_updated_since_cron_scenario",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_graph=two_assets_in_sequence.with_asset_properties(
             "B",
             auto_materialize_policy=AutoMaterializePolicy.from_asset_condition(
                 ~AssetCondition.updated_since_cron("@daily") & AssetCondition.parent_newer()
             ),
-        ).with_current_time("2024-01-01 00:01:00"),
-        execution_fn=lambda state: state.evaluate_tick()
+        ),
+        execution_fn=lambda state: state.with_current_time("2024-01-01 00:01:00")
+        .evaluate_tick()
         .assert_requested_runs()
         .with_runs(run_request("A"))
         # has not been updated since cron, and parent is newer

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/latest_materialization_run_tag_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/latest_materialization_run_tag_scenarios.py
@@ -24,7 +24,7 @@ filter_latest_run_tag_key_policy = (
 latest_materialization_run_tag_scenarios = [
     AssetDaemonScenario(
         id="latest_parent_materialization_has_required_tag",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_graph=two_assets_in_sequence.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(
@@ -35,7 +35,7 @@ latest_materialization_run_tag_scenarios = [
     ),
     AssetDaemonScenario(
         id="latest_parent_materialization_missing_required_tag",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_graph=two_assets_in_sequence.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(run_request(["A", "B"]), run_request(["A"]))
@@ -44,7 +44,7 @@ latest_materialization_run_tag_scenarios = [
     ),
     AssetDaemonScenario(
         id="latest_parent_materialization_missing_one_of_required_tags",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_graph=two_assets_in_sequence.with_asset_properties(
             auto_materialize_policy=AutoMaterializePolicy.eager()
             .without_rules(AutoMaterializeRule.materialize_on_parent_updated())
             .with_rules(
@@ -66,7 +66,7 @@ latest_materialization_run_tag_scenarios = [
     ),
     AssetDaemonScenario(
         id="earlier_parent_materialization_missing_required_tag",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_graph=two_assets_in_sequence.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(
@@ -79,7 +79,7 @@ latest_materialization_run_tag_scenarios = [
     ),
     AssetDaemonScenario(
         id="only_updated_parent_missing_required_tag",
-        initial_state=one_asset_depends_on_two.with_asset_properties(
+        initial_graph=one_asset_depends_on_two.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(
@@ -91,7 +91,7 @@ latest_materialization_run_tag_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_updated_parent_has_required_tag_but_other_does_not",
-        initial_state=one_asset_depends_on_two.with_asset_properties(
+        initial_graph=one_asset_depends_on_two.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(
@@ -104,7 +104,7 @@ latest_materialization_run_tag_scenarios = [
     ),
     AssetDaemonScenario(
         id="latest_materialization_missing_required_tag_but_will_update",
-        initial_state=three_assets_in_sequence.with_asset_properties(
+        initial_graph=three_assets_in_sequence.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(
@@ -119,7 +119,7 @@ latest_materialization_run_tag_scenarios = [
         # this ensures that updates that happened prior to the cursor of the current tick
         # get ignored if they're missing the required keys
         id="latest_materialization_missing_required_tag_previous_tick",
-        initial_state=one_asset_depends_on_two.with_asset_properties(
+        initial_graph=one_asset_depends_on_two.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
@@ -46,68 +46,66 @@ from .asset_daemon_scenario_states import (
 partition_scenarios = [
     AssetDaemonScenario(
         id="one_asset_one_partition_never_materialized",
-        initial_state=one_asset.with_asset_properties(
-            partitions_def=one_partitions_def
-        ).with_all_eager(),
-        execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
-            run_request(asset_keys=["A"], partition_key="1")
-        ),
+        initial_graph=one_asset.with_asset_properties(partitions_def=one_partitions_def),
+        execution_fn=lambda state: state.with_all_eager()
+        .evaluate_tick()
+        .assert_requested_runs(run_request(asset_keys=["A"], partition_key="1")),
     ),
     AssetDaemonScenario(
         id="one_asset_two_partitions_never_materialized",
-        initial_state=one_asset.with_asset_properties(
+        initial_graph=one_asset.with_asset_properties(
             partitions_def=two_partitions_def,
-        ).with_all_eager(2),
-        execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
+        ),
+        execution_fn=lambda state: state.with_all_eager(2)
+        .evaluate_tick()
+        .assert_requested_runs(
             run_request(asset_keys=["A"], partition_key="1"),
             run_request(asset_keys=["A"], partition_key="2"),
         ),
     ),
     AssetDaemonScenario(
         id="two_assets_one_partition_never_materialized",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_graph=two_assets_in_sequence.with_asset_properties(
             partitions_def=one_partitions_def
-        ).with_all_eager(),
-        execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
-            run_request(asset_keys=["A", "B"], partition_key="1")
         ),
+        execution_fn=lambda state: state.with_all_eager()
+        .evaluate_tick()
+        .assert_requested_runs(run_request(asset_keys=["A", "B"], partition_key="1")),
     ),
     AssetDaemonScenario(
         id="one_asset_one_partition_already_requested",
-        initial_state=one_asset.with_asset_properties(
-            partitions_def=one_partitions_def
-        ).with_all_eager(),
-        execution_fn=lambda state: state.evaluate_tick()
+        initial_graph=one_asset.with_asset_properties(partitions_def=one_partitions_def),
+        execution_fn=lambda state: state.with_all_eager()
+        .evaluate_tick()
         .assert_requested_runs(run_request(asset_keys=["A"], partition_key="1"))
         .evaluate_tick()
         .assert_requested_runs(),
     ),
     AssetDaemonScenario(
         id="one_asset_one_partition_already_materialized",
-        initial_state=one_asset.with_asset_properties(
-            partitions_def=one_partitions_def
-        ).with_all_eager(),
-        execution_fn=lambda state: state.with_runs(run_request(asset_keys=["A"], partition_key="1"))
+        initial_graph=one_asset.with_asset_properties(partitions_def=one_partitions_def),
+        execution_fn=lambda state: state.with_all_eager()
+        .with_runs(run_request(asset_keys=["A"], partition_key="1"))
         .evaluate_tick()
         .assert_requested_runs(),
     ),
     AssetDaemonScenario(
         id="two_assets_one_partition_already_materialized",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_graph=two_assets_in_sequence.with_asset_properties(
             partitions_def=one_partitions_def
-        ).with_all_eager(),
-        execution_fn=lambda state: state.with_runs(
-            run_request(asset_keys=["A", "B"], partition_key="1")
-        )
+        ),
+        execution_fn=lambda state: state.with_all_eager()
+        .with_runs(run_request(asset_keys=["A", "B"], partition_key="1"))
         .evaluate_tick()
         .assert_requested_runs(),
     ),
     AssetDaemonScenario(
         id="two_assets_both_upstream_partitions_materialized",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_graph=two_assets_in_sequence.with_asset_properties(
             partitions_def=two_partitions_def
-        ).with_all_eager(2),
-        execution_fn=lambda state: state.with_runs(
+        ),
+        execution_fn=lambda state: state.with_all_eager(2)
+        .with_runs(
             run_request(asset_keys=["A"], partition_key="1"),
             run_request(asset_keys=["A"], partition_key="2"),
         )
@@ -119,19 +117,21 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="parent_one_partition_one_run",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_graph=two_assets_in_sequence.with_asset_properties(
             partitions_def=one_partitions_def
-        ).with_all_eager(),
-        execution_fn=lambda state: state.with_runs(run_request(asset_keys=["A"], partition_key="1"))
+        ),
+        execution_fn=lambda state: state.with_all_eager()
+        .with_runs(run_request(asset_keys=["A"], partition_key="1"))
         .evaluate_tick()
         .assert_requested_runs(run_request(asset_keys=["B"], partition_key="1")),
     ),
     AssetDaemonScenario(
         id="parent_rematerialized_one_partition",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_graph=two_assets_in_sequence.with_asset_properties(
             partitions_def=one_partitions_def
-        ).with_all_eager(),
-        execution_fn=lambda state: state.with_runs(
+        ),
+        execution_fn=lambda state: state.with_all_eager()
+        .with_runs(
             run_request(asset_keys=["A", "B"], partition_key="1"),
             run_request(asset_keys=["A"], partition_key="1"),
         )
@@ -140,10 +140,11 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="unpartitioned_to_dynamic_partitions",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_graph=two_assets_in_sequence.with_asset_properties(
             keys=["B"], partitions_def=dynamic_partitions_def
-        ).with_all_eager(10),
-        execution_fn=lambda state: state.with_runs(run_request("A"))
+        ),
+        execution_fn=lambda state: state.with_all_eager(10)
+        .with_runs(run_request("A"))
         .evaluate_tick()
         .assert_requested_runs()
         .with_dynamic_partitions("dynamic", ["1"])
@@ -162,34 +163,41 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_asset_daily_partitions_never_materialized",
-        initial_state=one_asset.with_asset_properties(partitions_def=daily_partitions_def)
-        .with_current_time(time_partitions_start_str)
+        initial_graph=one_asset.with_asset_properties(partitions_def=daily_partitions_def),
+        execution_fn=lambda state: state.with_current_time(time_partitions_start_str)
         .with_current_time_advanced(days=2, hours=4)
-        .with_all_eager(),
-        execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
-            run_request(asset_keys=["A"], partition_key=day_partition_key(state.current_time))
+        .with_all_eager()
+        .evaluate_tick()
+        .assert_requested_runs(
+            run_request(
+                asset_keys=["A"],
+                partition_key=day_partition_key(time_partitions_start_datetime, delta=1),
+            )
         ),
     ),
     AssetDaemonScenario(
         id="one_asset_daily_partitions_never_materialized_respect_discards",
-        initial_state=one_asset.with_asset_properties(partitions_def=daily_partitions_def)
-        .with_current_time(time_partitions_start_str)
+        initial_graph=one_asset.with_asset_properties(partitions_def=daily_partitions_def),
+        execution_fn=lambda state: state.with_current_time(time_partitions_start_str)
         .with_current_time_advanced(days=30, hours=4)
-        .with_all_eager(),
-        execution_fn=lambda state: state.evaluate_tick()
+        .with_all_eager()
+        .evaluate_tick()
         .assert_requested_runs(
-            run_request(asset_keys=["A"], partition_key=day_partition_key(state.current_time))
+            run_request(
+                asset_keys=["A"],
+                partition_key=day_partition_key(time_partitions_start_datetime, delta=29),
+            )
         )
         .assert_evaluation(
             "A",
             [
                 AssetRuleEvaluationSpec(
                     AutoMaterializeRule.materialize_on_missing(),
-                    [day_partition_key(state.current_time, delta=-i) for i in range(30)],
+                    [day_partition_key(time_partitions_start_datetime, delta=i) for i in range(30)],
                 ),
                 AssetRuleEvaluationSpec(
                     DiscardOnMaxMaterializationsExceededRule(limit=1),
-                    [day_partition_key(state.current_time, delta=-i) for i in range(1, 30)],
+                    [day_partition_key(time_partitions_start_datetime, delta=i) for i in range(29)],
                 ),
             ],
             num_requested=1,
@@ -197,23 +205,30 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_asset_daily_partitions_two_years_never_materialized",
-        initial_state=one_asset.with_asset_properties(partitions_def=daily_partitions_def)
-        .with_current_time(time_partitions_start_str)
+        initial_graph=one_asset.with_asset_properties(partitions_def=daily_partitions_def),
+        execution_fn=lambda state: state.with_current_time(time_partitions_start_str)
         .with_current_time_advanced(years=2, hours=4)
-        .with_all_eager(),
-        execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
-            run_request(asset_keys=["A"], partition_key=day_partition_key(state.current_time))
+        .with_all_eager()
+        .evaluate_tick()
+        .assert_requested_runs(
+            run_request(
+                asset_keys=["A"],
+                partition_key=day_partition_key(time_partitions_start_datetime, delta=365 * 2 - 1),
+            )
         ),
     ),
     AssetDaemonScenario(
         id="hourly_to_daily_partitions_never_materialized",
-        initial_state=hourly_to_daily.with_current_time(time_partitions_start_str)
+        initial_graph=hourly_to_daily,
+        execution_fn=lambda state: state.with_current_time(time_partitions_start_str)
         .with_current_time_advanced(days=3, hours=1)
-        .with_all_eager(100),
-        execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
+        .with_all_eager(100)
+        .evaluate_tick()
+        .assert_requested_runs(
             *(
                 run_request(
-                    asset_keys=["A"], partition_key=hour_partition_key(state.current_time, delta=-i)
+                    asset_keys=["A"],
+                    partition_key=hour_partition_key(time_partitions_start_datetime, delta=i),
                 )
                 for i in range(24 * 3 + 1)
             )
@@ -221,13 +236,15 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="hourly_to_daily_partitions_never_materialized2",
-        initial_state=hourly_to_daily.with_current_time(time_partitions_start_str)
+        initial_graph=hourly_to_daily,
+        execution_fn=lambda state: state.with_current_time(time_partitions_start_str)
         .with_current_time_advanced(days=1, hours=4)
-        .with_all_eager(100),
-        execution_fn=lambda state: state.with_runs(
+        .with_all_eager(100)
+        .with_runs(
             *[
                 run_request(
-                    ["A"], partition_key=hour_partition_key(state.current_time, delta=-i - 4)
+                    ["A"],
+                    partition_key=hour_partition_key(time_partitions_start_datetime, delta=i),
                 )
                 for i in range(24)
             ]
@@ -236,16 +253,20 @@ partition_scenarios = [
         .assert_requested_runs(
             *(
                 run_request(
-                    asset_keys=["A"], partition_key=hour_partition_key(state.current_time, delta=-i)
+                    asset_keys=["A"],
+                    partition_key=hour_partition_key(time_partitions_start_datetime, delta=24 + i),
                 )
                 for i in range(4)
             ),
-            run_request(asset_keys=["B"], partition_key=day_partition_key(state.current_time)),
+            run_request(
+                asset_keys=["B"],
+                partition_key=day_partition_key(time_partitions_start_datetime),
+            ),
         ),
     ),
     AssetDaemonScenario(
         id="hourly_to_daily_nonexistent_partitions",
-        initial_state=hourly_to_daily.with_asset_properties(
+        initial_graph=hourly_to_daily.with_asset_properties(
             keys=["B"], partitions_def=daily_partitions_def._replace(end_offset=1)
         )
         # allow nonexistent upstream partitions
@@ -259,52 +280,60 @@ partition_scenarios = [
                     ),
                 )
             ],
-        )
-        .with_current_time(time_partitions_start_str)
+        ),
+        execution_fn=lambda state: state.with_current_time(time_partitions_start_str)
         .with_current_time_advanced(hours=9)
-        .with_all_eager(),
-        execution_fn=lambda state: state.with_runs(
+        .with_all_eager()
+        .with_runs(
             *(
                 run_request(
                     ["A"], partition_key=hour_partition_key(time_partitions_start_datetime, delta=i)
                 )
-                for i in range(1, 10)
+                for i in range(9)
             )
         )
         .evaluate_tick()
         .assert_requested_runs(
-            run_request(["B"], partition_key=day_partition_key(state.current_time, delta=1))
+            run_request(["B"], partition_key=day_partition_key(time_partitions_start_datetime))
         )
         .with_not_started_runs()
-        .with_runs(run_request(["A"], partition_key=hour_partition_key(state.current_time)))
+        .with_runs(
+            run_request(
+                ["A"], partition_key=hour_partition_key(time_partitions_start_datetime, delta=1)
+            )
+        )
         .evaluate_tick()
         .assert_requested_runs(
-            run_request(["B"], partition_key=day_partition_key(state.current_time, delta=1))
+            run_request(["B"], partition_key=day_partition_key(time_partitions_start_datetime))
         )
         .with_not_started_runs()
         .evaluate_tick()
         .assert_requested_runs()
         # now stop allowing non-existent upstream partitions and rematerialize A
         .with_asset_properties(keys=["B"], deps=["A"])
-        .with_runs(run_request(["A"], partition_key=hour_partition_key(state.current_time)))
+        .with_runs(
+            run_request(
+                ["A"], partition_key=hour_partition_key(time_partitions_start_datetime, delta=1)
+            )
+        )
         .evaluate_tick()
         # B cannot be materialized for this partition
         .assert_requested_runs(),
     ),
     AssetDaemonScenario(
         id="hourly_to_daily_nonexistent_partitions_become_existent",
-        initial_state=hourly_to_daily.with_asset_properties(
+        initial_graph=hourly_to_daily.with_asset_properties(
             keys=["B"], partitions_def=daily_partitions_def._replace(end_offset=1)
-        )
-        .with_current_time(time_partitions_start_str)
+        ),
+        execution_fn=lambda state: state.with_current_time(time_partitions_start_str)
         .with_current_time_advanced(hours=10)
-        .with_all_eager(),
-        execution_fn=lambda state: state.with_runs(
+        .with_all_eager()
+        .with_runs(
             *(
                 run_request(
                     ["A"], partition_key=hour_partition_key(time_partitions_start_datetime, delta=i)
                 )
-                for i in range(1, 11)
+                for i in range(10)
             )
         )
         .evaluate_tick()
@@ -315,7 +344,7 @@ partition_scenarios = [
                 run_request(
                     ["A"], partition_key=hour_partition_key(time_partitions_start_datetime, delta=i)
                 )
-                for i in range(11, 21)
+                for i in range(10, 20)
             )
         )
         .evaluate_tick()
@@ -327,24 +356,25 @@ partition_scenarios = [
                 run_request(
                     ["A"], partition_key=hour_partition_key(time_partitions_start_datetime, delta=i)
                 )
-                for i in range(21, 26)
+                for i in range(20, 25)
             )
         )
         .evaluate_tick()
         # this asset can now kick off
         .assert_requested_runs(
-            run_request(["B"], partition_key=day_partition_key(state.current_time, delta=1))
+            run_request(["B"], partition_key=day_partition_key(time_partitions_start_datetime))
         ),
     ),
     AssetDaemonScenario(
         id="time_dimension_multipartitioned",
-        initial_state=one_asset.with_asset_properties(
+        initial_graph=one_asset.with_asset_properties(
             partitions_def=time_multipartitions_def,
-        )
-        .with_current_time(time_partitions_start_str)
+        ),
+        execution_fn=lambda state: state.with_current_time(time_partitions_start_str)
         .with_current_time_advanced(days=1, hours=1)
-        .with_all_eager(100),
-        execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
+        .with_all_eager(100)
+        .evaluate_tick()
+        .assert_requested_runs(
             *(
                 run_request(["A"], partition_key=partition_key)
                 for partition_key in time_multipartitions_def.get_multipartition_keys_with_dimension_value(
@@ -355,10 +385,12 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="static_multipartitioned",
-        initial_state=one_asset.with_asset_properties(
+        initial_graph=one_asset.with_asset_properties(
             partitions_def=static_multipartitions_def,
-        ).with_all_eager(100),
-        execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
+        ),
+        execution_fn=lambda state: state.with_all_eager(100)
+        .evaluate_tick()
+        .assert_requested_runs(
             *(
                 run_request(["A"], partition_key=partition_key)
                 for partition_key in static_multipartitions_def.get_partition_keys()
@@ -367,30 +399,36 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="partitioned_after_non_partitioned_multiple_updated",
-        initial_state=one_asset_depends_on_two.with_asset_properties(
+        initial_graph=one_asset_depends_on_two.with_asset_properties(
             keys=["C"], partitions_def=daily_partitions_def
-        )
-        .with_current_time(time_partitions_start_str)
+        ),
+        execution_fn=lambda state: state.with_current_time(time_partitions_start_str)
         .with_current_time_advanced(days=2, hours=1)
-        .with_all_eager(),
-        execution_fn=lambda state: state.with_runs(
+        .with_all_eager()
+        .with_runs(
             run_request(["A", "B"]),
-            run_request(["C"], partition_key=day_partition_key(state.current_time)),
+            run_request(
+                ["C"], partition_key=day_partition_key(time_partitions_start_datetime, delta=1)
+            ),
             run_request(["A"]),
         )
         .evaluate_tick()
         .assert_requested_runs(
-            run_request(["C"], partition_key=day_partition_key(state.current_time))
+            run_request(
+                ["C"], partition_key=day_partition_key(time_partitions_start_datetime, delta=1)
+            )
         )
         .with_runs(run_request(["B"]))
         .evaluate_tick()
         .assert_requested_runs(
-            run_request(["C"], partition_key=day_partition_key(state.current_time))
+            run_request(
+                ["C"], partition_key=day_partition_key(time_partitions_start_datetime, delta=1)
+            )
         ),
     ),
     AssetDaemonScenario(
         id="one_asset_depends_on_two_nonexistent_partitions",
-        initial_state=one_asset_depends_on_two.with_asset_properties(
+        initial_graph=one_asset_depends_on_two.with_asset_properties(
             partitions_def=hourly_partitions_def
         )
         .with_asset_properties(
@@ -411,29 +449,38 @@ partition_scenarios = [
                     ),
                 ),
             ],
-        )
-        .with_all_eager(100)
+        ),
+        execution_fn=lambda state: state.with_all_eager(100)
         .with_current_time(time_partitions_start_str)
-        .with_current_time_advanced(hours=2),
-        execution_fn=lambda state: state.evaluate_tick()
+        .with_current_time_advanced(hours=2)
+        .evaluate_tick()
         .assert_requested_runs(
             # nonexistent partitions are allowed, so can materialize C with A here
-            run_request(["A", "C"], partition_key=hour_partition_key(state.current_time, delta=-1)),
-            run_request(["A"], partition_key=hour_partition_key(state.current_time)),
+            run_request(
+                ["A", "C"],
+                partition_key=hour_partition_key(time_partitions_start_datetime),
+            ),
+            run_request(
+                ["A"], partition_key=hour_partition_key(time_partitions_start_datetime, delta=1)
+            ),
             # B only exists for the second partition, and is in a separate run from A
-            run_request(["B"], partition_key=hour_partition_key(state.current_time)),
+            run_request(
+                ["B"], partition_key=hour_partition_key(time_partitions_start_datetime, delta=1)
+            ),
         )
         .with_not_started_runs()
         .evaluate_tick()
         # C is materialized in a separate run from B
         .assert_requested_runs(
-            run_request(["C"], partition_key=hour_partition_key(state.current_time))
+            run_request(
+                ["C"], partition_key=hour_partition_key(time_partitions_start_datetime, delta=1)
+            )
         )
         .with_not_started_runs()
         # now stop allowing non-existent upstream partitions and rematerialize A
         .with_asset_properties(keys=["C"], deps=["A", "B"])
         .with_runs(
-            run_request(["A"], partition_key=hour_partition_key(state.current_time, delta=-1))
+            run_request(["A"], partition_key=hour_partition_key(time_partitions_start_datetime))
         )
         .evaluate_tick()
         # C cannot be materialized for this partition
@@ -441,7 +488,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="two_assets_in_sequence_fan_in_partitions",
-        initial_state=two_assets_in_sequence_fan_in_partitions.with_asset_properties(
+        initial_graph=two_assets_in_sequence_fan_in_partitions.with_asset_properties(
             keys=["B"], auto_materialize_policy=AutoMaterializePolicy.eager()
         ),
         execution_fn=lambda state: state.evaluate_tick()
@@ -463,8 +510,9 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="two_assets_in_sequence_fan_out_partitions",
-        initial_state=two_assets_in_sequence_fan_out_partitions.with_all_eager(100),
-        execution_fn=lambda state: state.evaluate_tick()
+        initial_graph=two_assets_in_sequence_fan_out_partitions,
+        execution_fn=lambda state: state.with_all_eager(100)
+        .evaluate_tick()
         .assert_requested_runs(run_request(["A"], partition_key="1"))
         .with_not_started_runs()
         .evaluate_tick()
@@ -485,29 +533,26 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_asset_self_dependency",
-        initial_state=one_asset_self_dependency.with_all_eager()
+        initial_graph=one_asset_self_dependency,
+        execution_fn=lambda state: state.with_all_eager()
         .with_current_time(time_partitions_start_str)
-        .with_current_time_advanced(hours=2),
-        execution_fn=lambda state: state.evaluate_tick()
+        .with_current_time_advanced(hours=2)
+        .evaluate_tick()
         .assert_requested_runs(
-            run_request(
-                ["A"], partition_key=hour_partition_key(time_partitions_start_datetime, delta=1)
-            )
+            run_request(["A"], partition_key=hour_partition_key(time_partitions_start_datetime))
         )
         .with_not_started_runs()
         .evaluate_tick()
         .assert_requested_runs(
             run_request(
                 ["A"],
-                partition_key=hour_partition_key(time_partitions_start_datetime, delta=2),
+                partition_key=hour_partition_key(time_partitions_start_datetime, delta=1),
             )
         )
         # first partition rematerialized, don't kick off new run
         .with_not_started_runs()
         .with_runs(
-            run_request(
-                ["A"], partition_key=hour_partition_key(time_partitions_start_datetime, delta=1)
-            )
+            run_request(["A"], partition_key=hour_partition_key(time_partitions_start_datetime))
         )
         .evaluate_tick("FOO")
         .assert_requested_runs()
@@ -524,14 +569,14 @@ partition_scenarios = [
             run_request(
                 ["A"],
                 partition_key=hour_partition_key(
-                    time_partitions_start_datetime + datetime.timedelta(days=5), delta=1
+                    time_partitions_start_datetime + datetime.timedelta(days=5)
                 ),
             )
         ),
     ),
     AssetDaemonScenario(
         id="one_asset_self_dependency_multi_partitions_def",
-        initial_state=one_asset.with_asset_properties(
+        initial_graph=one_asset.with_asset_properties(
             partitions_def=time_multipartitions_def,
             deps=[
                 AssetDep(
@@ -546,11 +591,25 @@ partition_scenarios = [
                     ),
                 )
             ],
-        )
-        .with_all_eager(2)
+        ),
+        execution_fn=lambda state: state.with_all_eager(2)
         .with_current_time(time_partitions_start_str)
-        .with_current_time_advanced(days=10),
-        execution_fn=lambda state: state.evaluate_tick()
+        .with_current_time_advanced(days=10)
+        .evaluate_tick()
+        .assert_requested_runs(
+            *(
+                run_request(
+                    ["A"],
+                    partition_key=multi_partition_key(
+                        time=day_partition_key(time_partitions_start_datetime),
+                        static=static,
+                    ),
+                )
+                for static in ["1", "2"]
+            ),
+        )
+        .with_not_started_runs()
+        .evaluate_tick()
         .assert_requested_runs(
             *(
                 run_request(
@@ -562,72 +621,51 @@ partition_scenarios = [
                 )
                 for static in ["1", "2"]
             ),
-        )
-        .with_not_started_runs()
-        .evaluate_tick()
-        .assert_requested_runs(
-            *(
-                run_request(
-                    ["A"],
-                    partition_key=multi_partition_key(
-                        time=day_partition_key(time_partitions_start_datetime, delta=2),
-                        static=static,
-                    ),
-                )
-                for static in ["1", "2"]
-            ),
         ),
     ),
     AssetDaemonScenario(
         id="three_assets_in_sequence_self_dependency_in_middle",
-        initial_state=three_assets_in_sequence.with_asset_properties(
+        initial_graph=three_assets_in_sequence.with_asset_properties(
             partitions_def=daily_partitions_def
-        )
-        .with_asset_properties(
+        ).with_asset_properties(
             keys=["B"], deps=["A", AssetDep("B", partition_mapping=self_partition_mapping)]
-        )
-        .with_all_eager()
+        ),
+        execution_fn=lambda state: state.with_all_eager()
         .with_current_time(time_partitions_start_str)
-        .with_current_time_advanced(days=3, hours=1),
-        execution_fn=lambda state: state.with_runs(
+        .with_current_time_advanced(days=3, hours=1)
+        .with_runs(
             # materialize partitions out of order, the second one coming before the first
             run_request(
-                ["A"], partition_key=day_partition_key(time_partitions_start_datetime, delta=2)
+                ["A"], partition_key=day_partition_key(time_partitions_start_datetime, delta=1)
             )
         )
         # B's self dependency isn't satisfied yet, so don't kick off the downstream
         .evaluate_tick()
         .assert_requested_runs(
             run_request(
-                ["A"], partition_key=day_partition_key(time_partitions_start_datetime, delta=3)
+                ["A"], partition_key=day_partition_key(time_partitions_start_datetime, delta=2)
             )
         )
         .with_not_started_runs()
         # now the first partition of the self-dependent asset is manually materialized, which
         # unblocks the self dependency chain
         .with_runs(
-            run_request(
-                ["A", "B"], partition_key=day_partition_key(time_partitions_start_datetime, delta=1)
-            )
-        )
-        .evaluate_tick()
-        .assert_requested_runs(
-            run_request(
-                ["B", "C"], partition_key=day_partition_key(time_partitions_start_datetime, delta=2)
-            )
-        )
-        .with_not_started_runs()
-        # first partition of the upstream rematerialized, downstreams should be kicked off
-        .with_runs(
-            run_request(
-                ["A"], partition_key=day_partition_key(time_partitions_start_datetime, delta=1)
-            )
+            run_request(["A", "B"], partition_key=day_partition_key(time_partitions_start_datetime))
         )
         .evaluate_tick()
         .assert_requested_runs(
             run_request(
                 ["B", "C"], partition_key=day_partition_key(time_partitions_start_datetime, delta=1)
             )
+        )
+        .with_not_started_runs()
+        # first partition of the upstream rematerialized, downstreams should be kicked off
+        .with_runs(
+            run_request(["A"], partition_key=day_partition_key(time_partitions_start_datetime))
+        )
+        .evaluate_tick()
+        .assert_requested_runs(
+            run_request(["B", "C"], partition_key=day_partition_key(time_partitions_start_datetime))
         )
         .with_not_started_runs()
         # now B requires all parents to be updated before materializing
@@ -640,28 +678,22 @@ partition_scenarios = [
         # don't require the self-dependent asset to be updated in order for this to fire, even when
         # the skip rule is applied
         .with_runs(
-            run_request(
-                ["A"], partition_key=day_partition_key(time_partitions_start_datetime, delta=1)
-            )
+            run_request(["A"], partition_key=day_partition_key(time_partitions_start_datetime))
         )
         .evaluate_tick()
         .assert_requested_runs(
-            run_request(
-                ["B", "C"], partition_key=day_partition_key(time_partitions_start_datetime, delta=1)
-            )
+            run_request(["B", "C"], partition_key=day_partition_key(time_partitions_start_datetime))
         )
         # now old partition of B is materialized, only update the downstream, not B
         .with_not_started_runs()
         .with_runs(
-            run_request(
-                ["B"], partition_key=day_partition_key(time_partitions_start_datetime, delta=1)
-            )
+            run_request(["B"], partition_key=day_partition_key(time_partitions_start_datetime))
         )
         .evaluate_tick("THIS ONE")
         .assert_requested_runs(
             run_request(
                 ["C"],
-                partition_key=day_partition_key(time_partitions_start_datetime, delta=1),
+                partition_key=day_partition_key(time_partitions_start_datetime),
             )
         )
         # new day's partition is filled in, should still be able to materialize the new partition
@@ -669,40 +701,39 @@ partition_scenarios = [
         .with_not_started_runs()
         .with_runs(
             run_request(
-                ["A"], partition_key=day_partition_key(time_partitions_start_datetime, delta=3)
+                ["A"], partition_key=day_partition_key(time_partitions_start_datetime, delta=2)
             ),
         )
         .evaluate_tick()
         .assert_requested_runs(
             run_request(
-                ["B", "C"], partition_key=day_partition_key(time_partitions_start_datetime, delta=3)
+                ["B", "C"], partition_key=day_partition_key(time_partitions_start_datetime, delta=2)
             )
         ),
     ),
     AssetDaemonScenario(
         id="unpartitioned_downstream_of_asymmetric_time_assets_in_series",
-        initial_state=three_assets_in_sequence.with_asset_properties(
+        initial_graph=three_assets_in_sequence.with_asset_properties(
             keys=["A"],
             partitions_def=daily_partitions_def._replace(
                 start=time_partitions_start_datetime + datetime.timedelta(days=4)
             ),
-        )
-        .with_asset_properties(keys=["B"], partitions_def=daily_partitions_def)
-        .with_all_eager()
+        ).with_asset_properties(keys=["B"], partitions_def=daily_partitions_def),
+        execution_fn=lambda state: state.with_all_eager()
         .with_current_time(time_partitions_start_str)
-        .with_current_time_advanced(days=9),
-        execution_fn=lambda state: state.with_runs(
+        .with_current_time_advanced(days=9)
+        .with_runs(
             *(
                 run_request(
                     ["A"], partition_key=day_partition_key(time_partitions_start_datetime, delta=i)
                 )
-                for i in range(5, 10)
+                for i in range(4, 9)
             ),
             *(
                 run_request(
                     ["B"], partition_key=day_partition_key(time_partitions_start_datetime, delta=i)
                 )
-                for i in range(1, 10)
+                for i in range(9)
             ),
         )
         .evaluate_tick()
@@ -710,20 +741,22 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="partition_pops_into_existence_after_parent_update",
-        initial_state=two_assets_depend_on_one.with_asset_properties(
+        initial_graph=two_assets_depend_on_one.with_asset_properties(
             "A",
             # new partitions come into being one day early
             partitions_def=daily_partitions_def._replace(end_offset=1),
         )
         .with_asset_properties("B", partitions_def=daily_partitions_def)
-        .with_asset_properties("C", partitions_def=hourly_partitions_def)
-        .with_all_eager()
+        .with_asset_properties("C", partitions_def=hourly_partitions_def),
+        execution_fn=lambda state: state.with_all_eager()
         .with_current_time(time_partitions_start_str)
-        .with_current_time_advanced(days=9, minutes=5),
-        execution_fn=lambda state: state.with_runs()
+        .with_current_time_advanced(days=9, minutes=5)
+        .with_runs()
         .evaluate_tick()
         .assert_requested_runs(
-            run_request("A", partition_key=day_partition_key(state.current_time, delta=1))
+            run_request(
+                "A", partition_key=day_partition_key(time_partitions_start_datetime, delta=9)
+            )
         )
         .with_not_started_runs()
         .evaluate_tick()
@@ -731,9 +764,16 @@ partition_scenarios = [
         .with_current_time_advanced(days=1)
         .evaluate_tick()
         .assert_requested_runs(
-            run_request("A", partition_key=day_partition_key(state.current_time, delta=2)),
-            run_request("B", partition_key=day_partition_key(state.current_time, delta=1)),
-            run_request("C", partition_key=hour_partition_key(state.current_time, delta=24)),
+            run_request(
+                "A", partition_key=day_partition_key(time_partitions_start_datetime, delta=9 + 1)
+            ),
+            run_request(
+                "B", partition_key=day_partition_key(time_partitions_start_datetime, delta=9)
+            ),
+            run_request(
+                "C",
+                partition_key=hour_partition_key(time_partitions_start_datetime, delta=10 * 24 - 1),
+            ),
         )
         .with_not_started_runs()
         .evaluate_tick()
@@ -741,7 +781,10 @@ partition_scenarios = [
         .with_current_time_advanced(hours=3)
         .evaluate_tick()
         .assert_requested_runs(
-            run_request("C", partition_key=hour_partition_key(state.current_time, delta=27))
+            run_request(
+                "C",
+                partition_key=hour_partition_key(time_partitions_start_datetime, delta=10 * 24 + 2),
+            )
         )
         .with_current_time_advanced(seconds=30)
         .evaluate_tick()


### PR DESCRIPTION
## Summary & Motivation

Main goal here is to break out the reusable bit of this class into its own subclass. This way, we can repurpose the general concept of "thing that keeps track of the state of an instance / asset graph and lets you do operations over it" for doing things more specific to AssetCondition testing.

Most of the LoC here are from switching over to dataclasses from NamedTuple, as they work way better with subclassing.

To see this in action, see the third PR in this stack

## How I Tested These Changes
