### PR TITLE
[bugfix] ExternalAssetNode AssetExecutionType backcompat fix

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -13,7 +13,6 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.assets_job import ASSET_BASE_JOB_PREFIX
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.host_representation.external import ExternalRepository
@@ -158,9 +157,7 @@ class ExternalAssetGraph(AssetGraph):
         auto_observe_interval_minutes_by_key = {}
 
         for repo_handle, node in repo_handle_external_asset_nodes:
-            is_observable_by_key[node.asset_key] = (
-                node.execution_type == AssetExecutionType.OBSERVATION
-            )
+            is_observable_by_key[node.asset_key] = node.is_observable
             auto_observe_interval_minutes_by_key[
                 node.asset_key
             ] = node.auto_observe_interval_minutes

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1259,13 +1259,20 @@ class ExternalAssetNode(
                 )
             execution_type = metadata_execution_type
         else:
+            if is_source and is_observable:
+                default_execution_type = AssetExecutionType.OBSERVATION
+            elif is_source:
+                default_execution_type = AssetExecutionType.UNEXECUTABLE
+            else:
+                default_execution_type = AssetExecutionType.MATERIALIZATION
+
             execution_type = (
                 check.opt_inst_param(
                     execution_type,
                     "execution_type",
                     AssetExecutionType,
                 )
-                or AssetExecutionType.MATERIALIZATION
+                or default_execution_type
             )
 
         # backcompat logic to handle ExternalAssetNodes serialized without op_names/graph_name


### PR DESCRIPTION
## Summary & Motivation

Prior to this PR, `execution_type` on `ExternalAssetNode` was defaulting to `MATERIALIZATION` if it was not specified in the constructor. This caused an issue with backcompat for older versions of Dagster that did not specify execution type, as observable and source external asset nodes were erroneously being assigned a `MATERIALIZABLE` execution type.

The PR also reverts a change for observable status where we were looking at `execution_type` instead of `is_observable`. `is_observable` is the correct long-term solution in any case.

This resulted in the auto-materialize daemon, which reads `ExternalAssetNode.execution_type`, not functioning as expected in some cases.

## How I Tested These Changes

@OwenKephart Ran branch against malfunctioning deployment, observed corrected behavior.