### PR TITLE
Remove use effect in SearchDialog that closes search if pathname changes.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -37,8 +37,10 @@ type Action =
 const reducer = (state: State, action: Action) => {
   switch (action.type) {
     case 'show-dialog':
+      console.log('showing dialog');
       return {...state, shown: true, loaded: true};
     case 'hide-dialog':
+      console.log('hiding dialog');
       return {...state, shown: false, queryString: '', primaryResults: [], secondaryResults: []};
     case 'highlight':
       return {...state, highlight: action.highlight};
@@ -60,7 +62,7 @@ const reducer = (state: State, action: Action) => {
 };
 
 const initialState: State = {
-  shown: false,
+  shown: true,
   queryString: '',
   searching: false,
   primaryResults: [],
@@ -145,10 +147,6 @@ export const SearchDialog = ({searchPlaceholder}: {searchPlaceholder: string}) =
     dispatch({type: 'change-query', queryString: newValue});
     debouncedSearch(newValue);
   };
-
-  React.useEffect(() => {
-    dispatch({type: 'hide-dialog'});
-  }, [location.pathname]);
 
   const onClickResult = React.useCallback(
     (result: Fuse.FuseResult<SearchResult>) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -37,10 +37,8 @@ type Action =
 const reducer = (state: State, action: Action) => {
   switch (action.type) {
     case 'show-dialog':
-      console.log('showing dialog');
       return {...state, shown: true, loaded: true};
     case 'hide-dialog':
-      console.log('hiding dialog');
       return {...state, shown: false, queryString: '', primaryResults: [], secondaryResults: []};
     case 'highlight':
       return {...state, highlight: action.highlight};
@@ -62,7 +60,7 @@ const reducer = (state: State, action: Action) => {
 };
 
 const initialState: State = {
-  shown: true,
+  shown: false,
   queryString: '',
   searching: false,
   primaryResults: [],


### PR DESCRIPTION
## Summary & Motivation

Some routes overwrite the URL but do so only after definition data is loaded (ex: OverviewTimeline)  so if you open the dialog too soon it ends up closing automatically, This PR removes that behavior. It should be safe since we hide the dialog whenever you select a result.

## How I Tested These Changes

Locally clicked results and saw the dialog close. Shadow-dagit saw dialog not close for KH when opened before definitions loaded