### PR TITLE
[ui] Restore asset lineage tab in overview experiment, apply feedback to overview page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -98,6 +98,13 @@ export const AssetNodeOverview = ({
     return <AssetNodeOverviewLoading />;
   }
 
+  let tableSchema = materialization?.metadataEntries.find(isCanonicalTableSchemaEntry);
+  let tableSchemaLoadTimestamp = materialization ? Number(materialization.timestamp) : undefined;
+  if (!tableSchema) {
+    tableSchema = assetNode?.metadataEntries.find(isCanonicalTableSchemaEntry);
+    tableSchemaLoadTimestamp = assetNodeLoadTimestamp;
+  }
+
   const renderStatusSection = () => (
     <Box flex={{direction: 'row'}}>
       <Box flex={{direction: 'column', gap: 6}} style={{width: '50%'}}>
@@ -132,25 +139,6 @@ export const AssetNodeOverview = ({
         learnMoreLink="https://docs.dagster.io/_apidocs/assets#software-defined-assets"
       />
     );
-
-  const renderColumnsSection = () => {
-    let tableSchema = materialization?.metadataEntries.find(isCanonicalTableSchemaEntry);
-    let tableSchemaLoadTimestamp = materialization ? Number(materialization.timestamp) : undefined;
-    if (!tableSchema) {
-      tableSchema = assetNode?.metadataEntries.find(isCanonicalTableSchemaEntry);
-      tableSchemaLoadTimestamp = assetNodeLoadTimestamp;
-    }
-
-    return tableSchema ? (
-      <TableSchema schema={tableSchema.schema} schemaLoadTimestamp={tableSchemaLoadTimestamp} />
-    ) : (
-      <SectionEmptyState
-        title="No column schema found"
-        description="Dagster can render an assets column schema once it has been materialized."
-        learnMoreLink=""
-      />
-    );
-  };
 
   const renderLineageSection = () => (
     <>
@@ -340,9 +328,14 @@ export const AssetNodeOverview = ({
           <LargeCollapsibleSection header="Description" icon="sticky_note">
             {renderDescriptionSection()}
           </LargeCollapsibleSection>
-          <LargeCollapsibleSection header="Columns" icon="view_column">
-            {renderColumnsSection()}
-          </LargeCollapsibleSection>
+          {tableSchema && (
+            <LargeCollapsibleSection header="Columns" icon="view_column">
+              <TableSchema
+                schema={tableSchema.schema}
+                schemaLoadTimestamp={tableSchemaLoadTimestamp}
+              />
+            </LargeCollapsibleSection>
+          )}
           <LargeCollapsibleSection header="Metadata" icon="view_list">
             <AssetEventMetadataEntriesTable
               showHeader

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -27,6 +27,7 @@ import {AssetDefinedInMultipleReposNotice} from './AssetDefinedInMultipleReposNo
 import {AssetEventMetadataEntriesTable} from './AssetEventMetadataEntriesTable';
 import {metadataForAssetNode} from './AssetMetadata';
 import {insitigatorsByType} from './AssetNodeInstigatorTag';
+import {AutomaterializePolicyTag} from './AutomaterializePolicyTag';
 import {DependsOnSelfBanner} from './DependsOnSelfBanner';
 import {MaterializationTag} from './MaterializationTag';
 import {OverdueTag, freshnessPolicyDescription} from './OverdueTag';
@@ -233,6 +234,18 @@ export const AssetNodeOverview = ({
           <ScheduleOrSensorTag repoAddress={repoAddress} schedules={schedules} showSwitch={false} />
         )}
       </AttributeAndValue>
+
+      <AttributeAndValue label="Auto-materialize policy">
+        {assetNode.autoMaterializePolicy && (
+          <AutomaterializePolicyTag policy={assetNode.autoMaterializePolicy} />
+        )}
+      </AttributeAndValue>
+
+      <AttributeAndValue label="Freshness policy">
+        {assetNode.freshnessPolicy && (
+          <Body>{freshnessPolicyDescription(assetNode.freshnessPolicy)}</Body>
+        )}
+      </AttributeAndValue>
     </Box>
   );
 
@@ -303,12 +316,6 @@ export const AssetNodeOverview = ({
           >
             View type details
           </ButtonLink>
-        )}
-      </AttributeAndValue>
-
-      <AttributeAndValue label="Freshness policy">
-        {assetNode.autoMaterializePolicy && (
-          <Body>{freshnessPolicyDescription(assetNode.freshnessPolicy)}</Body>
         )}
       </AttributeAndValue>
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -88,11 +88,15 @@ export const AssetNodeOverview = ({
 
   const assetNodeLoadTimestamp = location ? location.updatedTimestamp * 1000 : undefined;
 
-  const {materialization, observation} = useLatestPartitionEvents(
+  const {materialization, observation, loading} = useLatestPartitionEvents(
     assetNode,
     assetNodeLoadTimestamp,
     liveData,
   );
+
+  if (loading) {
+    return <AssetNodeOverviewLoading />;
+  }
 
   const renderStatusSection = () => (
     <Box flex={{direction: 'row'}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
@@ -98,7 +98,6 @@ export const buildAssetTabMap = (input: AssetTabConfigInput): Record<string, Ass
       title: 'Lineage',
       to: buildAssetViewParams({...params, view: 'lineage'}),
       disabled: !definition,
-      hidden: flagUseNewOverviewPage,
     },
     automation: {
       id: 'automation',

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useLatestPartitionEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useLatestPartitionEvents.tsx
@@ -36,7 +36,7 @@ export function useLatestPartitionEvents(
   const observation =
     data?.assetOrError.__typename === 'Asset' ? data.assetOrError.assetObservations[0] : undefined;
 
-  return {materialization, observation};
+  return {materialization, observation, loading: !data};
 }
 
 export const ASSET_OVERVIEW_METADATA_EVENTS_QUERY = gql`

--- a/js_modules/dagster-ui/packages/ui-core/src/metadata/TableSchema.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/metadata/TableSchema.tsx
@@ -128,14 +128,21 @@ const iconForType = (type: string): IconName | null => {
   return null;
 };
 
-const TypeTag = ({type, icon}: {type: string; icon: IconName | null}) => (
-  <Tag intent="none">
-    <Box flex={{gap: 4}}>
-      {icon ? <Icon name={icon} /> : <span style={{width: 16}} />}
-      {type}
-    </Box>
-  </Tag>
-);
+const TypeTag = ({type = '', icon}: {type: string; icon: IconName | null}) => {
+  if (type.trim().replace(/\?/g, '').length === 0) {
+    // Do not render type '' or '?' or any other empty value.
+    return <span />;
+  }
+
+  return (
+    <Tag intent="none">
+      <Box flex={{gap: 4}}>
+        {icon ? <Icon name={icon} /> : <span style={{width: 16}} />}
+        {type}
+      </Box>
+    </Tag>
+  );
+};
 
 const NonNullableTag = <Tag intent="primary">non-nullable</Tag>;
 


### PR DESCRIPTION
## Summary & Motivation

This PR includes a few small changes, tested manually:

- With the new asset overview feature flag enabled, show the Lineage tab rather than hiding it

- On the Overview page, keep rendering a loading state until both the definition at the top level and the most recent materialization events have finished loading.

- Only render the “Columns” sections if column data is present, and do not show the section at all if it is missing. (There is no call-to-action to add columns, and for many people it will never be populated)

- Don’t render empty or “?” column type tags, just leave the Type column blank

- The freshness policy section on the right is moved up to Automation, and a new automation policy item has been added

Related: https://linear.app/dagster-labs/issue/FE-190/automation-details-on-asset-overview-does-not-show-amp