### PR TITLE
docs infra: remove unversioned layout bc everything is versioned thru git

### DIFF
--- a/docs/next/components/mdx/MDXRenderer.tsx
+++ b/docs/next/components/mdx/MDXRenderer.tsx
@@ -4,13 +4,11 @@ import {SHOW_VERSION_NOTICE} from 'util/version';
 
 import cx from 'classnames';
 import Icons from 'components/Icons';
-import {RightSidebar} from 'components/SidebarNavigation';
 import VersionDropdown from 'components/VersionDropdown';
 import MDXComponents, {SearchIndexContext} from 'components/mdx/MDXComponents';
 import hydrate from 'next-mdx-remote/hydrate';
 import {MdxRemote} from 'next-mdx-remote/types';
 import {NextSeo} from 'next-seo';
-import {useRouter} from 'next/router';
 import React from 'react';
 
 // The next-mdx-remote types are outdated.
@@ -153,64 +151,6 @@ export const VersionedContentLayout = ({children, asPath = null}) => {
     </div>
   );
 };
-
-export function UnversionedMDXRenderer({
-  data,
-  toggleFeedback,
-  bottomContent,
-}: {
-  data: MDXData;
-  toggleFeedback: any;
-  bottomContent?: React.ReactNode | null;
-}) {
-  const {mdxSource, frontMatter, searchIndex, tableOfContents, githubLink, asPath} = data;
-
-  const content = hydrate(mdxSource, {
-    components,
-    provider: {
-      component: searchProvider,
-      props: {value: searchIndex},
-    },
-  });
-  const navigationItemsForMDX = tableOfContents.items.filter((item) => item?.items);
-
-  return (
-    <>
-      <NextSeo
-        title={frontMatter.title}
-        description={frontMatter.description}
-        openGraph={{
-          title: frontMatter.title,
-          description: frontMatter.description,
-        }}
-      />
-      <div className="flex-1 min-w-0 relative z-0 focus:outline-none pt-4" tabIndex={0}>
-        <div className="pl-4 sm:pl-6 lg:pl-8 ">
-          <BreadcrumbNav asPath={asPath} />
-        </div>
-        <div
-          className="flex flex-row pb-8 max-w-7xl"
-          style={{marginLeft: 'auto', marginRight: 'auto'}}
-        >
-          {/* Start main area*/}
-
-          <div className="py-4 px-4 sm:px-6 lg:px-8 w-full">
-            <div className="DocSearch-content prose dark:prose-dark max-w-none">{content}</div>
-            {bottomContent ?? null}
-          </div>
-          {/* End main area */}
-        </div>
-      </div>
-
-      <RightSidebar
-        navigationItemsForMDX={navigationItemsForMDX}
-        markdownHeadings={null}
-        githubLink={githubLink}
-        toggleFeedback={toggleFeedback}
-      />
-    </>
-  );
-}
 
 function VersionedMDXRenderer({data}: {data: MDXData}) {
   const {mdxSource, frontMatter, searchIndex} = data;

--- a/docs/next/pages/changelog.tsx
+++ b/docs/next/pages/changelog.tsx
@@ -15,7 +15,7 @@ import visit from 'unist-util-visit';
 import FeedbackModal from '../components/FeedbackModal';
 import {PagePagination} from '../components/PagePagination';
 import MDXComponents from '../components/mdx/MDXComponents';
-import {MDXData, UnversionedMDXRenderer} from '../components/mdx/MDXRenderer';
+import MDXRenderer, {MDXData} from '../components/mdx/MDXRenderer';
 import {getPaginatedChangeLog} from '../util/paginatedChangelog';
 
 const PAGINATION_VERSION_COUNT_PER_PAGE = 5;
@@ -60,17 +60,8 @@ export default function MdxPage(props: Props) {
 
   return (
     <>
-      <FeedbackModal isOpen={isFeedbackOpen} closeFeedback={closeFeedback} />
-      <UnversionedMDXRenderer
-        data={props.data}
-        toggleFeedback={toggleFeedback}
-        bottomContent={
-          <PagePagination
-            currentPageIndex={currentPageIndex}
-            totalPageCount={props.totalPageCount}
-          />
-        }
-      />
+      <MDXRenderer data={props.data} />
+      <PagePagination currentPageIndex={currentPageIndex} totalPageCount={props.totalPageCount} />
     </>
   );
 }

--- a/docs/next/pages/migration.tsx
+++ b/docs/next/pages/migration.tsx
@@ -16,7 +16,7 @@ import visit from 'unist-util-visit';
 
 import FeedbackModal from '../components/FeedbackModal';
 import MDXComponents from '../components/mdx/MDXComponents';
-import {MDXData, UnversionedMDXRenderer} from '../components/mdx/MDXRenderer';
+import MDXRenderer, {MDXData} from '../components/mdx/MDXRenderer';
 
 // The next-mdx-remote types are outdated.
 const components: MdxRemote.Components = MDXComponents as any;
@@ -49,12 +49,7 @@ export default function MdxPage(props: Props) {
     return <Shimmer />;
   }
 
-  return (
-    <>
-      <FeedbackModal isOpen={isFeedbackOpen} closeFeedback={closeFeedback} />
-      <UnversionedMDXRenderer data={props.data} toggleFeedback={toggleFeedback} />
-    </>
-  );
+  return <MDXRenderer data={props.data} />;
 }
 
 // Travel the tree to get the headings


### PR DESCRIPTION
## Summary & Motivation
fixes DOC-151

similar to https://github.com/dagster-io/dagster/pull/19583, but this one is caused by unnecessary unversioned layout. as we no longer have our custom versioning logic, we don't need to differentiate UnversionedMDXRenderer vs VersionedMDXRenderer (we used to need so because they two pulled markdown source files from different places). so this PR removes that confusing layer and therefore fixes the double component layout issue.

## How I Tested These Changes
preview
- changelog: https://dagster-docs-oe171kjiu-elementl.vercel.app/changelog
- migration: https://dagster-docs-oe171kjiu-elementl.vercel.app/migration
both layouts were off in status quo on docs.dagster.io