### PR TITLE
Stop returning overlapping ranges from TimeWindowPartitionMapping 

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -171,9 +171,11 @@ class TimeWindowPartitionMapping(
 
         for window in sorted_time_windows[1:]:
             last_window = merged_time_windows[-1]
-            # window starts before the end of the pr
+            # window starts before the end of the previous one
             if window.start.timestamp() <= last_window.end.timestamp():
-                merged_time_windows[-1] = TimeWindow(last_window.start, window.end)
+                merged_time_windows[-1] = TimeWindow(
+                    last_window.start, max(last_window.end, window.end, key=lambda d: d.timestamp())
+                )
             else:
                 merged_time_windows.append(window)
 

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -10,6 +10,7 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
     TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,
+    merge_time_windows,
 )
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.instance import DynamicPartitionsStore
@@ -324,6 +325,8 @@ class TimeWindowPartitionMapping(
                         )
                     )
 
+        print("filtered time windows", filtered_time_windows)
+        # filtered_time_windows, _ = merge_time_windows([], filtered_time_windows)
         return UpstreamPartitionsResult(
             TimeWindowPartitionsSubset(
                 to_partitions_def, num_partitions=None, included_time_windows=filtered_time_windows

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import NamedTuple, Optional, cast
+from typing import List, NamedTuple, Optional, Sequence, cast
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, experimental_param
@@ -160,6 +160,21 @@ class TimeWindowPartitionMapping(
             start_offset=-self.end_offset,
             current_time=current_time,
         ).partitions_subset
+
+    def _merge_time_windows(self, time_windows: Sequence[TimeWindow]) -> Sequence[TimeWindow]:
+        """Takes a list of potentially-overlapping TimeWindows and merges any overlapping windows."""
+        sorted_time_windows = sorted(time_windows, key=lambda tw: tw.start.timestamp())
+        if not sorted_time_windows:
+            return []
+        merged_time_windows: List[TimeWindow] = [sorted_time_windows[0]]
+        for window in sorted_time_windows[1:]:
+            last_window = merged_time_windows[-1]
+            if window.start.timestamp() <= last_window.end.timestamp():
+                merged_time_windows[-1] = TimeWindow(last_window.start, window.end)
+            else:
+                merged_time_windows.append(window)
+
+        return merged_time_windows
 
     def _map_partitions(
         self,
@@ -326,7 +341,9 @@ class TimeWindowPartitionMapping(
 
         return UpstreamPartitionsResult(
             TimeWindowPartitionsSubset(
-                to_partitions_def, num_partitions=None, included_time_windows=filtered_time_windows
+                to_partitions_def,
+                num_partitions=None,
+                included_time_windows=self._merge_time_windows(filtered_time_windows),
             ),
             sorted(list(required_but_nonexistent_partition_keys)),
         )

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -10,7 +10,6 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
     TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,
-    merge_time_windows,
 )
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.instance import DynamicPartitionsStore
@@ -325,8 +324,6 @@ class TimeWindowPartitionMapping(
                         )
                     )
 
-        print("filtered time windows", filtered_time_windows)
-        # filtered_time_windows, _ = merge_time_windows([], filtered_time_windows)
         return UpstreamPartitionsResult(
             TimeWindowPartitionsSubset(
                 to_partitions_def, num_partitions=None, included_time_windows=filtered_time_windows

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -163,12 +163,15 @@ class TimeWindowPartitionMapping(
 
     def _merge_time_windows(self, time_windows: Sequence[TimeWindow]) -> Sequence[TimeWindow]:
         """Takes a list of potentially-overlapping TimeWindows and merges any overlapping windows."""
-        sorted_time_windows = sorted(time_windows, key=lambda tw: tw.start.timestamp())
-        if not sorted_time_windows:
+        if not time_windows:
             return []
+
+        sorted_time_windows = sorted(time_windows, key=lambda tw: tw.start.timestamp())
         merged_time_windows: List[TimeWindow] = [sorted_time_windows[0]]
+
         for window in sorted_time_windows[1:]:
             last_window = merged_time_windows[-1]
+            # window starts before the end of the pr
             if window.start.timestamp() <= last_window.end.timestamp():
                 merged_time_windows[-1] = TimeWindow(last_window.start, window.end)
             else:

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1614,58 +1614,6 @@ def weekly_partitioned_config(
     return inner
 
 
-def merge_time_windows(
-    initial_windows: Sequence[TimeWindow],
-    time_windows_to_add: Sequence[TimeWindow],
-) -> Tuple[Sequence[TimeWindow], int]:
-    result_windows = [*initial_windows]
-    time_windows = time_windows_to_add
-    num_added_partitions = 0
-    for window in sorted(time_windows, key=lambda tw: tw.start.timestamp()):
-        window_start_timestamp = window.start.timestamp()
-        # go in reverse order because it's more common to add partitions at the end than the
-        # beginning
-        for i in reversed(range(len(result_windows))):
-            included_window = result_windows[i]
-            lt_end_of_range = window_start_timestamp < included_window.end.timestamp()
-            gte_start_of_range = window_start_timestamp >= included_window.start.timestamp()
-
-            if lt_end_of_range and gte_start_of_range:
-                break
-
-            if not lt_end_of_range:
-                merge_with_range = included_window.end.timestamp() == window_start_timestamp
-                merge_with_later_range = i + 1 < len(result_windows) and (
-                    window.end.timestamp() == result_windows[i + 1].start.timestamp()
-                )
-
-                if merge_with_range and merge_with_later_range:
-                    result_windows[i] = TimeWindow(
-                        included_window.start, result_windows[i + 1].end
-                    )
-                    del result_windows[i + 1]
-                elif merge_with_range:
-                    result_windows[i] = TimeWindow(included_window.start, window.end)
-                elif merge_with_later_range:
-                    result_windows[i + 1] = TimeWindow(window.start, result_windows[i + 1].end)
-                else:
-                    result_windows.insert(i + 1, window)
-
-                num_added_partitions += 1
-                break
-        else:
-            if result_windows and window_start_timestamp == result_windows[0].start.timestamp():
-                result_windows[0] = TimeWindow(window.start, included_window.end)
-            elif result_windows and window.end == result_windows[0].start:
-                result_windows[0] = TimeWindow(window.start, included_window.end)
-            else:
-                result_windows.insert(0, window)
-
-            num_added_partitions += 1
-
-    return result_windows, num_added_partitions
-
-
 class BaseTimeWindowPartitionsSubset(PartitionsSubset):
     """A base class that represents PartitionSubsets for TimeWindowPartitionsDefinitions.
     Contains shared logic for time window partitions subsets, such as building time windows
@@ -1795,11 +1743,54 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
         """Merges a set of partition keys into an existing set of time windows, returning the
         minimized set of time windows and the number of partitions added.
         """
+        result_windows = [*initial_windows]
         time_windows = cast(
             TimeWindowPartitionsDefinition, self.partitions_def
         ).time_windows_for_partition_keys(frozenset(partition_keys), validate=validate)
+        num_added_partitions = 0
+        for window in sorted(time_windows, key=lambda tw: tw.start.timestamp()):
+            window_start_timestamp = window.start.timestamp()
+            # go in reverse order because it's more common to add partitions at the end than the
+            # beginning
+            for i in reversed(range(len(result_windows))):
+                included_window = result_windows[i]
+                lt_end_of_range = window_start_timestamp < included_window.end.timestamp()
+                gte_start_of_range = window_start_timestamp >= included_window.start.timestamp()
 
-        return merge_time_windows(initial_windows, time_windows)
+                if lt_end_of_range and gte_start_of_range:
+                    break
+
+                if not lt_end_of_range:
+                    merge_with_range = included_window.end.timestamp() == window_start_timestamp
+                    merge_with_later_range = i + 1 < len(result_windows) and (
+                        window.end.timestamp() == result_windows[i + 1].start.timestamp()
+                    )
+
+                    if merge_with_range and merge_with_later_range:
+                        result_windows[i] = TimeWindow(
+                            included_window.start, result_windows[i + 1].end
+                        )
+                        del result_windows[i + 1]
+                    elif merge_with_range:
+                        result_windows[i] = TimeWindow(included_window.start, window.end)
+                    elif merge_with_later_range:
+                        result_windows[i + 1] = TimeWindow(window.start, result_windows[i + 1].end)
+                    else:
+                        result_windows.insert(i + 1, window)
+
+                    num_added_partitions += 1
+                    break
+            else:
+                if result_windows and window_start_timestamp == result_windows[0].start.timestamp():
+                    result_windows[0] = TimeWindow(window.start, included_window.end)
+                elif result_windows and window.end == result_windows[0].start:
+                    result_windows[0] = TimeWindow(window.start, included_window.end)
+                else:
+                    result_windows.insert(0, window)
+
+                num_added_partitions += 1
+
+        return result_windows, num_added_partitions
 
     def serialize(self) -> str:
         return json.dumps(
@@ -1908,7 +1899,6 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
         )
 
     def __or__(self, other: "PartitionsSubset") -> "PartitionsSubset":
-        print("__OR__", self, other)
         if self is other:
             return self
         return self.with_partition_keys(other.get_partition_keys())

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -805,7 +805,7 @@ def test_nov_2023_dst_transition_with_hourly_partitions():
         assert downstream.get_partition_keys() == [downstream_key]
 
 
-def test_partition_mapping_output_has_no_overlap_ranges():
+def test_partition_mapping_output_has_no_overlap_ranges() -> None:
     partitions_def = DailyPartitionsDefinition("2023-01-01")
     partition_mapping = TimeWindowPartitionMapping(start_offset=-29, end_offset=0)
     current_time = datetime(2024, 12, 1, 9)
@@ -828,5 +828,5 @@ def test_partition_mapping_output_has_no_overlap_ranges():
         current_time=current_time,
     )
     assert downstream_partitions.get_partition_key_ranges(partitions_def) == [
-        PartitionKeyRange(start='2023-09-27', end='2024-03-05')
+        PartitionKeyRange(start="2023-09-27", end="2024-03-05")
     ]


### PR DESCRIPTION
When TimeWindowPartitionMapping._map_partitions is called with an input partitions subset containing multiple ranges, it can return a partitions subset that contains overlapping ranges. This happens when TimeWindowPartitionMapping's start offset or end offset is non-zero.

This PR fixes -- thanks @OwenKephart 