### PR TITLE
Document new features in run retries, make difference between OSS and cloud clearer

### DIFF
--- a/docs/content/dagster-cloud/managing-deployments/deployment-settings-reference.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/deployment-settings-reference.mdx
@@ -161,6 +161,19 @@ run_retries:
       </li>
     </ul>
   </ReferenceTableItem>
+  <ReferenceTableItem propertyName="run_retries.retry_on_asset_or_op_failure">
+    Whether to retry runs that failed due to assets or ops in the run failing.
+    Set this to false if you only want to retry failures that occur due to the
+    run worker crashing or unexpectedly terminating, and instead rely on op or
+    asset-level retry policies to retry assert or op failures. Setting this
+    field to false will only change retry behavior for runs on dagster version
+    1.6.7 or greater.
+    <ul>
+      <li>
+        <strong>Default</strong> - <code>0</code>
+      </li>
+    </ul>
+  </ReferenceTableItem>
 </ReferenceTable>
 
 ### SSO default role

--- a/docs/content/deployment/run-retries.mdx
+++ b/docs/content/deployment/run-retries.mdx
@@ -61,4 +61,4 @@ run_retries:
   retry_on_asset_or_op_failure: false
 ```
 
-**Note:** Setting `retry_on_asset_or_op_failure` for false will only change retry behavior for runs on dagster version 1.6.7 or greater.
+**Note:** Setting `retry_on_asset_or_op_failure` to `false` will only change retry behavior for runs on Dagster version 1.6.7 or greater.

--- a/docs/content/deployment/run-retries.mdx
+++ b/docs/content/deployment/run-retries.mdx
@@ -44,7 +44,7 @@ The `dagster/retry_strategy` tag controls which Ops the retry will run.
 
 By default, retries will re-execute from failure (tag value `FROM_FAILURE`). This means that any successful Ops will be skipped, but their output will be used for downstream Ops. If the `dagster/retry_strategy` tag is set to `ALL_STEPS`, all the Ops will run again.
 
-**Note:** `FROM_FAILURE` requires an IOManager that can access outputs from other runs. For example, on Kubernetes the [s3\_pickle_io_manager](/\_apidocs/libraries/dagster-aws#dagster_aws.s3.s3\_pickle_io_manager) would work but the [`FilesytemIOManager`](https://docs.dagster.io/\_apidocs/io-managers#dagster.FilesytemIOManager) would not, since the new run is in a new Kubernetes Job with a separate filesystem.
+**Note:** `FROM_FAILURE` requires an I/O manager that can access outputs from other runs. For example, on Kubernetes the <PyObject object="s3_pickle_io_manager" module="dagster_aws.s3.s3" /> would work but the <PyObject object="FilesytemIOManager" module="dagster" /> would not, since the new run is in a new Kubernetes Job with a separate filesystem.
 
 ### Combining op retries and run retries
 

--- a/docs/content/deployment/run-retries.mdx
+++ b/docs/content/deployment/run-retries.mdx
@@ -14,7 +14,7 @@ How to configure run retries depends on whether you're using Dagster Cloud or Da
 - **Dagster Cloud**: Use the [Dagster Cloud UI or the dagster-cloud CLI](/dagster-cloud/managing-deployments/managing-deployments#configuring-deployment-settings) to set a default maximum number of retries. Run retries do not need to be explicitly enabled.
 - **Dagster Open Source**: Use your instance's `dagster.yaml` to enable run retries.
 
-For example, the following will set a default maximum number of retries of 3 for all runs:
+For example, the following will set a default maximum number of retries of `3` for all runs:
 
 ```yaml
 run_retries:

--- a/docs/content/deployment/run-retries.mdx
+++ b/docs/content/deployment/run-retries.mdx
@@ -5,19 +5,24 @@ description: Automatically retry Dagster runs
 
 # Run Retries
 
