### PR TITLE
[external-assets] Make AssetGraph error when fetching missing asset properties

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -150,7 +150,7 @@ class AssetDaemonContext:
         return [
             key
             for key in self.auto_materialize_asset_keys_and_parents
-            if not self.asset_graph.is_source(key)
+            if (self.asset_graph.has_asset(key) and self.asset_graph.is_materializable(key))
         ]
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -756,10 +756,12 @@ class SkipOnParentMissingRule(AutoMaterializeRule, NamedTuple("_SkipOnParentMiss
             for parent in context.get_parents_that_will_not_be_materialized_on_current_tick(
                 asset_partition=candidate
             ):
-                # ignore non-observable sources, which will never have a materialization or observation
-                if context.asset_graph.is_source(
-                    parent.asset_key
-                ) and not context.asset_graph.is_observable(parent.asset_key):
+                # ignore missing or unexecutable assets, which will never have a materialization or
+                # observation
+                if not (
+                    context.asset_graph.has_asset(parent.asset_key)
+                    and context.asset_graph.is_executable(parent.asset_key)
+                ):
                     continue
                 if not context.instance_queryer.asset_partition_has_materialization_or_observation(
                     parent

--- a/python_modules/dagster/dagster/_core/definitions/internal_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/internal_asset_graph.py
@@ -139,17 +139,14 @@ class InternalAssetGraph(AssetGraph):
         return {key for ad in self._assets_defs if ad.is_observable for key in ad.keys}
 
     def is_observable(self, asset_key: AssetKey) -> bool:
-        # Performing an existence check temporarily until we change callsites
-        return self.has_asset(asset_key) and self.get_assets_def(asset_key).is_observable
+        return self.get_assets_def(asset_key).is_observable
 
     @property
     def external_asset_keys(self) -> AbstractSet[AssetKey]:
         return {key for ad in self._assets_defs if ad.is_external for key in ad.keys}
 
     def is_external(self, asset_key: AssetKey) -> bool:
-        # Preserving non-standard behavior of returning True for non-existent keys until callsites
-        # can be updated
-        return asset_key not in self.materializable_asset_keys
+        return self.get_assets_def(asset_key).is_external
 
     @property
     def executable_asset_keys(self) -> AbstractSet[AssetKey]:


### PR DESCRIPTION
## Summary & Motivation

The `CachingInstanceQueryer` and other components of the asset daemon sometimes rely on the asset graph reporting unknown keys as source assets. The asset graph is being refactored to no longer support this and error when reading properties for unknown keys. This PR adjusts the callsites that rely on reporting unknowns assets as source assets to instead perform an additional existence check for the asset.

## How I Tested These Changes

Existing test suite (which already includes cases for unknown assets).