### PR TITLE
[io manager] access output metadata in handle_output

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -74,6 +74,7 @@ class OutputContext:
     _job_name: Optional[str]
     _run_id: Optional[str]
     _definition_metadata: ArbitraryMetadataMapping
+    _output_metadata: ArbitraryMetadataMapping
     _user_generated_metadata: Mapping[str, MetadataValue]
     _mapping_key: Optional[str]
     _config: object

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -241,6 +241,14 @@ class OutputContext:
     @property
     def output_metadata(self) -> ArbitraryMetadataMapping:
         """A dict of the metadata that is assigned to the output at execution time."""
+        if self._warn_on_step_context_use:
+            warnings.warn(
+                "You are using InputContext.upstream_output.output_metadata."
+                "Output metadata is not available when accessed from the InputContext."
+                "https://github.com/dagster-io/dagster/issues/20094"
+            )
+            return {}
+
         return self._output_metadata
 
     @public

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -111,6 +111,7 @@ class OutputContext:
         asset_info: Optional[AssetOutputInfo] = None,
         warn_on_step_context_use: bool = False,
         partition_key: Optional[str] = None,
+        output_metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         # deprecated
         metadata: Optional[ArbitraryMetadataMapping] = None,
     ):
@@ -125,6 +126,7 @@ class OutputContext:
             definition_metadata, "definition_metadata", metadata, "metadata"
         )
         self._definition_metadata = normalized_metadata or {}
+        self._output_metadata = output_metadata or {}
         self._mapping_key = mapping_key
         self._config = config
         self._op_def = op_def
@@ -234,6 +236,12 @@ class OutputContext:
         or in the @asset decorator.
         """
         return self._definition_metadata
+
+    @public
+    @property
+    def output_metadata(self) -> ArbitraryMetadataMapping:
+        """A dict of the metadata that is assigned to the output at execution time."""
+        return self._output_metadata
 
     @public
     @property
@@ -744,6 +752,7 @@ def get_output_context(
     resources: Optional["Resources"],
     version: Optional[str],
     warn_on_step_context_use: bool = False,
+    output_metadata: Optional[Mapping[str, RawMetadataValue]] = None,
 ) -> "OutputContext":
     """Args:
     run_id (str): The run ID of the run that produced the output, not necessarily the run that
@@ -802,6 +811,7 @@ def get_output_context(
         resources=resources,
         asset_info=asset_info,
         warn_on_step_context_use=warn_on_step_context_use,
+        output_metadata=output_metadata,
     )
 
 

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -35,6 +35,7 @@ from dagster._core.definitions.events import AssetKey, AssetLineageInfo
 from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.job_base import IJob
 from dagster._core.definitions.job_definition import JobDefinition
+from dagster._core.definitions.metadata import RawMetadataValue
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
@@ -650,7 +651,11 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         output_manager = getattr(self.resources, io_manager_key)
         return check.inst(output_manager, IOManager)
 
