### PR TITLE
Document running multiple isolated agents with separate queues

### DIFF
--- a/docs/content/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference.mdx
@@ -175,6 +175,11 @@ user_code_launcher:
 
 isolated_agents:
   enabled: <true|false>
+agent_queues:
+  include_default_queue: <true|false>
+  queues:
+    - <queue name>
+    - <additional queue name>
 ```
 
 ### dagster_cloud_api properties

--- a/docs/content/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference.mdx
@@ -313,3 +313,29 @@ agent_queues:
   </ReferenceTableItem>
 
 </ReferenceTable>
+
+### isolated_agents properties
+
+<ReferenceTable>
+  <ReferenceTableItem propertyName="isolated_agents.enabled">
+    When enabled, agents are isolated and will not be able to access each
+    others' resources. See the
+    <a href="/dagster-cloud/deployment/agents/running-multiple-agents#running-multiple-agents-in-different-environments">
+      Running multiple agents guide
+    </a>
+    for more information.
+  </ReferenceTableItem>
+</ReferenceTable>
+
+### agent_queues properties
+
+These settings specify the queue(s) the agent will obtain requests from. See [Routing requests to specific agents](/dagster-cloud/deployment/agents/running-multiple-agents#routing-requests-to-specific-agents).
+
+<ReferenceTable>
+  <ReferenceTableItem propertyName="agent_queues.include_default_queue">
+    This agent process requests from the default queue if set to true.
+  </ReferenceTableItem>
+  <ReferenceTableItem propertyName="agent_queues.queues">
+    A list of additional queues to include in the agent's processing.
+  </ReferenceTableItem>
+</ReferenceTable>

--- a/docs/content/dagster-cloud/deployment/agents/running-multiple-agents.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/running-multiple-agents.mdx
@@ -203,7 +203,7 @@ dagsterCloud:
 
 #### In Amazon ECS
 
-Modify your ECS Cloud Formation template to add the following configuration to the config.yaml passed to the agent:
+Modify your ECS Cloud Formation template to add the following configuration to the `config.yaml` passed to the agent:
 
 ```yaml
 agent_queues:

--- a/docs/content/dagster-cloud/deployment/agents/running-multiple-agents.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/running-multiple-agents.mdx
@@ -199,4 +199,20 @@ dagsterCloud:
 ```
 
 </TabItem>
+<TabItem name="Amazon ECS">
+
+#### In Amazon ECS
+
+Modify your ECS Cloud Formation template to add the following configuration to the config.yaml passed to the agent:
+
+```yaml
+agent_queues:
+  # Continue to handle requests for code locations that aren't
+  # assigned to a specific agent queue
+  include_default_queue: true
+  additional_queues:
+    - special-queue
+```
+
+</TabItem>
 </TabGroup>


### PR DESCRIPTION
## Summary & Motivation

When answering dagster cloud support question, our documentation was missing instructions on how to configure agent queues on Amazon ECS. 

## How I Tested These Changes

- answer provided and accepted by customer 
