### PR TITLE
[docs] next fix invalid link anchors

### DIFF
--- a/docs/next/components/PagePagination.tsx
+++ b/docs/next/components/PagePagination.tsx
@@ -131,29 +131,27 @@ export function PagePagination(props: {currentPageIndex: number; totalPageCount:
       </div>
       <div className="-mt-px flex w-0 flex-1 justify-end">
         {currentPageIndex === totalPageCount - 1 ? null : (
-          <NextLink
+          (<NextLink
             href={{
               query: {...query, page: currentPageIndex + 2},
             }}
-          >
-            <a className="inline-flex items-center border-t-2 border-transparent pl-1 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">
-              Next
-              {/* Heroicon name: arrow-narrow-right */}
-              <svg
-                className="ml-3 h-5 w-5 text-gray-400"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M12.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-2.293-2.293a1 1 0 010-1.414z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            </a>
-          </NextLink>
+            className="inline-flex items-center border-t-2 border-transparent pl-1 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">
+            Next{/* Heroicon name: arrow-narrow-right */}
+            <svg
+              className="ml-3 h-5 w-5 text-gray-400"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                fillRule="evenodd"
+                d="M12.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-2.293-2.293a1 1 0 010-1.414z"
+                clipRule="evenodd"
+              />
+            </svg>
+
+          </NextLink>)
         )}
       </div>
     </nav>
@@ -168,20 +166,18 @@ function PaginationItem(props: {targetIndex: number; isCurrentPage?: boolean}) {
   const {query} = useRouter();
 
   return (
-    <NextLink
+    (<NextLink
       href={{
         query: {...query, page: targetIndex + 1},
       }}
-    >
-      <a
-        className={cx({
-          'inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700':
-            true,
-          'border-indigo-500 text-indigo-600': isCurrentPage,
-        })}
-      >
-        {targetIndex + 1}
-      </a>
-    </NextLink>
+      className={cx({
+        'inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700':
+          true,
+        'border-indigo-500 text-indigo-600': isCurrentPage,
+      })}>
+
+      {targetIndex + 1}
+
+    </NextLink>)
   );
 }


### PR DESCRIPTION
## Summary & Motivation

Running `make next-watch-build` and navigating to `/changelog` resulted in the following trace:

<img width="980" alt="image" src="https://github.com/dagster-io/dagster/assets/5807118/1dd4d5f3-5008-451c-bd32-5cab44d79a49">

One of the suggested ways of fixing this is to run `npx @next/codemod new-link .`.

https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor

## How I Tested These Changes

- Confirmed `/changelog` rendered appropriately