### PR TITLE
[ui] Enable displaying recently visited assets

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogRoot.tsx
@@ -1,11 +1,12 @@
 import {gql, useQuery} from '@apollo/client';
 import {Box, Colors, Page, Spinner} from '@dagster-io/ui-components';
+import React from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
 import {AssetGlobalLineageLink, AssetPageHeader} from './AssetPageHeader';
 import {AssetView} from './AssetView';
 import {AssetsCatalogTable} from './AssetsCatalogTable';
-import {WriteAssetVisitToLocalStorage} from './RecentlyVisitedAssetsStorage';
+import {writeAssetVisitToLocalStorage} from './RecentlyVisitedAssetsStorage';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {
   AssetsCatalogRootQuery,
@@ -45,6 +46,18 @@ export const AssetsCatalogRoot = () => {
     currentPath && currentPath.length === 0 ? 'AssetsCatalogRoot' : 'AssetCatalogAssetView',
   );
 
+  React.useEffect(() => {
+    // If the asset exists, add it to the recently visited list
+    if (
+      currentPath &&
+      currentPath.length &&
+      queryResult.loading === false &&
+      queryResult.data?.assetOrError.__typename === 'Asset'
+    ) {
+      writeAssetVisitToLocalStorage({path: currentPath});
+    }
+  }, [currentPath, queryResult]);
+
   if (queryResult.loading) {
     return (
       <Page>
@@ -83,10 +96,6 @@ export const AssetsCatalogRoot = () => {
     );
   }
 
-  // If the asset exists, add it to the recently visited list
-  if (currentPath && currentPath.length) {
-    WriteAssetVisitToLocalStorage({path: currentPath});
-  }
   return <AssetView assetKey={{path: currentPath}} trace={trace} />;
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogRoot.tsx
@@ -5,6 +5,7 @@ import {useHistory, useParams} from 'react-router-dom';
 import {AssetGlobalLineageLink, AssetPageHeader} from './AssetPageHeader';
 import {AssetView} from './AssetView';
 import {AssetsCatalogTable} from './AssetsCatalogTable';
+import {WriteAssetVisitToLocalStorage} from './RecentlyVisitedAssetsStorage';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {
   AssetsCatalogRootQuery,
@@ -82,6 +83,10 @@ export const AssetsCatalogRoot = () => {
     );
   }
 
+  // If the asset exists, add it to the recently visited list
+  if (currentPath && currentPath.length) {
+    WriteAssetVisitToLocalStorage({path: currentPath});
+  }
   return <AssetView assetKey={{path: currentPath}} trace={trace} />;
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 
 import {AssetGlobalLineageButton, AssetPageHeader} from './AssetPageHeader';
 import {ASSET_CATALOG_TABLE_QUERY} from './AssetsCatalogTable';
+import {FetchRecentlyVisitedAssetsFromLocalStorage} from './RecentlyVisitedAssetsStorage';
 import {AssetTableFragment} from './types/AssetTableFragment.types';
 import {
   AssetCatalogTableQuery,
@@ -15,6 +16,7 @@ import {
 import {useTrackPageView} from '../app/analytics';
 import {TimeContext} from '../app/time/TimeContext';
 import {browserTimezone} from '../app/time/browserTimezone';
+import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {TagIcon} from '../graph/OpTags';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
@@ -128,11 +130,11 @@ function getGreeting(timezone: string) {
 const CountForAssetType = ({children, assetsCount}: AssetOverviewCategoryProps) => {
   return (
     <Box
-      flex={{direction: 'row', justifyContent: 'space-between'}}
+      flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
       style={{width: 'calc(33% - 16px)'}}
     >
-      <div>{children}</div>
-      <AssetCount>{assetsCount} assets</AssetCount>
+      <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>{children}</Box>
+      {assetsCount !== 0 && <AssetCount>{assetsCount} assets</AssetCount>}
     </Box>
   );
 };
@@ -201,6 +203,7 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
   const {
     timezone: [timezone],
   } = useContext(TimeContext);
+  const recentlyVisitedAssets = FetchRecentlyVisitedAssetsFromLocalStorage();
 
   if (assetsQuery.loading) {
     return (
@@ -239,6 +242,21 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
           </Box>
         </Box>
         <Box flex={{direction: 'column'}}>
+          {recentlyVisitedAssets.length > 0 && (
+            <>
+              <SectionHeader sectionName="Recently visited" />
+              <SectionBody>
+                {recentlyVisitedAssets.map((assetKey, idx) => (
+                  <CountForAssetType key={idx} assetsCount={0}>
+                    <Icon name="asset" />
+                    <Link to={`/assets/${assetKey.path.join('/')}`}>
+                      {displayNameForAssetKey(assetKey)}
+                    </Link>
+                  </CountForAssetType>
+                ))}
+              </SectionBody>
+            </>
+          )}
           {Object.keys(assetCountBySection.countsByOwner).length > 0 && (
             <>
               <SectionHeader sectionName="Owner" />
@@ -257,10 +275,8 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
               <SectionBody>
                 {Object.entries(assetCountBySection.countsByComputeKind).map(([label, count]) => (
                   <CountForAssetType key={label} assetsCount={count}>
-                    <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-                      <TagIcon label={label} />
-                      <Link to={linkToAssetGraphComputeKind(label)}>{label}</Link>
-                    </Box>
+                    <TagIcon label={label} />
+                    <Link to={linkToAssetGraphComputeKind(label)}>{label}</Link>
                   </CountForAssetType>
                 ))}
               </SectionBody>
@@ -275,15 +291,13 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                     key={JSON.stringify(assetGroupCount.groupMetadata)}
                     assetsCount={assetGroupCount.assetCount}
                   >
-                    <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-                      <Icon name="asset_group" />
-                      <Link to={linkToAssetGraphGroup(assetGroupCount.groupMetadata)}>
-                        {assetGroupCount.groupMetadata.groupName}
-                      </Link>
-                      <span style={{color: Colors.textLighter()}}>
-                        {assetGroupCount.groupMetadata.repositoryLocationName}
-                      </span>
-                    </Box>
+                    <Icon name="asset_group" />
+                    <Link to={linkToAssetGraphGroup(assetGroupCount.groupMetadata)}>
+                      {assetGroupCount.groupMetadata.groupName}
+                    </Link>
+                    <span style={{color: Colors.textLighter()}}>
+                      {assetGroupCount.groupMetadata.repositoryLocationName}
+                    </span>
                   </CountForAssetType>
                 ))}
               </SectionBody>
@@ -298,12 +312,10 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                     key={repoAddressAsHumanString(countPerCodeLocation.repoAddress)}
                     assetsCount={countPerCodeLocation.assetCount}
                   >
-                    <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-                      <Icon name="folder" />
-                      <Link to={linkToCodeLocation(countPerCodeLocation.repoAddress)}>
-                        {repoAddressAsHumanString(countPerCodeLocation.repoAddress)}
-                      </Link>
-                    </Box>
+                    <Icon name="folder" />
+                    <Link to={linkToCodeLocation(countPerCodeLocation.repoAddress)}>
+                      {repoAddressAsHumanString(countPerCodeLocation.repoAddress)}
+                    </Link>
                   </CountForAssetType>
                 ))}
               </SectionBody>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 
 import {AssetGlobalLineageButton, AssetPageHeader} from './AssetPageHeader';
 import {ASSET_CATALOG_TABLE_QUERY} from './AssetsCatalogTable';
-import {FetchRecentlyVisitedAssetsFromLocalStorage} from './RecentlyVisitedAssetsStorage';
+import {fetchRecentlyVisitedAssetsFromLocalStorage} from './RecentlyVisitedAssetsStorage';
 import {AssetTableFragment} from './types/AssetTableFragment.types';
 import {
   AssetCatalogTableQuery,
@@ -203,7 +203,7 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
   const {
     timezone: [timezone],
   } = useContext(TimeContext);
-  const recentlyVisitedAssets = FetchRecentlyVisitedAssetsFromLocalStorage();
+  const recentlyVisitedAssets = fetchRecentlyVisitedAssetsFromLocalStorage();
 
   if (assetsQuery.loading) {
     return (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/RecentlyVisitedAssetsStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/RecentlyVisitedAssetsStorage.tsx
@@ -3,7 +3,7 @@ import {AssetKey} from './types';
 const RECENTLY_VISITED_ASSETS_CACHE_SIZE = 10;
 const RECENTLY_VISITED_ASSETS_STORAGE_KEY = 'recentlyVisitedAssets';
 
-export function WriteAssetVisitToLocalStorage(assetKey: AssetKey) {
+export function writeAssetVisitToLocalStorage(assetKey: AssetKey) {
   if (typeof window !== 'undefined') {
     const visitedAssetsStringified = localStorage.getItem(RECENTLY_VISITED_ASSETS_STORAGE_KEY);
     const visitedAssets: AssetKey[] = visitedAssetsStringified
@@ -29,7 +29,7 @@ export function WriteAssetVisitToLocalStorage(assetKey: AssetKey) {
   }
 }
 
-export function FetchRecentlyVisitedAssetsFromLocalStorage(): AssetKey[] {
+export function fetchRecentlyVisitedAssetsFromLocalStorage(): AssetKey[] {
   if (typeof window !== 'undefined') {
     const visitedAssetsStringified = localStorage.getItem(RECENTLY_VISITED_ASSETS_STORAGE_KEY);
     return visitedAssetsStringified ? JSON.parse(visitedAssetsStringified) : [];

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/RecentlyVisitedAssetsStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/RecentlyVisitedAssetsStorage.tsx
@@ -1,0 +1,38 @@
+import {AssetKey} from './types';
+
+const RECENTLY_VISITED_ASSETS_CACHE_SIZE = 10;
+const RECENTLY_VISITED_ASSETS_STORAGE_KEY = 'recentlyVisitedAssets';
+
+export function WriteAssetVisitToLocalStorage(assetKey: AssetKey) {
+  if (typeof window !== 'undefined') {
+    const visitedAssetsStringified = localStorage.getItem(RECENTLY_VISITED_ASSETS_STORAGE_KEY);
+    const visitedAssets: AssetKey[] = visitedAssetsStringified
+      ? JSON.parse(visitedAssetsStringified)
+      : [];
+
+    const assetIndex = visitedAssets.findIndex(
+      (key2) => JSON.stringify(key2) === JSON.stringify(assetKey),
+    );
+    if (assetIndex !== -1) {
+      // Remove the asset from the list
+      visitedAssets.splice(assetIndex, 1);
+    }
+
+    // Add the asset to the front of the list
+    visitedAssets.unshift(assetKey);
+
+    const truncatedVisitedAssets = visitedAssets.slice(0, RECENTLY_VISITED_ASSETS_CACHE_SIZE);
+    localStorage.setItem(
+      RECENTLY_VISITED_ASSETS_STORAGE_KEY,
+      JSON.stringify(truncatedVisitedAssets),
+    );
+  }
+}
+
+export function FetchRecentlyVisitedAssetsFromLocalStorage(): AssetKey[] {
+  if (typeof window !== 'undefined') {
+    const visitedAssetsStringified = localStorage.getItem(RECENTLY_VISITED_ASSETS_STORAGE_KEY);
+    return visitedAssetsStringified ? JSON.parse(visitedAssetsStringified) : [];
+  }
+  return [];
+}


### PR DESCRIPTION
Creates a LRU cache of the last 10 visited asset keys, storing them in local storage.

Displays the recently visited assets on the asset catalog page in chronological order of visit.