### PR TITLE
fix incorrect note on editing deployment permissions

### DIFF
--- a/docs/content/dagster-cloud/managing-deployments/managing-deployments.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/managing-deployments.mdx
@@ -102,7 +102,7 @@ To delete a deployment:
 
 <Note>
   <a href="/dagster-cloud/account/managing-users#understanding-user-permissions">
-    Organization Admin permissions
+    Editor permissions
   </a>{" "}
   are required to modify deployment settings.
 </Note>


### PR DESCRIPTION
Summary:
Editors can change these, not org admins. The table was already updated, this notice was just out of date.

## Summary & Motivation

## How I Tested These Changes
