### PR TITLE
fix: source assets `group_name` were not propagated

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -400,7 +400,7 @@ class SourceAsset(ResourceAddable):
                 io_manager_def=self.io_manager_def,
                 description=self.description,
                 partitions_def=self.partitions_def,
-                group_name=group_name,
+                group_name=group_name or self.group_name,
                 resource_defs=self.resource_defs,
                 observe_fn=self.observe_fn,
                 auto_observe_interval_minutes=self.auto_observe_interval_minutes,


### PR DESCRIPTION
## Summary & Motivation
During a call .`with_attributes` which is used during `load_assets_from_modules`, the `group_name` gets lost from every source_asset. This is caused by the fact that .with_attributes only returns the group_name that's provided during with_attributes, obviously it should keep the group_name if nothing is passed.


```python
@observable_source_asset(group_name="TEST_GROUP")
def dummy_source_asset():
    return DataVersion('1')
```

Before:
```python
dummy_source_asset.with_attributes(key=AssetKey([*"test", *dummy_source_asset.key.path])).group_name
'default'
```

After:
```python
dummy_source_asset.with_attributes(key=AssetKey([*"test", *dummy_source_asset.key.path])).group_name
'TEST_GROUP'
```