### PR TITLE
yield start and end of spans from daemons

### DIFF
--- a/python_modules/dagster/dagster/_daemon/daemon.py
+++ b/python_modules/dagster/dagster/_daemon/daemon.py
@@ -5,6 +5,7 @@ import uuid
 from abc import ABC, abstractmethod
 from collections import deque
 from contextlib import AbstractContextManager, ExitStack
+from enum import Enum
 from threading import Event
 from typing import TYPE_CHECKING, Any, Generator, Generic, Mapping, Optional, TypeVar, Union
 
@@ -46,8 +47,12 @@ def get_telemetry_daemon_session_id() -> str:
     return _telemetry_daemon_session_id
 
 
-# DaemonIterator = Iterator[Union[None, SerializableErrorInfo]]
-DaemonIterator: TypeAlias = Generator[Union[None, SerializableErrorInfo], None, None]
+class SpanMarker(Enum):
+    START_SPAN = "START_SPAN"
+    END_SPAN = "END_SPAN"
+
+
+DaemonIterator: TypeAlias = Generator[Union[None, SerializableErrorInfo, SpanMarker], None, None]
 
 TContext = TypeVar("TContext", bound=IWorkspaceProcessContext)
 
@@ -106,8 +111,8 @@ class DagsterDaemon(AbstractContextManager, ABC, Generic[TContext]):
                         )
 
                     try:
-                        result = check.opt_inst(next(daemon_generator), SerializableErrorInfo)
-                        if result:
+                        result = next(daemon_generator)
+                        if isinstance(result, SerializableErrorInfo):
                             self._errors.appendleft((result, pendulum.now("UTC")))
                     except StopIteration:
                         self._logger.error(
@@ -221,12 +226,14 @@ class IntervalDaemon(DagsterDaemon[TContext], ABC):
     ) -> DaemonIterator:
         while True:
             start_time = time.time()
+            yield SpanMarker.START_SPAN
             try:
                 yield from self.run_iteration(workspace_process_context)
             except Exception:
                 error_info = serializable_error_info_from_exc_info(sys.exc_info())
                 self._logger.error("Caught error:\n%s", error_info)
                 yield error_info
+            yield SpanMarker.END_SPAN
             while time.time() - start_time < self.interval_seconds:
                 shutdown_event.wait(0.5)
                 yield None

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -142,6 +142,8 @@ def execute_scheduler_iteration_loop(
     max_tick_retries: int,
     shutdown_event: threading.Event,
 ) -> "DaemonIterator":
+    from dagster._daemon.daemon import SpanMarker
+
     scheduler_run_futures: Dict[str, Future] = {}
 
     submit_threadpool_executor = None
@@ -169,6 +171,7 @@ def execute_scheduler_iteration_loop(
             start_time = pendulum.now("UTC").timestamp()
             end_datetime_utc = pendulum.now("UTC")
 
+            yield SpanMarker.START_SPAN
             yield from launch_scheduled_runs(
                 workspace_process_context,
                 logger,
@@ -179,7 +182,7 @@ def execute_scheduler_iteration_loop(
                 max_catchup_runs=max_catchup_runs,
                 max_tick_retries=max_tick_retries,
             )
-            yield
+            yield SpanMarker.END_SPAN
             end_time = pendulum.now("UTC").timestamp()
 
             next_minute_time = _get_next_scheduler_iteration_time(start_time)


### PR DESCRIPTION
## Summary & Motivation
This adds hooks that we can consume in the future to identify the start and end of specific iterations in specific daemons.

## How I Tested These Changes
BK, run daemon locally
