### PR TITLE
feat(dbt): support `duckdb-dbt==1.7.2`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/models/metricflow_time_spine.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/models/metricflow_time_spine.sql
@@ -5,7 +5,7 @@ with
 days as (
 
     --for BQ adapters use "DATE('01/01/2000','mm/dd/yyyy')"
-    {{ dbt_date.get_base_dates(n_dateparts=365*10, datepart="day") }}
+    {{ dbt_date.get_base_dates(start_date="2000-01-01", end_date="2027-01-01") }}
 
 ),
 

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -16,9 +16,8 @@ deps =
   dbt16: dbt-core==1.6.*
   dbt16: dbt-duckdb==1.6.*
   dbt17: dbt-core==1.7.*
-  dbt17: dbt-duckdb==1.7.1
+  dbt17: dbt-duckdb==1.7.*
   pydantic1: pydantic!=1.10.7,<2.0.0
-  pydantic1: dbt-duckdb==1.7.1
   -e .[test]
 allowlist_externals =
   /bin/bash


### PR DESCRIPTION
## Summary & Motivation
This stopped working probably because of https://github.com/duckdb/dbt-duckdb/pull/334. Just edit our usage of the `.get_base_dates`.

We still use https://github.com/calogica/dbt-date since `dbt.date_spine` is only available in >1.7. Also, it doesn't really matter how we generate this time spine since we just want a manifest to be created properly.

## How I Tested These Changes
bk, tox
