### PR TITLE
[docs] Add a pre-commit hook for make mdx-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,11 @@ repos:
       args: [--fix, --exit-non-zero-on-fix]
       types_or: [python, pyi, jupyter]
     - id: ruff-format
+- repo: local
+  hooks:
+    - id: docs-mdx-format
+      name: Format Docs
+      language: system
+      entry: bash -c "cd docs && make mdx-format"
+      pass_filenames: false
+      files: ^docs/content


### PR DESCRIPTION
## Summary & Motivation

Adds a pre-commit hook to run `make mdx-format` on changes to `docs/content`

## How I Tested These Changes

Ran `pre-commit run docs-mdx-format -a`
