### PR TITLE
[external-assets] Tweaks to AssetGraph interface

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -1,5 +1,4 @@
 import datetime
-import itertools
 import logging
 import os
 import time
@@ -230,7 +229,7 @@ class AssetDaemonContext:
         num_checked_assets = 0
         num_auto_materialize_asset_keys = len(self.auto_materialize_asset_keys)
 
-        for asset_key in itertools.chain(*self.asset_graph.toposort_asset_keys()):
+        for asset_key in self.asset_graph.toposorted_asset_keys:
             # an asset may have already been visited if it was part of a non-subsettable multi-asset
             if asset_key not in self.auto_materialize_asset_keys:
                 continue

--- a/python_modules/dagster/dagster/_core/definitions/internal_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/internal_asset_graph.py
@@ -86,16 +86,6 @@ class InternalAssetGraph(AssetGraph):
     def has_asset_check(self, asset_check_key: AssetCheckKey) -> bool:
         return asset_check_key in self._asset_checks_defs_by_key
 
-    def includes_materializable_and_external_assets(
-        self, asset_keys: AbstractSet[AssetKey]
-    ) -> bool:
-        """Returns true if the given asset keys contains at least one materializable asset and
-        at least one external asset.
-        """
-        selected_external_assets = self.external_asset_keys & asset_keys
-        selected_materializable_assets = self.materializable_asset_keys & asset_keys
-        return len(selected_external_assets) > 0 and len(selected_materializable_assets) > 0
-
     @property
     @cached_method
     def asset_dep_graph(self) -> DependencyGraph[AssetKey]:

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -183,9 +183,13 @@ class UnresolvedAssetJobDefinition(
         """Resolve this UnresolvedAssetJobDefinition into a JobDefinition."""
         assets = asset_graph.assets_defs
         selected_asset_keys = self.selection.resolve(asset_graph)
-        if asset_graph.includes_materializable_and_external_assets(selected_asset_keys):
+
+        if (
+            len(selected_asset_keys & asset_graph.materializable_asset_keys) > 0
+            and len(selected_asset_keys & asset_graph.external_asset_keys) > 0
+        ):
             raise DagsterInvalidDefinitionError(
-                f"Asset selection for job '{self.name}' specified both regular assets and source "
+                f"Asset selection for job '{self.name}' specified both regular assets and external "
                 "assets. This is not currently supported. Selections must be all regular "
                 "assets or all source assets.",
             )

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -308,15 +308,7 @@ class AssetBackfillData(NamedTuple):
 
         Orders keys in the same topological level alphabetically.
         """
-        toposorted_keys = asset_graph.toposort_asset_keys()
-
-        targeted_toposorted_keys = []
-        for level_keys in toposorted_keys:
-            for key in sorted(level_keys):
-                if key in self.target_subset.asset_keys:
-                    targeted_toposorted_keys.append(key)
-
-        return targeted_toposorted_keys
+        return [k for k in asset_graph.toposorted_asset_keys if k in self.target_subset.asset_keys]
 
     def get_backfill_status_per_asset_key(
         self, asset_graph: AssetGraph

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
@@ -102,7 +102,7 @@ def test_mixed_source_asset_observation_job():
         return 1
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match=r"specified both regular assets and source assets"
+        DagsterInvalidDefinitionError, match=r"specified both regular assets and external assets"
     ):
         Definitions(
             assets=[foo, bar],

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
@@ -1493,7 +1493,7 @@ def test_invalid_asset_selection():
     Definitions(assets=[source_asset, asset1], sensors=[sensor1])
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match="specified both regular assets and source"
+        DagsterInvalidDefinitionError, match="specified both regular assets and external"
     ):
         Definitions(
             assets=[source_asset, asset1],


### PR DESCRIPTION
## Summary & Motivation

- `toposort_asset_keys` -> `toposorted_asset_keys`. Also make it return a flat sequence of keys instead of a Sequence of sets (all callsites except an internal one use a flattened seq anyway). This is done for consistency with our other key subset accessors.
- Remove `includes_materializable_and_external_asset_keys`, which has only a single callsite.

## How I Tested These Changes

Existing test suite.