### PR TITLE
[dagster-databricks] Log databricks job run page url

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
@@ -195,6 +195,7 @@ def test_pyspark_databricks(
         DatabricksRunLifeCycleState.TERMINATED, DatabricksRunResultState.SUCCESS, ""
     )
     mock_get_run_state.side_effect = [running_state] * 5 + [final_state]
+    mock_get_run.return_value.as_dict = mock.Mock(return_value={})
 
     with instance_for_test() as instance:
         result = do_nothing_local_job.execute_in_process(instance=instance)
@@ -231,7 +232,7 @@ def test_pyspark_databricks(
         )
         assert result.success
         assert mock_perform_query.call_count == 2
-        assert mock_get_run.call_count == 1
+        assert mock_get_run.call_count == 2
         assert mock_get_run_state.call_count == 6
         assert mock_get_step_events.call_count == 6
         assert mock_put_file.call_count == 4


### PR DESCRIPTION
## Summary & Motivation
It is difficult to find the Databricks job run that is associated with a Dagster run in the Databricks console. This logs an event that surfaces the run page url for the launched Databricks job in the Dagster run details page.

## How I Tested These Changes
Confirmed events were being logged in asset details page from local deployment. The URL links to the current page if not databricks run page url exists.

![Screenshot 2024-02-28 at 2 53 18 PM](https://github.com/dagster-io/dagster/assets/23409221/8d7297cb-40aa-4b22-9a93-0853f115a3ce)


Confirmed that the event link is omitted when a databricks run page url does not exist.
![Screenshot 2024-02-28 at 5 37 12 PM](https://github.com/dagster-io/dagster/assets/23409221/704df78d-5547-460e-992a-97b019dbf2d3)





