### PR TITLE
Still use the full asset graph when computing AMP evaluations even after using a subsetted graph to compute the asset keys

### DIFF
--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -646,11 +646,8 @@ class AssetDaemon(DagsterDaemon):
         evaluation_time = pendulum.now("UTC")
 
         workspace = workspace_process_context.create_request_context()
-        asset_graph = (
-            ExternalAssetGraph.from_external_repository(check.not_none(repository))
-            if sensor
-            else ExternalAssetGraph.from_workspace(workspace)
-        )
+
+        asset_graph = ExternalAssetGraph.from_workspace(workspace)
 
         instance: DagsterInstance = workspace_process_context.instance
         error_info = None
@@ -673,7 +670,9 @@ class AssetDaemon(DagsterDaemon):
             print_group_name = self._get_print_sensor_name(sensor)
 
             if sensor:
-                eligible_keys = check.not_none(sensor.asset_selection).resolve(asset_graph)
+                eligible_keys = check.not_none(sensor.asset_selection).resolve(
+                    ExternalAssetGraph.from_external_repository(check.not_none(repository))
+                )
             else:
                 eligible_keys = {
                     *asset_graph.materializable_asset_keys,


### PR DESCRIPTION
Summary:
We actually need both asset graphs during AMP evaluation - the repo scoped one to determine which keys we care about, but the full one for the rest of the evaluation.

Test Plan: Still assembling a unit test case that would fail before this change was applied (I suspect two assets in different repositories, relying on the parent being missing to prevent the child from being materialized would be one example)

## Summary & Motivation

## How I Tested These Changes
