### PR TITLE
[external-assets] Cache asset key subsets in refactored AssetGraph

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -180,10 +180,12 @@ class ExternalAssetGraph(AssetGraph):
         return {"upstream": upstream, "downstream": downstream}
 
     @property
+    @cached_method
     def all_asset_keys(self) -> AbstractSet[AssetKey]:
         return {node.asset_key for node in self.asset_nodes}
 
     @property
+    @cached_method
     def materializable_asset_keys(self) -> AbstractSet[AssetKey]:
         return {
             node.asset_key
@@ -195,6 +197,7 @@ class ExternalAssetGraph(AssetGraph):
         return self.get_asset_node(asset_key).execution_type == AssetExecutionType.MATERIALIZATION
 
     @property
+    @cached_method
     def observable_asset_keys(self) -> AbstractSet[AssetKey]:
         return {
             node.asset_key
@@ -208,6 +211,7 @@ class ExternalAssetGraph(AssetGraph):
         return self.get_asset_node(asset_key).is_observable
 
     @property
+    @cached_method
     def external_asset_keys(self) -> AbstractSet[AssetKey]:
         return {
             node.asset_key
@@ -219,6 +223,7 @@ class ExternalAssetGraph(AssetGraph):
         return self.get_asset_node(asset_key).execution_type != AssetExecutionType.MATERIALIZATION
 
     @property
+    @cached_method
     def executable_asset_keys(self) -> AbstractSet[AssetKey]:
         return {node.asset_key for node in self.asset_nodes if node.is_executable}
 

--- a/python_modules/dagster/dagster/_core/definitions/internal_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/internal_asset_graph.py
@@ -112,10 +112,12 @@ class InternalAssetGraph(AssetGraph):
         return generate_asset_dep_graph(self._assets_defs, [])
 
     @property
+    @cached_method
     def all_asset_keys(self) -> AbstractSet[AssetKey]:
         return {key for ad in self._assets_defs for key in ad.keys}
 
     @property
+    @cached_method
     def materializable_asset_keys(self) -> AbstractSet[AssetKey]:
         return {key for ad in self._assets_defs if ad.is_materializable for key in ad.keys}
 
@@ -124,6 +126,7 @@ class InternalAssetGraph(AssetGraph):
         return self.has_asset(asset_key) and self.get_assets_def(asset_key).is_materializable
 
     @property
+    @cached_method
     def observable_asset_keys(self) -> AbstractSet[AssetKey]:
         return {key for ad in self._assets_defs if ad.is_observable for key in ad.keys}
 
@@ -131,6 +134,7 @@ class InternalAssetGraph(AssetGraph):
         return self.get_assets_def(asset_key).is_observable
 
     @property
+    @cached_method
     def external_asset_keys(self) -> AbstractSet[AssetKey]:
         return {key for ad in self._assets_defs if ad.is_external for key in ad.keys}
 
@@ -138,6 +142,7 @@ class InternalAssetGraph(AssetGraph):
         return self.get_assets_def(asset_key).is_external
 
     @property
+    @cached_method
     def executable_asset_keys(self) -> AbstractSet[AssetKey]:
         return {key for ad in self._assets_defs if ad.is_executable for key in ad.keys}
 


### PR DESCRIPTION
## Summary & Motivation

#19900 led to an auto-materialize performance regression caught by our regression tests. After investigating with a profiler, I found the issue was lack of caching on asset key subset methods in the new `AssetGraph`. This PR adds them.

## How I Tested These Changes

Ran perf regression tests against this branch.