### PR TITLE
[docs] increase admonition padding to 4 all around

### DIFF
--- a/docs/next/components/markdoc/Callouts.tsx
+++ b/docs/next/components/markdoc/Callouts.tsx
@@ -19,7 +19,7 @@ const ADMONITION_STYLES = {
 const Admonition = ({style, children}) => {
   const {colors, icon} = ADMONITION_STYLES[style];
   return (
-    <div className={`bg-${colors.bg} border-l-4 border-${colors.borderIcon} px-4 my-4`}>
+    <div className={`bg-${colors.bg} border-l-4 border-${colors.borderIcon} p-4 my-4`}>
       <div className="flex items-center">
         <div className="flex-shrink-0">
           <svg


### PR DESCRIPTION
## Summary & Motivation

This is definitely a nitpick, but currentnotes & warnings are rather skinny vertically, and I believe they would be slightly more aesthetically pleasing if we used `p-4` instead of `px-4`.

This is definitely personal preference - would be curious what others think.

### Examples

**Before**
<img width="1262" alt="image" src="https://github.com/dagster-io/dagster/assets/5807118/161f5807-c3af-40af-b11f-36605771384a">

**After**
<img width="1226" alt="image" src="https://github.com/dagster-io/dagster/assets/5807118/865f5966-46db-42f0-a5b2-9229208bce0c">
