### PR TITLE
[ui] Show date/time in run log timestamp tooltip

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/timestampToString.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/timestampToString.test.tsx
@@ -95,7 +95,7 @@ describe('timestampToString', () => {
 
   it('resolves to the same memoization key for the same config', () => {
     const expectedKey =
-      '1615708800000-en-US-America/Chicago-{"showTimezone":false,"showSeconds":false}-Automatic';
+      '1615708800000-en-US-America/Chicago-{"showTimezone":false,"showSeconds":false,"showMsec":false}-Automatic';
 
     expect(
       resolveTimestampKey({

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/TimestampFormat.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/TimestampFormat.tsx
@@ -1,9 +1,11 @@
 export type TimeFormat = {
   showTimezone?: boolean;
   showSeconds?: boolean;
+  showMsec?: boolean;
 };
 
 export const DEFAULT_TIME_FORMAT = {
   showTimezone: false,
   showSeconds: false,
+  showMsec: false,
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/timestampToString.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/timestampToString.tsx
@@ -51,6 +51,7 @@ export const timestampToString = memoize((config: Config) => {
     hour: 'numeric',
     minute: 'numeric',
     second: timeFormat.showSeconds ? 'numeric' : undefined,
+    fractionalSecondDigits: timeFormat.showMsec ? 3 : undefined,
     hourCycle: hourCycle === 'Automatic' ? undefined : hourCycle,
     timeZone: targetTimezone,
     timeZoneName: timeFormat.showTimezone ? 'short' : undefined,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -51,7 +51,6 @@ import {PAGE_SIZE} from '../AutoMaterializePolicyPage/useEvaluationsQueryResult'
 import {AssetKey} from '../types';
 
 export const AssetChecks = ({
-  lastMaterializationTimestamp,
   assetKey,
 }: {
   assetKey: AssetKey;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/util.tsx
@@ -13,7 +13,6 @@ export function assetCheckStatusDescription(
     return 'Not evaluated';
   }
   const status = lastExecution.status;
-  const date = lastExecution.timestamp;
   switch (status) {
     case AssetCheckExecutionResolvedStatus.EXECUTION_FAILED:
       return 'Execution failed';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowComponents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowComponents.tsx
@@ -1,4 +1,4 @@
-import {Colors, FontFamily, MetadataTable, Tooltip} from '@dagster-io/ui-components';
+import {Box, Colors, FontFamily, MetadataTable, Tooltip} from '@dagster-io/ui-components';
 import memoize from 'lodash/memoize';
 import qs from 'qs';
 import * as React from 'react';
@@ -11,6 +11,7 @@ import {formatElapsedTimeWithMsec} from '../app/Util';
 import {HourCycle} from '../app/time/HourCycle';
 import {TimeContext} from '../app/time/TimeContext';
 import {browserHourCycle, browserTimezone} from '../app/time/browserTimezone';
+import {TimestampDisplay} from '../schedules/TimestampDisplay';
 
 const bgcolorForLevel = (level: LogLevel) =>
   ({
@@ -162,37 +163,49 @@ export const TimestampColumn = React.memo((props: TimestampColumnProps) => {
       <Tooltip
         canShow={canShowTooltip}
         content={
-          <MetadataTable
-            spacing={0}
-            rows={[
-              {
-                key: 'Since start of run',
-                value: (
-                  <div
-                    style={{textAlign: 'right', fontFamily: FontFamily.monospace, fontSize: '13px'}}
-                  >
-                    {runElapsedTime}
-                  </div>
-                ),
-              },
-              stepStartTime
-                ? {
-                    key: 'Since start of step',
-                    value: (
-                      <div
-                        style={{
-                          textAlign: 'right',
-                          fontFamily: FontFamily.monospace,
-                          fontSize: '13px',
-                        }}
-                      >
-                        {stepElapsedTime}
-                      </div>
-                    ),
-                  }
-                : null,
-            ]}
-          />
+          <div>
+            <Box margin={{bottom: 8}}>
+              <TimestampDisplay
+                timestamp={Number(time) / 1000}
+                timeFormat={{showSeconds: true, showMsec: true, showTimezone: false}}
+              />
+            </Box>
+            <MetadataTable
+              spacing={0}
+              rows={[
+                {
+                  key: 'Since start of run',
+                  value: (
+                    <div
+                      style={{
+                        textAlign: 'right',
+                        fontFamily: FontFamily.monospace,
+                        fontSize: '13px',
+                      }}
+                    >
+                      {runElapsedTime}
+                    </div>
+                  ),
+                },
+                stepStartTime
+                  ? {
+                      key: 'Since start of step',
+                      value: (
+                        <div
+                          style={{
+                            textAlign: 'right',
+                            fontFamily: FontFamily.monospace,
+                            fontSize: '13px',
+                          }}
+                        >
+                          {stepElapsedTime}
+                        </div>
+                      ),
+                    }
+                  : null,
+              ]}
+            />
+          </div>
         }
         placement="left"
       >


### PR DESCRIPTION
## Summary & Motivation

Show the date/time in the run log timestamp tooltip. This should help with debugging runs that stretch over multiple days.

## How I Tested These Changes

View run logs from 2024 and 2023, with hour cycle value as both 12h and 24h. Hover on timestamp, verify that the date/time renders appropriately.

![Screenshot 2024-02-29 at 11.06.54.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/04l624FRNbtX4kJhQyXR/ee14dbff-ffd2-444e-abf6-39ba0fee13ec.png)

![Screenshot 2024-02-29 at 11.06.45.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/04l624FRNbtX4kJhQyXR/287f635f-8cf3-404f-8fad-8f535306954d.png)

![Screenshot 2024-02-29 at 11.06.34.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/04l624FRNbtX4kJhQyXR/a25c474f-de96-44de-b9b8-0048e0b01354.png)

