### PR TITLE
Fix duplicate events with asset check step launcher

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/external_step.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import pickle
 import shutil
@@ -14,7 +13,7 @@ from dagster._core.definitions.reconstruct import ReconstructableJob, Reconstruc
 from dagster._core.definitions.resource_definition import dagster_maintained_resource, resource
 from dagster._core.definitions.step_launcher import StepLauncher, StepRunRef
 from dagster._core.errors import raise_execution_interrupts
-from dagster._core.events import AssetCheckEvaluationPlanned, DagsterEvent, DagsterEventType
+from dagster._core.events import DagsterEvent
 from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.context.system import StepExecutionContext
@@ -253,27 +252,6 @@ def run_step_from_ref(
             step_context.instance.add_dynamic_partitions(
                 partitions_def_name=partitions_def.name, partition_keys=[step_context.partition_key]
             )
-
-    # Note: this patches ASSET_CHECK_EVALUATION_PLANNED events into the mini event log present
-    # on external steps. This is necessary because we test that ASSET_CHECK_EVALUATION events
-    # have corresponding ASSET_CHECK_EVALUATION_PLANNED events.
-    for output in step_context.step.step_outputs:
-        asset_check_key = check.not_none(output.properties).asset_check_key
-        if asset_check_key:
-            event = DagsterEvent(
-                event_type_value=DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED.value,
-                job_name=step_context.job_name,
-                message=(
-                    f"{step_context.job_name} intends to execute asset check {asset_check_key.name} on"
-                    f" asset {asset_check_key.asset_key.to_string()}"
-                ),
-                event_specific_data=AssetCheckEvaluationPlanned(
-                    asset_check_key.asset_key,
-                    check_name=asset_check_key.name,
-                ),
-                step_key=step_context.step.key,
-            )
-            instance.report_dagster_event(event, step_run_ref.run_id, logging.DEBUG)
 
     # The step should be forced to run locally with respect to the remote process that this step
     # context is being deserialized in

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2830,10 +2830,13 @@ class SqlEventLogStorage(EventLogStorage):
                     ),
                 )
             ).rowcount
-        if rows_updated != 1:
+
+        # 0 isn't normally expected, but occurs with the external instance of step launchers where
+        # they don't have planned events.
+        if rows_updated > 1:
             raise DagsterInvariantViolationError(
-                "Expected to update one row for asset check evaluation, but updated"
-                f" {rows_updated}."
+                f"Updated {rows_updated} rows for asset check evaluation {evaluation.asset_check_key} "
+                "as a result of duplicate AssetCheckPlanned events."
             )
 
     def get_asset_check_execution_history(

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
@@ -414,6 +414,20 @@ def test_asset_check_step_launcher():
             assert DagsterEventType.STEP_FAILURE not in event_types
 
 
+def test_asset_check_step_launcher_job():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with instance_for_test() as instance:
+            with execute_job(
+                reconstructable(define_asset_check_job),
+                run_config=make_run_config(tmpdir, "no_base"),
+                instance=instance,
+            ) as result:
+                assert result.success
+                check_evals = result.get_asset_check_evaluations()
+                assert len(check_evals) == 1
+                assert check_evals[0].passed
+
+
 @pytest.mark.parametrize("resource_set", ["external", "internal_and_external"])
 def test_job(resource_set):
     if resource_set == "external":


### PR DESCRIPTION
https://github.com/dagster-io/dagster/pull/19443 had a weak test case that only ran a standalone step. It didn't test an actual run, which would have failed with `dagster._core.errors.DagsterInvariantViolationError: Expected to one row for asset check evaluation, but updated 2.`

That diff was writing `AssetCheckEvaluationPlanned` events to the external instance. However, step launchers log their events back to the main instance so we ended up with 2 planned events. Duplicate planned events meant that we create duplicate rows in the `AssetCheckExecutionsTable` summary table. Options to avoid that duplicate row are:

- [this diff] Don't log the planned events to the external instance. As a result, we have to loosen a guarantee that every `AssetCheckEvaluation` has a corresponding row in `AssetCheckExecutionsTable`, created by the planned event. I'm not thrilled about this, but I've been expecting to have to do the same thing anyway to support wiping asset check executions (since you could wipe between the planned event and the result, and we'd delete the rows of the summary table)
- we could change `store_asset_check_event` to not deal with the summary table on external instances. We'd need a toggle on the instance to know if we're in an external context
- filter the `AssetCheckEvaluationPlanned` events out when we ingest the external step launcher events back in to the main instance. Unfortunately, step launchers call `step_context.instance.handle_new_event(event)` directly inside of `launch_step` instead of just yielding events out. We could change our step launchers but I expect that user step launchers do the same