### PR TITLE
Add op_output_metadata retrieval method to HookContext

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/_core/execution/context/hook.py
@@ -214,9 +214,9 @@ class HookContext:
                         step_output_handle.mapping_key: metadata
                     }
                 else:
-                    results[step_output_handle.output_name][
-                        step_output_handle.mapping_key
-                    ] = metadata
+                    results[step_output_handle.output_name][step_output_handle.mapping_key] = (
+                        metadata
+                    )
             else:
                 results[step_output_handle.output_name] = metadata
 

--- a/python_modules/dagster/dagster/_core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/_core/execution/context/hook.py
@@ -191,6 +191,39 @@ class HookContext:
         """Computed output values in an op."""
         return self.solid_output_values
 
+    @property
+    def solid_output_metadata(self) -> Mapping[str, Union[Any, Mapping[str, Any]]]:
+        """The applied output metadata.
+
+        Returns a dictionary where keys are output names and the values are:
+            * the applied output metadata in the normal case
+            * a dictionary from mapping key to corresponding metadata in the mapped case
+        """
+        results: Dict[str, Union[Any, Dict[str, Any]]] = {}
+        captured = self._step_execution_context.output_metadata
+
+        if captured is None:
+            check.failed("Outputs were unexpectedly not captured for hook")
+
+        # make the returned values more user-friendly
+        for step_output_handle, metadata in captured.items():
+            if step_output_handle.mapping_key:
+                if results.get(step_output_handle.output_name) is None:
+                    results[step_output_handle.output_name] = {
+                        step_output_handle.mapping_key: metadata
+                    }
+                else:
+                    results[step_output_handle.output_name][step_output_handle.mapping_key] = metadata
+            else:
+                results[step_output_handle.output_name] = metadata
+
+        return results
+
+    @public
+    @property
+    def op_output_metadata(self):
+        """Computed output values in an op."""
+        return self.solid_output_metadata
 
 class UnboundHookContext(HookContext):
     def __init__(

--- a/python_modules/dagster/dagster/_core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/_core/execution/context/hook.py
@@ -190,7 +190,7 @@ class HookContext:
     def op_output_values(self):
         """Computed output values in an op."""
         return self.solid_output_values
-    
+
     @public
     @property
     def op_output_metadata(self) -> Mapping[str, Union[Any, Mapping[str, Any]]]:

--- a/python_modules/dagster/dagster/_core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/_core/execution/context/hook.py
@@ -200,7 +200,7 @@ class HookContext:
             * a dictionary from mapping key to corresponding metadata in the mapped case
         """
         results: Dict[str, Union[Any, Dict[str, Any]]] = {}
-        captured = self._step_execution_context.output_metadata
+        captured = self._step_execution_context.step_output_metadata_capture
 
         if captured is None:
             check.failed("Outputs were unexpectedly not captured for hook")

--- a/python_modules/dagster/dagster/_core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/_core/execution/context/hook.py
@@ -190,9 +190,10 @@ class HookContext:
     def op_output_values(self):
         """Computed output values in an op."""
         return self.solid_output_values
-
+    
+    @public
     @property
-    def solid_output_metadata(self) -> Mapping[str, Union[Any, Mapping[str, Any]]]:
+    def op_output_metadata(self) -> Mapping[str, Union[Any, Mapping[str, Any]]]:
         """The applied output metadata.
 
         Returns a dictionary where keys are output names and the values are:
@@ -220,12 +221,6 @@ class HookContext:
                 results[step_output_handle.output_name] = metadata
 
         return results
-
-    @public
-    @property
-    def op_output_metadata(self):
-        """Computed output values in an op."""
-        return self.solid_output_metadata
 
 
 class UnboundHookContext(HookContext):
@@ -343,6 +338,16 @@ class UnboundHookContext(HookContext):
         raise DagsterInvalidPropertyError(_property_msg("solid_output_values", "method"))
 
     @property
+    def op_output_metadata(self) -> Mapping[str, Union[Any, Mapping[str, Any]]]:
+        """The applied output metadata.
+
+        Returns a dictionary where keys are output names and the values are:
+            * the applied output metadata in the normal case
+            * a dictionary from mapping key to corresponding metadata in the mapped case
+        """
+        raise DagsterInvalidPropertyError(_property_msg("op_output_metadata", "method"))
+
+    @property
     def instance(self) -> "DagsterInstance":
         if not self._instance:
             raise DagsterInvariantViolationError(
@@ -433,6 +438,16 @@ class BoundHookContext(HookContext):
             * a dictionary from mapping key to corresponding value in the mapped case
         """
         raise DagsterInvalidPropertyError(_property_msg("solid_output_values", "method"))
+
+    @property
+    def op_output_metadata(self) -> Mapping[str, Union[Any, Mapping[str, Any]]]:
+        """The applied output metadata.
+
+        Returns a dictionary where keys are output names and the values are:
+            * the applied output metadata in the normal case
+            * a dictionary from mapping key to corresponding metadata in the mapped case
+        """
+        raise DagsterInvalidPropertyError(_property_msg("op_output_metadata", "method"))
 
     @property
     def instance(self) -> "DagsterInstance":

--- a/python_modules/dagster/dagster/_core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/_core/execution/context/hook.py
@@ -213,7 +213,9 @@ class HookContext:
                         step_output_handle.mapping_key: metadata
                     }
                 else:
-                    results[step_output_handle.output_name][step_output_handle.mapping_key] = metadata
+                    results[step_output_handle.output_name][
+                        step_output_handle.mapping_key
+                    ] = metadata
             else:
                 results[step_output_handle.output_name] = metadata
 
@@ -224,6 +226,7 @@ class HookContext:
     def op_output_metadata(self):
         """Computed output values in an op."""
         return self.solid_output_metadata
+
 
 class UnboundHookContext(HookContext):
     def __init__(

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -891,6 +891,10 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         return self._step_output_capture
 
     @property
+    def output_metadata(self) -> Optional[Dict[str, Any]]:
+        return self._output_metadata
+
+    @property
     def previous_attempt_count(self) -> int:
         return self.get_known_state().get_retry_state().get_attempt_count(self._step.key)
 

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -563,11 +563,13 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         self._step_exception: Optional[BaseException] = None
 
         self._step_output_capture: Optional[Dict[StepOutputHandle, Any]] = None
+        self._step_output_metadata_capture: Optional[Dict[StepOutputHandle, Any]] = None
         # Enable step output capture if there are any hooks which will receive them.
         # Expect in the future that hooks may control whether or not they get outputs,
         # but for now presence of any will cause output capture.
         if self.job_def.get_all_hooks_for_handle(self.node_handle):
             self._step_output_capture = {}
+            self._step_output_metadata_capture = {}
 
         self._output_metadata: Dict[str, Any] = {}
         self._seen_outputs: Dict[str, Union[str, Set[str]]] = {}
@@ -891,8 +893,8 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         return self._step_output_capture
 
     @property
-    def output_metadata(self) -> Optional[Dict[str, Any]]:
-        return self._output_metadata
+    def step_output_metadata_capture(self) -> Optional[Dict[StepOutputHandle, Any]]:
+        return self._step_output_metadata_capture
 
     @property
     def previous_attempt_count(self) -> int:

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -566,9 +566,9 @@ def _type_check_and_store_output(
     if step_context.output_capture is not None:
         step_context.output_capture[step_output_handle] = output.value
     # capture output at the step level for threading the computed output values to hook context
-    if step_context.step_output_capture is not None:
+    if step_context.step_output_capture is not None and step_context.step_output_metadata_capture is not None:
         step_context.step_output_capture[step_output_handle] = output.value
-        step_context.output_metadata[step_output_handle] = output.metadata
+        step_context.step_output_metadata_capture[step_output_handle] = output.metadata
 
     version = (
         resolve_step_output_versions(

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -566,7 +566,10 @@ def _type_check_and_store_output(
     if step_context.output_capture is not None:
         step_context.output_capture[step_output_handle] = output.value
     # capture output at the step level for threading the computed output values to hook context
-    if step_context.step_output_capture is not None and step_context.step_output_metadata_capture is not None:
+    if (
+        step_context.step_output_capture is not None
+        and step_context.step_output_metadata_capture is not None
+    ):
         step_context.step_output_capture[step_output_handle] = output.value
         step_context.step_output_metadata_capture[step_output_handle] = output.metadata
 

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -568,6 +568,7 @@ def _type_check_and_store_output(
     # capture output at the step level for threading the computed output values to hook context
     if step_context.step_output_capture is not None:
         step_context.step_output_capture[step_output_handle] = output.value
+        step_context.output_metadata[step_output_handle] = output.metadata
 
     version = (
         resolve_step_output_versions(

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_run.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_run.py
@@ -335,10 +335,6 @@ def test_op_metadata_access():
     def my_success_hook(context):
         called[context.step_key] = context.op_output_metadata
 
-    @failure_hook
-    def my_failure_hook(context):
-        called[context.step_key] = context.op_output_metadata
-
     @op(out={"one": Out(), "two": Out(), "three": Out()})
     def output_metadata_op(_):
         yield Output(1, "one", metadata={"foo": "bar"})
@@ -351,7 +347,6 @@ def test_op_metadata_access():
         yield Output(value=1)
 
     @my_success_hook
-    @my_failure_hook
     @job
     def metadata_job():
         output_metadata_op()

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_run.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_run.py
@@ -5,7 +5,9 @@ from dagster import DynamicOut, DynamicOutput, Int, Out, Output, graph, job, op,
 from dagster._core.definitions import failure_hook, success_hook
 from dagster._core.definitions.decorators.hook_decorator import event_list_hook
 from dagster._core.definitions.events import Failure, HookExecutionResult
+from dagster._core.definitions.metadata import TextMetadataValue
 from dagster._core.errors import DagsterInvalidDefinitionError
+from dagster._core.execution.context.compute import OpExecutionContext
 
 
 class SomeUserException(Exception):
@@ -323,6 +325,47 @@ def test_op_outputs_access():
     assert called.get("dynamic_op") == {"result": {"mapping_1": 1, "mapping_2": 2}}
     assert called.get("echo[mapping_1]") == {"result": 1}
     assert called.get("echo[mapping_2]") == {"result": 2}
+
+
+def test_op_metadata_access():
+    """Test that HookContext op_output_metadata is successfully populated upon both Output(value, metadata) and context.add_output_metadata(metadata) calls."""
+    called = {}
+
+    @success_hook
+    def my_success_hook(context):
+        called[context.step_key] = context.op_output_metadata
+
+    @failure_hook
+    def my_failure_hook(context):
+        called[context.step_key] = context.op_output_metadata
+
+    @op(out={"one": Out(), "two": Out(), "three": Out()})
+    def output_metadata_op(_):
+        yield Output(1, "one", metadata={"foo": "bar"})
+        yield Output(2, "two", metadata={"baz": "qux"})
+        yield Output(3, "three", metadata={"quux": "quuz"})
+
+    @op()
+    def context_metadata_op(context: OpExecutionContext):
+        context.add_output_metadata(metadata={"foo": "bar"})
+        yield Output(value=1)
+
+    @my_success_hook
+    @my_failure_hook
+    @job
+    def metadata_job():
+        output_metadata_op()
+        context_metadata_op()
+
+    result = metadata_job.execute_in_process(raise_on_error=False)
+
+    assert result.success
+    assert called.get("context_metadata_op") == {"result": {"foo": TextMetadataValue(text="bar")}}
+    assert called.get("output_metadata_op") == {
+        "one": {"foo": TextMetadataValue(text="bar")},
+        "two": {"baz": TextMetadataValue(text="qux")},
+        "three": {"quux": TextMetadataValue(text="quuz")},
+    }
 
 
 def test_hook_on_job_def():


### PR DESCRIPTION
## Summary & Motivation
Please refer to the following issue/project spec for context and alternative solutions: https://github.com/dagster-io/dagster/issues/20025.

Context:
> Upon hook execution, one can access output values via the HookContext (using HookContext's `op_output_values`), but there is currently no way to access output metadata in the same way. Enabling this would allow users to pass information more dynamically to their hooks with respect to each individual ops Output metadata. One application of this is in dynamically applying tags to runs based on the metadata of the last failed/successful run.

_Transparency note: Long-time Dagster user, first time Dagster contributor, thanks in advance for your support!_

## How I Tested These Changes
- Ran `make ruff` and `make pyright` before committing
- Successfully ran `python -m pytest python_modules/dagster/dagster_tests/core_tests/`
- Installed these changes locally with `pip install -e dagster/python_modules/dagster` and confirmed successful cases