### PR TITLE
Improve error message for missing check_specs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
@@ -76,10 +76,17 @@ class AssetCheckResult(
         self, step_context: "StepExecutionContext"
     ) -> AssetCheckEvaluation:
         spec_check_names_by_asset_key = (
-            step_context.job_def.asset_layer.get_check_names_by_asset_key_for_node_handle(
+            step_context.job_def.asset_layer.check_names_by_asset_key_by_node_handle.get(
                 step_context.node_handle.root
             )
         )
+
+        if not spec_check_names_by_asset_key:
+            raise DagsterInvariantViolationError(
+                "Received unexpected AssetCheckResult. No AssetCheckSpecs were found for this step."
+                "You may need to set `check_specs` on the asset decorator, or you may be emitting an "
+                "AssetCheckResult that isn't in the subset passed in `context.selected_asset_check_keys`."
+            )
 
         asset_keys_with_specs = spec_check_names_by_asset_key.keys()
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -695,11 +695,6 @@ class AssetLayer(NamedTuple):
             else None
         )
 
-    def get_check_names_by_asset_key_for_node_handle(
-        self, node_handle: NodeHandle
-    ) -> Mapping[AssetKey, AbstractSet[str]]:
-        return self.check_names_by_asset_key_by_node_handle[node_handle]
-
     def asset_checks_def_for_node(
         self, node_handle: NodeHandle
     ) -> Optional["AssetChecksDefinition"]:

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
@@ -197,6 +197,21 @@ def test_result_missing_check_name():
         materialize(assets=[asset1])
 
 
+def test_unexpected_result():
+    @asset
+    def my_asset():
+        yield AssetCheckResult(passed=True)
+
+    result = materialize(assets=[my_asset], raise_on_error=False)
+    assert not result.success
+    assert (
+        "Received unexpected AssetCheckResult. No AssetCheckSpecs were found for this step."
+        "You may need to set `check_specs` on the asset decorator, or you may be emitting an "
+        "AssetCheckResult that isn't in the subset passed in `context.selected_asset_check_keys`."
+        in result.get_step_failure_events()[0].step_failure_data.error.message
+    )
+
+
 def test_asset_check_fails_downstream_still_executes():
     @asset(check_specs=[AssetCheckSpec("check1", asset="asset1")])
     def asset1():


### PR DESCRIPTION
Previously if you forgot to put `check_specs` on your asset, you'd get

```
KeyError: NodeHandle(name='my_asset', parent=None)

Stack Trace:
  File "/Users/johann/dagster/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py", line 286, in dagster_event_sequence_for_step
    for step_event in check.generator(step_events):
  File "/Users/johann/dagster/python_modules/dagster/dagster/_core/execution/plan/execute_step.py", line 529, in core_dagster_event_sequence_for_step
    for user_event in _step_output_error_checked_user_event_sequence(
  File "/Users/johann/dagster/python_modules/dagster/dagster/_core/execution/plan/execute_step.py", line 202, in _step_output_error_checked_user_event_sequence
    for user_event in user_event_sequence:
  File "/Users/johann/dagster/python_modules/dagster/dagster/_core/execution/plan/execute_step.py", line 101, in _process_asset_results_to_events
    yield from _process_user_event(step_context, user_event)
  File "/Users/johann/dagster/python_modules/dagster/dagster/_core/execution/plan/execute_step.py", line 131, in _process_user_event
    asset_check_evaluation = user_event.to_asset_check_evaluation(step_context)
```

when you returned an AssetCheckResult.