### PR TITLE
[bugfix] Fix copying of metadata, description in assets_def.from_attributes

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1207,11 +1207,17 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
                 **replaced_group_names_by_key,
                 **group_names_by_key,
             },
-            metadata_by_key=replaced_metadata_by_key,
+            metadata_by_key={
+                **self._metadata_by_key,
+                **replaced_metadata_by_key,
+            },
             freshness_policies_by_key=replaced_freshness_policies_by_key,
             auto_materialize_policies_by_key=replaced_auto_materialize_policies_by_key,
             backfill_policy=backfill_policy if backfill_policy else self.backfill_policy,
-            descriptions_by_key=replaced_descriptions_by_key,
+            descriptions_by_key={
+                **self._descriptions_by_key,
+                **replaced_descriptions_by_key,
+            },
             is_subset=is_subset,
             check_specs_by_output_name=check_specs_by_output_name
             if check_specs_by_output_name
@@ -1221,7 +1227,8 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             else self._selected_asset_check_keys,
         )
 
-        return self.__class__(**merge_dicts(self.get_attributes_dict(), replaced_attributes))
+        merged_attrs = merge_dicts(self.get_attributes_dict(), replaced_attributes)
+        return self.__class__.dagster_internal_init(**merged_attrs)
 
     def _subset_graph_backed_asset(
         self,


### PR DESCRIPTION
## Summary & Motivation

Copying of descriptions and metadata did not work correctly in `with_attributes` (I discovered this in an upstack unrelated PR)-- instead of merging orig and replacements, replacements would totally overwrite the originals. This only manifested as a problem for graph-backed assets, I think because the original values could be inferred in the constructor for non-GBAs.

## How I Tested These Changes

New test.