### PR TITLE
[pythonic resources] fix handling of default enum values

### DIFF
--- a/python_modules/dagster/dagster/_config/field.py
+++ b/python_modules/dagster/dagster/_config/field.py
@@ -33,7 +33,7 @@ VALID_CONFIG_DESC = """
    values in the dictionary get resolved by the same rules, recursively.
 
 4. A bare python list of length one which itself is config type.
-   Becomes Array with list element as an argument.
+   Becomes Array wtestith list element as an argument.
 """
 
 

--- a/python_modules/dagster/dagster/_config/field.py
+++ b/python_modules/dagster/dagster/_config/field.py
@@ -33,7 +33,7 @@ VALID_CONFIG_DESC = """
    values in the dictionary get resolved by the same rules, recursively.
 
 4. A bare python list of length one which itself is config type.
-   Becomes Array wtestith list element as an argument.
+   Becomes Array with list element as an argument.
 """
 
 

--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -111,6 +111,7 @@ class BaseResourceMeta(BaseConfigMeta):
         for field in annotations:
             if not field.startswith("__"):
                 # Check if the annotation is a ResourceDependency
+
                 if (
                     get_origin(annotations[field])
                     == LateBoundTypesForResourceTypeChecking.get_resource_rep_type()

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_enum.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_enum.py
@@ -1,0 +1,65 @@
+from enum import Enum
+
+from dagster import Config, ConfigurableResource, asset, materialize
+
+
+def test_enum_name_config():
+    class MyEnum(str, Enum):
+        TYPE_A = "a"
+        TYPE_B = "b"
+
+    class MyConfig(Config):
+        enum: MyEnum = MyEnum.TYPE_A
+
+    @asset
+    def my_asset(
+        config: MyConfig,
+    ):
+        return config.enum.value
+
+    materialize([my_asset])
+
+
+def test_enum_name_resource_x():
+    class MyEnum(str, Enum):
+        TYPE_A = "a"
+        TYPE_B = "b"
+
+    class MyResource(ConfigurableResource):
+        enum: MyEnum = MyEnum.TYPE_A
+
+    @asset
+    def my_asset(my_resource: MyResource):
+        return my_resource.enum.value
+
+    materialize([my_asset], resources={"my_resource": MyResource()})
+
+
+def test_enum_name_resource_override_name():
+    class MyEnum(str, Enum):
+        TYPE_A = "a"
+        TYPE_B = "b"
+
+    class MyResource(ConfigurableResource):
+        enum: MyEnum = MyEnum.TYPE_A
+
+    @asset
+    def my_asset(my_resource: MyResource):
+        return my_resource.enum.value
+
+    materialize([my_asset], resources={"my_resource": MyResource(enum=MyEnum.TYPE_A.name)})
+
+
+def test_enum_name_resource_override_enum():
+    class MyEnum(str, Enum):
+        TYPE_A = "a"
+        TYPE_B = "b"
+
+    class MyResource(ConfigurableResource):
+        enum: MyEnum = MyEnum.TYPE_A
+
+    @asset
+    def my_asset(my_resource: MyResource):
+        return my_resource.enum.value
+
+    materialize([my_asset], resources={"my_resource": MyResource(enum=MyEnum.TYPE_A)})


### PR DESCRIPTION
## Summary

Addresses #17004.

Improves handling of default enum values w/ Pythonic config and resources. The system now properly accepts actual enum instances as defaults, e.g.

```python

class MyEnum(str, Enum):
    TYPE_A = "a"
    TYPE_B = "b"

class MyResource(ConfigurableResource):
    enum_input: MyEnum = MyEnum.TYPE_A

```

## Test Plan

New unit tests.

