### PR TITLE
[RFC] Disable useQueryRefreshInterval background refresh while search is open

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
@@ -71,8 +71,9 @@ export function useQueryRefreshAtInterval(
       return;
     }
     if (
-      (documentVisible && documentVisiblityDidInterrupt.current) ||
-      (documentVisible && !searchVisible && searchVisibilityDidInterrupt.current)
+      documentVisible &&
+      !searchVisible &&
+      (searchVisibilityDidInterrupt.current || documentVisiblityDidInterrupt.current)
     ) {
       customRefetchRef.current ? customRefetchRef.current() : queryResultRef.current?.refetch();
       documentVisiblityDidInterrupt.current = false;

--- a/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
@@ -3,6 +3,7 @@ import {RefreshableCountdown, useCountdown} from '@dagster-io/ui-components';
 import {useEffect, useMemo, useRef, useState} from 'react';
 
 import {useDocumentVisibility} from '../hooks/useDocumentVisibility';
+import {isSearchVisible, useSearchVisibility} from '../search/useSearchVisibility';
 
 export const FIFTEEN_SECONDS = 15 * 1000;
 export const ONE_MONTH = 30 * 24 * 60 * 60 * 1000;
@@ -62,15 +63,22 @@ export function useQueryRefreshAtInterval(
   const documentVisiblityDidInterrupt = useRef(false);
   const documentVisible = useDocumentVisibility();
 
+  const searchVisibilityDidInterrupt = useRef(false);
+  const searchVisible = useSearchVisibility();
+
   useEffect(() => {
     if (!enabled) {
       return;
     }
-    if (documentVisible && documentVisiblityDidInterrupt.current) {
+    if (
+      (documentVisible && documentVisiblityDidInterrupt.current) ||
+      (documentVisible && !searchVisible && searchVisibilityDidInterrupt.current)
+    ) {
       customRefetchRef.current ? customRefetchRef.current() : queryResultRef.current?.refetch();
       documentVisiblityDidInterrupt.current = false;
+      searchVisibilityDidInterrupt.current = false;
     }
-  }, [documentVisible, enabled]);
+  }, [documentVisible, enabled, searchVisible]);
 
   useEffect(() => {
     clearTimeout(timer.current);
@@ -103,6 +111,10 @@ export function useQueryRefreshAtInterval(
         // If the document is no longer visible, mark that we have skipped an update rather
         // then updating in the background. We'll refresh when we return to the foreground.
         documentVisiblityDidInterrupt.current = true;
+        return;
+      }
+      if (isSearchVisible()) {
+        searchVisibilityDidInterrupt.current = true;
         return;
       }
       customRefetchRef.current ? customRefetchRef.current() : queryResultRef.current?.refetch();

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components';
 import {SearchResults} from './SearchResults';
 import {SearchResult} from './types';
 import {useGlobalSearch} from './useGlobalSearch';
+import {__updateSearchVisibility} from './useSearchVisibility';
 import {ShortcutHandler} from '../app/ShortcutHandler';
 import {useTrackEvent} from '../app/analytics';
 import {Trace, createTrace} from '../performance';
@@ -99,6 +100,7 @@ export const SearchDialog = ({searchPlaceholder}: {searchPlaceholder: string}) =
   }, [loading, primaryResults, secondaryResults]);
 
   React.useEffect(() => {
+    __updateSearchVisibility(shown);
     if (!shown && firstSearchTrace.current) {
       // When the dialog closes:
       // Either the trace finished and we logged it, or it didn't and so we throw it away
@@ -122,6 +124,13 @@ export const SearchDialog = ({searchPlaceholder}: {searchPlaceholder: string}) =
     },
     [searchSecondary],
   );
+
+  React.useEffect(() => {
+    console.log('SearchDialog intial render');
+    return () => {
+      console.log('SearchDialog unrender');
+    };
+  }, []);
 
   const debouncedSearch = React.useMemo(() => {
     const debouncedSearch = debounce(async (queryString: string) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -125,13 +125,6 @@ export const SearchDialog = ({searchPlaceholder}: {searchPlaceholder: string}) =
     [searchSecondary],
   );
 
-  React.useEffect(() => {
-    console.log('SearchDialog intial render');
-    return () => {
-      console.log('SearchDialog unrender');
-    };
-  }, []);
-
   const debouncedSearch = React.useMemo(() => {
     const debouncedSearch = debounce(async (queryString: string) => {
       searchAndHandlePrimary(queryString);

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useSearchVisibility.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useSearchVisibility.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+let _isSearchVisible = false;
+const _listeners: Array<(visible: boolean) => void> = [];
+
+export const useSearchVisibility = () => {
+  const [isSearchVisible, setIsSearchVisible] = React.useState(_isSearchVisible);
+
+  React.useEffect(() => {
+    _listeners.push(setIsSearchVisible);
+    return () => {
+      const index = _listeners.indexOf(setIsSearchVisible);
+      if (index !== -1) {
+        _listeners.splice(index, 1);
+      }
+    };
+  }, []);
+  return isSearchVisible;
+};
+
+export function __updateSearchVisibility(isVisible: boolean) {
+  if (_isSearchVisible !== isVisible) {
+    _isSearchVisible = isVisible;
+    _listeners.forEach((listener) => {
+      listener(_isSearchVisible);
+    });
+  }
+}
+
+export function isSearchVisible() {
+  return _isSearchVisible;
+}


### PR DESCRIPTION
## Summary & Motivation

Disabling the background refreshing while the search dialog is open so as to limit the amount of background activity that could cause the search experience to be laggy. Ideally I would love to allow the refresh request to go through but pause the the actual React updates but to do that I'd need to wrap `useQuery` which would require a lot of changes. Curious whether y'all think I should just do that instead? 

I think it makes sense to pause the background refreshing because searching signals an intent to navigate away meaning the results of the query **may** (may because it's possible they open in a new tab) not be used. 

## How I Tested These Changes

Tested with shadow-dagit with kraftheinz. This gets rid of all of the smaller mainthread locks that happen while search is open except for one caused by the very first fetch (we don't block the initial fetch) or ones caused by fetches that were in progress when it was opened.
