### PR TITLE
[logging] Remove JsonEventLoggerHandler

### DIFF
--- a/python_modules/dagster/dagster/_core/events/log.py
+++ b/python_modules/dagster/dagster/_core/events/log.py
@@ -12,7 +12,6 @@ from dagster._serdes.serdes import (
 )
 from dagster._utils.error import SerializableErrorInfo
 from dagster._utils.log import (
-    JsonEventLoggerHandler,
     StructuredLoggerHandler,
     StructuredLoggerMessage,
     construct_single_handler_logger,
@@ -192,26 +191,5 @@ def construct_event_logger(event_record_callback):
         "debug",
         StructuredLoggerHandler(
             lambda logger_message: event_record_callback(construct_event_record(logger_message))
-        ),
-    )
-
-
-def construct_json_event_logger(json_path):
-    """Record a stream of event records to json."""
-    check.str_param(json_path, "json_path")
-    return construct_single_handler_logger(
-        "json-event-record-logger",
-        "debug",
-        JsonEventLoggerHandler(
-            json_path,
-            lambda record: construct_event_record(
-                StructuredLoggerMessage(
-                    name=record.name,
-                    message=record.msg,
-                    level=record.levelno,
-                    meta=record.dagster_meta,
-                    record=record,
-                )
-            ),
         ),
     )

--- a/python_modules/dagster/dagster/_utils/log.py
+++ b/python_modules/dagster/dagster/_utils/log.py
@@ -77,25 +77,6 @@ class StructuredLoggerMessage(
         )
 
 
-class JsonEventLoggerHandler(logging.Handler):
-    def __init__(self, json_path: str, construct_event_record):
-        super(JsonEventLoggerHandler, self).__init__()
-        self.json_path = check.str_param(json_path, "json_path")
-        self.construct_event_record = construct_event_record
-
-    def emit(self, record: logging.LogRecord) -> None:
-        try:
-            event_record = self.construct_event_record(record)
-            with open(self.json_path, "a", encoding="utf8") as ff:
-                text_line = seven.json.dumps(event_record.to_dict())
-                ff.write(text_line + "\n")
-
-        # Need to catch Exception here, so disabling lint
-        except Exception as e:
-            logging.critical("[%s] Error during logging!", self.__class__.__name__)
-            logging.exception(str(e))
-
-
 class StructuredLoggerHandler(logging.Handler):
     def __init__(self, callback):
         super(StructuredLoggerHandler, self).__init__()


### PR DESCRIPTION
## Summary & Motivation

When I added some annotations to logging code, I noticed a type error here on a call to `EventLogRecord.to_dict()`, a method that doesn't exist. It appears this code is quite old and would throw a runtime error if executed.

## How I Tested These Changes

Existing test suite.