### PR TITLE
[ui] Add right-click menus on groups, assets in the sidebar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ContextMenuWrapper.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ContextMenuWrapper.tsx
@@ -97,3 +97,9 @@ export const ContextMenuWrapper = ({
     </div>
   );
 };
+
+export const triggerContextMenu = (e: React.MouseEvent) => {
+  const evt = new MouseEvent('contextmenu', e.nativeEvent);
+  e.target.dispatchEvent(evt);
+  e.stopPropagation();
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
@@ -1,36 +1,22 @@
-import {
-  Box,
-  Colors,
-  Icon,
-  MiddleTruncate,
-  Popover,
-  UnstyledButton,
-} from '@dagster-io/ui-components';
+import {Box, Colors, Icon, MiddleTruncate, UnstyledButton} from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled from 'styled-components';
 
 import {StatusDot} from './StatusDot';
-import {FolderNodeNonAssetType, getDisplayName} from './util';
+import {
+  FolderNodeCodeLocationType,
+  FolderNodeGroupType,
+  FolderNodeNonAssetType,
+  getDisplayName,
+} from './util';
 import {ExplorerPath} from '../../pipelines/PipelinePathUtils';
 import {AssetGroup} from '../AssetGraphExplorer';
-import {AssetNodeMenuProps, useAssetNodeMenu} from '../AssetNodeMenu';
+import {useAssetNodeMenu} from '../AssetNodeMenu';
 import {useGroupNodeContextMenu} from '../CollapsedGroupNode';
+import {ContextMenuWrapper, triggerContextMenu} from '../ContextMenuWrapper';
 import {GraphData, GraphNode} from '../Utils';
 
-export const AssetSidebarNode = ({
-  node,
-  level,
-  toggleOpen,
-  selectNode,
-  isOpen,
-  isSelected,
-  selectThisNode,
-  explorerPath,
-  onChangeExplorerPath,
-  fullAssetGraphData,
-  isLastSelected,
-  onFilterToGroup,
-}: {
+type AssetSidebarNodeProps = {
   fullAssetGraphData: GraphData;
   node: GraphNode | FolderNodeNonAssetType;
   level: number;
@@ -43,25 +29,150 @@ export const AssetSidebarNode = ({
   explorerPath: ExplorerPath;
   onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
   onFilterToGroup: (group: AssetGroup) => void;
-}) => {
+};
+
+export const AssetSidebarNode = (props: AssetSidebarNodeProps) => {
+  const {node, level, toggleOpen, isOpen, selectThisNode} = props;
   const isGroupNode = 'groupNode' in node;
   const isLocationNode = 'locationName' in node;
   const isAssetNode = !isGroupNode && !isLocationNode;
-
-  const displayName = React.useMemo(() => {
-    if (isAssetNode) {
-      return getDisplayName(node);
-    } else if (isGroupNode) {
-      return node.groupNode.groupName;
-    } else {
-      return node.locationName;
-    }
-  }, [isAssetNode, isGroupNode, node]);
 
   const elementRef = React.useRef<HTMLDivElement | null>(null);
 
   const showArrow = !isAssetNode;
 
+  return (
+    <Box ref={elementRef} padding={{left: 8}}>
+      <BoxWrapper level={level}>
+        <ItemContainer
+          padding={{right: 12}}
+          flex={{direction: 'row', alignItems: 'center'}}
+          onClick={selectThisNode}
+          onDoubleClick={(e) => !e.metaKey && toggleOpen()}
+        >
+          {showArrow ? (
+            <UnstyledButton
+              onClick={(e) => {
+                e.stopPropagation();
+                toggleOpen();
+              }}
+              onDoubleClick={(e) => {
+                e.stopPropagation();
+              }}
+              onKeyDown={(e) => {
+                if (e.code === 'Space') {
+                  // Prevent the default scrolling behavior
+                  e.preventDefault();
+                }
+              }}
+              style={{cursor: 'pointer', width: 18}}
+            >
+              <Icon
+                name="arrow_drop_down"
+                style={{transform: isOpen ? 'rotate(0deg)' : 'rotate(-90deg)'}}
+              />
+            </UnstyledButton>
+          ) : level === 1 && isAssetNode ? (
+            // Special case for when asset nodes are at the root (level = 1) due to their being only a single group.
+            // In this case we don't need the spacer div to align nodes because  none of the nodes will be collapsible/un-collapsible.
+            <div />
+          ) : (
+            // Spacer div to align nodes with collapse/un-collapse arrows with nodes that don't have collapse/un-collapse arrows
+            <div style={{width: 18}} />
+          )}
+          {isAssetNode ? (
+            <AssetSidebarAssetLabel {...props} node={node} />
+          ) : isGroupNode ? (
+            <AssetSidebarGroupLabel {...props} node={node} />
+          ) : (
+            <AssetSidebarLocationLabel {...props} node={node} />
+          )}
+        </ItemContainer>
+      </BoxWrapper>
+    </Box>
+  );
+};
+
+const AssetSidebarAssetLabel = ({
+  node,
+  isSelected,
+  isLastSelected,
+  fullAssetGraphData,
+  selectNode,
+  explorerPath,
+  onChangeExplorerPath,
+}: Omit<AssetSidebarNodeProps, 'node'> & {node: GraphNode}) => {
+  const {menu, dialog} = useAssetNodeMenu({
+    graphData: fullAssetGraphData,
+    node,
+    selectNode,
+    explorerPath,
+    onChangeExplorerPath,
+  });
+
+  return (
+    <ContextMenuWrapper stopPropagation menu={menu} wrapperOuterStyles={{width: '100%'}}>
+      <FocusableLabelContainer isSelected={isSelected} isLastSelected={isLastSelected}>
+        <StatusDot node={node} />
+        <MiddleTruncate text={getDisplayName(node)} />
+      </FocusableLabelContainer>
+      <ExpandMore onClick={triggerContextMenu}>
+        <Icon name="more_horiz" color={Colors.accentGray()} />
+      </ExpandMore>
+      {dialog}
+    </ContextMenuWrapper>
+  );
+};
+
+const AssetSidebarGroupLabel = ({
+  node,
+  isSelected,
+  isLastSelected,
+  onFilterToGroup,
+}: Omit<AssetSidebarNodeProps, 'node'> & {node: FolderNodeGroupType}) => {
+  const {menu, dialog} = useGroupNodeContextMenu({
+    onFilterToGroup: () => onFilterToGroup(node.groupNode),
+    assets: node.groupNode.assets,
+  });
+
+  return (
+    <ContextMenuWrapper stopPropagation menu={menu} wrapperOuterStyles={{width: '100%'}}>
+      <FocusableLabelContainer isSelected={isSelected} isLastSelected={isLastSelected}>
+        <Icon name="asset_group" />
+        <MiddleTruncate text={node.groupNode.groupName} />
+      </FocusableLabelContainer>
+      <ExpandMore onClick={triggerContextMenu}>
+        <Icon name="more_horiz" color={Colors.accentGray()} />
+      </ExpandMore>
+      {dialog}
+    </ContextMenuWrapper>
+  );
+};
+
+const AssetSidebarLocationLabel = ({
+  node,
+  isSelected,
+  isLastSelected,
+}: Omit<AssetSidebarNodeProps, 'node'> & {node: FolderNodeCodeLocationType}) => {
+  return (
+    <Box style={{width: '100%'}} onContextMenu={(e) => e.preventDefault()}>
+      <FocusableLabelContainer isSelected={isSelected} isLastSelected={isLastSelected}>
+        <Icon name="folder_open" />
+        <MiddleTruncate text={node.locationName} />
+      </FocusableLabelContainer>
+    </Box>
+  );
+};
+
+const FocusableLabelContainer = ({
+  isSelected,
+  isLastSelected,
+  children,
+}: {
+  isSelected: boolean;
+  isLastSelected: boolean;
+  children: React.ReactNode;
+}) => {
   const ref = React.useRef<HTMLButtonElement | null>(null);
   React.useLayoutEffect(() => {
     // When we click on a node in the graph it also changes "isSelected" in the sidebar.
@@ -74,133 +185,25 @@ export const AssetSidebarNode = ({
   }, [isLastSelected]);
 
   return (
-    <>
-      <Box ref={elementRef} padding={{left: 8}}>
-        <BoxWrapper level={level}>
-          <ItemContainer
-            padding={{right: 12}}
-            flex={{direction: 'row', alignItems: 'center'}}
-            onClick={selectThisNode}
-            onDoubleClick={(e) => !e.metaKey && toggleOpen()}
-          >
-            {showArrow ? (
-              <UnstyledButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  toggleOpen();
-                }}
-                onDoubleClick={(e) => {
-                  e.stopPropagation();
-                }}
-                onKeyDown={(e) => {
-                  if (e.code === 'Space') {
-                    // Prevent the default scrolling behavior
-                    e.preventDefault();
-                  }
-                }}
-                style={{cursor: 'pointer', width: 18}}
-              >
-                <Icon
-                  name="arrow_drop_down"
-                  style={{transform: isOpen ? 'rotate(0deg)' : 'rotate(-90deg)'}}
-                />
-              </UnstyledButton>
-            ) : level === 1 && isAssetNode ? (
-              // Special case for when asset nodes are at the root (level = 1) due to their being only a single group.
-              // In this case we don't need the spacer div to align nodes because  none of the nodes will be collapsible/un-collapsible.
-              <div />
-            ) : (
-              // Spacer div to align nodes with collapse/un-collapse arrows with nodes that don't have collapse/un-collapse arrows
-              <div style={{width: 18}} />
-            )}
-            <GrayOnHoverBox
-              style={{
-                width: '100%',
-                borderRadius: '8px',
-                ...(isSelected ? {background: Colors.backgroundBlue()} : {}),
-              }}
-              ref={ref}
-            >
-              <div
-                style={{
-                  display: 'grid',
-                  gridTemplateColumns: 'auto minmax(0, 1fr)',
-                  gap: '6px',
-                  alignItems: 'center',
-                }}
-              >
-                {isAssetNode ? (
-                  <StatusDot node={node} />
-                ) : isGroupNode ? (
-                  <Icon name="asset_group" />
-                ) : isLocationNode ? (
-                  <Icon name="folder_open" />
-                ) : null}
-                <MiddleTruncate text={displayName} />
-              </div>
-            </GrayOnHoverBox>
-            {isAssetNode ? (
-              <ExpandMore>
-                <AssetNodePopoverMenu
-                  graphData={fullAssetGraphData}
-                  node={node}
-                  selectNode={selectNode}
-                  explorerPath={explorerPath}
-                  onChangeExplorerPath={onChangeExplorerPath}
-                />
-              </ExpandMore>
-            ) : isGroupNode ? (
-              <ExpandMore>
-                <AssetGroupPopoverMenu
-                  onFilterToGroup={() => onFilterToGroup(node.groupNode)}
-                  assets={node.groupNode.assets}
-                />
-              </ExpandMore>
-            ) : null}
-          </ItemContainer>
-        </BoxWrapper>
-      </Box>
-    </>
-  );
-};
-
-const AssetGroupPopoverMenu = (props: Parameters<typeof useGroupNodeContextMenu>[0]) => {
-  const {menu, dialog} = useGroupNodeContextMenu(props);
-  return (
-    <>
-      {dialog}
-      <Popover
-        content={menu}
-        placement="right"
-        shouldReturnFocusOnClose
-        canEscapeKeyClose
-        modifiers={{offset: {enabled: true, options: {offset: [0, 12]}}}}
+    <GrayOnHoverBox
+      ref={ref}
+      style={{
+        width: '100%',
+        borderRadius: '8px',
+        ...(isSelected ? {background: Colors.backgroundBlue()} : {}),
+      }}
+    >
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'auto minmax(0, 1fr)',
+          gap: '6px',
+          alignItems: 'center',
+        }}
       >
-        <UnstyledButton>
-          <Icon name="more_horiz" color={Colors.accentGray()} />
-        </UnstyledButton>
-      </Popover>
-    </>
-  );
-};
-
-const AssetNodePopoverMenu = (props: AssetNodeMenuProps) => {
-  const {menu, dialog} = useAssetNodeMenu(props);
-  return (
-    <>
-      {dialog}
-      <Popover
-        content={menu}
-        placement="right"
-        shouldReturnFocusOnClose
-        canEscapeKeyClose
-        modifiers={{offset: {enabled: true, options: {offset: [0, 12]}}}}
-      >
-        <UnstyledButton>
-          <Icon name="more_horiz" color={Colors.accentGray()} />
-        </UnstyledButton>
-      </Popover>
-    </>
+        {children}
+      </div>
+    </GrayOnHoverBox>
   );
 };
 
@@ -227,7 +230,7 @@ const BoxWrapper = ({level, children}: {level: number; children: React.ReactNode
   return <>{wrapper}</>;
 };
 
-const ExpandMore = styled.div`
+const ExpandMore = styled(UnstyledButton)`
   position: absolute;
   top: 8px;
   right: 20px;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
@@ -112,10 +112,12 @@ const AssetSidebarAssetLabel = ({
 
   return (
     <ContextMenuWrapper stopPropagation menu={menu} wrapperOuterStyles={{width: '100%'}}>
-      <FocusableLabelContainer isSelected={isSelected} isLastSelected={isLastSelected}>
-        <StatusDot node={node} />
-        <MiddleTruncate text={getDisplayName(node)} />
-      </FocusableLabelContainer>
+      <FocusableLabelContainer
+        isSelected={isSelected}
+        isLastSelected={isLastSelected}
+        icon={<StatusDot node={node} />}
+        text={getDisplayName(node)}
+      />
       <ExpandMore onClick={triggerContextMenu}>
         <Icon name="more_horiz" color={Colors.accentGray()} />
       </ExpandMore>
@@ -137,10 +139,12 @@ const AssetSidebarGroupLabel = ({
 
   return (
     <ContextMenuWrapper stopPropagation menu={menu} wrapperOuterStyles={{width: '100%'}}>
-      <FocusableLabelContainer isSelected={isSelected} isLastSelected={isLastSelected}>
-        <Icon name="asset_group" />
-        <MiddleTruncate text={node.groupNode.groupName} />
-      </FocusableLabelContainer>
+      <FocusableLabelContainer
+        isSelected={isSelected}
+        isLastSelected={isLastSelected}
+        icon={<Icon name="asset_group" />}
+        text={node.groupNode.groupName}
+      />
       <ExpandMore onClick={triggerContextMenu}>
         <Icon name="more_horiz" color={Colors.accentGray()} />
       </ExpandMore>
@@ -156,10 +160,12 @@ const AssetSidebarLocationLabel = ({
 }: Omit<AssetSidebarNodeProps, 'node'> & {node: FolderNodeCodeLocationType}) => {
   return (
     <Box style={{width: '100%'}} onContextMenu={(e) => e.preventDefault()}>
-      <FocusableLabelContainer isSelected={isSelected} isLastSelected={isLastSelected}>
-        <Icon name="folder_open" />
-        <MiddleTruncate text={node.locationName} />
-      </FocusableLabelContainer>
+      <FocusableLabelContainer
+        isSelected={isSelected}
+        isLastSelected={isLastSelected}
+        icon={<Icon name="folder_open" />}
+        text={node.locationName}
+      />
     </Box>
   );
 };
@@ -167,11 +173,13 @@ const AssetSidebarLocationLabel = ({
 const FocusableLabelContainer = ({
   isSelected,
   isLastSelected,
-  children,
+  icon,
+  text,
 }: {
   isSelected: boolean;
   isLastSelected: boolean;
-  children: React.ReactNode;
+  icon: React.ReactNode;
+  text: string;
 }) => {
   const ref = React.useRef<HTMLButtonElement | null>(null);
   React.useLayoutEffect(() => {
@@ -188,21 +196,11 @@ const FocusableLabelContainer = ({
     <GrayOnHoverBox
       ref={ref}
       style={{
-        width: '100%',
-        borderRadius: '8px',
         ...(isSelected ? {background: Colors.backgroundBlue()} : {}),
       }}
     >
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'auto minmax(0, 1fr)',
-          gap: '6px',
-          alignItems: 'center',
-        }}
-      >
-        {children}
-      </div>
+      {icon}
+      <MiddleTruncate text={text} />
     </GrayOnHoverBox>
   );
 };
@@ -241,12 +239,13 @@ const GrayOnHoverBox = styled(UnstyledButton)`
   border-radius: 8px;
   user-select: none;
   width: 100%;
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
   flex-direction: row;
   align-items: center;
   padding: 5px 8px;
   justify-content: space-between;
-  gap: 6;
+  gap: 6px;
   flex-grow: 1;
   flex-shrink: 1;
   transition: background 100ms linear;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -326,11 +326,11 @@ export const AssetGraphExplorerSidebar = React.memo(
                 selectNode(e, nextNode.id);
               } else if (e.code === 'ArrowLeft' || e.code === 'ArrowRight') {
                 const open = e.code === 'ArrowRight';
+                const node = renderedNodes[indexOfLastSelectedNode];
+                if (!node || 'path' in node) {
+                  return;
+                }
                 setOpenNodes((nodes) => {
-                  const node = renderedNodes[indexOfLastSelectedNode];
-                  if (!node) {
-                    return nodes;
-                  }
                   const openNodes = new Set(nodes);
                   if (open) {
                     openNodes.add(nodePathKey(node));

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -178,7 +178,11 @@ export const AssetGraphExplorerSidebar = React.memo(
                 .forEach((assetNode) => {
                   folderNodes.push({
                     id: assetNode.id,
-                    path: locationName + ':' + groupNode.groupName + ':' + assetNode.assetKey,
+                    path: [
+                      locationName,
+                      groupNode.groupName,
+                      tokenForAssetKey(assetNode.assetKey),
+                    ].join(':'),
                     level: 3,
                   });
                 });

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.tsx
@@ -5,18 +5,20 @@ import styled, {keyframes} from 'styled-components';
 import {StatusCase} from '../AssetNodeStatusContent';
 import {GraphNode} from '../Utils';
 
-export type FolderNodeNonAssetType =
-  | {
-      id: string;
-      level: number;
-      groupNode: {
-        groupName: string;
-        assets: GraphNode[];
-        repositoryName: string;
-        repositoryLocationName: string;
-      };
-    }
-  | {locationName: string; id: string; level: number};
+export type FolderNodeGroupType = {
+  id: string;
+  level: number;
+  groupNode: {
+    groupName: string;
+    assets: GraphNode[];
+    repositoryName: string;
+    repositoryLocationName: string;
+  };
+};
+
+export type FolderNodeCodeLocationType = {locationName: string; id: string; level: number};
+
+export type FolderNodeNonAssetType = FolderNodeGroupType | FolderNodeCodeLocationType;
 
 export type FolderNodeType = FolderNodeNonAssetType | {path: string; id: string; level: number};
 


### PR DESCRIPTION
## Summary & Motivation

This PR brings the context menus to the assets and groups shown in the left sidebar.  You could previously access these using the "•••" icon on the far right, but now you can also right click! 

Because our context menus are provided by a React hook, and hooks can't be used conditionally, I had to split `AssetSidebarNode` into a common container, and create a separate "label" with the content for each type of node. It's only 11 more lines of code but it looks like a lot changed in the file...
 
![image](https://github.com/dagster-io/dagster/assets/1037212/5352ca36-136c-418f-8883-7ea7ff0920cb)


## How I Tested These Changes

I tested this by right clicking all three kinds of nodes in the asset graph sidebar. I also tried navigating with the arrow keys.
