### PR TITLE
[bugfix] Prevent AssetsDefinitions with no keys from being selected in assets jobs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -933,7 +933,8 @@ def _subset_assets_defs(
     included_assets: Set[AssetsDefinition] = set()
     excluded_assets: Set[AssetsDefinition] = set()
 
-    for asset in set(assets):
+    # Do not match any assets with no keys
+    for asset in set(a for a in assets if a.has_keys):
         # intersection
         selected_subset = selected_asset_keys & asset.keys
 

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -861,6 +861,10 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         """AbstractSet[AssetKey]: The asset keys associated with this AssetsDefinition."""
         return self._selected_asset_keys
 
+    @property
+    def has_keys(self) -> bool:
+        return len(self.keys) > 0
+
     @public
     @property
     def dependency_keys(self) -> Iterable[AssetKey]:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -2887,3 +2887,21 @@ def test_subset_cycle_dependencies():
     result = job.execute_in_process()
     assert result.success
     assert _all_asset_keys(result) == {AssetKey("a"), AssetKey("b")}
+
+
+def test_exclude_assets_without_keys():
+    @asset
+    def foo():
+        pass
+
+    # This is a valid AssetsDefinition but has no keys. It should not be executed.
+    @multi_asset()
+    def ghost():
+        assert False
+
+    foo_job = Definitions(
+        assets=[foo, ghost],
+        jobs=[define_asset_job("foo_job", [foo])],
+    ).get_job_def("foo_job")
+
+    assert foo_job.execute_in_process().success

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
@@ -48,7 +48,6 @@ def test_fivetran_group_label(group_name, expected_group_name):
 @pytest.mark.parametrize(
     "tables,infer_missing_tables,should_error",
     [
-        ([], False, False),
         (["schema1.tracked"], False, False),
         (["schema1.tracked", "schema2.tracked"], False, False),
         (["does.not_exist"], False, True),


### PR DESCRIPTION
## Summary & Motivation

Currently `AssetsDefinition` nodes with no keys are included in every assets job in the repo. This is due to a bug in subsetting logic. This PR fixes that bug and ensures that `AssetsDefinition` nodes with no keys are not included in any assets jobs.

There was one fivetran test that implicitly relied on the bug-- this test was deleted after consulation with @OwenKephart:

>the test that's failing is the case where you specify no tables that the connector will sync, and purely rely on the runtime asset materializations. I think we can consider this invalid behavior -- it's unclear why anyone would ever do this as you won't have any representation of this in the asset graph, it'd be very difficult to even find a way to execute the underlying op (I can't think of any way to do it, to be honest)... just deleting the case should be fine

## How I Tested These Changes

Existing test suite