### PR TITLE
[docs-only] Fix MultiPartitionMapping pluralization in docs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -700,7 +700,7 @@ class MultiPartitionMapping(
                 }
             )
 
-            MultiPartitionsMapping(
+            MultiPartitionMapping(
                 {
                     "abc": DimensionPartitionMapping(
                         dimension_name="123",
@@ -733,7 +733,7 @@ class MultiPartitionMapping(
                 }
             )
 
-            MultiPartitionsMapping(
+            MultiPartitionMapping(
                 {
                     "daily": DimensionPartitionMapping(
                         dimension_name="daily",


### PR DESCRIPTION
## Summary & Motivation

In the code itself, this class is named `MultiPartitionMapping`, but in the docs it was `MultiPartitionsMapping` (note the plural "Partition**s**" rather than "Partition").

Discovered this when copy-pasting from the docs into my code, and figured it was worth sending a quick docs-only PR.

## How I Tested These Changes

Cmd-F for "MultiPartitionsMapping", no hits.
Cmd-F for "MultiPartitionMapping", hits in both code and docs.
