### PR TITLE
[dagster-snowflake] add lower bound to snowflake-python-connector

### DIFF
--- a/python_modules/libraries/dagster-snowflake-pandas/setup.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/setup.py
@@ -40,7 +40,7 @@ setup(
         f"dagster-snowflake{pin}",
         "pandas",
         "requests",
-        "snowflake-connector-python[pandas]>=2.1.0",
+        "snowflake-connector-python[pandas]>=3.4.0",
         "sqlalchemy!=1.4.42",  # workaround for https://github.com/snowflakedb/snowflake-sqlalchemy/issues/350
         "snowflake-sqlalchemy>=1.2",
     ],

--- a/python_modules/libraries/dagster-snowflake/setup.py
+++ b/python_modules/libraries/dagster-snowflake/setup.py
@@ -36,7 +36,7 @@ setup(
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
-        "snowflake-connector-python>=2.1.0",
+        "snowflake-connector-python>=3.4.0",
     ],
     extras_require={
         "snowflake.sqlalchemy": [
@@ -45,7 +45,7 @@ setup(
         ],
         "pandas": [
             "pandas",
-            "snowflake-connector-python[pandas]>=2.1.0",
+            "snowflake-connector-python[pandas]>=3.4.0",
         ],
     },
     zip_safe=False,


### PR DESCRIPTION
## Summary & Motivation
https://github.com/dagster-io/dagster/pull/18410 updated the snowflake pandas io manager to use `write_pandas` with the `use_logical_type` parameter. But `use_logical_type` was only introduced in `snowflake-connector-python` version `3.4.0`. bump our lower bound pin so we are guaranteed to use this version

## How I Tested These Changes
