### PR TITLE
[Search performance] Cache search results in IndexedDB for 1 week

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -1,9 +1,15 @@
-import {gql, useLazyQuery} from '@apollo/client';
-import {useCallback, useRef} from 'react';
+import {gql} from '@apollo/client';
+import {useCallback, useEffect, useRef} from 'react';
 
 import {QueryResponse, WorkerSearchResult, createSearchWorker} from './createSearchWorker';
 import {SearchResult, SearchResultType} from './types';
-import {SearchPrimaryQuery, SearchSecondaryQuery} from './types/useGlobalSearch.types';
+import {
+  SearchPrimaryQuery,
+  SearchPrimaryQueryVariables,
+  SearchSecondaryQuery,
+  SearchSecondaryQueryVariables,
+} from './types/useGlobalSearch.types';
+import {useIndexedDBCachedQuery} from './useIndexedDBCachedQuery';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
@@ -186,37 +192,25 @@ export const useGlobalSearch = () => {
   const primarySearch = useRef<WorkerSearchResult | null>(null);
   const secondarySearch = useRef<WorkerSearchResult | null>(null);
 
-  const primary = useLazyQuery<SearchPrimaryQuery>(SEARCH_PRIMARY_QUERY, {
-    // Don't use the cache because it is slow and we only make this request once so we don't need the cache
-    fetchPolicy: 'no-cache',
-    onCompleted: (data: SearchPrimaryQuery) => {
-      const results = primaryDataToSearchResults({data});
-      if (!primarySearch.current) {
-        primarySearch.current = createSearchWorker('primary', fuseOptions);
-      }
-      primarySearch.current.update(results);
-      consumeBufferEffect(primarySearchBuffer, primarySearch.current);
-    },
+  const {
+    data: primaryData,
+    fetch: fetchPrimaryData,
+    loading: primaryDataLoading,
+  } = useIndexedDBCachedQuery<SearchPrimaryQuery, SearchPrimaryQueryVariables>({
+    query: SEARCH_PRIMARY_QUERY,
+    key: 'SearchPrimary',
+    variables: {},
   });
 
-  const secondary = useLazyQuery<SearchSecondaryQuery>(SEARCH_SECONDARY_QUERY, {
-    // Don't use the cache because it is slow and we only make this request once so we don't need the cache
-    fetchPolicy: 'no-cache',
-    onCompleted: (data: SearchSecondaryQuery) => {
-      const results = secondaryDataToSearchResults({data});
-      if (!secondarySearch.current) {
-        secondarySearch.current = createSearchWorker('secondary', fuseOptions);
-      }
-      secondarySearch.current.update(results);
-      consumeBufferEffect(secondarySearchBuffer, secondarySearch.current);
-    },
+  const {
+    data: secondaryData,
+    fetch: fetchSecondaryData,
+    loading: secondaryDataLoading,
+  } = useIndexedDBCachedQuery<SearchSecondaryQuery, SearchSecondaryQueryVariables>({
+    query: SEARCH_SECONDARY_QUERY,
+    key: 'SearchSecondary',
+    variables: {},
   });
-
-  const primarySearchBuffer = useRef<IndexBuffer | null>(null);
-  const secondarySearchBuffer = useRef<IndexBuffer | null>(null);
-
-  const [performPrimaryLazyQuery, primaryResult] = primary;
-  const [performSecondaryLazyQuery, secondaryResult] = secondary;
 
   const consumeBufferEffect = useCallback(
     async (buffer: React.MutableRefObject<IndexBuffer | null>, search: WorkerSearchResult) => {
@@ -230,14 +224,37 @@ export const useGlobalSearch = () => {
     [],
   );
 
+  useEffect(() => {
+    if (!primaryData) {
+      return;
+    }
+    const results = primaryDataToSearchResults({data: primaryData});
+    if (!primarySearch.current) {
+      primarySearch.current = createSearchWorker('primary', fuseOptions);
+    }
+    primarySearch.current.update(results);
+    consumeBufferEffect(primarySearchBuffer, primarySearch.current);
+  }, [consumeBufferEffect, primaryData]);
+
+  useEffect(() => {
+    if (!secondaryData) {
+      return;
+    }
+    const results = secondaryDataToSearchResults({data: secondaryData});
+    if (!secondarySearch.current) {
+      secondarySearch.current = createSearchWorker('secondary', fuseOptions);
+    }
+    secondarySearch.current.update(results);
+    consumeBufferEffect(primarySearchBuffer, secondarySearch.current);
+  }, [consumeBufferEffect, secondaryData]);
+
+  const primarySearchBuffer = useRef<IndexBuffer | null>(null);
+  const secondarySearchBuffer = useRef<IndexBuffer | null>(null);
+
   const initialize = useCallback(() => {
-    if (!primaryResult.data && !primaryResult.loading) {
-      performPrimaryLazyQuery();
-    }
-    if (!secondaryResult.data && !secondaryResult.loading) {
-      performSecondaryLazyQuery();
-    }
-  }, [performPrimaryLazyQuery, performSecondaryLazyQuery, primaryResult, secondaryResult]);
+    fetchPrimaryData();
+    fetchSecondaryData();
+  }, [fetchPrimaryData, fetchSecondaryData]);
 
   const searchIndex = useCallback(
     (
@@ -301,7 +318,7 @@ export const useGlobalSearch = () => {
 
   return {
     initialize,
-    loading: !primaryResult.data || !secondaryResult.data,
+    loading: primaryDataLoading || secondaryDataLoading,
     searchPrimary,
     searchSecondary,
     terminate,

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
@@ -1,0 +1,67 @@
+import {DocumentNode, OperationVariables, useApolloClient} from '@apollo/client';
+import {cache} from 'idb-lru-cache';
+import React from 'react';
+
+const ONE_WEEK = 1000 * 60 * 60 * 24 * 7;
+
+/**
+ * Returns data from the indexedDB cache initially while loading is true.
+ * Fetches data from the network/cache initially and does not receive any updates afterwards
+ */
+export function useIndexedDBCachedQuery<TQuery, TVariables extends OperationVariables>({
+  key,
+  query,
+  variables,
+}: {
+  key: string;
+  query: DocumentNode;
+  variables: TVariables;
+}) {
+  const client = useApolloClient();
+
+  const lru = React.useMemo(
+    () => cache<string, TQuery>({dbName: `indexdbQueryCache:${key}`, maxCount: 1}),
+    [key],
+  );
+
+  const [data, setData] = React.useState<TQuery | null>(null);
+
+  const [loading, setLoading] = React.useState(false);
+
+  React.useEffect(() => {
+    (async () => {
+      const {value} = await lru.get('cache');
+      if (value) {
+        setData(value);
+      }
+    })();
+  }, [lru]);
+
+  const didFetch = React.useRef(false);
+
+  const fetch = React.useCallback(async () => {
+    if (didFetch.current) {
+      return;
+    }
+    didFetch.current = true;
+    setLoading(true);
+    // Use client.query here so that we initially use the apollo cache if any data is available in it
+    // and so that we don't subscribe to any updates to that cache (useLazyQuery and useQuery would both subscribe to updates to the
+    // cache which can be very slow)
+    const {data} = await client.query<TQuery, TVariables>({
+      query,
+      variables,
+    });
+    setLoading(false);
+    lru.set('cache', data, {
+      expiry: new Date(Date.now() + ONE_WEEK),
+    });
+    setData(data);
+  }, [client, lru, query, variables]);
+
+  return {
+    fetch,
+    data,
+    loading,
+  };
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
@@ -38,6 +38,7 @@ type SetVisibleOrHiddenFn = (repoAddresses: RepoAddress[]) => void;
 type WorkspaceState = {
   error: PythonErrorFragment | null;
   loading: boolean;
+  data: RootWorkspaceQuery | undefined;
   locationEntries: WorkspaceRepositoryLocationNode[];
   allRepos: DagsterRepoOption[];
   visibleRepos: DagsterRepoOption[];
@@ -226,6 +227,7 @@ const useWorkspaceState = (): WorkspaceState => {
 
   return {
     refetch,
+    data,
     loading: loading && !data, // Only "loading" on initial load.
     error,
     locationEntries,

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
@@ -38,7 +38,6 @@ type SetVisibleOrHiddenFn = (repoAddresses: RepoAddress[]) => void;
 type WorkspaceState = {
   error: PythonErrorFragment | null;
   loading: boolean;
-  data: RootWorkspaceQuery | undefined;
   locationEntries: WorkspaceRepositoryLocationNode[];
   allRepos: DagsterRepoOption[];
   visibleRepos: DagsterRepoOption[];
@@ -227,7 +226,6 @@ const useWorkspaceState = (): WorkspaceState => {
 
   return {
     refetch,
-    data,
     loading: loading && !data, // Only "loading" on initial load.
     error,
     locationEntries,


### PR DESCRIPTION
## Summary & Motivation

We're caching search results cache in IndexedDB and giving the results an expiration of 1 week. 

Previously I added `no-cache` on the useLazyQuery to avoid subscribing to cache updates (because they're slow) but I realized now I could achieve the same thing **while also initially using the cache** (if available) by using `client.query` directly instead. 

## How I Tested These Changes

shadow dagit KH
locally.