### PR TITLE
feat: update op_tags on nodes in AssetDefinition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -506,6 +506,7 @@ class GraphDefinition(NodeDefinition):
 
     def copy(
         self,
+        node_defs: Optional[Sequence[NodeDefinition]] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
         input_mappings: Optional[Sequence[InputMapping]] = None,
@@ -515,7 +516,7 @@ class GraphDefinition(NodeDefinition):
         node_input_source_assets: Optional[Mapping[str, Mapping[str, "SourceAsset"]]] = None,
     ) -> Self:
         return self.__class__(
-            node_defs=self.node_defs,
+            node_defs=node_defs or self.node_defs,
             dependencies=self.dependencies,
             name=name or self.name,
             description=description or self.description,

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -368,6 +368,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         outs: Optional[Mapping[str, Out]] = None,
         config_schema: Optional[IDefinitionConfigSchema] = None,
         description: Optional[str] = None,
+        tags: Optional[Mapping[str, str]] = None,
     ) -> "OpDefinition":
         return OpDefinition.dagster_internal_init(
             name=name,
@@ -380,7 +381,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             compute_fn=self.compute_fn,
             config_schema=config_schema or self.config_schema,
             description=description or self.description,
-            tags=self.tags,
+            tags=tags or self.tags,
             required_resource_keys=self.required_resource_keys,
             code_version=self._version,
             retry_policy=self.retry_policy,


### PR DESCRIPTION
## Summary & Motivation
We need to update the `op_tags` to configure the k8s resources after all assets are defined, we cannot keep it static in each asset since the number of compute resources are dynamically configured based on our configuration.

- closes https://github.com/dagster-io/dagster/issues/20123

## How I Tested These Changes

Example of how it works:
```python
from dagster import asset, graph_asset, op

@asset
def upstream_asset():
    return 1

@op(tags={"foo":"old_value"})
def add_one(input_num):
    return input_num + 1

@op(tags={"bar":"old_value"})
def multiply_by_two(input_num):
    return input_num * 2

@graph_asset()
def middle_asset(upstream_asset):
    return multiply_by_two(add_one(upstream_asset))

@asset
def downstream_asset(middle_asset):
    return middle_asset + 7
```
We can now update the op_tags from an asset or graph_asset. The graph asset does it one layer only (I am not sure if nested graphs are allowed in a graph_asset, if that's the case, I need to make it recursive.
```python
print(middle_asset._node_def._node_defs[0]._tags, middle_asset._node_def._node_defs[1]._tags)
print(upstream_asset.op.tags)
{'foo': 'old_value'} {'bar': 'old_value'}
{}

updated_middle_asset = middle_asset.with_attributes(graph_op_tags={"multiply_by_two": {"bar":"new_value"}, "add_one": {"foo":"new_value"}})
downstream_asset = downstream_asset.with_attributes(op_tags={"baz":"this_tag_is_new"})

print(updated_middle_asset._node_def._node_defs[0].tags, updated_middle_asset._node_def._node_defs[1].tags)
print(downstream_asset.op.tags)
{'foo': 'new_value'} {'bar': 'new_value'}
{'baz': 'this_tag_is_new'}
```