### PR TITLE
Fix KH's laggy search input with this one weird trick

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/search/createSearchWorker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/createSearchWorker.tsx
@@ -12,7 +12,7 @@ type QueryListener = {
   listener: (response: QueryResponse) => void;
 };
 
-type QueryResponse = {queryString: string; results: Fuse.FuseResult<SearchResult>[]};
+export type QueryResponse = {queryString: string; results: Fuse.FuseResult<SearchResult>[]};
 
 export type WorkerSearchResult = {
   update: (results: SearchResult[]) => void;

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -1,5 +1,5 @@
 import {gql, useLazyQuery} from '@apollo/client';
-import React, {useCallback, useRef} from 'react';
+import {useCallback, useRef} from 'react';
 
 import {QueryResponse, WorkerSearchResult, createSearchWorker} from './createSearchWorker';
 import {SearchResult, SearchResultType} from './types';
@@ -218,7 +218,7 @@ export const useGlobalSearch = () => {
   const [performPrimaryLazyQuery, primaryResult] = primary;
   const [performSecondaryLazyQuery, secondaryResult] = secondary;
 
-  const consumeBufferEffect = React.useCallback(
+  const consumeBufferEffect = useCallback(
     async (
       buffer: typeof primarySearchBuffer | typeof secondarySearchBuffer,
       search: WorkerSearchResult,

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -230,15 +230,14 @@ export const useGlobalSearch = () => {
     [],
   );
 
-  // If we already have WebWorkers set up, initialization is complete and this will be a no-op.
   const initialize = useCallback(() => {
-    if (!primarySearch.current) {
+    if (!primaryResult.data && !primaryResult.loading) {
       performPrimaryLazyQuery();
     }
-    if (!secondarySearch.current) {
+    if (!secondaryResult.data && !secondaryResult.loading) {
       performSecondaryLazyQuery();
     }
-  }, [performPrimaryLazyQuery, performSecondaryLazyQuery]);
+  }, [performPrimaryLazyQuery, performSecondaryLazyQuery, primaryResult, secondaryResult]);
 
   const searchIndex = useCallback(
     (

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -230,14 +230,8 @@ export const useGlobalSearch = () => {
     [],
   );
 
-<<<<<<< HEAD
   const initialize = useCallback(() => {
     if (!primaryResult.data && !primaryResult.loading) {
-=======
-  // If we already have WebWorkers set up, initialization is complete and this will be a no-op.
-  const initialize = useCallback(() => {
-    if (!primarySearch.current) {
->>>>>>> e57f45fca9dfe37fd8dc75db0abd2a7218620315
       performPrimaryLazyQuery();
     }
     if (!secondaryResult.data && !secondaryResult.loading) {

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -219,10 +219,7 @@ export const useGlobalSearch = () => {
   const [performSecondaryLazyQuery, secondaryResult] = secondary;
 
   const consumeBufferEffect = useCallback(
-    async (
-      buffer: typeof primarySearchBuffer | typeof secondarySearchBuffer,
-      search: WorkerSearchResult,
-    ) => {
+    async (buffer: React.MutableRefObject<IndexBuffer | null>, search: WorkerSearchResult) => {
       const bufferValue = buffer.current;
       if (bufferValue) {
         buffer.current = null;
@@ -245,8 +242,8 @@ export const useGlobalSearch = () => {
 
   const searchIndex = useCallback(
     (
-      index: typeof primarySearch,
-      indexBuffer: typeof primarySearchBuffer,
+      index: React.MutableRefObject<WorkerSearchResult>,
+      indexBuffer: React.MutableRefObject<IndexBuffer | null>,
       query: string,
     ): Promise<QueryResponse> => {
       return new Promise(async (res) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -187,8 +187,8 @@ export const useGlobalSearch = () => {
   const secondarySearch = useRef<WorkerSearchResult | null>(null);
 
   const primary = useLazyQuery<SearchPrimaryQuery>(SEARCH_PRIMARY_QUERY, {
-    // Try to make aggressive use of workspace values from the Apollo cache.
-    fetchPolicy: 'cache-first',
+    // Don't use the cache because it is slow and we only make this request once so we don't need the cache
+    fetchPolicy: 'no-cache',
     onCompleted: (data: SearchPrimaryQuery) => {
       const results = primaryDataToSearchResults({data});
       if (!primarySearch.current) {
@@ -200,8 +200,8 @@ export const useGlobalSearch = () => {
   });
 
   const secondary = useLazyQuery<SearchSecondaryQuery>(SEARCH_SECONDARY_QUERY, {
-    // As above, try to aggressively use asset information from Apollo cache if possible.
-    fetchPolicy: 'cache-first',
+    // Don't use the cache because it is slow and we only make this request once so we don't need the cache
+    fetchPolicy: 'no-cache',
     onCompleted: (data: SearchSecondaryQuery) => {
       const results = secondaryDataToSearchResults({data});
       if (!secondarySearch.current) {

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -234,19 +234,21 @@ export const useGlobalSearch = () => {
   );
 
   // If we already have WebWorkers set up, initialization is complete and this will be a no-op.
-  const initialize = useCallback(async () => {
-    setTimeout(() => {
-      if (!primarySearch.current) {
-        performPrimaryLazyQuery();
-      }
-      if (!secondarySearch.current) {
-        performSecondaryLazyQuery();
-      }
-    }, 5000);
+  const initialize = useCallback(() => {
+    if (!primarySearch.current) {
+      performPrimaryLazyQuery();
+    }
+    if (!secondarySearch.current) {
+      performSecondaryLazyQuery();
+    }
   }, [performPrimaryLazyQuery, performSecondaryLazyQuery]);
 
   const searchIndex = useCallback(
-    (index: typeof primarySearch, indexBuffer: typeof primarySearchBuffer, query: string) => {
+    (
+      index: typeof primarySearch,
+      indexBuffer: typeof primarySearchBuffer,
+      query: string,
+    ): Promise<QueryResponse> => {
       return new Promise(async (res) => {
         if (index.current) {
           const result = await index.current.search(query);
@@ -264,7 +266,7 @@ export const useGlobalSearch = () => {
           }
           indexBuffer.current = {
             query,
-            resolve(response: typeof primaryResult) {
+            resolve(response: QueryResponse) {
               res(response);
             },
             cancel() {

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -242,7 +242,7 @@ export const useGlobalSearch = () => {
 
   const searchIndex = useCallback(
     (
-      index: React.MutableRefObject<WorkerSearchResult>,
+      index: React.MutableRefObject<WorkerSearchResult | null>,
       indexBuffer: React.MutableRefObject<IndexBuffer | null>,
       query: string,
     ): Promise<QueryResponse> => {

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -1,7 +1,7 @@
 import {gql, useLazyQuery} from '@apollo/client';
 import React, {useCallback, useRef} from 'react';
 
-import {WorkerSearchResult, createSearchWorker} from './createSearchWorker';
+import {QueryResponse, WorkerSearchResult, createSearchWorker} from './createSearchWorker';
 import {SearchResult, SearchResultType} from './types';
 import {SearchPrimaryQuery, SearchSecondaryQuery} from './types/useGlobalSearch.types';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
@@ -164,7 +164,7 @@ const EMPTY_RESPONSE = {queryString: '', results: []};
 
 type IndexBuffer = {
   query: string;
-  resolve: (value: any) => void;
+  resolve: (value: QueryResponse) => void;
   cancel: () => void;
 };
 
@@ -235,12 +235,14 @@ export const useGlobalSearch = () => {
 
   // If we already have WebWorkers set up, initialization is complete and this will be a no-op.
   const initialize = useCallback(async () => {
-    if (!primarySearch.current) {
-      performPrimaryLazyQuery();
-    }
-    if (!secondarySearch.current) {
-      performSecondaryLazyQuery();
-    }
+    setTimeout(() => {
+      if (!primarySearch.current) {
+        performPrimaryLazyQuery();
+      }
+      if (!secondarySearch.current) {
+        performSecondaryLazyQuery();
+      }
+    }, 5000);
   }, [performPrimaryLazyQuery, performSecondaryLazyQuery]);
 
   const searchIndex = useCallback(
@@ -301,7 +303,7 @@ export const useGlobalSearch = () => {
 
   return {
     initialize,
-    loading: primaryResult.loading || secondaryResult.loading,
+    loading: !primaryResult.data || !secondaryResult.data,
     searchPrimary,
     searchSecondary,
     terminate,


### PR DESCRIPTION
## Summary & Motivation

This fixes very long multi-second freeze ups that occur due to the apollo cache being very slow. We actually don't need the caching at all here because (1) we never make this query a second time, (2) there are no variables to the query, and (3) the worker already caches the results in memory.

## How I Tested These Changes

shadow-dagit, type a bunch of searches and observe that we never lock up the main thread for an extended period of time
