### PR TITLE
[auto-materialize] fix external asset amp again

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -149,7 +149,7 @@ class AssetDaemonContext:
         return [
             key
             for key in self.auto_materialize_asset_keys_and_parents
-            if (self.asset_graph.has_asset(key) and self.asset_graph.is_materializable(key))
+            if self.asset_graph.has_asset(key)
         ]
 
     @property

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -549,11 +549,8 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             )
         ]
         for parent_asset_key in self.asset_graph.get_parents(child_asset_key):
-            # ignore missing and non-executable parents
-            if not (
-                self.asset_graph.has_asset(parent_asset_key)
-                and self.asset_graph.is_executable(parent_asset_key)
-            ):
+            # ignore non-existent parents
+            if not self.asset_graph.has_asset(parent_asset_key):
                 continue
 
             # if the parent has not been updated at all since the latest_storage_id, then skip
@@ -899,11 +896,8 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             if parent_key in ignored_parent_keys:
                 continue
 
-            # ignore non-existent or unexecutable parents
-            if not (
-                self.asset_graph.has_asset(parent_key)
-                and self.asset_graph.is_executable(parent_key)
-            ):
+            # ignore non-existent parents
+            if not self.asset_graph.has_asset(parent_key):
                 continue
 
             # when mapping from unpartitioned assets to time partitioned assets, we ignore


### PR DESCRIPTION
## Summary & Motivation

Previously, external assets were still being ignored, even though they can have materialization events associated with them.

This fixes that behavior. There is no longer a distinction between an external asset and a "non observable source", and so we will simply look for materializations of any existing (i.e. represented in the asset graph) parent assets.

## How I Tested These Changes
