### PR TITLE
[logging] Clean up logging metadata APIs

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Union
 import dagster._check as check
 from dagster._core.definitions.instigation_logger import get_instigation_log_records
 from dagster._core.definitions.selector import InstigatorSelector
-from dagster._core.log_manager import DAGSTER_META_KEY
+from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR
 
 if TYPE_CHECKING:
     from dagster_graphql.schema.util import ResolveInfo
@@ -56,7 +56,7 @@ def get_tick_log_events(graphene_info: "ResolveInfo", tick) -> "GrapheneInstigat
     events = []
     for record_dict in records:
         exc_info = record_dict.get("exc_info")
-        message = record_dict[DAGSTER_META_KEY]["orig_message"]
+        message = record_dict[LOG_RECORD_METADATA_ATTR]["orig_message"]
         if exc_info:
             message = f"{message}\n\n{exc_info}"
 

--- a/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
+++ b/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
@@ -7,7 +7,7 @@ from typing import IO, Any, List, Mapping, Optional, Sequence
 
 from dagster import _seven
 from dagster._core.instance import DagsterInstance
-from dagster._core.log_manager import DAGSTER_META_KEY
+from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR
 from dagster._core.storage.captured_log_manager import CapturedLogManager
 from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.utils import coerce_valid_log_level
