### PR TITLE
[ui] Add view tracker to asset Plots tab

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPlots.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPlots.tsx
@@ -1,10 +1,11 @@
 import {Box, ButtonGroup, Spinner, Subheading} from '@dagster-io/ui-components';
-import {useMemo} from 'react';
+import {useEffect, useMemo} from 'react';
 
 import {AssetMaterializationGraphs} from './AssetMaterializationGraphs';
 import {useGroupedEvents} from './groupByPartition';
 import {AssetKey, AssetViewParams} from './types';
 import {useRecentAssetEvents} from './useRecentAssetEvents';
+import {useTrackEvent} from '../app/analytics';
 
 interface Props {
   assetKey: AssetKey;
@@ -14,6 +15,11 @@ interface Props {
 }
 
 export const AssetPlots = ({assetKey, assetHasDefinedPartitions, params, setParams}: Props) => {
+  // Track the event explicitly because the tab is based on a querystring, so the typical
+  // pageview event would not be matched to the Plots tab.
+  const trackEvent = useTrackEvent();
+  useEffect(() => trackEvent('viewAssetPlots'), [trackEvent]);
+
   const {materializations, observations, loadedPartitionKeys, loading, xAxis} =
     useRecentAssetEvents(assetKey, params, {assetHasDefinedPartitions});
 


### PR DESCRIPTION
## Summary & Motivation

Add an event tracker to the Asset Plots tab. Navigation to these tabs is based on a URL querystring, so we can't rely on routing elsewhere to track this specific tab view.

## How I Tested These Changes

View Plots tab for an asset. Verify that the `viewAssetPlots` event appears in the console.