### PR TITLE
Propagate annotations from user code helm chart to k8s run pods

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -144,5 +144,9 @@ DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP: "{{ template "dagster.fullname" . }}-pip
         {{- if .initContainers }}
         init_containers: {{- toYaml .initContainers | nindent 10 }}
         {{- end }}
+      {{- if .annotations }}
+      pod_template_spec_metadata:
+        annotations: {{- toYaml .annotations | nindent 10 }}
+      {{- end }}
   {{- end }}
 {{- end -}}

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -881,6 +881,60 @@ def test_user_deployment_labels(template: HelmTemplate, include_config_in_launch
 
 
 @pytest.mark.parametrize("include_config_in_launched_runs", [False, True])
+def test_annotations(template: HelmTemplate, include_config_in_launched_runs: bool):
+    name = "foo"
+
+    annotations = {"my-annotation-key": "my-annotation-val"}
+
+    deployment = UserDeployment.construct(
+        name=name,
+        image=kubernetes.Image(repository=f"repo/{name}", tag="tag1", pullPolicy="Always"),
+        dagsterApiGrpcArgs=["-m", name],
+        port=3030,
+        annotations=annotations,
+        includeConfigInLaunchedRuns=UserDeploymentIncludeConfigInLaunchedRuns(
+            enabled=include_config_in_launched_runs
+        ),
+    )
+
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(
+            enabled=True,
+            enableSubchart=True,
+            deployments=[deployment],
+        )
+    )
+
+    user_deployments = template.render(helm_values)
+
+    assert len(user_deployments) == 1
+
+    if include_config_in_launched_runs:
+        container_context = user_deployments[0].spec.template.spec.containers[0].env[2]
+        assert container_context.name == "DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT"
+        assert json.loads(container_context.value) == {
+            "k8s": {
+                "image_pull_policy": "Always",
+                "env_config_maps": [
+                    "release-name-dagster-user-deployments-foo-user-env",
+                ],
+                "namespace": "default",
+                "service_account_name": "release-name-dagster-user-deployments-user-deployments",
+                "run_k8s_config": {
+                    "pod_spec_config": {
+                        "automount_service_account_token": True,
+                    },
+                    "pod_template_spec_metadata": {
+                        "annotations": annotations,
+                    }
+                },
+            }
+        }
+    else:
+        _assert_no_container_context(user_deployments[0])
+
+
+@pytest.mark.parametrize("include_config_in_launched_runs", [False, True])
 def test_user_deployment_resources(template: HelmTemplate, include_config_in_launched_runs: bool):
     name = "foo"
 

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -926,7 +926,7 @@ def test_annotations(template: HelmTemplate, include_config_in_launched_runs: bo
                     },
                     "pod_template_spec_metadata": {
                         "annotations": annotations,
-                    }
+                    },
                 },
             }
         }

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
@@ -84,19 +84,16 @@ def test_runs_base_sling_config(
 
 def test_with_custom_name(replication_config: SlingReplicationParam):
     @sling_assets(replication_config=replication_config)
-    def my_sling_assets():
-        ...
+    def my_sling_assets(): ...
 
     assert my_sling_assets.op.name == "my_sling_assets"
 
     @sling_assets(replication_config=replication_config)
-    def my_other_assets():
-        ...
+    def my_other_assets(): ...
 
     assert my_other_assets.op.name == "my_other_assets"
 
     @sling_assets(replication_config=replication_config, name="custom_name")
-    def my_third_sling_assets():
-        ...
+    def my_third_sling_assets(): ...
 
     assert my_third_sling_assets.op.name == "custom_name"


### PR DESCRIPTION
## Summary & Motivation
Closes: https://github.com/dagster-io/dagster/issues/20010

## How I Tested These Changes

- Added unit test to ensure annotations were passed to `DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT` environment var
- Tested on local minkube cluster that the annotations in the user code helm chart were propagated to launched run pods