### PR TITLE
[external-assets] Add group accessor methods

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -168,6 +168,11 @@ class AssetGraph:
             self.asset_dep_graph, self.observable_asset_keys | self.materializable_asset_keys
         )
 
+    @property
+    @abstractmethod
+    def all_group_names(self) -> AbstractSet[str]:
+        ...
+
     @abstractmethod
     def get_partitions_def(self, asset_key: AssetKey) -> Optional[PartitionsDefinition]:
         ...
@@ -205,6 +210,10 @@ class AssetGraph:
         # Temporarily performing an existence check here for backcompat. Callsites need to be
         # changed to verify this first.
         return asset_key in self.all_asset_keys and self.get_partitions_def(asset_key) is not None
+
+    @abstractmethod
+    def get_group_name(self, asset_key: AssetKey) -> Optional[str]:
+        ...
 
     @abstractmethod
     def get_freshness_policy(self, asset_key: AssetKey) -> Optional[FreshnessPolicy]:

--- a/python_modules/dagster/dagster/_core/definitions/internal_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/internal_asset_graph.py
@@ -181,12 +181,22 @@ class InternalAssetGraph(AssetGraph):
         else:
             return {*asset.keys, *asset.check_keys}
 
+    @property
+    @cached_method
+    def all_group_names(self) -> AbstractSet[str]:
+        return {
+            group_name for ad in self._assets_defs for group_name in ad.group_names_by_key.values()
+        }
+
     def get_partitions_def(self, asset_key: AssetKey) -> Optional[PartitionsDefinition]:
         # Performing an existence check temporarily until we change callsites
         return self.get_assets_def(asset_key).partitions_def if self.has_asset(asset_key) else None
 
     def get_partition_mappings(self, asset_key: AssetKey) -> Mapping[AssetKey, PartitionMapping]:
         return self.get_assets_def(asset_key).partition_mappings
+
+    def get_group_name(self, asset_key: AssetKey) -> Optional[str]:
+        return self.get_assets_def(asset_key).group_names_by_key.get(asset_key)
 
     def get_freshness_policy(self, asset_key: AssetKey) -> Optional[FreshnessPolicy]:
         return self.get_assets_def(asset_key).freshness_policies_by_key.get(asset_key)


### PR DESCRIPTION
## Summary & Motivation

Add methods to `AssetGraph`, omitted from previous refactor (an oversight).

- `get_group_name`
- `all_group_names`

Also rename `all_jobs` to `all_job_names` on `ExternalAssetGraph` for consistency.

## How I Tested These Changes

BK