### PR TITLE
[AssetCondition] Refactor the testing suite

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_state.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_state.py
@@ -1,0 +1,346 @@
+import dataclasses
+import datetime
+import json
+import os
+import sys
+from collections import namedtuple
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Iterable, NamedTuple, Optional, Sequence, Union, cast
+
+import mock
+import pendulum
+from dagster import (
+    AssetExecutionContext,
+    AssetKey,
+    AssetsDefinition,
+    AssetSpec,
+    AutoMaterializePolicy,
+    DagsterRunStatus,
+    Definitions,
+    PartitionsDefinition,
+    RunRequest,
+    RunsFilter,
+    SensorDefinition,
+    asset,
+    multi_asset,
+)
+from dagster._core.definitions import materialize
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.definitions_class import create_repository_using_definitions_args
+from dagster._core.definitions.events import CoercibleToAssetKey
+from dagster._core.definitions.executor_definition import in_process_executor
+from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
+from dagster._core.definitions.repository_definition.repository_definition import (
+    RepositoryDefinition,
+)
+from dagster._core.definitions.repository_definition.valid_definitions import (
+    SINGLETON_REPOSITORY_NAME,
+)
+from dagster._core.host_representation.external_data import external_repository_data_from_def
+from dagster._core.host_representation.origin import InProcessCodeLocationOrigin
+from dagster._core.instance import DagsterInstance
+from dagster._core.storage.tags import PARTITION_NAME_TAG
+from dagster._core.test_utils import (
+    InProcessTestWorkspaceLoadTarget,
+    create_test_daemon_workspace_context,
+)
+from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+from dagster._serdes.utils import create_snapshot_id
+from dagster._seven.compat.pendulum import pendulum_freeze_time
+from typing_extensions import Self
+
+from .base_scenario import run_request
+
+FAIL_TAG = "test/fail"
+
+
+def get_code_location_origin(
+    scenario_spec: "ScenarioSpec",
+    location_name="test_location",
+    repository_name=SINGLETON_REPOSITORY_NAME,
+) -> InProcessCodeLocationOrigin:
+    """Hacky method to allow us to point a code location at a module-scoped attribute, even though
+    the attribute is not defined until the scenario is run.
+    """
+    repository = create_repository_using_definitions_args(
+        name=repository_name,
+        assets=scenario_spec.assets,
+        executor=in_process_executor,
+        sensors=scenario_spec.sensors,
+    )
+
+    return _get_code_location_origin_from_repository(
+        cast(RepositoryDefinition, repository), location_name=location_name
+    )
+
+
+def _get_code_location_origin_from_repository(repository: RepositoryDefinition, location_name: str):
+    attribute_name = (
+        f"_asset_daemon_target_{create_snapshot_id(external_repository_data_from_def(repository))}"
+    )
+
+    if attribute_name not in globals():
+        globals()[attribute_name] = repository
+
+    return InProcessCodeLocationOrigin(
+        loadable_target_origin=LoadableTargetOrigin(
+            executable_path=sys.executable,
+            module_name=("dagster_tests.definitions_tests.auto_materialize_tests.scenario_state"),
+            working_directory=os.getcwd(),
+            attribute=attribute_name,
+        ),
+        location_name=location_name,
+    )
+
+
+class AssetSpecWithPartitionsDef(
+    namedtuple(
+        "AssetSpecWithPartitionsDef",
+        AssetSpec._fields + ("partitions_def",),
+        defaults=(None,) * (1 + len(AssetSpec._fields)),
+    )
+): ...
+
+
+class MultiAssetSpec(NamedTuple):
+    specs: Sequence[AssetSpec]
+    partitions_def: Optional[PartitionsDefinition] = None
+    can_subset: bool = False
+
+
+@dataclass(frozen=True)
+class ScenarioSpec:
+    """A construct for declaring and modifying a desired Definitions object."""
+
+    asset_specs: Sequence[Union[AssetSpec, AssetSpecWithPartitionsDef, MultiAssetSpec]]
+    current_time: datetime.datetime = field(default_factory=lambda: pendulum.now("UTC"))
+    sensors: Sequence[SensorDefinition] = field(default_factory=list)
+    additional_repo_specs: Sequence["ScenarioSpec"] = field(default_factory=list)
+
+    def with_sensors(self, sensors: Sequence[SensorDefinition]) -> "ScenarioSpec":
+        return dataclasses.replace(self, sensors=sensors)
+
+    @property
+    def assets(self) -> Sequence[AssetsDefinition]:
+        def compute_fn(context: AssetExecutionContext) -> None:
+            fail_keys = {
+                AssetKey.from_coercible(s)
+                for s in json.loads(context.run.tags.get(FAIL_TAG) or "[]")
+            }
+            for asset_key in context.selected_asset_keys:
+                if asset_key in fail_keys:
+                    raise Exception("Asset failed")
+
+        assets = []
+        for spec in self.asset_specs:
+            if isinstance(spec, MultiAssetSpec):
+
+                @multi_asset(**spec._asdict())
+                def _multi_asset(context: AssetExecutionContext):
+                    return compute_fn(context)
+
+                assets.append(_multi_asset)
+            else:
+                params = {
+                    "key",
+                    "deps",
+                    "group_name",
+                    "code_version",
+                    "auto_materialize_policy",
+                    "freshness_policy",
+                    "partitions_def",
+                }
+                assets.append(
+                    asset(
+                        compute_fn=compute_fn,
+                        **{k: v for k, v in spec._asdict().items() if k in params},
+                    )
+                )
+        return assets
+
+    @property
+    def defs(self) -> Definitions:
+        return Definitions(assets=self.assets, sensors=self.sensors)
+
+    @property
+    def asset_graph(self) -> AssetGraph:
+        return InternalAssetGraph.from_assets(self.assets)
+
+    def with_additional_repositories(
+        self,
+        scenario_specs: Sequence["ScenarioSpec"],
+    ) -> "ScenarioSpec":
+        return dataclasses.replace(
+            self, additional_repo_specs=[*self.additional_repo_specs, *scenario_specs]
+        )
+
+    def with_current_time(self, time: Union[str, datetime.datetime]) -> "ScenarioSpec":
+        if isinstance(time, str):
+            time = pendulum.parse(time)
+        return dataclasses.replace(self, current_time=time)
+
+    def with_current_time_advanced(self, **kwargs) -> "ScenarioSpec":
+        # hacky support for adding years
+        if "years" in kwargs:
+            kwargs["days"] = kwargs.get("days", 0) + 365 * kwargs.pop("years")
+        return dataclasses.replace(
+            self, current_time=self.current_time + datetime.timedelta(**kwargs)
+        )
+
+    def with_asset_properties(
+        self, keys: Optional[Iterable[CoercibleToAssetKey]] = None, **kwargs
+    ) -> "ScenarioSpec":
+        """Convenience method to update the properties of one or more assets in the scenario state."""
+        new_asset_specs = []
+        for spec in self.asset_specs:
+            if isinstance(spec, MultiAssetSpec):
+                partitions_def = kwargs.get("partitions_def", spec.partitions_def)
+                new_multi_specs = [
+                    s._replace(**{k: v for k, v in kwargs.items() if k != "partitions_def"})
+                    if keys is None or s.key in keys
+                    else s
+                    for s in spec.specs
+                ]
+                new_asset_specs.append(
+                    spec._replace(partitions_def=partitions_def, specs=new_multi_specs)
+                )
+            else:
+                if keys is None or spec.key in {AssetKey.from_coercible(key) for key in keys}:
+                    if "partitions_def" in kwargs:
+                        # partitions_def is not a field on AssetSpec, so we need to do this hack
+                        new_asset_specs.append(
+                            AssetSpecWithPartitionsDef(**{**spec._asdict(), **kwargs})
+                        )
+                    else:
+                        new_asset_specs.append(spec._replace(**kwargs))
+                else:
+                    new_asset_specs.append(spec)
+        return dataclasses.replace(self, asset_specs=new_asset_specs)
+
+    def with_all_eager(self, max_materializations_per_minute: int = 1) -> "ScenarioSpec":
+        return self.with_asset_properties(
+            auto_materialize_policy=AutoMaterializePolicy.eager(
+                max_materializations_per_minute=max_materializations_per_minute
+            )
+        )
+
+
+@dataclass(frozen=True)
+class ScenarioState:
+    """A reference to the state of a specific scenario alongside an instance."""
+
+    scenario_spec: ScenarioSpec
+    instance: DagsterInstance = field(default_factory=lambda: DagsterInstance.ephemeral())
+
+    @property
+    def current_time(self) -> datetime.datetime:
+        return self.scenario_spec.current_time
+
+    @property
+    def asset_graph(self) -> AssetGraph:
+        return self.scenario_spec.asset_graph
+
+    def with_current_time(self, time: str) -> Self:
+        return dataclasses.replace(self, scenario_spec=self.scenario_spec.with_current_time(time))
+
+    def with_current_time_advanced(self, **kwargs) -> Self:
+        return dataclasses.replace(
+            self, scenario_spec=self.scenario_spec.with_current_time_advanced(**kwargs)
+        )
+
+    def with_asset_properties(
+        self, keys: Optional[Iterable[CoercibleToAssetKey]] = None, **kwargs
+    ) -> Self:
+        return dataclasses.replace(
+            self, scenario_spec=self.scenario_spec.with_asset_properties(keys, **kwargs)
+        )
+
+    def with_runs(self, *run_requests: RunRequest) -> Self:
+        start = datetime.datetime.now()
+
+        def test_time_fn() -> float:
+            # this function will increment the current timestamp in real time, relative to the
+            # fake current_time on the scenario state
+            return (self.current_time + (datetime.datetime.now() - start)).timestamp()
+
+        with pendulum_freeze_time(self.current_time), mock.patch("time.time", new=test_time_fn):
+            for rr in run_requests:
+                materialize(
+                    assets=self.scenario_spec.assets,
+                    instance=self.instance,
+                    partition_key=rr.partition_key,
+                    tags=rr.tags,
+                    raise_on_error=False,
+                    selection=rr.asset_selection,
+                )
+        # increment current_time by however much time elapsed during the materialize call
+        return dataclasses.replace(
+            self,
+            scenario_spec=self.scenario_spec.with_current_time(
+                pendulum.from_timestamp(test_time_fn())
+            ),
+        )
+
+    def with_not_started_runs(self) -> Self:
+        """Execute all runs in the NOT_STARTED state and delete them from the instance. The scenario
+        adds in the run requests from previous ticks as runs in the NOT_STARTED state, so this method
+        executes requested runs from previous ticks.
+        """
+        not_started_runs = self.instance.get_runs(
+            filters=RunsFilter(statuses=[DagsterRunStatus.NOT_STARTED])
+        )
+        for run in not_started_runs:
+            self.instance.delete_run(run_id=run.run_id)
+        return self.with_runs(
+            *[
+                run_request(
+                    asset_keys=list(run.asset_selection or set()),
+                    partition_key=run.tags.get(PARTITION_NAME_TAG),
+                )
+                for run in not_started_runs
+            ]
+        )
+
+    def with_dynamic_partitions(
+        self, partitions_def_name: str, partition_keys: Sequence[str]
+    ) -> Self:
+        self.instance.add_dynamic_partitions(
+            partitions_def_name=partitions_def_name, partition_keys=partition_keys
+        )
+        return self
+
+    def start_sensor(self, sensor_name: str) -> Self:
+        with self._get_external_sensor(sensor_name) as sensor:
+            self.instance.start_sensor(sensor)
+        return self
+
+    def stop_sensor(self, sensor_name: str) -> Self:
+        with self._get_external_sensor(sensor_name) as sensor:
+            self.instance.stop_sensor(sensor.get_external_origin_id(), sensor.selector_id, sensor)
+        return self
+
+    @contextmanager
+    def _get_external_sensor(self, sensor_name):
+        with self._create_workspace_context() as workspace_context:
+            workspace = workspace_context.create_request_context()
+            sensor = next(
+                iter(workspace.get_code_location("test_location").get_repositories().values())
+            ).get_external_sensor(sensor_name)
+            assert sensor
+            yield sensor
+
+    @contextmanager
+    def _create_workspace_context(self):
+        origins = [
+            _get_code_location_origin_from_repository(
+                scenario_spec.defs.get_repository_def(), f"extra_location_{i}"
+            )
+            for i, scenario_spec in enumerate(self.scenario_spec.additional_repo_specs)
+        ] + [get_code_location_origin(self.scenario_spec)]
+
+        target = InProcessTestWorkspaceLoadTarget(origins)
+        with create_test_daemon_workspace_context(
+            workspace_load_target=target, instance=self.instance
+        ) as workspace_context:
+            yield workspace_context

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario_states.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario_states.py
@@ -10,7 +10,7 @@ from dagster._core.definitions.time_window_partitions import (
     HourlyPartitionsDefinition,
 )
 
