### PR TITLE
[external-assets] Normalize assets defs in InternalAssetGraph

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_different_io_managers.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_different_io_managers.py
@@ -2,5 +2,5 @@ from docs_snippets.concepts.assets.asset_different_io_managers import defs
 
 
 def test():
-    assets_defs_by_key = defs.get_repository_def().assets_defs_by_key
-    assert len(assets_defs_by_key) == 2
+    assets_defs = defs.get_repository_def().asset_graph.assets_defs
+    assert len(assets_defs) == 2

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_io_manager.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_io_manager.py
@@ -2,5 +2,5 @@ from docs_snippets.concepts.assets.asset_io_manager import defs
 
 
 def test():
-    assets_defs_by_key = defs.get_repository_def().assets_defs_by_key
-    assert len(assets_defs_by_key) == 2
+    assets_defs = defs.get_repository_def().asset_graph.assets_defs
+    assert len(assets_defs) == 2

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_io_managers_prod_local.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_io_managers_prod_local.py
@@ -6,9 +6,9 @@ from docs_snippets.concepts.assets.asset_io_manager_prod_local import defs
 
 @mock.patch.dict(os.environ, {"ENV": "prod"})
 def test_prod_assets():
-    assert len(defs.get_repository_def().assets_defs_by_key.keys()) == 2
+    assert len(defs.get_repository_def().asset_graph.assets_defs) == 2
 
 
 @mock.patch.dict(os.environ, {"ENV": "local"})
 def test_local_assets():
-    assert len(defs.get_repository_def().assets_defs_by_key.keys()) == 2
+    assert len(defs.get_repository_def().asset_graph.assets_defs) == 2

