### PR TITLE
Subset multi_graph_asset with checks

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/asset_checks.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_checks.py
@@ -372,6 +372,7 @@ def graph_multi_asset_2_check_1(staged_asset):
             description="A always passes.",
         ),
     ],
+    can_subset=True,
 )
 def many_tests_graph_multi_asset():
     staged_asset = create_staged_asset()

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -44,6 +44,7 @@ from .policy import RetryPolicy
 from .resource_definition import ResourceDefinition
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.asset_graph import AssetKeyOrCheckKey
     from dagster._core.definitions.assets import AssetsDefinition, SourceAsset
     from dagster._core.definitions.job_definition import JobDefinition
     from dagster._core.definitions.partition_mapping import PartitionMapping
@@ -246,7 +247,7 @@ def _get_dependency_node_output_handles(
 
 def get_dep_node_handles_of_graph_backed_asset(
     graph_def: GraphDefinition, assets_def: "AssetsDefinition"
-) -> Mapping[AssetKey, Set[NodeHandle]]:
+) -> Mapping["AssetKeyOrCheckKey", Set[NodeHandle]]:
     """Given a graph-backed asset with graph_def, return a mapping of asset keys outputted by the graph
     to a list of node handles within graph_def that are the dependencies of the asset.
 
@@ -259,17 +260,20 @@ def get_dep_node_handles_of_graph_backed_asset(
     # node is a top-level asset node. Create a dummy graph that wraps around graph_def and pass
     # the dummy graph to asset_key_to_dep_node_handles
     dummy_parent_graph = GraphDefinition("dummy_parent_graph", node_defs=[graph_def])
-    dep_node_handles_by_asset_key, _ = asset_key_to_dep_node_handles(
+    (dep_node_handles_by_asset_key, _) = asset_or_check_key_to_dep_node_handles(
         dummy_parent_graph,
         {NodeHandle(name=graph_def.name, parent=None): assets_def},
     )
     return dep_node_handles_by_asset_key
 
 
-def asset_key_to_dep_node_handles(
+def asset_or_check_key_to_dep_node_handles(
     graph_def: GraphDefinition,
     assets_defs_by_node_handle: Mapping[NodeHandle, "AssetsDefinition"],
-) -> Tuple[Mapping[AssetKey, Set[NodeHandle]], Mapping[AssetKey, Sequence[NodeOutputHandle]]]:
+) -> Tuple[
+    Mapping["AssetKeyOrCheckKey", Set[NodeHandle]],
+    Mapping["AssetKeyOrCheckKey", Sequence[NodeOutputHandle]],
+]:
     """For each asset in assets_defs_by_node_handle, determines all the op handles and output handles
     within the asset's node that are upstream dependencies of the asset.
 
@@ -296,24 +300,28 @@ def asset_key_to_dep_node_handles(
         assets_defs_by_node_handle=assets_defs_by_node_handle,
     )
 
-    dep_nodes_by_asset_key: Dict[AssetKey, List[NodeHandle]] = {}
-    dep_node_outputs_by_asset_key: Dict[AssetKey, List[NodeOutputHandle]] = {}
+    dep_nodes_by_asset_or_check_key: Dict["AssetKeyOrCheckKey", List[NodeHandle]] = {}
+    dep_node_outputs_by_asset_or_check_key: Dict["AssetKeyOrCheckKey", List[NodeOutputHandle]] = {}
 
     for node_handle, assets_defs in assets_defs_by_node_handle.items():
         dep_node_output_handles_by_node: Dict[
             NodeOutputHandle, Sequence[NodeOutputHandle]
         ] = {}  # memoized map of node output handles to all node output handle dependencies that are from ops
