### PR TITLE
Inline fasttypes argument in cached_method

### DIFF
--- a/python_modules/dagster/dagster/_utils/cached_method.py
+++ b/python_modules/dagster/dagster/_utils/cached_method.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import AbstractSet, Callable, Dict, Hashable, Mapping, Tuple, Type, TypeVar
+from typing import Callable, Dict, Hashable, Mapping, Tuple, TypeVar
 
 from typing_extensions import Concatenate, ParamSpec
 
@@ -126,7 +126,6 @@ class _HashedSeq(list):
 
 def _make_key(
     canonical_kwargs: Mapping[str, object],
-    fasttypes: AbstractSet[Type[object]] = {int, str},
 ) -> Hashable:
     """Adapted from https://github.com/python/cpython/blob/f9433fff476aa13af9cb314fcc6962055faa4085/Lib/functools.py#L448.
 
@@ -145,7 +144,8 @@ def _make_key(
     # if single fast (str/int) arg, use that value for hash
     if len(canonical_kwargs) == 1:
         k, v = next(iter(canonical_kwargs.items()))
-        if type(v) in fasttypes:
+        type_v = type(v)
+        if type_v is str or type_v is int:
             return f"{k}.{v}"
 
     return _HashedSeq(tuple(sorted(canonical_kwargs.items())))


### PR DESCRIPTION
## Summary & Motivation

`_make_key` in `cached_method` was copied from https://github.com/python/cpython/blob/f9433fff476aa13af9cb314fcc6962055faa4085/Lib/functools.py#L448 which passes `fasttypes` as a set with a default set value. I'm not sure why they wrote it that way but it doesn't seem like a good idea. 

* We never parameterize this so why even bother. 
* In the event that we did, this uses the dangerous pattern of defaulting the parameter to a hardcoded set/dict (see https://stackoverflow.com/questions/26320899/why-is-the-empty-dictionary-a-dangerous-default-value-in-python) so if we were ever to parameterize this it would introduce a bug in core primitive in our stack.

This instead just does inline comparisons to `str` and `int` which is probably marginally faster.

## How I Tested These Changes

BK
