### PR TITLE
point users to required_multi_asset_neighbors in error

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -971,7 +971,8 @@ def _subset_assets_defs(
                 f"{sorted(list(asset.check_keys))}, but "
                 f"attempted to select only {sorted(list(selected_subset))}. "
                 "This AssetsDefinition does not support subsetting. Please select all "
-                "asset keys produced by this asset."
+                "asset keys produced by this asset.\n\nIf using an AssetSelection, you may "
+                "append required_multi_asset_neighbors() to select any remaining assets, for example:\nAssetSelection.groups('my_group').upstream().required_multi_asset_neighbors()"
             )
 
     return (

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -972,7 +972,8 @@ def _subset_assets_defs(
                 f"attempted to select only {sorted(list(selected_subset))}. "
                 "This AssetsDefinition does not support subsetting. Please select all "
                 "asset keys produced by this asset.\n\nIf using an AssetSelection, you may "
-                "use required_multi_asset_neighbors() to select any remaining assets, for example:\nAssetSelection.keys('my_asset').required_multi_asset_neighbors()"
+                "use required_multi_asset_neighbors() to select any remaining assets, for "
+                "example:\nAssetSelection.keys('my_asset').required_multi_asset_neighbors()"
             )
 
     return (

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -972,7 +972,7 @@ def _subset_assets_defs(
                 f"attempted to select only {sorted(list(selected_subset))}. "
                 "This AssetsDefinition does not support subsetting. Please select all "
                 "asset keys produced by this asset.\n\nIf using an AssetSelection, you may "
-                "append required_multi_asset_neighbors() to select any remaining assets, for example:\nAssetSelection.groups('my_group').upstream().required_multi_asset_neighbors()"
+                "use required_multi_asset_neighbors() to select any remaining assets, for example:\nAssetSelection.keys('my_asset').required_multi_asset_neighbors()"
             )
 
     return (


### PR DESCRIPTION
## Summary

Adds a call-out to use `required_multi_asset_neighbors` if selecting a subset of non-subsettable multi-assets.

## Test Plan

Tested locally

<img width="1274" alt="Screenshot 2024-03-04 at 2 33 20 PM" src="https://github.com/dagster-io/dagster/assets/10215173/f64f86f2-fdac-47e9-8afb-06b2209dffdc">

