### PR TITLE
[Asset checks] Fall back to selectedCheck.name

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -446,7 +446,7 @@ const CheckRow = styled(Row)<{$selected: boolean} & RowProps>`
   cursor: pointer;
   border-radius: 8px;
   &:hover {
-    background: ${Colors.backgroundBlue()};
+    background: ${Colors.backgroundLightHover()};
   }
   ${({$selected}) => ($selected ? `background: ${Colors.backgroundBlue()};` : '')}
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -309,7 +309,10 @@ export const AssetChecks = ({
             >
               <Box padding={{top: 12}}>
                 {lastExecution ? (
-                  <CheckExecutions assetKey={assetKey} checkName={selectedCheckName} />
+                  <CheckExecutions
+                    assetKey={assetKey}
+                    checkName={selectedCheckName || selectedCheck.name}
+                  />
                 ) : (
                   <Caption color={Colors.textLight()}>No execution history</Caption>
                 )}


### PR DESCRIPTION
## Summary & Motivation

Fix an issue where `selectedCheckName` is empty string because the user didn't select a check and so we're falling back to the first check. In this case we also need to fallback to the name of that check. The reason there is both a selectedCheck and selectedCheckName in state is that selectedCheckName (coming from URL parameter) determines the selectedCheck, but when the URL parameter is absent the selectedCheckName actually comes from the selectedCheck (the default first one).

## How I Tested These Changes

`elementl cloud run shadow-dagit dogfood dogfood-test-1  --push-ssh-key ~/.ssh/id_rsa.pub --perms org-admin`

go to https://dogfood-test-1.dogfood.dagster.cloud/prod/assets/test_prefix/checked_asset?view=checks
