### PR TITLE
Design exploration: structured metadata two ways

### DIFF
--- a/standardized-metadata-flexible-spec.py
+++ b/standardized-metadata-flexible-spec.py
@@ -1,0 +1,218 @@
+from abc import ABC, abstractmethod
+from typing import Any, Mapping, Optional, Sequence
+
+from dagster import (
+    MaterializeResult,
+    TableRecord,
+    UrlMetadataValue,
+    asset,
+)
+from pydantic import BaseModel
+
+
+class Metadata(BaseModel, ABC):
+    """Extend this class to define a set of metadata fields in the same namespace.
+
+    Supports syntactic sugar for converting to a dictionary that can be placed inside a metadata
+    argument along with other dictionary-structured metadata.
+
+    .. code-block:: python
+
+        my_metadata: Metadata = ...
+        return MaterializeResult(metadata={**my_metadata, ...})
+    """
+
+    @classmethod
+    @abstractmethod
+    def namespace(cls) -> str:
+        raise NotImplementedError()
+
+    @classmethod
+    @abstractmethod
+    def version(cls) -> str:
+        """Versions are expected to be SemVer strings."""
+        raise NotImplementedError()
+
+    def keys(self):
+        dictionary = self.dict()
+        return {
+            f"{self.namespace()}/{key}" for key in dictionary.keys() if dictionary[key] is not None
+        } | {f"{self.namespace()}/_version"}
+
+    def __getitem__(self, key):
+        if key == f"{self.namespace()}/_version":
+            return self.version()
+        else:
+            return self.dict()[key.split("/", 1)[1]]
+
+    @classmethod
+    def from_metadata_dict(cls, metadata_dict: Mapping[str, Any]):
+        derived_dict = {
+            key.split("/", 1)[1]: value
+            for key, value in metadata_dict.items()
+            if key.startswith(f"{cls.namespace()}/")
+        }
+
+        return cls.parse_obj(derived_dict)
+
+
+####################################################################################################
+# Metadata that's relevant to all assets.
+####################################################################################################
+
+
+class AssetMetadata(Metadata):
+    """Metadata fields that apply to definitions, observations, or materializations of any asset."""
+
+    storage_kind: Optional[str]
+    storage_address_string: Optional[str]
+    source_code_link: Optional[UrlMetadataValue]
+
+    @classmethod
+    def namespace(cls) -> str:
+        return "dagster"
+
+    @classmethod
+    def version(cls) -> str:
+        return "1.0.0"
+
+
+####################################################################################################
+# Metadata that's relevant to assets that are tables. Lives inside the "dagster.table" package.
+####################################################################################################
+
+
+class TableColumn(BaseModel):
+    name: str
+    data_type: str
+
+
+class TableMetadata(Metadata):
+    """Metadata fields that apply to definitions, observations, or materializations of assets that
+    are tables.
+    """
+
+    columns: Optional[Sequence[TableColumn]]
+
+    @classmethod
+    def namespace(cls) -> str:
+        return "dagster.table"
+
+    @classmethod
+    def version(cls) -> str:
+        return "1.0.0"
+
+
+class TableObservationMetadata(TableMetadata):
+    """Metadata fields that apply to observations or materializations of assets that are tables."""
+
+    num_rows_total: Optional[int]
+    sample: Optional[Sequence[TableRecord]]
+
+
+class TableMaterializationMetadata(TableObservationMetadata):
+    """Metadata fields that apply to materializations of assets that are tables."""
+
+    num_rows_inserted: Optional[int]
+    num_rows_updated: Optional[int]
+    num_rows_deleted: Optional[int]
+
+
+####################################################################################################
+# Metadata that's relevant to assets that are Snowflake tables. Lives inside the "dagster_snowflake"
+# package.
+####################################################################################################
+
+
+class SnowflakeTableAddress(BaseModel):
+    """An identifier for a table in Snowflake."""
+
+    database: Optional[str]
+    db_schema: Optional[str]
+    table_name: Optional[str]
+
+
+class SnowflakeTableMetadata(Metadata):
+    """Metadata fields that apply to assets that are tables in Snowflake."""
+
+    snowflake_address: Optional[SnowflakeTableAddress]
+    cluster_by: Optional[str]
+
+    @classmethod
+    def namespace(cls) -> str:
+        return "dagster_snowflake"
+
+    @classmethod
+    def version(cls) -> str:
+        return "1.0.0"
+
+
+####################################################################################################
+# An asset with metadata constructed using the structured metadata APIs.
+####################################################################################################
+
+
+@asset
+def asset1():
+    return MaterializeResult(
+        metadata={
+            **AssetMetadata(
+                storage_kind="snowflake", storage_address_string="my_db.my_schema.asset1"
+            ),
+            **TableMaterializationMetadata(
+                num_rows_total=500,
+                num_rows_inserted=5,
+                columns=[TableColumn(name="user_id", data_type="str")],
+            ),
+            **SnowflakeTableMetadata(
+                snowflake_address=SnowflakeTableAddress(
+                    database="my_db", db_schema="my_schema", table_name="asset1"
+                )
+            ),
+            # non-structured metadata
+            "my_unschematized_piece_of_metadata": 5,
+            "staging_address": SnowflakeTableAddress(
+                database="my_staging_db", db_schema="my_schema", table_name="asset1"
+            ).dict(),
+        }
+    )
+
+
+####################################################################################################
+# An asset with metadata constructed using plain JSON-objects. Has identical metadata to the asset
+# above.
+####################################################################################################
+
+
+@asset
+def asset2():
+    return MaterializeResult(
+        metadata={
+            "dagster.table/num_rows_inserted": 5,
+            "dagster.table/columns": [{"name": "user_id", "data_type": "str"}],
+            "dagster.table/num_rows_total": 500,
+            "dagster.table/_version": "1.0.0",
+            "dagster/storage_kind": "snowflake",
+            "dagster/storage_address_string": "my_db.my_schema.asset1",
+            "dagster/_version": "1.0.0",
+            "dagster_snowflake/snowflake_address": {
+                "database": "my_db",
+                "db_schema": "my_schema",
+                "table_name": "asset1",
+            },
+            "dagster_snowflake/_version": "1.0.0",
+            "staging_address": {
+                "database": "my_staging_db",
+                "db_schema": "my_schema",
+                "table_name": "asset1",
+            },
+            "my_unschematized_piece_of_metadata": 5,
+        }
+    )
+
+
+def test():
+    asset1_result = asset1()
+    asset2_result = asset2()
+    assert TableObservationMetadata.from_metadata_dict(asset1_result.metadata).num_rows_total == 500
+    assert asset1_result.metadata == asset2_result.metadata

