### PR TITLE
[external-assets] Hoist resolution of input asset keys to RepositoryDataBuilder

### DIFF
--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -119,10 +119,6 @@ class AssetSelectionData(
 def generate_asset_dep_graph(
     assets_defs: Iterable["AssetsDefinition"], source_assets: Iterable["SourceAsset"]
 ) -> DependencyGraph[AssetKey]:
-    from dagster._core.definitions.resolved_asset_deps import ResolvedAssetDependencies
-
-    resolved_asset_deps = ResolvedAssetDependencies(assets_defs, source_assets)
-
     upstream: Dict[AssetKey, Set[AssetKey]] = {}
     downstream: Dict[AssetKey, Set[AssetKey]] = {}
     for assets_def in assets_defs:
@@ -130,10 +126,7 @@ def generate_asset_dep_graph(
             upstream[asset_key] = set()
             downstream[asset_key] = downstream.get(asset_key, set())
             # for each asset upstream of this one, set that as upstream, and this downstream of it
-            upstream_asset_keys = resolved_asset_deps.get_resolved_upstream_asset_keys(
-                assets_def, asset_key
-            )
-            for upstream_key in upstream_asset_keys:
+            for upstream_key in assets_def.asset_deps[asset_key]:
                 upstream[asset_key].add(upstream_key)
                 downstream[upstream_key] = downstream.get(upstream_key, set()) | {asset_key}
     return {"upstream": upstream, "downstream": downstream}

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -25,7 +25,6 @@ from dagster import (
 from dagster._core.definitions import asset, multi_asset
 from dagster._core.definitions.decorators.hook_decorator import failure_hook, success_hook
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.load_assets_from_modules import prefix_assets
 from dagster._core.definitions.partition import (
     StaticPartitionsDefinition,
@@ -35,7 +34,7 @@ from dagster._core.definitions.partitioned_schedule import build_schedule_from_p
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidSubsetError
 from dagster._core.execution.with_resources import with_resources
 from dagster._core.storage.tags import PARTITION_NAME_TAG
-from dagster._core.test_utils import instance_for_test
+from dagster._core.test_utils import create_test_asset_job, instance_for_test
 
 
 def _all_asset_keys(result):
@@ -222,15 +221,12 @@ def _get_assets_defs(use_multi: bool = False, allow_subset: bool = False):
     ],
 )
 def test_resolve_subset_job_errors(job_selection, use_multi, expected_error):
-    job_def = define_asset_job(name="some_name", selection=job_selection)
     if expected_error:
         expected_class, expected_message = expected_error
         with pytest.raises(expected_class, match=expected_message):
-            job_def.resolve(asset_graph=InternalAssetGraph.from_assets(_get_assets_defs(use_multi)))
+            create_test_asset_job(_get_assets_defs(use_multi), selection=job_selection)
     else:
-        assert job_def.resolve(
-            asset_graph=InternalAssetGraph.from_assets(_get_assets_defs(use_multi))
-        )
+        assert create_test_asset_job(_get_assets_defs(use_multi), selection=job_selection)
 
 
 @pytest.mark.parametrize(
@@ -276,14 +272,10 @@ def test_simple_graph_backed_asset_subset(job_selection, expected_assets):
     final_assets = with_resources([a_asset, b_asset, c_asset], {"asset_io_manager": io_manager_def})
 
     # run once so values exist to load from
-    define_asset_job("initial").resolve(
-        asset_graph=InternalAssetGraph.from_assets(final_assets)
-    ).execute_in_process()
+    create_test_asset_job(final_assets).execute_in_process()
 
     # now build the subset job
-    job = define_asset_job("asset_job", selection=job_selection).resolve(
-        asset_graph=InternalAssetGraph.from_assets(final_assets)
-    )
+    job = create_test_asset_job(final_assets, selection=job_selection)
 
     result = job.execute_in_process()
 
@@ -370,14 +362,10 @@ def test_define_selection_job(job_selection, expected_assets, use_multi, prefixe
     )
 
     # run once so values exist to load from
-    define_asset_job("initial").resolve(
-        asset_graph=InternalAssetGraph.from_assets(final_assets)
-    ).execute_in_process()
+    create_test_asset_job(final_assets).execute_in_process()
 
     # now build the subset job
-    job = define_asset_job("asset_job", selection=job_selection).resolve(
-        asset_graph=InternalAssetGraph.from_assets(final_assets)
-    )
+    job = create_test_asset_job(final_assets, selection=job_selection)
 
     with instance_for_test() as instance:
         result = job.execute_in_process(instance=instance)
@@ -462,9 +450,7 @@ def test_define_selection_job_assets_definition_selection():
 
     all_assets = [asset1, asset2, asset3]
 
-    job1 = define_asset_job("job1", selection=[asset1, asset2]).resolve(
-        asset_graph=InternalAssetGraph.from_assets(all_assets)
-    )
+    job1 = create_test_asset_job(all_assets, selection=[asset1, asset2])
     asset_keys = list(job1.asset_layer.asset_keys)
     assert len(asset_keys) == 2
     assert set(asset_keys) == {asset1.key, asset2.key}
@@ -481,9 +467,7 @@ def test_root_asset_selection():
         return a + 1
 
     # Source asset should not be included in the job
-    assert define_asset_job("job", selection="*b").resolve(
-        asset_graph=InternalAssetGraph.from_assets([a, b, SourceAsset("source")])
-    )
+    assert create_test_asset_job([a, b, SourceAsset("source")], selection="*b")
 
 
 def test_source_asset_selection_missing():
@@ -496,9 +480,7 @@ def test_source_asset_selection_missing():
         return a + 1
 
     with pytest.raises(DagsterInvalidDefinitionError, match="sources"):
-        define_asset_job("job", selection="*b").resolve(
-            asset_graph=InternalAssetGraph.from_assets([a, b])
-        )
+        create_test_asset_job([a, b], selection="*b")
 
 
 @asset
@@ -507,25 +489,19 @@ def foo():
 
 
 def test_executor_def():
-    job = define_asset_job("with_exec", executor_def=in_process_executor).resolve(
-        asset_graph=InternalAssetGraph.from_assets([foo])
-    )
+    job = create_test_asset_job([foo], executor_def=in_process_executor)
     assert job.executor_def == in_process_executor
 
 
 def test_tags():
     my_tags = {"foo": "bar"}
-    job = define_asset_job("with_tags", tags=my_tags).resolve(
-        asset_graph=InternalAssetGraph.from_assets([foo])
-    )
+    job = create_test_asset_job([foo], tags=my_tags)
     assert job.tags == my_tags
 
 
 def test_description():
     description = "Some very important description"
-    job = define_asset_job("with_tags", description=description).resolve(
-        asset_graph=InternalAssetGraph.from_assets([foo])
-    )
+    job = create_test_asset_job([foo], description=description)
     assert job.description == description
 
 
@@ -558,15 +534,15 @@ def test_config():
     def other_config_asset(context, config_asset):
         return config_asset + context.op_execution_context.op_config["val"]
 
-    job = define_asset_job(
-        "config_job",
+    job = create_test_asset_job(
+        [foo, config_asset, other_config_asset],
         config={
             "ops": {
                 "config_asset": {"config": {"val": 2}},
                 "other_config_asset": {"config": {"val": 3}},
             }
         },
-    ).resolve(asset_graph=InternalAssetGraph.from_assets([foo, config_asset, other_config_asset]))
+    )
 
     result = job.execute_in_process()
 
@@ -610,9 +586,7 @@ def test_subselect_config(selection, config):
         [foo, config_asset, other_config_asset],
         resource_defs={"asset_io_manager": io_manager_def},
     )
-    job = define_asset_job("config_job", config={"ops": config}, selection=selection).resolve(
-        asset_graph=InternalAssetGraph.from_assets(all_assets)
-    )
+    job = create_test_asset_job(all_assets, config={"ops": config}, selection=selection)
 
     result = job.execute_in_process()
 
@@ -621,8 +595,8 @@ def test_subselect_config(selection, config):
 
 def test_simple_partitions():
     partitions_def = HourlyPartitionsDefinition(start_date="2020-01-01-00:00")
-    job = define_asset_job("hourly", partitions_def=partitions_def).resolve(
-        asset_graph=InternalAssetGraph.from_assets(_get_partitioned_assets(partitions_def)),
+    job = create_test_asset_job(
+        _get_partitioned_assets(partitions_def), partitions_def=partitions_def
     )
     assert job.partitions_def == partitions_def
 
@@ -644,9 +618,7 @@ def test_hooks():
     def bar(_):
         pass
 
-    job = define_asset_job("with_hooks", hooks={foo, bar}).resolve(
-        asset_graph=InternalAssetGraph.from_assets([a, b])
-    )
+    job = create_test_asset_job([a, b], hooks={foo, bar})
     assert job.hook_defs == {foo, bar}
 
 
@@ -667,9 +639,7 @@ def test_hooks_with_resources():
     def bar(_):
         pass
 
-    job = define_asset_job("with_hooks", hooks={foo, bar}).resolve(
-        asset_graph=InternalAssetGraph.from_assets([a, b]), resource_defs={"a": 1, "b": 2, "c": 3}
-    )
+    job = create_test_asset_job([a, b], hooks={foo, bar}, resources={"a": 1, "b": 2, "c": 3})
     assert job.hook_defs == {foo, bar}
 
     defs = Definitions(
@@ -843,9 +813,8 @@ def test_op_retry_policy():
         tries["b"] += 1
         raise Exception()
 
-    job1 = define_asset_job("job", op_retry_policy=ops_retry_policy)
-    assert job1.op_retry_policy == ops_retry_policy
-    job1_resolved = job1.resolve(asset_graph=InternalAssetGraph.from_assets([a, b]))
-    job1_resolved.execute_in_process(raise_on_error=False)
+    job1 = create_test_asset_job([a, b], op_retry_policy=ops_retry_policy)
+    assert job1._op_retry_policy == ops_retry_policy  # noqa: SLF001
+    job1.execute_in_process(raise_on_error=False)
 
     assert tries == {"a": 3, "b": 4}

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -957,8 +957,8 @@ def test_multi_asset_sensor_has_assets():
 
     @multi_asset_sensor(monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")])
     def passing_sensor(context):
-        assert context.assets_defs_by_key[AssetKey("asset_a")] == two_assets
-        assert context.assets_defs_by_key[AssetKey("asset_b")] == two_assets
+        assert context.assets_defs_by_key[AssetKey("asset_a")].keys == two_assets.keys
+        assert context.assets_defs_by_key[AssetKey("asset_b")].keys == two_assets.keys
         assert len(context.assets_defs_by_key) == 2
 
     @repository


### PR DESCRIPTION
## Summary & Motivation

We have some hairy logic that resolves "relative" asset keys associated with asset inputs. Currently this resolution is done in multiple internal places, which complicates internal codepaths dealing with assets.

This PR hoists resolution to repository build time, in the same place that we convert source assets to assets def. This simplifies internal pathways.

In order to support this change, I had to alter tests that were directly calling `UnresolvedAssetsJobDefinition.resolve` with an `AssetGraph` to instead go through repository construction. With the external asset conversion happening at the repo level, this is something that needed to be done anyway.

## How I Tested These Changes

Existing test suite