### PR TITLE
[bk] Remove 3.11 restrictions, change python version fallback logic

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/package_spec.py
@@ -165,9 +165,9 @@ class PackageSpec:
                 pytest_python_versions = sorted(
                     list(set(default_python_versions) - set(unsupported_python_versions))
                 )
-                # Use lowest supported python version if no defaults match.
+                # Use highest supported python version if no defaults_match
                 if len(pytest_python_versions) == 0:
-                    pytest_python_versions = [supported_python_versions[0]]
+                    pytest_python_versions = [supported_python_versions[-1]]
 
                 for py_version in pytest_python_versions:
                     version_factor = AvailablePythonVersion.to_tox_factor(py_version)

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -355,17 +355,6 @@ def _unsupported_dagster_python_versions(tox_factor: Optional[str]) -> List[Avai
     if tox_factor == "general_tests_old_protobuf":
         return [AvailablePythonVersion.V3_11, AvailablePythonVersion.V3_12]
 
-    if (
-        tox_factor
-        in {
-            "cli_tests",  # test suite prone to hangs on unpinned grpcio version due to https://github.com/grpc/grpc/issues/31885
-        }
-    ):
-        return [AvailablePythonVersion.V3_11]
-
-    if tox_factor in {"scheduler_tests", "definitions_tests"}:
-        return [AvailablePythonVersion.V3_11]
-
     if tox_factor in {
         "definitions_tests_pendulum_1",
         "definitions_tests_pendulum_2",


### PR DESCRIPTION
## Summary & Motivation

- Remove 3.11 from list of "unsupported python versions" for core test suites-- this was added in the past when grpc was unstable on 3.11.
- When the default pytest python version is unsupported for a package, use the highest supported python version for tests instead of the lowest

## How I Tested These Changes

BK