### PR TITLE
[dagster-dbt] log_columns_in_relation macro to to only log table_schema if present

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -1,5 +1,5 @@
+import json
 import os
-import re
 import subprocess
 from typing import Any, Dict, cast
 
@@ -92,13 +92,13 @@ def test_dbt_cli_no_jinja_log_info() -> None:
 def test_dbt_cli_no_jinja_log_info_raw() -> None:
     # Ensure `log_columns_in_relation.sql` does not produce empty `{}` statements when run outside of the context of `dagster-dbt`
     result = subprocess.run(
-        ["dbt", "parse", "--no-partial-parse", "--no-use-colors"],
+        ["dbt", "--log-format", "json", "--no-partial-parse", "parse"],
         capture_output=True,
         text=True,
         cwd=test_metadata_path,
         check=False,
     )
 
-    pattern = r"\d{2}:\d{2}:\d{2}\s+{}$"  # eg. `16:31:51  {}`
-
-    assert not any(re.match(pattern, line) for line in result.stdout.splitlines())
+    assert not any(
+        [json.loads(line)["info"]["name"] == "JinjaLogInfo" for line in result.stdout.splitlines()]
+    )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -1,4 +1,6 @@
 import os
+import re
+import subprocess
 from typing import Any, Dict, cast
 
 from dagster import (
@@ -85,3 +87,18 @@ def test_dbt_cli_no_jinja_log_info() -> None:
         event.raw_event["info"]["name"] == "JinjaLogInfo"
         for event in dbt_cli_parse_invocation.stream_raw_events()
     )
+
+
+def test_dbt_cli_no_jinja_log_info_raw() -> None:
+    # Ensure `log_columns_in_relation.sql` does not produce empty `{}` statements when run outside of the context of `dagster-dbt`
+    result = subprocess.run(
+        ["dbt", "parse", "--no-partial-parse", "--no-use-colors"],
+        capture_output=True,
+        text=True,
+        cwd=test_metadata_path,
+        check=False,
+    )
+
+    pattern = r"\d{2}:\d{2}:\d{2}\s+{}$"  # eg. `16:31:51  {}`
+
+    assert not any(re.match(pattern, line) for line in result.stdout.splitlines())

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -74,3 +74,14 @@ def test_columns_metadata(test_metadata_manifest: Dict[str, Any]) -> None:
     )
 
     assert result.success
+
+
+def test_dbt_cli_no_jinja_log_info() -> None:
+    dbt = DbtCliResource(project_dir=os.fspath(test_metadata_path))
+    dbt_cli_parse_invocation = dbt.cli(["parse"])
+
+    assert dbt_cli_parse_invocation.is_successful()
+    assert not any(
+        event.raw_event["info"]["name"] == "JinjaLogInfo"
+        for event in dbt_cli_parse_invocation.stream_raw_events()
+    )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -89,7 +89,7 @@ def test_dbt_cli_no_jinja_log_info() -> None:
     )
 
 
-def test_dbt_cli_no_jinja_log_info_raw() -> None:
+def test_dbt_raw_cli_no_empty_jinja_log_info() -> None:
     # Ensure `log_columns_in_relation.sql` does not produce empty `{}` statements when run outside of the context of `dagster-dbt`
     result = subprocess.run(
         ["dbt", "--log-format", "json", "--no-partial-parse", "parse"],

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -520,3 +520,14 @@ def test_to_default_asset_output_events() -> None:
         "Execution Duration": FloatMetadataValue(60.0),
         "rows_affected": IntMetadataValue(100),
     }
+
+
+def test_dbt_cli_no_jinja_log_info() -> None:
+    dbt = DbtCliResource(project_dir=test_jaffle_shop_path)  # type: ignore
+    dbt_cli_parse_invocation = dbt.cli(["parse"])
+
+    assert dbt_cli_parse_invocation.is_successful()
+    assert not any(
+        event.raw_event["info"]["name"] == "JinjaLogInfo"
+        for event in dbt_cli_parse_invocation.stream_raw_events()
+    )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -520,14 +520,3 @@ def test_to_default_asset_output_events() -> None:
         "Execution Duration": FloatMetadataValue(60.0),
         "rows_affected": IntMetadataValue(100),
     }
-
-
-def test_dbt_cli_no_jinja_log_info() -> None:
-    dbt = DbtCliResource(project_dir=test_jaffle_shop_path)  # type: ignore
-    dbt_cli_parse_invocation = dbt.cli(["parse"])
-
-    assert dbt_cli_parse_invocation.is_successful()
-    assert not any(
-        event.raw_event["info"]["name"] == "JinjaLogInfo"
-        for event in dbt_cli_parse_invocation.stream_raw_events()
-    )

--- a/python_modules/libraries/dagster-dbt/dbt_packages/dagster/macros/log_columns_in_relation.sql
+++ b/python_modules/libraries/dagster-dbt/dbt_packages/dagster/macros/log_columns_in_relation.sql
@@ -7,5 +7,7 @@
         {%- set _ = table_schema.update(serializable_column) -%}
     {% endfor %}
 
-    {% do log(tojson(table_schema), info=true) %}
+    {% if table_schema %}
+        {% do log(tojson(table_schema), info=true) %}
+    {% endif %}
 {% endmacro %}


### PR DESCRIPTION
## Summary & Motivation

When running the `dbt parse` command on a project like `dagster-open-platform`, the post hook `log_columns_in_relation` macro produces many empty log statements. This updates the macro to only log `table_schema` when it is non-null.

```
make manifest
cd dbt && dbt parse && cd ..
15:24:05  Running with dbt=1.7.6
15:24:09  Registered adapter: snowflake=1.7.1
15:24:09  Unable to do partial parsing because profile has changed
15:24:09  Unable to do partial parsing because a project dependency has been added
15:24:09  Unable to do partial parsing because a project config has changed
15:24:09  {}
15:24:09  {}
15:24:09  {}
15:24:09  {}
15:24:09  {}
15:24:09  {}
15:24:09  {}
15:24:09  {}
```

## How I Tested These Changes

Only tested happy-path by updating the macro in the `dbt_modules` directory and running the project.

I confirmed that the logs were _not_ produced in my project, but I was unable to test when they _are_ produced.