@@ -122,7 +122,7 @@ class InstigationLogger(logging.Logger):
             message = record.getMessage()
             setattr(
                 record,
-                DAGSTER_META_KEY,
+                LOG_RECORD_METADATA_ATTR,
                 {
                     "repository_name": self._repository_name,
                     "name": self._name,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -48,7 +48,7 @@ from dagster._core.errors import (
     DagsterRunAlreadyExists,
     DagsterRunConflict,
 )
-from dagster._core.log_manager import DagsterLogRecord
+from dagster._core.log_manager import get_log_record_metadata
 from dagster._core.origin import JobPythonOrigin
 from dagster._core.storage.dagster_run import (
     IN_PROGRESS_RUN_STATUSES,
@@ -219,7 +219,7 @@ class _EventListenerLogHandler(logging.Handler):
         self._instance = instance
         super(_EventListenerLogHandler, self).__init__()
 
-    def emit(self, record: DagsterLogRecord) -> None:
+    def emit(self, record: logging.LogRecord) -> None:
         from dagster._core.events import EngineEventData
         from dagster._core.events.log import StructuredLoggerMessage, construct_event_record
 
@@ -228,7 +228,7 @@ class _EventListenerLogHandler(logging.Handler):
                 name=record.name,
                 message=record.msg,
                 level=record.levelno,
-                meta=record.dagster_meta,  # type: ignore
+                meta=get_log_record_metadata(record),
                 record=record,
             )
         )

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -3,7 +3,7 @@ import logging
 import threading
 from typing import TYPE_CHECKING, Any, Mapping, NamedTuple, Optional, Sequence, Union, cast
 
-from typing_extensions import Protocol
+from typing_extensions import Final, TypeAlias
 
 import dagster._check as check
 from dagster._core.utils import coerce_valid_log_level, make_new_run_id
@@ -14,25 +14,46 @@ if TYPE_CHECKING:
     from dagster._core.events import DagsterEvent
     from dagster._core.storage.dagster_run import DagsterRun
 
-DAGSTER_META_KEY = "dagster_meta"
+# Python's logging system allows you to attach arbitrary values to a log message/record by passing a
+# dictionary as `extra` to a logging method. The keys of extra are "splatted" directly into the
+# `logging.LogRecord` created by this call-- i.e. `foo` will be set as an attribute on the
+# `LogRecord`, not `extra`. The lack of an intervening abstraction between attached data and the
+# `LogRecord` necessitates providing our own. There are only types of data that we attach: (1) a
+# `DagsterEvent`; (2) a dictionary of assorted metadata about the context of the log message. The
+# below APIs should be used for get/set/has operations on these types of data.
+
+LOG_RECORD_EVENT_ATTR: Final = "dagster_event"
 
 
-class IDagsterMeta(Protocol):
-    @property
-    def dagster_meta(self) -> "DagsterLoggingMetadata":
-        ...
+def get_log_record_event(record: logging.LogRecord) -> "DagsterEvent":
+    return cast("DagsterEvent", getattr(record, LOG_RECORD_EVENT_ATTR))
 
 
-# The type-checker complains here that DagsterLogRecord does not implement the `dagster_meta`
-# property of `IDagsterMeta`. We ignore this error because we don't need to implement this method--
-# `DagsterLogRecord` is a stub class that is never instantiated. We only ever cast
-# `logging.LogRecord` objects to `DagsterLogRecord`, because it gives us typed access to the
-# `dagster_meta` property. `dagster_meta` itself is set on these `logging.LogRecord` objects via the
-# `extra` argument to `logging.Logger.log` (see `DagsterLogManager.log_dagster_event`), but
-# `logging.LogRecord` has no way of exposing to the type-checker the attributes that are dynamically
-# defined via `extra`.
-class DagsterLogRecord(logging.LogRecord, IDagsterMeta):
-    pass
+def set_log_record_event(record: logging.LogRecord, event: "DagsterEvent") -> None:
+    setattr(record, LOG_RECORD_EVENT_ATTR, event)
+
+
+def has_log_record_event(record: logging.LogRecord) -> bool:
+    return hasattr(record, LOG_RECORD_EVENT_ATTR)
+
+
+LOG_RECORD_METADATA_ATTR: Final = "dagster_meta"
+
+DagsterLogRecordMetadata: TypeAlias = Mapping[str, Any]
+
+
+def get_log_record_metadata(record: logging.LogRecord) -> "DagsterLogRecordMetadata":
+    return getattr(record, LOG_RECORD_METADATA_ATTR)
+
+
+def set_log_record_metadata(
+    record: logging.LogRecord, metadata: "DagsterLogRecordMetadata"
+) -> None:
+    setattr(record, LOG_RECORD_METADATA_ATTR, metadata)
+
+
+def has_log_record_metadata(record: logging.LogRecord) -> bool:
+    return hasattr(record, LOG_RECORD_METADATA_ATTR)
 
 
 class DagsterMessageProps(
@@ -248,28 +269,24 @@ class DagsterLogHandler(logging.Handler):
         ]
         return {k: v for k, v in record.__dict__.items() if k not in ref_attrs}
 
-    def _convert_record(self, record: logging.LogRecord) -> DagsterLogRecord:
-        # we store the originating DagsterEvent in the DAGSTER_META_KEY field, if applicable
-        dagster_meta = getattr(record, DAGSTER_META_KEY, None)
+    def _convert_record(self, record: logging.LogRecord) -> logging.LogRecord:
+        # If this was a logged DagsterEvent, the event will be stored on the record
+        event = get_log_record_event(record) if has_log_record_event(record) else None
 
         # generate some properties for this specific record
         dagster_message_props = DagsterMessageProps(
-            orig_message=record.getMessage(), dagster_event=dagster_meta
+            orig_message=record.getMessage(), dagster_event=event
         )
 
         # set the dagster meta info for the record
-        setattr(
-            record,
-            DAGSTER_META_KEY,
-            get_dagster_meta_dict(self._logging_metadata, dagster_message_props),
+        set_log_record_metadata(
+            record, get_dagster_meta_dict(self._logging_metadata, dagster_message_props)
         )
 
         # update the message to be formatted like other dagster logs
         record.msg = construct_log_string(self._logging_metadata, dagster_message_props)
         record.args = ()
-
-        # DagsterLogRecord is a LogRecord with a `dagster_meta` field
-        return cast(DagsterLogRecord, record)
+        return record
 
     def filter(self, record: logging.LogRecord) -> bool:
         """If you list multiple levels of a python logging hierarchy as managed loggers, and do not
@@ -283,9 +300,7 @@ class DagsterLogHandler(logging.Handler):
             # we need to set a default value for all other threads here.
             self._local_thread_context.should_capture = True
 
-        return self._local_thread_context.should_capture and not isinstance(
-            getattr(record, DAGSTER_META_KEY, None), dict
-        )
+        return self._local_thread_context.should_capture and not has_log_record_metadata(record)
 
     def emit(self, record: logging.LogRecord) -> None:
         """For any received record, add Dagster metadata, and have handlers handle it."""
@@ -417,7 +432,7 @@ class DagsterLogManager(logging.Logger):
             msg (str): message describing the event
             dagster_event (DagsterEvent): DagsterEvent that will be logged
         """
-        self.log(level=level, msg=msg, extra={DAGSTER_META_KEY: dagster_event})
+        self.log(level=level, msg=msg, extra={LOG_RECORD_EVENT_ATTR: dagster_event})
 
     def log(self, level: Union[str, int], msg: object, *args: Any, **kwargs: Any) -> None:
         """Log a message at the given level. Attributes about the context it was logged in (such as
@@ -431,7 +446,9 @@ class DagsterLogManager(logging.Logger):
         """
         level = coerce_valid_log_level(level)
         # log DagsterEvents regardless of level
-        if self.isEnabledFor(level) or ("extra" in kwargs and DAGSTER_META_KEY in kwargs["extra"]):
+        if self.isEnabledFor(level) or (
+            "extra" in kwargs and LOG_RECORD_EVENT_ATTR in kwargs["extra"]
+        ):
             self._log(level, msg, args, **kwargs)
 
     def with_tags(self, **new_tags: str) -> "DagsterLogManager":

--- a/python_modules/dagster/dagster/_utils/log.py
+++ b/python_modules/dagster/dagster/_utils/log.py
@@ -35,6 +35,8 @@ class JsonFileHandler(logging.Handler):
         self.json_path = check.str_param(json_path, "json_path")
 
     def emit(self, record: logging.LogRecord) -> None:
+        from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR
+
         try:
             log_dict = copy.copy(record.__dict__)
 
@@ -45,9 +47,9 @@ class JsonFileHandler(logging.Handler):
             # and uploads all of those properties to a redshift table for
             # in order to do analytics on the log
 
-            if "dagster_meta" in log_dict:
-                dagster_meta_dict = log_dict["dagster_meta"]
-                del log_dict["dagster_meta"]
+            if LOG_RECORD_METADATA_ATTR in log_dict:
+                dagster_meta_dict = log_dict[LOG_RECORD_METADATA_ATTR]
+                del log_dict[LOG_RECORD_METADATA_ATTR]
             else:
                 dagster_meta_dict = {}
 
@@ -69,7 +71,7 @@ class StructuredLoggerMessage(
             ("name", str),
             ("message", str),
             ("level", int),
-            ("meta", Mapping[object, object]),
+            ("meta", Mapping[str, object]),
             ("record", logging.LogRecord),
         ],
     )
@@ -79,7 +81,7 @@ class StructuredLoggerMessage(
         name: str,
         message: str,
         level: int,
-        meta: Mapping[object, object],
+        meta: Mapping[str, object],
         record: logging.LogRecord,
     ):
         return super(StructuredLoggerMessage, cls).__new__(

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -19,7 +19,7 @@ from dagster._core.events import DagsterEvent, DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._core.host_representation import CodeLocation, ExternalRepository
 from dagster._core.instance import DagsterInstance
-from dagster._core.log_manager import DAGSTER_META_KEY
+from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR
 from dagster._core.scheduler.instigation import SensorInstigatorData, TickStatus
 from dagster._core.storage.event_log.base import EventRecordsFilter
 from dagster._core.test_utils import create_test_daemon_workspace_context, instance_for_test
@@ -1474,5 +1474,5 @@ def test_logging_run_status_sensor(
         assert len(records) == 1
         assert records
         record = records[0]
-        assert record[DAGSTER_META_KEY]["orig_message"] == f"run succeeded: {run.run_id}"
+        assert record[LOG_RECORD_METADATA_ATTR]["orig_message"] == f"run succeeded: {run.run_id}"
         instance.compute_log_manager.delete_logs(log_key=tick.log_key)  # type: ignore

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -65,7 +65,7 @@ from dagster._core.host_representation.origin import (
     ManagedGrpcPythonEnvCodeLocationOrigin,
 )
 from dagster._core.instance import DagsterInstance
-from dagster._core.log_manager import DAGSTER_META_KEY
+from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR
 from dagster._core.scheduler.instigation import (
     DynamicPartitionsRequestResult,
     InstigatorState,
@@ -2987,9 +2987,9 @@ def test_sensor_logging(executor, instance, workspace_context, external_repo):
     assert tick.status == TickStatus.SKIPPED
     records = get_instigation_log_records(instance, tick.log_key)
     assert len(records) == 3
-    assert records[0][DAGSTER_META_KEY]["orig_message"] == "hello hello"
-    assert records[1][DAGSTER_META_KEY]["orig_message"].endswith("hello hello")
-    assert records[2][DAGSTER_META_KEY]["orig_message"] == ("goodbye goodbye")
+    assert records[0][LOG_RECORD_METADATA_ATTR]["orig_message"] == "hello hello"
+    assert records[1][LOG_RECORD_METADATA_ATTR]["orig_message"].endswith("hello hello")
+    assert records[2][LOG_RECORD_METADATA_ATTR]["orig_message"] == ("goodbye goodbye")
     assert records[2]["exc_info"].startswith("Traceback")
     assert "Exception: hi hi" in records[2]["exc_info"]
     instance.compute_log_manager.delete_logs(log_key=tick.log_key)
@@ -3037,7 +3037,7 @@ def test_sensor_logging_on_tick_failure(
     records = get_instigation_log_records(instance, tick.log_key)
 
     assert len(records) == 1
-    assert records[0][DAGSTER_META_KEY]["orig_message"] == "hello hello"
+    assert records[0][LOG_RECORD_METADATA_ATTR]["orig_message"] == "hello hello"
 
     assert isinstance(instance.compute_log_manager, CapturedLogManager)
     instance.compute_log_manager.delete_logs(log_key=tick.log_key)

--- a/python_modules/dagster/dagster_tests/logging_tests/test_logging.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_logging.py
@@ -21,7 +21,7 @@ from dagster._core.events import DagsterEvent
 from dagster._core.execution.context.logger import InitLoggerContext
 from dagster._core.execution.plan.objects import StepFailureData
 from dagster._core.execution.plan.outputs import StepOutputHandle
-from dagster._core.log_manager import DagsterLogManager
+from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR, DagsterLogManager
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.test_utils import instance_for_test
 from dagster._loggers import colored_console_logger, default_system_loggers, json_console_logger
@@ -308,7 +308,7 @@ def test_json_console_logger(capsys):
     for line in captured.err.split("\n"):
         if line:
             parsed = json.loads(line)
-            if parsed["dagster_meta"]["orig_message"] == "Hello, world!":
+            if parsed[LOG_RECORD_METADATA_ATTR]["orig_message"] == "Hello, world!":
                 found_msg = True
 
     assert found_msg


### PR DESCRIPTION
## Summary & Motivation

The existing code around attaching ancillary data to `logging.LogRecord` objects is confusing:

- We always use a single metadata key (`dagster_meta`) to attach data, but the kind of data we attach under this key varies in type (sometimes `DagsterEvent`, sometimes a dict).
- There is a defined class and protocol `DagsterLogRecord`/`IDagsterMeta` that add a `dagster_meta` property to `LogRecord` (added by me in the past) that is used inconsistently and not really worth it's weight.

This PR cleans up these APIs by:

- Eliminating the single `dagster_meta` key in favor of two keys that correspond to the different kinds of data we attach.
- Defining `get`/`set`/`has` for the different kinds of data we attach to log records and standardizing callsites/access points.
- Deleting `DagsterLogRecord`


## How I Tested These Changes

Existing test suite.