### PR TITLE
add warning dialog when starting a run status sensor with a stale cursor

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetNodeDefinition.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetNodeDefinition.types.ts
@@ -15759,6 +15759,10 @@ export type AssetNodeDefinitionFragment = {
           id: string;
           selectorId: string;
           status: Types.InstigationStatus;
+          typeSpecificData:
+            | {__typename: 'ScheduleData'}
+            | {__typename: 'SensorData'; lastCursor: string | null}
+            | null;
         };
       }
   >;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetNodeInstigatorTag.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetNodeInstigatorTag.types.ts
@@ -30,6 +30,10 @@ export type AssetNodeInstigatorsFragment = {
           id: string;
           selectorId: string;
           status: Types.InstigationStatus;
+          typeSpecificData:
+            | {__typename: 'ScheduleData'}
+            | {__typename: 'SensorData'; lastCursor: string | null}
+            | null;
         };
       }
   >;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
@@ -67,6 +67,10 @@ export type AssetViewDefinitionQuery = {
                   id: string;
                   selectorId: string;
                   status: Types.InstigationStatus;
+                  typeSpecificData:
+                    | {__typename: 'ScheduleData'}
+                    | {__typename: 'SensorData'; lastCursor: string | null}
+                    | null;
                 };
               }
           >;
@@ -15972,6 +15976,10 @@ export type AssetViewDefinitionNodeFragment = {
           id: string;
           selectorId: string;
           status: Types.InstigationStatus;
+          typeSpecificData:
+            | {__typename: 'ScheduleData'}
+            | {__typename: 'SensorData'; lastCursor: string | null}
+            | null;
         };
       }
   >;

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/types/JobMetadata.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/types/JobMetadata.types.ts
@@ -42,6 +42,10 @@ export type JobMetadataQuery = {
             id: string;
             selectorId: string;
             status: Types.InstigationStatus;
+            typeSpecificData:
+              | {__typename: 'ScheduleData'}
+              | {__typename: 'SensorData'; lastCursor: string | null}
+              | null;
           };
         }>;
       }
@@ -118,6 +122,10 @@ export type JobMetadataFragment = {
       id: string;
       selectorId: string;
       status: Types.InstigationStatus;
+      typeSpecificData:
+        | {__typename: 'ScheduleData'}
+        | {__typename: 'SensorData'; lastCursor: string | null}
+        | null;
     };
   }>;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorSwitch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorSwitch.tsx
@@ -1,11 +1,25 @@
 import {gql, useMutation} from '@apollo/client';
-import {Checkbox, Tooltip} from '@dagster-io/ui-components';
+import {
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogBody,
+  DialogFooter,
+  Tooltip,
+} from '@dagster-io/ui-components';
+import * as React from 'react';
 
+import {SET_CURSOR_MUTATION} from './EditCursorDialog';
 import {
   START_SENSOR_MUTATION,
   STOP_SENSOR_MUTATION,
   displaySensorMutationErrors,
 } from './SensorMutations';
