### PR TITLE
[external-assets] Create external assets defs for undefined assets in repo construction

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -32,6 +32,20 @@ SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE = "dagster/asset_execution_type"
 # `AutoMaterializeRule`.
 SYSTEM_METADATA_KEY_AUTO_OBSERVE_INTERVAL_MINUTES = "dagster/auto_observe_interval_minutes"
 
+# SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET lives on the metadata of external assets that are
+# created for undefined but referenced assets during asset graph normalization. For example, in the
+# below definitions, `foo` is referenced by upstream `bar` but has no corresponding definition:
+#
+#
+#     @asset(deps=["foo"])
+#     def bar(context: AssetExecutionContext):
+#         ...
+#
+#     defs=Definitions(assets=[bar])
+#
+# During normalization we create a "stub" definition for `foo` and attach this metadata to it.
+SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET = "dagster/auto_created_stub_asset"
+
 
 @whitelist_for_serdes
 class AssetExecutionType(Enum):

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -23,6 +23,7 @@ from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheck
 from dagster._core.definitions.asset_layer import get_dep_node_handles_of_graph_backed_asset
 from dagster._core.definitions.asset_spec import (
     SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE,
+    SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET,
     SYSTEM_METADATA_KEY_AUTO_OBSERVE_INTERVAL_MINUTES,
     AssetExecutionType,
 )
@@ -937,6 +938,15 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
                 f"Expected auto_observe_interval_minutes to be a number or None, not {value}"
             )
         return value
+
+    # Applies to AssetsDefinition that were auto-created because some asset referenced a key as a
+    # dependency, but no definition was provided for that key.
+    @property
+    def is_auto_created_stub(self) -> bool:
+        return (
+            self._get_external_asset_metadata_value(SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET)
+            is not None
+        )
 
     def _get_external_asset_metadata_value(self, metadata_key: str) -> object:
         first_key = next(iter(self.keys), None)

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -24,6 +24,10 @@ from dagster._config.pythonic_config import (
 )
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_spec import (
+    SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET,
+    AssetSpec,
+)
 from dagster._core.definitions.assets_job import (
     get_base_asset_jobs,
     is_base_asset_job_name,
@@ -32,7 +36,10 @@ from dagster._core.definitions.auto_materialize_sensor_definition import (
     AutoMaterializeSensorDefinition,
 )
 from dagster._core.definitions.executor_definition import ExecutorDefinition
-from dagster._core.definitions.external_asset import create_external_asset_from_source_asset
+from dagster._core.definitions.external_asset import (
+    create_external_asset_from_source_asset,
+    external_asset_from_spec,
+)
 from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.job_definition import JobDefinition
@@ -229,6 +236,7 @@ def build_caching_repository_data_from_list(
         elif isinstance(definition, SourceAsset):
             source_assets.append(definition)
             assets_defs.append(create_external_asset_from_source_asset(definition))
+            asset_keys.add(definition.key)
         elif isinstance(definition, AssetChecksDefinition):
             asset_checks_defs.append(definition)
         else:
@@ -246,6 +254,20 @@ def build_caching_repository_data_from_list(
         )
         for ad in assets_defs
     ]
+
+    # Create unexecutable external assets definitions for any referenced keys for which no
+    # definition was provided.
+    all_referenced_asset_keys = {
+        *(key for asset_def in assets_defs for key in asset_def.dependency_keys),
+        *(checks_def.asset_key for checks_def in asset_checks_defs),
+    }
+    for key in all_referenced_asset_keys.difference(asset_keys):
+        assets_defs.append(
+            external_asset_from_spec(
+                AssetSpec(key=key, metadata={SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET: True})
+            )
+        )
+        asset_keys.add(key)
 
     if assets_defs or source_assets or asset_checks_defs:
         for job_def in get_base_asset_jobs(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -405,21 +405,6 @@ def test_required_multi_asset_sets_same_op_in_different_assets(
         assert asset_graph.get_required_multi_asset_keys(asset_def.key) == set()
 
 
-def test_get_non_source_roots_missing_source(asset_graph_from_assets: Callable[..., AssetGraph]):
-    @asset
-    def foo():
-        pass
-
-    @asset(deps=["this_source_is_fake", "source_asset"])
-    def bar(foo):
-        pass
-
-    source_asset = SourceAsset("source_asset")
-
-    asset_graph = asset_graph_from_assets([foo, bar, source_asset])
-    assert asset_graph.get_materializable_roots(AssetKey("bar")) == {AssetKey("foo")}
-
-
 def test_partitioned_source_asset(asset_graph_from_assets: Callable[..., AssetGraph]):
     partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
@@ -84,19 +84,16 @@ def test_runs_base_sling_config(
 
 def test_with_custom_name(replication_config: SlingReplicationParam):
     @sling_assets(replication_config=replication_config)
-    def my_sling_assets():
-        ...
+    def my_sling_assets(): ...
 
     assert my_sling_assets.op.name == "my_sling_assets"
 
     @sling_assets(replication_config=replication_config)
-    def my_other_assets():
-        ...
+    def my_other_assets(): ...
 
     assert my_other_assets.op.name == "my_other_assets"
 
     @sling_assets(replication_config=replication_config, name="custom_name")
-    def my_third_sling_assets():
-        ...
+    def my_third_sling_assets(): ...
 
     assert my_third_sling_assets.op.name == "custom_name"


### PR DESCRIPTION
## Summary & Motivation

Currently it is possible for assets to be referenced as dependencies when they have no corresponding `AssetsDefinition` (only when using `deps`). This complicates implementation of the `AssetGraph` and `AssetLayer`.

This PR generates unexecutable external assets during repository construction (the same place source assets are converted to external assets) for any referenced keys without a corresponding user-provided definition.

## How I Tested These Changes

Existing test suite. One test was removed-- this made sure the internal asset graph could handle undefined asset references, but we no longer rely on this behavior.