### PR TITLE
Fix bootstrapping behavior of MaterializeOnCron

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -294,7 +294,8 @@ class MaterializeOnCronRule(
         self, context: AssetConditionEvaluationContext
     ) -> Sequence[datetime.datetime]:
         """Returns the cron ticks which have been missed since the previous cursor was generated."""
-        if not context.previous_evaluation_timestamp:
+        # if it's the first time evaluating this rule, then just count the latest tick as missed
+        if not context.previous_evaluation or not context.previous_evaluation_timestamp:
             previous_dt = next(
                 reverse_cron_string_iterator(
                     end_timestamp=context.evaluation_time.timestamp(),
@@ -314,11 +315,9 @@ class MaterializeOnCronRule(
             missed_ticks.append(dt)
         return missed_ticks
 
-    def get_new_asset_partitions_to_request(
-        self, context: AssetConditionEvaluationContext
+    def get_new_candidate_asset_partitions(
+        self, context: AssetConditionEvaluationContext, missed_ticks: Sequence[datetime.datetime]
     ) -> AbstractSet[AssetKeyPartitionKey]:
-        missed_ticks = self.missed_cron_ticks(context)
-
         if not missed_ticks:
             return set()
 
@@ -382,9 +381,20 @@ class MaterializeOnCronRule(
     ) -> "AssetConditionResult":
         from .asset_condition.asset_condition import AssetConditionResult
 
-        new_asset_partitions_to_request = self.get_new_asset_partitions_to_request(context)
+        missed_ticks = self.missed_cron_ticks(context)
+        new_asset_partitions = self.get_new_candidate_asset_partitions(context, missed_ticks)
+
+        # if it's the first time evaluating this rule, must query for the actual subset that has
+        # been materialized since the previous cron tick, as materializations may have happened
+        # before the previous evaluation, which
+        # `context.materialized_requested_or_discarded_since_previous_tick_subset` would not capture
+        if context.previous_evaluation is None:
+            new_asset_partitions -= context.instance_queryer.get_asset_subset_updated_after_time(
+                asset_key=context.asset_key, after_time=missed_ticks[-1]
+            ).asset_partitions
+
         asset_subset_to_request = AssetSubset.from_asset_partitions_set(
-            context.asset_key, context.partitions_def, new_asset_partitions_to_request
+            context.asset_key, context.partitions_def, new_asset_partitions
         ) | (
             context.previous_true_subset.as_valid(context.partitions_def)
             - context.materialized_requested_or_discarded_since_previous_tick_subset


### PR DESCRIPTION
## Summary & Motivation

Previously, if you added this rule to your policy, it would not "notice" that a cron tick had been missed until the first cron tick _after_ the rule was added. This PR adds some additional logic to allow this asset to detect that it's the first time this rule has been evaluated, and if it is, does an explicit query to figure out if this asset has been materialized since the previous cron tick.

Note that this implementation should get significantly simpler once we port over to AssetConditions -- right now we basically have a replica of the LatestPartitionsAssetCondition built into this rule. Ideally, we could just refactor them both to call a single utility.

## How I Tested These Changes

Added test which failed before and passes now
