### PR TITLE
[asset-backfill] Fix edge case when grouping runs with backfill policies and partition mappings.

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1392,7 +1392,7 @@ def should_backfill_atomic_asset_partitions_unit(
                 (parent in asset_partitions_to_request or parent in candidates_unit)
                 and asset_graph.have_same_partitioning(parent.asset_key, candidate.asset_key)
                 and (
-                    # if there is a one to one mapping with the parent, then the child can be run
+                    # if there is a simple mapping between the parent and the child, then
                     # with the parent
                     has_one_to_one_partition_mapping
                     # candidate shares a partition key that is already being requested by the parent

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1314,6 +1314,79 @@ def execute_asset_backfill_iteration_inner(
     yield AssetBackfillIterationResult(run_requests, updated_asset_backfill_data)
 
 
+def can_run_with_parent(
+    parent: AssetKeyPartitionKey,
+    candidate: AssetKeyPartitionKey,
+    candidates_unit: Iterable[AssetKeyPartitionKey],
+    asset_graph: ExternalAssetGraph,
+    target_subset: AssetGraphSubset,
+    asset_partitions_to_request_map: Mapping[AssetKey, AbstractSet[Optional[str]]],
+) -> bool:
+    """Returns if a given candidate can be materialized in the same run as a given parent on
+    this tick.
+    """
+    parent_target_subset = target_subset.get_asset_subset(parent.asset_key, asset_graph)
+    parent_backfill_policy = asset_graph.get_backfill_policy(parent.asset_key)
+    candidate_target_subset = target_subset.get_asset_subset(candidate.asset_key, asset_graph)
+    candidate_backfill_policy = asset_graph.get_backfill_policy(candidate.asset_key)
+    partition_mapping = asset_graph.get_partition_mapping(
+        candidate.asset_key, in_asset_key=parent.asset_key
+    )
+
+    # checks if there is a simple partition mapping between the parent and the child
+    has_identity_partition_mapping = (
+        # both unpartitioned
+        (
+            not asset_graph.is_partitioned(candidate.asset_key)
+            and not asset_graph.is_partitioned(parent.asset_key)
+        )
+        # normal identity partition mapping
+        or isinstance(partition_mapping, IdentityPartitionMapping)
+        # for assets with the same time partitions definition, a non-offset partition
+        # mapping functions as an identity partition mapping
+        or (
+            isinstance(partition_mapping, TimeWindowPartitionMapping)
+            and partition_mapping.start_offset == 0
+            and partition_mapping.end_offset == 0
+        )
+    )
+    return (
+        parent_backfill_policy == candidate_backfill_policy
+        and asset_graph.get_repository_handle(candidate.asset_key)
+        is asset_graph.get_repository_handle(parent.asset_key)
+        and asset_graph.have_same_partitioning(parent.asset_key, candidate.asset_key)
+        and (
+            parent.partition_key in asset_partitions_to_request_map[parent.asset_key]
+            or parent in candidates_unit
+        )
+        and (
+            # if there is a simple mapping between the parent and the child, then
+            # with the parent
+            has_identity_partition_mapping
+            # if there is not a simple mapping, we can only materialize this asset with its
+            # parent if...
+            or (
+                # there is a backfill policy for the parent
+                parent_backfill_policy is not None
+                # the same subset of parents is targeted as the child
+                and parent_target_subset.value == candidate_target_subset.value
+                and (
+                    # there is no limit on the size of a single run or...
+                    parent_backfill_policy.max_partitions_per_run is None
+                    # a single run can materialize all requested parent partitions
+                    or parent_backfill_policy.max_partitions_per_run
+                    > len(asset_partitions_to_request_map[parent.asset_key])
+                )
+                # all targeted parents are being requested this tick
+                and len(asset_partitions_to_request_map[parent.asset_key])
+                == parent_target_subset.size
+            )
+            # if all the above are true, then a single run can be launched this tick which
+            # will materialize all requested partitions
+        )
+    )
+
+
 def should_backfill_atomic_asset_partitions_unit(
     asset_graph: ExternalAssetGraph,
     candidates_unit: Iterable[AssetKeyPartitionKey],
@@ -1354,69 +1427,18 @@ def should_backfill_atomic_asset_partitions_unit(
                 asset_partition.partition_key
             )
 
-        candidate_target_subset = target_subset.get_asset_subset(candidate.asset_key, asset_graph)
-        candidate_backfill_policy = asset_graph.get_backfill_policy(candidate.asset_key)
         for parent in parent_partitions_result.parent_partitions:
-            parent_target_subset = target_subset.get_asset_subset(parent.asset_key, asset_graph)
-            parent_backfill_policy = asset_graph.get_backfill_policy(parent.asset_key)
-
-            partition_mapping = asset_graph.get_partition_mapping(
-                candidate.asset_key, in_asset_key=parent.asset_key
-            )
-            # checks if there is a simple partition mapping between the parent and the child
-            has_identity_partition_mapping = (
-                # both unpartitioned
-                (
-                    not asset_graph.is_partitioned(candidate.asset_key)
-                    and not asset_graph.is_partitioned(parent.asset_key)
-                )
-                # normal identity partition mapping
-                or isinstance(partition_mapping, IdentityPartitionMapping)
-                # for assets with the same time partitions definition, a non-offset partition
-                # mapping functions as an identity partition mapping
-                or (
-                    isinstance(partition_mapping, TimeWindowPartitionMapping)
-                    and partition_mapping.start_offset == 0
-                    and partition_mapping.end_offset == 0
-                )
-            )
-            can_run_with_parent = (
-                (parent in asset_partitions_to_request or parent in candidates_unit)
-                and asset_graph.have_same_partitioning(parent.asset_key, candidate.asset_key)
-                and (
-                    # if there is a simple mapping between the parent and the child, then
-                    # with the parent
-                    has_identity_partition_mapping
-                    # if there is not a simple mapping, we can only materialize this asset with its
-                    # parent if...
-                    or (
-                        # there is a backfill policy for the parent
-                        parent_backfill_policy is not None
-                        # the same subset of parents is targeted as the child
-                        and parent_target_subset.value == candidate_target_subset.value
-                        and (
-                            # there is no limit on the size of a single run or...
-                            parent_backfill_policy.max_partitions_per_run is None
-                            # a single run can materialize all requested parent partitions
-                            or parent_backfill_policy.max_partitions_per_run
-                            > len(asset_partitions_to_request_map[parent.asset_key])
-                        )
-                        # all targeted parents are being requested this tick
-                        and len(asset_partitions_to_request_map[parent.asset_key])
-                        == parent_target_subset.size
-                    )
-                    # if all the above are true, then a single run can be launched this tick which
-                    # will materialize all requested partitions
-                )
-                and asset_graph.get_repository_handle(candidate.asset_key)
-                is asset_graph.get_repository_handle(parent.asset_key)
-                and parent_backfill_policy == candidate_backfill_policy
-            )
-
             if (
                 parent in target_subset
-                and not can_run_with_parent
                 and parent not in materialized_subset
+                and not can_run_with_parent(
+                    parent,
+                    candidate,
+                    candidates_unit,
+                    asset_graph,
+                    target_subset,
+                    asset_partitions_to_request_map,
+                )
             ):
                 return False
 

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1353,40 +1353,32 @@ def should_backfill_atomic_asset_partitions_unit(
             asset_partitions_to_request_map[asset_partition.asset_key].add(
                 asset_partition.partition_key
             )
+
+        candidate_target_subset = target_subset.get_asset_subset(candidate.asset_key, asset_graph)
         candidate_backfill_policy = asset_graph.get_backfill_policy(candidate.asset_key)
         for parent in parent_partitions_result.parent_partitions:
+            parent_target_subset = target_subset.get_asset_subset(parent.asset_key, asset_graph)
             parent_backfill_policy = asset_graph.get_backfill_policy(parent.asset_key)
 
             partition_mapping = asset_graph.get_partition_mapping(
                 candidate.asset_key, in_asset_key=parent.asset_key
             )
             # checks if there is a simple partition mapping between the parent and the child
-            has_one_to_one_partition_mapping = (
+            has_identity_partition_mapping = (
                 # both unpartitioned
                 (
                     not asset_graph.is_partitioned(candidate.asset_key)
                     and not asset_graph.is_partitioned(parent.asset_key)
                 )
+                # normal identity partition mapping
                 or isinstance(partition_mapping, IdentityPartitionMapping)
+                # for assets with the same time partitions definition, a non-offset partition
+                # mapping functions as an identity partition mapping
                 or (
                     isinstance(partition_mapping, TimeWindowPartitionMapping)
                     and partition_mapping.start_offset == 0
                     and partition_mapping.end_offset == 0
                 )
-            )
-            # checks if this parent with partitions mapped has a backfill policy which would allow
-            # partition mappings which are not one-one with the child to be executed in a way
-            # that respects the dependencies
-            has_partition_mapping_safe_backfill_policy = (
-                parent_backfill_policy is not None
-                and (
-                    # single run backfill policy can incorporate all partitions in one run
-                    parent_backfill_policy.max_partitions_per_run is None
-                    # multi-run backfill policy
-                    or parent_backfill_policy.max_partitions_per_run
-                    >= len(asset_partitions_to_request_map[parent.asset_key])
-                )
-                and candidate.partition_key in asset_partitions_to_request_map[parent.asset_key]
             )
             can_run_with_parent = (
                 (parent in asset_partitions_to_request or parent in candidates_unit)
@@ -1394,11 +1386,27 @@ def should_backfill_atomic_asset_partitions_unit(
                 and (
                     # if there is a simple mapping between the parent and the child, then
                     # with the parent
-                    has_one_to_one_partition_mapping
-                    # candidate shares a partition key that is already being requested by the parent
-                    # and both candidate and parent have backfill policies and max_partitions_per_run is
-                    # not greater than the number of partitions being requested
-                    or has_partition_mapping_safe_backfill_policy
+                    has_identity_partition_mapping
+                    # if there is not a simple mapping, we can only materialize this asset with its
+                    # parent if...
+                    or (
+                        # there is a backfill policy for the parent
+                        parent_backfill_policy is not None
+                        # the same subset of parents is targeted as the child
+                        and parent_target_subset.value == candidate_target_subset.value
+                        and (
+                            # there is no limit on the size of a single run or...
+                            parent_backfill_policy.max_partitions_per_run is None
+                            # a single run can materialize all requested parent partitions
+                            or parent_backfill_policy.max_partitions_per_run
+                            > len(asset_partitions_to_request_map[parent.asset_key])
+                        )
+                        # all targeted parents are being requested this tick
+                        and len(asset_partitions_to_request_map[parent.asset_key])
+                        == parent_target_subset.size
+                    )
+                    # if all the above are true, then a single run can be launched this tick which
+                    # will materialize all requested partitions
                 )
                 and asset_graph.get_repository_handle(candidate.asset_key)
                 is asset_graph.get_repository_handle(parent.asset_key)

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1379,7 +1379,7 @@ def should_backfill_atomic_asset_partitions_unit(
                     (
                         # always allow runs to be grouped if there is a simple 1-1 partition mapping
                         parent.partition_key == candidate.partition_key
-                        or len(parent_partitions_by_key[parent.asset_key]) == 1
+                        and len(parent_partitions_by_key[parent.asset_key]) == 1
                     )
                     # candidate shares a partition key that is already being requested by the parent
                     # and both candidate and parent have backfill policies and max_partitions_per_run is

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
@@ -573,10 +573,14 @@ def test_dynamic_partitions_single_run_backfill_policy():
     assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_END_TAG) == "bar"
 
 
-def test_assets_backfill_with_partition_mapping():
+@pytest.mark.parametrize("same_partitions", [True, False])
+def test_assets_backfill_with_partition_mapping(same_partitions):
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
-    # time at which there will be an identical set of partitions for the downstream asset
-    test_time = pendulum.parse("2023-03-04T00:00:00", tz="UTC")
+    if same_partitions:
+        # time at which there will be an identical set of partitions for the downstream asset
+        test_time = pendulum.parse("2023-03-04T00:00:00", tz="UTC")
+    else:
+        test_time = pendulum.now("UTC")
 
     @asset(
         name="upstream_a",
@@ -627,14 +631,24 @@ def test_assets_backfill_with_partition_mapping():
             instance=instance,
         )
     assert len(result.run_requests) == 1
-    assert set(result.run_requests[0].asset_selection) == {upstream_a.key, downstream_b.key}
+
+    if same_partitions:
+        assert set(result.run_requests[0].asset_selection) == {upstream_a.key, downstream_b.key}
+    else:
+        assert set(result.run_requests[0].asset_selection) == {upstream_a.key}
+
     assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "2023-03-01"
     assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_END_TAG) == "2023-03-03"
 
 
-def test_assets_backfill_with_partition_mapping_run_to_complete():
+@pytest.mark.parametrize("same_partitions", [True, False])
+def test_assets_backfill_with_partition_mapping_run_to_complete(same_partitions):
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
-    time_now = pendulum.now("UTC")
+    if same_partitions:
+        # time at which there will be an identical set of partitions for the downstream asset
+        test_time = pendulum.parse("2023-03-04T00:00:00", tz="UTC")
+    else:
+        test_time = pendulum.now("UTC")
 
     @asset(
         name="upstream_a",
@@ -673,7 +687,7 @@ def test_assets_backfill_with_partition_mapping_run_to_complete():
         asset_graph=asset_graph,
         asset_selection=[upstream_a.key, downstream_b.key],
         dynamic_partitions_store=MagicMock(),
-        backfill_start_time=time_now,
+        backfill_start_time=test_time,
         all_partitions=False,
     )
 
@@ -696,7 +710,11 @@ def test_assets_backfill_with_partition_mapping_run_to_complete():
     assert counts[0].partitions_counts_by_status[AssetBackfillStatus.IN_PROGRESS] == 0
 
     assert counts[1].asset_key == downstream_b.key
-    assert counts[1].partitions_counts_by_status[AssetBackfillStatus.MATERIALIZED] == 6
+    assert (
+        counts[1].partitions_counts_by_status[AssetBackfillStatus.MATERIALIZED] == 3
+        if same_partitions
+        else 6
+    )
     assert counts[1].partitions_counts_by_status[AssetBackfillStatus.FAILED] == 0
     assert counts[1].partitions_counts_by_status[AssetBackfillStatus.IN_PROGRESS] == 0
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
@@ -20,6 +20,7 @@ from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
     ASSET_PARTITION_RANGE_START_TAG,
 )
+from dagster._seven.compat.pendulum import pendulum_freeze_time
 
 from dagster_tests.core_tests.execution_tests.test_asset_backfill import (
     execute_asset_backfill_iteration_consume_generator,
@@ -574,7 +575,8 @@ def test_dynamic_partitions_single_run_backfill_policy():
 
 def test_assets_backfill_with_partition_mapping():
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
-    time_now = pendulum.now("UTC")
+    # time at which there will be an identical set of partitions for the downstream asset
+    test_time = pendulum.parse("2023-03-04T00:00:00", tz="UTC")
 
     @asset(
         name="upstream_a",
@@ -613,16 +615,17 @@ def test_assets_backfill_with_partition_mapping():
         asset_graph=asset_graph,
         asset_selection=[upstream_a.key, downstream_b.key],
         dynamic_partitions_store=MagicMock(),
-        backfill_start_time=time_now,
+        backfill_start_time=test_time,
         all_partitions=False,
     )
     assert backfill_data
-    result = execute_asset_backfill_iteration_consume_generator(
-        backfill_id="test_backfill_id",
-        asset_backfill_data=backfill_data,
-        asset_graph=asset_graph,
-        instance=instance,
-    )
+    with pendulum_freeze_time(test_time):
+        result = execute_asset_backfill_iteration_consume_generator(
+            backfill_id="test_backfill_id",
+            asset_backfill_data=backfill_data,
+            asset_graph=asset_graph,
+            instance=instance,
+        )
     assert len(result.run_requests) == 1
     assert set(result.run_requests[0].asset_selection) == {upstream_a.key, downstream_b.key}
     assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "2023-03-01"
@@ -877,7 +880,7 @@ def test_assets_backfill_with_partition_mapping_with_multi_partitions_multi_run_
 
 def test_assets_backfill_with_partition_mapping_with_single_run_backfill_policy():
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
-    time_now = pendulum.now("UTC")
+    test_time = pendulum.parse("2023-03-10T00:00:00", tz="UTC")
 
     @asset(
         name="upstream_a",
@@ -921,16 +924,17 @@ def test_assets_backfill_with_partition_mapping_with_single_run_backfill_policy(
         asset_graph=asset_graph,
         asset_selection=[upstream_a.key, downstream_b.key],
         dynamic_partitions_store=MagicMock(),
-        backfill_start_time=time_now,
+        backfill_start_time=test_time,
         all_partitions=False,
     )
     assert backfill_data
-    result = execute_asset_backfill_iteration_consume_generator(
-        backfill_id="test_backfill_id",
-        asset_backfill_data=backfill_data,
-        asset_graph=asset_graph,
-        instance=instance,
-    )
+    with pendulum_freeze_time(test_time):
+        result = execute_asset_backfill_iteration_consume_generator(
+            backfill_id="test_backfill_id",
+            asset_backfill_data=backfill_data,
+            asset_graph=asset_graph,
+            instance=instance,
+        )
 
     assert len(result.run_requests) == 1
     assert set(result.run_requests[0].asset_selection) == {upstream_a.key, downstream_b.key}


### PR DESCRIPTION
## Summary & Motivation

This PR refactors how we detect "simple" partition mappings, and limits the scope of when we can group assets into runs in that case.

In terms of "simple" partition mappings, we now explicitly check for Identity / TimeWindow partition mappings with no offsets. Previously, we were looking for the case of "has a single upstream parent partition that is the same as the child partition", which certainly sounds like a "simple partition mapping" but actually does not cover all potential cases.

In particular, imagine you have two daily-partitioned assets, with the downstream asset depending on the previous N days of the upstream. In this case, the first partition of the downstream asset only has a single parent, and that partition is the same as the child partition, even though this isn't a "simple" partition mapping! This meant it would be erroneously allowed to run with its parent.

For the scope of when we group assets together, there were too many weird cases to consider here and so instead I just reworked this logic entirely to only allow weird partition mappings to run together if:

- The exact same set of upstream / downstream partitions are targeted
- All upstream partitions are set to be materialized on this tick

This means that we can be confident that all downstream partitions will be requested this tick, and that they will be the same exact partitions (meaning they will be grouped together into the same run)

## How I Tested These Changes

Test failed before, passes now
