### PR TITLE
Asset checks polish

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/CollapsibleSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/CollapsibleSection.tsx
@@ -8,11 +8,13 @@ export const CollapsibleSection = ({
   headerWrapperProps,
   children,
   isInitiallyCollapsed = false,
+  arrowSide = 'left',
 }: {
   header: React.ReactNode;
   headerWrapperProps?: React.ComponentProps<typeof Box>;
   children: React.ReactNode;
   isInitiallyCollapsed?: boolean;
+  arrowSide?: 'left' | 'right';
 }) => {
   const [isCollapsed, setIsCollapsed] = React.useState(isInitiallyCollapsed);
   return (
@@ -25,11 +27,23 @@ export const CollapsibleSection = ({
           headerWrapperProps?.onClick?.();
         }}
       >
-        <Icon
-          name="arrow_drop_down"
-          style={{transform: isCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)'}}
-        />
-        <div>{header}</div>
+        {arrowSide === 'left' ? (
+          <>
+            <Icon
+              name="arrow_drop_down"
+              style={{transform: isCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)'}}
+            />
+            <div>{header}</div>
+          </>
+        ) : (
+          <Box flex={{justifyContent: 'space-between', alignItems: 'center'}}>
+            <div>{header}</div>
+            <Icon
+              name="arrow_drop_down"
+              style={{transform: isCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)'}}
+            />
+          </Box>
+        )}
       </Box>
       {isCollapsed ? null : children}
     </Box>

--- a/js_modules/dagster-ui/packages/ui-components/src/components/CollapsibleSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/CollapsibleSection.tsx
@@ -21,7 +21,13 @@ export const CollapsibleSection = ({
     <Box flex={{direction: 'column'}}>
       <Box
         {...headerWrapperProps}
-        flex={{direction: 'row', alignItems: 'center', gap: 6, ...(headerWrapperProps?.flex || {})}}
+        flex={{
+          direction: 'row',
+          alignItems: 'center',
+          gap: 6,
+          grow: 1,
+          ...(headerWrapperProps?.flex || {}),
+        }}
         onClick={() => {
           setIsCollapsed(!isCollapsed);
           headerWrapperProps?.onClick?.();

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
@@ -333,7 +333,7 @@ export const AutomaterializeMiddlePanelWithData = ({
           <Box border="bottom" padding={{vertical: 12}} margin={{bottom: 12}}>
             <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 24}}>
               <Box flex={{direction: 'column', gap: 5}}>
-                <Subtitle2>Evaluation Result</Subtitle2>
+                <Subtitle2>Evaluation result</Subtitle2>
                 <div>{statusTag}</div>
               </Box>
               {selectedEvaluation?.timestamp ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -241,6 +241,7 @@ export const AssetChecks = ({
             <CollapsibleSection
               header={<Subtitle2>About</Subtitle2>}
               headerWrapperProps={headerWrapperProps}
+              arrowSide="right"
             >
               <Box padding={{top: 12}} flex={{gap: 12, direction: 'column'}}>
                 <Body2>
@@ -267,11 +268,12 @@ export const AssetChecks = ({
             <CollapsibleSection
               header={<Subtitle2>Latest execution</Subtitle2>}
               headerWrapperProps={headerWrapperProps}
+              arrowSide="right"
             >
               <Box padding={{top: 12}}>
-                <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 24}}>
+                <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 24}}>
                   <Box flex={{direction: 'column', gap: 6}}>
-                    <Subtitle2>Evaluation Result</Subtitle2>
+                    <Subtitle2>Evaluation result</Subtitle2>
                     <div>
                       <AssetCheckStatusTag
                         execution={selectedCheck.executionForLatestMaterialization}
@@ -299,12 +301,19 @@ export const AssetChecks = ({
                       </Link>
                     </Box>
                   ) : null}
+                  {lastExecution?.evaluation?.metadataEntries ? (
+                    <Box flex={{direction: 'column', gap: 6}}>
+                      <Subtitle2>Metadata</Subtitle2>
+                      <MetadataCell metadataEntries={lastExecution.evaluation.metadataEntries} />
+                    </Box>
+                  ) : null}
                 </div>
               </Box>
             </CollapsibleSection>
             <CollapsibleSection
               header={<Subtitle2>Execution history</Subtitle2>}
               headerWrapperProps={headerWrapperProps}
+              arrowSide="right"
             >
               <Box padding={{top: 12}}>
                 {lastExecution ? (
@@ -352,7 +361,11 @@ const CheckExecutions = ({assetKey, checkName}: {assetKey: AssetKeyInput; checkN
   // TODO - in a follow up PR we should have some kind of queryRefresh context that can merge all of the uses of queryRefresh.
   useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
 
-  const executions = queryResult.data?.assetCheckExecutions;
+  const executions = React.useMemo(
+    // Remove first element since the latest execution info is already shown above
+    () => queryResult.data?.assetCheckExecutions.slice(1),
+    [queryResult],
+  );
 
   const runHistory = () => {
     if (!executions) {
@@ -363,7 +376,7 @@ const CheckExecutions = ({assetKey, checkName}: {assetKey: AssetKeyInput; checkN
         <Table>
           <thead>
             <tr>
-              <th style={{width: '160px'}}>Evaluation Result</th>
+              <th style={{width: '160px'}}>Evaluation result</th>
               <th style={{width: '200px'}}>Timestamp</th>
               <th style={{width: '200px'}}>Target materialization</th>
               <th>Metadata</th>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -143,6 +143,8 @@ export const AssetChecks = ({
   const lastExecution = selectedCheck.executionForLatestMaterialization;
   const targetMaterialization = lastExecution?.evaluation?.targetMaterialization;
 
+  console.log({lastExecution});
+
   return (
     <Box flex={{grow: 1, direction: 'column'}}>
       {didDismissAssetChecksBanner ? null : (
@@ -303,7 +305,7 @@ export const AssetChecks = ({
                     </Box>
                   ) : null}
                 </div>
-                {lastExecution?.evaluation?.metadataEntries ? (
+                {lastExecution?.evaluation?.metadataEntries.length ? (
                   <Box flex={{direction: 'column', gap: 6}}>
                     <Subtitle2>Metadata</Subtitle2>
                     <MetadataEntries entries={lastExecution.evaluation.metadataEntries} />
@@ -485,8 +487,8 @@ export const ASSET_CHECKS_QUERY = gql`
           }
           ... on AssetChecks {
             checks {
-              ...AssetCheckTableFragment
               ...ExecuteChecksButtonCheckFragment
+              ...AssetCheckTableFragment
             }
           }
         }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -41,6 +41,7 @@ import {Timestamp} from '../../app/time/Timestamp';
 import {AssetKeyInput} from '../../graphql/types';
 import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
 import {useStateWithStorage} from '../../hooks/useStateWithStorage';
+import {MetadataEntries} from '../../metadata/MetadataEntry';
 import {linkToRunEvent} from '../../runs/RunUtils';
 import {useCursorPaginatedQuery} from '../../runs/useCursorPaginatedQuery';
 import {TimestampDisplay} from '../../schedules/TimestampDisplay';
@@ -270,7 +271,7 @@ export const AssetChecks = ({
               headerWrapperProps={headerWrapperProps}
               arrowSide="right"
             >
-              <Box padding={{top: 12}}>
+              <Box padding={{top: 12}} flex={{direction: 'column', gap: 12}}>
                 <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 24}}>
                   <Box flex={{direction: 'column', gap: 6}}>
                     <Subtitle2>Evaluation result</Subtitle2>
@@ -301,13 +302,13 @@ export const AssetChecks = ({
                       </Link>
                     </Box>
                   ) : null}
-                  {lastExecution?.evaluation?.metadataEntries ? (
-                    <Box flex={{direction: 'column', gap: 6}}>
-                      <Subtitle2>Metadata</Subtitle2>
-                      <MetadataCell metadataEntries={lastExecution.evaluation.metadataEntries} />
-                    </Box>
-                  ) : null}
                 </div>
+                {lastExecution?.evaluation?.metadataEntries ? (
+                  <Box flex={{direction: 'column', gap: 6}}>
+                    <Subtitle2>Metadata</Subtitle2>
+                    <MetadataEntries entries={lastExecution.evaluation.metadataEntries} />
+                  </Box>
+                ) : null}
               </Box>
             </CollapsibleSection>
             <CollapsibleSection

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/__fixtures__/AssetChecks.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/__fixtures__/AssetChecks.fixtures.tsx
@@ -24,7 +24,7 @@ export const TestAssetCheck = buildAssetCheck({
         timestamp: testLatestMaterializationTimeStamp,
         runId: testLatestMaterializationRunId,
       }),
-      metadataEntries: [buildIntMetadataEntry({})],
+      metadataEntries: [],
       severity: AssetCheckSeverity.ERROR,
     }),
     runId: testLatestMaterializationRunId,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
@@ -22,8 +22,8 @@ export type AssetChecksQuery = {
               checks: Array<{
                 __typename: 'AssetCheck';
                 name: string;
-                description: string | null;
                 canExecuteIndividually: Types.AssetCheckCanExecuteIndividually;
+                description: string | null;
                 executionForLatestMaterialization: {
                   __typename: 'AssetCheckExecution';
                   id: string;


### PR DESCRIPTION
## Summary & Motivation
<img width="1727" alt="Screenshot 2024-03-05 at 1 42 03 PM" src="https://github.com/dagster-io/dagster/assets/2286579/e1f51883-2b00-4d49-be73-f16c6c2f821b">

1. Lowercase "result" in "Evaluation result".
2. Move the collapse arrows to the right side
3. Don't show the latest execution in the table since we already show it above

## How I Tested These Changes

