### PR TITLE
[external-assets] Expose `asset_checks_defs_by_key` on `RepositoryDefinition`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data.py
@@ -15,6 +15,8 @@ from typing import (
 
 import dagster._check as check
 from dagster._annotations import public
+from dagster._core.definitions.asset_check_spec import AssetCheckKey
+from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.graph_definition import SubselectedGraphDefinition
@@ -194,6 +196,11 @@ class RepositoryData(ABC):
         """Mapping[AssetKey, AssetsDefinition]: Get the asset definitions for the repository."""
         return {}
 
+    @public
+    def get_asset_checks_defs_by_key(self) -> Mapping[AssetKey, "AssetChecksDefinition"]:
+        """Mapping[AssetKey, AssetChecksDefinition]: Get the asset checks definitions for the repository."""
+        return {}
+
     def load_all_definitions(self):
         # force load of all lazy constructed code artifacts
         self.get_all_jobs()
@@ -215,6 +222,7 @@ class CachingRepositoryData(RepositoryData):
         sensors: Mapping[str, Union[SensorDefinition, Resolvable[SensorDefinition]]],
         source_assets_by_key: Mapping[AssetKey, SourceAsset],
         assets_defs_by_key: Mapping[AssetKey, "AssetsDefinition"],
+        asset_checks_defs_by_key: Mapping[AssetCheckKey, "AssetChecksDefinition"],
         top_level_resources: Mapping[str, ResourceDefinition],
         utilized_env_vars: Mapping[str, AbstractSet[str]],
         resource_key_mapping: Mapping[int, str],
@@ -243,6 +251,8 @@ class CachingRepositoryData(RepositoryData):
             source_assets_by_key (Mapping[AssetKey, SourceAsset]): The source assets belonging to a repository.
             assets_defs_by_key (Mapping[AssetKey, AssetsDefinition]): The assets definitions
                 belonging to a repository.
+            asset_checks_defs_by_key (Mapping[AssetKey, AssetChecksDefinition]): The asset checks definitions
+                belonging to a repository.
             top_level_resources (Mapping[str, ResourceDefinition]): A dict of top-level
                 resource keys to defintions, for resources which should be displayed in the UI.
         """
@@ -260,6 +270,12 @@ class CachingRepositoryData(RepositoryData):
         )
         check.mapping_param(
             assets_defs_by_key, "assets_defs_by_key", key_type=AssetKey, value_type=AssetsDefinition
+        )
+        check.mapping_param(
+            asset_checks_defs_by_key,
+            "assets_checks_defs_by_key",
+            key_type=AssetCheckKey,
+            value_type=AssetChecksDefinition,
         )
         check.mapping_param(
             top_level_resources, "top_level_resources", key_type=str, value_type=ResourceDefinition
@@ -303,6 +319,7 @@ class CachingRepositoryData(RepositoryData):
 
         self._source_assets_by_key = source_assets_by_key
         self._assets_defs_by_key = assets_defs_by_key
+        self._assets_checks_defs_by_key = asset_checks_defs_by_key
         self._top_level_resources = top_level_resources
         self._utilized_env_vars = utilized_env_vars
         self._resource_key_mapping = resource_key_mapping
@@ -490,6 +507,9 @@ class CachingRepositoryData(RepositoryData):
 
     def get_assets_defs_by_key(self) -> Mapping[AssetKey, "AssetsDefinition"]:
         return self._assets_defs_by_key
+
+    def get_asset_checks_defs_by_key(self) -> Mapping[AssetCheckKey, "AssetChecksDefinition"]:
+        return self._assets_checks_defs_by_key
 
     def _check_node_defs(self, job_defs: Sequence[JobDefinition]) -> None:
         node_defs = {}

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -280,9 +280,13 @@ def build_caching_repository_data_from_list(
 
         source_assets_by_key = {source_asset.key: source_asset for source_asset in source_assets}
         assets_defs_by_key = {key: asset for asset in assets_defs for key in asset.keys}
+        asset_checks_defs_by_key = {
+            key: checks_def for checks_def in asset_checks_defs for key in checks_def.keys
+        }
     else:
         source_assets_by_key = {}
         assets_defs_by_key = {}
+        asset_checks_defs_by_key = {}
 
     for name, sensor_def in sensors.items():
         if sensor_def.has_loadable_targets():
@@ -354,6 +358,7 @@ def build_caching_repository_data_from_list(
         sensors=sensors,
         source_assets_by_key=source_assets_by_key,
         assets_defs_by_key=assets_defs_by_key,
+        asset_checks_defs_by_key=asset_checks_defs_by_key,
         top_level_resources=top_level_resources or {},
         utilized_env_vars=utilized_env_vars,
         resource_key_mapping=resource_key_mapping or {},
@@ -416,6 +421,7 @@ def build_caching_repository_data_from_dict(
         **repository_definitions,
         source_assets_by_key={},
         assets_defs_by_key={},
+        asset_checks_defs_by_key={},
         top_level_resources={},
         utilized_env_vars={},
         resource_key_mapping={},

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -43,6 +43,7 @@ from .valid_definitions import (
 
 if TYPE_CHECKING:
     from dagster._core.definitions import AssetsDefinition
+    from dagster._core.definitions.asset_checks import AssetChecksDefinition
     from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
     from dagster._core.storage.asset_value_loader import AssetValueLoader
 
@@ -251,6 +252,12 @@ class RepositoryDefinition:
     def assets_defs_by_key(self) -> Mapping[AssetKey, "AssetsDefinition"]:
         """Mapping[AssetKey, AssetsDefinition]: The assets definitions defined in the repository."""
         return self._repository_data.get_assets_defs_by_key()
+
+    @public
+    @property
+    def asset_checks_defs_by_key(self) -> Mapping[AssetKey, "AssetChecksDefinition"]:
+        """Mapping[AssetCheckKey, AssetChecksDefinition]: The assets checks defined in the repository."""
+        return self._repository_data.get_asset_checks_defs_by_key()
 
     @property
     def external_assets_defs_by_key(self) -> Mapping[AssetKey, "AssetsDefinition"]:


### PR DESCRIPTION
## Summary & Motivation

Currently `AssetChecksDefinition` are not stored directly on the `RepositoryDefinition`-- they are only accessible indirectly via the job defs they are associated with. This PR stores them side by side with `AssetsDefinition` and `SourceAsset`. This is done both for consistency and to support an upstack PR that makes an `InternalAssetGraph` the source of "internal truth" for the repo.

## How I Tested These Changes

New unit test.