### PR TITLE
[embedded-elt] Fix a bug when creating a `SlingConnectionResource` where a blank keyword argument would be emitted as an environment variable

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -341,7 +341,6 @@ class SlingResource(ConfigurableResource):
             temp_dir = tempfile.gettempdir()
             temp_file = os.path.join(temp_dir, f"sling-replication-{uid}.json")
             env = os.environ.copy()
-            logger.info(f"env: {env}")
 
             with open(temp_file, "w") as file:
                 json.dump(replication_config, file, cls=sling.JsonEncoder)


### PR DESCRIPTION
## Summary & Motivation

When using a `SlingConnectionResource` with `SlingResource` using keyword arguments, the resource would emit an empty `url` keyword in the Environment Variable which shows up as `URL: None`. 
This would cause Sling to try and read the blank `url` keyword instead of the other keyword arguments in the database credentials.

## How I Tested These Changes

Added unit tests
