### PR TITLE
move treeless clone setup

### DIFF
--- a/.buildkite/hooks/pre-checkout
+++ b/.buildkite/hooks/pre-checkout
@@ -1,2 +1,0 @@
-export BUILDKITE_GIT_CLONE_FLAGS="--filter tree:0"
-export BUILDKITE_GIT_CLONE_MIRROR_FLAGS="--filter tree:0"


### PR DESCRIPTION
pre-checkout file isn't there yet if its part of the checkout

I tried to move the env vars to the pipeline generation, but they are protected so you cant do that

Then I moved them to the secrets bucket

`BUILDKITE_GIT_CLONE_FLAGS`
seems to be respected, but
`BUILDKITE_GIT_CLONE_MIRROR_FLAGS` wont be until we get agent version > 3.47.0
we are on agentCF stack 5.11.1 with agent  3.38.0
latest CF stack v6.16.0 has agent 3.63.0
https://buildkite.com/docs/agent/v3/configuration