-from ..asset_daemon_scenario import AssetDaemonScenarioState, MultiAssetSpec
+from ..scenario_state import MultiAssetSpec, ScenarioSpec
 
 ############
 # PARTITIONS
@@ -36,25 +36,25 @@ self_partition_mapping = TimeWindowPartitionMapping(start_offset=-1, end_offset=
 ##############
 # BASIC STATES
 ##############
-one_asset = AssetDaemonScenarioState(asset_specs=[AssetSpec("A")])
+one_asset = ScenarioSpec(asset_specs=[AssetSpec("A")])
 
-two_assets_in_sequence = AssetDaemonScenarioState(
+two_assets_in_sequence = ScenarioSpec(
     asset_specs=[AssetSpec("A"), AssetSpec("B", deps=["A"])],
 )
 
-three_assets_in_sequence = AssetDaemonScenarioState(
+three_assets_in_sequence = ScenarioSpec(
     asset_specs=[AssetSpec("A"), AssetSpec("B", deps=["A"]), AssetSpec("C", deps=["B"])],
 )
 
-two_assets_depend_on_one = AssetDaemonScenarioState(
+two_assets_depend_on_one = ScenarioSpec(
     asset_specs=[AssetSpec("A"), AssetSpec("B", deps=["A"]), AssetSpec("C", deps=["A"])]
 )
 
-one_asset_depends_on_two = AssetDaemonScenarioState(
+one_asset_depends_on_two = ScenarioSpec(
     asset_specs=[AssetSpec("A"), AssetSpec("B"), AssetSpec("C", deps=["A", "B"])]
 )
 
-diamond = AssetDaemonScenarioState(
+diamond = ScenarioSpec(
     asset_specs=[
         AssetSpec(key="A"),
         AssetSpec(key="B", deps=["A"]),
@@ -63,12 +63,8 @@ diamond = AssetDaemonScenarioState(
     ]
 )
 
-three_assets_not_subsettable = AssetDaemonScenarioState(
-    asset_specs=[
-        MultiAssetSpec(
-            specs=[AssetSpec("A"), AssetSpec("B"), AssetSpec("C")],
-        )
-    ]
+three_assets_not_subsettable = ScenarioSpec(
+    asset_specs=[MultiAssetSpec(specs=[AssetSpec("A"), AssetSpec("B"), AssetSpec("C")])]
 )
 
 ##################

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/basic_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/basic_scenarios.py
@@ -5,10 +5,10 @@ from dagster._core.definitions.auto_materialize_rule_evaluation import (
 
 from ..asset_daemon_scenario import (
     AssetDaemonScenario,
-    AssetDaemonScenarioState,
     AssetRuleEvaluationSpec,
 )
 from ..base_scenario import run_request
+from ..scenario_state import ScenarioSpec
 from .asset_daemon_scenario_states import (
     diamond,
     one_asset,
@@ -21,7 +21,7 @@ from .asset_daemon_scenario_states import (
 basic_scenarios = [
     AssetDaemonScenario(
         id="one_asset_never_materialized",
-        initial_state=one_asset.with_all_eager(),
+        initial_spec=one_asset.with_all_eager(),
         execution_fn=lambda state: state.evaluate_tick()
         .assert_requested_runs(run_request(asset_keys=["A"]))
         .assert_evaluation(
@@ -30,7 +30,7 @@ basic_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_asset_already_launched",
-        initial_state=one_asset.with_all_eager(),
+        initial_spec=one_asset.with_all_eager(),
         execution_fn=lambda state: state.evaluate_tick()
         .assert_requested_runs(run_request(asset_keys=["A"]))
         .evaluate_tick()
@@ -38,7 +38,7 @@ basic_scenarios = [
     ),
     AssetDaemonScenario(
         id="two_assets_in_sequence_never_materialized",
-        initial_state=two_assets_in_sequence.with_all_eager(),
+        initial_spec=two_assets_in_sequence.with_all_eager(),
         execution_fn=lambda state: state.evaluate_tick()
         .assert_requested_runs(run_request(asset_keys=["A", "B"]))
         .assert_evaluation(
@@ -60,7 +60,7 @@ basic_scenarios = [
     ),
     AssetDaemonScenario(
         id="parent_materialized_child_not",
-        initial_state=two_assets_in_sequence.with_all_eager(),
+        initial_spec=two_assets_in_sequence.with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(["A"]))
         .evaluate_tick()
         .assert_requested_runs(run_request(["B"]))
@@ -82,7 +82,7 @@ basic_scenarios = [
     ),
     AssetDaemonScenario(
         id="parent_materialized_launch_two_children",
-        initial_state=two_assets_depend_on_one.with_all_eager(),
+        initial_spec=two_assets_depend_on_one.with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(["A"]))
         .evaluate_tick()
         .assert_requested_runs(run_request(["B", "C"]))
@@ -115,7 +115,7 @@ basic_scenarios = [
     ),
     AssetDaemonScenario(
         id="parent_materialized_with_source_asset_launch_child",
-        initial_state=AssetDaemonScenarioState(
+        initial_spec=ScenarioSpec(
             asset_specs=[AssetSpec("A"), AssetSpec("B", deps=["A", "source"])]
         ).with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(["A"]))
@@ -124,7 +124,7 @@ basic_scenarios = [
     ),
     AssetDaemonScenario(
         id="parent_rematerialized_after_tick",
-        initial_state=two_assets_in_sequence.with_all_eager(),
+        initial_spec=two_assets_in_sequence.with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(["A", "B"]))
         .evaluate_tick()
         .assert_requested_runs()
@@ -137,14 +137,14 @@ basic_scenarios = [
     ),
     AssetDaemonScenario(
         id="parent_rematerialized",
-        initial_state=two_assets_in_sequence.with_all_eager(),
+        initial_spec=two_assets_in_sequence.with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(["A", "B"]), run_request(["A"]))
         .evaluate_tick()
         .assert_requested_runs(run_request(["B"])),
     ),
     AssetDaemonScenario(
         id="one_parent_materialized_other_never_materialized",
-        initial_state=one_asset_depends_on_two.with_all_eager(),
+        initial_spec=one_asset_depends_on_two.with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(["A"]))
         .evaluate_tick()
         .assert_requested_runs(run_request(["B", "C"]))
@@ -161,7 +161,7 @@ basic_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_parent_materialized_others_materialized_before",
-        initial_state=one_asset_depends_on_two.with_all_eager(),
+        initial_spec=one_asset_depends_on_two.with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(["A", "B", "C"]))
         .evaluate_tick()
         .assert_requested_runs()
@@ -183,21 +183,21 @@ basic_scenarios = [
     ),
     AssetDaemonScenario(
         id="diamond_never_materialized",
-        initial_state=diamond.with_all_eager(),
+        initial_spec=diamond.with_all_eager(),
         execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
             run_request(["A", "B", "C", "D"])
         ),
     ),
     AssetDaemonScenario(
         id="diamond_only_root_materialized",
-        initial_state=diamond.with_all_eager(),
+        initial_spec=diamond.with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(["A"]))
         .evaluate_tick()
         .assert_requested_runs(run_request(["B", "C", "D"])),
     ),
     AssetDaemonScenario(
         id="diamond_root_rematerialized",
-        initial_state=diamond.with_all_eager(),
+        initial_spec=diamond.with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(["A", "B", "C", "D"]))
         .evaluate_tick()
         .assert_requested_runs()
@@ -243,7 +243,7 @@ basic_scenarios = [
     ),
     AssetDaemonScenario(
         id="diamond_root_and_one_in_middle_rematerialized",
-        initial_state=diamond.with_all_eager(),
+        initial_spec=diamond.with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(["A", "B", "C", "D"]))
         .evaluate_tick()
         .assert_requested_runs()
@@ -253,7 +253,7 @@ basic_scenarios = [
     ),
     AssetDaemonScenario(
         id="diamond_root_and_sink_rematerialized",
-        initial_state=diamond.with_all_eager(),
+        initial_spec=diamond.with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(["A", "B", "C", "D"]))
         .evaluate_tick()
         .assert_requested_runs()
@@ -263,14 +263,14 @@ basic_scenarios = [
     ),
     AssetDaemonScenario(
         id="parents_materialized_separate_runs",
-        initial_state=three_assets_in_sequence.with_all_eager(),
+        initial_spec=three_assets_in_sequence.with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(["A"]), run_request(["B"]))
         .evaluate_tick()
         .assert_requested_runs(run_request(["C"])),
     ),
     AssetDaemonScenario(
         id="parent_materialized_twice",
-        initial_state=two_assets_in_sequence.with_all_eager(),
+        initial_spec=two_assets_in_sequence.with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(["A"]), run_request(["A"]))
         .evaluate_tick()
         .assert_requested_runs(run_request(["B"]))
@@ -279,7 +279,7 @@ basic_scenarios = [
     ),
     AssetDaemonScenario(
         id="parent_rematerialized_twice",
-        initial_state=two_assets_in_sequence.with_all_eager(),
+        initial_spec=two_assets_in_sequence.with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(["A", "B"]))
         .evaluate_tick()
         .assert_requested_runs()

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
@@ -47,7 +47,7 @@ basic_hourly_cron_rule = AutoMaterializeRule.materialize_on_cron(
 cron_scenarios = [
     AssetDaemonScenario(
         id="basic_hourly_cron_unpartitioned",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             auto_materialize_policy=get_cron_policy(basic_hourly_cron_schedule)
         ).with_current_time("2020-01-01T00:05"),
         execution_fn=lambda state: state.evaluate_tick()
@@ -73,7 +73,7 @@ cron_scenarios = [
     ),
     AssetDaemonScenario(
         id="basic_hourly_cron_unpartitioned_multi_asset",
-        initial_state=three_assets_not_subsettable.with_asset_properties(
+        initial_spec=three_assets_not_subsettable.with_asset_properties(
             auto_materialize_policy=get_cron_policy(basic_hourly_cron_schedule)
         ).with_current_time("2020-01-01T00:05"),
         execution_fn=lambda state: state.evaluate_tick()
@@ -90,7 +90,7 @@ cron_scenarios = [
     ),
     AssetDaemonScenario(
         id="basic_hourly_cron_partitioned",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             partitions_def=hourly_partitions_def,
             auto_materialize_policy=get_cron_policy(basic_hourly_cron_schedule),
         )
@@ -121,7 +121,7 @@ cron_scenarios = [
     ),
     AssetDaemonScenario(
         id="basic_hourly_cron_partitioned_with_timezone",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             auto_materialize_policy=get_cron_policy("@daily", cron_timezone="America/Los_Angeles"),
             partitions_def=daily_partitions_def,
         ).with_current_time("2020-01-02T12:00"),
@@ -142,7 +142,7 @@ cron_scenarios = [
     ),
     AssetDaemonScenario(
         id="hourly_cron_unpartitioned_wait_for_parents",
-        initial_state=one_asset_depends_on_two.with_asset_properties(
+        initial_spec=one_asset_depends_on_two.with_asset_properties(
             keys="C", auto_materialize_policy=get_cron_policy(basic_hourly_cron_schedule)
         ).with_current_time("2020-01-01T00:05"),
         execution_fn=lambda state: state.evaluate_tick()
@@ -205,7 +205,7 @@ cron_scenarios = [
     ),
     AssetDaemonScenario(
         id="hourly_cron_partitioned_wait_for_parents",
-        initial_state=one_asset_depends_on_two.with_asset_properties(
+        initial_spec=one_asset_depends_on_two.with_asset_properties(
             partitions_def=hourly_partitions_def,
         )
         .with_asset_properties(
@@ -364,7 +364,7 @@ cron_scenarios = [
     ),
     AssetDaemonScenario(
         id="hourly_cron_all_partitions",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             auto_materialize_policy=get_cron_policy(
                 basic_hourly_cron_schedule,
                 all_partitions=True,
@@ -391,7 +391,7 @@ cron_scenarios = [
     ),
     AssetDaemonScenario(
         id="dynamic_cron_all_partitions",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             partitions_def=dynamic_partitions_def,
             auto_materialize_policy=get_cron_policy(
                 basic_hourly_cron_schedule,
@@ -423,7 +423,7 @@ cron_scenarios = [
     ),
     AssetDaemonScenario(
         id="dynamic_cron_last_partition",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             partitions_def=dynamic_partitions_def,
             auto_materialize_policy=get_cron_policy(
                 basic_hourly_cron_schedule,
@@ -449,7 +449,7 @@ cron_scenarios = [
     ),
     AssetDaemonScenario(
         id="hourly_cron_unpartitioned_wait_for_parents_with_cron_skip",
-        initial_state=one_asset_depends_on_two.with_asset_properties(
+        initial_spec=one_asset_depends_on_two.with_asset_properties(
             keys="C",
             auto_materialize_policy=get_cron_policy(
                 basic_hourly_cron_schedule, use_cron_skip_rule=True
@@ -499,7 +499,7 @@ cron_scenarios = [
     ),
     AssetDaemonScenario(
         id="hourly_cron_unpartitioned_wait_for_parents_with_cron_skip_single_run",
-        initial_state=one_asset_depends_on_two.with_asset_properties(
+        initial_spec=one_asset_depends_on_two.with_asset_properties(
             # all assets get this policy
             auto_materialize_policy=get_cron_policy(
                 basic_hourly_cron_schedule, use_cron_skip_rule=True
@@ -519,7 +519,7 @@ cron_scenarios = [
     ),
     AssetDaemonScenario(
         id="hourly_cron_partitioned_wait_for_parents_with_cron_skip",
-        initial_state=one_asset_depends_on_two.with_asset_properties(
+        initial_spec=one_asset_depends_on_two.with_asset_properties(
             partitions_def=hourly_partitions_def,
         )
         .with_asset_properties(
@@ -571,7 +571,7 @@ cron_scenarios = [
     ),
     AssetDaemonScenario(
         id="daily_unpartitioned_downstream_of_hourly_and_static_with_cron_skip",
-        initial_state=one_asset_depends_on_two.with_asset_properties(
+        initial_spec=one_asset_depends_on_two.with_asset_properties(
             keys="A", partitions_def=two_partitions_def
         )
         .with_asset_properties(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cursor_migration_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cursor_migration_scenarios.py
@@ -27,7 +27,7 @@ from .asset_daemon_scenario_states import (
 cursor_migration_scenarios = [
     AssetDaemonScenario(
         id="one_asset_daily_partitions_never_materialized_respect_discards_migrate_after_discard",
-        initial_state=one_asset.with_asset_properties(partitions_def=daily_partitions_def)
+        initial_spec=one_asset.with_asset_properties(partitions_def=daily_partitions_def)
         .with_current_time(time_partitions_start_str)
         .with_current_time_advanced(days=30, hours=4)
         .with_all_eager(),
@@ -60,7 +60,7 @@ cursor_migration_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_asset_daily_partitions_two_years_never_materialized_migrate_after_run_requested",
-        initial_state=one_asset.with_asset_properties(partitions_def=daily_partitions_def)
+        initial_spec=one_asset.with_asset_properties(partitions_def=daily_partitions_def)
         .with_current_time(time_partitions_start_str)
         .with_current_time_advanced(years=2, hours=4)
         .with_all_eager(),
@@ -80,7 +80,7 @@ cursor_migration_scenarios = [
     ),
     AssetDaemonScenario(
         id="partitioned_non_root_asset_missing_after_migrate",
-        initial_state=three_assets_in_sequence.with_asset_properties(
+        initial_spec=three_assets_in_sequence.with_asset_properties(
             partitions_def=daily_partitions_def
         )
         .with_current_time(time_partitions_start_str)
@@ -114,7 +114,7 @@ cursor_migration_scenarios = [
     ),
     AssetDaemonScenario(
         id="basic_hourly_cron_unpartitioned_migrate",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             auto_materialize_policy=get_cron_policy(basic_hourly_cron_schedule)
         ).with_current_time("2020-01-01T00:05"),
         execution_fn=lambda state: state.evaluate_tick()
@@ -143,7 +143,7 @@ cursor_migration_scenarios = [
     ),
     AssetDaemonScenario(
         id="basic_hourly_cron_partitioned_migrate",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             partitions_def=hourly_partitions_def,
             auto_materialize_policy=get_cron_policy(basic_hourly_cron_schedule),
         )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
@@ -11,7 +11,7 @@ from .asset_daemon_scenario_states import one_asset, two_assets_in_sequence
 custom_condition_scenarios = [
     AssetDaemonScenario(
         id="funky_custom_condition_scenario",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             auto_materialize_policy=AutoMaterializePolicy.from_asset_condition(
                 # intentionally funky condition
                 # not ((not missing) | (parent_updated)) ->
@@ -28,7 +28,7 @@ custom_condition_scenarios = [
     ),
     AssetDaemonScenario(
         id="funky_custom_condition_static_constructor_scenario",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             auto_materialize_policy=AutoMaterializePolicy.from_asset_condition(
                 # same as above, but with static constructor
                 ~(~AssetCondition.missing() & AssetCondition.parent_newer())
@@ -40,7 +40,7 @@ custom_condition_scenarios = [
     ),
     AssetDaemonScenario(
         id="parent_newer_and_not_updated_since_cron_scenario",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_spec=two_assets_in_sequence.with_asset_properties(
             "B",
             auto_materialize_policy=AutoMaterializePolicy.from_asset_condition(
                 ~AssetCondition.updated_since_cron("@daily") & AssetCondition.parent_newer()

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/latest_materialization_run_tag_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/latest_materialization_run_tag_scenarios.py
@@ -24,7 +24,7 @@ filter_latest_run_tag_key_policy = (
 latest_materialization_run_tag_scenarios = [
     AssetDaemonScenario(
         id="latest_parent_materialization_has_required_tag",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_spec=two_assets_in_sequence.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(
@@ -35,7 +35,7 @@ latest_materialization_run_tag_scenarios = [
     ),
     AssetDaemonScenario(
         id="latest_parent_materialization_missing_required_tag",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_spec=two_assets_in_sequence.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(run_request(["A", "B"]), run_request(["A"]))
@@ -44,7 +44,7 @@ latest_materialization_run_tag_scenarios = [
     ),
     AssetDaemonScenario(
         id="latest_parent_materialization_missing_one_of_required_tags",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_spec=two_assets_in_sequence.with_asset_properties(
             auto_materialize_policy=AutoMaterializePolicy.eager()
             .without_rules(AutoMaterializeRule.materialize_on_parent_updated())
             .with_rules(
@@ -66,7 +66,7 @@ latest_materialization_run_tag_scenarios = [
     ),
     AssetDaemonScenario(
         id="earlier_parent_materialization_missing_required_tag",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_spec=two_assets_in_sequence.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(
@@ -79,7 +79,7 @@ latest_materialization_run_tag_scenarios = [
     ),
     AssetDaemonScenario(
         id="only_updated_parent_missing_required_tag",
-        initial_state=one_asset_depends_on_two.with_asset_properties(
+        initial_spec=one_asset_depends_on_two.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(
@@ -91,7 +91,7 @@ latest_materialization_run_tag_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_updated_parent_has_required_tag_but_other_does_not",
-        initial_state=one_asset_depends_on_two.with_asset_properties(
+        initial_spec=one_asset_depends_on_two.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(
@@ -104,7 +104,7 @@ latest_materialization_run_tag_scenarios = [
     ),
     AssetDaemonScenario(
         id="latest_materialization_missing_required_tag_but_will_update",
-        initial_state=three_assets_in_sequence.with_asset_properties(
+        initial_spec=three_assets_in_sequence.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(
@@ -119,7 +119,7 @@ latest_materialization_run_tag_scenarios = [
         # this ensures that updates that happened prior to the cursor of the current tick
         # get ignored if they're missing the required keys
         id="latest_materialization_missing_required_tag_previous_tick",
-        initial_state=one_asset_depends_on_two.with_asset_properties(
+        initial_spec=one_asset_depends_on_two.with_asset_properties(
             auto_materialize_policy=filter_latest_run_tag_key_policy
         ),
         execution_fn=lambda state: state.with_runs(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
@@ -46,7 +46,7 @@ from .asset_daemon_scenario_states import (
 partition_scenarios = [
     AssetDaemonScenario(
         id="one_asset_one_partition_never_materialized",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             partitions_def=one_partitions_def
         ).with_all_eager(),
         execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
@@ -55,7 +55,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_asset_two_partitions_never_materialized",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             partitions_def=two_partitions_def,
         ).with_all_eager(2),
         execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
@@ -65,7 +65,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="two_assets_one_partition_never_materialized",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_spec=two_assets_in_sequence.with_asset_properties(
             partitions_def=one_partitions_def
         ).with_all_eager(),
         execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
@@ -74,7 +74,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_asset_one_partition_already_requested",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             partitions_def=one_partitions_def
         ).with_all_eager(),
         execution_fn=lambda state: state.evaluate_tick()
@@ -84,7 +84,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_asset_one_partition_already_materialized",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             partitions_def=one_partitions_def
         ).with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(asset_keys=["A"], partition_key="1"))
@@ -93,7 +93,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="two_assets_one_partition_already_materialized",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_spec=two_assets_in_sequence.with_asset_properties(
             partitions_def=one_partitions_def
         ).with_all_eager(),
         execution_fn=lambda state: state.with_runs(
@@ -104,7 +104,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="two_assets_both_upstream_partitions_materialized",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_spec=two_assets_in_sequence.with_asset_properties(
             partitions_def=two_partitions_def
         ).with_all_eager(2),
         execution_fn=lambda state: state.with_runs(
@@ -119,7 +119,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="parent_one_partition_one_run",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_spec=two_assets_in_sequence.with_asset_properties(
             partitions_def=one_partitions_def
         ).with_all_eager(),
         execution_fn=lambda state: state.with_runs(run_request(asset_keys=["A"], partition_key="1"))
@@ -128,7 +128,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="parent_rematerialized_one_partition",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_spec=two_assets_in_sequence.with_asset_properties(
             partitions_def=one_partitions_def
         ).with_all_eager(),
         execution_fn=lambda state: state.with_runs(
@@ -140,7 +140,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="unpartitioned_to_dynamic_partitions",
-        initial_state=two_assets_in_sequence.with_asset_properties(
+        initial_spec=two_assets_in_sequence.with_asset_properties(
             keys=["B"], partitions_def=dynamic_partitions_def
         ).with_all_eager(10),
         execution_fn=lambda state: state.with_runs(run_request("A"))
@@ -162,7 +162,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_asset_daily_partitions_never_materialized",
-        initial_state=one_asset.with_asset_properties(partitions_def=daily_partitions_def)
+        initial_spec=one_asset.with_asset_properties(partitions_def=daily_partitions_def)
         .with_current_time(time_partitions_start_str)
         .with_current_time_advanced(days=2, hours=4)
         .with_all_eager(),
@@ -172,7 +172,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_asset_daily_partitions_never_materialized_respect_discards",
-        initial_state=one_asset.with_asset_properties(partitions_def=daily_partitions_def)
+        initial_spec=one_asset.with_asset_properties(partitions_def=daily_partitions_def)
         .with_current_time(time_partitions_start_str)
         .with_current_time_advanced(days=30, hours=4)
         .with_all_eager(),
@@ -197,7 +197,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_asset_daily_partitions_two_years_never_materialized",
-        initial_state=one_asset.with_asset_properties(partitions_def=daily_partitions_def)
+        initial_spec=one_asset.with_asset_properties(partitions_def=daily_partitions_def)
         .with_current_time(time_partitions_start_str)
         .with_current_time_advanced(years=2, hours=4)
         .with_all_eager(),
@@ -207,7 +207,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="hourly_to_daily_partitions_never_materialized",
-        initial_state=hourly_to_daily.with_current_time(time_partitions_start_str)
+        initial_spec=hourly_to_daily.with_current_time(time_partitions_start_str)
         .with_current_time_advanced(days=3, hours=1)
         .with_all_eager(100),
         execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
@@ -221,7 +221,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="hourly_to_daily_partitions_never_materialized2",
-        initial_state=hourly_to_daily.with_current_time(time_partitions_start_str)
+        initial_spec=hourly_to_daily.with_current_time(time_partitions_start_str)
         .with_current_time_advanced(days=1, hours=4)
         .with_all_eager(100),
         execution_fn=lambda state: state.with_runs(
@@ -245,7 +245,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="hourly_to_daily_nonexistent_partitions",
-        initial_state=hourly_to_daily.with_asset_properties(
+        initial_spec=hourly_to_daily.with_asset_properties(
             keys=["B"], partitions_def=daily_partitions_def._replace(end_offset=1)
         )
         # allow nonexistent upstream partitions
@@ -293,7 +293,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="hourly_to_daily_nonexistent_partitions_become_existent",
-        initial_state=hourly_to_daily.with_asset_properties(
+        initial_spec=hourly_to_daily.with_asset_properties(
             keys=["B"], partitions_def=daily_partitions_def._replace(end_offset=1)
         )
         .with_current_time(time_partitions_start_str)
@@ -338,7 +338,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="time_dimension_multipartitioned",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             partitions_def=time_multipartitions_def,
         )
         .with_current_time(time_partitions_start_str)
@@ -355,7 +355,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="static_multipartitioned",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             partitions_def=static_multipartitions_def,
         ).with_all_eager(100),
         execution_fn=lambda state: state.evaluate_tick().assert_requested_runs(
@@ -367,7 +367,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="partitioned_after_non_partitioned_multiple_updated",
-        initial_state=one_asset_depends_on_two.with_asset_properties(
+        initial_spec=one_asset_depends_on_two.with_asset_properties(
             keys=["C"], partitions_def=daily_partitions_def
         )
         .with_current_time(time_partitions_start_str)
@@ -390,7 +390,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_asset_depends_on_two_nonexistent_partitions",
-        initial_state=one_asset_depends_on_two.with_asset_properties(
+        initial_spec=one_asset_depends_on_two.with_asset_properties(
             partitions_def=hourly_partitions_def
         )
         .with_asset_properties(
@@ -441,7 +441,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="two_assets_in_sequence_fan_in_partitions",
-        initial_state=two_assets_in_sequence_fan_in_partitions.with_asset_properties(
+        initial_spec=two_assets_in_sequence_fan_in_partitions.with_asset_properties(
             keys=["B"], auto_materialize_policy=AutoMaterializePolicy.eager()
         ),
         execution_fn=lambda state: state.evaluate_tick()
@@ -463,7 +463,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="two_assets_in_sequence_fan_out_partitions",
-        initial_state=two_assets_in_sequence_fan_out_partitions.with_all_eager(100),
+        initial_spec=two_assets_in_sequence_fan_out_partitions.with_all_eager(100),
         execution_fn=lambda state: state.evaluate_tick()
         .assert_requested_runs(run_request(["A"], partition_key="1"))
         .with_not_started_runs()
@@ -485,7 +485,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_asset_self_dependency",
-        initial_state=one_asset_self_dependency.with_all_eager()
+        initial_spec=one_asset_self_dependency.with_all_eager()
         .with_current_time(time_partitions_start_str)
         .with_current_time_advanced(hours=2),
         execution_fn=lambda state: state.evaluate_tick()
@@ -531,7 +531,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="one_asset_self_dependency_multi_partitions_def",
-        initial_state=one_asset.with_asset_properties(
+        initial_spec=one_asset.with_asset_properties(
             partitions_def=time_multipartitions_def,
             deps=[
                 AssetDep(
@@ -580,7 +580,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="three_assets_in_sequence_self_dependency_in_middle",
-        initial_state=three_assets_in_sequence.with_asset_properties(
+        initial_spec=three_assets_in_sequence.with_asset_properties(
             partitions_def=daily_partitions_def
         )
         .with_asset_properties(
@@ -681,7 +681,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="unpartitioned_downstream_of_asymmetric_time_assets_in_series",
-        initial_state=three_assets_in_sequence.with_asset_properties(
+        initial_spec=three_assets_in_sequence.with_asset_properties(
             keys=["A"],
             partitions_def=daily_partitions_def._replace(
                 start=time_partitions_start_datetime + datetime.timedelta(days=4)
@@ -710,7 +710,7 @@ partition_scenarios = [
     ),
     AssetDaemonScenario(
         id="partition_pops_into_existence_after_parent_update",
-        initial_state=two_assets_depend_on_one.with_asset_properties(
+        initial_spec=two_assets_depend_on_one.with_asset_properties(
             "A",
             # new partitions come into being one day early
             partitions_def=daily_partitions_def._replace(end_offset=1),


### PR DESCRIPTION
## Summary & Motivation

This disentangles the generically-useful concept of "representation of a set of definitions at a certain point in time" and that concept + an instance from anything specific to AssetDaemonScenarios.

This allows these concepts to be reused in other places (the next target for this is going to be testing AssetConditions in a vacuum, but this same pattern would certainly be useful in backfill tests as well).


At a high level, AssetDaemonScenarioState is now a subclass of ScenarioState, which is something that has a DagsterInstance + a ScenarioSpec and provides convenience methods like `.with_runs()` etc.

A ScenarioSpec just contains information about definitions that you want to exist, which is useful as it allows you to specify a base set of assets / dependencies between them, then modify those structures (for example by adding different partitions defintions). This enables the creation of "libraries" of standard asset graph shapes (e.g. fan in, fan out, hourly to daily, etc.), which multiple ScenarioStates can use.

## How I Tested These Changes
