### PR TITLE
feat: adding --ngrok/--expose flag to dagster-dev/dagster-webserver t…

### DIFF
--- a/docs/content/guides/running-dagster-locally.mdx
+++ b/docs/content/guides/running-dagster-locally.mdx
@@ -54,6 +54,32 @@ If the `DAGSTER_HOME` environment variable is set, `dagster dev` will look for a
 
 For the full list of options that can be set in the `dagster.yaml` file, refer to the [Dagster instance documentation](/deployment/dagster-instance).
 
+### Exposing the dev server
+
+You can use [ngrok](https://ngrok.com/) to expose the `dagster dev` server to the internet. ngrok is a globally distributed gateway that provides secure connectivity for applications and services running in any environment.
+
+This can be useful for sharing your work with others or for testing integrations with external systems.
+
+You will need a free authtoken. To obtain one, sign up for free at [ngrok.com](https://dashboard.ngrok.com/signup) and retrieve it from the [authtoken page](https://dashboard.ngrok.com/get-started/your-authtoken) in your ngrok dashboard.
+
+Set `NGROK_AUTHTOKEN` on your shell:
+
+```bash
+export NGROK_AUTHTOKEN=your_token_here
+echo 'export NGROK_AUTHTOKEN=your_token_here' >> ~/.bashrc # or ~/.zshrc / ...
+```
+
+This token is your personal access token, so keep it secret and don't add it to your repository.
+
+Make sure the `ngrok` [Python package](https://pypi.org/project/ngrok/) is installed in the same environment where the `dagster` and `dagster-webserver` packages are installed and use the `--ngrok` flag.
+
+```bash
+pip3 install ngrok # if necessary
+dagster dev --ngrok
+```
+
+This will output your temporary ngrok URL on your console. You can share this link, which will stay valid until you shut down the dev server. To use permanent domains, limit access to the domain via OAuth, and to use other features, please see the [ngrok documentation](https://ngrok.com/docs/).
+
 ---
 
 ## Moving to production

--- a/docs/content/guides/running-dagster-locally.mdx
+++ b/docs/content/guides/running-dagster-locally.mdx
@@ -78,7 +78,18 @@ pip3 install ngrok # if necessary
 dagster dev --ngrok
 ```
 
-This will output your temporary ngrok URL on your console. You can share this link, which will stay valid until you shut down the dev server. To use permanent domains, limit access to the domain via OAuth, and to use other features, please see the [ngrok documentation](https://ngrok.com/docs/).
+This will output your temporary ngrok URL on your console. You can share this link, which will stay valid until you shut down the dev server.
+
+To use a static domain, you can set `NGROK_DAGSTER_DOMAIN`:
+
+```bash
+export NGROK_DAGSTER_DOMAIN=mydomain.ngrok.dev
+dagster dev --ngrok
+```
+
+Make sure you've registered your domain on your ngrok dashboard beforehand.
+
+For advanced features, such as limiting the access to the domain via OAuth, and to use other features, please see the [ngrok documentation](https://ngrok.com/docs/).
 
 ---
 

--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -185,7 +185,10 @@ DEFAULT_POOL_RECYCLE = 3600  # 1 hr
     "-n",
     "--expose",
     "use_ngrok",
-    help="Exposes the dagster webserver to the internet using ngrok. Requires NGROK_AUTHTOKEN to be set.",
+    help=(
+        "Exposes the dagster webserver to the internet using ngrok. Requires NGROK_AUTHTOKEN to be set."
+        "If you've configured a static ngrok domain, set NGROK_DAGSTER_DOMAIN to use that domain."
+    ),
     is_flag=True,
     show_default=True,
     default=False,
@@ -303,13 +306,19 @@ def host_dagster_ui_with_workspace_process_context(
                 "The --ngrok/--expose flag requires the NGROK_AUTHTOKEN environment variable to be set."
                 " You can find your auth token at https://https://dashboard.ngrok.com/get-started/your-authtoken"
             )
+        ngrok_domain = os.environ.get("NGROK_DAGSTER_DOMAIN", None)
         listener = ngrok.forward(
             f"{host}:{port}",
             authtoken_from_env=True,
+            domain=ngrok_domain,
         )
         logger.info(
             f"Serving dagster-webserver on {listener.url()} in process {os.getpid()} with ngrok"
         )
+        if not ngrok_domain:
+            logger.info(
+                "To use a static domain you've configured in your ngrok dashboard, set the NGROK_DAGSTER_DOMAIN environment variable."
+            )
     else:
         logger.info(
             f"Serving dagster-webserver on http://{host}:{port}{path_prefix} in process {os.getpid()}"

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -96,6 +96,17 @@ def dev_command_options(f):
     show_default=True,
     required=False,
 )
+@click.option(
+    "--ngrok",
+    "-n",
+    "--expose",
+    "use_ngrok",
+    help="Exposes the dagster webserver to the internet using ngrok. Requires NGROK_AUTHTOKEN to be set.",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    required=False,
+)
 @deprecated(
     breaking_version="2.0", subject="--dagit-port and --dagit-host args", emit_runtime_warning=False
 )
@@ -106,6 +117,7 @@ def dev_command(
     port: Optional[str],
     host: Optional[str],
     live_data_poll_rate: Optional[str],
+    use_ngrok: bool,
     **kwargs: ClickArgValue,
 ) -> None:
     # check if dagster-webserver installed, crash if not
@@ -117,7 +129,6 @@ def dev_command(
             " command. If you're using pip, you can install the dagster-webserver package by"
             ' running "pip install dagster-webserver" in your Python environment.'
         )
-
     os.environ["DAGSTER_IS_DEV_CLI"] = "1"
 
     configure_loggers(formatter=log_format, log_level=log_level.upper())
@@ -184,6 +195,7 @@ def dev_command(
             + (["--dagster-log-level", log_level])
             + (["--log-format", log_format])
             + (["--live-data-poll-rate", live_data_poll_rate] if live_data_poll_rate else [])
+            + (["--ngrok"] if use_ngrok else [])
             + args
         )
         daemon_process = open_ipc_subprocess(

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -101,7 +101,10 @@ def dev_command_options(f):
     "-n",
     "--expose",
     "use_ngrok",
-    help="Exposes the dagster webserver to the internet using ngrok. Requires NGROK_AUTHTOKEN to be set.",
+    help=(
+        "Exposes the dagster webserver to the internet using ngrok. Requires NGROK_AUTHTOKEN to be set."
+        "If you've configured a static ngrok domain, set NGROK_DAGSTER_DOMAIN to use that domain."
+    ),
     is_flag=True,
     show_default=True,
     default=False,


### PR DESCRIPTION
## Summary & Motivation

### What

This PR adds an optional flag to `dagster dev` to expose the dagster web server via [ngrok](https://ngrok.com), as `--ngrok`, aliased to `--expose`.

Technically also adds the same functionality to `dagster-webserver`.

Also adds documentation. 

### Why

While `dagster dev` doesn't replace a proper deployment and/or Dagster Cloud, it's still super useful to have the resulting web server available on the internet, quickly. 

My personal main use case is having the dagster ui available when working on our own dagster deployment, since we use headless Linux VMs as dev machines. 

It's also very useful to simply share a working branch of e.g. assets that rely on local infra and/or data with colleagues by simply handing them an ngrok link. You can, of course, also use some of the advanced features (traffic inspection, oauth, static domains etc) if you want to, which is neat.

But it's worth noting that this works just as well with just a free ngrok account, which I suspect most devs would use.

### 

```bash
export NGROK_AUTHTOKEN=your_token_here
dagster dev --ngrok # or dagster dev --expose
# dagster-webserver - INFO - Serving dagster-webserver on https://XXX.ngrok.app in process 89732 with ngrok
```

The resulting URL can be shared and stays valid until the dev server is closed. 

To use a static domain:

```bash 
export NGROK_AUTHTOKEN=your_token_here
export NGROK_DAGSTER_DOMAIN=mydomain.ngrok.dev
dagster dev --ngrok
```

We could also add more options later (e.g., auth) but this is the most barebones usage pattern that I think is most useful for most developers. I don't love the environment variables, but the token is a secret that shouldn't wind up on git + I did not want to pollute the CLI.

## How I Tested These Changes

### Bad Setup

```bash
unset NGROK_AUTHTOKEN
dagster dev --ngrok
...
2024-02-29 16:02:34 -0500 - dagster - INFO - Launching Dagster services...
2024-02-29 16:02:38 -0500 - dagster.daemon - INFO - Instance is configured with the following daemons: ['AssetDaemon', 'BackfillDaemon', 'SchedulerDaemon', 'SensorDaemon']
2024-02-29 16:02:39 -0500 - dagster-webserver - WARNING - Port 3000 is in use - using port 64293 instead
Usage: python -m dagster_webserver [OPTIONS]
Try 'python -m dagster_webserver --help' for help.

Error: The --ngrok/--expose flag requires the NGROK_AUTHTOKEN environment variable to be set. You can find your auth token at https://https://dashboard.ngrok.com/get-started/your-authtoken
2024-02-29 16:02:39 -0500 - dagster - ERROR - An unexpected exception has occurred
Traceback (most recent call last):
  File "/Users/christian/workspace/dagster/python_modules/dagster/dagster/_cli/dev.py", line 219, in dev_command
    raise Exception(
Exception: dagster-webserver process shut down unexpectedly with return code 2
2024-02-29 16:02:39 -0500 - dagster - INFO - Shutting down Dagster services...
2024-02-29 16:02:39 -0500 - dagster.daemon - INFO - Received interrupt, shutting down daemon threads...
2024-02-29 16:02:39 -0500 - dagster.daemon - INFO - Daemon threads shut down.
2024-02-29 16:02:39 -0500 - dagster - INFO - Dagster services shut down.
```

### Happy Path

```bash
export NGROK_AUTHTOKEN=token
dagster dev --ngrok                           ...
2024-02-29 16:04:39 -0500 - dagster - INFO - Launching Dagster services...
2024-02-29 16:04:43 -0500 - dagster.daemon - INFO - Instance is configured with the following daemons: ['AssetDaemon', 'BackfillDaemon', 'SchedulerDaemon', 'SensorDaemon']
2024-02-29 16:04:43 -0500 - dagster-webserver - WARNING - Port 3000 is in use - using port 64318 instead
2024-02-29 16:04:44 -0500 - dagster-webserver - INFO - Serving dagster-webserver on https://1e6ab2401606.ngrok.app in process 54965 with ngrok
```

Opening the resulting domain gets me access to the dagster environment + I see my tunnel in the ngrok web UI:

![image](https://github.com/dagster-io/dagster/assets/6397962/aa672d97-3321-488f-a855-435b33478fab)


![image](https://github.com/dagster-io/dagster/assets/6397962/df5e1f4c-0dd9-4895-8b39-90ed5ffbebe6)

### W/o the flag

Since this is 100% optional, this all work as it did before.

```bash
dagster dev         
...
2024-02-29 16:13:20 -0500 - dagster - INFO - Launching Dagster services...
2024-02-29 16:13:24 -0500 - dagster.daemon - INFO - Instance is configured with the following daemons: ['AssetDaemon', 'BackfillDaemon', 'SchedulerDaemon', 'SensorDaemon']
2024-02-29 16:13:24 -0500 - dagster-webserver - WARNING - Port 3000 is in use - using port 64696 instead
2024-02-29 16:13:24 -0500 - dagster-webserver - INFO - Serving dagster-webserver on http://127.0.0.1:64696 in process 65471
```

### Test w/ separate services/processes

This is only necessary for the web server, since everything else actually still runs locally. 

Setup

```bash
mkdir .dagster-home
export DAGSTER_HOME="$(pwd)/.dagster_home"
```

UI

```bash
dagster-webserver --expose -f complex_job.py                            
...
2024-02-29 16:20:01 -0500 - dagster-webserver - WARNING - Port 3000 is in use - using port 65000 instead
2024-02-29 16:20:01 -0500 - dagster-webserver - INFO - Serving dagster-webserver on https://7d3ff9e4ed1a.ngrok.app in process 75516 with ngrok
```

No services:

![image](https://github.com/dagster-io/dagster/assets/6397962/b3e11b5d-0571-4954-a66c-3e7d76cdd9f6)

And

```bash
dagster-daemon run
```

![image](https://github.com/dagster-io/dagster/assets/6397962/2c8ea0fe-114e-40a7-abff-762b3e61b6c5)

### Static Domain Test

```bash
export NGROK_DAGSTER_DOMAIN=XYZ.ngrok.dev # valid domain
dagster dev  --expose
...
Serving dagster-webserver on https://XYZ.ngrok.dev in process 31871 with ngrok
```

```bash
export NGROK_DAGSTER_DOMAIN=invaliddomain.ngrok.dev # invalid domain / not one i have registered
dagster dev  --expose
...
ValueError: ('failed to start listener', "You must reserve a custom hostname for your account before it can be bound.\nFailed to bind the domain 'invaliddomain.ngrok.dev' for the account 'XXX@example.org''.\nReserve this name on your dashboard: https://dashboard.ngrok.com/cloud-edge/domains/new", 'ERR_NGROK_319')
2024-02-29 17:01:18 -0500 - dagster - ERROR - An unexpected exception has occurred
2024-02-29 17:01:18 -0500 - dagster - INFO - Shutting down Dagster services...
2024-02-29 17:01:18 -0500 - dagster.daemon - INFO - Received interrupt, shutting down daemon threads...
2024-02-29 17:01:18 -0500 - dagster.daemon - INFO - Daemon threads shut down.
2024-02-29 17:01:19 -0500 - dagster - INFO - Dagster services shut down.
```