--- a/standardized-metadata-nested.py
+++ b/standardized-metadata-nested.py
@@ -1,0 +1,225 @@
+from abc import ABC, abstractmethod
+from typing import Any, Mapping, Optional, Sequence
+
+from dagster import (
+    MaterializeResult,
+    TableRecord,
+    UrlMetadataValue,
+    asset,
+)
+from pydantic import BaseModel
+
+
+class Metadata(BaseModel, ABC):
+    """Extend this class to define a set of metadata fields in the same namespace.
+
+    Supports syntactic sugar for converting to a dictionary that can be placed inside a metadata
+    argument along with other dictionary-structured metadata.
+
+    .. code-block:: python
+
+        my_metadata: Metadata = ...
+        return MaterializeResult(metadata={**my_metadata, ...})
+    """
+
+    @classmethod
+    @abstractmethod
+    def namespace(cls) -> str:
+        raise NotImplementedError()
+
+    @classmethod
+    @abstractmethod
+    def version(cls) -> str:
+        """Versions are expected to be SemVer strings."""
+        raise NotImplementedError()
+
+    def keys(self):
+        return {self.namespace()}
+
+    def __getitem__(self, key):
+        assert key == self.namespace()
+        result = {"_version": self.version()}
+        for key, value in self.dict().items():
+            if value is not None:
+                result[key] = value
+
+        return result
+
+    @classmethod
+    def from_metadata_dict(cls, metadata_dict: Mapping[str, Any]):
+        return cls.parse_obj(metadata_dict[cls.namespace()])
+
+
+####################################################################################################
+# Metadata that's relevant to all assets.
+####################################################################################################
+
+
+class AssetMetadata(Metadata):
+    """Metadata fields that apply to definitions, observations, or materializations of any asset."""
+
+    storage_kind: Optional[str]
+    storage_address_string: Optional[str]
+    source_code_link: Optional[UrlMetadataValue]
+
+    @classmethod
+    def namespace(cls) -> str:
+        return "dagster"
+
+    @classmethod
+    def version(cls) -> str:
+        return "1.0.0"
+
+
+####################################################################################################
+# Metadata that's relevant to assets that are tables. Lives inside the "dagster.table" package.
+####################################################################################################
+
+
+class TableColumn(BaseModel):
+    name: str
+    data_type: str
+
+
+class TableMetadata(Metadata):
+    """Metadata fields that apply to definitions, observations, or materializations of assets that
+    are tables.
+    """
+
+    columns: Optional[Sequence[TableColumn]]
+
+    @classmethod
+    def namespace(cls) -> str:
+        return "dagster.table"
+
+    @classmethod
+    def version(cls) -> str:
+        return "1.0.0"
+
+
+class TableObservationMetadata(TableMetadata):
+    """Metadata fields that apply to observations or materializations of assets that are tables."""
+
+    num_rows_total: Optional[int]
+    sample: Optional[Sequence[TableRecord]]
+
+
+class TableMaterializationMetadata(TableObservationMetadata):
+    """Metadata fields that apply to materializations of assets that are tables."""
+
+    num_rows_inserted: Optional[int]
+    num_rows_updated: Optional[int]
+    num_rows_deleted: Optional[int]
+    num_rows_affected: Optional[int]
+
+
+####################################################################################################
+# Metadata that's relevant to assets that are Snowflake tables. Lives inside the "dagster_snowflake"
+# package.
+####################################################################################################
+
+
+class SnowflakeTableAddress(BaseModel):
+    """An identifier for a table in Snowflake."""
+
+    database: Optional[str]
+    db_schema: Optional[str]
+    table_name: Optional[str]
+
+
+class SnowflakeTableMetadata(Metadata):
+    """Metadata fields that apply to assets that are tables in Snowflake."""
+
+    snowflake_address: Optional[SnowflakeTableAddress]
+    cluster_by: Optional[str]
+
+    @classmethod
+    def namespace(cls) -> str:
+        return "dagster_snowflake"
+
+    @classmethod
+    def version(cls) -> str:
+        return "1.0.0"
+
+
+####################################################################################################
+# An asset with metadata constructed using the structured metadata APIs.
+####################################################################################################
+
+
+@asset
+def asset1():
+    return MaterializeResult(
+        metadata={
+            **AssetMetadata(
+                storage_kind="snowflake", storage_address_string="my_db.my_schema.asset1"
+            ),
+            **TableMaterializationMetadata(
+                num_rows_total=500,
+                num_rows_inserted=5,
+                columns=[TableColumn(name="user_id", data_type="str")],
+            ),
+            **SnowflakeTableMetadata(
+                snowflake_address=SnowflakeTableAddress(
+                    database="my_db", db_schema="my_schema", table_name="asset1"
+                )
+            ),
+            # non-structured metadata
+            "my_unschematized_piece_of_metadata": 5,
+            "staging_address": SnowflakeTableAddress(
+                database="my_staging_db", db_schema="my_schema", table_name="asset1"
+            ).dict(),
+        }
+    )
+
+
+####################################################################################################
+# An asset with metadata constructed using plain JSON-objects. Has identical metadata to the asset
+# above.
+####################################################################################################
+
+
+@asset
+def asset2():
+    return MaterializeResult(
+        metadata={
+            "dagster.table": {
+                "_version": "1.0.0",
+                "num_rows_inserted": 5,
+                "columns": [{"name": "user_id", "data_type": "str"}],
+                "num_rows_total": 500,
+            },
+            "dagster": {
+                "_version": "1.0.0",
+                "storage_kind": "snowflake",
+                "storage_address_string": "my_db.my_schema.asset1",
+            },
+            "dagster_snowflake": {
+                "_version": "1.0.0",
+                "snowflake_address": {
+                    "database": "my_db",
+                    "db_schema": "my_schema",
+                    "table_name": "asset1",
+                },
+            },
+            # non-structured metadata
+            "my_unschematized_piece_of_metadata": 5,
+            "staging_address": {
+                "database": "my_staging_db",
+                "db_schema": "my_schema",
+                "table_name": "asset1",
+            },
+        }
+    )
+
+
+####################################################################################################
+# Test
+####################################################################################################
+
+
+def test():
+    asset1_result = asset1()
+    asset2_result = asset2()
+    assert TableObservationMetadata.from_metadata_dict(asset1_result.metadata).num_rows_total == 500
+    assert asset1_result.metadata == asset2_result.metadata


