### PR TITLE
chore(dbt): pin `dbt-duckdb==1.7.1`

### DIFF
--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -16,8 +16,9 @@ deps =
   dbt16: dbt-core==1.6.*
   dbt16: dbt-duckdb==1.6.*
   dbt17: dbt-core==1.7.*
-  dbt17: dbt-duckdb==1.7.*
+  dbt17: dbt-duckdb==1.7.1
   pydantic1: pydantic!=1.10.7,<2.0.0
+  pydantic1: dbt-duckdb==1.7.1
   -e .[test]
 allowlist_externals =
   /bin/bash


### PR DESCRIPTION
## Summary & Motivation
Builds started breaking with release https://github.com/duckdb/dbt-duckdb/releases/tag/1.7.2. Pin it.

## How I Tested These Changes
tox, bk
