### PR TITLE
Make @cached_method support ordinal args

### DIFF
--- a/python_modules/dagster/dagster/_utils/cached_method.py
+++ b/python_modules/dagster/dagster/_utils/cached_method.py
@@ -109,7 +109,7 @@ class _HashedSeq(list):
 
 
 def _make_key(
-    original_kwargs: Mapping[str, object],
+    canonical_kwargs: Mapping[str, object],
     fasttypes: AbstractSet[Type[object]] = {int, str},
 ) -> Hashable:
     """Adapted from https://github.com/python/cpython/blob/f9433fff476aa13af9cb314fcc6962055faa4085/Lib/functools.py#L448.
@@ -122,13 +122,13 @@ def _make_key(
     saves space and improves lookup speed.
     """
     # if no args return a shared value
-    if not original_kwargs:
+    if not canonical_kwargs:
         return NO_ARGS_HASH_VALUE
 
     # if single fast (str/int) arg, use that value for hash
-    if len(original_kwargs) == 1:
-        k, v = next(iter(original_kwargs.items()))
+    if len(canonical_kwargs) == 1:
+        k, v = next(iter(canonical_kwargs.items()))
         if type(v) in fasttypes:
             return f"{k}.{v}"
 
-    return _HashedSeq(tuple(sorted(original_kwargs.items())))
+    return _HashedSeq(tuple(sorted(canonical_kwargs.items())))

--- a/python_modules/dagster/dagster/_utils/cached_method.py
+++ b/python_modules/dagster/dagster/_utils/cached_method.py
@@ -50,6 +50,15 @@ def cached_method(method: Callable[Concatenate[S, P], T]) -> Callable[Concatenat
 
     With this decorator, keyword and non-keyword arg usage is canonicalized and the above
     calls result in the same cache entry
+
+    Using ordinal arguments rather than kwargs represents introduces about 15% more overhead
+    per call.
+
+    However, the use of _any_ @cached_method decorated method a introduces ~20x (as in 2100%)
+    overhead per call over undecorated methods, so use this carefully. The operation
+    that this caches should be expensive enough so that 15% overhead on the function
+    call is immaterial.  See for https://github.com/dagster-io/dagster/pull/20212
+    script, data, and discussion of these matters.
     """
     cache_attr_name = method.__name__ + CACHED_METHOD_FIELD_SUFFIX
 
@@ -65,6 +74,9 @@ def cached_method(method: Callable[Concatenate[S, P], T]) -> Callable[Concatenat
 
         canonical_kwargs = None
         if args:
+            # Entering this block introduces about 15% overhead per call
+            # See top-level docblock for more details.
+
             # nonlocal required to bind to variable in enclosing scope
             nonlocal arg_names
             # only create the lookup table on demand to avoid overhead

--- a/python_modules/dagster/dagster/_utils/cached_method.py
+++ b/python_modules/dagster/dagster/_utils/cached_method.py
@@ -69,7 +69,7 @@ def cached_method(method: Callable[Concatenate[S, P], T]) -> Callable[Concatenat
             nonlocal arg_names
             # only create the lookup table on demand to avoid overhead
             # if the cached method is never called with positional arguments
-            arg_names = arg_names if arg_names is not None else get_arg_names(method)
+            arg_names = arg_names if arg_names is not None else get_arg_names(method)[1:]
 
             translated_kwargs = {}
             for arg_ordinal, arg_value in enumerate(args):
@@ -120,7 +120,8 @@ def _make_key(
 
     Make a cache key from optionally typed positional and keyword arguments
     The key is constructed in a way that is flat as possible rather than
-    s a nested structure that would take more memory.
+    as a nested structure that would take more memory.
+
     If there is only a single argument and its data type is known to cache
     its hash value, then that argument is returned without a wrapper.  This
     saves space and improves lookup speed.

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_cached_method.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_cached_method.py
@@ -1,20 +1,20 @@
 # mypy: disable-error-code=annotation-unchecked
 
 import gc
-from typing import Dict, NamedTuple
+from typing import Dict, NamedTuple, Tuple
 
 import objgraph
 from dagster._utils.cached_method import cached_method
 
 
-def test_cached_method():
+def test_cached_method() -> None:
     class MyClass:
-        def __init__(self, attr1):
+        def __init__(self, attr1) -> None:
             self._attr1 = attr1
             self.calls = []
 
         @cached_method
-        def my_method(self, arg1):
+        def my_method(self, arg1) -> Tuple:
             self.calls.append(arg1)
             return (arg1, self._attr1)
 
@@ -31,13 +31,13 @@ def test_cached_method():
     assert obj2.calls == ["a", "b"]
 
 
-def test_kwargs_order_irrelevant_and_no_kwargs():
+def test_kwargs_order_irrelevant_and_no_kwargs() -> None:
     class MyClass:
-        def __init__(self):
+        def __init__(self) -> None:
             self.calls = []
 
         @cached_method
-        def my_method(self, arg1, arg2):
+        def my_method(self, arg1, arg2) -> Tuple:
             self.calls.append(arg1)
             return arg1, arg2
 
@@ -47,7 +47,7 @@ def test_kwargs_order_irrelevant_and_no_kwargs():
     assert len(obj1.calls) == 1
 
 
-def test_does_not_leak():
+def test_does_not_leak() -> None:
     class LeakTestKey(NamedTuple):
         attr: str
 
@@ -76,10 +76,10 @@ def test_does_not_leak():
     assert objgraph.count("LeakTestValue") == 0
 
 
-def test_collisions():
+def test_collisions() -> None:
     class MyClass:
         @cached_method
-        def stuff(self, a=None, b=None):
+        def stuff(self, a=None, b=None) -> Dict:
             return {"a": a, "b": b}
 
     obj = MyClass()


### PR DESCRIPTION
## Summary & Motivation

Currently @cached_method has the limitation that one can only use kwargs. This is an artificial limitation. Additionally one only discovers this at runtime, rather than definition time, which is problematic.

This is a bit annoying as a user. More importantly, if one was in the situation were you wanted to apply @cached_method to something in the codebase to solve a performance issue, you would also need to go and update all callsites to use kwargs, which is thrashy.

This PR canonicalizes args and kwargs into a single kwargs dictionary for the purposes of caching values. 

## How I Tested These Changes

Included unit tests and BK
