### PR TITLE
[performance] Instrument search

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -53,7 +53,7 @@ import {closestNodeInDirection, isNodeOffscreen} from '../graph/common';
 import {AssetGroupSelector} from '../graphql/types';
 import {useQueryAndLocalStoragePersistedState} from '../hooks/useQueryAndLocalStoragePersistedState';
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
-import {useStartTrace} from '../performance';
+import {PageLoadTrace} from '../performance';
 import {
   GraphExplorerOptions,
   OptionsOverlay,
@@ -88,7 +88,7 @@ type Props = {
   onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
   onNavigateToSourceAssetNode: (node: AssetLocation) => void;
   isGlobalGraph?: boolean;
-  trace?: ReturnType<typeof useStartTrace>;
+  trace?: PageLoadTrace;
 } & OptionalFilters;
 
 export const MINIMAL_SCALE = 0.6;
@@ -193,7 +193,7 @@ type WithDataProps = Props & {
   filterButton?: React.ReactNode;
   filterBar?: React.ReactNode;
   isGlobalGraph?: boolean;
-  trace?: ReturnType<typeof useStartTrace>;
+  trace?: PageLoadTrace;
 };
 
 const AssetGraphExplorerWithData = ({

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -49,13 +49,13 @@ import {StaleReasonsTags} from '../assets/Stale';
 import {AssetComputeKindTag} from '../graph/OpTags';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {RepositoryLink} from '../nav/RepositoryLink';
-import {useStartTrace} from '../performance';
+import {PageLoadTrace} from '../performance';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 interface Props {
   assetKey: AssetKey;
-  trace?: ReturnType<typeof useStartTrace>;
+  trace?: PageLoadTrace;
 }
 
 export const AssetView = ({assetKey, trace}: Props) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogRoot.tsx
@@ -13,7 +13,7 @@ import {
 import {useTrackPageView} from '../app/analytics';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
-import {useStartTrace} from '../performance';
+import {usePageLoadTrace} from '../performance';
 import {ReloadAllButton} from '../workspace/ReloadAllButton';
 
 export const AssetsCatalogRoot = () => {
@@ -40,7 +40,7 @@ export const AssetsCatalogRoot = () => {
       : 'Assets',
   );
 
-  const trace = useStartTrace(
+  const trace = usePageLoadTrace(
     currentPath && currentPath.length === 0 ? 'AssetsCatalogRoot' : 'AssetCatalogAssetView',
   );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -27,7 +27,7 @@ import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment.types';
 import {AssetGroupSelector} from '../graphql/types';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
-import {useStartTrace} from '../performance';
+import {PageLoadTrace} from '../performance';
 import {LoadingSpinner} from '../ui/Loading';
 
 type Asset = AssetTableFragment;
@@ -76,7 +76,7 @@ interface AssetCatalogTableProps {
   prefixPath: string[];
   setPrefixPath: (prefixPath: string[]) => void;
   groupSelector?: AssetGroupSelector;
-  trace?: ReturnType<typeof useStartTrace>;
+  trace?: PageLoadTrace;
 }
 
 export const AssetsCatalogTable = ({

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
@@ -15,7 +15,7 @@ import {AssetLocation} from '../asset-graph/useFindAssetLocation';
 import {AssetGroupSelector} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
-import {useStartTrace} from '../performance';
+import {usePageLoadTrace} from '../performance';
 import {ExplorerPath} from '../pipelines/PipelinePathUtils';
 import {ReloadAllButton} from '../workspace/ReloadAllButton';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
@@ -44,7 +44,7 @@ export const AssetsGroupsGlobalGraphRoot = () => {
   });
 
   useDocumentTitle(`Global Asset Lineage`);
-  const trace = useStartTrace('GlobalAssetGraph');
+  const trace = usePageLoadTrace('GlobalAssetGraph');
 
   const onChangeExplorerPath = useCallback(
     (path: ExplorerPath, mode: 'push' | 'replace') => {

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadAllowedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadAllowedRoot.tsx
@@ -14,7 +14,7 @@ import {LaunchpadRootQuery, LaunchpadRootQueryVariables} from './types/Launchpad
 import {IExecutionSession} from '../app/ExecutionSessionStorage';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {useTrackPageView} from '../app/analytics';
-import {useStartTrace} from '../performance';
+import {usePageLoadTrace} from '../performance';
 import {explorerPathFromString, useStripSnapshotFromPath} from '../pipelines/PipelinePathUtils';
 import {useJobTitle} from '../pipelines/useJobTitle';
 import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
@@ -48,7 +48,7 @@ const filterDefaultYamlForSubselection = (defaultYaml: string, opNames: Set<stri
 
 export const LaunchpadAllowedRoot = (props: Props) => {
   useTrackPageView();
-  const trace = useStartTrace('LaunchpadAllowedRoot');
+  const trace = usePageLoadTrace('LaunchpadAllowedRoot');
 
   const {pipelinePath, repoAddress, launchpadType, sessionPresets} = props;
   const explorerPath = explorerPathFromString(pipelinePath);

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
@@ -6,7 +6,7 @@ import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {RepoFilterButton} from '../instance/RepoFilterButton';
-import {useStartTrace} from '../performance';
+import {usePageLoadTrace} from '../performance';
 import {RunTimeline} from '../runs/RunTimeline';
 import {HourWindow, useHourWindow} from '../runs/useHourWindow';
 import {makeJobKey, useRunsForTimeline} from '../runs/useRunsForTimeline';
@@ -37,7 +37,7 @@ type Props = {
 export const OverviewTimelineRoot = ({Header, TabButton}: Props) => {
   useTrackPageView();
   useDocumentTitle('Overview | Timeline');
-  const trace = useStartTrace('OverviewTimelineRoot');
+  const trace = usePageLoadTrace('OverviewTimelineRoot');
 
   const {allRepos, visibleRepos} = React.useContext(WorkspaceContext);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRunsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRunsRoot.tsx
@@ -26,7 +26,7 @@ import {
   useQueryRefreshAtInterval,
 } from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
-import {useStartTrace} from '../performance';
+import {usePageLoadTrace} from '../performance';
 import {RUN_TABLE_RUN_FRAGMENT, RunTable} from '../runs/RunTable';
 import {DagsterTag} from '../runs/RunTag';
 import {RunsQueryRefetchContext} from '../runs/RunUtils';
@@ -72,7 +72,7 @@ export const PipelineRunsRoot = (props: Props) => {
 
   useJobTitle(explorerPath, isJob);
 
-  const trace = useStartTrace('PipelineRunsRoot');
+  const trace = usePageLoadTrace('PipelineRunsRoot');
 
   const [filterTokens, setFilterTokens] = useQueryPersistedRunFilters(ENABLED_FILTERS);
   const permanentTokens = useMemo(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRootTrace.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRootTrace.tsx
@@ -1,9 +1,9 @@
 import {useMemo} from 'react';
 
-import {useStartTrace} from '../performance';
+import {usePageLoadTrace} from '../performance';
 
 export const useRunRootTrace = () => {
-  const trace = useStartTrace('RunRoot');
+  const trace = usePageLoadTrace('RunRoot');
   return useMemo(() => {
     let logsLoaded = false;
     let runsLoaded = false;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsRoot.tsx
@@ -36,7 +36,7 @@ import {
 } from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {usePortalSlot} from '../hooks/usePortalSlot';
-import {useStartTrace} from '../performance';
+import {usePageLoadTrace} from '../performance';
 import {Loading} from '../ui/Loading';
 import {StickyTableContainer} from '../ui/StickyTableContainer';
 
@@ -44,7 +44,7 @@ const PAGE_SIZE = 25;
 
 export const RunsRoot = () => {
   useTrackPageView();
-  const trace = useStartTrace('RunsRoot');
+  const trace = usePageLoadTrace('RunsRoot');
 
   const [filterTokens, setFilterTokens] = useQueryPersistedRunFilters();
   const filter = runsFilterForSearchTokens(filterTokens);
@@ -262,7 +262,7 @@ export const RunsRoot = () => {
   );
 };
 
-const RunsRootPerformanceEmitter = ({trace}: {trace: ReturnType<typeof useStartTrace>}) => {
+const RunsRootPerformanceEmitter = ({trace}: {trace: ReturnType<typeof usePageLoadTrace>}) => {
   useLayoutEffect(() => {
     trace.endTrace();
   }, [trace]);

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -85,7 +85,7 @@ export const SearchDialog = ({searchPlaceholder}: {searchPlaceholder: string}) =
   const numRenderedResults = renderedResults.length;
 
   const isFirstSearch = React.useRef(true);
-  const currentTrace = React.useRef<null | Trace>(null);
+  const firstSearchTrace = React.useRef<null | Trace>(null);
 
   const openSearch = React.useCallback(() => {
     trackEvent('searchOpen');
@@ -95,16 +95,16 @@ export const SearchDialog = ({searchPlaceholder}: {searchPlaceholder: string}) =
 
   React.useEffect(() => {
     if (primaryResults && secondaryResults) {
-      currentTrace.current?.endTrace();
+      firstSearchTrace.current?.endTrace();
     }
   }, [primaryResults, secondaryResults]);
 
   React.useEffect(() => {
-    if (!shown && currentTrace.current) {
+    if (!shown && firstSearchTrace.current) {
       // When the dialog closes:
       // Either the trace finished and we logged it, or it didn't and so we throw it away
-      // Either way we don't need the current trace object anymore
-      currentTrace.current = null;
+      // Either way we don't need the trace object anymore
+      firstSearchTrace.current = null;
     }
   }, [shown]);
 
@@ -130,9 +130,10 @@ export const SearchDialog = ({searchPlaceholder}: {searchPlaceholder: string}) =
       searchAndHandleSecondary(queryString);
     }, DEBOUNCE_MSEC);
     return (queryString: string) => {
-      if (!currentTrace.current && isFirstSearch.current) {
-        const trace = createTrace('Search');
-        currentTrace.current = trace;
+      if (!firstSearchTrace.current && isFirstSearch.current) {
+        isFirstSearch.current = false;
+        const trace = createTrace('SearchDialog:FirstSearch');
+        firstSearchTrace.current = trace;
         trace.startTrace();
       }
       return debouncedSearch(queryString);

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -94,10 +94,10 @@ export const SearchDialog = ({searchPlaceholder}: {searchPlaceholder: string}) =
   }, [initialize, trackEvent]);
 
   React.useEffect(() => {
-    if (primaryResults && secondaryResults) {
+    if (!loading && primaryResults && secondaryResults) {
       firstSearchTrace.current?.endTrace();
     }
-  }, [primaryResults, secondaryResults]);
+  }, [loading, primaryResults, secondaryResults]);
 
   React.useEffect(() => {
     if (!shown && firstSearchTrace.current) {

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceJobsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceJobsRoot.tsx
@@ -14,10 +14,10 @@ import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
-import {useStartTrace} from '../performance';
+import {usePageLoadTrace} from '../performance';
 
 export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
-  const trace = useStartTrace('WorkspaceJobsRoot');
+  const trace = usePageLoadTrace('WorkspaceJobsRoot');
   useTrackPageView();
 
   const repoName = repoAddressAsHumanString(repoAddress);


### PR DESCRIPTION
## Summary & Motivation
Instrumenting "first search" and also renaming `useStartTrace` -> `usePageLoadTrace`.

## How I Tested These Changes

Open search bar and type, see the trace in the console:
<img width="679" alt="Screenshot 2024-02-23 at 1 01 09 PM" src="https://github.com/dagster-io/dagster/assets/2286579/45fed870-2e69-4d1d-b5b1-90c621820ca1">
