### PR TITLE
Add op_output_metadata retrieval method to HookContext

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -562,7 +562,10 @@ def _type_check_and_store_output(
     mapping_key = output.mapping_key if isinstance(output, DynamicOutput) else None
 
     step_output_handle = StepOutputHandle(
-        step_key=step_context.step.key, output_name=output.output_name, mapping_key=mapping_key
+        step_key=step_context.step.key,
+        output_name=output.output_name,
+        metadata=output.metadata,
+        mapping_key=mapping_key,
     )
 
     # If we are executing using the execute_in_process API, then we allow for the outputs of ops

--- a/python_modules/dagster/dagster/_core/execution/plan/outputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/outputs.py
@@ -158,16 +158,30 @@ class StepOutputData(
 class StepOutputHandle(
     NamedTuple(
         "_StepOutputHandle",
-        [("step_key", str), ("output_name", str), ("mapping_key", Optional[str])],
+        [
+            ("step_key", str),
+            ("output_name", str),
+            ("metadata", Mapping[str, MetadataValue]),
+            ("mapping_key", Optional[str]),
+        ],
     )
 ):
     """A reference to a specific output that has or will occur within the scope of an execution."""
 
-    def __new__(cls, step_key: str, output_name: str = "result", mapping_key: Optional[str] = None):
+    def __new__(
+        cls,
+        step_key: str,
+        output_name: str = "result",
+        metadata: Optional[Mapping[str, MetadataValue]] = None,
+        mapping_key: Optional[str] = None,
+    ):
         return super(StepOutputHandle, cls).__new__(
             cls,
             step_key=check.str_param(step_key, "step_key"),
             output_name=check.str_param(output_name, "output_name"),
+            metadata=normalize_metadata(
+                check.opt_mapping_param(metadata, "metadata", key_type=str)
+            ),
             mapping_key=check.opt_str_param(mapping_key, "mapping_key"),
         )
 


### PR DESCRIPTION
## Summary & Motivation
Please refer to the following issue/project spec for context and alternative solutions: https://github.com/dagster-io/dagster/issues/20025.

> Upon hook execution, one can access output values via the HookContext (HookContext.op_output_values, but there is currently no way to access output metadata in the same way. Enabling this would allow users to pass information more dynamically to their hooks, flexible with respect to each individual ops Output metadata. One application of this is in dynamically applying tags to runs based on the metadata of the last failed/successful run.

_Transparency note: Long-time Dagster user, first time Dagster contributor, thanks in advance for your support!_

## How I Tested These Changes
Ran `make ruff` and `make pyright` before committing.
Successfully ran `python -m pytest python_modules/dagster/dagster_tests/core_tests/`