### PR TITLE
Add op_tags to observable source asset decorator

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset_decorator.py
@@ -98,3 +98,13 @@ def test_key_and_name_args():
         @observable_source_asset(name=["peach"], key=["peach", "nectarine"])
         def name_and_key_specified():
             ...
+
+
+def test_op_tags():
+    tags = {"foo": "bar"}
+
+    @observable_source_asset(op_tags=tags)
+    def op_tags_specified():
+        ...
+
+    assert op_tags_specified.op.tags == tags


### PR DESCRIPTION
## Summary & Motivation
Closes https://github.com/dagster-io/dagster/issues/20004

## How I Tested These Changes
Added unit test to check that `op_tags` are passed to the `Op`