### PR TITLE
Fix alerts docs admin -> editor

### DIFF
--- a/docs/content/dagster-cloud/managing-deployments/setting-up-alerts.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/setting-up-alerts.mdx
@@ -33,15 +33,11 @@ Alert policies are configured on a per-deployment basis. For example, asset aler
 ## Managing alert policies in Dagster Cloud
 
 <Note>
-  <strong>Organization Admin</strong>, <strong>Admin</strong>, or{" "}
-  <strong>Editor</strong> permissions are required to manage alerts in Dagster
-  Cloud.
-  <br />
-  <br />
-  If you're a Dagster Cloud <a href="/dagster-cloud/account/managing-users">
-    <strong>Admin</strong>
-  </a> or <strong>Editor</strong>, you can only manage alerts in deployments where
-  you're an <strong>Admin</strong>.
+  <a href="/dagster-cloud/account/managing-users">
+    <strong>Organization Admin</strong>, <strong>Admin</strong>, or{" "}
+    <strong>Editor</strong>
+  </a>{" "}
+  permissions are required to manage alerts in Dagster Cloud.
 </Note>
 
 - [Creating alert policies](#creating-alert-policies)


### PR DESCRIPTION
Editors have alerts permissions, so this was wrong. I don't think we need to point out that you need the perms for the specific deployment.