### PR TITLE
New test framework for testing AssetConditions

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/missing_tests.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/missing_tests.py
@@ -1,0 +1,56 @@
+from dagster._core.definitions.asset_condition.asset_condition import AssetCondition
+
+from ..base_scenario import run_request
+from ..utils import day_partition_key
+from ..utils.asset_condition_scenario import AssetConditionScenarioState
+from ..utils.asset_scenario_states import (
+    daily_partitions_def,
+    one_asset,
+    time_partitions_start_datetime,
+)
+
+
+def test_missing_unpartitioned() -> None:
+    state = AssetConditionScenarioState.create_from_state(one_asset, AssetCondition.missing())
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+    # still true
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+    # after a run of A it's now False
+    state, result = state.with_runs(run_request("A")).evaluate("A")
+    assert result.true_subset.size == 0
+
+    # if we evaluate from scratch, it's also False
+    _, result = state.without_previous_evaluation_state().evaluate("A")
+    assert result.true_subset.size == 0
+
+
+def test_missing_time_partitioned() -> None:
+    state = (
+        AssetConditionScenarioState.create_from_state(one_asset, AssetCondition.missing())
+        .with_asset_properties(partitions_def=daily_partitions_def)
+        .with_current_time(time_partitions_start_datetime)
+        .with_current_time_advanced(days=6, minutes=1)
+    )
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 6
+
+    # still true
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 6
+
+    # after two runs of A those partitions are now False
+    state, result = state.with_runs(
+        run_request("A", day_partition_key(time_partitions_start_datetime, 1)),
+        run_request("A", day_partition_key(time_partitions_start_datetime, 3)),
+    ).evaluate("A")
+    assert result.true_subset.size == 4
+
+    # if we evaluate from scratch, they're still False
+    _, result = state.without_previous_evaluation_state().evaluate("A")
+    assert result.true_subset.size == 4

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/utils/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/utils/asset_condition_scenario.py
@@ -1,0 +1,90 @@
+import dataclasses
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import dagster._check as check
+from dagster import AssetKey
+from dagster._core.definitions.asset_condition.asset_condition import (
+    AssetCondition,
+    AssetConditionEvaluationState,
+    AssetConditionResult,
+)
+from dagster._core.definitions.asset_condition.asset_condition_evaluation_context import (
+    AssetConditionEvaluationContext,
+)
+from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
+from dagster._core.definitions.events import CoercibleToAssetKey
+from dagster._core.instance import DagsterInstance
+from dagster._seven.compat.pendulum import pendulum_freeze_time
+from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
+
+from .asset_scenario_state import AssetScenarioState
+
+
+@dataclass(frozen=True)
+class AssetConditionScenarioState(AssetScenarioState):
+    asset_condition: Optional[AssetCondition] = None
+    previous_evaluation_state: Optional[AssetConditionEvaluationState] = None
+
+    @staticmethod
+    def create_from_state(
+        state: AssetScenarioState, asset_condition: AssetCondition
+    ) -> "AssetConditionScenarioState":
+        return AssetConditionScenarioState(
+            **{
+                **{f.name: getattr(state, f.name) for f in dataclasses.fields(state)},
+                "scenario_instance": DagsterInstance.ephemeral(),
+                "asset_condition": asset_condition,
+            },
+        )
+
+    def evaluate(
+        self, asset: CoercibleToAssetKey
+    ) -> Tuple["AssetConditionScenarioState", AssetConditionResult]:
+        asset_key = AssetKey.from_coercible(asset)
+        asset_condition = check.not_none(self.asset_condition)
+
+        with pendulum_freeze_time(self.current_time):
+            context = AssetConditionEvaluationContext.create(
+                asset_key=asset_key,
+                condition=asset_condition,
+                previous_evaluation_state=self.previous_evaluation_state,
+                instance_queryer=CachingInstanceQueryer(
+                    instance=self.instance,
+                    asset_graph=self.asset_graph,
+                ),
+                data_time_resolver=None,  # type: ignore
+                evaluation_state_by_key={},
+                expected_data_time_mapping={},
+                # If you are an intrepid developer who has added a new field to AssetDaemonContext and
+                # have found yourself here, it's likely that you can just set the value to None and
+                # 'type: ignore' it. Most fields will not be accessed in these tests.
+                daemon_context=AssetDaemonContext(
+                    evaluation_id=1,
+                    instance=self.instance,
+                    asset_graph=self.asset_graph,
+                    cursor=None,  # type: ignore
+                    materialize_run_tags={},
+                    observe_run_tags={},
+                    auto_observe_asset_keys=None,
+                    auto_materialize_asset_keys=None,
+                    respect_materialization_data_versions=False,
+                    logger=self.logger,
+                    evaluation_time=self.current_time,
+                ),
+                is_scheduling_policy_evaluation=False,
+            )
+
+            result = asset_condition.evaluate(context)
+            new_state = dataclasses.replace(
+                self,
+                previous_evaluation_state=AssetConditionEvaluationState.create(context, result),
+            )
+
+        return new_state, result
+
+    def without_previous_evaluation_state(self) -> "AssetConditionScenarioState":
+        """Removes the previous evaluation state from the state. This is useful for testing
+        re-evaluating this data "from scratch" after much computation has occurred.
+        """
+        return dataclasses.replace(self, previous_evaluation_state=None)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/utils/asset_scenario_state.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/utils/asset_scenario_state.py
@@ -155,8 +155,9 @@ class AssetScenarioState:
             )
         )
 
-    def with_current_time(self, time: str) -> Self:
-        return dataclasses.replace(self, current_time=pendulum.parse(time))
+    def with_current_time(self, time: Union[str, datetime.datetime]) -> Self:
+        time = pendulum.parse(time) if isinstance(time, str) else time
+        return dataclasses.replace(self, current_time=time)
 
     def with_current_time_advanced(self, **kwargs) -> Self:
         # hacky support for adding years


### PR DESCRIPTION
## Summary & Motivation

As the title -- adds a new test framework that is more ergonomic for testing individual AssetConditions without the overhead of a whole scenario etc.

Mostly as a demonstration, adds a couple of tests for `AssetCondition.missing()`. I'm imagining adding more over time, as well as adding tests for all statically-constructable AssetConditions.

## How I Tested These Changes
