### PR TITLE
Revert ParentAssetGraphDiffer

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -647,7 +647,6 @@ type AssetNode {
     limit: Int
   ): [ObservationEvent!]!
   backfillPolicy: BackfillPolicy
-  changedReasons: [ChangeReason!]!
   computeKind: String
   configField: ConfigTypeField
   dataVersion(partition: String): String
@@ -711,13 +710,6 @@ type BackfillPolicy {
 enum BackfillPolicyType {
   SINGLE_RUN
   MULTI_RUN
-}
-
-enum ChangeReason {
-  NEW
-  CODE_VERSION
-  INPUTS
-  PARTITIONS_DEFINITION
 }
 
 type AssetDependency {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -410,7 +410,6 @@ export type AssetNode = {
   assetPartitionStatuses: AssetPartitionStatuses;
   autoMaterializePolicy: Maybe<AutoMaterializePolicy>;
   backfillPolicy: Maybe<BackfillPolicy>;
-  changedReasons: Array<ChangeReason>;
   computeKind: Maybe<Scalars['String']>;
   configField: Maybe<ConfigTypeField>;
   currentAutoMaterializeEvaluationId: Maybe<Scalars['Int']>;
@@ -727,13 +726,6 @@ export type CapturedLogsMetadata = {
   stdoutDownloadUrl: Maybe<Scalars['String']>;
   stdoutLocation: Maybe<Scalars['String']>;
 };
-
-export enum ChangeReason {
-  CODE_VERSION = 'CODE_VERSION',
-  INPUTS = 'INPUTS',
-  NEW = 'NEW',
-  PARTITIONS_DEFINITION = 'PARTITIONS_DEFINITION',
-}
 
 export type ClaimedConcurrencySlot = {
   __typename: 'ClaimedConcurrencySlot';
@@ -6161,8 +6153,6 @@ export const buildAssetNode = (
         : relationshipsToOmit.has('BackfillPolicy')
         ? ({} as BackfillPolicy)
         : buildBackfillPolicy({}, relationshipsToOmit),
-    changedReasons:
-      overrides && overrides.hasOwnProperty('changedReasons') ? overrides.changedReasons! : [],
     computeKind:
       overrides && overrides.hasOwnProperty('computeKind') ? overrides.computeKind! : 'quasi',
     configField:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -21,7 +21,6 @@ from dagster import (
     MultiPartitionsDefinition,
     _check as check,
 )
-from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition import (
@@ -234,7 +233,6 @@ def get_asset_nodes_by_asset_key(
         context=graphene_info.context,
         asset_keys=asset_nodes_by_asset_key.keys(),
     )
-    base_deployment_context = graphene_info.context.get_base_deployment_context()
 
     return {
         external_asset_node.asset_key: GrapheneAssetNode(
@@ -245,15 +243,6 @@ def get_asset_nodes_by_asset_key(
             depended_by_loader=depended_by_loader,
             stale_status_loader=stale_status_loader,
             dynamic_partitions_loader=dynamic_partitions_loader,
-            # base_deployment_context will be None if we are not in a branch deployment
-            asset_graph_differ=AssetGraphDiffer.from_external_repositories(
-                code_location_name=repo_loc.name,
-                repository_name=repo.name,
-                branch_workspace=graphene_info.context,
-                base_workspace=base_deployment_context,
-            )
-            if base_deployment_context is not None
-            else None,
         )
         for repo_loc, repo, external_asset_node in asset_nodes_by_asset_key.values()
     }

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -6,7 +6,6 @@ from dagster import (
     DagsterInstance,
     _check as check,
 )
-from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
 from dagster._core.definitions.sensor_definition import (
@@ -275,17 +274,6 @@ class GrapheneRepository(graphene.ObjectType):
             asset_graph=lambda: ExternalAssetGraph.from_external_repository(repository),
         )
         self._dynamic_partitions_loader = CachingDynamicPartitionsLoader(instance)
-
-        self._asset_graph_differ = None
-        base_deployment_context = workspace_context.get_base_deployment_context()
-        if base_deployment_context is not None:
-            # then we are in a branch deployment
-            self._asset_graph_differ = AssetGraphDiffer.from_external_repositories(
-                code_location_name=self._repository_location.name,
-                repository_name=self._repository.name,
-                branch_workspace=workspace_context,
-                base_workspace=base_deployment_context,
-            )
         super().__init__(name=repository.name)
 
     def resolve_id(self, _graphene_info: ResolveInfo):
@@ -375,7 +363,6 @@ class GrapheneRepository(graphene.ObjectType):
                 asset_checks_loader=asset_checks_loader,
                 stale_status_loader=self._stale_status_loader,
                 dynamic_partitions_loader=self._dynamic_partitions_loader,
-                asset_graph_differ=self._asset_graph_differ,
             )
             for external_asset_node in self._repository.get_external_asset_nodes()
         ]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, cast
 import dagster._check as check
 import graphene
 from dagster import AssetCheckKey
-from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
@@ -961,8 +960,6 @@ class GrapheneQuery(graphene.ObjectType):
             asset_graph=load_asset_graph,
         )
 
-        base_deployment_context = graphene_info.context.get_base_deployment_context()
-
         nodes = [
             GrapheneAssetNode(
                 node.repository_location,
@@ -973,15 +970,6 @@ class GrapheneQuery(graphene.ObjectType):
                 depended_by_loader=depended_by_loader,
                 stale_status_loader=stale_status_loader,
                 dynamic_partitions_loader=dynamic_partitions_loader,
-                # base_deployment_context will be None if we are not in a branch deployment
-                asset_graph_differ=AssetGraphDiffer.from_external_repositories(
-                    code_location_name=node.repository_location.name,
-                    repository_name=node.external_repository.name,
-                    branch_workspace=graphene_info.context,
-                    base_workspace=base_deployment_context,
-                )
-                if base_deployment_context is not None
-                else None,
             )
             for node in results
         ]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence, Union
 import dagster._check as check
 import graphene
 from dagster._core.definitions import NodeHandle
-from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.host_representation import RepresentedJob
 from dagster._core.host_representation.external import ExternalJob
 from dagster._core.host_representation.historical import HistoricalJob
@@ -436,25 +435,8 @@ class ISolidDefinitionMixin:
             asset_checks_loader = AssetChecksLoader(
                 context=graphene_info.context, asset_keys=[node.asset_key for node in nodes]
             )
-
-            base_deployment_context = graphene_info.context.get_base_deployment_context()
-
             return [
-                GrapheneAssetNode(
-                    location,
-                    ext_repo,
-                    node,
-                    asset_checks_loader=asset_checks_loader,
-                    # base_deployment_context will be None if we are not in a branch deployment
-                    asset_graph_differ=AssetGraphDiffer.from_external_repositories(
-                        code_location_name=location.name,
-                        repository_name=ext_repo.name,
-                        branch_workspace=graphene_info.context,
-                        base_workspace=base_deployment_context,
-                    )
-                    if base_deployment_context is not None
-                    else None,
-                )
+                GrapheneAssetNode(location, ext_repo, node, asset_checks_loader=asset_checks_loader)
                 for node in nodes
             ]
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -54,7 +54,7 @@ class AssetGraphDiffer:
     ):
         if base_asset_graph is None:
             # if base_asset_graph is None, then the asset graph in the branch deployment does not exist
-            # in the base deployment
+            # in the parent deployment
             self._base_asset_graph = None
             self._base_asset_graph_load_fn = None
         elif isinstance(base_asset_graph, ExternalAssetGraph):
@@ -77,10 +77,10 @@ class AssetGraphDiffer:
         code_location_name: str,
         repository_name: str,
         branch_workspace: BaseWorkspaceRequestContext,
-        base_workspace: BaseWorkspaceRequestContext,
+        parent_workspace: BaseWorkspaceRequestContext,
     ) -> "AssetGraphDiffer":
-        """Constructs an AssetGraphDiffer for a particular repository in a code location for two
-        deployment workspaces, the base deployment and the branch deployment.
+        """Constructs a ParentAssetGraphDiffer for a particular repository in a code location for two
+        deployment workspaces, the parent deployment and the branch deployment.
 
         We cannot make ExternalAssetGraphs directly from the workspaces because if multiple code locations
         use the same asset key, those asset keys will override each other in the dictionaries the ExternalAssetGraph
@@ -90,7 +90,7 @@ class AssetGraphDiffer:
         that could override each other.
         """
         check.inst_param(branch_workspace, "branch_workspace", BaseWorkspaceRequestContext)
-        check.inst_param(base_workspace, "base_workspace", BaseWorkspaceRequestContext)
+        check.inst_param(parent_workspace, "parent_workspace", BaseWorkspaceRequestContext)
 
         branch_repo = _get_external_repo_from_context(
             branch_workspace, code_location_name, repository_name
@@ -99,23 +99,23 @@ class AssetGraphDiffer:
             raise DagsterInvariantViolationError(
                 f"Repository {repository_name} does not exist in code location {code_location_name} for the branch deployment."
             )
-        base_repo = _get_external_repo_from_context(
-            base_workspace, code_location_name, repository_name
+        parent_repo = _get_external_repo_from_context(
+            parent_workspace, code_location_name, repository_name
         )
         return AssetGraphDiffer(
             branch_asset_graph=lambda: ExternalAssetGraph.from_external_repository(branch_repo),
-            base_asset_graph=(lambda: ExternalAssetGraph.from_external_repository(base_repo))
-            if base_repo is not None
+            base_asset_graph=(lambda: ExternalAssetGraph.from_external_repository(parent_repo))
+            if parent_repo is not None
             else None,
         )
 
-    def _compare_base_and_branch_assets(self, asset_key: "AssetKey") -> Sequence[ChangeReason]:
+    def _compare_parent_and_branch_assets(self, asset_key: "AssetKey") -> Sequence[ChangeReason]:
         """Computes the diff between a branch deployment asset and the
-        corresponding base deployment asset.
+        corresponding parent deployment asset.
         """
         if self.base_asset_graph is None:
-            # if the base asset graph is None, it is because the the asset graph in the branch deployment
-            # is new and doesn't exist in the base deployment. Thus all assets are new.
+            # if the parent asset graph is None, it is because the the asset graph in the branch deployment
+            # is new and doesn't exist in the parent deployment. Thus all assets are new.
             return [ChangeReason.NEW]
 
         if asset_key not in self.base_asset_graph.all_asset_keys:
@@ -149,8 +149,8 @@ class AssetGraphDiffer:
         return changes
 
     def get_changes_for_asset(self, asset_key: "AssetKey") -> Sequence[ChangeReason]:
-        """Returns list of ChangeReasons for asset_key as compared to the base deployment."""
-        return self._compare_base_and_branch_assets(asset_key)
+        """Returns list of ChangeReasons for asset_key as compared to the parent deployment."""
+        return self._compare_parent_and_branch_assets(asset_key)
 
     @property
     def branch_asset_graph(self) -> "ExternalAssetGraph":

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -308,7 +308,7 @@ class BaseWorkspaceRequestContext(IWorkspace):
         code_location = self.get_code_location(code_location_name)
         return code_location.get_external_notebook_data(notebook_path=notebook_path)
 
-    def get_base_deployment_context(self) -> Optional["BaseWorkspaceRequestContext"]:
+    def get_parent_deployment_context(self) -> Optional["BaseWorkspaceRequestContext"]:
         return None
 
 

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -72,38 +72,38 @@ def _make_workspace_context(
 
 def get_asset_graph_differ(
     instance,
-    base_code_locations: List[str],
+    parent_code_locations: List[str],
     branch_code_location_to_definitions: Mapping[str, str],
     code_location_to_diff: str,
-) -> AssetGraphDiffer:
-    """Returns a, AssetGraphDiffer to compare a particular repository in a branch deployment to
-    the corresponding repository in the base deployment.
+):
+    """Returns a ParentAssetClassDiffer to compare a particular repository in a branch deployment to
+    the corresponding repository in the parent deployment.
 
-    For each deployment (base and branch) we need to create a workspace context with a set of code locations in it.
+    For each deployment (parent and branch) we need to create a workspace context with a set of code locations in it.
     The folders in asset_graph_scenarios define various code locations. Each folder contains a base_asset_graph.py file, which
-    contains the Definitions object for the base deployment. The remaining files in the folder (prefixed branch_deployment_*)
+    contains the Definitions object for the parent deployment. The remaining files in the folder (prefixed branch_deployment_*)
     are various modifications to the base_asset_graph.py file, to represent branch deployments that may be opened against
-    the base deployment. To make the workspace for each deployment, we need a list of code locations to load in the base deployment
+    the parent deployment. To make the workspace for each deployment, we need a list of code locations to load in the parent deployment
     and a mapping of code location names to definitions file names to load the correct changes in the branch deployment. Finally, we
-    need the name of the code location to compare between the branch deployment and base deployment.
+    need the name of the code location to compare between the branch deployment and parent deployment.
 
     Args:
         instance: A DagsterInstance
-        base_code_locations: List of code locations to load in the base deployment
+        parent_code_locations: List of code locations to load in the parent deployment
         branch_code_location_to_definitions: Mapping of code location to definitions file to load in the branch deployment
-        code_location_to_diff: Name of the code location to compute differences between base and branch deployments
+        code_location_to_diff: Name of the code location to compute differences between parent and branch deployments
     """
     branch_worksapce_ctx = _make_workspace_context(instance, branch_code_location_to_definitions)
 
-    base_worksapce_ctx = _make_workspace_context(
-        instance, {code_location: "base_asset_graph" for code_location in base_code_locations}
+    parent_worksapce_ctx = _make_workspace_context(
+        instance, {code_location: "base_asset_graph" for code_location in parent_code_locations}
     )
 
     return AssetGraphDiffer.from_external_repositories(
         code_location_name=code_location_to_diff,
         repository_name=SINGLETON_REPOSITORY_NAME,
         branch_workspace=branch_worksapce_ctx,
-        base_workspace=base_worksapce_ctx,
+        parent_workspace=parent_worksapce_ctx,
     )
 
 
@@ -111,7 +111,7 @@ def test_new_asset(instance):
     differ = get_asset_graph_differ(
         instance=instance,
         code_location_to_diff="basic_asset_graph",
-        base_code_locations=["basic_asset_graph"],
+        parent_code_locations=["basic_asset_graph"],
         branch_code_location_to_definitions={"basic_asset_graph": "branch_deployment_new_asset"},
     )
 
@@ -123,7 +123,7 @@ def test_new_asset_connected(instance):
     differ = get_asset_graph_differ(
         instance=instance,
         code_location_to_diff="basic_asset_graph",
-        base_code_locations=["basic_asset_graph"],
+        parent_code_locations=["basic_asset_graph"],
         branch_code_location_to_definitions={
             "basic_asset_graph": "branch_deployment_new_asset_connected"
         },
@@ -138,7 +138,7 @@ def test_update_code_version(instance):
     differ = get_asset_graph_differ(
         instance=instance,
         code_location_to_diff="code_versions_asset_graph",
-        base_code_locations=["code_versions_asset_graph"],
+        parent_code_locations=["code_versions_asset_graph"],
         branch_code_location_to_definitions={
             "code_versions_asset_graph": "branch_deployment_update_code_version"
         },
@@ -152,7 +152,7 @@ def test_change_inputs(instance):
     differ = get_asset_graph_differ(
         instance=instance,
         code_location_to_diff="basic_asset_graph",
-        base_code_locations=["basic_asset_graph"],
+        parent_code_locations=["basic_asset_graph"],
         branch_code_location_to_definitions={
             "basic_asset_graph": "branch_deployment_change_inputs"
         },
@@ -166,7 +166,7 @@ def test_multiple_changes_for_one_asset(instance):
     differ = get_asset_graph_differ(
         instance=instance,
         code_location_to_diff="code_versions_asset_graph",
-        base_code_locations=["code_versions_asset_graph"],
+        parent_code_locations=["code_versions_asset_graph"],
         branch_code_location_to_definitions={
             "code_versions_asset_graph": "branch_deployment_multiple_changes"
         },
@@ -183,7 +183,7 @@ def test_change_then_revert(instance):
     differ = get_asset_graph_differ(
         instance=instance,
         code_location_to_diff="code_versions_asset_graph",
-        base_code_locations=["code_versions_asset_graph"],
+        parent_code_locations=["code_versions_asset_graph"],
         branch_code_location_to_definitions={
             "code_versions_asset_graph": "branch_deployment_update_code_version"
         },
@@ -195,7 +195,7 @@ def test_change_then_revert(instance):
     differ = get_asset_graph_differ(
         instance=instance,
         code_location_to_diff="code_versions_asset_graph",
-        base_code_locations=["code_versions_asset_graph"],
+        parent_code_locations=["code_versions_asset_graph"],
         branch_code_location_to_definitions={"code_versions_asset_graph": "base_asset_graph"},
     )
 
@@ -207,7 +207,7 @@ def test_large_asset_graph(instance):
     differ = get_asset_graph_differ(
         instance=instance,
         code_location_to_diff="huge_asset_graph",
-        base_code_locations=["huge_asset_graph"],
+        parent_code_locations=["huge_asset_graph"],
         branch_code_location_to_definitions={
             "huge_asset_graph": "branch_deployment_restructure_graph"
         },
@@ -224,12 +224,12 @@ def test_large_asset_graph(instance):
 
 def test_multiple_code_locations(instance):
     # There are duplicate asset keys in the asset graphs of basic_asset_graph and code_versions_asset_graph
-    # this test ensures that the AssetGraphDiffer constructs AssetGraphs of the intended code location and does not
+    # this test ensures that the ParentAssetGraph differ constructs AssetGraphs of the intended code location and does not
     # include assets from other code locations
     differ = get_asset_graph_differ(
         instance=instance,
         code_location_to_diff="basic_asset_graph",
-        base_code_locations=["basic_asset_graph", "code_versions_asset_graph"],
+        parent_code_locations=["basic_asset_graph", "code_versions_asset_graph"],
         branch_code_location_to_definitions={
             "basic_asset_graph": "branch_deployment_new_asset_connected"
         },
@@ -245,7 +245,7 @@ def test_new_code_location(instance):
     differ = get_asset_graph_differ(
         instance=instance,
         code_location_to_diff="basic_asset_graph",
-        base_code_locations=[],
+        parent_code_locations=[],
         branch_code_location_to_definitions={"basic_asset_graph": "branch_deployment_new_asset"},
     )
     assert differ.get_changes_for_asset(AssetKey("new_asset")) == [ChangeReason.NEW]


### PR DESCRIPTION
This reverts https://github.com/dagster-io/dagster/pull/19814 and https://github.com/dagster-io/dagster/pull/19980 because we saw some performance issues with the changes issuing a new query for every asset.