### PR TITLE
AssetSpec passes code version and metadata to underlying Out

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -657,6 +657,8 @@ def multi_asset(
                         Nothing,
                         is_required=not (can_subset or asset_spec.skippable),
                         description=asset_spec.description,
+                        code_version=asset_spec.code_version,
+                        metadata=asset_spec.metadata,
                     ),
                 )
             if upstream_asset_deps:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2119,3 +2119,29 @@ def test_multi_asset_owners():
         AssetKey("out1"): [TeamAssetOwner("team1"), UserAssetOwner("user@dagsterlabs.com")],
         AssetKey("out2"): [UserAssetOwner("user2@dagsterlabs.com")],
     }
+
+
+def test_asset_spec_with_code_versions():
+    @multi_asset(specs=[AssetSpec(key="a", code_version="1"), AssetSpec(key="b", code_version="2")])
+    def multi_asset_with_versions():
+        yield MaterializeResult("a")
+        yield MaterializeResult("b")
+
+    assert multi_asset_with_versions.code_versions_by_key == {
+        AssetKey(["a"]): "1",
+        AssetKey(["b"]): "2",
+    }
+
+
+def test_asset_spec_with_metadata():
+    @multi_asset(
+        specs=[AssetSpec(key="a", metadata={"foo": "1"}), AssetSpec(key="b", metadata={"bar": "2"})]
+    )
+    def multi_asset_with_metadata():
+        yield MaterializeResult("a")
+        yield MaterializeResult("b")
+
+    assert multi_asset_with_metadata.metadata_by_key == {
+        AssetKey(["a"]): {"foo": "1"},
+        AssetKey(["b"]): {"bar": "2"},
+    }


### PR DESCRIPTION
## Summary & Motivation
In updating some documentation I found that the code version and metadata specified on an `AssetSpec` is not passed through to the `Out` we use to represent it in the `AssetsDefinition`

## How I Tested These Changes
new unit tests