-If you configure retries at the [Job](/\_apidocs/jobs#jobs) level, a new run will be kicked off when a run for that job fails. Compared to [Op retries](/concepts/ops-jobs-graphs/op-retries), the max retry limit for run retries applies to the whole run instead of each individual Op. Run retries also handle the cases where a run worker crashed.
+If you configure run retries, a new run will be kicked off whenever a run fails for any reason. Compared to [Op retries](/concepts/ops-jobs-graphs/op-retries), the maximum retry limit for run retries applies to the whole run instead of each individual Op. Run retries also handle the case where the run process crashes or is unexpectedly terminated.
 
 ## Configuration
 
-To enable run retries, add the following to your `dagster.yaml`. This will start a new daemon which polls to the event log for run failure events.
+How to configure run retries depends on whether you're using Dagster Cloud or Dagster Open Source:
 
-```yaml file=/deploying/dagster_instance/dagster.yaml startafter=start_run_retries endbefore=end_run_retries
+- **Dagster Cloud**: Use the [Dagster Cloud UI or the dagster-cloud CLI](/dagster-cloud/managing-deployments/managing-deployments#configuring-deployment-settings) to set a default maximum number of retries. Run retries do not need to be explicitly enabled.
+- **Dagster Open Source**: Use your instance's `dagster.yaml` to enable run retries.
+
+For example, the following will set a default maximum number of retries of 3 for all runs:
+
+```yaml
 run_retries:
-  enabled: true
-  max_retries: 3 # Sets a default for all jobs. 0 if not set
+  enabled: true # Omit this key if using Dagster Cloud, since run retries are enabled by default
+  max_retries: 3
 ```
 
-You can also configure retries using tags either on Job definitions or in the Dagster UI [Launchpad](/concepts/webserver/ui#launchpad-tab).
+In both Dagster Cloud and Dagster Open Source, you can also configure retries using tags either on Job definitions or in the Dagster UI [Launchpad](/concepts/webserver/ui#launchpad-tab).
 
 ```python file=/deploying/job_retries.py
 from dagster import job
@@ -39,4 +44,21 @@ The `dagster/retry_strategy` tag controls which Ops the retry will run.
 
 By default, retries will re-execute from failure (tag value `FROM_FAILURE`). This means that any successful Ops will be skipped, but their output will be used for downstream Ops. If the `dagster/retry_strategy` tag is set to `ALL_STEPS`, all the Ops will run again.
 
-NOTE: `FROM_FAILURE` requires an IOManager that can access outputs from other runs. For example, on Kubernetes the [s3\_pickle_io_manager](/\_apidocs/libraries/dagster-aws#dagster_aws.s3.s3\_pickle_io_manager) would work but the [`FilesytemIOManager`](https://docs.dagster.io/\_apidocs/io-managers#dagster.FilesytemIOManager) would not, since the new run is in a new Kubernetes Job with a separate filesystem.
+**Note:** `FROM_FAILURE` requires an IOManager that can access outputs from other runs. For example, on Kubernetes the [s3\_pickle_io_manager](/\_apidocs/libraries/dagster-aws#dagster_aws.s3.s3\_pickle_io_manager) would work but the [`FilesytemIOManager`](https://docs.dagster.io/\_apidocs/io-managers#dagster.FilesytemIOManager) would not, since the new run is in a new Kubernetes Job with a separate filesystem.
+
+### Combining op retries and run retries
+
+By default, if a run fails due to an op failure and both op retries and run retries are enabled, the overlapping retries might cause the op to be retried more times than desired, since the op retry count will reset for each retried run.
+
+To prevent this from happening, you can configure run retries to only retry when the failure is due to a reason other than an op failure (for example, a crash or an unexpected termination of the run worker). This is controlled by the `run_retries.retry_on_asset_or_op_failure` setting, which defaults to true but can be overridden to false.
+
+For example, the following configures run retries so that they ignore runs that failed due to a step failure:
+
+```yaml
+run_retries:
+  enabled: true # Omit this key if using Dagster Cloud, since run retries are enabled by default
+  max_retries: 3
+  retry_on_asset_or_op_failure: false
+```
+
+**Note:** Setting `retry_on_asset_or_op_failure` for false will only change retry behavior for runs on dagster version 1.6.7 or greater.

--- a/docs/content/deployment/run-retries.mdx
+++ b/docs/content/deployment/run-retries.mdx
@@ -48,7 +48,7 @@ By default, retries will re-execute from failure (tag value `FROM_FAILURE`). Thi
 
 ### Combining op retries and run retries
 
-By default, if a run fails due to an op failure and both op retries and run retries are enabled, the overlapping retries might cause the op to be retried more times than desired, since the op retry count will reset for each retried run.
+By default, if a run fails due to an op failure and both op and run retries are enabled, the overlapping retries might cause the op to be retried more times than desired. This is because the op retry count will reset for each retried run.
 
 To prevent this from happening, you can configure run retries to only retry when the failure is due to a reason other than an op failure (for example, a crash or an unexpected termination of the run worker). This is controlled by the `run_retries.retry_on_asset_or_op_failure` setting, which defaults to true but can be overridden to false.
 

--- a/docs/content/deployment/run-retries.mdx
+++ b/docs/content/deployment/run-retries.mdx
@@ -5,7 +5,7 @@ description: Automatically retry Dagster runs
 
 # Run Retries
 
-If you configure run retries, a new run will be kicked off whenever a run fails for any reason. Compared to [Op retries](/concepts/ops-jobs-graphs/op-retries), the maximum retry limit for run retries applies to the whole run instead of each individual Op. Run retries also handle the case where the run process crashes or is unexpectedly terminated.
+If you configure run retries, a new run will be kicked off whenever a run fails for any reason. Compared to [op retries](/concepts/ops-jobs-graphs/op-retries), the maximum retry limit for run retries applies to the whole run instead of each individual op. Run retries also handle the case where the run process crashes or is unexpectedly terminated.
 
 ## Configuration
 
@@ -40,17 +40,17 @@ def other_sample_sample_job():
 
 ### Retry Strategy
 
-The `dagster/retry_strategy` tag controls which Ops the retry will run.
+The `dagster/retry_strategy` tag controls which ops the retry will run.
 
-By default, retries will re-execute from failure (tag value `FROM_FAILURE`). This means that any successful Ops will be skipped, but their output will be used for downstream Ops. If the `dagster/retry_strategy` tag is set to `ALL_STEPS`, all the Ops will run again.
+By default, retries will re-execute from failure (tag value `FROM_FAILURE`). This means that any successful ops will be skipped, but their output will be used for downstream ops. If the `dagster/retry_strategy` tag is set to `ALL_STEPS`, all the ops will run again.
 
-**Note:** `FROM_FAILURE` requires an I/O manager that can access outputs from other runs. For example, on Kubernetes the <PyObject object="s3_pickle_io_manager" module="dagster_aws.s3.s3" /> would work but the <PyObject object="FilesytemIOManager" module="dagster" /> would not, since the new run is in a new Kubernetes Job with a separate filesystem.
+**Note:** `FROM_FAILURE` requires an I/O manager that can access outputs from other runs. For example, on Kubernetes the <PyObject object="s3_pickle_io_manager" module="dagster_aws.s3.s3" /> would work but the <PyObject object="FilesytemIOManager" module="dagster" /> would not, since the new run is in a new Kubernetes job with a separate filesystem.
 
-### Combining op retries and run retries
+### Combining op and run retries
 
 By default, if a run fails due to an op failure and both op and run retries are enabled, the overlapping retries might cause the op to be retried more times than desired. This is because the op retry count will reset for each retried run.
 
-To prevent this from happening, you can configure run retries to only retry when the failure is due to a reason other than an op failure (for example, a crash or an unexpected termination of the run worker). This is controlled by the `run_retries.retry_on_asset_or_op_failure` setting, which defaults to true but can be overridden to false.
+To prevent this, you can configure run retries to only retry when the failure is for a reason other than an op failure, like a crash or an unexpected termination of the run worker. This behavior is controlled by the `run_retries.retry_on_asset_or_op_failure` setting, which defaults to `true` but can be overridden to `false`.
 
 For example, the following configures run retries so that they ignore runs that failed due to a step failure:
 

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -369,10 +369,10 @@ def dagster_instance_config_schema() -> Mapping[str, Field]:
                     bool,
                     is_required=False,
                     default_value=True,
-                    description="Whether to retry runs that failed due to steps in the run failing. "
+                    description="Whether to retry runs that failed due to assets or ops in the run failing. "
                     "Set this to false if you only want to retry failures that occur "
                     "due to the run worker crashing or unexpectedly terminating, and instead "
-                    "rely on op or asset-level retry policies to retry step failures. Setting this "
+                    "rely on op or asset-level retry policies to retry asset or op failures. Setting this "
                     "field to false will only change retry behavior for runs on dagster "
                     "version 1.6.7 or greater.",
                 ),


### PR DESCRIPTION
- Make it easier to understand how to set run retries in cloud
- Document the new feature we added that make op retries and run retries play more nicely together: https://github.com/dagster-io/dagster/pull/19961
- General tidy
