### PR TITLE
feat(dbt): log column schema only when using `DbtCliResource`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -982,6 +982,8 @@ class DbtCliResource(ConfigurableResource):
         target_path = target_path or self._get_unique_target_path(context=context)
         env = {
             **os.environ.copy(),
+            # An environment variable to indicate that the dbt CLI is being invoked from Dagster.
+            "DAGSTER_DBT_CLI": "true",
             # Run dbt with unbuffered output.
             "PYTHONUNBUFFERED": "1",
             # Disable anonymous usage statistics for performance.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -90,15 +90,24 @@ def test_dbt_cli_no_jinja_log_info() -> None:
 
 
 def test_dbt_raw_cli_no_empty_jinja_log_info() -> None:
-    # Ensure `log_columns_in_relation.sql` does not produce empty `{}` statements when run outside of the context of `dagster-dbt`
-    result = subprocess.run(
+    result = subprocess.check_output(
         ["dbt", "--log-format", "json", "--no-partial-parse", "parse"],
-        capture_output=True,
         text=True,
         cwd=test_metadata_path,
-        check=False,
     )
 
     assert not any(
-        [json.loads(line)["info"]["name"] == "JinjaLogInfo" for line in result.stdout.splitlines()]
+        json.loads(line)["info"]["name"] == "JinjaLogInfo" for line in result.splitlines()
+    )
+
+
+def test_dbt_raw_cli_no_jinja_log_info() -> None:
+    result = subprocess.check_output(
+        ["dbt", "--log-format", "json", "--no-partial-parse", "build"],
+        text=True,
+        cwd=test_metadata_path,
+    )
+
+    assert not any(
+        json.loads(line)["info"]["name"] == "JinjaLogInfo" for line in result.splitlines()
     )

--- a/python_modules/libraries/dagster-dbt/dbt_packages/dagster/macros/log_columns_in_relation.sql
+++ b/python_modules/libraries/dagster-dbt/dbt_packages/dagster/macros/log_columns_in_relation.sql
@@ -1,4 +1,5 @@
 {% macro log_columns_in_relation() %}
+    {%- set is_dagster_dbt_cli = env_var('DAGSTER_DBT_CLI', '') == 'true' -%}
     {%- set columns = adapter.get_columns_in_relation(this) -%}
     {%- set table_schema = {} -%}
 
@@ -7,7 +8,7 @@
         {%- set _ = table_schema.update(serializable_column) -%}
     {% endfor %}
 
-    {% if table_schema %}
+    {% if is_dagster_dbt_cli and table_schema %}
         {% do log(tojson(table_schema), info=true) %}
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
## Summary & Motivation
In local development, when using the `dbt` CLI without `dagster-dbt` (but with the `dagster` dbt package installed), seeing log messages with column schema is distracting.

These log messages are only used by the `dagster-dbt` framework, and should not be exposed to the user. So don't log them when just using `dbt`, even if the `dagster` dbt package is installed.

## How I Tested These Changes
pytest