-    def get_output_context(self, step_output_handle: StepOutputHandle) -> OutputContext:
+    def get_output_context(
+        self,
+        step_output_handle: StepOutputHandle,
+        output_metadata: Optional[Mapping[str, RawMetadataValue]] = None,
+    ) -> OutputContext:
         return get_output_context(
             self.execution_plan,
             self.job_def,
@@ -661,6 +666,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             step_context=self,
             resources=None,
             version=self.execution_plan.get_version_for_step_output_handle(step_output_handle),
+            output_metadata=output_metadata,
         )
 
     def for_input_manager(

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -767,7 +767,7 @@ def _store_output(
 ) -> Iterator[DagsterEvent]:
     output_def = step_context.op_def.output_def_named(step_output_handle.output_name)
     output_manager = step_context.get_io_manager(step_output_handle)
-    output_context = step_context.get_output_context(step_output_handle)
+    output_context = step_context.get_output_context(step_output_handle, output.metadata)
 
     manager_materializations = []
     manager_metadata: Dict[str, MetadataValue] = {}

--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -107,10 +107,8 @@ class AssetValueLoader:
             io_manager_def = resource_defs[io_manager_key]
             name = assets_def.get_output_name_for_asset_key(asset_key)
             output_definition_metadata = assets_def.metadata_by_key[asset_key]
+            definition_metadata = assets_def.metadata_by_key[asset_key]
             op_def = assets_def.get_op_def_for_asset_key(asset_key)
-            asset_partitions_def = assets_def.partitions_def
-        else:
-            check.failed(f"Asset key {asset_key} not found")
 
         required_resource_keys = get_transitive_required_resource_keys(
             io_manager_def.required_resource_keys, resource_defs

--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -108,6 +108,9 @@ class AssetValueLoader:
             name = assets_def.get_output_name_for_asset_key(asset_key)
             output_definition_metadata = assets_def.metadata_by_key[asset_key]
             op_def = assets_def.get_op_def_for_asset_key(asset_key)
+            asset_partitions_def = assets_def.partitions_def
+        else:
+            check.failed(f"Asset key {asset_key} not found")
 
         required_resource_keys = get_transitive_required_resource_keys(
             io_manager_def.required_resource_keys, resource_defs

--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -107,7 +107,6 @@ class AssetValueLoader:
             io_manager_def = resource_defs[io_manager_key]
             name = assets_def.get_output_name_for_asset_key(asset_key)
             output_definition_metadata = assets_def.metadata_by_key[asset_key]
-            definition_metadata = assets_def.metadata_by_key[asset_key]
             op_def = assets_def.get_op_def_for_asset_key(asset_key)
 
         required_resource_keys = get_transitive_required_resource_keys(

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
@@ -1143,11 +1143,11 @@ def test_metadata_in_io_manager():
 
     class MyDefinitionMetadataIOManager(IOManager):
         def handle_output(self, context: OutputContext, obj):
-            assert context.metadata == expected_metadata
+            assert context.definition_metadata == expected_metadata
 
         def load_input(self, context: InputContext):
             assert context.upstream_output
-            assert context.upstream_output.metadata == expected_metadata
+            assert context.upstream_output.definition_metadata == expected_metadata
 
     class MyOutputMetadataIOManager(IOManager):
         def handle_output(self, context: OutputContext, obj):
@@ -1177,12 +1177,12 @@ def test_metadata_in_io_manager():
             )
             assert normalized_metadata == expected_metadata
 
-            assert context.metadata == expected_metadata
+            assert context.definition_metadata == expected_metadata
 
         def load_input(self, context: InputContext):
             assert context.upstream_output
             assert context.upstream_output.output_metadata == {}
-            assert context.upstream_output.metadata == expected_metadata
+            assert context.upstream_output.definition_metadata == expected_metadata
 
     @asset(metadata=expected_metadata)
     def metadata_on_def():


### PR DESCRIPTION
## Summary & Motivation

Runtime/output metadata is not available in in handle_output of the I/O manager. This [issue](https://github.com/dagster-io/dagster/issues/17923) has gotten a few upvotes and came up in support recently. This PR introduces a new property `output_metadata` where users can access the metadata assigned to an output (either in `Output` or with `context.add_output_metadata`). If accessed from the `InputContext` `output_metadata` will log a warning and return `{}` since accessing the output metadata would require that we query the db, and we don't have an efficient way to do this for ops (see https://github.com/dagster-io/dagster/issues/20094)

---
Reasoning for not combining output metadata with definition metadata. 

Having a single property for metadata causes issues for the `InputContext`. It isn't reasonable to access output metadata from the `InputContext` since this would require querying the event log for the latest run and fetching the metadata from the output event (further info [here](https://github.com/dagster-io/dagster/issues/20094) if interested). Since we cannot fetch the output metadata in the InputContext there would be a consistency error in the metadata provided to the user in the `OutputContext` and in the `InputContext`. For example:

```python
@asset(
    metadata={"foo": "bar"}
)
def asset_adds_metadata_two_ways():
    return Output(1, metadata={"baz": "qux"}
```
If we merged metadata together, the user would get `{"foo":"bar", "baz":"qux"}` in the `OutputContext` but only `{"foo":"bar"}` in the `InputContext`. If instead the user did this:

```python
@asset(
    metadata={"foo": "bar"}
)
def asset_adds_metadata_two_ways():
    return Output(1, metadata={"foo": "qux"} # overriding the same metadata key
```
it could be even more problematic since the user would get `{"foo": "qux"} in the `OutputContext` and `{"foo": "bar"}` in the input context. 

## How I Tested These Changes

New unit tests. Before implementing the change, the assets that add runtime metadata (via `Output` and `context.add_output_metadata`) failed because the I/O manager could not access the metadata

