### PR TITLE
[external-assets] Standardize terminology on "execution set"

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
@@ -136,7 +136,7 @@ class AssetChecksLoader:
                     can_execute_individually = (
                         GrapheneAssetCheckCanExecuteIndividually.CAN_EXECUTE
                         if len(
-                            asset_graph.get_required_asset_and_check_keys(external_check.key) or []
+                            asset_graph.get_execution_set_asset_and_check_keys(external_check.key)
                         )
                         <= 1
                         # NOTE: once we support multi checks, we'll need to add a case for

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -145,16 +145,17 @@ def get_additional_required_keys(
     asset_nodes_by_key = get_asset_nodes_by_asset_key(graphene_info)
 
     # the set of atomic execution ids that any of the input asset keys are a part of
-    required_atomic_execution_ids = {
-        asset_nodes_by_key[asset_key].external_asset_node.atomic_execution_unit_id
+    required_execution_set_identifiers = {
+        asset_nodes_by_key[asset_key].external_asset_node.execution_set_identifier
         for asset_key in asset_keys
     } - {None}
 
-    # the set of all asset keys that are part of the required atomic execution units
+    # the set of all asset keys that are part of the required execution sets
     required_asset_keys = {
         asset_node.external_asset_node.asset_key
         for asset_node in asset_nodes_by_key.values()
-        if asset_node.external_asset_node.atomic_execution_unit_id in required_atomic_execution_ids
+        if asset_node.external_asset_node.execution_set_identifier
+        in required_execution_set_identifiers
     }
 
     return list(required_asset_keys - asset_keys)

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -269,8 +269,9 @@ class AssetDaemonContext:
 
             # if we need to materialize any partitions of a non-subsettable multi-asset, we need to
             # materialize all of them
-            if num_requested > 0:
-                for neighbor_key in self.asset_graph.get_required_multi_asset_keys(asset_key):
+            execution_unit_keys = self.asset_graph.get_execution_set_asset_keys(asset_key)
+            if len(execution_unit_keys) > 1 and num_requested > 0:
+                for neighbor_key in execution_unit_keys:
                     expected_data_time_mapping[neighbor_key] = expected_data_time
 
                     # make sure that the true_subset of the neighbor is accurate -- when it was

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -620,7 +620,7 @@ class RequiredNeighborsAssetSelection(
         selection = self.child.resolve_inner(asset_graph)
         output = set(selection)
         for asset_key in selection:
-            output.update(asset_graph.get_required_multi_asset_keys(asset_key))
+            output.update(asset_graph.get_execution_set_asset_keys(asset_key))
         return output
 
     def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -237,37 +237,37 @@ class ExternalAssetGraph(AssetGraph):
     def asset_keys_for_job(self, job_name: str) -> AbstractSet[AssetKey]:
         return {node.asset_key for node in self.asset_nodes if job_name in node.job_names}
 
-    def get_required_asset_and_check_keys(
+    def get_execution_set_asset_and_check_keys(
         self, asset_or_check_key: AssetKeyOrCheckKey
     ) -> AbstractSet[AssetKeyOrCheckKey]:
         if isinstance(asset_or_check_key, AssetKey):
-            atomic_execution_unit_id = self.get_asset_node(
+            execution_set_identifier = self.get_asset_node(
                 asset_or_check_key
-            ).atomic_execution_unit_id
+            ).execution_set_identifier
         else:  # AssetCheckKey
-            atomic_execution_unit_id = self.get_asset_check(
+            execution_set_identifier = self.get_asset_check(
                 asset_or_check_key
-            ).atomic_execution_unit_id
-        if atomic_execution_unit_id is None:
-            return set()
+            ).execution_set_identifier
+        if execution_set_identifier is None:
+            return {asset_or_check_key}
         else:
             return {
                 *(
                     node.asset_key
                     for node in self.asset_nodes
-                    if node.atomic_execution_unit_id == atomic_execution_unit_id
+                    if node.execution_set_identifier == execution_set_identifier
                 ),
                 *(
                     node.key
                     for node in self.asset_checks
-                    if node.atomic_execution_unit_id == atomic_execution_unit_id
+                    if node.execution_set_identifier == execution_set_identifier
                 ),
             }
 
-    def get_required_multi_asset_keys(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
+    def get_execution_set_asset_keys(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
         return {
             key
-            for key in self.get_required_asset_and_check_keys(asset_key)
+            for key in self.get_execution_set_asset_and_check_keys(asset_key)
             if isinstance(key, AssetKey)
         }
 

--- a/python_modules/dagster/dagster/_core/definitions/internal_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/internal_asset_graph.py
@@ -136,11 +136,11 @@ class InternalAssetGraph(AssetGraph):
             if ad.group_names_by_key[key] == group_name
         }
 
-    def get_required_multi_asset_keys(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
+    def get_execution_set_asset_keys(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
         asset = self.get_assets_def(asset_key)
-        return set() if len(asset.keys) <= 1 or asset.can_subset else asset.keys
+        return {asset_key} if len(asset.keys) <= 1 or asset.can_subset else asset.keys
 
-    def get_required_asset_and_check_keys(
+    def get_execution_set_asset_and_check_keys(
         self, asset_or_check_key: AssetKeyOrCheckKey
     ) -> AbstractSet[AssetKeyOrCheckKey]:
         if isinstance(asset_or_check_key, AssetKey):
@@ -148,14 +148,14 @@ class InternalAssetGraph(AssetGraph):
         else:  # AssetCheckKey
             # only checks emitted by AssetsDefinition have required keys
             if self.has_asset_check(asset_or_check_key):
-                return set()
+                return {asset_or_check_key}
             else:
                 asset = self.get_assets_def_for_check(asset_or_check_key)
                 if asset is None or asset_or_check_key not in asset.check_keys:
-                    return set()
+                    return {asset_or_check_key}
         has_checks = len(asset.check_keys) > 0
         if asset.can_subset or len(asset.keys) <= 1 and not has_checks:
-            return set()
+            return {asset_or_check_key}
         else:
             return {*asset.keys, *asset.check_keys}
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -92,7 +92,7 @@ def test_basics(asset_graph_from_assets):
     assert asset_graph.get_children(asset0.key) == {asset1.key, asset2.key}
     assert asset_graph.get_parents(asset3.key) == {asset1.key, asset2.key}
     for asset_def in assets:
-        assert asset_graph.get_required_multi_asset_keys(asset_def.key) == set()
+        assert asset_graph.get_execution_set_asset_keys(asset_def.key) == {asset_def.key}
     assert asset_graph.get_code_version(asset0.key) == "1"
     assert asset_graph.get_code_version(asset1.key) is None
 
@@ -349,7 +349,7 @@ def test_required_multi_asset_sets_non_subsettable_multi_asset(
     asset_graph = asset_graph_from_assets([non_subsettable_multi_asset])
     for asset_key in non_subsettable_multi_asset.keys:
         assert (
-            asset_graph.get_required_multi_asset_keys(asset_key) == non_subsettable_multi_asset.keys
+            asset_graph.get_execution_set_asset_keys(asset_key) == non_subsettable_multi_asset.keys
         )
 
 
@@ -364,7 +364,7 @@ def test_required_multi_asset_sets_subsettable_multi_asset(
 
     asset_graph = asset_graph_from_assets([subsettable_multi_asset])
     for asset_key in subsettable_multi_asset.keys:
-        assert asset_graph.get_required_multi_asset_keys(asset_key) == set()
+        assert asset_graph.get_execution_set_asset_keys(asset_key) == {asset_key}
 
 
 def test_required_multi_asset_sets_graph_backed_multi_asset(
@@ -387,7 +387,7 @@ def test_required_multi_asset_sets_graph_backed_multi_asset(
     graph_backed_multi_asset = AssetsDefinition.from_graph(graph1)
     asset_graph = asset_graph_from_assets([graph_backed_multi_asset])
     for asset_key in graph_backed_multi_asset.keys:
-        assert asset_graph.get_required_multi_asset_keys(asset_key) == graph_backed_multi_asset.keys
+        assert asset_graph.get_execution_set_asset_keys(asset_key) == graph_backed_multi_asset.keys
 
 
 def test_required_multi_asset_sets_same_op_in_different_assets(
@@ -402,7 +402,7 @@ def test_required_multi_asset_sets_same_op_in_different_assets(
 
     asset_graph = asset_graph_from_assets(assets)
     for asset_def in assets:
-        assert asset_graph.get_required_multi_asset_keys(asset_def.key) == set()
+        assert asset_graph.get_execution_set_asset_keys(asset_def.key) == {asset_def.key}
 
 
 def test_partitioned_source_asset(asset_graph_from_assets: Callable[..., AssetGraph]):
@@ -753,8 +753,8 @@ def test_required_assets_and_checks_by_key_check_decorator(
     def check0(): ...
 
     asset_graph = asset_graph_from_assets([asset0], asset_checks=[check0])
-    assert asset_graph.get_required_asset_and_check_keys(asset0.key) == set()
-    assert asset_graph.get_required_asset_and_check_keys(check0.spec.key) == set()
+    assert asset_graph.get_execution_set_asset_and_check_keys(asset0.key) == {asset0.key}
+    assert asset_graph.get_execution_set_asset_and_check_keys(check0.spec.key) == {check0.spec.key}
 
 
 def test_required_assets_and_checks_by_key_asset_decorator(
@@ -773,9 +773,9 @@ def test_required_assets_and_checks_by_key_asset_decorator(
 
     grouped_keys = [asset0.key, foo_check.key, bar_check.key]
     for key in grouped_keys:
-        assert asset_graph.get_required_asset_and_check_keys(key) == set(grouped_keys)
+        assert asset_graph.get_execution_set_asset_and_check_keys(key) == set(grouped_keys)
 
-    assert asset_graph.get_required_asset_and_check_keys(check0.spec.key) == set()
+    assert asset_graph.get_execution_set_asset_and_check_keys(check0.spec.key) == {check0.spec.key}
 
 
 def test_required_assets_and_checks_by_key_multi_asset(
@@ -808,14 +808,14 @@ def test_required_assets_and_checks_by_key_multi_asset(
         bar_check.key,
     ]
     for key in grouped_keys:
-        assert asset_graph.get_required_asset_and_check_keys(key) == set(grouped_keys)
+        assert asset_graph.get_execution_set_asset_and_check_keys(key) == set(grouped_keys)
 
     for key in [
         AssetKey(["subsettable_asset0"]),
         AssetKey(["subsettable_asset1"]),
         biz_check.key,
     ]:
-        assert asset_graph.get_required_asset_and_check_keys(key) == set()
+        assert asset_graph.get_execution_set_asset_and_check_keys(key) == {key}
 
 
 def test_required_assets_and_checks_by_key_multi_asset_single_asset(
@@ -834,4 +834,4 @@ def test_required_assets_and_checks_by_key_multi_asset_single_asset(
     asset_graph = asset_graph_from_assets([asset_fn])
 
     for key in [AssetKey(["asset0"]), foo_check.key, bar_check.key]:
-        assert asset_graph.get_required_asset_and_check_keys(key) == set()
+        assert asset_graph.get_execution_set_asset_and_check_keys(key) == {key}

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -568,7 +568,7 @@ def test_basic_multi_asset():
         Definitions(assets=[assets], jobs=[assets_job])
     )
 
-    atomic_execution_unit_id = assets.unique_id
+    execution_set_identifier = assets.unique_id
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -584,7 +584,7 @@ def test_basic_multi_asset():
             job_names=["__ASSET_JOB", "assets_job"],
             output_name=f"out{i}",
             group_name=DEFAULT_GROUP_NAME,
-            atomic_execution_unit_id=atomic_execution_unit_id,
+            execution_set_identifier=execution_set_identifier,
         )
         for i in range(10)
     ]


### PR DESCRIPTION
## Summary & Motivation

The terminology around groups of assets/checks that must be executed together is currently a little mixed:

- `AssetGraph` has `get_required_multi_asset_keys` and `get_required_asset_and_check_keys`
- `ExternalAssetNode` and `ExternalAssetCheck` have a field `atomic_execution_unit_id`

It's not obvious that these are related to one another. This PR attempts to tighten up and standardize the terminology around the phrase "execution set":

- `AssetGraph.get_required_multi_asset_keys` -> `get_execution_set_asset_keys`
- `AssetGraph.get_required_asset_and_check_keys` -> `get_execution_set_asset_and_check_keys`
- `ExternalAsset{Node,Check}.atomic_execution_unit_id` -> `execution_set_id`

It also tweaks the return value of the `AssetGraph` functions-- the current behavior is to return an empty set for subsettable assets, which does not make sense for "execution sets"-- this changes it to return a set with a single element (the passed asset key).

## How I Tested These Changes

Existing test suite.