+import {
+  SetSensorCursorMutation,
+  SetSensorCursorMutationVariables,
+} from './types/EditCursorDialog.types';
 import {
   StartSensorMutation,
   StartSensorMutationVariables,
@@ -14,9 +28,12 @@ import {
 } from './types/SensorMutations.types';
 import {SensorSwitchFragment} from './types/SensorSwitch.types';
 import {usePermissionsForLocation} from '../app/Permissions';
-import {InstigationStatus} from '../graphql/types';
+import {InstigationStatus, SensorType} from '../graphql/types';
+import {TimeFromNow} from '../ui/TimeFromNow';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
+
+const WARN_RUN_STATUS_SENSOR_LAG_SECONDS = 24 * 60 * 60; // 24 hours
 
 interface Props {
   repoAddress: RepoAddress;
@@ -50,6 +67,19 @@ export const SensorSwitch = (props: Props) => {
   >(STOP_SENSOR_MUTATION, {
     onCompleted: displaySensorMutationErrors,
   });
+  const [setSensorCursor] = useMutation<SetSensorCursorMutation, SetSensorCursorMutationVariables>(
+    SET_CURSOR_MUTATION,
+  );
+  const clearCursor = async () => {
+    await setSensorCursor({variables: {sensorSelector, cursor: undefined}});
+  };
+  const cursor =
+    (sensor.sensorState.typeSpecificData &&
+      sensor.sensorState.typeSpecificData.__typename === 'SensorData' &&
+      sensor.sensorState.typeSpecificData.lastCursor) ||
+    null;
+
+  const [showRunStatusSensorWarningDialog, setShowRunStatusWarningDialog] = React.useState(false);
 
   const onChangeSwitch = () => {
     if (status === InstigationStatus.RUNNING) {
@@ -60,6 +90,74 @@ export const SensorSwitch = (props: Props) => {
   };
 
   const running = status === InstigationStatus.RUNNING;
+
+  if (
+    !running &&
+    canStartSensor &&
+    sensor.sensorType === SensorType.RUN_STATUS &&
+    _isRunStatusSensorLagging(cursor)
+  ) {
+    // We are turning back on a sensor that has a persisted cursor for a position far back in time.
+    // We should warn the user that this is what is happening.
+    const last_processed_timestamp = _parseRunStatusSensorCursor(cursor);
+    return (
+      <>
+        <Checkbox
+          format="switch"
+          disabled={toggleOnInFlight || toggleOffInFlight}
+          checked={running || toggleOnInFlight}
+          onChange={() => setShowRunStatusWarningDialog(true)}
+          size={size}
+        />
+        <Dialog
+          isOpen={showRunStatusSensorWarningDialog}
+          title="Run status sensor"
+          canOutsideClickClose
+          canEscapeKeyClose
+          onClose={() => {
+            setShowRunStatusWarningDialog(false);
+          }}
+          style={{width: '700px'}}
+        >
+          <DialogBody>
+            <Box margin={{bottom: 16}}>
+              This run status sensor will resume processing runs from{' '}
+              <TimeFromNow unixTimestamp={last_processed_timestamp! / 1000} />.
+            </Box>
+            To instead resume processing runs starting from now, clear the cursor before starting
+            the sensor.
+          </DialogBody>
+          <DialogFooter topBorder>
+            <Button
+              onClick={() => {
+                setShowRunStatusWarningDialog(false);
+              }}
+            >
+              Close
+            </Button>
+            <Button
+              onClick={() => {
+                onChangeSwitch();
+                setShowRunStatusWarningDialog(false);
+              }}
+            >
+              Start sensor without clearing
+            </Button>
+            <Button
+              intent="primary"
+              onClick={() => {
+                clearCursor();
+                onChangeSwitch();
+                setShowRunStatusWarningDialog(false);
+              }}
+            >
+              Clear cursor and start sensor
+            </Button>
+          </DialogFooter>
+        </Dialog>
+      </>
+    );
+  }
 
   if (canStartSensor && canStopSensor) {
     return (
@@ -98,6 +196,30 @@ export const SensorSwitch = (props: Props) => {
   );
 };
 
+const _isRunStatusSensorLagging = (cursor: string | null) => {
+  const last_processed_timestamp = _parseRunStatusSensorCursor(cursor);
+
+  if (!last_processed_timestamp) {
+    return false;
+  }
+
+  return Date.now() - last_processed_timestamp > WARN_RUN_STATUS_SENSOR_LAG_SECONDS * 1000;
+};
+
+const _parseRunStatusSensorCursor = (cursor: string | null) => {
+  if (!cursor) {
+    return null;
+  }
+
+  try {
+    const cursor_payload = JSON.parse(cursor);
+    const timestamp = cursor_payload.record_timestamp || cursor_payload.update_timestamp;
+    return timestamp ? new Date(timestamp).getTime() : null;
+  } catch (e) {
+    return null;
+  }
+};
+
 export const SENSOR_SWITCH_FRAGMENT = gql`
   fragment SensorSwitchFragment on Sensor {
     id
@@ -107,6 +229,11 @@ export const SENSOR_SWITCH_FRAGMENT = gql`
       id
       selectorId
       status
+      typeSpecificData {
+        ... on SensorData {
+          lastCursor
+        }
+      }
     }
     sensorType
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorSwitch.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorSwitch.types.ts
@@ -13,5 +13,9 @@ export type SensorSwitchFragment = {
     id: string;
     selectorId: string;
     status: Types.InstigationStatus;
+    typeSpecificData:
+      | {__typename: 'ScheduleData'}
+      | {__typename: 'SensorData'; lastCursor: string | null}
+      | null;
   };
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
@@ -20,7 +20,6 @@ import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment.types';
 import {PipelineSelector} from '../graphql/types';
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
-import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
 
 type Repository = WorkspaceRepositoryFragment;
 type RepositoryLocation = WorkspaceLocationFragment;
@@ -172,12 +171,10 @@ export const ROOT_WORKSPACE_QUERY = gql`
       status
     }
     sensorType
-    ...SensorSwitchFragment
   }
 
   ${PYTHON_ERROR_FRAGMENT}
   ${REPOSITORY_INFO_FRAGMENT}
-  ${SENSOR_SWITCH_FRAGMENT}
 `;
 
 /**

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
@@ -20,6 +20,7 @@ import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment.types';
 import {PipelineSelector} from '../graphql/types';
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
+import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
 
 type Repository = WorkspaceRepositoryFragment;
 type RepositoryLocation = WorkspaceLocationFragment;
@@ -171,10 +172,12 @@ export const ROOT_WORKSPACE_QUERY = gql`
       status
     }
     sensorType
+    ...SensorSwitchFragment
   }
 
   ${PYTHON_ERROR_FRAGMENT}
   ${REPOSITORY_INFO_FRAGMENT}
+  ${SENSOR_SWITCH_FRAGMENT}
 `;
 
 /**

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedJobRow.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedJobRow.types.ts
@@ -49,6 +49,10 @@ export type SingleJobQuery = {
             id: string;
             selectorId: string;
             status: Types.InstigationStatus;
+            typeSpecificData:
+              | {__typename: 'ScheduleData'}
+              | {__typename: 'SensorData'; lastCursor: string | null}
+              | null;
           };
         }>;
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedSensorRow.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedSensorRow.types.ts
@@ -57,6 +57,10 @@ export type SingleSensorQuery = {
             updateTime: number | null;
           }>;
           nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number | null} | null;
+          typeSpecificData:
+            | {__typename: 'ScheduleData'}
+            | {__typename: 'SensorData'; lastCursor: string | null}
+            | null;
         };
       }
     | {__typename: 'SensorNotFoundError'}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceContext.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceContext.types.ts
@@ -93,10 +93,6 @@ export type RootWorkspaceQuery = {
                       id: string;
                       selectorId: string;
                       status: Types.InstigationStatus;
-                      typeSpecificData:
-                        | {__typename: 'ScheduleData'}
-                        | {__typename: 'SensorData'; lastCursor: string | null}
-                        | null;
                     };
                   }>;
                   partitionSets: Array<{
@@ -193,10 +189,6 @@ export type WorkspaceLocationNodeFragment = {
               id: string;
               selectorId: string;
               status: Types.InstigationStatus;
-              typeSpecificData:
-                | {__typename: 'ScheduleData'}
-                | {__typename: 'SensorData'; lastCursor: string | null}
-                | null;
             };
           }>;
           partitionSets: Array<{
@@ -274,10 +266,6 @@ export type WorkspaceLocationFragment = {
         id: string;
         selectorId: string;
         status: Types.InstigationStatus;
-        typeSpecificData:
-          | {__typename: 'ScheduleData'}
-          | {__typename: 'SensorData'; lastCursor: string | null}
-          | null;
       };
     }>;
     partitionSets: Array<{
@@ -332,10 +320,6 @@ export type WorkspaceRepositoryFragment = {
       id: string;
       selectorId: string;
       status: Types.InstigationStatus;
-      typeSpecificData:
-        | {__typename: 'ScheduleData'}
-        | {__typename: 'SensorData'; lastCursor: string | null}
-        | null;
     };
   }>;
   partitionSets: Array<{
@@ -378,9 +362,5 @@ export type WorkspaceSensorFragment = {
     id: string;
     selectorId: string;
     status: Types.InstigationStatus;
-    typeSpecificData:
-      | {__typename: 'ScheduleData'}
-      | {__typename: 'SensorData'; lastCursor: string | null}
-      | null;
   };
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceContext.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceContext.types.ts
@@ -93,6 +93,10 @@ export type RootWorkspaceQuery = {
                       id: string;
                       selectorId: string;
                       status: Types.InstigationStatus;
+                      typeSpecificData:
+                        | {__typename: 'ScheduleData'}
+                        | {__typename: 'SensorData'; lastCursor: string | null}
+                        | null;
                     };
                   }>;
                   partitionSets: Array<{
@@ -189,6 +193,10 @@ export type WorkspaceLocationNodeFragment = {
               id: string;
               selectorId: string;
               status: Types.InstigationStatus;
+              typeSpecificData:
+                | {__typename: 'ScheduleData'}
+                | {__typename: 'SensorData'; lastCursor: string | null}
+                | null;
             };
           }>;
           partitionSets: Array<{
@@ -266,6 +274,10 @@ export type WorkspaceLocationFragment = {
         id: string;
         selectorId: string;
         status: Types.InstigationStatus;
+        typeSpecificData:
+          | {__typename: 'ScheduleData'}
+          | {__typename: 'SensorData'; lastCursor: string | null}
+          | null;
       };
     }>;
     partitionSets: Array<{
@@ -320,6 +332,10 @@ export type WorkspaceRepositoryFragment = {
       id: string;
       selectorId: string;
       status: Types.InstigationStatus;
+      typeSpecificData:
+        | {__typename: 'ScheduleData'}
+        | {__typename: 'SensorData'; lastCursor: string | null}
+        | null;
     };
   }>;
   partitionSets: Array<{
@@ -362,5 +378,9 @@ export type WorkspaceSensorFragment = {
     id: string;
     selectorId: string;
     status: Types.InstigationStatus;
+    typeSpecificData:
+      | {__typename: 'ScheduleData'}
+      | {__typename: 'SensorData'; lastCursor: string | null}
+      | null;
   };
 };


### PR DESCRIPTION
## Summary & Motivation
Run status sensors are a bit weird since they can be turned off/on, and the cursor doesn't automatically reset.

We can consider doing a breaking behavior change and reset the cursor state when the sensor is turned on, but short of the behavior change, we can do some UI treatments to bring this to people's attention.

https://github.com/dagster-io/dagster/assets/1040172/b9356bb4-6248-4a61-8f26-f2ef92bf607c


## How I Tested These Changes
BK, manual testing