### PR DESCRIPTION
This presents an approach to structured asset metadata, with two variants: one nested and one non-nested.

Nowadays, you can do this:
```python
return MaterializeResult(
    metadata={"row_count": 2309, "source_code_link" "http://...", "columns": my_column_schema}
)
```

Two problems with this:
- There are no corresponding symbols in the Python API. Python symbols act as documentation for the metadata, allow it to be type-checked, and allow the use of auto-complete.
- It's not namespaced. If I have an asset that contains data about a farm, and I come across a metadata key named "row_count", how do I know whether it's referring to "the number of rows in a warehouse table" or "the number of rows of cabbages on the farm"?

The approached proposed here looks somewhat similar to the "Approach 1" that @rexledesma described [in this Notion doc](https://www.notion.so/dagster/Standardizing-metadata-fields-7efda2c4de754717a026bc00601f6b84).

### Common to both of the variants:
- Does not change or add any properties on `MaterializeResult` or `AssetSpec`. I.e. the structured metadata classes involved are intended to be translated to the plain dictionaries that these APIs already expect.
- Structured metadata can be intermixed with unstructured metadata.
- Uses Python package as a namespacing convention. If you encounter a metadata entry on asset "foo" with namespace="package_x", key="row_count", and value="7", you're meant to understand that "foo's row_count is 7, according to the definition of row_count intended by the developers of package_x".
- All the subclasses of `NamespacedMetadata` are identical across both examples.
- They maintain our ability to interpret a metadata dict as a flat list of metadata entries, for display in the UI, like this:
<img width="684" alt="image" src="https://github.com/dagster-io/dagster/assets/654855/e5b525cf-32b7-44f1-a7c3-c4849e488de5">

### Differences between the variants
- The constructed metadata dictionaries are different between the variants.
  - In `standardized-metadata-flexible-spec.py`, the namespaces are included as parts of the metadata keys.
  - In `standardized-metadata-nested.py`, the metadata attributes are nested underneath their namespaces, which are themselves nested underneath a `__namespaced_metadata` top-level key.
- The implementation of `asset2`, which showcases the constructed metadata dictionaries, is different between the variants.

### Comparing the approaches

In favor of the unnested approach:

- In the unnested approach, each entry in the dictionary that's passed to the `metadata` argument corresponds to a metadata entry shown in the UI. This feels simple and expected, and is consistent way the way Dagster metadata currently works.
- Consequently, basic operations like checking whether a metadata dictionary contains an expected entry are very straightforward and don't require use of helper APIs to interpret the metadata.
- The unnested approach matches our convention for naming keys in tag dictionaries, where we use namespace prefixes like "dagster/" and "dagster-kubernetes/".
- The nested approach requires introducing an additional API for constructing the metadata dictionary –
 `build_metadata_dict`.
- In the unnested approach, you can use basic Python dictionary manipulation to combine metadata entries from different sources. Users don't need to learn the behavior bespoke APIs for combining metadata.

In favor of the nested approach:

- In the unnested approach, if we want the UI to render metadata entries in a way that gives special treatment to the namespace, then we need to rely on string parsing to separate it out.
- If there are metadata keys that include slashes, but the part before the slash isn't intended to be the namespace, then any special treatment we apply in the UI will still treat it as the namespace, which will look weird.
- Even if we set the namespace convention going forward, there's still historical metadata keys from before this was a convention.

### Relevant other systems
- [OpenLineage Facets](https://openlineage.io/docs/spec/facets/).
  - Individual OpenLineage facets roughly correspond to Dagster metadata entries. Example built-in OpenLineage facets include "columnLineage", "ownership", "schema", "storage", and "outputStatistics" (which is just rowCount and size).
  - Facets keys are not namespaced, but there's a naming convention for non-built-in facets that includes the name of the technology they relate to
  - Facet values are schematized JSON
- [Kubernetes Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
  - Here's their documentation on "well-known" annotations: https://kubernetes.io/docs/reference/labels-annotations-taints/
  - They use slashes to delimit within annotation keys, e.g. "apf.kubernetes.io/autoupdate-spec"
  - Annotation values are just strings.