### PR TITLE
[ui] Support choosing a single day in the run time range filter

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -513,6 +513,7 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
 
   const createdDateFilter = useTimeRangeFilter({
     name: 'Created date',
+    activeFilterTerm: 'Created',
     icon: 'date',
     state: useMemo(() => {
       const before = tokens.find((token) => token.token === 'created_date_before');

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/__stories__/useFilters.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/__stories__/useFilters.stories.tsx
@@ -83,6 +83,7 @@ const TestComponent = () => {
 
   const timeRangeFilter = useTimeRangeFilter({
     name: 'Timestamp',
+    activeFilterTerm: 'Timestamp',
     icon: 'date',
   });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/__tests__/useTimeRangeFilter.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/__tests__/useTimeRangeFilter.test.tsx
@@ -97,8 +97,8 @@ describe('CustomTimeRangeFilterDialog', () => {
     );
 
     // Mock selecting start and end dates
-    const startDate = moment().subtract(10, 'days');
-    const endDate = moment().subtract(5, 'days');
+    const startDate = moment().startOf('day').subtract(10, 'days');
+    const endDate = moment().endOf('day').subtract(5, 'days');
 
     act(() => {
       ((mockReactDates.mock.calls[0] as any)[0] as any).onDatesChange({
@@ -206,7 +206,7 @@ describe('ActiveFilterState', () => {
       />,
     );
 
-    expect(getByText(/Timestamp is after/)).toBeInTheDocument();
+    expect(getByText(/Created after/)).toBeInTheDocument();
   });
 
   it('should render custom filter state with upper boundary', () => {
@@ -220,7 +220,7 @@ describe('ActiveFilterState', () => {
       />,
     );
 
-    expect(getByText(/Timestamp is before/)).toBeInTheDocument();
+    expect(getByText(/Created before/)).toBeInTheDocument();
   });
 
   it('should render custom filter state with both boundaries', () => {
@@ -237,6 +237,6 @@ describe('ActiveFilterState', () => {
       />,
     );
 
-    expect(getByText(/Timestamp is in range/)).toBeInTheDocument();
+    expect(getByText(/Created from/)).toBeInTheDocument();
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/__tests__/useTimeRangeFilter.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/__tests__/useTimeRangeFilter.test.tsx
@@ -24,6 +24,7 @@ jest.mock('react-dates', () => {
 });
 const mockFilterProps = {
   name: 'Test Filter',
+  activeFilterTerm: 'Timestamp',
   icon: 'date' as IconName,
   state: [null, null] as TimeRangeState,
 };
@@ -146,6 +147,7 @@ describe('ActiveFilterState', () => {
   it('should render Today filter state', () => {
     const {getByText} = render(
       <ActiveFilterState
+        activeFilterTerm="Timestamp"
         state={timeRanges.TODAY.range}
         remove={removeMock}
         timezone={mockTimezone}
@@ -159,6 +161,7 @@ describe('ActiveFilterState', () => {
   it('should render Yesterday filter state', () => {
     const {getByText} = render(
       <ActiveFilterState
+        activeFilterTerm="Timestamp"
         state={timeRanges.YESTERDAY.range}
         remove={removeMock}
         timezone={mockTimezone}
@@ -172,6 +175,7 @@ describe('ActiveFilterState', () => {
   it('should render Within last 7 days filter state', () => {
     const {getByText} = render(
       <ActiveFilterState
+        activeFilterTerm="Timestamp"
         state={timeRanges.LAST_7_DAYS.range}
         remove={removeMock}
         timezone={mockTimezone}
@@ -185,6 +189,7 @@ describe('ActiveFilterState', () => {
   it('should render Within last 30 days filter state', () => {
     const {getByText} = render(
       <ActiveFilterState
+        activeFilterTerm="Timestamp"
         state={timeRanges.LAST_30_DAYS.range}
         remove={removeMock}
         timezone={mockTimezone}
@@ -199,6 +204,7 @@ describe('ActiveFilterState', () => {
     const customRange = [moment().subtract(3, 'days').valueOf(), null] as TimeRangeState;
     const {getByText} = render(
       <ActiveFilterState
+        activeFilterTerm="Timestamp"
         state={customRange}
         remove={removeMock}
         timezone={mockTimezone}
@@ -206,13 +212,14 @@ describe('ActiveFilterState', () => {
       />,
     );
 
-    expect(getByText(/Created after/)).toBeInTheDocument();
+    expect(getByText(/Timestamp after/)).toBeInTheDocument();
   });
 
   it('should render custom filter state with upper boundary', () => {
     const customRange = [null, moment().subtract(1, 'days').valueOf()] as TimeRangeState;
     const {getByText} = render(
       <ActiveFilterState
+        activeFilterTerm="Timestamp"
         state={customRange}
         remove={removeMock}
         timezone={mockTimezone}
@@ -220,7 +227,7 @@ describe('ActiveFilterState', () => {
       />,
     );
 
-    expect(getByText(/Created before/)).toBeInTheDocument();
+    expect(getByText(/Timestamp before/)).toBeInTheDocument();
   });
 
   it('should render custom filter state with both boundaries', () => {
@@ -230,6 +237,7 @@ describe('ActiveFilterState', () => {
     ] as TimeRangeState;
     const {getByText} = render(
       <ActiveFilterState
+        activeFilterTerm="Timestamp"
         state={customRange}
         remove={removeMock}
         timezone={mockTimezone}
@@ -237,6 +245,6 @@ describe('ActiveFilterState', () => {
       />,
     );
 
-    expect(getByText(/Created from/)).toBeInTheDocument();
+    expect(getByText(/Timestamp from/)).toBeInTheDocument();
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useTimeRangeFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useTimeRangeFilter.tsx
@@ -37,14 +37,14 @@ export function calculateTimeRanges(timezone: string) {
     LAST_7_DAYS: {
       label: 'Within last 7 days',
       range: [
-        dayjs(nowTimestamp).tz(targetTimezone).subtract(1, 'week').valueOf(),
+        dayjs(nowTimestamp).tz(targetTimezone).startOf('day').subtract(1, 'week').valueOf(),
         null,
       ] as TimeRangeState,
     },
     LAST_30_DAYS: {
       label: 'Within last 30 days',
       range: [
-        dayjs(nowTimestamp).tz(targetTimezone).subtract(30, 'days').valueOf(),
+        dayjs(nowTimestamp).tz(targetTimezone).startOf('day').subtract(30, 'days').valueOf(),
         null,
       ] as TimeRangeState,
     },
@@ -201,49 +201,54 @@ export function ActiveFilterState({
     if (isEqual(state, timeRanges.TODAY.range)) {
       return (
         <>
-          is <FilterTagHighlightedText>Today</FilterTagHighlightedText>
+          <FilterTagHighlightedText>Today</FilterTagHighlightedText>
         </>
       );
     } else if (isEqual(state, timeRanges.YESTERDAY.range)) {
       return (
         <>
-          is <FilterTagHighlightedText>Yesterday</FilterTagHighlightedText>
+          <FilterTagHighlightedText>Yesterday</FilterTagHighlightedText>
         </>
       );
     } else if (isEqual(state, timeRanges.LAST_7_DAYS.range)) {
       return (
         <>
-          is within <FilterTagHighlightedText>Last 7 days</FilterTagHighlightedText>
+          in <FilterTagHighlightedText>Last 7 days</FilterTagHighlightedText>
         </>
       );
     } else if (isEqual(state, timeRanges.LAST_30_DAYS.range)) {
       return (
         <>
-          is within <FilterTagHighlightedText>Last 30 days</FilterTagHighlightedText>
+          in <FilterTagHighlightedText>Last 30 days</FilterTagHighlightedText>
         </>
       );
     } else {
       if (!state[0]) {
         return (
           <>
-            is before{' '}
-            <FilterTagHighlightedText>{L_FORMAT.format(state[1]!)}</FilterTagHighlightedText>
+            before <FilterTagHighlightedText>{L_FORMAT.format(state[1]!)}</FilterTagHighlightedText>
           </>
         );
       }
       if (!state[1]) {
         return (
           <>
-            is after{' '}
+            after <FilterTagHighlightedText>{L_FORMAT.format(state[0]!)}</FilterTagHighlightedText>
+          </>
+        );
+      }
+      if (state[1] - state[0] === (24 * 60 * 60 - 1) * 1000) {
+        return (
+          <>
+            on
             <FilterTagHighlightedText>{L_FORMAT.format(state[0]!)}</FilterTagHighlightedText>
           </>
         );
       }
       return (
         <>
-          is in range{' '}
-          <FilterTagHighlightedText>{L_FORMAT.format(state[0]!)}</FilterTagHighlightedText>
-          {' - '}
+          from <FilterTagHighlightedText>{L_FORMAT.format(state[0]!)}</FilterTagHighlightedText>
+          {' through '}
           <FilterTagHighlightedText>{L_FORMAT.format(state[1]!)}</FilterTagHighlightedText>
         </>
       );
@@ -253,9 +258,7 @@ export function ActiveFilterState({
   return (
     <FilterTag
       iconName="date"
-      label={
-        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>Timestamp {dateLabel}</Box>
-      }
+      label={<Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>Created {dateLabel}</Box>}
       onRemove={remove}
     />
   );
@@ -288,9 +291,10 @@ export function CustomTimeRangeFilterDialog({
         <Box flex={{direction: 'row', gap: 8}} padding={16}>
           <Suspense fallback={<div />}>
             <DateRangePicker
+              minimumNights={0}
               onDatesChange={({startDate, endDate}) => {
-                setStartDate(startDate);
-                setEndDate(endDate);
+                setStartDate(startDate ? startDate.clone().startOf('day') : null);
+                setEndDate(endDate ? endDate.clone().endOf('day') : null);
               }}
               onFocusChange={(focusedInput) => {
                 focusedInput && setFocusedInput(focusedInput);

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useTimeRangeFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useTimeRangeFilter.tsx
@@ -65,9 +65,12 @@ export type TimeRangeFilter = FilterObject & {
   state: [number | null, number | null];
   setState: (state: TimeRangeState) => void;
 };
+
 type TimeRangeKey = keyof ReturnType<typeof calculateTimeRanges>['timeRanges'];
+
 type Args = {
   name: string;
+  activeFilterTerm: string;
   icon: IconName;
 
   // This hook is NOT a "controlled component". Changing state only updates the component's current state.
@@ -77,7 +80,14 @@ type Args = {
   state?: TimeRangeState;
   onStateChanged?: (state: TimeRangeState) => void;
 };
-export function useTimeRangeFilter({name, icon, state, onStateChanged}: Args): TimeRangeFilter {
+
+export function useTimeRangeFilter({
+  name,
+  activeFilterTerm,
+  icon,
+  state,
+  onStateChanged,
+}: Args): TimeRangeFilter {
   const {
     timezone: [_timezone],
   } = useContext(TimeContext);
@@ -153,6 +163,7 @@ export function useTimeRangeFilter({name, icon, state, onStateChanged}: Args): T
       },
       activeJSX: (
         <ActiveFilterState
+          activeFilterTerm={activeFilterTerm}
           timeRanges={timeRanges}
           state={innerState}
           timezone={timezone}
@@ -177,11 +188,13 @@ function TimeRangeResult({range}: {range: string}) {
 }
 
 export function ActiveFilterState({
+  activeFilterTerm,
   state,
   remove,
   timezone,
   timeRanges,
 }: {
+  activeFilterTerm: string;
   state: TimeRangeState;
   remove: () => void;
   timezone: string;
@@ -258,7 +271,11 @@ export function ActiveFilterState({
   return (
     <FilterTag
       iconName="date"
-      label={<Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>Created {dateLabel}</Box>}
+      label={
+        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+          {activeFilterTerm} {dateLabel}
+        </Box>
+      }
       onRemove={remove}
     />
   );


### PR DESCRIPTION
## Summary & Motivation

While making this change, I QA'd this filter against my local run history and noticed a few other bugs:

- The Last 7 days and Last 30 day filters used "now", so if you refreshed the page you would no longer see the "last 7 day" description because now() had shifted slightly.  I changed them to be "since 7 days ago midnight"

- The Date picker returns times at "noon" by default. So if you choose "2024-02-02", the timestamp is "2024-02-02 12:00:00". Previously, choosing 2024-02-02 -> 2024-02-03 was actually giving 24 hours from noon to noon, which was weird. I made the date picker pick inclusive ranges (from the start of the first day and the end of the last day.)

- The "Created at" filter appeared as "Timestamp between X - Y" in the filter bar. I changed the language so the terminology is "Created" in both places.  "Created on 2024-02-02", "Created in last 7 days"  also sound a bit better than "Timestamp is within last 7 days" and "Timestamp on 2024-02-02".

<img width="390" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/05fac2cd-cc6d-4ad7-aa5e-64be97649a1d">

#### Note

I'm still able to produce some "odd" behavior with this filter, because we map to "created before" and "updated after" at the GraphQL layer (two different fields!) For example,  this run was created on 2024-01-26 and updated on 2024-02-11, so it matches this query. Using "created after" + "updated before" would be better, since updated is always after created, but it seems the existing options are plumbed through quite a ways and it'd require some backend support to fix this.

<img width="625" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/589ef0e2-556d-4686-8756-df6a7c68c16e">
