### PR TITLE
[external-assets] Replace source assets with external assets at the repository level

### DIFF
--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -49,7 +49,6 @@ def execute_materialize_command(instance: DagsterInstance, kwargs: Mapping[str, 
 
     asset_keys = parse_asset_selection(
         assets_defs=list(repo_def.assets_defs_by_key.values()),
-        source_assets=list(repo_def.source_assets_by_key.values()),
         asset_selection=kwargs["select"].split(","),
     )
 
@@ -97,7 +96,6 @@ def asset_list_command(**kwargs):
     if select is not None:
         asset_keys = parse_asset_selection(
             assets_defs=list(repo_def.assets_defs_by_key.values()),
-            source_assets=list(repo_def.source_assets_by_key.values()),
             asset_selection=select.split(","),
             raise_on_clause_has_no_matches=False,
         )

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -63,16 +63,15 @@ def is_base_asset_job_name(name: str) -> bool:
 
 def get_base_asset_jobs(
     assets: Sequence[AssetsDefinition],
-    source_assets: Sequence[SourceAsset],
     asset_checks: Sequence[AssetChecksDefinition],
     resource_defs: Optional[Mapping[str, ResourceDefinition]],
     executor_def: Optional[ExecutorDefinition],
 ) -> Sequence[JobDefinition]:
-    executable_assets = [a for a in (*assets, *source_assets) if a.is_executable]
-    unexecutable_assets = [a for a in (*assets, *source_assets) if not a.is_executable]
+    executable_assets = [a for a in assets if a.is_executable]
+    unexecutable_assets = [a for a in assets if not a.is_executable]
 
     executable_assets_by_partitions_def: Dict[
-        Optional[PartitionsDefinition], List[Union[AssetsDefinition, SourceAsset]]
+        Optional[PartitionsDefinition], List[AssetsDefinition]
     ] = defaultdict(list)
     for asset in executable_assets:
         executable_assets_by_partitions_def[asset.partitions_def].append(asset)

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -250,10 +250,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         self._monitored_asset_keys: Sequence[AssetKey]
         if isinstance(monitored_assets, AssetSelection):
             repo_assets = self._repository_def.assets_defs_by_key.values()
-            repo_source_assets = self._repository_def.source_assets_by_key.values()
-            self._monitored_asset_keys = list(
-                monitored_assets.resolve([*repo_assets, *repo_source_assets])
-            )
+            self._monitored_asset_keys = list(monitored_assets.resolve(repo_assets))
         else:
             self._monitored_asset_keys = monitored_assets
 
@@ -263,13 +260,8 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
             assets_def = self._repository_def.assets_defs_by_key.get(asset_key)
             self._assets_by_key[asset_key] = assets_def
 
-            source_asset_def = self._repository_def.source_assets_by_key.get(asset_key)
             self._partitions_def_by_asset_key[asset_key] = (
-                assets_def.partitions_def
-                if assets_def
-                else source_asset_def.partitions_def
-                if source_asset_def
-                else None
+                assets_def.partitions_def if assets_def else None
             )
 
         # Cursor object with utility methods for updating and retrieving cursor information.

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -32,6 +32,7 @@ from dagster._core.definitions.auto_materialize_sensor_definition import (
     AutoMaterializeSensorDefinition,
 )
 from dagster._core.definitions.executor_definition import ExecutorDefinition
+from dagster._core.definitions.external_asset import create_external_asset_from_source_asset
 from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.job_definition import JobDefinition
@@ -226,6 +227,7 @@ def build_caching_repository_data_from_list(
             assets_defs.append(definition)
         elif isinstance(definition, SourceAsset):
             source_assets.append(definition)
+            assets_defs.append(create_external_asset_from_source_asset(definition))
         elif isinstance(definition, AssetChecksDefinition):
             asset_checks_defs.append(definition)
         else:
@@ -234,7 +236,6 @@ def build_caching_repository_data_from_list(
     if assets_defs or source_assets or asset_checks_defs:
         for job_def in get_base_asset_jobs(
             assets=assets_defs,
-            source_assets=source_assets,
             executor_def=default_executor_def,
             resource_defs=top_level_resources,
             asset_checks=asset_checks_defs,
@@ -262,9 +263,7 @@ def build_caching_repository_data_from_list(
                 schedule_def, coerced_graphs, unresolved_jobs, jobs, target
             )
 
-    asset_graph = InternalAssetGraph.from_assets(
-        [*assets_defs, *source_assets], asset_checks=asset_checks_defs
-    )
+    asset_graph = InternalAssetGraph.from_assets(assets_defs, asset_checks=asset_checks_defs)
     _validate_auto_materialize_sensors(sensors.values(), asset_graph)
 
     if unresolved_partitioned_asset_schedules:

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -248,6 +248,10 @@ class RepositoryDefinition:
     def assets_defs_by_key(self) -> Mapping[AssetKey, "AssetsDefinition"]:
         return self._repository_data.get_assets_defs_by_key()
 
+    @property
+    def external_assets_defs_by_key(self) -> Mapping[AssetKey, "AssetsDefinition"]:
+        return {k: v for k, v in self.assets_defs_by_key.items() if v.is_external}
+
     def has_implicit_global_asset_job_def(self) -> bool:
         """Returns true is there is a single implicit asset job for all asset keys in a repository."""
         return self.has_job(ASSET_BASE_JOB_PREFIX)
@@ -349,9 +353,7 @@ class RepositoryDefinition:
         """
         from dagster._core.storage.asset_value_loader import AssetValueLoader
 
-        with AssetValueLoader(
-            self.assets_defs_by_key, self.source_assets_by_key, instance=instance
-        ) as loader:
+        with AssetValueLoader(self.assets_defs_by_key, instance=instance) as loader:
             return loader.load_asset_value(
                 asset_key,
                 python_type=python_type,
@@ -380,15 +382,11 @@ class RepositoryDefinition:
         """
         from dagster._core.storage.asset_value_loader import AssetValueLoader
 
-        return AssetValueLoader(
-            self.assets_defs_by_key, self.source_assets_by_key, instance=instance
-        )
+        return AssetValueLoader(self.assets_defs_by_key, instance=instance)
 
     @property
     def asset_graph(self) -> InternalAssetGraph:
-        return InternalAssetGraph.from_assets(
-            [*set(self.assets_defs_by_key.values()), *self.source_assets_by_key.values()]
-        )
+        return InternalAssetGraph.from_assets(list(dict.fromkeys(self.assets_defs_by_key.values())))
 
     # If definition comes from the @repository decorator, then the __call__ method will be
     # overwritten. Therefore, we want to maintain the call-ability of repository definitions.

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -465,7 +465,6 @@ def parse_step_selection(
 
 def parse_asset_selection(
     assets_defs: Sequence["AssetsDefinition"],
-    source_assets: Sequence["SourceAsset"],
     asset_selection: Sequence[str],
     raise_on_clause_has_no_matches: bool = True,
 ) -> AbstractSet[AssetKey]:
@@ -486,7 +485,7 @@ def parse_asset_selection(
     if len(asset_selection) == 1 and asset_selection[0] == "*":
         return {key for ad in assets_defs for key in ad.keys}
 
-    graph = generate_asset_dep_graph(assets_defs, source_assets)
+    graph = generate_asset_dep_graph(assets_defs, [])
     assets_set: Set[AssetKey] = set()
 
     # loop over clauses

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -53,7 +53,7 @@ def to_external_asset_graph(assets, asset_checks=None) -> AssetGraph:
         return assets + (asset_checks or [])
 
     external_asset_nodes = external_asset_nodes_from_defs(
-        repo.get_all_jobs(), repo.assets_defs_by_key, source_assets_by_key={}
+        repo.get_all_jobs(), repo.assets_defs_by_key
     )
     return ExternalAssetGraph.from_repository_handles_and_external_asset_nodes(
         [(MagicMock(), asset_node) for asset_node in external_asset_nodes],

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -40,6 +40,7 @@ from dagster._core.definitions.asset_selection import AssetSelection, CoercibleT
 from dagster._core.definitions.assets_job import get_base_asset_jobs
 from dagster._core.definitions.dependency import NodeHandle, NodeInvocation
 from dagster._core.definitions.executor_definition import in_process_executor
+from dagster._core.definitions.external_asset import create_external_asset_from_source_asset
 from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.load_assets_from_modules import prefix_assets
@@ -1978,7 +1979,6 @@ def test_get_base_asset_jobs_multiple_partitions_defs():
             hourly_asset,
             unpartitioned_asset,
         ],
-        source_assets=[],
         executor_def=None,
         resource_defs={},
         asset_checks=[],
@@ -2022,10 +2022,8 @@ def test_get_base_asset_jobs_multiple_partitions_defs_and_observable_assets():
     jobs = get_base_asset_jobs(
         assets=[
             asset_x,
-        ],
-        source_assets=[
-            asset_a,
-            asset_b,
+            create_external_asset_from_source_asset(asset_a),
+            create_external_asset_from_source_asset(asset_b),
         ],
         executor_def=None,
         resource_defs={},

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -711,7 +711,6 @@ def external_asset_graph_from_assets_by_repo_name(
         external_asset_nodes = external_asset_nodes_from_defs(
             repo.get_all_jobs(),
             repo.assets_defs_by_key,
-            source_assets_by_key=repo.source_assets_by_key,
         )
         repo_handle = MagicMock(repository_name=repo_name)
         from_repository_handles_and_external_asset_nodes.extend(

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -333,7 +333,7 @@ def observe_sources(*args):
     def observe_sources_fn(*, instance, times_by_key, **kwargs):
         for arg in args:
             key = AssetKey(arg)
-            observe(assets=[versioned_repo.source_assets_by_key[key]], instance=instance)
+            observe(assets=[versioned_repo.external_assets_defs_by_key[key]], instance=instance)
             latest_record = instance.get_latest_data_version_record(key, is_source=True)
             latest_timestamp = latest_record.timestamp
             times_by_key[key].append(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -204,7 +204,7 @@ def test_resource_coercion():
 def test_source_asset():
     defs = Definitions(assets=[SourceAsset("a-source-asset")])
     repo = resolve_pending_repo_if_required(defs)
-    all_assets = list(repo.source_assets_by_key.values())
+    all_assets = list(repo.assets_defs_by_key.values())
     assert len(all_assets) == 1
     assert all_assets[0].key.to_user_string() == "a-source-asset"
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
@@ -650,10 +650,9 @@ def test_source_assets():
     def my_repo():
         return [foo, bar]
 
-    assert my_repo.source_assets_by_key == {
-        AssetKey("foo"): SourceAsset(key=AssetKey("foo")),
-        AssetKey("bar"): SourceAsset(key=AssetKey("bar")),
-    }
+    all_assets = list(my_repo.assets_defs_by_key.values())
+    assert len(all_assets) == 2
+    assert {key.to_user_string() for a in all_assets for key in a.keys} == {"foo", "bar"}
 
 
 def test_direct_assets():

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_value_loader.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_value_loader.py
@@ -77,7 +77,7 @@ def test_source_asset():
             assert context.asset_key == AssetKey("asset1")
             assert context.upstream_output.asset_key == AssetKey("asset1")
             assert context.upstream_output.metadata["a"] == "b"
-            assert context.upstream_output.name == "asset1"
+            assert context.upstream_output.name == "result"
             assert context.dagster_type.typing_type == int
             return 5
 


### PR DESCRIPTION
## Summary & Motivation

Convert all source assets into external assets in `CachingRepositoryData`. Remove internal calls to retrieve source assets from the repository definition, instead only retrieving assets defs that include the "externalized" source assets.

We can't totally discard the source assets because they are exposed via a `@public` method on `RepositoryData`. I explored discarding them and then converting from external assets back to `SourceAsset` in this method-- this would've given us a clean "single source of truth"-- but I ran into difficulties with the reverse conversion (in particular obtaining the original `observe_fn` and resources).

## How I Tested These Changes

Existing test suite. A few tests needed modifications:

- Tests that looked at metadata of source assets needed to account for the system metadata added in the conversion
- The output_name used for loading an upstream externalized source asset is `"result"` (as in a regular asset), whereas for a `SourceAsset` it's the stringifed asset key. Pretty sure this is just an implementation detail so I just changed the tests.