### PR TITLE
[io managers] pass output metadata through to handle_output

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -30,6 +30,7 @@ from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.errors import DagsterInvalidMetadata, DagsterInvariantViolationError
 from dagster._core.execution.plan.utils import build_resources_for_manager
+from dagster._utils.merger import merge_dicts
 
 if TYPE_CHECKING:
     from dagster._core.definitions import JobDefinition, PartitionsDefinition
@@ -212,7 +213,8 @@ class OutputContext:
     @property
     def metadata(self) -> Optional[ArbitraryMetadataMapping]:
         """A dict of the metadata that is assigned to the OutputDefinition that produced
-        the output.
+        the output, or attached to the output at runtime. If duplicate metadata keys are used,
+        the value used at runtime will take precedence.
         """
         return self._metadata
 
@@ -725,6 +727,7 @@ def get_output_context(
     resources: Optional["Resources"],
     version: Optional[str],
     warn_on_step_context_use: bool = False,
+    output_metadata: Optional[Mapping[str, RawMetadataValue]] = None,
 ) -> "OutputContext":
     """Args:
     run_id (str): The run ID of the run that produced the output, not necessarily the run that
@@ -754,6 +757,9 @@ def get_output_context(
         metadata = job_def.asset_layer.metadata_for_asset(asset_info.key) or output_def.metadata
     else:
         metadata = output_def.metadata
+
+    if output_metadata is not None:
+        metadata = merge_dicts(metadata, output_metadata)
 
     if step_context:
         check.invariant(

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -34,6 +34,7 @@ from dagster._core.definitions.events import AssetKey, AssetLineageInfo
 from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.job_base import IJob
 from dagster._core.definitions.job_definition import JobDefinition
+from dagster._core.definitions.metadata import RawMetadataValue
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
@@ -643,7 +644,11 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         output_manager = getattr(self.resources, io_manager_key)
         return check.inst(output_manager, IOManager)
 
-    def get_output_context(self, step_output_handle: StepOutputHandle) -> OutputContext:
+    def get_output_context(
+        self,
+        step_output_handle: StepOutputHandle,
+        output_metadata: Optional[Mapping[str, RawMetadataValue]] = None,
+    ) -> OutputContext:
         return get_output_context(
             self.execution_plan,
             self.job_def,
@@ -654,6 +659,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             step_context=self,
             resources=None,
             version=self.execution_plan.get_version_for_step_output_handle(step_output_handle),
+            output_metadata=output_metadata,
         )
 
     def for_input_manager(

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -766,7 +766,7 @@ def _store_output(
 ) -> Iterator[DagsterEvent]:
     output_def = step_context.op_def.output_def_named(step_output_handle.output_name)
     output_manager = step_context.get_io_manager(step_output_handle)
-    output_context = step_context.get_output_context(step_output_handle)
+    output_context = step_context.get_output_context(step_output_handle, output.metadata)
 
     manager_materializations = []
     manager_metadata: Dict[str, MetadataValue] = {}


### PR DESCRIPTION
## Summary & Motivation


## How I Tested These Changes
New unit tests. Before implementing the change, the assets that add runtime metadata (via `Output` and `context.add_output_metadata`) failed because the I/O manager could not access the metadata
