### PR TITLE
[external-assets] Build base asset jobs using AssetGraph

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -254,6 +254,9 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
     def assets_defs(self) -> Sequence[AssetsDefinition]:
         return list(dict.fromkeys(asset.assets_def for asset in self.asset_nodes))
 
+    def assets_defs_for_keys(self, keys: Iterable[AssetKey]) -> Sequence[AssetsDefinition]:
+        return list(dict.fromkeys([self.get(key).assets_def for key in keys]))
+
     @property
     def asset_checks_defs(self) -> Sequence[AssetChecksDefinition]:
         return list(dict.fromkeys(self._asset_checks_defs_by_key.values()))

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -215,8 +215,18 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
         """
         return [set(level) for level in toposort.toposort(self.asset_dep_graph["upstream"])]
 
+    @cached_property
+    def unpartitioned_asset_keys(self) -> AbstractSet[AssetKey]:
+        return {node.key for node in self.asset_nodes if not node.is_partitioned}
+
     def asset_keys_for_group(self, group_name: str) -> AbstractSet[AssetKey]:
         return {node.key for node in self.asset_nodes if node.group_name == group_name}
+
+    @cached_method
+    def asset_keys_for_partitions_def(
+        self, partitions_def: PartitionsDefinition
+    ) -> AbstractSet[AssetKey]:
+        return {node.key for node in self.asset_nodes if node.partitions_def == partitions_def}
 
     @cached_property
     def root_materializable_asset_keys(self) -> AbstractSet[AssetKey]:
@@ -235,6 +245,12 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
     @cached_property
     def asset_check_keys(self) -> AbstractSet[AssetCheckKey]:
         return {key for asset in self.asset_nodes for key in asset.check_keys}
+
+    @cached_property
+    def all_partitions_defs(self) -> Sequence[PartitionsDefinition]:
+        return sorted(
+            set(node.partitions_def for node in self.asset_nodes if node.partitions_def), key=repr
+        )
 
     @cached_property
     def all_group_names(self) -> AbstractSet[str]:

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -243,10 +243,9 @@ def build_caching_repository_data_from_list(
     )
     if assets_defs or source_assets or asset_checks_defs:
         for job_def in get_base_asset_jobs(
-            assets=asset_graph.assets_defs,
+            asset_graph=asset_graph,
             executor_def=default_executor_def,
             resource_defs=top_level_resources,
-            asset_checks=asset_checks_defs,
         ):
             jobs[job_def.name] = job_def
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -1951,16 +1951,17 @@ def test_get_base_asset_jobs_multiple_partitions_defs():
     def unpartitioned_asset(): ...
 
     jobs = get_base_asset_jobs(
-        assets=[
-            daily_asset,
-            daily_asset2,
-            daily_asset_different_start_date,
-            hourly_asset,
-            unpartitioned_asset,
-        ],
+        asset_graph=AssetGraph.from_assets(
+            [
+                daily_asset,
+                daily_asset2,
+                daily_asset_different_start_date,
+                hourly_asset,
+                unpartitioned_asset,
+            ]
+        ),
         executor_def=None,
         resource_defs={},
-        asset_checks=[],
     )
     assert len(jobs) == 3
     assert {job_def.name for job_def in jobs} == {
@@ -1995,14 +1996,15 @@ def test_get_base_asset_jobs_multiple_partitions_defs_and_observable_assets():
     def asset_x(asset_b: B): ...
 
     jobs = get_base_asset_jobs(
-        assets=[
-            asset_x,
-            create_external_asset_from_source_asset(asset_a),
-            create_external_asset_from_source_asset(asset_b),
-        ],
+        asset_graph=AssetGraph.from_assets(
+            [
+                asset_x,
+                create_external_asset_from_source_asset(asset_a),
+                create_external_asset_from_source_asset(asset_b),
+            ]
+        ),
         executor_def=None,
         resource_defs={},
-        asset_checks=[],
     )
     assert len(jobs) == 2
     assert {job_def.name for job_def in jobs} == {

--- a/python_modules/dagster/dagster_tests/general_tests/test_pending_repository.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_pending_repository.py
@@ -133,7 +133,7 @@ def test_resolve_wrong_data():
         )
 
 
-def define_resource_dependent_cacheable_and_uncacheable_assets():
+def define_uncacheable_and_resource_dependent_cacheable_assets():
     class ResourceDependentCacheableAsset(CacheableAssetsDefinition):
         def __init__(self):
             super().__init__("res_downstream")
@@ -160,11 +160,11 @@ def define_resource_dependent_cacheable_and_uncacheable_assets():
                 for cd in data
             ]
 
-    @asset(required_resource_keys={"foo"})
+    @asset
     def res_upstream(context):
         return context.resources.foo
 
-    @asset(required_resource_keys={"foo"})
+    @asset
     def res_downstream(context, res_midstream):
         return res_midstream + context.resources.foo
 
@@ -181,7 +181,7 @@ def test_resolve_no_resources():
             @repository
             def resource_dependent_repo_no_resources():
                 return [
-                    define_resource_dependent_cacheable_and_uncacheable_assets(),
+                    define_uncacheable_and_resource_dependent_cacheable_assets(),
                     define_asset_job(
                         "all_asset_job",
                     ),
@@ -207,7 +207,7 @@ def test_resolve_with_resources():
     def resource_dependent_repo_with_resources():
         return [
             with_resources(
-                define_resource_dependent_cacheable_and_uncacheable_assets(), {"foo": foo_resource}
+                define_uncacheable_and_resource_dependent_cacheable_assets(), {"foo": foo_resource}
             ),
             define_asset_job(
                 "all_asset_job",
@@ -289,7 +289,7 @@ def test_multiple_wrapped_cached_assets():
         for x in with_resources(
             [
                 x.with_attributes(group_names_by_key={AssetKey("res_midstream"): "my_cool_group"})
-                for x in define_resource_dependent_cacheable_and_uncacheable_assets()
+                for x in define_uncacheable_and_resource_dependent_cacheable_assets()
             ],
             {"foo": foo_resource},
         )


### PR DESCRIPTION
## Summary & Motivation

Reap some benefits of the new `AssetGraph`. Construct the base jobs for a repository from the asset graph instead of lists of assets and checks.

## How I Tested These Changes

Existing test suite.