-        for output_name, asset_key in assets_defs.keys_by_output_name.items():
-            dep_nodes_by_asset_key[
-                asset_key
+        for (
+            output_name,
+            asset_or_check_key,
+        ) in assets_defs.asset_and_check_keys_by_output_name.items():
+            dep_nodes_by_asset_or_check_key[
+                asset_or_check_key
             ] = []  # first element in list is node that outputs asset
 
-            dep_node_outputs_by_asset_key[asset_key] = []
+            dep_node_outputs_by_asset_or_check_key[asset_or_check_key] = []
 
             if node_handle not in outputs_by_graph_handle:
-                dep_nodes_by_asset_key[asset_key].extend([node_handle])
+                dep_nodes_by_asset_or_check_key[asset_or_check_key].extend([node_handle])
             else:  # is graph
                 # node output handle for the given asset key
+                print(outputs_by_graph_handle[node_handle])
                 node_output_handle = outputs_by_graph_handle[node_handle][output_name]
 
                 dep_node_output_handles = _get_dependency_node_output_handles(
@@ -323,7 +331,9 @@ def asset_key_to_dep_node_handles(
                     node_output_handle,
                 )
 
-                dep_node_outputs_by_asset_key[asset_key].extend(dep_node_output_handles)
+                dep_node_outputs_by_asset_or_check_key[asset_or_check_key].extend(
+                    dep_node_output_handles
+                )
 
     # handle internal_asset_deps within graph-backed assets
     for assets_def in assets_defs_by_node_handle.values():
@@ -331,35 +341,35 @@ def asset_key_to_dep_node_handles(
             if asset_key not in assets_def.keys:
                 continue
             for dep_asset_key in [key for key in dep_asset_keys if key in assets_def.keys]:
-                if len(dep_node_outputs_by_asset_key[asset_key]) == 0:
+                if len(dep_node_outputs_by_asset_or_check_key[asset_key]) == 0:
                     # This case occurs when the asset is not yielded from a graph-backed asset
                     continue
-                node_output_handle = dep_node_outputs_by_asset_key[asset_key][
+                node_output_handle = dep_node_outputs_by_asset_or_check_key[asset_key][
                     0
                 ]  # first item in list is the original node output handle that outputs the asset
                 dep_asset_key_node_output_handles = [
                     output_handle
-                    for output_handle in dep_node_outputs_by_asset_key[dep_asset_key]
+                    for output_handle in dep_node_outputs_by_asset_or_check_key[dep_asset_key]
                     if output_handle != node_output_handle
                 ]
-                dep_node_outputs_by_asset_key[asset_key] = [
+                dep_node_outputs_by_asset_or_check_key[asset_key] = [
                     node_output
-                    for node_output in dep_node_outputs_by_asset_key[asset_key]
+                    for node_output in dep_node_outputs_by_asset_or_check_key[asset_key]
                     if node_output not in dep_asset_key_node_output_handles
                 ]
 
     # For graph-backed assets, we've resolved the upstream node output handles dependencies for each
-    # node output handle in dep_node_outputs_by_asset_key. We use this to find the upstream
+    # node output handle in dep_node_outputs_by_asset_or_check_key. We use this to find the upstream
     # node handle dependencies.
-    for asset_key, dep_node_outputs in dep_node_outputs_by_asset_key.items():
-        dep_nodes_by_asset_key[asset_key].extend(
+    for asset_key, dep_node_outputs in dep_node_outputs_by_asset_or_check_key.items():
+        dep_nodes_by_asset_or_check_key[asset_key].extend(
             [node_output.node_handle for node_output in dep_node_outputs]
         )
 
-    dep_node_set_by_asset_key: Dict[AssetKey, Set[NodeHandle]] = {}
-    for asset_key, dep_node_handles in dep_nodes_by_asset_key.items():
-        dep_node_set_by_asset_key[asset_key] = set(dep_node_handles)
-    return dep_node_set_by_asset_key, dep_node_outputs_by_asset_key
+    dep_node_set_by_asset_or_check_key: Dict["AssetKeyOrCheckKey", Set[NodeHandle]] = {}
+    for key, dep_node_handles in dep_nodes_by_asset_or_check_key.items():
+        dep_node_set_by_asset_or_check_key[key] = set(dep_node_handles)
+    return dep_node_set_by_asset_or_check_key, dep_node_outputs_by_asset_or_check_key
 
 
 class AssetLayer(NamedTuple):
@@ -423,9 +433,20 @@ class AssetLayer(NamedTuple):
         partition_mappings_by_asset_dep: Dict[Tuple[NodeHandle, AssetKey], "PartitionMapping"] = {}
 
         (
-            dep_node_handles_by_asset_key,
-            dep_node_output_handles_by_asset_key,
-        ) = asset_key_to_dep_node_handles(graph_def, assets_defs_by_outer_node_handle)
+            dep_node_handles_by_asset_or_check_key,
+            dep_node_output_handles_by_asset_or_check_key,
+        ) = asset_or_check_key_to_dep_node_handles(graph_def, assets_defs_by_outer_node_handle)
+
+        dep_node_handles_by_asset_key = {
+            key: handles
+            for key, handles in dep_node_handles_by_asset_or_check_key.items()
+            if isinstance(key, AssetKey)
+        }
+        dep_node_output_handles_by_asset_key = {
+            key: handles
+            for key, handles in dep_node_output_handles_by_asset_or_check_key.items()
+            if isinstance(key, AssetKey)
+        }
 
         node_output_handles_by_asset_check_key: Mapping[AssetCheckKey, NodeOutputHandle] = {}
         check_names_by_asset_key_by_node_handle: Dict[NodeHandle, Dict[AssetKey, Set[str]]] = {}

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -272,14 +272,14 @@ def asset_or_check_key_to_dep_node_handles(
     assets_defs_by_node_handle: Mapping[NodeHandle, "AssetsDefinition"],
 ) -> Tuple[
     Mapping["AssetKeyOrCheckKey", Set[NodeHandle]],
-    Mapping[AssetKey, Sequence[NodeOutputHandle]],
+    Mapping["AssetKeyOrCheckKey", Sequence[NodeOutputHandle]],
 ]:
     """For each asset in assets_defs_by_node_handle, determines all the op handles and output handles
     within the asset's node that are upstream dependencies of the asset.
 
     Returns a tuple with two objects:
     1. A mapping of each asset or check key to a set of node handles that are upstream dependencies of the asset.
-    2. A mapping of each asset key to a list of node output handles that are upstream dependencies of the asset.
+    2. A mapping of each asset or check key to a list of node output handles that are upstream dependencies of the asset.
 
     Arguments:
     graph_def: The graph definition of the job, where each top level node is an asset.
@@ -301,7 +301,7 @@ def asset_or_check_key_to_dep_node_handles(
     )
 
     dep_nodes_by_asset_or_check_key: Dict["AssetKeyOrCheckKey", List[NodeHandle]] = {}
-    dep_node_outputs_by_asset_key: Dict[AssetKey, List[NodeOutputHandle]] = {}
+    dep_node_outputs_by_asset_or_check_key: Dict["AssetKeyOrCheckKey", List[NodeOutputHandle]] = {}
 
     for node_handle, assets_defs in assets_defs_by_node_handle.items():
         dep_node_output_handles_by_node: Dict[
@@ -315,8 +315,7 @@ def asset_or_check_key_to_dep_node_handles(
                 asset_or_check_key
             ] = []  # first element in list is node that outputs asset
 
-            if isinstance(asset_or_check_key, AssetKey):
-                dep_node_outputs_by_asset_key[asset_or_check_key] = []
+            dep_node_outputs_by_asset_or_check_key[asset_or_check_key] = []
 
             if node_handle not in outputs_by_graph_handle:
                 dep_nodes_by_asset_or_check_key[asset_or_check_key].extend([node_handle])
@@ -331,10 +330,9 @@ def asset_or_check_key_to_dep_node_handles(
                     node_output_handle,
                 )
 
-                if isinstance(asset_or_check_key, AssetKey):
-                    dep_node_outputs_by_asset_key[asset_or_check_key].extend(
-                        dep_node_output_handles
-                    )
+                dep_node_outputs_by_asset_or_check_key[asset_or_check_key].extend(
+                    dep_node_output_handles
+                )
 
     # handle internal_asset_deps within graph-backed assets
     for assets_def in assets_defs_by_node_handle.values():
@@ -342,27 +340,27 @@ def asset_or_check_key_to_dep_node_handles(
             if asset_key not in assets_def.keys:
                 continue
             for dep_asset_key in [key for key in dep_asset_keys if key in assets_def.keys]:
-                if len(dep_node_outputs_by_asset_key[asset_key]) == 0:
+                if len(dep_node_outputs_by_asset_or_check_key[asset_key]) == 0:
                     # This case occurs when the asset is not yielded from a graph-backed asset
                     continue
-                node_output_handle = dep_node_outputs_by_asset_key[asset_key][
+                node_output_handle = dep_node_outputs_by_asset_or_check_key[asset_key][
                     0
                 ]  # first item in list is the original node output handle that outputs the asset
                 dep_asset_key_node_output_handles = [
                     output_handle
-                    for output_handle in dep_node_outputs_by_asset_key[dep_asset_key]
+                    for output_handle in dep_node_outputs_by_asset_or_check_key[dep_asset_key]
                     if output_handle != node_output_handle
                 ]
-                dep_node_outputs_by_asset_key[asset_key] = [
+                dep_node_outputs_by_asset_or_check_key[asset_key] = [
                     node_output
-                    for node_output in dep_node_outputs_by_asset_key[asset_key]
+                    for node_output in dep_node_outputs_by_asset_or_check_key[asset_key]
                     if node_output not in dep_asset_key_node_output_handles
                 ]
 
     # For graph-backed assets, we've resolved the upstream node output handles dependencies for each
-    # node output handle in dep_node_outputs_by_asset_key. We use this to find the upstream
+    # node output handle in dep_node_outputs_by_asset_or_check_key. We use this to find the upstream
     # node handle dependencies.
-    for key, dep_node_outputs in dep_node_outputs_by_asset_key.items():
+    for key, dep_node_outputs in dep_node_outputs_by_asset_or_check_key.items():
         dep_nodes_by_asset_or_check_key[key].extend(
             [node_output.node_handle for node_output in dep_node_outputs]
         )
@@ -370,7 +368,7 @@ def asset_or_check_key_to_dep_node_handles(
     dep_node_set_by_asset_or_check_key: Dict["AssetKeyOrCheckKey", Set[NodeHandle]] = {}
     for key, dep_node_handles in dep_nodes_by_asset_or_check_key.items():
         dep_node_set_by_asset_or_check_key[key] = set(dep_node_handles)
-    return dep_node_set_by_asset_or_check_key, dep_node_outputs_by_asset_key
+    return dep_node_set_by_asset_or_check_key, dep_node_outputs_by_asset_or_check_key
 
 
 class AssetLayer(NamedTuple):

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -321,7 +321,6 @@ def asset_or_check_key_to_dep_node_handles(
                 dep_nodes_by_asset_or_check_key[asset_or_check_key].extend([node_handle])
             else:  # is graph
                 # node output handle for the given asset key
-                print(outputs_by_graph_handle[node_handle])
                 node_output_handle = outputs_by_graph_handle[node_handle][output_name]
 
                 dep_node_output_handles = _get_dependency_node_output_handles(
@@ -361,8 +360,8 @@ def asset_or_check_key_to_dep_node_handles(
     # For graph-backed assets, we've resolved the upstream node output handles dependencies for each
     # node output handle in dep_node_outputs_by_asset_or_check_key. We use this to find the upstream
     # node handle dependencies.
-    for asset_key, dep_node_outputs in dep_node_outputs_by_asset_or_check_key.items():
-        dep_nodes_by_asset_or_check_key[asset_key].extend(
+    for key, dep_node_outputs in dep_node_outputs_by_asset_or_check_key.items():
+        dep_nodes_by_asset_or_check_key[key].extend(
             [node_output.node_handle for node_output in dep_node_outputs]
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1245,7 +1245,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             for dep_node_handle in dep_node_handles:
                 op_selection.append(".".join(dep_node_handle.path[1:]))
         for asset_check_key in selected_asset_check_keys:
-            dep_node_handles = dep_node_handles_by_asset_key[asset_check_key.asset_key]
+            dep_node_handles = dep_node_handles_by_asset_key[asset_check_key]
             for dep_node_handle in dep_node_handles:
                 op_selection.append(".".join(dep_node_handle.path[1:]))
 
@@ -1324,6 +1324,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
                 node_def=subsetted_node,
                 asset_deps=subsetted_asset_deps,
                 selected_asset_keys=selected_asset_keys & self.keys,
+                selected_asset_check_keys=asset_check_subselection,
                 is_subset=True,
             )
 

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -73,6 +73,7 @@ from dagster._core.definitions.dependency import (
 )
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.metadata import (
     MetadataFieldSerializer,
     MetadataMapping,
@@ -1535,7 +1536,14 @@ def external_asset_checks_from_defs(
                 of_type=AssetsDefinition,
                 additional_message=f"Check {check_key} is redefined in an AssetsDefinition and an AssetChecksDefinition",
             )
-            atomic_execution_unit_id = first_node.unique_id if not first_node.can_subset else None
+
+            # Executing individual checks isn't supported in graph assets
+            if isinstance(first_node.node_def, GraphDefinition):
+                atomic_execution_unit_id = first_node.unique_id
+            else:
+                atomic_execution_unit_id = (
+                    first_node.unique_id if not first_node.can_subset else None
+                )
         else:
             check.failed(f"Unexpected node type {first_node}")
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
@@ -772,3 +772,87 @@ def test_graph_asset_subset_with_checks():
 
     assert len(result.get_asset_materialization_events()) == 1
     assert len(result.get_asset_check_evaluations()) == 1
+
+
+@op
+def validate_asset_1(word):
+    return AssetCheckResult(check_name="check1", passed=True, metadata={"foo": "bar"})
+
+
+@op
+def validate_asset_2(word):
+    return word
+
+
+@graph_multi_asset(
+    outs={"asset_one": AssetOut(), "asset_two": AssetOut()},
+    check_specs=[AssetCheckSpec("check1", asset="asset_one", description="desc")],
+    can_subset=True,
+)
+def nested_check_graph_asset():
+    asset_one = create_asset()
+    return {
+        "asset_one": asset_one,
+        "asset_one_check1": validate_asset_2(validate_asset_1(asset_one)),
+        "asset_two": create_asset(),
+    }
+
+
+def test_nested_graph_asset_all():
+    result = materialize(assets=[nested_check_graph_asset])
+    assert result.success
+
+    assert len(result.get_asset_materialization_events()) == 2
+    assert len(result.get_asset_check_evaluations()) == 1
+
+
+def test_nested_graph_asset_subset_no_checks():
+    result = materialize(
+        assets=[nested_check_graph_asset],
+        selection=AssetSelection.keys(AssetKey("asset_one")).without_checks(),
+    )
+    assert result.success
+
+    assert len(result.get_asset_materialization_events()) == 1
+    assert not result.get_asset_check_evaluations()
+
+
+def test_nested_graph_asset_subset_with_checks():
+    result = materialize(
+        assets=[nested_check_graph_asset], selection=AssetSelection.keys(AssetKey("asset_one"))
+    )
+    assert result.success
+
+    assert len(result.get_asset_materialization_events()) == 1
+    assert len(result.get_asset_check_evaluations()) == 1
+
+
+@op(ins={"staging_asset": In(Nothing), "check_result": In(Nothing)})
+def promote_asset():
+    return None
+
+
+@graph_multi_asset(
+    outs={"asset_one": AssetOut(), "asset_two": AssetOut()},
+    check_specs=[AssetCheckSpec("check1", asset="asset_one", description="desc")],
+    can_subset=True,
+)
+def validate_promote_graph_asset():
+    staging_asset = create_asset()
+    check_result = validate_asset(staging_asset)
+    promoted_asset = promote_asset(staging_asset=staging_asset, check_result=check_result)
+    return {
+        "asset_one": promoted_asset,
+        "asset_one_check1": check_result,
+        "asset_two": create_asset(),
+    }
+
+
+def test_validate_promote_graph_asset_subset_checks_and_asset():
+    result = materialize(
+        assets=[validate_promote_graph_asset], selection=AssetSelection.keys(AssetKey("asset_one"))
+    )
+    assert result.success
+
+    assert len(result.get_asset_materialization_events()) == 1
+    assert len(result.get_asset_check_evaluations()) == 1


### PR DESCRIPTION
Closes https://github.com/dagster-io/dagster/issues/19915

Remove the block against subsetting `@graph_multi_asset`s with checks, and include check outputs in the `op_selection` calculation. The result is that subsetting with checks behaves like subsetting with just assets- we filter the graph down to the required nodes.

Test plan: unit tests, manually testing in toys