--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -48,7 +48,7 @@ def execute_materialize_command(instance: DagsterInstance, kwargs: Mapping[str, 
     repo_def = recon_repo.get_definition()
 
     asset_keys = parse_asset_selection(
-        assets_defs=list(repo_def.assets_defs_by_key.values()),
+        assets_defs=list(repo_def.asset_graph.assets_defs),
         asset_selection=kwargs["select"].split(","),
     )
 
@@ -95,14 +95,14 @@ def asset_list_command(**kwargs):
     select = kwargs.get("select")
     if select is not None:
         asset_keys = parse_asset_selection(
-            assets_defs=list(repo_def.assets_defs_by_key.values()),
+            assets_defs=list(repo_def.asset_graph.assets_defs),
             asset_selection=select.split(","),
             raise_on_clause_has_no_matches=False,
         )
     else:
         asset_keys = [
             asset_key
-            for assets_def in repo_def.assets_defs_by_key.values()
+            for assets_def in repo_def.asset_graph.assets_defs
             for asset_key in assets_def.keys
         ]
 

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -24,10 +24,6 @@ from dagster._config.pythonic_config import (
 )
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.asset_spec import (
-    SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET,
-    AssetSpec,
-)
 from dagster._core.definitions.assets_job import (
     get_base_asset_jobs,
     is_base_asset_job_name,
@@ -36,10 +32,6 @@ from dagster._core.definitions.auto_materialize_sensor_definition import (
     AutoMaterializeSensorDefinition,
 )
 from dagster._core.definitions.executor_definition import ExecutorDefinition
-from dagster._core.definitions.external_asset import (
-    create_external_asset_from_source_asset,
-    external_asset_from_spec,
-)
 from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.job_definition import JobDefinition
@@ -47,7 +39,6 @@ from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.definitions.partitioned_schedule import (
     UnresolvedPartitionedAssetScheduleDefinition,
 )
-from dagster._core.definitions.resolved_asset_deps import ResolvedAssetDependencies
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.schedule_definition import ScheduleDefinition
 from dagster._core.definitions.sensor_definition import SensorDefinition
@@ -235,43 +226,18 @@ def build_caching_repository_data_from_list(
             assets_defs.append(definition)
         elif isinstance(definition, SourceAsset):
             source_assets.append(definition)
-            assets_defs.append(create_external_asset_from_source_asset(definition))
             asset_keys.add(definition.key)
         elif isinstance(definition, AssetChecksDefinition):
             asset_checks_defs.append(definition)
         else:
             check.failed(f"Unexpected repository entry {definition}")
 
-    # Resolve all asset dependencies. An asset dependency is resolved when it's key is an AssetKey
-    # not subject to any further manipulation.
-    resolved_deps = ResolvedAssetDependencies(assets_defs, [])
-    assets_defs = [
-        ad.with_attributes(
-            input_asset_key_replacements={
-                raw_key: resolved_deps.get_resolved_asset_key_for_input(ad, input_name)
-                for input_name, raw_key in ad.keys_by_input_name.items()
-            }
-        )
-        for ad in assets_defs
-    ]
-
-    # Create unexecutable external assets definitions for any referenced keys for which no
-    # definition was provided.
-    all_referenced_asset_keys = {
-        *(key for asset_def in assets_defs for key in asset_def.dependency_keys),
-        *(checks_def.asset_key for checks_def in asset_checks_defs),
-    }
-    for key in all_referenced_asset_keys.difference(asset_keys):
-        assets_defs.append(
-            external_asset_from_spec(
-                AssetSpec(key=key, metadata={SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET: True})
-            )
-        )
-        asset_keys.add(key)
-
+    asset_graph = InternalAssetGraph.from_assets(
+        [*assets_defs, *source_assets], asset_checks=asset_checks_defs
+    )
     if assets_defs or source_assets or asset_checks_defs:
         for job_def in get_base_asset_jobs(
-            assets=assets_defs,
+            assets=asset_graph.assets_defs,
             executor_def=default_executor_def,
             resource_defs=top_level_resources,
             asset_checks=asset_checks_defs,
@@ -303,7 +269,6 @@ def build_caching_repository_data_from_list(
                 schedule_def, coerced_graphs, unresolved_jobs, jobs, target
             )
 
-    asset_graph = InternalAssetGraph.from_assets(assets_defs, asset_checks=asset_checks_defs)
     _validate_auto_materialize_sensors(sensors.values(), asset_graph)
 
     if unresolved_partitioned_asset_schedules:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1560,12 +1560,12 @@ def test_self_dependency():
 def test_context_assets_def():
     @asset
     def a(context):
-        assert context.assets_def == a
+        assert context.assets_def.keys == {a.key}
         return 1
 
     @asset
     def b(context, a):
-        assert context.assets_def == b
+        assert context.assets_def.keys == {b.key}
         return 2
 
     asset_job = define_asset_job("yay", [a, b]).resolve(

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -333,7 +333,7 @@ def observe_sources(*args):
     def observe_sources_fn(*, instance, times_by_key, **kwargs):
         for arg in args:
             key = AssetKey(arg)
-            observe(assets=[versioned_repo.external_assets_defs_by_key[key]], instance=instance)
+            observe(assets=[versioned_repo.asset_graph.get_assets_def(key)], instance=instance)
             latest_record = instance.get_latest_data_version_record(key, is_source=True)
             latest_timestamp = latest_record.timestamp
             times_by_key[key].append(
@@ -345,7 +345,7 @@ def observe_sources(*args):
 
 def run_assets(*args):
     def run_assets_fn(*, instance, **kwargs):
-        assets = [versioned_repo.assets_defs_by_key[AssetKey(arg)] for arg in args]
+        assets = [versioned_repo.asset_graph.get_assets_def(AssetKey(arg)) for arg in args]
         materialize_to_memory(assets=assets, instance=instance)
 
     return run_assets_fn

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -53,7 +53,7 @@ from dagster._core.test_utils import instance_for_test
 def get_all_assets_from_defs(defs: Definitions):
     # could not find public method on repository to do this
     repo = resolve_pending_repo_if_required(defs)
-    return list(repo.assets_defs_by_key.values())
+    return list(repo.asset_graph.assets_defs)
 
 
 def resolve_pending_repo_if_required(definitions: Definitions) -> RepositoryDefinition:
@@ -204,7 +204,7 @@ def test_resource_coercion():
 def test_source_asset():
     defs = Definitions(assets=[SourceAsset("a-source-asset")])
     repo = resolve_pending_repo_if_required(defs)
-    all_assets = list(repo.assets_defs_by_key.values())
+    all_assets = list(repo.asset_graph.assets_defs)
     assert len(all_assets) == 1
     assert all_assets[0].key.to_user_string() == "a-source-asset"
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
@@ -651,7 +651,7 @@ def test_source_assets():
     def my_repo():
         return [foo, bar]
 
-    all_assets = list(my_repo.assets_defs_by_key.values())
+    all_assets = list(my_repo.asset_graph.assets_defs)
     assert len(all_assets) == 2
     assert {key.to_user_string() for a in all_assets for key in a.keys} == {"foo", "bar"}
 

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
@@ -34,7 +34,7 @@ class DefinitionsRunner:
             yield DefinitionsRunner(defs, instance)
 
     def materialize_all_assets(self, partition_key: Optional[str] = None) -> ExecuteInProcessResult:
-        all_keys = list(self.defs.get_repository_def().assets_defs_by_key.keys())
+        all_keys = list(self.defs.get_repository_def().asset_graph.all_asset_keys)
         job_def = self.defs.get_implicit_job_def_for_assets(all_keys)
         assert job_def
         return job_def.execute_in_process(instance=self.instance, partition_key=partition_key)


### PR DESCRIPTION
## Summary & Motivation

Move the site of normalization of the assets definitions in a repo to the `InternalAssetGraph`. Normalization is: source asset conversion + dependency relative asset key resolution + generation of missing assets def for referenced assets.

A previous PR introduced conversion of source assets to external assets at the `RepositoryDataBuilder` level. However, we couldn't completely expunge `SourceAsset` here because repositories have a public API that returns `SourceAsset`-- so we needed to keep around the `SourceAssets` passed into the repo, while only passing their external asset representation into our internals.

This external asset representation of `SourceAsset` was merged into the `assets_defs_by_key` map for the repo. Though we have not heard any reports of problems from this, this was technically a breaking change, as `assets_defs_by_key` would now return not only the assets defs a user provided to a repo, but also the external asset representation of source assets.

This PR improves on this situation in several ways:

- It reverts the change to `RepositoryDefinition.assets_defs_by_key`. After this PR, this method will return only the `AssetsDefinition` passed in by the user. This is consistent with `source_assets_by_key`.
- It moves asset normalization logic  into `AssetGraph`. The `AssetGraph` cached on a `RepositoryDefinition` becomes the source of truth for us internally-- internal pathways operate on the normalized set of assets obtained from the `AssetGraph`. This creates a clean separation between our public exposure of the definitions our `RepositoryDefinition` takes in and their private internal representation.
- A bonus is that our tests can keep using `AssetGraph.from_assets` instead of going through a repository in order to get access to realistic behavior (as there is no normalization stage skipped when going through `from_assets`).

Most of the changes in the PR are just changing internal callsites of `RepositoryDefinition.assets_defs_by_key` to `RepositoryDefinition.asset_graph.assets_defs`.

## How I Tested These Changes

Existing test suite.