### PR TITLE
[graph differ] consider partition changes when determining if the asset graph has changed

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -717,6 +717,7 @@ enum ChangeReason {
   NEW
   CODE_VERSION
   INPUTS
+  PARTITIONS_DEFINITION
 }
 
 type AssetDependency {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -732,6 +732,7 @@ export enum ChangeReason {
   CODE_VERSION = 'CODE_VERSION',
   INPUTS = 'INPUTS',
   NEW = 'NEW',
+  PARTITIONS_DEFINITION = 'PARTITIONS_DEFINITION',
 }
 
 export type ClaimedConcurrencySlot = {

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -17,6 +17,7 @@ class ChangeReason(Enum):
     NEW = "NEW"
     CODE_VERSION = "CODE_VERSION"
     INPUTS = "INPUTS"
+    PARTITIONS_DEFINITION = "PARTITIONS_DEFINITION"
 
 
 def _get_external_repo_from_context(
@@ -130,6 +131,20 @@ class AssetGraphDiffer:
             asset_key
         ):
             changes.append(ChangeReason.INPUTS)
+        else:
+            # if the set of inputs is different, then we don't need to check if the partition mappings
+            # for inputs have changed since ChangeReason.INPUTS is already in the list of changes
+            for upstream_asset in self.branch_asset_graph.get_parents(asset_key):
+                if self.branch_asset_graph.get_partition_mapping(
+                    asset_key, upstream_asset
+                ) != self.base_asset_graph.get_partition_mapping(asset_key, upstream_asset):
+                    changes.append(ChangeReason.INPUTS)
+                    break
+
+        if self.branch_asset_graph.get_partitions_def(
+            asset_key
+        ) != self.base_asset_graph.get_partitions_def(asset_key):
+            changes.append(ChangeReason.PARTITIONS_DEFINITION)
 
         return changes
 

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/partitioned_asset_graph/base_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/partitioned_asset_graph/base_asset_graph.py
@@ -1,0 +1,70 @@
+from dagster import (
+    AssetIn,
+    DailyPartitionsDefinition,
+    Definitions,
+    MultiPartitionsDefinition,
+    StaticPartitionMapping,
+    StaticPartitionsDefinition,
+    TimeWindowPartitionMapping,
+    asset,
+)
+
+daily_partitions_def = DailyPartitionsDefinition(start_date="2024-02-01")
+static_partitions_def = StaticPartitionsDefinition(["apple", "orange", "banana"])
+multi_partitions_def = MultiPartitionsDefinition(
+    {"date": daily_partitions_def, "fruits": static_partitions_def}
+)
+
+
+@asset(partitions_def=daily_partitions_def)
+def daily_upstream():
+    return 1
+
+
+@asset(
+    partitions_def=daily_partitions_def,
+    ins={"daily_upstream": AssetIn(partition_mapping=TimeWindowPartitionMapping(start_offset=-2))},
+)
+def daily_downstream(daily_upstream):
+    return daily_upstream + 1
+
+
+@asset(partitions_def=static_partitions_def)
+def static_upstream():
+    return 1
+
+
+@asset(
+    partitions_def=static_partitions_def,
+    ins={
+        "static_upstream": AssetIn(
+            partition_mapping=StaticPartitionMapping(
+                {"apple": "orange", "orange": "banana", "banana": "apple"}
+            )
+        )
+    },
+)
+def static_downstream(static_upstream):
+    return static_upstream + 1
+
+
+@asset(partitions_def=multi_partitions_def)
+def multi_partitioned_upstream():
+    return 1
+
+
+@asset(partitions_def=multi_partitions_def)
+def multi_partitioned_downstream(multi_partitioned_upstream):
+    return multi_partitioned_upstream + 1
+
+
+defs = Definitions(
+    assets=[
+        daily_upstream,
+        daily_downstream,
+        static_upstream,
+        static_downstream,
+        multi_partitioned_upstream,
+        multi_partitioned_downstream,
+    ]
+)

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/partitioned_asset_graph/branch_deployment_change_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/partitioned_asset_graph/branch_deployment_change_partition_mappings.py
@@ -1,0 +1,93 @@
+from dagster import (
+    AssetIn,
+    DailyPartitionsDefinition,
+    Definitions,
+    DimensionPartitionMapping,
+    MultiPartitionMapping,
+    MultiPartitionsDefinition,
+    StaticPartitionMapping,
+    StaticPartitionsDefinition,
+    TimeWindowPartitionMapping,
+    asset,
+)
+
+daily_partitions_def = DailyPartitionsDefinition(start_date="2024-02-01")
+static_partitions_def = StaticPartitionsDefinition(["apple", "orange", "banana"])
+multi_partitions_def = MultiPartitionsDefinition(
+    {"date": daily_partitions_def, "fruits": static_partitions_def}
+)
+
+
+@asset(partitions_def=daily_partitions_def)
+def daily_upstream():
+    return 1
+
+
+@asset(
+    partitions_def=daily_partitions_def,
+    ins={
+        "daily_upstream": AssetIn(partition_mapping=TimeWindowPartitionMapping(start_offset=-4))
+    },  # change the time window partition mapping
+)
+def daily_downstream(daily_upstream):
+    return daily_upstream + 1
+
+
+@asset(partitions_def=static_partitions_def)
+def static_upstream():
+    return 1
+
+
+@asset(
+    partitions_def=static_partitions_def,
+    ins={
+        "static_upstream": AssetIn(
+            partition_mapping=StaticPartitionMapping(
+                {"apple": "banana", "orange": "apple", "banana": "orange"}
+            )
+        )
+    },  # change the static partition mapping
+)
+def static_downstream(static_upstream):
+    return static_upstream + 1
+
+
+@asset(partitions_def=multi_partitions_def)
+def multi_partitioned_upstream():
+    return 1
+
+
+@asset(
+    partitions_def=multi_partitions_def,
+    ins={
+        "multi_partitioned_upstream": AssetIn(
+            partition_mapping=MultiPartitionMapping(
+                {
+                    "date": DimensionPartitionMapping(
+                        "daily", TimeWindowPartitionMapping(start_offset=-2)
+                    ),
+                    "fruits": DimensionPartitionMapping(
+                        "fruits",
+                        StaticPartitionMapping(
+                            {"apple": "banana", "orange": "apple", "banana": "orange"}
+                        ),
+                    ),
+                }
+            )
+        )
+    },
+)
+def multi_partitioned_downstream(multi_partitioned_upstream):
+    return multi_partitioned_upstream + 1
+
+
+defs = Definitions(
+    assets=[
+        daily_upstream,
+        daily_downstream,
+        static_upstream,
+        static_downstream,
+        multi_partitioned_upstream,
+        multi_partitioned_downstream,
+    ]
+)

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/partitioned_asset_graph/branch_deployment_change_partitions_def.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/partitioned_asset_graph/branch_deployment_change_partitions_def.py
@@ -1,0 +1,74 @@
+from dagster import (
+    AssetIn,
+    DailyPartitionsDefinition,
+    Definitions,
+    MultiPartitionsDefinition,
+    StaticPartitionMapping,
+    StaticPartitionsDefinition,
+    TimeWindowPartitionMapping,
+    asset,
+)
+
+daily_partitions_def = DailyPartitionsDefinition(
+    start_date="2024-01-01"
+)  # change the daily partitions definition start date
+static_partitions_def = StaticPartitionsDefinition(
+    ["apple", "orange", "banana", "kiwi"]
+)  # add to the static partitions definition
+multi_partitions_def = MultiPartitionsDefinition(
+    {"date": daily_partitions_def, "fruits": static_partitions_def}
+)
+
+
+@asset(partitions_def=daily_partitions_def)
+def daily_upstream():
+    return 1
+
+
+@asset(
+    partitions_def=daily_partitions_def,
+    ins={"daily_upstream": AssetIn(partition_mapping=TimeWindowPartitionMapping(start_offset=-2))},
+)
+def daily_downstream(daily_upstream):
+    return daily_upstream + 1
+
+
+@asset(partitions_def=static_partitions_def)
+def static_upstream():
+    return 1
+
+
+@asset(
+    partitions_def=static_partitions_def,
+    ins={
+        "static_upstream": AssetIn(
+            partition_mapping=StaticPartitionMapping(
+                {"apple": "orange", "orange": "banana", "banana": "apple"}
+            )
+        )
+    },
+)
+def static_downstream(static_upstream):
+    return static_upstream + 1
+
+
+@asset(partitions_def=multi_partitions_def)
+def multi_partitioned_upstream():
+    return 1
+
+
+@asset(partitions_def=multi_partitions_def)
+def multi_partitioned_downstream(multi_partitioned_upstream):
+    return multi_partitioned_upstream + 1
+
+
+defs = Definitions(
+    assets=[
+        daily_upstream,
+        daily_downstream,
+        static_upstream,
+        static_downstream,
+        multi_partitioned_upstream,
+        multi_partitioned_downstream,
+    ]
+)

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -251,3 +251,51 @@ def test_new_code_location(instance):
     assert differ.get_changes_for_asset(AssetKey("new_asset")) == [ChangeReason.NEW]
     assert differ.get_changes_for_asset(AssetKey("upstream")) == [ChangeReason.NEW]
     assert differ.get_changes_for_asset(AssetKey("downstream")) == [ChangeReason.NEW]
+
+
+def test_change_partitions_definitions(instance):
+    differ = get_asset_graph_differ(
+        instance=instance,
+        code_location_to_diff="partitioned_asset_graph",
+        base_code_locations=["partitioned_asset_graph"],
+        branch_code_location_to_definitions={
+            "partitioned_asset_graph": "branch_deployment_change_partitions_def"
+        },
+    )
+    assert differ.get_changes_for_asset(AssetKey("daily_upstream")) == [
+        ChangeReason.PARTITIONS_DEFINITION
+    ]
+    assert differ.get_changes_for_asset(AssetKey("daily_downstream")) == [
+        ChangeReason.PARTITIONS_DEFINITION
+    ]
+    assert differ.get_changes_for_asset(AssetKey("static_upstream")) == [
+        ChangeReason.PARTITIONS_DEFINITION
+    ]
+    assert differ.get_changes_for_asset(AssetKey("static_downstream")) == [
+        ChangeReason.PARTITIONS_DEFINITION
+    ]
+    assert differ.get_changes_for_asset(AssetKey("multi_partitioned_upstream")) == [
+        ChangeReason.PARTITIONS_DEFINITION
+    ]
+    assert differ.get_changes_for_asset(AssetKey("multi_partitioned_downstream")) == [
+        ChangeReason.PARTITIONS_DEFINITION
+    ]
+
+
+def test_change_partition_mapping(instance):
+    differ = get_asset_graph_differ(
+        instance=instance,
+        code_location_to_diff="partitioned_asset_graph",
+        base_code_locations=["partitioned_asset_graph"],
+        branch_code_location_to_definitions={
+            "partitioned_asset_graph": "branch_deployment_change_partition_mappings"
+        },
+    )
+    assert len(differ.get_changes_for_asset(AssetKey("daily_upstream"))) == 0
+    assert differ.get_changes_for_asset(AssetKey("daily_downstream")) == [ChangeReason.INPUTS]
+    assert len(differ.get_changes_for_asset(AssetKey("static_upstream"))) == 0
+    assert differ.get_changes_for_asset(AssetKey("static_downstream")) == [ChangeReason.INPUTS]
+    assert len(differ.get_changes_for_asset(AssetKey("multi_partitioned_upstream"))) == 0
+    assert differ.get_changes_for_asset(AssetKey("multi_partitioned_downstream")) == [
+        ChangeReason.INPUTS
+    ]


### PR DESCRIPTION
## Summary & Motivation
Adds the following partition modifications to the branch deployment asset graph differ:
- Change in Partitions definition - captures if the type of partition definitions changes (ie daily to weekly) the set of static partitions changes, the start date of a time based partition changes 
- Change in a partition mapping for an input

## How I Tested These Changes
new unit tests