### PR TITLE
feat(declarative-instigator-status): delete unloadable instigators on daemon iteration

### DIFF
--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -5,7 +5,7 @@ import threading
 from collections import defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import AbstractContextManager, ExitStack
-from typing import TYPE_CHECKING, Dict, List, Mapping, NamedTuple, Optional, Sequence, cast
+from typing import TYPE_CHECKING, Dict, List, Mapping, NamedTuple, Optional, Sequence, Set, cast
 
 import pendulum
 from typing_extensions import Self
@@ -230,7 +230,7 @@ def launch_scheduled_runs(
     tick_retention_settings = instance.get_tick_retention_settings(InstigatorType.SCHEDULE)
 
     schedules: Dict[str, ExternalSchedule] = {}
-    error_locations = set()
+    error_locations: Set[str] = set()
 
     for location_entry in workspace_snapshot.values():
         code_location = location_entry.code_location
@@ -250,27 +250,26 @@ def launch_scheduled_runs(
                 )
             error_locations.add(location_entry.origin.location_name)
 
-    # Remove any schedule states that were previously created with DECLARED_IN_CODE
-    # and can no longer be found in the workspace (so that if they are later added
-    # back again, their timestamps will start at the correct place)
+    # Remove any schedule states that can no longer be found in the workspace
+    # (if they are later added back again, their timestamps will start at the correct place)
     states_to_delete = [
         schedule_state
         for selector_id, schedule_state in all_schedule_states.items()
         if selector_id not in schedules
-        and schedule_state.status == InstigatorStatus.DECLARED_IN_CODE
     ]
     for state in states_to_delete:
         location_name = state.origin.external_repository_origin.code_location_origin.location_name
-        # don't clean up auto running state if its location is an error state
+        # don't clean up state if its location is an error state
         if location_name not in error_locations:
             logger.info(
-                f"Removing state for automatically running schedule {state.instigator_name} "
+                f"Removing state for schedule {state.instigator_name} "
                 f"that is no longer present in {location_name}."
             )
             instance.delete_instigator_state(state.instigator_origin_id, state.selector_id)
 
     if not schedules:
-        logger.debug("Not checking for any runs since no schedules have been started.")
+        if log_verbose_checks:
+            logger.debug("Not checking for any runs since no schedules have been started.")
         yield
         return
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -1202,6 +1202,9 @@ def test_bad_load_sensor_repository(
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(invalid_state.instigator_origin_id, invalid_state.selector_id)
         assert len(ticks) == 0
+        assert not instance.get_instigator_state(
+            invalid_state.instigator_origin_id, invalid_state.selector_id
+        )
 
 
 def test_bad_load_sensor(executor, instance, workspace_context, external_repo):
@@ -1234,6 +1237,9 @@ def test_bad_load_sensor(executor, instance, workspace_context, external_repo):
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(invalid_state.instigator_origin_id, invalid_state.selector_id)
         assert len(ticks) == 0
+        assert not instance.get_instigator_state(
+            invalid_state.instigator_origin_id, invalid_state.selector_id
+        )
 
 
 def test_error_sensor(caplog, executor, instance, workspace_context, external_repo):

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -2232,6 +2232,9 @@ class TestSchedulerRun:
             )
 
             assert len(ticks) == 0
+            assert not scheduler_instance.get_instigator_state(
+                schedule_state.instigator_origin_id, schedule_state.selector_id
+            )
 
     @pytest.mark.parametrize("executor", get_schedule_executors())
     def test_bad_load_schedule(
@@ -2271,6 +2274,9 @@ class TestSchedulerRun:
             )
 
             assert len(ticks) == 0
+            assert not scheduler_instance.get_instigator_state(
+                schedule_state.instigator_origin_id, schedule_state.selector_id
+            )
 
     @pytest.mark.parametrize("executor", get_schedule_executors())
     def test_load_code_location_not_in_workspace(
@@ -2324,6 +2330,9 @@ class TestSchedulerRun:
             )
 
             assert len(ticks) == 0
+            assert not scheduler_instance.get_instigator_state(
+                schedule_state.instigator_origin_id, schedule_state.selector_id
+            )
 
     @pytest.mark.parametrize("executor", get_schedule_executors())
     def test_multiple_schedules_on_different_time_ranges(


### PR DESCRIPTION
## Summary & Motivation
Delete unloadable instigators states managed by the sensor and schedule daemon.

Note that logic was already in the schedule daemon, but not in the sensor daemon. So add it there. 

## How I Tested These Changes
pytest
