### PR TITLE
[external-assets] AssetGraph class renames

### DIFF
--- a/examples/docs_snippets/docs_snippets/integrations/dagstermill/iris_notebook_config.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dagstermill/iris_notebook_config.py
@@ -1,6 +1,6 @@
 from dagster import asset
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.asset_graph_interface import IAssetGraph
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 
 
 # placeholder so that the test works. this isn't used in the docs

--- a/examples/docs_snippets/docs_snippets/integrations/dagstermill/iris_notebook_config.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dagstermill/iris_notebook_config.py
@@ -1,6 +1,6 @@
 from dagster import asset
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_interface import IAssetGraph
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 
 
 # placeholder so that the test works. this isn't used in the docs
@@ -47,4 +47,4 @@ assets_with_resource = with_resources(
 config_asset_job = define_asset_job(
     name="config_asset_job",
     selection=AssetSelection.assets(iris_kmeans_jupyter_notebook).upstream(),
-).resolve(asset_graph=InternalAssetGraph.from_assets(assets_with_resource))
+).resolve(asset_graph=AssetGraph.from_assets(assets_with_resource))

--- a/examples/docs_snippets/docs_snippets/integrations/dagstermill/iris_notebook_config.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dagstermill/iris_notebook_config.py
@@ -1,5 +1,5 @@
 from dagster import asset
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
@@ -6,7 +6,7 @@ from dagster import (
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.selector import RepositorySelector
 from dagster._core.host_representation.code_location import CodeLocation
 from dagster._core.host_representation.external import ExternalRepository
@@ -125,7 +125,7 @@ class AssetChecksLoader:
             self._context.instance, check_keys=all_check_keys
         )
 
-        asset_graph = ExternalAssetGraph.from_workspace(self._context)
+        asset_graph = HostAssetGraph.from_workspace(self._context)
         graphene_checks: Mapping[AssetKey, AssetChecksOrErrorUnion] = {}
         for asset_key in self._asset_keys:
             if asset_key in errors:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
@@ -6,7 +6,7 @@ from dagster import (
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.selector import RepositorySelector
 from dagster._core.host_representation.code_location import CodeLocation
 from dagster._core.host_representation.external import ExternalRepository
@@ -125,7 +125,7 @@ class AssetChecksLoader:
             self._context.instance, check_keys=all_check_keys
         )
 
-        asset_graph = HostAssetGraph.from_workspace(self._context)
+        asset_graph = RemoteAssetGraph.from_workspace(self._context)
         graphene_checks: Mapping[AssetKey, AssetChecksOrErrorUnion] = {}
         for asset_key in self._asset_keys:
             if asset_key in errors:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, List, Sequence, Union, cast
 
 import dagster._check as check
 import pendulum
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.selector import PartitionsByAssetSelector, RepositorySelector
 from dagster._core.errors import (
     DagsterError,
@@ -46,7 +46,7 @@ def get_asset_backfill_preview(
 ) -> Sequence["GrapheneAssetPartitions"]:
     from ...schema.backfill import GrapheneAssetPartitions
 
-    asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
+    asset_graph = HostAssetGraph.from_workspace(graphene_info.context)
 
     check.invariant(backfill_preview_params.get("assetSelection") is not None)
     check.invariant(backfill_preview_params.get("partitionNames") is not None)
@@ -198,7 +198,7 @@ def create_and_launch_partition_backfill(
         if backfill_params.get("fromFailure"):
             raise DagsterError("fromFailure is not supported for pure asset backfills")
 
-        asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
+        asset_graph = HostAssetGraph.from_workspace(graphene_info.context)
 
         assert_permission_for_asset_graph(
             graphene_info, asset_graph, asset_selection, Permissions.LAUNCH_PARTITION_BACKFILL
@@ -227,7 +227,7 @@ def create_and_launch_partition_backfill(
         if backfill_params.get("fromFailure"):
             raise DagsterError("fromFailure is not supported for pure asset backfills")
 
-        asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
+        asset_graph = HostAssetGraph.from_workspace(graphene_info.context)
         assert_permission_for_asset_graph(
             graphene_info, asset_graph, asset_selection, Permissions.LAUNCH_PARTITION_BACKFILL
         )
@@ -265,7 +265,7 @@ def cancel_partition_backfill(
         check.failed(f"No backfill found for id: {backfill_id}")
 
     if backfill.is_asset_backfill:
-        asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
+        asset_graph = HostAssetGraph.from_workspace(graphene_info.context)
         assert_permission_for_asset_graph(
             graphene_info,
             asset_graph,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, List, Sequence, Union, cast
 
 import dagster._check as check
 import pendulum
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.selector import PartitionsByAssetSelector, RepositorySelector
 from dagster._core.errors import (
     DagsterError,
@@ -46,7 +46,7 @@ def get_asset_backfill_preview(
 ) -> Sequence["GrapheneAssetPartitions"]:
     from ...schema.backfill import GrapheneAssetPartitions
 
-    asset_graph = HostAssetGraph.from_workspace(graphene_info.context)
+    asset_graph = RemoteAssetGraph.from_workspace(graphene_info.context)
 
     check.invariant(backfill_preview_params.get("assetSelection") is not None)
     check.invariant(backfill_preview_params.get("partitionNames") is not None)
@@ -198,7 +198,7 @@ def create_and_launch_partition_backfill(
         if backfill_params.get("fromFailure"):
             raise DagsterError("fromFailure is not supported for pure asset backfills")
 
-        asset_graph = HostAssetGraph.from_workspace(graphene_info.context)
+        asset_graph = RemoteAssetGraph.from_workspace(graphene_info.context)
 
         assert_permission_for_asset_graph(
             graphene_info, asset_graph, asset_selection, Permissions.LAUNCH_PARTITION_BACKFILL
@@ -227,7 +227,7 @@ def create_and_launch_partition_backfill(
         if backfill_params.get("fromFailure"):
             raise DagsterError("fromFailure is not supported for pure asset backfills")
 
-        asset_graph = HostAssetGraph.from_workspace(graphene_info.context)
+        asset_graph = RemoteAssetGraph.from_workspace(graphene_info.context)
         assert_permission_for_asset_graph(
             graphene_info, asset_graph, asset_selection, Permissions.LAUNCH_PARTITION_BACKFILL
         )
@@ -265,7 +265,7 @@ def cancel_partition_backfill(
         check.failed(f"No backfill found for id: {backfill_id}")
 
     if backfill.is_asset_backfill:
-        asset_graph = HostAssetGraph.from_workspace(graphene_info.context)
+        asset_graph = RemoteAssetGraph.from_workspace(graphene_info.context)
         assert_permission_for_asset_graph(
             graphene_info,
             asset_graph,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -23,12 +23,12 @@ from dagster import (
 )
 from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.definitions.data_time import CachingDataTimeResolver
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.partition import (
     CachingDynamicPartitionsLoader,
     PartitionsDefinition,
     PartitionsSubset,
 )
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.time_window_partitions import (
     BaseTimeWindowPartitionsSubset,
     PartitionRangeStatus,
@@ -211,7 +211,7 @@ def get_asset_nodes_by_asset_key(
 
     stale_status_loader = StaleStatusLoader(
         instance=graphene_info.context.instance,
-        asset_graph=lambda: HostAssetGraph.from_workspace(graphene_info.context),
+        asset_graph=lambda: RemoteAssetGraph.from_workspace(graphene_info.context),
     )
 
     dynamic_partitions_loader = CachingDynamicPartitionsLoader(graphene_info.context.instance)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -23,7 +23,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.definitions.data_time import CachingDataTimeResolver
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.partition import (
     CachingDynamicPartitionsLoader,
     PartitionsDefinition,
@@ -211,7 +211,7 @@ def get_asset_nodes_by_asset_key(
 
     stale_status_loader = StaleStatusLoader(
         instance=graphene_info.context.instance,
-        asset_graph=lambda: ExternalAssetGraph.from_workspace(graphene_info.context),
+        asset_graph=lambda: HostAssetGraph.from_workspace(graphene_info.context),
     )
 
     dynamic_partitions_loader = CachingDynamicPartitionsLoader(graphene_info.context.instance)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -24,7 +24,7 @@ from typing import (
 import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.selector import GraphSelector, JobSubsetSelector
 from dagster._core.workspace.context import BaseWorkspaceRequestContext
 from dagster._utils.error import serializable_error_info_from_exc_info
@@ -88,7 +88,7 @@ def assert_permission(graphene_info: "ResolveInfo", permission: str) -> None:
 
 def assert_permission_for_asset_graph(
     graphene_info: "ResolveInfo",
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     asset_selection: Optional[Sequence[AssetKey]],
     permission: str,
 ) -> None:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -24,7 +24,7 @@ from typing import (
 import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.selector import GraphSelector, JobSubsetSelector
 from dagster._core.workspace.context import BaseWorkspaceRequestContext
 from dagster._utils.error import serializable_error_info_from_exc_info
@@ -88,7 +88,7 @@ def assert_permission(graphene_info: "ResolveInfo", permission: str) -> None:
 
 def assert_permission_for_asset_graph(
     graphene_info: "ResolveInfo",
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     asset_selection: Optional[Sequence[AssetKey]],
     permission: str,
 ) -> None:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -13,7 +13,7 @@ from dagster._core.definitions.data_version import (
     StaleCauseCategory,
     StaleStatus,
 )
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader, PartitionsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.sensor_definition import (
@@ -565,7 +565,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             return []
 
         instance = graphene_info.context.instance
-        asset_graph = ExternalAssetGraph.from_external_repository(self._external_repository)
+        asset_graph = HostAssetGraph.from_external_repository(self._external_repository)
         asset_key = self._external_asset_node.asset_key
 
         # in the future, we can share this same CachingInstanceQueryer across all
@@ -883,7 +883,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         self, graphene_info: ResolveInfo
     ) -> Optional[GrapheneAssetFreshnessInfo]:
         if self._external_asset_node.freshness_policy:
-            asset_graph = ExternalAssetGraph.from_external_repository(self._external_repository)
+            asset_graph = HostAssetGraph.from_external_repository(self._external_repository)
             return get_freshness_info(
                 asset_key=self._external_asset_node.asset_key,
                 # in the future, we can share this same CachingInstanceQueryer across all
@@ -912,7 +912,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         return None
 
     def _sensor_targets_asset(
-        self, sensor: ExternalSensor, asset_graph: ExternalAssetGraph, job_names: Set[str]
+        self, sensor: ExternalSensor, asset_graph: HostAssetGraph, job_names: Set[str]
     ) -> bool:
         asset_key = self._external_asset_node.asset_key
 
@@ -927,7 +927,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         external_sensors = self._external_repository.get_external_sensors()
         external_schedules = self._external_repository.get_external_schedules()
 
-        asset_graph = ExternalAssetGraph.from_external_repository(self._external_repository)
+        asset_graph = HostAssetGraph.from_external_repository(self._external_repository)
 
         job_names = {
             job_name
@@ -957,7 +957,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         return results
 
     def _get_auto_materialize_external_sensor(self) -> Optional[ExternalSensor]:
-        asset_graph = ExternalAssetGraph.from_external_repository(self._external_repository)
+        asset_graph = HostAssetGraph.from_external_repository(self._external_repository)
 
         asset_key = self._external_asset_node.asset_key
         matching_sensors = [

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -13,9 +13,9 @@ from dagster._core.definitions.data_version import (
     StaleCauseCategory,
     StaleStatus,
 )
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader, PartitionsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.sensor_definition import (
     SensorType,
 )
@@ -565,7 +565,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             return []
 
         instance = graphene_info.context.instance
-        asset_graph = HostAssetGraph.from_external_repository(self._external_repository)
+        asset_graph = RemoteAssetGraph.from_external_repository(self._external_repository)
         asset_key = self._external_asset_node.asset_key
 
         # in the future, we can share this same CachingInstanceQueryer across all
@@ -883,7 +883,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         self, graphene_info: ResolveInfo
     ) -> Optional[GrapheneAssetFreshnessInfo]:
         if self._external_asset_node.freshness_policy:
-            asset_graph = HostAssetGraph.from_external_repository(self._external_repository)
+            asset_graph = RemoteAssetGraph.from_external_repository(self._external_repository)
             return get_freshness_info(
                 asset_key=self._external_asset_node.asset_key,
                 # in the future, we can share this same CachingInstanceQueryer across all
@@ -912,7 +912,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         return None
 
     def _sensor_targets_asset(
-        self, sensor: ExternalSensor, asset_graph: HostAssetGraph, job_names: Set[str]
+        self, sensor: ExternalSensor, asset_graph: RemoteAssetGraph, job_names: Set[str]
     ) -> bool:
         asset_key = self._external_asset_node.asset_key
 
@@ -927,7 +927,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         external_sensors = self._external_repository.get_external_sensors()
         external_schedules = self._external_repository.get_external_schedules()
 
-        asset_graph = HostAssetGraph.from_external_repository(self._external_repository)
+        asset_graph = RemoteAssetGraph.from_external_repository(self._external_repository)
 
         job_names = {
             job_name
@@ -957,7 +957,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         return results
 
     def _get_auto_materialize_external_sensor(self) -> Optional[ExternalSensor]:
-        asset_graph = HostAssetGraph.from_external_repository(self._external_repository)
+        asset_graph = RemoteAssetGraph.from_external_repository(self._external_repository)
 
         asset_key = self._external_asset_node.asset_key
         matching_sensors = [

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_selections.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_selections.py
@@ -1,6 +1,6 @@
 import graphene
 from dagster._core.definitions.asset_selection import AssetSelection
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.host_representation.external import ExternalRepository
 
 from ..implementation.fetch_assets import get_asset_nodes_by_asset_key
@@ -21,7 +21,7 @@ class GrapheneAssetSelection(graphene.ObjectType):
         return str(self._asset_selection)
 
     def resolve_assetKeys(self, _graphene_info):
-        asset_graph = HostAssetGraph.from_external_repository(self._external_repository)
+        asset_graph = RemoteAssetGraph.from_external_repository(self._external_repository)
         return [
             GrapheneAssetKey(path=asset_key.path)
             for asset_key in self._asset_selection.resolve(asset_graph)
@@ -30,7 +30,7 @@ class GrapheneAssetSelection(graphene.ObjectType):
     def resolve_assets(self, graphene_info):
         from dagster_graphql.schema.pipelines.pipeline import GrapheneAsset
 
-        asset_graph = HostAssetGraph.from_external_repository(self._external_repository)
+        asset_graph = RemoteAssetGraph.from_external_repository(self._external_repository)
         asset_nodes_by_asset_key = get_asset_nodes_by_asset_key(graphene_info)
 
         return [

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_selections.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_selections.py
@@ -1,6 +1,6 @@
 import graphene
 from dagster._core.definitions.asset_selection import AssetSelection
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.host_representation.external import ExternalRepository
 
 from ..implementation.fetch_assets import get_asset_nodes_by_asset_key
@@ -21,7 +21,7 @@ class GrapheneAssetSelection(graphene.ObjectType):
         return str(self._asset_selection)
 
     def resolve_assetKeys(self, _graphene_info):
-        asset_graph = ExternalAssetGraph.from_external_repository(self._external_repository)
+        asset_graph = HostAssetGraph.from_external_repository(self._external_repository)
         return [
             GrapheneAssetKey(path=asset_key.path)
             for asset_key in self._asset_selection.resolve(asset_graph)
@@ -30,7 +30,7 @@ class GrapheneAssetSelection(graphene.ObjectType):
     def resolve_assets(self, graphene_info):
         from dagster_graphql.schema.pipelines.pipeline import GrapheneAsset
 
-        asset_graph = ExternalAssetGraph.from_external_repository(self._external_repository)
+        asset_graph = HostAssetGraph.from_external_repository(self._external_repository)
         asset_nodes_by_asset_key = get_asset_nodes_by_asset_key(graphene_info)
 
         return [

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -7,7 +7,7 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
 from dagster._core.definitions.sensor_definition import (
     SensorType,
@@ -275,7 +275,7 @@ class GrapheneRepository(graphene.ObjectType):
         self._batch_loader = RepositoryScopedBatchLoader(instance, repository)
         self._stale_status_loader = StaleStatusLoader(
             instance=instance,
-            asset_graph=lambda: ExternalAssetGraph.from_external_repository(repository),
+            asset_graph=lambda: HostAssetGraph.from_external_repository(repository),
         )
         self._dynamic_partitions_loader = CachingDynamicPartitionsLoader(instance)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -7,8 +7,8 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.sensor_definition import (
     SensorType,
 )
@@ -275,7 +275,7 @@ class GrapheneRepository(graphene.ObjectType):
         self._batch_loader = RepositoryScopedBatchLoader(instance, repository)
         self._stale_status_loader = StaleStatusLoader(
             instance=instance,
-            asset_graph=lambda: HostAssetGraph.from_external_repository(repository),
+            asset_graph=lambda: RemoteAssetGraph.from_external_repository(repository),
         )
         self._dynamic_partitions_loader = CachingDynamicPartitionsLoader(instance)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -3,7 +3,7 @@ from typing import Optional, Sequence, Union
 import dagster._check as check
 import graphene
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.nux import get_has_seen_nux, set_nux_seen
 from dagster._core.workspace.permissions import Permissions
@@ -727,7 +727,7 @@ class GrapheneReportRunlessAssetEventsMutation(graphene.Mutation):
 
         reporting_user_tags = {**graphene_info.context.get_reporting_user_tags()}
 
-        asset_graph = HostAssetGraph.from_workspace(graphene_info.context)
+        asset_graph = RemoteAssetGraph.from_workspace(graphene_info.context)
 
         assert_permission_for_asset_graph(
             graphene_info, asset_graph, [asset_key], Permissions.REPORT_RUNLESS_ASSET_EVENTS

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -3,7 +3,7 @@ from typing import Optional, Sequence, Union
 import dagster._check as check
 import graphene
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.nux import get_has_seen_nux, set_nux_seen
 from dagster._core.workspace.permissions import Permissions
@@ -727,7 +727,7 @@ class GrapheneReportRunlessAssetEventsMutation(graphene.Mutation):
 
         reporting_user_tags = {**graphene_info.context.get_reporting_user_tags()}
 
-        asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
+        asset_graph = HostAssetGraph.from_workspace(graphene_info.context)
 
         assert_permission_for_asset_graph(
             graphene_info, asset_graph, [asset_key], Permissions.REPORT_RUNLESS_ASSET_EVENTS

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -5,7 +5,7 @@ import graphene
 from dagster import AssetCheckKey
 from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
 from dagster._core.definitions.selector import (
     InstigatorSelector,
@@ -950,11 +950,11 @@ class GrapheneQuery(graphene.ObjectType):
 
         depended_by_loader = CrossRepoAssetDependedByLoader(context=graphene_info.context)
 
-        def load_asset_graph() -> ExternalAssetGraph:
+        def load_asset_graph() -> HostAssetGraph:
             if repo is not None:
-                return ExternalAssetGraph.from_external_repository(repo)
+                return HostAssetGraph.from_external_repository(repo)
             else:
-                return ExternalAssetGraph.from_workspace(graphene_info.context)
+                return HostAssetGraph.from_workspace(graphene_info.context)
 
         stale_status_loader = StaleStatusLoader(
             instance=graphene_info.context.instance,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -5,8 +5,8 @@ import graphene
 from dagster import AssetCheckKey
 from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.selector import (
     InstigatorSelector,
     RepositorySelector,
@@ -950,11 +950,11 @@ class GrapheneQuery(graphene.ObjectType):
 
         depended_by_loader = CrossRepoAssetDependedByLoader(context=graphene_info.context)
 
-        def load_asset_graph() -> HostAssetGraph:
+        def load_asset_graph() -> RemoteAssetGraph:
             if repo is not None:
-                return HostAssetGraph.from_external_repository(repo)
+                return RemoteAssetGraph.from_external_repository(repo)
             else:
-                return HostAssetGraph.from_workspace(graphene_info.context)
+                return RemoteAssetGraph.from_workspace(graphene_info.context)
 
         stale_status_loader = StaleStatusLoader(
             instance=graphene_info.context.instance,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -10,8 +10,8 @@ from dagster import (
     asset,
     define_asset_job,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
+from dagster._core.definitions.internal_asset_graph import AssetGraph
 from dagster._core.execution.asset_backfill import (
     AssetBackfillIterationResult,
     execute_asset_backfill_iteration,
@@ -202,7 +202,7 @@ def _get_run_stats(partition_statuses):
 
 
 def _execute_asset_backfill_iteration_no_side_effects(
-    graphql_context, backfill_id: str, asset_graph: ExternalAssetGraph
+    graphql_context, backfill_id: str, asset_graph: HostAssetGraph
 ) -> None:
     """Executes an asset backfill iteration and updates the serialized asset backfill data.
     However, does not execute side effects i.e. launching runs.
@@ -251,7 +251,7 @@ def _execute_backfill_iteration_with_side_effects(graphql_context, backfill_id):
 def _mock_asset_backfill_runs(
     graphql_context,
     asset_key: AssetKey,
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     backfill_id: str,
     status: DagsterRunStatus,
     partition_key: Optional[str],
@@ -555,7 +555,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         # since launching the run will cause test process will hang forever.
         code_location = graphql_context.get_code_location("test")
         repository = code_location.get_repository("test_repo")
-        asset_graph = ExternalAssetGraph.from_external_repository(repository)
+        asset_graph = HostAssetGraph.from_external_repository(repository)
         _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
 
         # Launch the run that runs forever
@@ -793,7 +793,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
 
         code_location = graphql_context.get_code_location("test")
         repository = code_location.get_repository("test_repo")
-        asset_graph = ExternalAssetGraph.from_external_repository(repository)
+        asset_graph = HostAssetGraph.from_external_repository(repository)
 
         _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
 
@@ -836,7 +836,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
     def test_asset_backfill_status_with_upstream_failure(self, graphql_context):
         code_location = graphql_context.get_code_location("test")
         repository = code_location.get_repository("test_repo")
-        asset_graph = ExternalAssetGraph.from_external_repository(repository)
+        asset_graph = HostAssetGraph.from_external_repository(repository)
 
         asset_keys = [
             AssetKey("unpartitioned_upstream_of_partitioned"),

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -10,8 +10,8 @@ from dagster import (
     asset,
     define_asset_job,
 )
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.execution.asset_backfill import (
     AssetBackfillIterationResult,
     execute_asset_backfill_iteration,
@@ -269,7 +269,7 @@ def _mock_asset_backfill_runs(
         return Output(5)
 
     define_asset_job("my_job", [dummy_asset]).resolve(
-        asset_graph=InternalAssetGraph.from_assets([dummy_asset])
+        asset_graph=AssetGraph.from_assets([dummy_asset])
     ).execute_in_process(
         tags={**DagsterRun.tags_for_backfill_id(backfill_id)},
         partition_key=partition_key,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -10,8 +10,8 @@ from dagster import (
     asset,
     define_asset_job,
 )
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
-from dagster._core.definitions.internal_asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.execution.asset_backfill import (
     AssetBackfillIterationResult,
     execute_asset_backfill_iteration,
@@ -202,7 +202,7 @@ def _get_run_stats(partition_statuses):
 
 
 def _execute_asset_backfill_iteration_no_side_effects(
-    graphql_context, backfill_id: str, asset_graph: HostAssetGraph
+    graphql_context, backfill_id: str, asset_graph: RemoteAssetGraph
 ) -> None:
     """Executes an asset backfill iteration and updates the serialized asset backfill data.
     However, does not execute side effects i.e. launching runs.
@@ -251,7 +251,7 @@ def _execute_backfill_iteration_with_side_effects(graphql_context, backfill_id):
 def _mock_asset_backfill_runs(
     graphql_context,
     asset_key: AssetKey,
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     backfill_id: str,
     status: DagsterRunStatus,
     partition_key: Optional[str],
@@ -555,7 +555,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         # since launching the run will cause test process will hang forever.
         code_location = graphql_context.get_code_location("test")
         repository = code_location.get_repository("test_repo")
-        asset_graph = HostAssetGraph.from_external_repository(repository)
+        asset_graph = RemoteAssetGraph.from_external_repository(repository)
         _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
 
         # Launch the run that runs forever
@@ -793,7 +793,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
 
         code_location = graphql_context.get_code_location("test")
         repository = code_location.get_repository("test_repo")
-        asset_graph = HostAssetGraph.from_external_repository(repository)
+        asset_graph = RemoteAssetGraph.from_external_repository(repository)
 
         _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_id, asset_graph)
 
@@ -836,7 +836,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
     def test_asset_backfill_status_with_upstream_failure(self, graphql_context):
         code_location = graphql_context.get_code_location("test")
         repository = code_location.get_repository("test_repo")
-        asset_graph = HostAssetGraph.from_external_repository(repository)
+        asset_graph = RemoteAssetGraph.from_external_repository(repository)
 
         asset_keys = [
             AssetKey("unpartitioned_upstream_of_partitioned"),

--- a/python_modules/dagster-test/dagster_test/benchmarks/partition_stale_status.py
+++ b/python_modules/dagster-test/dagster_test/benchmarks/partition_stale_status.py
@@ -7,13 +7,13 @@ from dagster import (
     StaticPartitionsDefinition,
     asset,
 )
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import (
     SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD,
     CachingStaleStatusResolver,
     StaleStatus,
 )
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance_for_test import instance_for_test
@@ -85,7 +85,7 @@ def get_stale_status_resolver(
 ) -> CachingStaleStatusResolver:
     return CachingStaleStatusResolver(
         instance=instance,
-        asset_graph=InternalAssetGraph.from_assets(assets),
+        asset_graph=AssetGraph.from_assets(assets),
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition_evaluation_context.py
@@ -29,7 +29,7 @@ from dagster._core.definitions.partition_mapping import IdentityPartitionMapping
 from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
-from ..asset_graph import AssetGraph
+from ..asset_graph_interface import IAssetGraph
 from ..asset_subset import AssetSubset, ValidAssetSubset
 
 if TYPE_CHECKING:
@@ -131,7 +131,7 @@ class AssetConditionEvaluationContext:
         return self.root_ref or self
 
     @property
-    def asset_graph(self) -> AssetGraph:
+    def asset_graph(self) -> IAssetGraph:
         return self.instance_queryer.asset_graph
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition_evaluation_context.py
@@ -300,7 +300,7 @@ class AssetConditionEvaluationContext:
 
     def materializable_in_same_run(self, child_key: AssetKey, parent_key: AssetKey) -> bool:
         """Returns whether a child asset can be materialized in the same run as a parent asset."""
-        from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+        from dagster._core.definitions.host_asset_graph import HostAssetGraph
 
         return (
             # both assets must be materializable
@@ -318,7 +318,7 @@ class AssetConditionEvaluationContext:
             )
             # the parent must be in the same repository to be materialized alongside the candidate
             and (
-                not isinstance(self.asset_graph, ExternalAssetGraph)
+                not isinstance(self.asset_graph, HostAssetGraph)
                 or self.asset_graph.get_repository_handle(child_key)
                 == self.asset_graph.get_repository_handle(parent_key)
             )

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition_evaluation_context.py
@@ -29,8 +29,8 @@ from dagster._core.definitions.partition_mapping import IdentityPartitionMapping
 from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
-from ..asset_graph_interface import IAssetGraph
 from ..asset_subset import AssetSubset, ValidAssetSubset
+from ..base_asset_graph import BaseAssetGraph
 
 if TYPE_CHECKING:
     from ..asset_daemon_context import AssetDaemonContext
@@ -131,7 +131,7 @@ class AssetConditionEvaluationContext:
         return self.root_ref or self
 
     @property
-    def asset_graph(self) -> IAssetGraph:
+    def asset_graph(self) -> BaseAssetGraph:
         return self.instance_queryer.asset_graph
 
     @property
@@ -300,7 +300,7 @@ class AssetConditionEvaluationContext:
 
     def materializable_in_same_run(self, child_key: AssetKey, parent_key: AssetKey) -> bool:
         """Returns whether a child asset can be materialized in the same run as a parent asset."""
-        from dagster._core.definitions.host_asset_graph import HostAssetGraph
+        from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 
         return (
             # both assets must be materializable
@@ -318,7 +318,7 @@ class AssetConditionEvaluationContext:
             )
             # the parent must be in the same repository to be materialized alongside the candidate
             and (
-                not isinstance(self.asset_graph, HostAssetGraph)
+                not isinstance(self.asset_graph, RemoteAssetGraph)
                 or self.asset_graph.get_repository_handle(child_key)
                 == self.asset_graph.get_repository_handle(parent_key)
             )

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -38,9 +38,9 @@ from .asset_condition.asset_condition_evaluation_context import (
     AssetConditionEvaluationContext,
 )
 from .asset_daemon_cursor import AssetDaemonCursor
-from .asset_graph_interface import IAssetGraph
 from .auto_materialize_rule import AutoMaterializeRule
 from .backfill_policy import BackfillPolicy, BackfillPolicyType
+from .base_asset_graph import BaseAssetGraph
 from .freshness_based_auto_materialize import get_expected_data_time_for_asset_key
 from .partition import PartitionsDefinition, ScheduleType
 
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 
 
 def get_implicit_auto_materialize_policy(
-    asset_key: AssetKey, asset_graph: IAssetGraph
+    asset_key: AssetKey, asset_graph: BaseAssetGraph
 ) -> Optional[AutoMaterializePolicy]:
     """For backcompat with pre-auto materialize policy graphs, assume a default scope of 1 day."""
     auto_materialize_policy = asset_graph.get_auto_materialize_policy(asset_key)
@@ -84,7 +84,7 @@ class AssetDaemonContext:
         self,
         evaluation_id: int,
         instance: "DagsterInstance",
-        asset_graph: IAssetGraph,
+        asset_graph: BaseAssetGraph,
         cursor: AssetDaemonCursor,
         materialize_run_tags: Optional[Mapping[str, str]],
         observe_run_tags: Optional[Mapping[str, str]],
@@ -129,7 +129,7 @@ class AssetDaemonContext:
         return self._cursor
 
     @property
-    def asset_graph(self) -> IAssetGraph:
+    def asset_graph(self) -> BaseAssetGraph:
         return self.instance_queryer.asset_graph
 
     @property
@@ -346,7 +346,7 @@ class AssetDaemonContext:
 
 def build_run_requests(
     asset_partitions: Iterable[AssetKeyPartitionKey],
-    asset_graph: IAssetGraph,
+    asset_graph: BaseAssetGraph,
     run_tags: Optional[Mapping[str, str]],
 ) -> Sequence[RunRequest]:
     assets_to_reconcile_by_partitions_def_partition_key: Mapping[
@@ -393,7 +393,7 @@ def build_run_requests(
 
 def build_run_requests_with_backfill_policies(
     asset_partitions: Iterable[AssetKeyPartitionKey],
-    asset_graph: IAssetGraph,
+    asset_graph: BaseAssetGraph,
     run_tags: Optional[Mapping[str, str]],
     dynamic_partitions_store: DynamicPartitionsStore,
 ) -> Sequence[RunRequest]:
@@ -560,7 +560,7 @@ def _build_run_request_for_partition_key_range(
 def get_auto_observe_run_requests(
     last_observe_request_timestamp_by_asset_key: Mapping[AssetKey, float],
     current_timestamp: float,
-    asset_graph: IAssetGraph,
+    asset_graph: BaseAssetGraph,
     run_tags: Optional[Mapping[str, str]],
     auto_observe_asset_keys: AbstractSet[AssetKey],
 ) -> Sequence[RunRequest]:

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -38,7 +38,7 @@ from .asset_condition.asset_condition_evaluation_context import (
     AssetConditionEvaluationContext,
 )
 from .asset_daemon_cursor import AssetDaemonCursor
-from .asset_graph import AssetGraph
+from .asset_graph_interface import IAssetGraph
 from .auto_materialize_rule import AutoMaterializeRule
 from .backfill_policy import BackfillPolicy, BackfillPolicyType
 from .freshness_based_auto_materialize import get_expected_data_time_for_asset_key
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 
 
 def get_implicit_auto_materialize_policy(
-    asset_key: AssetKey, asset_graph: AssetGraph
+    asset_key: AssetKey, asset_graph: IAssetGraph
 ) -> Optional[AutoMaterializePolicy]:
     """For backcompat with pre-auto materialize policy graphs, assume a default scope of 1 day."""
     auto_materialize_policy = asset_graph.get_auto_materialize_policy(asset_key)
@@ -84,7 +84,7 @@ class AssetDaemonContext:
         self,
         evaluation_id: int,
         instance: "DagsterInstance",
-        asset_graph: AssetGraph,
+        asset_graph: IAssetGraph,
         cursor: AssetDaemonCursor,
         materialize_run_tags: Optional[Mapping[str, str]],
         observe_run_tags: Optional[Mapping[str, str]],
@@ -129,7 +129,7 @@ class AssetDaemonContext:
         return self._cursor
 
     @property
-    def asset_graph(self) -> AssetGraph:
+    def asset_graph(self) -> IAssetGraph:
         return self.instance_queryer.asset_graph
 
     @property
@@ -346,7 +346,7 @@ class AssetDaemonContext:
 
 def build_run_requests(
     asset_partitions: Iterable[AssetKeyPartitionKey],
-    asset_graph: AssetGraph,
+    asset_graph: IAssetGraph,
     run_tags: Optional[Mapping[str, str]],
 ) -> Sequence[RunRequest]:
     assets_to_reconcile_by_partitions_def_partition_key: Mapping[
@@ -393,7 +393,7 @@ def build_run_requests(
 
 def build_run_requests_with_backfill_policies(
     asset_partitions: Iterable[AssetKeyPartitionKey],
-    asset_graph: AssetGraph,
+    asset_graph: IAssetGraph,
     run_tags: Optional[Mapping[str, str]],
     dynamic_partitions_store: DynamicPartitionsStore,
 ) -> Sequence[RunRequest]:
@@ -560,7 +560,7 @@ def _build_run_request_for_partition_key_range(
 def get_auto_observe_run_requests(
     last_observe_request_timestamp_by_asset_key: Mapping[AssetKey, float],
     current_timestamp: float,
-    asset_graph: AssetGraph,
+    asset_graph: IAssetGraph,
     run_tags: Optional[Mapping[str, str]],
     auto_observe_asset_keys: AbstractSet[AssetKey],
 ) -> Sequence[RunRequest]:

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -25,7 +25,7 @@ from dagster._serdes.serdes import (
     whitelist_for_serdes,
 )
 
-from .asset_graph_interface import IAssetGraph
+from .base_asset_graph import BaseAssetGraph
 
 if TYPE_CHECKING:
     from .asset_condition.asset_condition import (
@@ -168,7 +168,7 @@ def get_backcompat_asset_condition_evaluation_state(
 
 
 def backcompat_deserialize_asset_daemon_cursor_str(
-    cursor_str: str, asset_graph: Optional[IAssetGraph], default_evaluation_id: int
+    cursor_str: str, asset_graph: Optional[BaseAssetGraph], default_evaluation_id: int
 ) -> AssetDaemonCursor:
     """This serves as a backcompat layer for deserializing the old cursor format. Some information
     is impossible to fully recover, this will recover enough to continue operating as normal.
@@ -272,7 +272,7 @@ class LegacyAssetDaemonCursorWrapper(NamedTuple):
 
     serialized_cursor: str
 
-    def get_asset_daemon_cursor(self, asset_graph: Optional[IAssetGraph]) -> AssetDaemonCursor:
+    def get_asset_daemon_cursor(self, asset_graph: Optional[BaseAssetGraph]) -> AssetDaemonCursor:
         return backcompat_deserialize_asset_daemon_cursor_str(
             self.serialized_cursor, asset_graph, 0
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -25,7 +25,7 @@ from dagster._serdes.serdes import (
     whitelist_for_serdes,
 )
 
-from .asset_graph import AssetGraph
+from .asset_graph_interface import IAssetGraph
 
 if TYPE_CHECKING:
     from .asset_condition.asset_condition import (
@@ -168,7 +168,7 @@ def get_backcompat_asset_condition_evaluation_state(
 
 
 def backcompat_deserialize_asset_daemon_cursor_str(
-    cursor_str: str, asset_graph: Optional[AssetGraph], default_evaluation_id: int
+    cursor_str: str, asset_graph: Optional[IAssetGraph], default_evaluation_id: int
 ) -> AssetDaemonCursor:
     """This serves as a backcompat layer for deserializing the old cursor format. Some information
     is impossible to fully recover, this will recover enough to continue operating as normal.
@@ -272,7 +272,7 @@ class LegacyAssetDaemonCursorWrapper(NamedTuple):
 
     serialized_cursor: str
 
-    def get_asset_daemon_cursor(self, asset_graph: Optional[AssetGraph]) -> AssetDaemonCursor:
+    def get_asset_daemon_cursor(self, asset_graph: Optional[IAssetGraph]) -> AssetDaemonCursor:
         return backcompat_deserialize_asset_daemon_cursor_str(
             self.serialized_cursor, asset_graph, 0
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -20,7 +20,7 @@ from dagster._core.selector.subset_selector import DependencyGraph, generate_ass
 from dagster._utils.cached_method import cached_method
 
 
-class InternalAssetGraph(IAssetGraph):
+class AssetGraph(IAssetGraph):
     def __init__(
         self,
         assets_defs: Sequence[AssetsDefinition],
@@ -104,9 +104,9 @@ class InternalAssetGraph(IAssetGraph):
         cls,
         all_assets: Iterable[Union[AssetsDefinition, SourceAsset]],
         asset_checks: Optional[Sequence[AssetChecksDefinition]] = None,
-    ) -> "InternalAssetGraph":
+    ) -> "AssetGraph":
         assets_defs = cls.normalize_assets(all_assets)
-        return InternalAssetGraph(
+        return AssetGraph(
             assets_defs=assets_defs,
             asset_checks_defs=asset_checks or [],
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -2,7 +2,6 @@ from typing import AbstractSet, Iterable, Mapping, Optional, Sequence, Union
 
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
-from dagster._core.definitions.asset_graph_interface import AssetKeyOrCheckKey, IAssetGraph
 from dagster._core.definitions.asset_spec import (
     SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET,
     AssetSpec,
@@ -10,6 +9,7 @@ from dagster._core.definitions.asset_spec import (
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicy
+from dagster._core.definitions.base_asset_graph import AssetKeyOrCheckKey, BaseAssetGraph
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.partition import PartitionsDefinition
@@ -20,7 +20,7 @@ from dagster._core.selector.subset_selector import DependencyGraph, generate_ass
 from dagster._utils.cached_method import cached_method
 
 
-class AssetGraph(IAssetGraph):
+class AssetGraph(BaseAssetGraph):
     def __init__(
         self,
         assets_defs: Sequence[AssetsDefinition],

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Callable, Optional, Sequence, Union
 
 import dagster._check as check
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.host_representation import ExternalRepository
 from dagster._core.workspace.context import BaseWorkspaceRequestContext
@@ -40,29 +40,31 @@ class AssetGraphDiffer:
     we will consider every asset New.
     """
 
-    _branch_asset_graph: Optional["HostAssetGraph"]
-    _branch_asset_graph_load_fn: Optional[Callable[[], "HostAssetGraph"]]
-    _base_asset_graph: Optional["HostAssetGraph"]
-    _base_asset_graph_load_fn: Optional[Callable[[], "HostAssetGraph"]]
+    _branch_asset_graph: Optional["RemoteAssetGraph"]
+    _branch_asset_graph_load_fn: Optional[Callable[[], "RemoteAssetGraph"]]
+    _base_asset_graph: Optional["RemoteAssetGraph"]
+    _base_asset_graph_load_fn: Optional[Callable[[], "RemoteAssetGraph"]]
 
     def __init__(
         self,
-        branch_asset_graph: Union["HostAssetGraph", Callable[[], "HostAssetGraph"]],
-        base_asset_graph: Optional[Union["HostAssetGraph", Callable[[], "HostAssetGraph"]]] = None,
+        branch_asset_graph: Union["RemoteAssetGraph", Callable[[], "RemoteAssetGraph"]],
+        base_asset_graph: Optional[
+            Union["RemoteAssetGraph", Callable[[], "RemoteAssetGraph"]]
+        ] = None,
     ):
         if base_asset_graph is None:
             # if base_asset_graph is None, then the asset graph in the branch deployment does not exist
             # in the base deployment
             self._base_asset_graph = None
             self._base_asset_graph_load_fn = None
-        elif isinstance(base_asset_graph, HostAssetGraph):
+        elif isinstance(base_asset_graph, RemoteAssetGraph):
             self._base_asset_graph = base_asset_graph
             self._base_asset_graph_load_fn = None
         else:
             self._base_asset_graph = None
             self._base_asset_graph_load_fn = base_asset_graph
 
-        if isinstance(branch_asset_graph, HostAssetGraph):
+        if isinstance(branch_asset_graph, RemoteAssetGraph):
             self._branch_asset_graph = branch_asset_graph
             self._branch_asset_graph_load_fn = None
         else:
@@ -80,11 +82,11 @@ class AssetGraphDiffer:
         """Constructs an AssetGraphDiffer for a particular repository in a code location for two
         deployment workspaces, the base deployment and the branch deployment.
 
-        We cannot make ExternalAssetGraphs directly from the workspaces because if multiple code locations
-        use the same asset key, those asset keys will override each other in the dictionaries the ExternalAssetGraph
-        creates (see from_repository_handles_and_external_asset_nodes in ExternalAssetGraph). We need to ensure
+        We cannot make RemoteAssetGraphs directly from the workspaces because if multiple code locations
+        use the same asset key, those asset keys will override each other in the dictionaries the RemoteAssetGraph
+        creates (see from_repository_handles_and_external_asset_nodes in RemoteAssetGraph). We need to ensure
         that we are comparing assets in the same code location and repository, so we need to make the
-        ExternalAssetGraph from an ExternalRepository to ensure that there are no duplicate asset keys
+        RemoteAssetGraph from an ExternalRepository to ensure that there are no duplicate asset keys
         that could override each other.
         """
         check.inst_param(branch_workspace, "branch_workspace", BaseWorkspaceRequestContext)
@@ -101,8 +103,8 @@ class AssetGraphDiffer:
             base_workspace, code_location_name, repository_name
         )
         return AssetGraphDiffer(
-            branch_asset_graph=lambda: HostAssetGraph.from_external_repository(branch_repo),
-            base_asset_graph=(lambda: HostAssetGraph.from_external_repository(base_repo))
+            branch_asset_graph=lambda: RemoteAssetGraph.from_external_repository(branch_repo),
+            base_asset_graph=(lambda: RemoteAssetGraph.from_external_repository(base_repo))
             if base_repo is not None
             else None,
         )
@@ -151,13 +153,13 @@ class AssetGraphDiffer:
         return self._compare_base_and_branch_assets(asset_key)
 
     @property
-    def branch_asset_graph(self) -> "HostAssetGraph":
+    def branch_asset_graph(self) -> "RemoteAssetGraph":
         if self._branch_asset_graph is None:
             self._branch_asset_graph = check.not_none(self._branch_asset_graph_load_fn)()
         return self._branch_asset_graph
 
     @property
-    def base_asset_graph(self) -> Optional["HostAssetGraph"]:
+    def base_asset_graph(self) -> Optional["RemoteAssetGraph"]:
         if self._base_asset_graph is None and self._base_asset_graph_load_fn is not None:
             self._base_asset_graph = self._base_asset_graph_load_fn()
         return self._base_asset_graph

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_interface.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_interface.py
@@ -67,7 +67,7 @@ class ParentsPartitionsResult(NamedTuple):
     required_but_nonexistent_parents_partitions: AbstractSet[AssetKeyPartitionKey]
 
 
-class AssetGraph(ABC):
+class IAssetGraph(ABC):
     @property
     @abstractmethod
     def asset_dep_graph(self) -> DependencyGraph[AssetKey]: ...
@@ -691,7 +691,7 @@ class AssetGraph(ABC):
 
 
 def sort_key_for_asset_partition(
-    asset_graph: AssetGraph, asset_partition: AssetKeyPartitionKey
+    asset_graph: IAssetGraph, asset_partition: AssetKeyPartitionKey
 ) -> float:
     """Returns an integer sort key such that asset partitions are sorted in the order in which they
     should be materialized. For assets without a time window partition dimension, this is always 0.
@@ -748,7 +748,7 @@ class ToposortedPriorityQueue:
 
     def __init__(
         self,
-        asset_graph: AssetGraph,
+        asset_graph: IAssetGraph,
         items: Iterable[AssetKeyPartitionKey],
         include_full_execution_set: bool,
     ):

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -30,8 +30,8 @@ from dagster._serdes.serdes import (
     whitelist_for_serdes,
 )
 
-from .asset_graph_interface import IAssetGraph
 from .asset_subset import AssetSubset
+from .base_asset_graph import BaseAssetGraph
 from .events import AssetKey, AssetKeyPartitionKey
 
 
@@ -79,7 +79,7 @@ class AssetGraphSubset(NamedTuple):
             len(subset) for subset in self.partitions_subsets_by_asset_key.values()
         )
 
-    def get_asset_subset(self, asset_key: AssetKey, asset_graph: IAssetGraph) -> AssetSubset:
+    def get_asset_subset(self, asset_key: AssetKey, asset_graph: BaseAssetGraph) -> AssetSubset:
         """Returns an AssetSubset representing the subset of a specific asset that this
         AssetGraphSubset contains.
         """
@@ -97,7 +97,7 @@ class AssetGraphSubset(NamedTuple):
             )
 
     def get_partitions_subset(
-        self, asset_key: AssetKey, asset_graph: Optional[IAssetGraph] = None
+        self, asset_key: AssetKey, asset_graph: Optional[BaseAssetGraph] = None
     ) -> PartitionsSubset:
         if asset_graph:
             partitions_def = asset_graph.get_partitions_def(asset_key)
@@ -139,7 +139,7 @@ class AssetGraphSubset(NamedTuple):
             return partitions_subset is not None and asset.partition_key in partitions_subset
 
     def to_storage_dict(
-        self, dynamic_partitions_store: DynamicPartitionsStore, asset_graph: IAssetGraph
+        self, dynamic_partitions_store: DynamicPartitionsStore, asset_graph: BaseAssetGraph
     ) -> Mapping[str, object]:
         return {
             "partitions_subsets_by_asset_key": {
@@ -242,7 +242,7 @@ class AssetGraphSubset(NamedTuple):
     def from_asset_partition_set(
         cls,
         asset_partitions_set: AbstractSet[AssetKeyPartitionKey],
-        asset_graph: IAssetGraph,
+        asset_graph: BaseAssetGraph,
     ) -> "AssetGraphSubset":
         partitions_by_asset_key = defaultdict(set)
         non_partitioned_asset_keys = set()
@@ -265,7 +265,9 @@ class AssetGraphSubset(NamedTuple):
         )
 
     @classmethod
-    def can_deserialize(cls, serialized_dict: Mapping[str, Any], asset_graph: IAssetGraph) -> bool:
+    def can_deserialize(
+        cls, serialized_dict: Mapping[str, Any], asset_graph: BaseAssetGraph
+    ) -> bool:
         serializable_partitions_ids = serialized_dict.get(
             "serializable_partitions_def_ids_by_asset_key", {}
         )
@@ -297,7 +299,7 @@ class AssetGraphSubset(NamedTuple):
     def from_storage_dict(
         cls,
         serialized_dict: Mapping[str, Any],
-        asset_graph: IAssetGraph,
+        asset_graph: BaseAssetGraph,
         allow_partial: bool = False,
     ) -> "AssetGraphSubset":
         serializable_partitions_ids = serialized_dict.get(
@@ -357,7 +359,7 @@ class AssetGraphSubset(NamedTuple):
     @classmethod
     def all(
         cls,
-        asset_graph: IAssetGraph,
+        asset_graph: BaseAssetGraph,
         dynamic_partitions_store: DynamicPartitionsStore,
         current_time: datetime,
     ) -> "AssetGraphSubset":
@@ -372,7 +374,7 @@ class AssetGraphSubset(NamedTuple):
     def from_asset_keys(
         cls,
         asset_keys: Iterable[AssetKey],
-        asset_graph: IAssetGraph,
+        asset_graph: BaseAssetGraph,
         dynamic_partitions_store: DynamicPartitionsStore,
         current_time: datetime,
     ) -> "AssetGraphSubset":

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -30,7 +30,7 @@ from dagster._serdes.serdes import (
     whitelist_for_serdes,
 )
 
-from .asset_graph import AssetGraph
+from .asset_graph_interface import IAssetGraph
 from .asset_subset import AssetSubset
 from .events import AssetKey, AssetKeyPartitionKey
 
@@ -79,7 +79,7 @@ class AssetGraphSubset(NamedTuple):
             len(subset) for subset in self.partitions_subsets_by_asset_key.values()
         )
 
-    def get_asset_subset(self, asset_key: AssetKey, asset_graph: AssetGraph) -> AssetSubset:
+    def get_asset_subset(self, asset_key: AssetKey, asset_graph: IAssetGraph) -> AssetSubset:
         """Returns an AssetSubset representing the subset of a specific asset that this
         AssetGraphSubset contains.
         """
@@ -97,7 +97,7 @@ class AssetGraphSubset(NamedTuple):
             )
 
     def get_partitions_subset(
-        self, asset_key: AssetKey, asset_graph: Optional[AssetGraph] = None
+        self, asset_key: AssetKey, asset_graph: Optional[IAssetGraph] = None
     ) -> PartitionsSubset:
         if asset_graph:
             partitions_def = asset_graph.get_partitions_def(asset_key)
@@ -139,7 +139,7 @@ class AssetGraphSubset(NamedTuple):
             return partitions_subset is not None and asset.partition_key in partitions_subset
 
     def to_storage_dict(
-        self, dynamic_partitions_store: DynamicPartitionsStore, asset_graph: AssetGraph
+        self, dynamic_partitions_store: DynamicPartitionsStore, asset_graph: IAssetGraph
     ) -> Mapping[str, object]:
         return {
             "partitions_subsets_by_asset_key": {
@@ -242,7 +242,7 @@ class AssetGraphSubset(NamedTuple):
     def from_asset_partition_set(
         cls,
         asset_partitions_set: AbstractSet[AssetKeyPartitionKey],
-        asset_graph: AssetGraph,
+        asset_graph: IAssetGraph,
     ) -> "AssetGraphSubset":
         partitions_by_asset_key = defaultdict(set)
         non_partitioned_asset_keys = set()
@@ -265,7 +265,7 @@ class AssetGraphSubset(NamedTuple):
         )
 
     @classmethod
-    def can_deserialize(cls, serialized_dict: Mapping[str, Any], asset_graph: AssetGraph) -> bool:
+    def can_deserialize(cls, serialized_dict: Mapping[str, Any], asset_graph: IAssetGraph) -> bool:
         serializable_partitions_ids = serialized_dict.get(
             "serializable_partitions_def_ids_by_asset_key", {}
         )
@@ -297,7 +297,7 @@ class AssetGraphSubset(NamedTuple):
     def from_storage_dict(
         cls,
         serialized_dict: Mapping[str, Any],
-        asset_graph: AssetGraph,
+        asset_graph: IAssetGraph,
         allow_partial: bool = False,
     ) -> "AssetGraphSubset":
         serializable_partitions_ids = serialized_dict.get(
@@ -357,7 +357,7 @@ class AssetGraphSubset(NamedTuple):
     @classmethod
     def all(
         cls,
-        asset_graph: AssetGraph,
+        asset_graph: IAssetGraph,
         dynamic_partitions_store: DynamicPartitionsStore,
         current_time: datetime,
     ) -> "AssetGraphSubset":
@@ -372,7 +372,7 @@ class AssetGraphSubset(NamedTuple):
     def from_asset_keys(
         cls,
         asset_keys: Iterable[AssetKey],
-        asset_graph: AssetGraph,
+        asset_graph: IAssetGraph,
         dynamic_partitions_store: DynamicPartitionsStore,
         current_time: datetime,
     ) -> "AssetGraphSubset":

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -44,8 +44,8 @@ from .policy import RetryPolicy
 from .resource_definition import ResourceDefinition
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.asset_graph import AssetKeyOrCheckKey
     from dagster._core.definitions.assets import AssetsDefinition, SourceAsset
+    from dagster._core.definitions.base_asset_graph import AssetKeyOrCheckKey
     from dagster._core.definitions.job_definition import JobDefinition
     from dagster._core.definitions.partition_mapping import PartitionMapping
     from dagster._core.execution.context.output import OutputContext

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -23,7 +23,7 @@ from dagster._core.selector.subset_selector import (
 from dagster._serdes.serdes import whitelist_for_serdes
 
 from .asset_check_spec import AssetCheckKey
-from .asset_graph import AssetGraph
+from .asset_graph_interface import IAssetGraph
 from .assets import AssetsDefinition
 from .events import (
     AssetKey,
@@ -328,9 +328,9 @@ class AssetSelection(ABC, BaseModel, frozen=True):
         return SubtractAssetSelection(left=self, right=other)
 
     def resolve(
-        self, all_assets: Union[Iterable[Union[AssetsDefinition, SourceAsset]], AssetGraph]
+        self, all_assets: Union[Iterable[Union[AssetsDefinition, SourceAsset]], IAssetGraph]
     ) -> AbstractSet[AssetKey]:
-        if isinstance(all_assets, AssetGraph):
+        if isinstance(all_assets, IAssetGraph):
             asset_graph = all_assets
         else:
             check.iterable_param(all_assets, "all_assets", (AssetsDefinition, SourceAsset))
@@ -339,7 +339,7 @@ class AssetSelection(ABC, BaseModel, frozen=True):
         return self.resolve_inner(asset_graph)
 
     @abstractmethod
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         raise NotImplementedError()
 
     def resolve_checks(self, asset_graph: InternalAssetGraph) -> AbstractSet[AssetCheckKey]:
@@ -407,7 +407,7 @@ class AssetSelection(ABC, BaseModel, frozen=True):
                 f" {type(selection)}."
             )
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return AssetSelection.keys(*self.resolve(asset_graph))
 
     def replace(self, **kwargs):
@@ -431,14 +431,14 @@ class AssetSelection(ABC, BaseModel, frozen=True):
 class AllSelection(AssetSelection, frozen=True):
     include_sources: Optional[bool] = None
 
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         return (
             asset_graph.all_asset_keys
             if self.include_sources
             else asset_graph.materializable_asset_keys
         )
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return self
 
     def __str__(self) -> str:
@@ -447,13 +447,13 @@ class AllSelection(AssetSelection, frozen=True):
 
 @whitelist_for_serdes
 class AllAssetCheckSelection(AssetSelection, frozen=True):
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         return set()
 
     def resolve_checks_inner(self, asset_graph: InternalAssetGraph) -> AbstractSet[AssetCheckKey]:
         return asset_graph.asset_check_keys
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return self
 
     def __str__(self) -> str:
@@ -464,7 +464,7 @@ class AllAssetCheckSelection(AssetSelection, frozen=True):
 class AssetChecksForAssetKeysSelection(AssetSelection, frozen=True):
     selected_asset_keys: Sequence[AssetKey]
 
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         return set()
 
     def resolve_checks_inner(self, asset_graph: InternalAssetGraph) -> AbstractSet[AssetCheckKey]:
@@ -474,7 +474,7 @@ class AssetChecksForAssetKeysSelection(AssetSelection, frozen=True):
             if handle.asset_key in self.selected_asset_keys
         }
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return self
 
 
@@ -482,7 +482,7 @@ class AssetChecksForAssetKeysSelection(AssetSelection, frozen=True):
 class AssetCheckKeysSelection(AssetSelection, frozen=True):
     selected_asset_check_keys: Sequence[AssetCheckKey]
 
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         return set()
 
     def resolve_checks_inner(self, asset_graph: InternalAssetGraph) -> AbstractSet[AssetCheckKey]:
@@ -492,7 +492,7 @@ class AssetCheckKeysSelection(AssetSelection, frozen=True):
             if handle in self.selected_asset_check_keys
         }
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return self
 
 
@@ -504,7 +504,7 @@ class AndAssetSelection(
 ):
     operands: Sequence[AssetSelection]
 
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         return reduce(
             operator.and_, (selection.resolve_inner(asset_graph) for selection in self.operands)
         )
@@ -515,7 +515,7 @@ class AndAssetSelection(
             (selection.resolve_checks_inner(asset_graph) for selection in self.operands),
         )
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return self.replace(
             operands=[
                 operand.to_serializable_asset_selection(asset_graph) for operand in self.operands
@@ -537,7 +537,7 @@ class OrAssetSelection(
 ):
     operands: Sequence[AssetSelection]
 
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         return reduce(
             operator.or_, (selection.resolve_inner(asset_graph) for selection in self.operands)
         )
@@ -548,7 +548,7 @@ class OrAssetSelection(
             (selection.resolve_checks_inner(asset_graph) for selection in self.operands),
         )
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return self.replace(
             operands=[
                 operand.to_serializable_asset_selection(asset_graph) for operand in self.operands
@@ -571,7 +571,7 @@ class SubtractAssetSelection(
     left: AssetSelection
     right: AssetSelection
 
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         return self.left.resolve_inner(asset_graph) - self.right.resolve_inner(asset_graph)
 
     def resolve_checks_inner(self, asset_graph: InternalAssetGraph) -> AbstractSet[AssetCheckKey]:
@@ -579,7 +579,7 @@ class SubtractAssetSelection(
             asset_graph
         )
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return self.replace(
             left=self.left.to_serializable_asset_selection(asset_graph),
             right=self.right.to_serializable_asset_selection(asset_graph),
@@ -600,11 +600,11 @@ class SinksAssetSelection(
 ):
     child: AssetSelection
 
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         selection = self.child.resolve_inner(asset_graph)
         return fetch_sinks(asset_graph.asset_dep_graph, selection)
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return self.replace(child=self.child.to_serializable_asset_selection(asset_graph))
 
 
@@ -616,14 +616,14 @@ class RequiredNeighborsAssetSelection(
 ):
     child: AssetSelection
 
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         selection = self.child.resolve_inner(asset_graph)
         output = set(selection)
         for asset_key in selection:
             output.update(asset_graph.get_execution_set_asset_keys(asset_key))
         return output
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return self.replace(child=self.child.to_serializable_asset_selection(asset_graph))
 
 
@@ -635,11 +635,11 @@ class RootsAssetSelection(
 ):
     child: AssetSelection
 
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         selection = self.child.resolve_inner(asset_graph)
         return fetch_sources(asset_graph.asset_dep_graph, selection)
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return self.replace(child=self.child.to_serializable_asset_selection(asset_graph))
 
 
@@ -653,7 +653,7 @@ class DownstreamAssetSelection(
     depth: Optional[int]
     include_self: bool
 
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         selection = self.child.resolve_inner(asset_graph)
         return operator.sub(
             reduce(
@@ -672,7 +672,7 @@ class DownstreamAssetSelection(
             selection if not self.include_self else set(),
         )
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return self.replace(child=self.child.to_serializable_asset_selection(asset_graph))
 
 
@@ -681,7 +681,7 @@ class GroupsAssetSelection(AssetSelection, frozen=True):
     selected_groups: Sequence[str]
     include_sources: bool
 
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.all_asset_keys
             if self.include_sources
@@ -694,7 +694,7 @@ class GroupsAssetSelection(AssetSelection, frozen=True):
             if key in base_set
         }
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return self
 
     def __str__(self) -> str:
@@ -708,7 +708,7 @@ class GroupsAssetSelection(AssetSelection, frozen=True):
 class KeysAssetSelection(AssetSelection, frozen=True):
     selected_keys: Sequence[AssetKey]
 
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         specified_keys = set(self.selected_keys)
         invalid_keys = {key for key in specified_keys if key not in asset_graph.all_asset_keys}
 
@@ -733,7 +733,7 @@ class KeysAssetSelection(AssetSelection, frozen=True):
             )
         return specified_keys
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return self
 
     def needs_parentheses_when_operand(self) -> bool:
@@ -751,7 +751,7 @@ class KeyPrefixesAssetSelection(AssetSelection, frozen=True):
     selected_key_prefixes: Sequence[Sequence[str]]
     include_sources: bool
 
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.all_asset_keys
             if self.include_sources
@@ -763,7 +763,7 @@ class KeyPrefixesAssetSelection(AssetSelection, frozen=True):
             if any(key.has_prefix(prefix) for prefix in self.selected_key_prefixes)
         }
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return self
 
     def __str__(self) -> str:
@@ -776,7 +776,7 @@ class KeyPrefixesAssetSelection(AssetSelection, frozen=True):
 
 def _fetch_all_upstream(
     selection: AbstractSet[AssetKey],
-    asset_graph: AssetGraph,
+    asset_graph: IAssetGraph,
     depth: Optional[int] = None,
     include_self: bool = True,
 ) -> AbstractSet[AssetKey]:
@@ -809,14 +809,14 @@ class UpstreamAssetSelection(
     depth: Optional[int]
     include_self: bool
 
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         selection = self.child.resolve_inner(asset_graph)
         if len(selection) == 0:
             return selection
         all_upstream = _fetch_all_upstream(selection, asset_graph, self.depth, self.include_self)
         return {key for key in all_upstream if key in asset_graph.materializable_asset_keys}
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return self.replace(child=self.child.to_serializable_asset_selection(asset_graph))
 
     def __str__(self) -> str:
@@ -841,12 +841,12 @@ class ParentSourcesAssetSelection(
 ):
     child: AssetSelection
 
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         selection = self.child.resolve_inner(asset_graph)
         if len(selection) == 0:
             return selection
         all_upstream = _fetch_all_upstream(selection, asset_graph)
         return {key for key in all_upstream if key in asset_graph.external_asset_keys}
 
-    def to_serializable_asset_selection(self, asset_graph: AssetGraph) -> "AssetSelection":
+    def to_serializable_asset_selection(self, asset_graph: IAssetGraph) -> "AssetSelection":
         return self.replace(child=self.child.to_serializable_asset_selection(asset_graph))

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -72,7 +72,7 @@ from .source_asset import SourceAsset
 from .utils import DEFAULT_GROUP_NAME, validate_group_name
 
 if TYPE_CHECKING:
-    from .asset_graph import AssetKeyOrCheckKey
+    from .base_asset_graph import AssetKeyOrCheckKey
     from .graph_definition import GraphDefinition
 
 ASSET_SUBSET_INPUT_PREFIX = "__subset_input__"

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -46,7 +46,7 @@ from dagster._utils.schedules import (
 )
 
 from .asset_condition.asset_condition_evaluation_context import AssetConditionEvaluationContext
-from .asset_graph import sort_key_for_asset_partition
+from .base_asset_graph import sort_key_for_asset_partition
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_condition.asset_condition import (

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -67,7 +67,7 @@ class ParentsPartitionsResult(NamedTuple):
     required_but_nonexistent_parents_partitions: AbstractSet[AssetKeyPartitionKey]
 
 
-class IAssetGraph(ABC):
+class BaseAssetGraph(ABC):
     @property
     @abstractmethod
     def asset_dep_graph(self) -> DependencyGraph[AssetKey]: ...
@@ -691,7 +691,7 @@ class IAssetGraph(ABC):
 
 
 def sort_key_for_asset_partition(
-    asset_graph: IAssetGraph, asset_partition: AssetKeyPartitionKey
+    asset_graph: BaseAssetGraph, asset_partition: AssetKeyPartitionKey
 ) -> float:
     """Returns an integer sort key such that asset partitions are sorted in the order in which they
     should be materialized. For assets without a time window partition dimension, this is always 0.
@@ -748,7 +748,7 @@ class ToposortedPriorityQueue:
 
     def __init__(
         self,
-        asset_graph: IAssetGraph,
+        asset_graph: BaseAssetGraph,
         items: Iterable[AssetKeyPartitionKey],
         include_full_execution_set: bool,
     ):

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -18,8 +18,8 @@ from typing import AbstractSet, Dict, Mapping, Optional, Sequence, Tuple, cast
 import pendulum
 
 import dagster._check as check
-from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.data_version import (
     DATA_VERSION_TAG,
     DataVersion,
@@ -43,7 +43,7 @@ DATA_TIME_METADATA_KEY = "dagster/data_time"
 
 class CachingDataTimeResolver:
     _instance_queryer: CachingInstanceQueryer
-    _asset_graph: IAssetGraph
+    _asset_graph: BaseAssetGraph
 
     def __init__(self, instance_queryer: CachingInstanceQueryer):
         self._instance_queryer = instance_queryer
@@ -53,7 +53,7 @@ class CachingDataTimeResolver:
         return self._instance_queryer
 
     @property
-    def asset_graph(self) -> IAssetGraph:
+    def asset_graph(self) -> BaseAssetGraph:
         return self.instance_queryer.asset_graph
 
     ####################

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -18,7 +18,7 @@ from typing import AbstractSet, Dict, Mapping, Optional, Sequence, Tuple, cast
 import pendulum
 
 import dagster._check as check
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.data_version import (
     DATA_VERSION_TAG,
@@ -43,7 +43,7 @@ DATA_TIME_METADATA_KEY = "dagster/data_time"
 
 class CachingDataTimeResolver:
     _instance_queryer: CachingInstanceQueryer
-    _asset_graph: AssetGraph
+    _asset_graph: IAssetGraph
 
     def __init__(self, instance_queryer: CachingInstanceQueryer):
         self._instance_queryer = instance_queryer
@@ -53,7 +53,7 @@ class CachingDataTimeResolver:
         return self._instance_queryer
 
     @property
-    def asset_graph(self) -> AssetGraph:
+    def asset_graph(self) -> IAssetGraph:
         return self.instance_queryer.asset_graph
 
     ####################

--- a/python_modules/dagster/dagster/_core/definitions/data_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_version.py
@@ -20,7 +20,7 @@ from dagster._annotations import deprecated, experimental
 from dagster._utils.cached_method import cached_method
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.asset_graph import AssetGraph
+    from dagster._core.definitions.asset_graph_interface import IAssetGraph
     from dagster._core.definitions.events import (
         AssetKey,
         AssetKeyPartitionKey,
@@ -374,19 +374,19 @@ class CachingStaleStatusResolver:
 
     _instance: "DagsterInstance"
     _instance_queryer: Optional["CachingInstanceQueryer"]
-    _asset_graph: Optional["AssetGraph"]
-    _asset_graph_load_fn: Optional[Callable[[], "AssetGraph"]]
+    _asset_graph: Optional["IAssetGraph"]
+    _asset_graph_load_fn: Optional[Callable[[], "IAssetGraph"]]
 
     def __init__(
         self,
         instance: "DagsterInstance",
-        asset_graph: Union["AssetGraph", Callable[[], "AssetGraph"]],
+        asset_graph: Union["IAssetGraph", Callable[[], "IAssetGraph"]],
     ):
-        from dagster._core.definitions.asset_graph import AssetGraph
+        from dagster._core.definitions.asset_graph_interface import IAssetGraph
 
         self._instance = instance
         self._instance_queryer = None
-        if isinstance(asset_graph, AssetGraph):
+        if isinstance(asset_graph, IAssetGraph):
             self._asset_graph = asset_graph
             self._asset_graph_load_fn = None
         else:
@@ -602,7 +602,7 @@ class CachingStaleStatusResolver:
         return root_causes
 
     @property
-    def asset_graph(self) -> "AssetGraph":
+    def asset_graph(self) -> "IAssetGraph":
         if self._asset_graph is None:
             self._asset_graph = check.not_none(self._asset_graph_load_fn)()
         return self._asset_graph

--- a/python_modules/dagster/dagster/_core/definitions/data_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_version.py
@@ -20,7 +20,7 @@ from dagster._annotations import deprecated, experimental
 from dagster._utils.cached_method import cached_method
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.asset_graph_interface import IAssetGraph
+    from dagster._core.definitions.base_asset_graph import BaseAssetGraph
     from dagster._core.definitions.events import (
         AssetKey,
         AssetKeyPartitionKey,
@@ -374,19 +374,19 @@ class CachingStaleStatusResolver:
 
     _instance: "DagsterInstance"
     _instance_queryer: Optional["CachingInstanceQueryer"]
-    _asset_graph: Optional["IAssetGraph"]
-    _asset_graph_load_fn: Optional[Callable[[], "IAssetGraph"]]
+    _asset_graph: Optional["BaseAssetGraph"]
+    _asset_graph_load_fn: Optional[Callable[[], "BaseAssetGraph"]]
 
     def __init__(
         self,
         instance: "DagsterInstance",
-        asset_graph: Union["IAssetGraph", Callable[[], "IAssetGraph"]],
+        asset_graph: Union["BaseAssetGraph", Callable[[], "BaseAssetGraph"]],
     ):
-        from dagster._core.definitions.asset_graph_interface import IAssetGraph
+        from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 
         self._instance = instance
         self._instance_queryer = None
-        if isinstance(asset_graph, IAssetGraph):
+        if isinstance(asset_graph, BaseAssetGraph):
             self._asset_graph = asset_graph
             self._asset_graph_load_fn = None
         else:
@@ -602,7 +602,7 @@ class CachingStaleStatusResolver:
         return root_causes
 
     @property
-    def asset_graph(self) -> "IAssetGraph":
+    def asset_graph(self) -> "BaseAssetGraph":
         if self._asset_graph is None:
             self._asset_graph = check.not_none(self._asset_graph_load_fn)()
         return self._asset_graph

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -18,9 +18,9 @@ from dagster._config.pythonic_config import (
     attach_resource_id_to_key_mapping,
 )
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import ExecutorDefinition
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.build_resources import wrap_resources_for_execution
@@ -570,6 +570,6 @@ class Definitions:
         """
         return self._created_pending_or_normal_repo
 
-    def get_asset_graph(self) -> InternalAssetGraph:
+    def get_asset_graph(self) -> AssetGraph:
         """Get the AssetGraph for this set of definitions."""
         return self.get_repository_def().asset_graph

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -24,7 +24,7 @@ from dagster._core.selector.subset_selector import DependencyGraph
 from dagster._core.workspace.workspace import IWorkspace
 from dagster._utils.cached_method import cached_method
 
-from .asset_graph import AssetGraph, AssetKeyOrCheckKey
+from .asset_graph_interface import AssetKeyOrCheckKey, IAssetGraph
 from .backfill_policy import BackfillPolicy
 from .events import AssetKey
 from .freshness_policy import FreshnessPolicy
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     )
 
 
-class ExternalAssetGraph(AssetGraph):
+class ExternalAssetGraph(IAssetGraph):
     def __init__(
         self,
         asset_nodes_by_key: Mapping[AssetKey, "ExternalAssetNode"],

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -118,7 +118,7 @@ def get_expected_data_time_for_asset_key(
     """Returns the data time that you would expect this asset to have if you were to execute it
     on this tick.
     """
-    from dagster._core.definitions.host_asset_graph import HostAssetGraph
+    from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 
     asset_key = context.asset_key
     asset_graph = context.asset_graph
@@ -135,7 +135,7 @@ def get_expected_data_time_for_asset_key(
         for parent_key in asset_graph.get_parents(asset_key):
             # if the parent will be materialized on this tick, and it's not in the same repo, then
             # we must wait for this asset to be materialized
-            if isinstance(asset_graph, HostAssetGraph) and context.will_update_asset_partition(
+            if isinstance(asset_graph, RemoteAssetGraph) and context.will_update_asset_partition(
                 AssetKeyPartitionKey(parent_key)
             ):
                 parent_repo = asset_graph.get_repository_handle(parent_key)

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -118,7 +118,7 @@ def get_expected_data_time_for_asset_key(
     """Returns the data time that you would expect this asset to have if you were to execute it
     on this tick.
     """
-    from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+    from dagster._core.definitions.host_asset_graph import HostAssetGraph
 
     asset_key = context.asset_key
     asset_graph = context.asset_graph
@@ -135,7 +135,7 @@ def get_expected_data_time_for_asset_key(
         for parent_key in asset_graph.get_parents(asset_key):
             # if the parent will be materialized on this tick, and it's not in the same repo, then
             # we must wait for this asset to be materialized
-            if isinstance(asset_graph, ExternalAssetGraph) and context.will_update_asset_partition(
+            if isinstance(asset_graph, HostAssetGraph) and context.will_update_asset_partition(
                 AssetKeyPartitionKey(parent_key)
             ):
                 parent_repo = asset_graph.get_repository_handle(parent_key)

--- a/python_modules/dagster/dagster/_core/definitions/host_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/host_asset_graph.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     )
 
 
-class ExternalAssetGraph(IAssetGraph):
+class HostAssetGraph(IAssetGraph):
     def __init__(
         self,
         asset_nodes_by_key: Mapping[AssetKey, "ExternalAssetNode"],
@@ -50,7 +50,7 @@ class ExternalAssetGraph(IAssetGraph):
         self._repo_handles_by_key = repo_handles_by_key
 
     @classmethod
-    def from_workspace(cls, context: IWorkspace) -> "ExternalAssetGraph":
+    def from_workspace(cls, context: IWorkspace) -> "HostAssetGraph":
         code_locations = (
             location_entry.code_location
             for location_entry in context.get_workspace_snapshot().values()
@@ -78,9 +78,7 @@ class ExternalAssetGraph(IAssetGraph):
         )
 
     @classmethod
-    def from_external_repository(
-        cls, external_repository: ExternalRepository
-    ) -> "ExternalAssetGraph":
+    def from_external_repository(cls, external_repository: ExternalRepository) -> "HostAssetGraph":
         return cls.from_repository_handles_and_external_asset_nodes(
             repo_handle_external_asset_nodes=[
                 (external_repository.handle, asset_node)
@@ -94,7 +92,7 @@ class ExternalAssetGraph(IAssetGraph):
         cls,
         repo_handle_external_asset_nodes: Sequence[Tuple[RepositoryHandle, "ExternalAssetNode"]],
         external_asset_checks: Sequence["ExternalAssetCheck"],
-    ) -> "ExternalAssetGraph":
+    ) -> "HostAssetGraph":
         repo_handles_by_key = {
             node.asset_key: repo_handle
             for repo_handle, node in repo_handle_external_asset_nodes

--- a/python_modules/dagster/dagster/_core/definitions/internal_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/internal_asset_graph.py
@@ -2,7 +2,7 @@ from typing import AbstractSet, Iterable, Mapping, Optional, Sequence, Union
 
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
-from dagster._core.definitions.asset_graph import AssetGraph, AssetKeyOrCheckKey
+from dagster._core.definitions.asset_graph_interface import AssetKeyOrCheckKey, IAssetGraph
 from dagster._core.definitions.asset_spec import (
     SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET,
     AssetSpec,
@@ -20,7 +20,7 @@ from dagster._core.selector.subset_selector import DependencyGraph, generate_ass
 from dagster._utils.cached_method import cached_method
 
 
-class InternalAssetGraph(AssetGraph):
+class InternalAssetGraph(IAssetGraph):
     def __init__(
         self,
         assets_defs: Sequence[AssetsDefinition],

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -24,7 +24,6 @@ from dagster._config.pythonic_config import (
 )
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.assets_job import (
     get_base_asset_jobs,
     is_base_asset_job_name,
@@ -32,6 +31,7 @@ from dagster._core.definitions.assets_job import (
 from dagster._core.definitions.auto_materialize_sensor_definition import (
     AutoMaterializeSensorDefinition,
 )
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.job_definition import JobDefinition
@@ -457,7 +457,7 @@ def _process_and_validate_target(
 
 
 def _validate_auto_materialize_sensors(
-    sensors: Iterable[SensorDefinition], asset_graph: IAssetGraph
+    sensors: Iterable[SensorDefinition], asset_graph: BaseAssetGraph
 ) -> None:
     """Raises an error if two or more automation policy sensors target the same asset."""
     sensor_names_by_asset_key: Dict[AssetKey, str] = {}

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -23,7 +23,7 @@ from dagster._config.pythonic_config import (
     ResourceWithKeyMapping,
 )
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.assets_job import (
     get_base_asset_jobs,
     is_base_asset_job_name,
@@ -457,7 +457,7 @@ def _process_and_validate_target(
 
 
 def _validate_auto_materialize_sensors(
-    sensors: Iterable[SensorDefinition], asset_graph: AssetGraph
+    sensors: Iterable[SensorDefinition], asset_graph: IAssetGraph
 ) -> None:
     """Raises an error if two or more automation policy sensors target the same asset."""
     sensor_names_by_asset_key: Dict[AssetKey, str] = {}

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -23,6 +23,7 @@ from dagster._config.pythonic_config import (
     ResourceWithKeyMapping,
 )
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.assets_job import (
     get_base_asset_jobs,
@@ -33,7 +34,6 @@ from dagster._core.definitions.auto_materialize_sensor_definition import (
 )
 from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.graph_definition import GraphDefinition
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.definitions.partitioned_schedule import (
@@ -107,7 +107,7 @@ def _env_vars_from_resource_defaults(resource_def: ResourceDefinition) -> Set[st
 
 def _resolve_unresolved_job_def_lambda(
     unresolved_job_def: UnresolvedAssetJobDefinition,
-    asset_graph: InternalAssetGraph,
+    asset_graph: AssetGraph,
     default_executor_def: Optional[ExecutorDefinition],
     top_level_resources: Optional[Mapping[str, ResourceDefinition]],
     default_logger_defs: Optional[Mapping[str, LoggerDefinition]],
@@ -232,7 +232,7 @@ def build_caching_repository_data_from_list(
         else:
             check.failed(f"Unexpected repository entry {definition}")
 
-    asset_graph = InternalAssetGraph.from_assets(
+    asset_graph = AssetGraph.from_assets(
         [*assets_defs, *source_assets], asset_checks=asset_checks_defs
     )
     if assets_defs or source_assets or asset_checks_defs:
@@ -368,7 +368,7 @@ def build_caching_repository_data_from_dict(
         elif isinstance(raw_job_def, UnresolvedAssetJobDefinition):
             repository_definitions["jobs"][key] = raw_job_def.resolve(
                 # TODO: https://github.com/dagster-io/dagster/issues/8263
-                asset_graph=InternalAssetGraph.from_assets([]),
+                asset_graph=AssetGraph.from_assets([]),
                 default_executor_def=None,
             )
         elif not isinstance(raw_job_def, JobDefinition) and not isfunction(raw_job_def):

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -16,13 +16,13 @@ from typing import (
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.assets_job import (
     ASSET_BASE_JOB_PREFIX,
 )
 from dagster._core.definitions.cacheable_assets import AssetsDefinitionCacheableData
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import ExecutorDefinition
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.definitions.metadata import MetadataMapping
@@ -412,8 +412,8 @@ class RepositoryDefinition:
 
     @property
     @cached_method
-    def asset_graph(self) -> InternalAssetGraph:
-        return InternalAssetGraph.from_assets(
+    def asset_graph(self) -> AssetGraph:
+        return AssetGraph.from_assets(
             [
                 *list(dict.fromkeys(self.assets_defs_by_key.values())),
                 *self.source_assets_by_key.values(),

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
         PartitionsDefinition,
         ResourceDefinition,
     )
+    from dagster._core.definitions.asset_graph import AssetGraph
     from dagster._core.definitions.asset_selection import CoercibleToAssetSelection
-    from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
     from dagster._core.definitions.run_config import RunConfig
 
 
@@ -176,7 +176,7 @@ class UnresolvedAssetJobDefinition(
 
     def resolve(
         self,
-        asset_graph: "InternalAssetGraph",
+        asset_graph: "AssetGraph",
         default_executor_def: Optional["ExecutorDefinition"] = None,
         resource_defs: Optional[Mapping[str, "ResourceDefinition"]] = None,
     ) -> "JobDefinition":

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -31,7 +31,7 @@ from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import IdentityPartitionMapping
@@ -576,7 +576,7 @@ class AssetBackfillData(NamedTuple):
 
 
 def create_asset_backfill_data_from_asset_partitions(
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     asset_selection: Sequence[AssetKey],
     partition_names: Sequence[str],
     dynamic_partitions_store: DynamicPartitionsStore,
@@ -617,7 +617,7 @@ class AssetBackfillIterationResult(NamedTuple):
 
 def _get_requested_asset_partitions_from_run_requests(
     run_requests: Sequence[RunRequest],
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     instance_queryer: CachingInstanceQueryer,
 ) -> AbstractSet[AssetKeyPartitionKey]:
     requested_partitions = set()
@@ -663,7 +663,7 @@ def _submit_runs_and_update_backfill_in_chunks(
     backfill_id: str,
     asset_backfill_iteration_result: AssetBackfillIterationResult,
     previous_asset_backfill_data: AssetBackfillData,
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     instance_queryer: CachingInstanceQueryer,
     logger: logging.Logger,
 ) -> Iterable[Optional[AssetBackfillData]]:
@@ -884,7 +884,7 @@ def execute_asset_backfill_iteration(
 
     workspace_context = workspace_process_context.create_request_context()
 
-    asset_graph = ExternalAssetGraph.from_workspace(workspace_context)
+    asset_graph = HostAssetGraph.from_workspace(workspace_context)
 
     if not backfill.is_asset_backfill:
         check.failed("Backfill must be an asset backfill")
@@ -1053,7 +1053,7 @@ def get_canceling_asset_backfill_iteration_data(
     backfill_id: str,
     asset_backfill_data: AssetBackfillData,
     instance_queryer: CachingInstanceQueryer,
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     backfill_start_time: datetime,
 ) -> Iterable[Optional[AssetBackfillData]]:
     """For asset backfills in the "canceling" state, fetch the asset backfill data with the updated
@@ -1091,7 +1091,7 @@ def get_canceling_asset_backfill_iteration_data(
 def get_asset_backfill_iteration_materialized_partitions(
     backfill_id: str,
     asset_backfill_data: AssetBackfillData,
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     instance_queryer: CachingInstanceQueryer,
 ) -> Iterable[Optional[AssetGraphSubset]]:
     """Returns the partitions that have been materialized by the backfill.
@@ -1135,7 +1135,7 @@ def get_asset_backfill_iteration_materialized_partitions(
 def _get_failed_and_downstream_asset_partitions(
     backfill_id: str,
     asset_backfill_data: AssetBackfillData,
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     instance_queryer: CachingInstanceQueryer,
     backfill_start_time: datetime,
 ) -> AssetGraphSubset:
@@ -1171,7 +1171,7 @@ def _get_next_latest_storage_id(instance_queryer: CachingInstanceQueryer) -> int
 def execute_asset_backfill_iteration_inner(
     backfill_id: str,
     asset_backfill_data: AssetBackfillData,
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     instance_queryer: CachingInstanceQueryer,
     run_tags: Mapping[str, str],
     backfill_start_time: datetime,
@@ -1310,7 +1310,7 @@ def can_run_with_parent(
     parent: AssetKeyPartitionKey,
     candidate: AssetKeyPartitionKey,
     candidates_unit: Iterable[AssetKeyPartitionKey],
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     target_subset: AssetGraphSubset,
     asset_partitions_to_request_map: Mapping[AssetKey, AbstractSet[Optional[str]]],
 ) -> bool:
@@ -1380,7 +1380,7 @@ def can_run_with_parent(
 
 
 def should_backfill_atomic_asset_partitions_unit(
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     candidates_unit: Iterable[AssetKeyPartitionKey],
     asset_partitions_to_request: AbstractSet[AssetKeyPartitionKey],
     target_subset: AssetGraphSubset,
@@ -1438,7 +1438,7 @@ def should_backfill_atomic_asset_partitions_unit(
 
 
 def _get_failed_asset_partitions(
-    instance_queryer: CachingInstanceQueryer, backfill_id: str, asset_graph: ExternalAssetGraph
+    instance_queryer: CachingInstanceQueryer, backfill_id: str, asset_graph: HostAssetGraph
 ) -> Sequence[AssetKeyPartitionKey]:
     """Returns asset partitions that materializations were requested for as part of the backfill, but
     will not be materialized.

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -27,14 +27,14 @@ from dagster._core.definitions.asset_daemon_context import (
     build_run_requests,
     build_run_requests_with_backfill_policies,
 )
-from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import IdentityPartitionMapping
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.selector import PartitionsByAssetSelector
 from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
@@ -268,7 +268,7 @@ class AssetBackfillData(NamedTuple):
         return self.target_subset.get_partitions_subset(asset_key)
 
     def get_target_root_partitions_subset(
-        self, asset_graph: IAssetGraph
+        self, asset_graph: BaseAssetGraph
     ) -> Optional[PartitionsSubset]:
         """Returns the most upstream partitions subset that was targeted by the backfill."""
         target_partitioned_asset_keys = {
@@ -301,7 +301,7 @@ class AssetBackfillData(NamedTuple):
             return None
 
     def get_targeted_asset_keys_topological_order(
-        self, asset_graph: IAssetGraph
+        self, asset_graph: BaseAssetGraph
     ) -> Sequence[AssetKey]:
         """Returns a topological ordering of asset keys targeted by the backfill
         that exist in the asset graph.
@@ -311,7 +311,7 @@ class AssetBackfillData(NamedTuple):
         return [k for k in asset_graph.toposorted_asset_keys if k in self.target_subset.asset_keys]
 
     def get_backfill_status_per_asset_key(
-        self, asset_graph: IAssetGraph
+        self, asset_graph: BaseAssetGraph
     ) -> Sequence[Union[PartitionedAssetBackfillStatus, UnpartitionedAssetBackfillStatus]]:
         """Returns a list containing each targeted asset key's backfill status.
         This list orders assets topologically and only contains statuses for assets that are
@@ -407,7 +407,7 @@ class AssetBackfillData(NamedTuple):
         )
 
     @classmethod
-    def is_valid_serialization(cls, serialized: str, asset_graph: IAssetGraph) -> bool:
+    def is_valid_serialization(cls, serialized: str, asset_graph: BaseAssetGraph) -> bool:
         storage_dict = json.loads(serialized)
         return AssetGraphSubset.can_deserialize(
             storage_dict["serialized_target_subset"], asset_graph
@@ -415,7 +415,7 @@ class AssetBackfillData(NamedTuple):
 
     @classmethod
     def from_serialized(
-        cls, serialized: str, asset_graph: IAssetGraph, backfill_start_timestamp: float
+        cls, serialized: str, asset_graph: BaseAssetGraph, backfill_start_timestamp: float
     ) -> "AssetBackfillData":
         storage_dict = json.loads(serialized)
 
@@ -440,7 +440,7 @@ class AssetBackfillData(NamedTuple):
     @classmethod
     def from_partitions_by_assets(
         cls,
-        asset_graph: IAssetGraph,
+        asset_graph: BaseAssetGraph,
         dynamic_partitions_store: DynamicPartitionsStore,
         backfill_start_time: datetime,
         partitions_by_assets: Sequence[PartitionsByAssetSelector],
@@ -492,7 +492,7 @@ class AssetBackfillData(NamedTuple):
     @classmethod
     def from_asset_partitions(
         cls,
-        asset_graph: IAssetGraph,
+        asset_graph: BaseAssetGraph,
         partition_names: Optional[Sequence[str]],
         asset_selection: Sequence[AssetKey],
         dynamic_partitions_store: DynamicPartitionsStore,
@@ -554,7 +554,7 @@ class AssetBackfillData(NamedTuple):
         return cls.empty(target_subset, backfill_start_time, dynamic_partitions_store)
 
     def serialize(
-        self, dynamic_partitions_store: DynamicPartitionsStore, asset_graph: IAssetGraph
+        self, dynamic_partitions_store: DynamicPartitionsStore, asset_graph: BaseAssetGraph
     ) -> str:
         storage_dict = {
             "requested_runs_for_target_roots": self.requested_runs_for_target_roots,
@@ -576,7 +576,7 @@ class AssetBackfillData(NamedTuple):
 
 
 def create_asset_backfill_data_from_asset_partitions(
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     asset_selection: Sequence[AssetKey],
     partition_names: Sequence[str],
     dynamic_partitions_store: DynamicPartitionsStore,
@@ -617,7 +617,7 @@ class AssetBackfillIterationResult(NamedTuple):
 
 def _get_requested_asset_partitions_from_run_requests(
     run_requests: Sequence[RunRequest],
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     instance_queryer: CachingInstanceQueryer,
 ) -> AbstractSet[AssetKeyPartitionKey]:
     requested_partitions = set()
@@ -663,7 +663,7 @@ def _submit_runs_and_update_backfill_in_chunks(
     backfill_id: str,
     asset_backfill_iteration_result: AssetBackfillIterationResult,
     previous_asset_backfill_data: AssetBackfillData,
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     instance_queryer: CachingInstanceQueryer,
     logger: logging.Logger,
 ) -> Iterable[Optional[AssetBackfillData]]:
@@ -763,7 +763,7 @@ def _submit_runs_and_update_backfill_in_chunks(
 
 def _check_target_partitions_subset_is_valid(
     asset_key: AssetKey,
-    asset_graph: IAssetGraph,
+    asset_graph: BaseAssetGraph,
     target_partitions_subset: Optional[PartitionsSubset],
     instance_queryer: CachingInstanceQueryer,
 ) -> None:
@@ -823,7 +823,7 @@ def _check_target_partitions_subset_is_valid(
 def _check_validity_and_deserialize_asset_backfill_data(
     workspace_context: BaseWorkspaceRequestContext,
     backfill: "PartitionBackfill",
-    asset_graph: IAssetGraph,
+    asset_graph: BaseAssetGraph,
     instance_queryer: CachingInstanceQueryer,
     logger: logging.Logger,
 ) -> Optional[AssetBackfillData]:
@@ -884,7 +884,7 @@ def execute_asset_backfill_iteration(
 
     workspace_context = workspace_process_context.create_request_context()
 
-    asset_graph = HostAssetGraph.from_workspace(workspace_context)
+    asset_graph = RemoteAssetGraph.from_workspace(workspace_context)
 
     if not backfill.is_asset_backfill:
         check.failed("Backfill must be an asset backfill")
@@ -1053,7 +1053,7 @@ def get_canceling_asset_backfill_iteration_data(
     backfill_id: str,
     asset_backfill_data: AssetBackfillData,
     instance_queryer: CachingInstanceQueryer,
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     backfill_start_time: datetime,
 ) -> Iterable[Optional[AssetBackfillData]]:
     """For asset backfills in the "canceling" state, fetch the asset backfill data with the updated
@@ -1091,7 +1091,7 @@ def get_canceling_asset_backfill_iteration_data(
 def get_asset_backfill_iteration_materialized_partitions(
     backfill_id: str,
     asset_backfill_data: AssetBackfillData,
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     instance_queryer: CachingInstanceQueryer,
 ) -> Iterable[Optional[AssetGraphSubset]]:
     """Returns the partitions that have been materialized by the backfill.
@@ -1135,7 +1135,7 @@ def get_asset_backfill_iteration_materialized_partitions(
 def _get_failed_and_downstream_asset_partitions(
     backfill_id: str,
     asset_backfill_data: AssetBackfillData,
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     instance_queryer: CachingInstanceQueryer,
     backfill_start_time: datetime,
 ) -> AssetGraphSubset:
@@ -1171,7 +1171,7 @@ def _get_next_latest_storage_id(instance_queryer: CachingInstanceQueryer) -> int
 def execute_asset_backfill_iteration_inner(
     backfill_id: str,
     asset_backfill_data: AssetBackfillData,
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     instance_queryer: CachingInstanceQueryer,
     run_tags: Mapping[str, str],
     backfill_start_time: datetime,
@@ -1310,7 +1310,7 @@ def can_run_with_parent(
     parent: AssetKeyPartitionKey,
     candidate: AssetKeyPartitionKey,
     candidates_unit: Iterable[AssetKeyPartitionKey],
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     target_subset: AssetGraphSubset,
     asset_partitions_to_request_map: Mapping[AssetKey, AbstractSet[Optional[str]]],
 ) -> bool:
@@ -1380,7 +1380,7 @@ def can_run_with_parent(
 
 
 def should_backfill_atomic_asset_partitions_unit(
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     candidates_unit: Iterable[AssetKeyPartitionKey],
     asset_partitions_to_request: AbstractSet[AssetKeyPartitionKey],
     target_subset: AssetGraphSubset,
@@ -1438,7 +1438,7 @@ def should_backfill_atomic_asset_partitions_unit(
 
 
 def _get_failed_asset_partitions(
-    instance_queryer: CachingInstanceQueryer, backfill_id: str, asset_graph: HostAssetGraph
+    instance_queryer: CachingInstanceQueryer, backfill_id: str, asset_graph: RemoteAssetGraph
 ) -> Sequence[AssetKeyPartitionKey]:
     """Returns asset partitions that materializations were requested for as part of the backfill, but
     will not be materialized.

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -6,7 +6,7 @@ import pendulum
 from dagster import _check as check
 from dagster._core.definitions import AssetKey
 from dagster._core.definitions.asset_graph_interface import IAssetGraph
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.errors import DagsterDefinitionChangedDeserializationError
 from dagster._core.execution.bulk_actions import BulkActionType
@@ -154,7 +154,7 @@ class PartitionBackfill(
             if self.serialized_asset_backfill_data:
                 return AssetBackfillData.is_valid_serialization(
                     self.serialized_asset_backfill_data,
-                    ExternalAssetGraph.from_workspace(workspace),
+                    HostAssetGraph.from_workspace(workspace),
                 )
             else:
                 return True
@@ -171,7 +171,7 @@ class PartitionBackfill(
             return []
 
         if self.is_asset_backfill:
-            asset_graph = ExternalAssetGraph.from_workspace(workspace)
+            asset_graph = HostAssetGraph.from_workspace(workspace)
             try:
                 asset_backfill_data = self.get_asset_backfill_data(asset_graph)
             except DagsterDefinitionChangedDeserializationError:
@@ -188,7 +188,7 @@ class PartitionBackfill(
             return None
 
         if self.is_asset_backfill:
-            asset_graph = ExternalAssetGraph.from_workspace(workspace)
+            asset_graph = HostAssetGraph.from_workspace(workspace)
             try:
                 asset_backfill_data = self.get_asset_backfill_data(asset_graph)
             except DagsterDefinitionChangedDeserializationError:
@@ -205,7 +205,7 @@ class PartitionBackfill(
             return None
 
         if self.is_asset_backfill:
-            asset_graph = ExternalAssetGraph.from_workspace(workspace)
+            asset_graph = HostAssetGraph.from_workspace(workspace)
             try:
                 asset_backfill_data = self.get_asset_backfill_data(asset_graph)
             except DagsterDefinitionChangedDeserializationError:
@@ -220,7 +220,7 @@ class PartitionBackfill(
             return 0
 
         if self.is_asset_backfill:
-            asset_graph = ExternalAssetGraph.from_workspace(workspace)
+            asset_graph = HostAssetGraph.from_workspace(workspace)
             try:
                 asset_backfill_data = self.get_asset_backfill_data(asset_graph)
             except DagsterDefinitionChangedDeserializationError:
@@ -238,7 +238,7 @@ class PartitionBackfill(
             return []
 
         if self.is_asset_backfill:
-            asset_graph = ExternalAssetGraph.from_workspace(workspace)
+            asset_graph = HostAssetGraph.from_workspace(workspace)
             try:
                 asset_backfill_data = self.get_asset_backfill_data(asset_graph)
             except DagsterDefinitionChangedDeserializationError:

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -5,7 +5,7 @@ import pendulum
 
 from dagster import _check as check
 from dagster._core.definitions import AssetKey
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.errors import DagsterDefinitionChangedDeserializationError
@@ -117,7 +117,7 @@ class PartitionBackfill(
             self.serialized_asset_backfill_data is not None or self.asset_backfill_data is not None
         )
 
-    def get_asset_backfill_data(self, asset_graph: AssetGraph) -> AssetBackfillData:
+    def get_asset_backfill_data(self, asset_graph: IAssetGraph) -> AssetBackfillData:
         if self.serialized_asset_backfill_data:
             asset_backfill_data = AssetBackfillData.from_serialized(
                 self.serialized_asset_backfill_data, asset_graph, self.backfill_timestamp
@@ -333,7 +333,7 @@ class PartitionBackfill(
         self,
         asset_backfill_data: AssetBackfillData,
         dynamic_partitions_store: DynamicPartitionsStore,
-        asset_graph: AssetGraph,
+        asset_graph: IAssetGraph,
     ) -> "PartitionBackfill":
         is_backcompat = self.serialized_asset_backfill_data is not None
         return PartitionBackfill(
@@ -360,7 +360,7 @@ class PartitionBackfill(
     def from_asset_partitions(
         cls,
         backfill_id: str,
-        asset_graph: AssetGraph,
+        asset_graph: IAssetGraph,
         partition_names: Optional[Sequence[str]],
         asset_selection: Sequence[AssetKey],
         backfill_timestamp: float,
@@ -399,7 +399,7 @@ class PartitionBackfill(
     def from_partitions_by_assets(
         cls,
         backfill_id: str,
-        asset_graph: AssetGraph,
+        asset_graph: IAssetGraph,
         backfill_timestamp: float,
         tags: Mapping[str, str],
         dynamic_partitions_store: DynamicPartitionsStore,

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -5,9 +5,9 @@ import pendulum
 
 from dagster import _check as check
 from dagster._core.definitions import AssetKey
-from dagster._core.definitions.asset_graph_interface import IAssetGraph
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.partition import PartitionsSubset
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.errors import DagsterDefinitionChangedDeserializationError
 from dagster._core.execution.bulk_actions import BulkActionType
 from dagster._core.host_representation.origin import ExternalPartitionSetOrigin
@@ -117,7 +117,7 @@ class PartitionBackfill(
             self.serialized_asset_backfill_data is not None or self.asset_backfill_data is not None
         )
 
-    def get_asset_backfill_data(self, asset_graph: IAssetGraph) -> AssetBackfillData:
+    def get_asset_backfill_data(self, asset_graph: BaseAssetGraph) -> AssetBackfillData:
         if self.serialized_asset_backfill_data:
             asset_backfill_data = AssetBackfillData.from_serialized(
                 self.serialized_asset_backfill_data, asset_graph, self.backfill_timestamp
@@ -154,7 +154,7 @@ class PartitionBackfill(
             if self.serialized_asset_backfill_data:
                 return AssetBackfillData.is_valid_serialization(
                     self.serialized_asset_backfill_data,
-                    HostAssetGraph.from_workspace(workspace),
+                    RemoteAssetGraph.from_workspace(workspace),
                 )
             else:
                 return True
@@ -171,7 +171,7 @@ class PartitionBackfill(
             return []
 
         if self.is_asset_backfill:
-            asset_graph = HostAssetGraph.from_workspace(workspace)
+            asset_graph = RemoteAssetGraph.from_workspace(workspace)
             try:
                 asset_backfill_data = self.get_asset_backfill_data(asset_graph)
             except DagsterDefinitionChangedDeserializationError:
@@ -188,7 +188,7 @@ class PartitionBackfill(
             return None
 
         if self.is_asset_backfill:
-            asset_graph = HostAssetGraph.from_workspace(workspace)
+            asset_graph = RemoteAssetGraph.from_workspace(workspace)
             try:
                 asset_backfill_data = self.get_asset_backfill_data(asset_graph)
             except DagsterDefinitionChangedDeserializationError:
@@ -205,7 +205,7 @@ class PartitionBackfill(
             return None
 
         if self.is_asset_backfill:
-            asset_graph = HostAssetGraph.from_workspace(workspace)
+            asset_graph = RemoteAssetGraph.from_workspace(workspace)
             try:
                 asset_backfill_data = self.get_asset_backfill_data(asset_graph)
             except DagsterDefinitionChangedDeserializationError:
@@ -220,7 +220,7 @@ class PartitionBackfill(
             return 0
 
         if self.is_asset_backfill:
-            asset_graph = HostAssetGraph.from_workspace(workspace)
+            asset_graph = RemoteAssetGraph.from_workspace(workspace)
             try:
                 asset_backfill_data = self.get_asset_backfill_data(asset_graph)
             except DagsterDefinitionChangedDeserializationError:
@@ -238,7 +238,7 @@ class PartitionBackfill(
             return []
 
         if self.is_asset_backfill:
-            asset_graph = HostAssetGraph.from_workspace(workspace)
+            asset_graph = RemoteAssetGraph.from_workspace(workspace)
             try:
                 asset_backfill_data = self.get_asset_backfill_data(asset_graph)
             except DagsterDefinitionChangedDeserializationError:
@@ -333,7 +333,7 @@ class PartitionBackfill(
         self,
         asset_backfill_data: AssetBackfillData,
         dynamic_partitions_store: DynamicPartitionsStore,
-        asset_graph: IAssetGraph,
+        asset_graph: BaseAssetGraph,
     ) -> "PartitionBackfill":
         is_backcompat = self.serialized_asset_backfill_data is not None
         return PartitionBackfill(
@@ -360,7 +360,7 @@ class PartitionBackfill(
     def from_asset_partitions(
         cls,
         backfill_id: str,
-        asset_graph: IAssetGraph,
+        asset_graph: BaseAssetGraph,
         partition_names: Optional[Sequence[str]],
         asset_selection: Sequence[AssetKey],
         backfill_timestamp: float,
@@ -399,7 +399,7 @@ class PartitionBackfill(
     def from_partitions_by_assets(
         cls,
         backfill_id: str,
-        asset_graph: IAssetGraph,
+        asset_graph: BaseAssetGraph,
         backfill_timestamp: float,
         tags: Mapping[str, str],
         dynamic_partitions_store: DynamicPartitionsStore,

--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -5,7 +5,7 @@ from typing import Dict, Iterator, List, NamedTuple, Optional, Sequence, Tuple, 
 import dagster._check as check
 from dagster._core.definitions.assets_job import is_base_asset_job_name
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.selector import JobSubsetSelector
@@ -30,7 +30,7 @@ class RunRequestExecutionData(NamedTuple):
 
 
 def _get_implicit_job_name_for_assets(
-    asset_graph: ExternalAssetGraph, asset_keys: Sequence[AssetKey]
+    asset_graph: HostAssetGraph, asset_keys: Sequence[AssetKey]
 ) -> Optional[str]:
     job_names = set(asset_graph.get_materialization_job_names(asset_keys[0]))
     for asset_key in asset_keys[1:]:
@@ -53,7 +53,7 @@ def _execution_plan_targets_asset_selection(
 
 
 def _get_job_execution_data_from_run_request(
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     run_request: RunRequest,
     instance: DagsterInstance,
     workspace: BaseWorkspaceRequestContext,
@@ -114,7 +114,7 @@ def _create_asset_run(
     run_request_index: int,
     instance: DagsterInstance,
     run_request_execution_data_cache: Dict[int, RunRequestExecutionData],
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     workspace_process_context: IWorkspaceProcessContext,
     debug_crash_flags: SingleInstigatorDebugCrashFlags,
     logger: logging.Logger,
@@ -188,7 +188,7 @@ def _create_asset_run(
         # likely is outdated and targeting the wrong job, refetch the asset
         # graph from the workspace
         workspace = workspace_process_context.create_request_context()
-        asset_graph = ExternalAssetGraph.from_workspace(workspace)
+        asset_graph = HostAssetGraph.from_workspace(workspace)
 
     check.failed(
         f"Failed to target asset selection {run_request.asset_selection} in run after retrying."
@@ -201,7 +201,7 @@ def submit_asset_run(
     run_request_index: int,
     instance: DagsterInstance,
     workspace_process_context: IWorkspaceProcessContext,
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     run_request_execution_data_cache: Dict[int, RunRequestExecutionData],
     debug_crash_flags: SingleInstigatorDebugCrashFlags,
     logger: logging.Logger,
@@ -274,7 +274,7 @@ def submit_asset_runs_in_chunks(
     chunk_size: int,
     instance: DagsterInstance,
     workspace_process_context: IWorkspaceProcessContext,
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     debug_crash_flags: SingleInstigatorDebugCrashFlags,
     logger: logging.Logger,
     backfill_id: Optional[str] = None,

--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -5,8 +5,8 @@ from typing import Dict, Iterator, List, NamedTuple, Optional, Sequence, Tuple, 
 import dagster._check as check
 from dagster._core.definitions.assets_job import is_base_asset_job_name
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.partition import PartitionsDefinition
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.errors import (
@@ -30,7 +30,7 @@ class RunRequestExecutionData(NamedTuple):
 
 
 def _get_implicit_job_name_for_assets(
-    asset_graph: HostAssetGraph, asset_keys: Sequence[AssetKey]
+    asset_graph: RemoteAssetGraph, asset_keys: Sequence[AssetKey]
 ) -> Optional[str]:
     job_names = set(asset_graph.get_materialization_job_names(asset_keys[0]))
     for asset_key in asset_keys[1:]:
@@ -53,7 +53,7 @@ def _execution_plan_targets_asset_selection(
 
 
 def _get_job_execution_data_from_run_request(
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     run_request: RunRequest,
     instance: DagsterInstance,
     workspace: BaseWorkspaceRequestContext,
@@ -114,7 +114,7 @@ def _create_asset_run(
     run_request_index: int,
     instance: DagsterInstance,
     run_request_execution_data_cache: Dict[int, RunRequestExecutionData],
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     workspace_process_context: IWorkspaceProcessContext,
     debug_crash_flags: SingleInstigatorDebugCrashFlags,
     logger: logging.Logger,
@@ -188,7 +188,7 @@ def _create_asset_run(
         # likely is outdated and targeting the wrong job, refetch the asset
         # graph from the workspace
         workspace = workspace_process_context.create_request_context()
-        asset_graph = HostAssetGraph.from_workspace(workspace)
+        asset_graph = RemoteAssetGraph.from_workspace(workspace)
 
     check.failed(
         f"Failed to target asset selection {run_request.asset_selection} in run after retrying."
@@ -201,7 +201,7 @@ def submit_asset_run(
     run_request_index: int,
     instance: DagsterInstance,
     workspace_process_context: IWorkspaceProcessContext,
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     run_request_execution_data_cache: Dict[int, RunRequestExecutionData],
     debug_crash_flags: SingleInstigatorDebugCrashFlags,
     logger: logging.Logger,
@@ -274,7 +274,7 @@ def submit_asset_runs_in_chunks(
     chunk_size: int,
     instance: DagsterInstance,
     workspace_process_context: IWorkspaceProcessContext,
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     debug_crash_flags: SingleInstigatorDebugCrashFlags,
     logger: logging.Logger,
     backfill_id: Optional[str] = None,

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -185,7 +185,7 @@ class ExternalRepository:
     @property
     @cached_method
     def _external_sensors(self) -> Dict[str, "ExternalSensor"]:
-        from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+        from dagster._core.definitions.host_asset_graph import HostAssetGraph
 
         sensor_datas = {
             external_sensor_data.name: ExternalSensor(external_sensor_data, self._handle)
@@ -193,7 +193,7 @@ class ExternalRepository:
         }
 
         if self._instance.auto_materialize_use_sensors:
-            asset_graph = ExternalAssetGraph.from_external_repository(self)
+            asset_graph = HostAssetGraph.from_external_repository(self)
 
             has_any_auto_observe_source_assets = False
 

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -185,7 +185,7 @@ class ExternalRepository:
     @property
     @cached_method
     def _external_sensors(self) -> Dict[str, "ExternalSensor"]:
-        from dagster._core.definitions.host_asset_graph import HostAssetGraph
+        from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 
         sensor_datas = {
             external_sensor_data.name: ExternalSensor(external_sensor_data, self._handle)
@@ -193,7 +193,7 @@ class ExternalRepository:
         }
 
         if self._instance.auto_materialize_use_sensors:
-            asset_graph = HostAssetGraph.from_external_repository(self)
+            asset_graph = RemoteAssetGraph.from_external_repository(self)
 
             has_any_auto_observe_source_assets = False
 

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -18,7 +18,7 @@ from dagster._core.definitions.asset_daemon_cursor import (
     LegacyAssetDaemonCursorWrapper,
     backcompat_deserialize_asset_daemon_cursor_str,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.repository_definition.valid_definitions import (
@@ -118,7 +118,7 @@ def set_auto_materialize_paused(instance: DagsterInstance, paused: bool):
 
 
 def _get_pre_sensor_auto_materialize_cursor(
-    instance: DagsterInstance, full_asset_graph: Optional[AssetGraph]
+    instance: DagsterInstance, full_asset_graph: Optional[IAssetGraph]
 ) -> AssetDaemonCursor:
     """Gets a deserialized cursor by either reading from the new cursor key and simply deserializing
     the value, or by reading from the old cursor key and converting the legacy cursor into the
@@ -179,7 +179,7 @@ def asset_daemon_cursor_to_instigator_serialized_cursor(cursor: AssetDaemonCurso
 
 
 def asset_daemon_cursor_from_instigator_serialized_cursor(
-    serialized_cursor: Optional[str], asset_graph: Optional[AssetGraph]
+    serialized_cursor: Optional[str], asset_graph: Optional[IAssetGraph]
 ) -> AssetDaemonCursor:
     """This method decompresses the serialized cursor and returns a deserialized cursor object,
     converting from the legacy cursor format if necessary.

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -20,7 +20,7 @@ from dagster._core.definitions.asset_daemon_cursor import (
 )
 from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
 )
@@ -485,7 +485,7 @@ class AssetDaemon(DagsterDaemon):
                 if not get_has_migrated_to_sensors(instance):
                     # Do a one-time migration to create the cursors for each sensor, based on the
                     # existing cursor for the legacy AMP tick
-                    asset_graph = ExternalAssetGraph.from_workspace(workspace)
+                    asset_graph = HostAssetGraph.from_workspace(workspace)
                     pre_sensor_cursor = _get_pre_sensor_auto_materialize_cursor(
                         instance, asset_graph
                     )
@@ -647,7 +647,7 @@ class AssetDaemon(DagsterDaemon):
 
         workspace = workspace_process_context.create_request_context()
 
-        asset_graph = ExternalAssetGraph.from_workspace(workspace)
+        asset_graph = HostAssetGraph.from_workspace(workspace)
 
         instance: DagsterInstance = workspace_process_context.instance
         error_info = None
@@ -671,7 +671,7 @@ class AssetDaemon(DagsterDaemon):
 
             if sensor:
                 eligible_keys = check.not_none(sensor.asset_selection).resolve(
-                    ExternalAssetGraph.from_external_repository(check.not_none(repository))
+                    HostAssetGraph.from_external_repository(check.not_none(repository))
                 )
             else:
                 eligible_keys = {
@@ -832,7 +832,7 @@ class AssetDaemon(DagsterDaemon):
         tick: InstigatorTick,
         sensor: Optional[ExternalSensor],
         workspace_process_context: IWorkspaceProcessContext,
-        asset_graph: ExternalAssetGraph,
+        asset_graph: HostAssetGraph,
         auto_materialize_asset_keys: Set[AssetKey],
         stored_cursor: AssetDaemonCursor,
         auto_observe_asset_keys: Set[AssetKey],

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -18,9 +18,9 @@ from dagster._core.definitions.asset_daemon_cursor import (
     LegacyAssetDaemonCursorWrapper,
     backcompat_deserialize_asset_daemon_cursor_str,
 )
-from dagster._core.definitions.asset_graph_interface import IAssetGraph
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
 )
@@ -118,7 +118,7 @@ def set_auto_materialize_paused(instance: DagsterInstance, paused: bool):
 
 
 def _get_pre_sensor_auto_materialize_cursor(
-    instance: DagsterInstance, full_asset_graph: Optional[IAssetGraph]
+    instance: DagsterInstance, full_asset_graph: Optional[BaseAssetGraph]
 ) -> AssetDaemonCursor:
     """Gets a deserialized cursor by either reading from the new cursor key and simply deserializing
     the value, or by reading from the old cursor key and converting the legacy cursor into the
@@ -179,7 +179,7 @@ def asset_daemon_cursor_to_instigator_serialized_cursor(cursor: AssetDaemonCurso
 
 
 def asset_daemon_cursor_from_instigator_serialized_cursor(
-    serialized_cursor: Optional[str], asset_graph: Optional[IAssetGraph]
+    serialized_cursor: Optional[str], asset_graph: Optional[BaseAssetGraph]
 ) -> AssetDaemonCursor:
     """This method decompresses the serialized cursor and returns a deserialized cursor object,
     converting from the legacy cursor format if necessary.
@@ -485,7 +485,7 @@ class AssetDaemon(DagsterDaemon):
                 if not get_has_migrated_to_sensors(instance):
                     # Do a one-time migration to create the cursors for each sensor, based on the
                     # existing cursor for the legacy AMP tick
-                    asset_graph = HostAssetGraph.from_workspace(workspace)
+                    asset_graph = RemoteAssetGraph.from_workspace(workspace)
                     pre_sensor_cursor = _get_pre_sensor_auto_materialize_cursor(
                         instance, asset_graph
                     )
@@ -647,7 +647,7 @@ class AssetDaemon(DagsterDaemon):
 
         workspace = workspace_process_context.create_request_context()
 
-        asset_graph = HostAssetGraph.from_workspace(workspace)
+        asset_graph = RemoteAssetGraph.from_workspace(workspace)
 
         instance: DagsterInstance = workspace_process_context.instance
         error_info = None
@@ -671,7 +671,7 @@ class AssetDaemon(DagsterDaemon):
 
             if sensor:
                 eligible_keys = check.not_none(sensor.asset_selection).resolve(
-                    HostAssetGraph.from_external_repository(check.not_none(repository))
+                    RemoteAssetGraph.from_external_repository(check.not_none(repository))
                 )
             else:
                 eligible_keys = {
@@ -832,7 +832,7 @@ class AssetDaemon(DagsterDaemon):
         tick: InstigatorTick,
         sensor: Optional[ExternalSensor],
         workspace_process_context: IWorkspaceProcessContext,
-        asset_graph: HostAssetGraph,
+        asset_graph: RemoteAssetGraph,
         auto_materialize_asset_keys: Set[AssetKey],
         stored_cursor: AssetDaemonCursor,
         auto_observe_asset_keys: Set[AssetKey],

--- a/python_modules/dagster/dagster/_scheduler/stale.py
+++ b/python_modules/dagster/dagster/_scheduler/stale.py
@@ -6,7 +6,7 @@ from dagster._core.definitions.data_version import (
     StaleStatus,
 )
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.host_representation.external import (
     ExternalSchedule,
@@ -20,7 +20,7 @@ def resolve_stale_or_missing_assets(
     run_request: RunRequest,
     instigator: Union[ExternalSensor, ExternalSchedule],
 ) -> Sequence[AssetKey]:
-    asset_graph = ExternalAssetGraph.from_workspace(context.create_request_context())
+    asset_graph = HostAssetGraph.from_workspace(context.create_request_context())
     asset_selection = (
         run_request.asset_selection
         if run_request.asset_selection is not None

--- a/python_modules/dagster/dagster/_scheduler/stale.py
+++ b/python_modules/dagster/dagster/_scheduler/stale.py
@@ -6,7 +6,7 @@ from dagster._core.definitions.data_version import (
     StaleStatus,
 )
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.host_representation.external import (
     ExternalSchedule,
@@ -20,7 +20,7 @@ def resolve_stale_or_missing_assets(
     run_request: RunRequest,
     instigator: Union[ExternalSensor, ExternalSchedule],
 ) -> Sequence[AssetKey]:
-    asset_graph = HostAssetGraph.from_workspace(context.create_request_context())
+    asset_graph = RemoteAssetGraph.from_workspace(context.create_request_context())
     asset_selection = (
         run_request.asset_selection
         if run_request.asset_selection is not None

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -18,7 +18,7 @@ from typing import (
 import pendulum
 
 import dagster._check as check
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_subset import AssetSubset, ValidAssetSubset
 from dagster._core.definitions.data_version import (
@@ -67,7 +67,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
     def __init__(
         self,
         instance: DagsterInstance,
-        asset_graph: AssetGraph,
+        asset_graph: IAssetGraph,
         evaluation_time: Optional[datetime] = None,
         logger: Optional[logging.Logger] = None,
     ):
@@ -96,7 +96,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         return self._instance
 
     @property
-    def asset_graph(self) -> AssetGraph:
+    def asset_graph(self) -> IAssetGraph:
         return self._asset_graph
 
     @property

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -18,9 +18,9 @@ from typing import (
 import pendulum
 
 import dagster._check as check
-from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_subset import AssetSubset, ValidAssetSubset
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.data_version import (
     DATA_VERSION_TAG,
     DataVersion,
@@ -67,7 +67,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
     def __init__(
         self,
         instance: DagsterInstance,
-        asset_graph: IAssetGraph,
+        asset_graph: BaseAssetGraph,
         evaluation_time: Optional[datetime] = None,
         logger: Optional[logging.Logger] = None,
     ):
@@ -96,7 +96,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         return self._instance
 
     @property
-    def asset_graph(self) -> IAssetGraph:
+    def asset_graph(self) -> BaseAssetGraph:
         return self._asset_graph
 
     @property

--- a/python_modules/dagster/dagster/_utils/test/data_versions.py
+++ b/python_modules/dagster/dagster/_utils/test/data_versions.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union, c
 
 from typing_extensions import Literal
 
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import (
     CODE_VERSION_TAG,
@@ -11,7 +12,6 @@ from dagster._core.definitions.data_version import (
     DataVersion,
 )
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.materialize import materialize
 from dagster._core.definitions.run_config import RunConfig
 from dagster._core.definitions.source_asset import SourceAsset
@@ -214,5 +214,5 @@ def get_stale_status_resolver(
 ) -> CachingStaleStatusResolver:
     return CachingStaleStatusResolver(
         instance=instance,
-        asset_graph=InternalAssetGraph.from_assets(assets),
+        asset_graph=AssetGraph.from_assets(assets),
     )

--- a/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
+++ b/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
@@ -15,8 +15,8 @@ from dagster import (
     schedule,
     usable_as_dagster_type,
 )
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.decorators.sensor_decorator import sensor
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.partition import (
     PartitionedConfig,
     StaticPartitionsDefinition,
@@ -203,7 +203,7 @@ def bar_repo():
             "baz": lambda: baz_job,
             "dynamic_job": define_asset_job(
                 "dynamic_job", [dynamic_asset], partitions_def=dynamic_partitions_def
-            ).resolve(asset_graph=InternalAssetGraph.from_assets([dynamic_asset])),
+            ).resolve(asset_graph=AssetGraph.from_assets([dynamic_asset])),
             "fail": fail_job,
             "foo": foo_job,
             "forever": forever_job,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -33,10 +33,10 @@ from dagster import (
     op,
 )
 from dagster._core.definitions.asset_dep import AssetDep
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.partition import (
     DefaultPartitionsSubset,
     DynamicPartitionsDefinition,
@@ -437,7 +437,7 @@ def test_multipartitions_def_partition_mapping_infer_identity():
         assert context.asset_partition_keys_for_input("upstream") == context.partition_keys
         return 1
 
-    asset_graph = InternalAssetGraph.from_assets([upstream, downstream])
+    asset_graph = AssetGraph.from_assets([upstream, downstream])
     assets_job = define_asset_job("foo", [upstream, downstream]).resolve(asset_graph=asset_graph)
 
     assert (
@@ -470,7 +470,7 @@ def test_multipartitions_def_partition_mapping_infer_single_dim_to_multi():
         assert context.partition_keys == [MultiPartitionKey({"abc": "a", "123": "1"})]
         return 1
 
-    asset_graph = InternalAssetGraph.from_assets([upstream, downstream])
+    asset_graph = AssetGraph.from_assets([upstream, downstream])
 
     assert (
         asset_graph.get_partition_mapping(upstream.key, downstream.key)
@@ -525,7 +525,7 @@ def test_multipartitions_def_partition_mapping_infer_multi_to_single_dim():
         assert context.partition_keys == ["a"]
         return 1
 
-    asset_graph = InternalAssetGraph.from_assets([upstream, downstream])
+    asset_graph = AssetGraph.from_assets([upstream, downstream])
 
     assert (
         asset_graph.get_partition_mapping(upstream.key, downstream.key)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -24,13 +24,13 @@ from dagster import (
     repository,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.decorators.asset_check_decorator import asset_check
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
+from dagster._core.definitions.internal_asset_graph import AssetGraph
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import UpstreamPartitionsResult
@@ -55,7 +55,7 @@ def to_external_asset_graph(assets, asset_checks=None) -> IAssetGraph:
     external_asset_nodes = external_asset_nodes_from_defs(
         repo.get_all_jobs(), repo.asset_graph.assets_defs
     )
-    return ExternalAssetGraph.from_repository_handles_and_external_asset_nodes(
+    return HostAssetGraph.from_repository_handles_and_external_asset_nodes(
         [(MagicMock(), asset_node) for asset_node in external_asset_nodes],
         external_asset_checks=external_asset_checks_from_defs(repo.get_all_jobs()),
     )
@@ -419,7 +419,7 @@ def test_partitioned_source_asset(asset_graph_from_assets: Callable[..., IAssetG
 
     asset_graph = asset_graph_from_assets([partitioned_source, downstream_of_partitioned_source])
 
-    if isinstance(asset_graph, ExternalAssetGraph):
+    if isinstance(asset_graph, HostAssetGraph):
         pytest.xfail("not supported with ExternalAssetGraph")
 
     assert asset_graph.is_partitioned(AssetKey("partitioned_source"))

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -24,13 +24,13 @@ from dagster import (
     repository,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.decorators.asset_check_decorator import asset_check
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import UpstreamPartitionsResult
@@ -62,7 +62,7 @@ def to_external_asset_graph(assets, asset_checks=None) -> IAssetGraph:
 
 
 @pytest.fixture(
-    name="asset_graph_from_assets", params=[InternalAssetGraph.from_assets, to_external_asset_graph]
+    name="asset_graph_from_assets", params=[AssetGraph.from_assets, to_external_asset_graph]
 )
 def asset_graph_from_assets_fixture(request) -> Callable[[List[AssetsDefinition]], IAssetGraph]:
     return request.param
@@ -321,7 +321,7 @@ def test_custom_unsupported_partition_mapping():
         )
         def child(parent): ...
 
-    internal_asset_graph = InternalAssetGraph.from_assets([parent, child])
+    internal_asset_graph = AssetGraph.from_assets([parent, child])
     external_asset_graph = to_external_asset_graph([parent, child])
 
     with instance_for_test() as instance:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -24,16 +24,16 @@ from dagster import (
     repository,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
-from dagster._core.definitions.asset_graph_interface import IAssetGraph
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_subset import AssetSubset
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.decorators.asset_check_decorator import asset_check
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
-from dagster._core.definitions.internal_asset_graph import AssetGraph
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import UpstreamPartitionsResult
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import (
     DagsterDefinitionChangedDeserializationError,
@@ -47,7 +47,7 @@ from dagster._core.test_utils import instance_for_test
 from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_freeze_time
 
 
-def to_external_asset_graph(assets, asset_checks=None) -> IAssetGraph:
+def to_external_asset_graph(assets, asset_checks=None) -> BaseAssetGraph:
     @repository
     def repo():
         return assets + (asset_checks or [])
@@ -55,7 +55,7 @@ def to_external_asset_graph(assets, asset_checks=None) -> IAssetGraph:
     external_asset_nodes = external_asset_nodes_from_defs(
         repo.get_all_jobs(), repo.asset_graph.assets_defs
     )
-    return HostAssetGraph.from_repository_handles_and_external_asset_nodes(
+    return RemoteAssetGraph.from_repository_handles_and_external_asset_nodes(
         [(MagicMock(), asset_node) for asset_node in external_asset_nodes],
         external_asset_checks=external_asset_checks_from_defs(repo.get_all_jobs()),
     )
@@ -64,7 +64,7 @@ def to_external_asset_graph(assets, asset_checks=None) -> IAssetGraph:
 @pytest.fixture(
     name="asset_graph_from_assets", params=[AssetGraph.from_assets, to_external_asset_graph]
 )
-def asset_graph_from_assets_fixture(request) -> Callable[[List[AssetsDefinition]], IAssetGraph]:
+def asset_graph_from_assets_fixture(request) -> Callable[[List[AssetsDefinition]], BaseAssetGraph]:
     return request.param
 
 
@@ -131,7 +131,7 @@ def test_get_children_partitions_unpartitioned_parent_partitioned_child(
 
 
 def test_get_parent_partitions_unpartitioned_child_partitioned_parent(
-    asset_graph_from_assets: Callable[..., IAssetGraph],
+    asset_graph_from_assets: Callable[..., BaseAssetGraph],
 ):
     @asset(partitions_def=StaticPartitionsDefinition(["a", "b"]))
     def parent(): ...
@@ -163,7 +163,7 @@ def test_get_parent_partitions_unpartitioned_child_partitioned_parent(
         )
 
 
-def test_get_children_partitions_fan_out(asset_graph_from_assets: Callable[..., IAssetGraph]):
+def test_get_children_partitions_fan_out(asset_graph_from_assets: Callable[..., BaseAssetGraph]):
     @asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
     def parent(): ...
 
@@ -197,7 +197,9 @@ def test_get_children_partitions_fan_out(asset_graph_from_assets: Callable[..., 
         )
 
 
-def test_get_parent_partitions_fan_in(asset_graph_from_assets: Callable[..., IAssetGraph]) -> None:
+def test_get_parent_partitions_fan_in(
+    asset_graph_from_assets: Callable[..., BaseAssetGraph],
+) -> None:
     @asset(partitions_def=HourlyPartitionsDefinition(start_date="2022-01-01-00:00"))
     def parent(): ...
 
@@ -235,7 +237,7 @@ def test_get_parent_partitions_fan_in(asset_graph_from_assets: Callable[..., IAs
 
 
 def test_get_parent_partitions_non_default_partition_mapping(
-    asset_graph_from_assets: Callable[..., IAssetGraph],
+    asset_graph_from_assets: Callable[..., BaseAssetGraph],
 ):
     @asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
     def parent(): ...
@@ -341,7 +343,7 @@ def test_custom_unsupported_partition_mapping():
 
 
 def test_required_multi_asset_sets_non_subsettable_multi_asset(
-    asset_graph_from_assets: Callable[..., IAssetGraph],
+    asset_graph_from_assets: Callable[..., BaseAssetGraph],
 ):
     @multi_asset(outs={"a": AssetOut(), "b": AssetOut()})
     def non_subsettable_multi_asset(): ...
@@ -354,7 +356,7 @@ def test_required_multi_asset_sets_non_subsettable_multi_asset(
 
 
 def test_required_multi_asset_sets_subsettable_multi_asset(
-    asset_graph_from_assets: Callable[..., IAssetGraph],
+    asset_graph_from_assets: Callable[..., BaseAssetGraph],
 ):
     @multi_asset(
         outs={"a": AssetOut(), "b": AssetOut()},
@@ -368,7 +370,7 @@ def test_required_multi_asset_sets_subsettable_multi_asset(
 
 
 def test_required_multi_asset_sets_graph_backed_multi_asset(
-    asset_graph_from_assets: Callable[..., IAssetGraph],
+    asset_graph_from_assets: Callable[..., BaseAssetGraph],
 ):
     @op
     def op1():
@@ -391,7 +393,7 @@ def test_required_multi_asset_sets_graph_backed_multi_asset(
 
 
 def test_required_multi_asset_sets_same_op_in_different_assets(
-    asset_graph_from_assets: Callable[..., IAssetGraph],
+    asset_graph_from_assets: Callable[..., BaseAssetGraph],
 ):
     @op
     def op1(): ...
@@ -405,7 +407,7 @@ def test_required_multi_asset_sets_same_op_in_different_assets(
         assert asset_graph.get_execution_set_asset_keys(asset_def.key) == {asset_def.key}
 
 
-def test_partitioned_source_asset(asset_graph_from_assets: Callable[..., IAssetGraph]):
+def test_partitioned_source_asset(asset_graph_from_assets: Callable[..., BaseAssetGraph]):
     partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
 
     partitioned_source = SourceAsset(
@@ -419,14 +421,14 @@ def test_partitioned_source_asset(asset_graph_from_assets: Callable[..., IAssetG
 
     asset_graph = asset_graph_from_assets([partitioned_source, downstream_of_partitioned_source])
 
-    if isinstance(asset_graph, HostAssetGraph):
-        pytest.xfail("not supported with ExternalAssetGraph")
+    if isinstance(asset_graph, RemoteAssetGraph):
+        pytest.xfail("not supported with RemoteAssetGraph")
 
     assert asset_graph.is_partitioned(AssetKey("partitioned_source"))
     assert asset_graph.is_partitioned(AssetKey("downstream_of_partitioned_source"))
 
 
-def test_bfs_filter_asset_subsets(asset_graph_from_assets: Callable[..., IAssetGraph]):
+def test_bfs_filter_asset_subsets(asset_graph_from_assets: Callable[..., BaseAssetGraph]):
     daily_partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
 
     @asset(partitions_def=daily_partitions_def)
@@ -516,7 +518,7 @@ def test_bfs_filter_asset_subsets(asset_graph_from_assets: Callable[..., IAssetG
 
 
 def test_bfs_filter_asset_subsets_different_mappings(
-    asset_graph_from_assets: Callable[..., IAssetGraph],
+    asset_graph_from_assets: Callable[..., BaseAssetGraph],
 ):
     daily_partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
 
@@ -573,7 +575,9 @@ def test_bfs_filter_asset_subsets_different_mappings(
     )
 
 
-def test_asset_graph_subset_contains(asset_graph_from_assets: Callable[..., IAssetGraph]) -> None:
+def test_asset_graph_subset_contains(
+    asset_graph_from_assets: Callable[..., BaseAssetGraph],
+) -> None:
     daily_partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
 
     @asset(partitions_def=daily_partitions_def)
@@ -607,7 +611,7 @@ def test_asset_graph_subset_contains(asset_graph_from_assets: Callable[..., IAss
     assert AssetKeyPartitionKey(partitioned2.key, "2022-01-01") not in asset_graph_subset
 
 
-def test_asset_graph_difference(asset_graph_from_assets: Callable[..., IAssetGraph]):
+def test_asset_graph_difference(asset_graph_from_assets: Callable[..., BaseAssetGraph]):
     daily_partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
 
     @asset(partitions_def=daily_partitions_def)
@@ -666,11 +670,13 @@ def test_asset_graph_difference(asset_graph_from_assets: Callable[..., IAssetGra
     )
 
 
-def test_asset_graph_partial_deserialization(asset_graph_from_assets: Callable[..., IAssetGraph]):
+def test_asset_graph_partial_deserialization(
+    asset_graph_from_assets: Callable[..., BaseAssetGraph],
+):
     daily_partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
     static_partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
 
-    def get_ag1() -> IAssetGraph:
+    def get_ag1() -> BaseAssetGraph:
         @asset(partitions_def=daily_partitions_def)
         def partitioned1(): ...
 
@@ -685,7 +691,7 @@ def test_asset_graph_partial_deserialization(asset_graph_from_assets: Callable[.
 
         return asset_graph_from_assets([partitioned1, partitioned2, unpartitioned1, unpartitioned2])
 
-    def get_ag2() -> IAssetGraph:
+    def get_ag2() -> BaseAssetGraph:
         @asset(partitions_def=daily_partitions_def)
         def partitioned1(): ...
 
@@ -744,7 +750,7 @@ def test_asset_graph_partial_deserialization(asset_graph_from_assets: Callable[.
 
 
 def test_required_assets_and_checks_by_key_check_decorator(
-    asset_graph_from_assets: Callable[..., IAssetGraph],
+    asset_graph_from_assets: Callable[..., BaseAssetGraph],
 ):
     @asset
     def asset0(): ...
@@ -758,7 +764,7 @@ def test_required_assets_and_checks_by_key_check_decorator(
 
 
 def test_required_assets_and_checks_by_key_asset_decorator(
-    asset_graph_from_assets: Callable[..., IAssetGraph],
+    asset_graph_from_assets: Callable[..., BaseAssetGraph],
 ):
     foo_check = AssetCheckSpec(name="foo", asset="asset0")
     bar_check = AssetCheckSpec(name="bar", asset="asset0")
@@ -779,7 +785,7 @@ def test_required_assets_and_checks_by_key_asset_decorator(
 
 
 def test_required_assets_and_checks_by_key_multi_asset(
-    asset_graph_from_assets: Callable[..., IAssetGraph],
+    asset_graph_from_assets: Callable[..., BaseAssetGraph],
 ):
     foo_check = AssetCheckSpec(name="foo", asset="asset0")
     bar_check = AssetCheckSpec(name="bar", asset="asset1")
@@ -819,7 +825,7 @@ def test_required_assets_and_checks_by_key_multi_asset(
 
 
 def test_required_assets_and_checks_by_key_multi_asset_single_asset(
-    asset_graph_from_assets: Callable[..., IAssetGraph],
+    asset_graph_from_assets: Callable[..., BaseAssetGraph],
 ):
     foo_check = AssetCheckSpec(name="foo", asset="asset0")
     bar_check = AssetCheckSpec(name="bar", asset="asset0")

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -24,7 +24,7 @@ from dagster import (
     repository,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.decorators.asset_check_decorator import asset_check
@@ -47,7 +47,7 @@ from dagster._core.test_utils import instance_for_test
 from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_freeze_time
 
 
-def to_external_asset_graph(assets, asset_checks=None) -> AssetGraph:
+def to_external_asset_graph(assets, asset_checks=None) -> IAssetGraph:
     @repository
     def repo():
         return assets + (asset_checks or [])
@@ -64,7 +64,7 @@ def to_external_asset_graph(assets, asset_checks=None) -> AssetGraph:
 @pytest.fixture(
     name="asset_graph_from_assets", params=[InternalAssetGraph.from_assets, to_external_asset_graph]
 )
-def asset_graph_from_assets_fixture(request) -> Callable[[List[AssetsDefinition]], AssetGraph]:
+def asset_graph_from_assets_fixture(request) -> Callable[[List[AssetsDefinition]], IAssetGraph]:
     return request.param
 
 
@@ -131,7 +131,7 @@ def test_get_children_partitions_unpartitioned_parent_partitioned_child(
 
 
 def test_get_parent_partitions_unpartitioned_child_partitioned_parent(
-    asset_graph_from_assets: Callable[..., AssetGraph],
+    asset_graph_from_assets: Callable[..., IAssetGraph],
 ):
     @asset(partitions_def=StaticPartitionsDefinition(["a", "b"]))
     def parent(): ...
@@ -163,7 +163,7 @@ def test_get_parent_partitions_unpartitioned_child_partitioned_parent(
         )
 
 
-def test_get_children_partitions_fan_out(asset_graph_from_assets: Callable[..., AssetGraph]):
+def test_get_children_partitions_fan_out(asset_graph_from_assets: Callable[..., IAssetGraph]):
     @asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
     def parent(): ...
 
@@ -197,7 +197,7 @@ def test_get_children_partitions_fan_out(asset_graph_from_assets: Callable[..., 
         )
 
 
-def test_get_parent_partitions_fan_in(asset_graph_from_assets: Callable[..., AssetGraph]) -> None:
+def test_get_parent_partitions_fan_in(asset_graph_from_assets: Callable[..., IAssetGraph]) -> None:
     @asset(partitions_def=HourlyPartitionsDefinition(start_date="2022-01-01-00:00"))
     def parent(): ...
 
@@ -235,7 +235,7 @@ def test_get_parent_partitions_fan_in(asset_graph_from_assets: Callable[..., Ass
 
 
 def test_get_parent_partitions_non_default_partition_mapping(
-    asset_graph_from_assets: Callable[..., AssetGraph],
+    asset_graph_from_assets: Callable[..., IAssetGraph],
 ):
     @asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"))
     def parent(): ...
@@ -341,7 +341,7 @@ def test_custom_unsupported_partition_mapping():
 
 
 def test_required_multi_asset_sets_non_subsettable_multi_asset(
-    asset_graph_from_assets: Callable[..., AssetGraph],
+    asset_graph_from_assets: Callable[..., IAssetGraph],
 ):
     @multi_asset(outs={"a": AssetOut(), "b": AssetOut()})
     def non_subsettable_multi_asset(): ...
@@ -354,7 +354,7 @@ def test_required_multi_asset_sets_non_subsettable_multi_asset(
 
 
 def test_required_multi_asset_sets_subsettable_multi_asset(
-    asset_graph_from_assets: Callable[..., AssetGraph],
+    asset_graph_from_assets: Callable[..., IAssetGraph],
 ):
     @multi_asset(
         outs={"a": AssetOut(), "b": AssetOut()},
@@ -368,7 +368,7 @@ def test_required_multi_asset_sets_subsettable_multi_asset(
 
 
 def test_required_multi_asset_sets_graph_backed_multi_asset(
-    asset_graph_from_assets: Callable[..., AssetGraph],
+    asset_graph_from_assets: Callable[..., IAssetGraph],
 ):
     @op
     def op1():
@@ -391,7 +391,7 @@ def test_required_multi_asset_sets_graph_backed_multi_asset(
 
 
 def test_required_multi_asset_sets_same_op_in_different_assets(
-    asset_graph_from_assets: Callable[..., AssetGraph],
+    asset_graph_from_assets: Callable[..., IAssetGraph],
 ):
     @op
     def op1(): ...
@@ -405,7 +405,7 @@ def test_required_multi_asset_sets_same_op_in_different_assets(
         assert asset_graph.get_execution_set_asset_keys(asset_def.key) == {asset_def.key}
 
 
-def test_partitioned_source_asset(asset_graph_from_assets: Callable[..., AssetGraph]):
+def test_partitioned_source_asset(asset_graph_from_assets: Callable[..., IAssetGraph]):
     partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
 
     partitioned_source = SourceAsset(
@@ -426,7 +426,7 @@ def test_partitioned_source_asset(asset_graph_from_assets: Callable[..., AssetGr
     assert asset_graph.is_partitioned(AssetKey("downstream_of_partitioned_source"))
 
 
-def test_bfs_filter_asset_subsets(asset_graph_from_assets: Callable[..., AssetGraph]):
+def test_bfs_filter_asset_subsets(asset_graph_from_assets: Callable[..., IAssetGraph]):
     daily_partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
 
     @asset(partitions_def=daily_partitions_def)
@@ -516,7 +516,7 @@ def test_bfs_filter_asset_subsets(asset_graph_from_assets: Callable[..., AssetGr
 
 
 def test_bfs_filter_asset_subsets_different_mappings(
-    asset_graph_from_assets: Callable[..., AssetGraph],
+    asset_graph_from_assets: Callable[..., IAssetGraph],
 ):
     daily_partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
 
@@ -573,7 +573,7 @@ def test_bfs_filter_asset_subsets_different_mappings(
     )
 
 
-def test_asset_graph_subset_contains(asset_graph_from_assets: Callable[..., AssetGraph]) -> None:
+def test_asset_graph_subset_contains(asset_graph_from_assets: Callable[..., IAssetGraph]) -> None:
     daily_partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
 
     @asset(partitions_def=daily_partitions_def)
@@ -607,7 +607,7 @@ def test_asset_graph_subset_contains(asset_graph_from_assets: Callable[..., Asse
     assert AssetKeyPartitionKey(partitioned2.key, "2022-01-01") not in asset_graph_subset
 
 
-def test_asset_graph_difference(asset_graph_from_assets: Callable[..., AssetGraph]):
+def test_asset_graph_difference(asset_graph_from_assets: Callable[..., IAssetGraph]):
     daily_partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
 
     @asset(partitions_def=daily_partitions_def)
@@ -666,11 +666,11 @@ def test_asset_graph_difference(asset_graph_from_assets: Callable[..., AssetGrap
     )
 
 
-def test_asset_graph_partial_deserialization(asset_graph_from_assets: Callable[..., AssetGraph]):
+def test_asset_graph_partial_deserialization(asset_graph_from_assets: Callable[..., IAssetGraph]):
     daily_partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
     static_partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
 
-    def get_ag1() -> AssetGraph:
+    def get_ag1() -> IAssetGraph:
         @asset(partitions_def=daily_partitions_def)
         def partitioned1(): ...
 
@@ -685,7 +685,7 @@ def test_asset_graph_partial_deserialization(asset_graph_from_assets: Callable[.
 
         return asset_graph_from_assets([partitioned1, partitioned2, unpartitioned1, unpartitioned2])
 
-    def get_ag2() -> AssetGraph:
+    def get_ag2() -> IAssetGraph:
         @asset(partitions_def=daily_partitions_def)
         def partitioned1(): ...
 
@@ -744,7 +744,7 @@ def test_asset_graph_partial_deserialization(asset_graph_from_assets: Callable[.
 
 
 def test_required_assets_and_checks_by_key_check_decorator(
-    asset_graph_from_assets: Callable[..., AssetGraph],
+    asset_graph_from_assets: Callable[..., IAssetGraph],
 ):
     @asset
     def asset0(): ...
@@ -758,7 +758,7 @@ def test_required_assets_and_checks_by_key_check_decorator(
 
 
 def test_required_assets_and_checks_by_key_asset_decorator(
-    asset_graph_from_assets: Callable[..., AssetGraph],
+    asset_graph_from_assets: Callable[..., IAssetGraph],
 ):
     foo_check = AssetCheckSpec(name="foo", asset="asset0")
     bar_check = AssetCheckSpec(name="bar", asset="asset0")
@@ -779,7 +779,7 @@ def test_required_assets_and_checks_by_key_asset_decorator(
 
 
 def test_required_assets_and_checks_by_key_multi_asset(
-    asset_graph_from_assets: Callable[..., AssetGraph],
+    asset_graph_from_assets: Callable[..., IAssetGraph],
 ):
     foo_check = AssetCheckSpec(name="foo", asset="asset0")
     bar_check = AssetCheckSpec(name="bar", asset="asset1")
@@ -819,7 +819,7 @@ def test_required_assets_and_checks_by_key_multi_asset(
 
 
 def test_required_assets_and_checks_by_key_multi_asset_single_asset(
-    asset_graph_from_assets: Callable[..., AssetGraph],
+    asset_graph_from_assets: Callable[..., IAssetGraph],
 ):
     foo_check = AssetCheckSpec(name="foo", asset="asset0")
     bar_check = AssetCheckSpec(name="bar", asset="asset0")

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -21,7 +21,6 @@ from dagster import (
 from dagster._core.definitions import AssetSelection, asset
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_selection import (
     AllAssetCheckSelection,
     AllSelection,
@@ -41,6 +40,7 @@ from dagster._core.definitions.asset_selection import (
     UpstreamAssetSelection,
 )
 from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.events import AssetKey
 from dagster._serdes import deserialize_value
 from dagster._serdes.serdes import _WHITELIST_MAP
@@ -533,7 +533,7 @@ def test_all_asset_selection_subclasses_serializable():
 
 def test_to_serializable_asset_selection():
     class UnserializableAssetSelection(AssetSelection, frozen=True):
-        def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
+        def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
             return asset_graph.materializable_asset_keys - {AssetKey("asset2")}
 
     @asset

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -20,6 +20,7 @@ from dagster import (
 )
 from dagster._core.definitions import AssetSelection, asset
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_selection import (
     AllAssetCheckSelection,
@@ -41,7 +42,6 @@ from dagster._core.definitions.asset_selection import (
 )
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._serdes import deserialize_value
 from dagster._serdes.serdes import _WHITELIST_MAP
 from pydantic import ValidationError
@@ -545,7 +545,7 @@ def test_to_serializable_asset_selection():
     @asset_check(asset=asset1)
     def check1(): ...
 
-    asset_graph = InternalAssetGraph.from_assets([asset1, asset2], asset_checks=[check1])
+    asset_graph = AssetGraph.from_assets([asset1, asset2], asset_checks=[check1])
 
     def assert_serializable_same(asset_selection: AssetSelection) -> None:
         assert asset_selection.to_serializable_asset_selection(asset_graph) == asset_selection

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -20,7 +20,7 @@ from dagster import (
 )
 from dagster._core.definitions import AssetSelection, asset
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_selection import (
     AllAssetCheckSelection,
     AllSelection,
@@ -533,7 +533,7 @@ def test_all_asset_selection_subclasses_serializable():
 
 def test_to_serializable_asset_selection():
     class UnserializableAssetSelection(AssetSelection, frozen=True):
-        def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+        def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
             return asset_graph.materializable_asset_keys - {AssetKey("asset2")}
 
     @asset

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -38,12 +38,12 @@ from dagster import (
 )
 from dagster._check import CheckError
 from dagster._core.definitions import AssetIn, SourceAsset, asset, multi_asset
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.assets import TeamAssetOwner, UserAssetOwner
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.decorators.asset_decorator import graph_asset
 from dagster._core.definitions.events import AssetMaterialization
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.result import MaterializeResult
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
@@ -1081,7 +1081,7 @@ def test_graph_backed_asset_subset():
         return bar.alias("bar_1")(one), bar.alias("bar_2")(one)
 
     asset_job = define_asset_job("yay").resolve(
-        asset_graph=InternalAssetGraph.from_assets(
+        asset_graph=AssetGraph.from_assets(
             [
                 AssetsDefinition.from_graph(my_graph, can_subset=True),
             ]
@@ -1110,7 +1110,7 @@ def test_graph_backed_asset_partial_output_selection():
         return one, two
 
     asset_job = define_asset_job("yay").resolve(
-        asset_graph=InternalAssetGraph.from_assets(
+        asset_graph=AssetGraph.from_assets(
             [
                 AssetsDefinition.from_graph(graph_asset, can_subset=True),
             ]
@@ -1157,7 +1157,7 @@ def test_input_subsetting_graph_backed_asset():
 
     with tempfile.TemporaryDirectory() as tmpdir_path:
         asset_job = define_asset_job("yay").resolve(
-            asset_graph=InternalAssetGraph.from_assets(
+            asset_graph=AssetGraph.from_assets(
                 with_resources(
                     [
                         upstream_1,
@@ -1275,7 +1275,7 @@ def test_graph_backed_asset_subset_context(
         return {"asset_one": out_1, "asset_two": out_2, "asset_three": out_3}
 
     asset_job = define_asset_job("yay").resolve(
-        asset_graph=InternalAssetGraph.from_assets(
+        asset_graph=AssetGraph.from_assets(
             [AssetsDefinition.from_graph(three, can_subset=True)],
         )
     )
@@ -1356,7 +1356,7 @@ def test_graph_backed_asset_subset_context_intermediate_ops(
         }
 
     asset_job = define_asset_job("yay").resolve(
-        asset_graph=InternalAssetGraph.from_assets(
+        asset_graph=AssetGraph.from_assets(
             [AssetsDefinition.from_graph(graph_asset, can_subset=True)],
         )
     )
@@ -1418,7 +1418,7 @@ def test_nested_graph_subset_context(
         return {"a": a, "b": b, "c": c, "d": d}
 
     asset_job = define_asset_job("yay").resolve(
-        asset_graph=InternalAssetGraph.from_assets(
+        asset_graph=AssetGraph.from_assets(
             [AssetsDefinition.from_graph(nested_graph, can_subset=True)],
         )
     )
@@ -1455,7 +1455,7 @@ def test_graph_backed_asset_reused():
 
     with tempfile.TemporaryDirectory() as tmpdir_path:
         asset_job = define_asset_job("yay").resolve(
-            asset_graph=InternalAssetGraph.from_assets(
+            asset_graph=AssetGraph.from_assets(
                 with_resources(
                     [
                         upstream,
@@ -1569,7 +1569,7 @@ def test_context_assets_def():
         return 2
 
     asset_job = define_asset_job("yay", [a, b]).resolve(
-        asset_graph=InternalAssetGraph.from_assets(
+        asset_graph=AssetGraph.from_assets(
             [a, b],
         )
     )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -35,12 +35,12 @@ from dagster import (
 )
 from dagster._config import StringSource
 from dagster._core.definitions import AssetIn, SourceAsset, asset
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_selection import AssetSelection, CoercibleToAssetSelection
 from dagster._core.definitions.assets_job import get_base_asset_jobs
 from dagster._core.definitions.dependency import NodeHandle, NodeInvocation
 from dagster._core.definitions.executor_definition import in_process_executor
 from dagster._core.definitions.external_asset import create_external_asset_from_source_asset
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.load_assets_from_modules import prefix_assets
 from dagster._core.errors import DagsterInvalidSubsetError
 from dagster._core.execution.api import execute_run_iterator
@@ -1366,7 +1366,7 @@ dbt_asset_def = AssetsDefinition(
 )
 
 my_job = define_asset_job("foo", selection=["a", "b", "c", "d", "e", "f"]).resolve(
-    asset_graph=InternalAssetGraph.from_assets(
+    asset_graph=AssetGraph.from_assets(
         with_resources(
             [dbt_asset_def, fivetran_asset],
             resource_defs={"my_resource": my_resource, "my_resource_2": my_resource_2},
@@ -1431,7 +1431,7 @@ def test_job_preserved_with_asset_subset():
         },
         description="my cool job",
         tags={"yay": 1},
-    ).resolve(asset_graph=InternalAssetGraph.from_assets([asset_one, two, three]))
+    ).resolve(asset_graph=AssetGraph.from_assets([asset_one, two, three]))
 
     result = foo_job.execute_in_process(asset_selection=[AssetKey("one")])
     assert result.success
@@ -1456,7 +1456,7 @@ def test_job_default_config_preserved_with_asset_subset():
         assert context.op_execution_context.op_config["baz"] == 3
 
     foo_job = define_asset_job("foo_job").resolve(
-        asset_graph=InternalAssetGraph.from_assets([asset_one, two, three])
+        asset_graph=AssetGraph.from_assets([asset_one, two, three])
     )
 
     result = foo_job.execute_in_process(asset_selection=[AssetKey("one")])
@@ -1476,7 +1476,7 @@ def test_empty_asset_job():
     assert empty_selection.resolve([a, b]) == set()
 
     empty_job = define_asset_job("empty_job", selection=empty_selection).resolve(
-        asset_graph=InternalAssetGraph.from_assets([a, b])
+        asset_graph=AssetGraph.from_assets([a, b])
     )
     assert empty_job.all_node_defs == []
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -21,7 +21,7 @@ from dagster._core.definitions.auto_materialize_policy import AutoMaterializePol
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.data_version import CachingStaleStatusResolver
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.host_representation import InProcessCodeLocationOrigin
 from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
@@ -171,7 +171,7 @@ def _make_context(instance: DagsterInstance, defs_attrs):
 
 
 def test_get_repository_handle(instance):
-    asset_graph = HostAssetGraph.from_workspace(_make_context(instance, ["defs1", "defs2"]))
+    asset_graph = RemoteAssetGraph.from_workspace(_make_context(instance, ["defs1", "defs2"]))
 
     assert asset_graph.get_materialization_job_names(asset1.key) == ["__ASSET_JOB"]
     repo_handle1 = asset_graph.get_repository_handle(asset1.key)
@@ -185,7 +185,7 @@ def test_get_repository_handle(instance):
 
 
 def test_cross_repo_dep_with_source_asset(instance):
-    asset_graph = HostAssetGraph.from_workspace(
+    asset_graph = RemoteAssetGraph.from_workspace(
         _make_context(instance, ["defs1", "downstream_defs"])
     )
     assert len(asset_graph.external_asset_keys) == 0
@@ -208,7 +208,7 @@ def test_cross_repo_dep_with_source_asset(instance):
 
 
 def test_cross_repo_dep_no_source_asset(instance):
-    asset_graph = HostAssetGraph.from_workspace(
+    asset_graph = RemoteAssetGraph.from_workspace(
         _make_context(instance, ["defs1", "downstream_defs_no_source"])
     )
     assert len(asset_graph.external_asset_keys) == 0
@@ -233,14 +233,14 @@ def test_cross_repo_dep_no_source_asset(instance):
 
 
 def test_partitioned_source_asset(instance):
-    asset_graph = HostAssetGraph.from_workspace(_make_context(instance, ["partitioned_defs"]))
+    asset_graph = RemoteAssetGraph.from_workspace(_make_context(instance, ["partitioned_defs"]))
 
     assert asset_graph.is_partitioned(AssetKey("partitioned_source"))
     assert asset_graph.is_partitioned(AssetKey("downstream_of_partitioned_source"))
 
 
 def test_get_implicit_job_name_for_assets(instance):
-    asset_graph = HostAssetGraph.from_workspace(_make_context(instance, ["defs1", "defs2"]))
+    asset_graph = RemoteAssetGraph.from_workspace(_make_context(instance, ["defs1", "defs2"]))
     assert (
         asset_graph.get_implicit_job_name_for_assets([asset1.key], external_repo=None)
         == "__ASSET_JOB"
@@ -255,7 +255,7 @@ def test_get_implicit_job_name_for_assets(instance):
     )
 
     partitioned_defs_workspace = _make_context(instance, ["partitioned_defs"])
-    asset_graph = HostAssetGraph.from_workspace(partitioned_defs_workspace)
+    asset_graph = RemoteAssetGraph.from_workspace(partitioned_defs_workspace)
     external_repo = next(
         iter(partitioned_defs_workspace.code_locations[0].get_repositories().values())
     )
@@ -279,7 +279,7 @@ def test_get_implicit_job_name_for_assets(instance):
         == "__ASSET_JOB_0"
     )
 
-    asset_graph = HostAssetGraph.from_workspace(
+    asset_graph = RemoteAssetGraph.from_workspace(
         _make_context(instance, ["different_partitions_defs"])
     )
     assert (
@@ -322,7 +322,7 @@ def test_get_implicit_job_name_for_assets(instance):
 
 
 def test_auto_materialize_policy(instance):
-    asset_graph = HostAssetGraph.from_workspace(_make_context(instance, ["partitioned_defs"]))
+    asset_graph = RemoteAssetGraph.from_workspace(_make_context(instance, ["partitioned_defs"]))
 
     assert asset_graph.get_auto_materialize_policy(
         AssetKey("downstream_of_partitioned_source")
@@ -347,7 +347,9 @@ partition_mapping_defs = Definitions(assets=[static_partitioned_asset, partition
 
 
 def test_partition_mapping(instance):
-    asset_graph = HostAssetGraph.from_workspace(_make_context(instance, ["partition_mapping_defs"]))
+    asset_graph = RemoteAssetGraph.from_workspace(
+        _make_context(instance, ["partition_mapping_defs"])
+    )
     assert isinstance(
         asset_graph.get_partition_mapping(
             AssetKey("partition_mapping_asset"), AssetKey("static_partitioned_asset")
@@ -396,7 +398,7 @@ backfill_assets_defs = Definitions(
 
 
 def test_assets_with_backfill_policies(instance):
-    asset_graph = HostAssetGraph.from_workspace(_make_context(instance, ["backfill_assets_defs"]))
+    asset_graph = RemoteAssetGraph.from_workspace(_make_context(instance, ["backfill_assets_defs"]))
     assert (
         asset_graph.get_backfill_policy(AssetKey("static_partitioned_single_run_backfill_asset"))
         == BackfillPolicy.single_run()
@@ -425,7 +427,7 @@ cycle_defs_b = Definitions(assets=[b])
 
 
 def test_cycle_status(instance):
-    asset_graph = HostAssetGraph.from_workspace(
+    asset_graph = RemoteAssetGraph.from_workspace(
         _make_context(instance, ["cycle_defs_a", "cycle_defs_b"])
     )
     resolver = CachingStaleStatusResolver(DagsterInstance.ephemeral(), asset_graph)
@@ -455,7 +457,7 @@ def test_dup_node_detection(instance):
             re.DOTALL,
         ),
     ):
-        HostAssetGraph.from_workspace(
+        RemoteAssetGraph.from_workspace(
             _make_context(instance, ["dup_materialization_defs_a", "dup_materialization_defs_b"])
         )
 
@@ -465,6 +467,6 @@ def test_dup_node_detection(instance):
             r'Only one OBSERVATION node is allowed per asset.*"single_observable_asset"', re.DOTALL
         ),
     ):
-        HostAssetGraph.from_workspace(
+        RemoteAssetGraph.from_workspace(
             _make_context(instance, ["dup_observation_defs_a", "dup_observation_defs_b"])
         )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -31,9 +31,9 @@ from dagster import (
 )
 from dagster._check import CheckError
 from dagster._core.definitions import asset, multi_asset
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.materialize import materialize_to_memory
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import TimeWindow
@@ -543,7 +543,7 @@ def test_job_config_with_asset_partitions():
         "job",
         partitions_def=daily_partitions_def,
         config={"ops": {"asset1": {"config": {"a": 5}}}},
-    ).resolve(asset_graph=InternalAssetGraph.from_assets([asset1]))
+    ).resolve(asset_graph=AssetGraph.from_assets([asset1]))
 
     assert the_job.execute_in_process(partition_key="2020-01-01").success
     assert (
@@ -566,7 +566,7 @@ def test_job_partitioned_config_with_asset_partitions():
         return {"ops": {"asset1": {"config": {"day_of_month": start.day}}}}
 
     the_job = define_asset_job("job", config=myconfig).resolve(
-        asset_graph=InternalAssetGraph.from_assets([asset1])
+        asset_graph=AssetGraph.from_assets([asset1])
     )
 
     assert the_job.execute_in_process(partition_key="2020-01-01").success
@@ -592,7 +592,7 @@ def test_mismatched_job_partitioned_config_with_asset_partitions():
         ),
     ):
         define_asset_job("job", config=myconfig).resolve(
-            asset_graph=InternalAssetGraph.from_assets([asset1])
+            asset_graph=AssetGraph.from_assets([asset1])
         )
 
 
@@ -619,7 +619,7 @@ def test_partition_range_single_run():
         )
 
     the_job = define_asset_job("job").resolve(
-        asset_graph=InternalAssetGraph.from_assets([upstream_asset, downstream_asset])
+        asset_graph=AssetGraph.from_assets([upstream_asset, downstream_asset])
     )
 
     result = the_job.execute_in_process(
@@ -659,7 +659,7 @@ def test_multipartition_range_single_run():
         assert all(isinstance(key, MultiPartitionKey) for key in context.partition_keys)
 
     the_job = define_asset_job("job").resolve(
-        asset_graph=InternalAssetGraph.from_assets([multipartitioned_asset])
+        asset_graph=AssetGraph.from_assets([multipartitioned_asset])
     )
 
     result = the_job.execute_in_process(
@@ -722,7 +722,7 @@ def test_dynamic_partition_range_single_run():
         assert len(context.partition_keys) == 3
 
     the_job = define_asset_job("job").resolve(
-        asset_graph=InternalAssetGraph.from_assets([dynamicpartitioned_asset])
+        asset_graph=AssetGraph.from_assets([dynamicpartitioned_asset])
     )
 
     instance = DagsterInstance.ephemeral()

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -41,7 +41,7 @@ from dagster import (
 from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.selector import (
     PartitionRangeSelector,
     PartitionsByAssetSelector,
@@ -436,7 +436,7 @@ def test_do_not_rerequest_while_existing_run_in_progress():
 
 def make_backfill_data(
     some_or_all: str,
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     instance: DagsterInstance,
     current_time: datetime.datetime,
 ) -> AssetBackfillData:
@@ -459,7 +459,7 @@ def make_backfill_data(
 
 
 def make_random_subset(
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     instance: DagsterInstance,
     evaluation_time: datetime.datetime,
 ) -> AssetGraphSubset:
@@ -493,7 +493,7 @@ def make_random_subset(
 
 def make_subset_from_partition_keys(
     partition_keys: Sequence[str],
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     instance: DagsterInstance,
     evaluation_time: datetime.datetime,
 ) -> AssetGraphSubset:
@@ -516,7 +516,7 @@ def make_subset_from_partition_keys(
 
 def get_asset_graph(
     assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
-) -> ExternalAssetGraph:
+) -> HostAssetGraph:
     assets_defs_by_key = {
         key: assets_def
         for assets in assets_by_repo_name.values()
@@ -540,7 +540,7 @@ def get_asset_graph(
 def execute_asset_backfill_iteration_consume_generator(
     backfill_id: str,
     asset_backfill_data: AssetBackfillData,
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     instance: DagsterInstance,
 ) -> AssetBackfillIterationResult:
     counter = Counter()
@@ -564,7 +564,7 @@ def execute_asset_backfill_iteration_consume_generator(
 
 
 def run_backfill_to_completion(
-    asset_graph: ExternalAssetGraph,
+    asset_graph: HostAssetGraph,
     assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
     backfill_data: AssetBackfillData,
     fail_asset_partitions: Iterable[AssetKeyPartitionKey],
@@ -702,7 +702,7 @@ def _requested_asset_partitions_in_run_request(
 
 def external_asset_graph_from_assets_by_repo_name(
     assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
-) -> ExternalAssetGraph:
+) -> HostAssetGraph:
     from_repository_handles_and_external_asset_nodes = []
 
     for repo_name, assets in assets_by_repo_name.items():
@@ -717,7 +717,7 @@ def external_asset_graph_from_assets_by_repo_name(
             [(repo_handle, asset_node) for asset_node in external_asset_nodes]
         )
 
-    return ExternalAssetGraph.from_repository_handles_and_external_asset_nodes(
+    return HostAssetGraph.from_repository_handles_and_external_asset_nodes(
         from_repository_handles_and_external_asset_nodes, external_asset_checks=[]
     )
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -38,10 +38,10 @@ from dagster import (
     materialize,
     multi_asset,
 )
-from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.selector import (
     PartitionRangeSelector,
     PartitionsByAssetSelector,
@@ -436,7 +436,7 @@ def test_do_not_rerequest_while_existing_run_in_progress():
 
 def make_backfill_data(
     some_or_all: str,
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     instance: DagsterInstance,
     current_time: datetime.datetime,
 ) -> AssetBackfillData:
@@ -459,7 +459,7 @@ def make_backfill_data(
 
 
 def make_random_subset(
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     instance: DagsterInstance,
     evaluation_time: datetime.datetime,
 ) -> AssetGraphSubset:
@@ -493,7 +493,7 @@ def make_random_subset(
 
 def make_subset_from_partition_keys(
     partition_keys: Sequence[str],
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     instance: DagsterInstance,
     evaluation_time: datetime.datetime,
 ) -> AssetGraphSubset:
@@ -516,7 +516,7 @@ def make_subset_from_partition_keys(
 
 def get_asset_graph(
     assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
-) -> HostAssetGraph:
+) -> RemoteAssetGraph:
     assets_defs_by_key = {
         key: assets_def
         for assets in assets_by_repo_name.values()
@@ -540,7 +540,7 @@ def get_asset_graph(
 def execute_asset_backfill_iteration_consume_generator(
     backfill_id: str,
     asset_backfill_data: AssetBackfillData,
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     instance: DagsterInstance,
 ) -> AssetBackfillIterationResult:
     counter = Counter()
@@ -564,7 +564,7 @@ def execute_asset_backfill_iteration_consume_generator(
 
 
 def run_backfill_to_completion(
-    asset_graph: HostAssetGraph,
+    asset_graph: RemoteAssetGraph,
     assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
     backfill_data: AssetBackfillData,
     fail_asset_partitions: Iterable[AssetKeyPartitionKey],
@@ -661,7 +661,7 @@ def run_backfill_to_completion(
 
 
 def _requested_asset_partitions_in_run_request(
-    run_request: RunRequest, asset_graph: IAssetGraph
+    run_request: RunRequest, asset_graph: BaseAssetGraph
 ) -> Set[AssetKeyPartitionKey]:
     asset_keys = run_request.asset_selection
     assert asset_keys is not None
@@ -702,7 +702,7 @@ def _requested_asset_partitions_in_run_request(
 
 def external_asset_graph_from_assets_by_repo_name(
     assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
-) -> HostAssetGraph:
+) -> RemoteAssetGraph:
     from_repository_handles_and_external_asset_nodes = []
 
     for repo_name, assets in assets_by_repo_name.items():
@@ -717,7 +717,7 @@ def external_asset_graph_from_assets_by_repo_name(
             [(repo_handle, asset_node) for asset_node in external_asset_nodes]
         )
 
-    return HostAssetGraph.from_repository_handles_and_external_asset_nodes(
+    return RemoteAssetGraph.from_repository_handles_and_external_asset_nodes(
         from_repository_handles_and_external_asset_nodes, external_asset_checks=[]
     )
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -38,7 +38,7 @@ from dagster import (
     materialize,
     multi_asset,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
@@ -661,7 +661,7 @@ def run_backfill_to_completion(
 
 
 def _requested_asset_partitions_in_run_request(
-    run_request: RunRequest, asset_graph: AssetGraph
+    run_request: RunRequest, asset_graph: IAssetGraph
 ) -> Set[AssetKeyPartitionKey]:
     asset_keys = run_request.asset_selection
     assert asset_keys is not None

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -20,6 +20,7 @@ from dagster import (
 )
 from dagster._check import ParameterCheckError
 from dagster._core.definitions import AssetIn, SourceAsset, asset, multi_asset
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_spec import (
     SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE,
     AssetExecutionType,
@@ -28,7 +29,6 @@ from dagster._core.definitions.asset_spec import (
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.external_asset import external_assets_from_specs
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.metadata import MetadataValue, TextMetadataValue, normalize_metadata
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.partition import ScheduleType
@@ -356,10 +356,10 @@ def test_assets_excluded_from_subset_not_in_job():
 
     all_assets = [abc, a2, c2]
     as_job = define_asset_job("as_job", selection="a*").resolve(
-        asset_graph=InternalAssetGraph.from_assets(all_assets)
+        asset_graph=AssetGraph.from_assets(all_assets)
     )
     cs_job = define_asset_job("cs_job", selection="*c2").resolve(
-        asset_graph=InternalAssetGraph.from_assets(all_assets)
+        asset_graph=AssetGraph.from_assets(all_assets)
     )
 
     external_asset_nodes = _get_external_asset_nodes_from_definitions(
@@ -616,7 +616,7 @@ def test_inter_op_dependency():
         pass
 
     subset_job = define_asset_job("subset_job", selection="mixed").resolve(
-        asset_graph=InternalAssetGraph.from_assets([in1, in2, assets, downstream]),
+        asset_graph=AssetGraph.from_assets([in1, in2, assets, downstream]),
     )
     all_assets_job = define_asset_job("assets_job", [in1, in2, assets, downstream])
 

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_sensor_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_sensor_data.py
@@ -1,7 +1,7 @@
 from typing import AbstractSet
 
 from dagster import AssetKey, AssetSelection, Definitions, asset, sensor
-from dagster._core.definitions.asset_graph_interface import IAssetGraph
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.host_representation.external_data import external_sensor_data_from_def
 
 
@@ -25,7 +25,7 @@ def test_unserializable_asset_selection():
     def asset2(): ...
 
     class MySpecialAssetSelection(AssetSelection, frozen=True):
-        def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
+        def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
             return asset_graph.materializable_asset_keys - {AssetKey("asset2")}
 
     @sensor(asset_selection=MySpecialAssetSelection())

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_sensor_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_sensor_data.py
@@ -1,7 +1,7 @@
 from typing import AbstractSet
 
 from dagster import AssetKey, AssetSelection, Definitions, asset, sensor
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.host_representation.external_data import external_sensor_data_from_def
 
 
@@ -25,7 +25,7 @@ def test_unserializable_asset_selection():
     def asset2(): ...
 
     class MySpecialAssetSelection(AssetSelection, frozen=True):
-        def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+        def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
             return asset_graph.materializable_asset_keys - {AssetKey("asset2")}
 
     @sensor(asset_selection=MySpecialAssetSelection())

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -17,12 +17,12 @@ from dagster import (
     multi_asset,
     repository,
 )
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_layer import build_asset_selection_job
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.data_version import DataVersion
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.materialize import materialize_to_memory
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition
@@ -106,7 +106,7 @@ def test_calculate_data_time_unpartitioned(ignore_asset_tags, runs_to_expected_d
 
     all_assets = [a, bcd, e, f]
 
-    asset_graph = InternalAssetGraph.from_assets(all_assets)
+    asset_graph = AssetGraph.from_assets(all_assets)
 
     with DagsterInstance.ephemeral() as instance:
         # mapping from asset key to a mapping of materialization timestamp to run index

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -37,6 +37,7 @@ from dagster import (
     repository,
     run_failure_sensor,
 )
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.auto_materialize_sensor_definition import (
     AutoMaterializeSensorDefinition,
 )
@@ -44,7 +45,6 @@ from dagster._core.definitions.decorators import op
 from dagster._core.definitions.decorators.job_decorator import job
 from dagster._core.definitions.decorators.sensor_decorator import asset_sensor, sensor
 from dagster._core.definitions.instigation_logger import get_instigation_log_records
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.run_request import InstigatorType, SensorResult
 from dagster._core.definitions.run_status_sensor_definition import run_status_sensor
 from dagster._core.definitions.sensor_definition import (
@@ -719,7 +719,7 @@ def partitioned_asset():
 daily_partitioned_job = define_asset_job(
     "daily_partitioned_job",
     partitions_def=daily_partitions_def,
-).resolve(asset_graph=InternalAssetGraph.from_assets([partitioned_asset]))
+).resolve(asset_graph=AssetGraph.from_assets([partitioned_asset]))
 
 
 @run_status_sensor(run_status=DagsterRunStatus.SUCCESS, monitored_jobs=[daily_partitioned_job])

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -38,7 +38,7 @@ from dagster._core.definitions import (
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.partition import PartitionedConfig
 from dagster._core.definitions.selector import (
     PartitionRangeSelector,
@@ -714,9 +714,7 @@ def test_unloadable_backfill_retry(
     partition_keys = partitions_a.get_partition_keys()
     instance.add_backfill(
         PartitionBackfill.from_asset_partitions(
-            asset_graph=ExternalAssetGraph.from_workspace(
-                workspace_context.create_request_context()
-            ),
+            asset_graph=HostAssetGraph.from_workspace(workspace_context.create_request_context()),
             backfill_id="retry_backfill",
             tags={"custom_tag_key": "custom_tag_value"},
             backfill_timestamp=pendulum.now().timestamp(),
@@ -848,9 +846,7 @@ def test_pure_asset_backfill_with_multiple_assets_selected(
 
     instance.add_backfill(
         PartitionBackfill.from_asset_partitions(
-            asset_graph=ExternalAssetGraph.from_workspace(
-                workspace_context.create_request_context()
-            ),
+            asset_graph=HostAssetGraph.from_workspace(workspace_context.create_request_context()),
             backfill_id="backfill_with_multiple_assets_selected",
             tags={"custom_tag_key": "custom_tag_value"},
             backfill_timestamp=pendulum.now().timestamp(),
@@ -913,9 +909,7 @@ def test_pure_asset_backfill(
     asset_selection = [AssetKey("foo"), AssetKey("a1"), AssetKey("bar")]
     instance.add_backfill(
         PartitionBackfill.from_asset_partitions(
-            asset_graph=ExternalAssetGraph.from_workspace(
-                workspace_context.create_request_context()
-            ),
+            asset_graph=HostAssetGraph.from_workspace(workspace_context.create_request_context()),
             backfill_id="backfill_with_asset_selection",
             tags={"custom_tag_key": "custom_tag_value"},
             backfill_timestamp=pendulum.now().timestamp(),
@@ -1003,9 +997,7 @@ def test_asset_backfill_cancellation(
 
     instance.add_backfill(
         PartitionBackfill.from_asset_partitions(
-            asset_graph=ExternalAssetGraph.from_workspace(
-                workspace_context.create_request_context()
-            ),
+            asset_graph=HostAssetGraph.from_workspace(workspace_context.create_request_context()),
             backfill_id=backfill_id,
             tags={"custom_tag_key": "custom_tag_value"},
             backfill_timestamp=pendulum.now().timestamp(),
@@ -1064,9 +1056,7 @@ def test_asset_backfill_submit_runs_in_chunks(
 
     instance.add_backfill(
         PartitionBackfill.from_asset_partitions(
-            asset_graph=ExternalAssetGraph.from_workspace(
-                workspace_context.create_request_context()
-            ),
+            asset_graph=HostAssetGraph.from_workspace(workspace_context.create_request_context()),
             backfill_id=backfill_id,
             tags={},
             backfill_timestamp=pendulum.now().timestamp(),
@@ -1097,7 +1087,7 @@ def test_asset_backfill_mid_iteration_cancel(
     instance: DagsterInstance, workspace_context: WorkspaceProcessContext
 ):
     asset_selection = [AssetKey("daily_1"), AssetKey("daily_2")]
-    asset_graph = ExternalAssetGraph.from_workspace(workspace_context.create_request_context())
+    asset_graph = HostAssetGraph.from_workspace(workspace_context.create_request_context())
 
     num_partitions = RUN_CHUNK_SIZE * 2
     target_partitions = daily_partitions_def.get_partition_keys()[0:num_partitions]
@@ -1166,7 +1156,7 @@ def test_asset_backfill_forcible_mark_as_canceled_during_canceling_iteration(
     instance: DagsterInstance, workspace_context: WorkspaceProcessContext
 ):
     asset_selection = [AssetKey("daily_1"), AssetKey("daily_2")]
-    asset_graph = ExternalAssetGraph.from_workspace(workspace_context.create_request_context())
+    asset_graph = HostAssetGraph.from_workspace(workspace_context.create_request_context())
 
     backfill_id = "backfill_id"
     backfill = PartitionBackfill.from_asset_partitions(
@@ -1234,7 +1224,7 @@ def test_asset_backfill_mid_iteration_code_location_unreachable_error(
     from dagster._core.execution.submit_asset_runs import _get_job_execution_data_from_run_request
 
     asset_selection = [AssetKey("asset_a"), AssetKey("asset_e")]
-    asset_graph = ExternalAssetGraph.from_workspace(workspace_context.create_request_context())
+    asset_graph = HostAssetGraph.from_workspace(workspace_context.create_request_context())
 
     num_partitions = 1
     target_partitions = partitions_a.get_partition_keys()[0:num_partitions]
@@ -1342,7 +1332,7 @@ def test_fail_backfill_when_runs_completed_but_partitions_marked_as_in_progress(
     instance: DagsterInstance, workspace_context: WorkspaceProcessContext
 ):
     asset_selection = [AssetKey("daily_1"), AssetKey("daily_2")]
-    asset_graph = ExternalAssetGraph.from_workspace(workspace_context.create_request_context())
+    asset_graph = HostAssetGraph.from_workspace(workspace_context.create_request_context())
 
     target_partitions = ["2023-01-01"]
     backfill_id = "backfill_with_hanging_partitions"
@@ -1419,7 +1409,7 @@ def test_asset_backfill_with_single_run_backfill_policy(
     instance: DagsterInstance, workspace_context: WorkspaceProcessContext
 ):
     partitions = ["2023-01-01", "2023-01-02", "2023-01-03", "2023-01-04", "2023-01-05"]
-    asset_graph = ExternalAssetGraph.from_workspace(workspace_context.create_request_context())
+    asset_graph = HostAssetGraph.from_workspace(workspace_context.create_request_context())
 
     backfill_id = "asset_backfill_with_backfill_policy"
     backfill = PartitionBackfill.from_partitions_by_assets(
@@ -1461,7 +1451,7 @@ def test_asset_backfill_with_multi_run_backfill_policy(
     instance: DagsterInstance, workspace_context: WorkspaceProcessContext
 ):
     partitions = ["2023-01-01", "2023-01-02", "2023-01-03", "2023-01-04"]
-    asset_graph = ExternalAssetGraph.from_workspace(workspace_context.create_request_context())
+    asset_graph = HostAssetGraph.from_workspace(workspace_context.create_request_context())
 
     backfill_id = "asset_backfill_with_multi_run_backfill_policy"
     backfill = PartitionBackfill.from_asset_partitions(
@@ -1513,9 +1503,7 @@ def test_error_code_location(
 
     instance.add_backfill(
         PartitionBackfill.from_asset_partitions(
-            asset_graph=ExternalAssetGraph.from_workspace(
-                workspace_context.create_request_context()
-            ),
+            asset_graph=HostAssetGraph.from_workspace(workspace_context.create_request_context()),
             backfill_id=backfill_id,
             tags={},
             backfill_timestamp=pendulum.now().timestamp(),
@@ -1552,7 +1540,7 @@ def test_raise_error_on_asset_backfill_partitions_defs_changes(
     asset_selection = [AssetKey("time_partitions_def_changes")]
     partition_keys = ["2023-01-01"]
     backfill_id = "dummy_backfill"
-    asset_graph = ExternalAssetGraph.from_workspace(
+    asset_graph = HostAssetGraph.from_workspace(
         partitions_defs_changes_location_1_workspace_context.create_request_context()
     )
 
@@ -1602,7 +1590,7 @@ def test_raise_error_on_partitions_defs_removed(
     asset_selection = [AssetKey("partitions_def_removed")]
     partition_keys = ["2023-01-01"]
     backfill_id = "dummy_backfill"
-    asset_graph = ExternalAssetGraph.from_workspace(
+    asset_graph = HostAssetGraph.from_workspace(
         partitions_defs_changes_location_1_workspace_context.create_request_context()
     )
 
@@ -1647,7 +1635,7 @@ def test_raise_error_on_target_static_partition_removed(
 ):
     asset_selection = [AssetKey("static_partition_removed")]
     partition_keys = ["a"]
-    asset_graph = ExternalAssetGraph.from_workspace(
+    asset_graph = HostAssetGraph.from_workspace(
         partitions_defs_changes_location_1_workspace_context.create_request_context()
     )
 
@@ -1708,7 +1696,7 @@ def test_partitions_def_changed_backfill_retry_envvar_set(
     asset_selection = [AssetKey("time_partitions_def_changes")]
     partition_keys = ["2023-01-01"]
     backfill_id = "dummy_backfill"
-    asset_graph = ExternalAssetGraph.from_workspace(
+    asset_graph = HostAssetGraph.from_workspace(
         partitions_defs_changes_location_1_workspace_context.create_request_context()
     )
 
@@ -1748,9 +1736,7 @@ def test_asset_backfill_logging(caplog, instance, workspace_context):
 
     instance.add_backfill(
         PartitionBackfill.from_asset_partitions(
-            asset_graph=ExternalAssetGraph.from_workspace(
-                workspace_context.create_request_context()
-            ),
+            asset_graph=HostAssetGraph.from_workspace(workspace_context.create_request_context()),
             backfill_id=backfill_id,
             tags={"custom_tag_key": "custom_tag_value"},
             backfill_timestamp=pendulum.now().timestamp(),
@@ -1787,10 +1773,10 @@ def test_asset_backfill_asset_graph_out_of_sync_with_workspace(
     base_job_name_changes_location_1_workspace_context,
     base_job_name_changes_location_2_workspace_context,
 ):
-    location_1_asset_graph = ExternalAssetGraph.from_workspace(
+    location_1_asset_graph = HostAssetGraph.from_workspace(
         base_job_name_changes_location_1_workspace_context.create_request_context()
     )
-    location_2_asset_graph = ExternalAssetGraph.from_workspace(
+    location_2_asset_graph = HostAssetGraph.from_workspace(
         base_job_name_changes_location_2_workspace_context.create_request_context()
     )
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -38,8 +38,8 @@ from dagster._core.definitions import (
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.partition import PartitionedConfig
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.selector import (
     PartitionRangeSelector,
     PartitionsByAssetSelector,
@@ -714,7 +714,7 @@ def test_unloadable_backfill_retry(
     partition_keys = partitions_a.get_partition_keys()
     instance.add_backfill(
         PartitionBackfill.from_asset_partitions(
-            asset_graph=HostAssetGraph.from_workspace(workspace_context.create_request_context()),
+            asset_graph=RemoteAssetGraph.from_workspace(workspace_context.create_request_context()),
             backfill_id="retry_backfill",
             tags={"custom_tag_key": "custom_tag_value"},
             backfill_timestamp=pendulum.now().timestamp(),
@@ -846,7 +846,7 @@ def test_pure_asset_backfill_with_multiple_assets_selected(
 
     instance.add_backfill(
         PartitionBackfill.from_asset_partitions(
-            asset_graph=HostAssetGraph.from_workspace(workspace_context.create_request_context()),
+            asset_graph=RemoteAssetGraph.from_workspace(workspace_context.create_request_context()),
             backfill_id="backfill_with_multiple_assets_selected",
             tags={"custom_tag_key": "custom_tag_value"},
             backfill_timestamp=pendulum.now().timestamp(),
@@ -909,7 +909,7 @@ def test_pure_asset_backfill(
     asset_selection = [AssetKey("foo"), AssetKey("a1"), AssetKey("bar")]
     instance.add_backfill(
         PartitionBackfill.from_asset_partitions(
-            asset_graph=HostAssetGraph.from_workspace(workspace_context.create_request_context()),
+            asset_graph=RemoteAssetGraph.from_workspace(workspace_context.create_request_context()),
             backfill_id="backfill_with_asset_selection",
             tags={"custom_tag_key": "custom_tag_value"},
             backfill_timestamp=pendulum.now().timestamp(),
@@ -997,7 +997,7 @@ def test_asset_backfill_cancellation(
 
     instance.add_backfill(
         PartitionBackfill.from_asset_partitions(
-            asset_graph=HostAssetGraph.from_workspace(workspace_context.create_request_context()),
+            asset_graph=RemoteAssetGraph.from_workspace(workspace_context.create_request_context()),
             backfill_id=backfill_id,
             tags={"custom_tag_key": "custom_tag_value"},
             backfill_timestamp=pendulum.now().timestamp(),
@@ -1056,7 +1056,7 @@ def test_asset_backfill_submit_runs_in_chunks(
 
     instance.add_backfill(
         PartitionBackfill.from_asset_partitions(
-            asset_graph=HostAssetGraph.from_workspace(workspace_context.create_request_context()),
+            asset_graph=RemoteAssetGraph.from_workspace(workspace_context.create_request_context()),
             backfill_id=backfill_id,
             tags={},
             backfill_timestamp=pendulum.now().timestamp(),
@@ -1087,7 +1087,7 @@ def test_asset_backfill_mid_iteration_cancel(
     instance: DagsterInstance, workspace_context: WorkspaceProcessContext
 ):
     asset_selection = [AssetKey("daily_1"), AssetKey("daily_2")]
-    asset_graph = HostAssetGraph.from_workspace(workspace_context.create_request_context())
+    asset_graph = RemoteAssetGraph.from_workspace(workspace_context.create_request_context())
 
     num_partitions = RUN_CHUNK_SIZE * 2
     target_partitions = daily_partitions_def.get_partition_keys()[0:num_partitions]
@@ -1156,7 +1156,7 @@ def test_asset_backfill_forcible_mark_as_canceled_during_canceling_iteration(
     instance: DagsterInstance, workspace_context: WorkspaceProcessContext
 ):
     asset_selection = [AssetKey("daily_1"), AssetKey("daily_2")]
-    asset_graph = HostAssetGraph.from_workspace(workspace_context.create_request_context())
+    asset_graph = RemoteAssetGraph.from_workspace(workspace_context.create_request_context())
 
     backfill_id = "backfill_id"
     backfill = PartitionBackfill.from_asset_partitions(
@@ -1224,7 +1224,7 @@ def test_asset_backfill_mid_iteration_code_location_unreachable_error(
     from dagster._core.execution.submit_asset_runs import _get_job_execution_data_from_run_request
 
     asset_selection = [AssetKey("asset_a"), AssetKey("asset_e")]
-    asset_graph = HostAssetGraph.from_workspace(workspace_context.create_request_context())
+    asset_graph = RemoteAssetGraph.from_workspace(workspace_context.create_request_context())
 
     num_partitions = 1
     target_partitions = partitions_a.get_partition_keys()[0:num_partitions]
@@ -1332,7 +1332,7 @@ def test_fail_backfill_when_runs_completed_but_partitions_marked_as_in_progress(
     instance: DagsterInstance, workspace_context: WorkspaceProcessContext
 ):
     asset_selection = [AssetKey("daily_1"), AssetKey("daily_2")]
-    asset_graph = HostAssetGraph.from_workspace(workspace_context.create_request_context())
+    asset_graph = RemoteAssetGraph.from_workspace(workspace_context.create_request_context())
 
     target_partitions = ["2023-01-01"]
     backfill_id = "backfill_with_hanging_partitions"
@@ -1409,7 +1409,7 @@ def test_asset_backfill_with_single_run_backfill_policy(
     instance: DagsterInstance, workspace_context: WorkspaceProcessContext
 ):
     partitions = ["2023-01-01", "2023-01-02", "2023-01-03", "2023-01-04", "2023-01-05"]
-    asset_graph = HostAssetGraph.from_workspace(workspace_context.create_request_context())
+    asset_graph = RemoteAssetGraph.from_workspace(workspace_context.create_request_context())
 
     backfill_id = "asset_backfill_with_backfill_policy"
     backfill = PartitionBackfill.from_partitions_by_assets(
@@ -1451,7 +1451,7 @@ def test_asset_backfill_with_multi_run_backfill_policy(
     instance: DagsterInstance, workspace_context: WorkspaceProcessContext
 ):
     partitions = ["2023-01-01", "2023-01-02", "2023-01-03", "2023-01-04"]
-    asset_graph = HostAssetGraph.from_workspace(workspace_context.create_request_context())
+    asset_graph = RemoteAssetGraph.from_workspace(workspace_context.create_request_context())
 
     backfill_id = "asset_backfill_with_multi_run_backfill_policy"
     backfill = PartitionBackfill.from_asset_partitions(
@@ -1503,7 +1503,7 @@ def test_error_code_location(
 
     instance.add_backfill(
         PartitionBackfill.from_asset_partitions(
-            asset_graph=HostAssetGraph.from_workspace(workspace_context.create_request_context()),
+            asset_graph=RemoteAssetGraph.from_workspace(workspace_context.create_request_context()),
             backfill_id=backfill_id,
             tags={},
             backfill_timestamp=pendulum.now().timestamp(),
@@ -1540,7 +1540,7 @@ def test_raise_error_on_asset_backfill_partitions_defs_changes(
     asset_selection = [AssetKey("time_partitions_def_changes")]
     partition_keys = ["2023-01-01"]
     backfill_id = "dummy_backfill"
-    asset_graph = HostAssetGraph.from_workspace(
+    asset_graph = RemoteAssetGraph.from_workspace(
         partitions_defs_changes_location_1_workspace_context.create_request_context()
     )
 
@@ -1590,7 +1590,7 @@ def test_raise_error_on_partitions_defs_removed(
     asset_selection = [AssetKey("partitions_def_removed")]
     partition_keys = ["2023-01-01"]
     backfill_id = "dummy_backfill"
-    asset_graph = HostAssetGraph.from_workspace(
+    asset_graph = RemoteAssetGraph.from_workspace(
         partitions_defs_changes_location_1_workspace_context.create_request_context()
     )
 
@@ -1635,7 +1635,7 @@ def test_raise_error_on_target_static_partition_removed(
 ):
     asset_selection = [AssetKey("static_partition_removed")]
     partition_keys = ["a"]
-    asset_graph = HostAssetGraph.from_workspace(
+    asset_graph = RemoteAssetGraph.from_workspace(
         partitions_defs_changes_location_1_workspace_context.create_request_context()
     )
 
@@ -1696,7 +1696,7 @@ def test_partitions_def_changed_backfill_retry_envvar_set(
     asset_selection = [AssetKey("time_partitions_def_changes")]
     partition_keys = ["2023-01-01"]
     backfill_id = "dummy_backfill"
-    asset_graph = HostAssetGraph.from_workspace(
+    asset_graph = RemoteAssetGraph.from_workspace(
         partitions_defs_changes_location_1_workspace_context.create_request_context()
     )
 
@@ -1736,7 +1736,7 @@ def test_asset_backfill_logging(caplog, instance, workspace_context):
 
     instance.add_backfill(
         PartitionBackfill.from_asset_partitions(
-            asset_graph=HostAssetGraph.from_workspace(workspace_context.create_request_context()),
+            asset_graph=RemoteAssetGraph.from_workspace(workspace_context.create_request_context()),
             backfill_id=backfill_id,
             tags={"custom_tag_key": "custom_tag_value"},
             backfill_timestamp=pendulum.now().timestamp(),
@@ -1773,10 +1773,10 @@ def test_asset_backfill_asset_graph_out_of_sync_with_workspace(
     base_job_name_changes_location_1_workspace_context,
     base_job_name_changes_location_2_workspace_context,
 ):
-    location_1_asset_graph = HostAssetGraph.from_workspace(
+    location_1_asset_graph = RemoteAssetGraph.from_workspace(
         base_job_name_changes_location_1_workspace_context.create_request_context()
     )
-    location_2_asset_graph = HostAssetGraph.from_workspace(
+    location_2_asset_graph = RemoteAssetGraph.from_workspace(
         base_job_name_changes_location_2_workspace_context.create_request_context()
     )
 
@@ -1799,7 +1799,7 @@ def test_asset_backfill_asset_graph_out_of_sync_with_workspace(
     assert backfill.status == BulkActionStatus.REQUESTED
 
     with mock.patch(
-        "dagster._core.execution.asset_backfill.ExternalAssetGraph.from_workspace",
+        "dagster._core.execution.asset_backfill.RemoteAssetGraph.from_workspace",
         side_effect=[
             location_2_asset_graph,
             location_1_asset_graph,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_locations/concurrency_limited_workspace.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_locations/concurrency_limited_workspace.py
@@ -6,7 +6,7 @@ from dagster import (
     job,
     op,
 )
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG
 
 
@@ -33,7 +33,7 @@ concurrency_limited_asset_job = define_asset_job(
     "concurrency_limited_asset_job",
     [foo_limited_asset, bar_limited_asset, baz_limited_asset_depends_on_foo],
 ).resolve(
-    asset_graph=InternalAssetGraph.from_assets(
+    asset_graph=AssetGraph.from_assets(
         [foo_limited_asset, bar_limited_asset, baz_limited_asset_depends_on_foo]
     )
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -14,7 +14,7 @@ from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.auto_materialize_sensor_definition import (
     AutoMaterializeSensorDefinition,
 )
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
 from dagster._core.definitions.sensor_definition import (
     SensorType,
 )
@@ -223,7 +223,7 @@ def test_combine_default_sensors_with_non_default_sensors(instance_with_auto_mat
     assert external_repo.has_external_sensor("default_auto_materialize_sensor")
     assert external_repo.has_external_sensor("my_custom_policy_sensor")
 
-    asset_graph = ExternalAssetGraph.from_external_repository(external_repo)
+    asset_graph = HostAssetGraph.from_external_repository(external_repo)
 
     # default sensor includes all assets that weren't covered by the custom one
 
@@ -293,7 +293,7 @@ def test_custom_sensors_cover_all(instance_with_auto_materialize_sensors):
     assert external_repo.has_external_sensor("normal_sensor")
     assert external_repo.has_external_sensor("my_custom_policy_sensor")
 
-    asset_graph = ExternalAssetGraph.from_external_repository(external_repo)
+    asset_graph = HostAssetGraph.from_external_repository(external_repo)
 
     # Custom sensor covered all the valid assets
     custom_sensor = external_repo.get_external_sensor("my_custom_policy_sensor")

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -14,7 +14,7 @@ from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.auto_materialize_sensor_definition import (
     AutoMaterializeSensorDefinition,
 )
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.sensor_definition import (
     SensorType,
 )
@@ -223,7 +223,7 @@ def test_combine_default_sensors_with_non_default_sensors(instance_with_auto_mat
     assert external_repo.has_external_sensor("default_auto_materialize_sensor")
     assert external_repo.has_external_sensor("my_custom_policy_sensor")
 
-    asset_graph = HostAssetGraph.from_external_repository(external_repo)
+    asset_graph = RemoteAssetGraph.from_external_repository(external_repo)
 
     # default sensor includes all assets that weren't covered by the custom one
 
@@ -293,7 +293,7 @@ def test_custom_sensors_cover_all(instance_with_auto_materialize_sensors):
     assert external_repo.has_external_sensor("normal_sensor")
     assert external_repo.has_external_sensor("my_custom_policy_sensor")
 
-    asset_graph = HostAssetGraph.from_external_repository(external_repo)
+    asset_graph = RemoteAssetGraph.from_external_repository(external_repo)
 
     # Custom sensor covered all the valid assets
     custom_sensor = external_repo.get_external_sensor("my_custom_policy_sensor")

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -34,6 +34,7 @@ from dagster._core.definitions.asset_daemon_cursor import (
     AssetDaemonCursor,
     backcompat_deserialize_asset_daemon_cursor_str,
 )
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -34,7 +34,7 @@ from dagster._core.definitions.asset_daemon_cursor import (
     AssetDaemonCursor,
     backcompat_deserialize_asset_daemon_cursor_str,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
@@ -127,7 +127,7 @@ class AssetRuleEvaluationSpec(NamedTuple):
             rule_evaluation_data=data_type(**transformed_kwargs),
         )
 
-    def resolve(self, asset_key: AssetKey, asset_graph: AssetGraph) -> AssetSubsetWithMetadata:
+    def resolve(self, asset_key: AssetKey, asset_graph: IAssetGraph) -> AssetSubsetWithMetadata:
         """Returns a tuple of the resolved AutoMaterializeRuleEvaluation for this spec and the
         partitions that it applies to.
         """

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_daemon_scenario.py
@@ -34,13 +34,12 @@ from dagster._core.definitions.asset_daemon_cursor import (
     AssetDaemonCursor,
     backcompat_deserialize_asset_daemon_cursor_str,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeRuleEvaluationData,
 )
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.events import AssetKeyPartitionKey, CoercibleToAssetKey
 from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
@@ -128,7 +127,7 @@ class AssetRuleEvaluationSpec(NamedTuple):
             rule_evaluation_data=data_type(**transformed_kwargs),
         )
 
-    def resolve(self, asset_key: AssetKey, asset_graph: IAssetGraph) -> AssetSubsetWithMetadata:
+    def resolve(self, asset_key: AssetKey, asset_graph: BaseAssetGraph) -> AssetSubsetWithMetadata:
         """Returns a tuple of the resolved AutoMaterializeRuleEvaluation for this spec and the
         partitions that it applies to.
         """

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -52,7 +52,7 @@ from dagster._core.definitions.asset_daemon_context import (
 from dagster._core.definitions.asset_daemon_cursor import (
     AssetDaemonCursor,
 )
-from dagster._core.definitions.asset_graph_interface import IAssetGraph
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
@@ -61,15 +61,15 @@ from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeRuleEvaluation,
     AutoMaterializeRuleEvaluationData,
 )
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.data_version import DataVersionsByPartition
 from dagster._core.definitions.events import CoercibleToAssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
-from dagster._core.definitions.host_asset_graph import HostAssetGraph
-from dagster._core.definitions.internal_asset_graph import AssetGraph
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.partition import (
     PartitionsSubset,
 )
+from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.events import AssetMaterializationPlannedData, DagsterEvent, DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.asset_backfill import AssetBackfillData
@@ -391,7 +391,7 @@ class AssetReconciliationScenario(
                     assert (
                         workspace.get_code_location_error("test_location") is None
                     ), workspace.get_code_location_error("test_location")
-                    asset_graph = HostAssetGraph.from_workspace(workspace)
+                    asset_graph = RemoteAssetGraph.from_workspace(workspace)
 
             auto_materialize_asset_keys = (
                 self.asset_selection.resolve(asset_graph)
@@ -720,7 +720,7 @@ def with_auto_materialize_policy(
 
 def with_implicit_auto_materialize_policies(
     assets_defs: Sequence[Union[SourceAsset, AssetsDefinition]],
-    asset_graph: IAssetGraph,
+    asset_graph: BaseAssetGraph,
     targeted_assets: Optional[AbstractSet[AssetKey]] = None,
 ) -> Sequence[AssetsDefinition]:
     """Accepts a list of assets, adding implied auto-materialize policies to targeted assets

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -52,7 +52,6 @@ from dagster._core.definitions.asset_daemon_context import (
 from dagster._core.definitions.asset_daemon_cursor import (
     AssetDaemonCursor,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
@@ -64,8 +63,9 @@ from dagster._core.definitions.auto_materialize_rule_evaluation import (
 )
 from dagster._core.definitions.data_version import DataVersionsByPartition
 from dagster._core.definitions.events import CoercibleToAssetKey
-from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.host_asset_graph import HostAssetGraph
+from dagster._core.definitions.internal_asset_graph import AssetGraph
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.partition import (
     PartitionsSubset,
@@ -391,7 +391,7 @@ class AssetReconciliationScenario(
                     assert (
                         workspace.get_code_location_error("test_location") is None
                     ), workspace.get_code_location_error("test_location")
-                    asset_graph = ExternalAssetGraph.from_workspace(workspace)
+                    asset_graph = HostAssetGraph.from_workspace(workspace)
 
             auto_materialize_asset_keys = (
                 self.asset_selection.resolve(asset_graph)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -52,7 +52,7 @@ from dagster._core.definitions.asset_daemon_context import (
 from dagster._core.definitions.asset_daemon_cursor import (
     AssetDaemonCursor,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
@@ -720,7 +720,7 @@ def with_auto_materialize_policy(
 
 def with_implicit_auto_materialize_policies(
     assets_defs: Sequence[Union[SourceAsset, AssetsDefinition]],
-    asset_graph: AssetGraph,
+    asset_graph: IAssetGraph,
     targeted_assets: Optional[AbstractSet[AssetKey]] = None,
 ) -> Sequence[AssetsDefinition]:
     """Accepts a list of assets, adding implied auto-materialize policies to targeted assets

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -52,6 +52,7 @@ from dagster._core.definitions.asset_daemon_context import (
 from dagster._core.definitions.asset_daemon_cursor import (
     AssetDaemonCursor,
 )
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_interface import IAssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
@@ -65,7 +66,6 @@ from dagster._core.definitions.data_version import DataVersionsByPartition
 from dagster._core.definitions.events import CoercibleToAssetKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.partition import (
     PartitionsSubset,
@@ -194,7 +194,7 @@ class AssetReconciliationScenario(
             or isinstance(a, SourceAsset)
             for a in assets
         ):
-            asset_graph = InternalAssetGraph.from_assets(assets, asset_checks=asset_checks)
+            asset_graph = AssetGraph.from_assets(assets, asset_checks=asset_checks)
             auto_materialize_asset_keys = (
                 asset_selection.resolve(asset_graph)
                 if asset_selection is not None

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_state.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_state.py
@@ -30,7 +30,6 @@ from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.definitions_class import create_repository_using_definitions_args
 from dagster._core.definitions.events import CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import in_process_executor
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.repository_definition.repository_definition import (
     RepositoryDefinition,
 )
@@ -165,7 +164,7 @@ class ScenarioSpec:
 
     @property
     def asset_graph(self) -> AssetGraph:
-        return InternalAssetGraph.from_assets(self.assets)
+        return AssetGraph.from_assets(self.assets)
 
     def with_additional_repositories(
         self,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_cursor.py
@@ -6,7 +6,7 @@ from dagster._core.definitions.asset_daemon_cursor import (
     AssetDaemonCursor,
     backcompat_deserialize_asset_daemon_cursor_str,
 )
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._serdes.serdes import deserialize_value, serialize_value
 
 partitions = StaticPartitionsDefinition(partition_keys=["a", "b", "c"])
@@ -29,7 +29,7 @@ def test_asset_reconciliation_cursor_evaluation_id_backcompat() -> None:
         backcompat_serialized, None, 0
     ) == AssetDaemonCursor.empty(20)
 
-    asset_graph = InternalAssetGraph.from_assets([my_asset])
+    asset_graph = AssetGraph.from_assets([my_asset])
     c = backcompat_deserialize_asset_daemon_cursor_str(backcompat_serialized, asset_graph, 0)
 
     assert c == AssetDaemonCursor.empty(20)
@@ -74,6 +74,6 @@ def test_asset_reconciliation_cursor_auto_observe_backcompat() -> None:
     )
 
     cursor = backcompat_deserialize_asset_daemon_cursor_str(
-        serialized, InternalAssetGraph.from_assets([asset1, asset2]), 0
+        serialized, AssetGraph.from_assets([asset1, asset2]), 0
     )
     assert cursor.evaluation_id == 25

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
@@ -20,7 +20,7 @@ from .scenarios.scenarios import ASSET_RECONCILIATION_SCENARIOS
 # FAST auto materialize tests
 #############################
 #
-# Run the auto materialize scenarios, but use an InternalAssetGraph instead of External to speed things up.
+# Run the auto materialize scenarios, but use an AssetGraph instead of RemoteAssetGraph to speed things up.
 
 
 @pytest.mark.parametrize(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_observe.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_auto_observe.py
@@ -6,8 +6,8 @@ from dagster._core.definitions.asset_daemon_context import (
     get_auto_observe_run_requests,
 )
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.external_asset import create_external_asset_from_source_asset
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from pytest import fixture
 
 
@@ -15,7 +15,7 @@ def test_single_observable_source_asset_no_auto_observe():
     @observable_source_asset
     def asset1(): ...
 
-    asset_graph = InternalAssetGraph.from_assets([asset1])
+    asset_graph = AssetGraph.from_assets([asset1])
 
     assert (
         len(
@@ -50,7 +50,7 @@ def single_auto_observe_asset_graph(request):
     def asset1(): ...
 
     observable = create_external_asset_from_source_asset(asset1) if request.param else asset1
-    asset_graph = InternalAssetGraph.from_assets([observable])
+    asset_graph = AssetGraph.from_assets([observable])
     return asset_graph
 
 
@@ -105,7 +105,7 @@ def test_reconcile():
     @observable_source_asset(auto_observe_interval_minutes=30)
     def asset1(): ...
 
-    asset_graph = InternalAssetGraph.from_assets([asset1])
+    asset_graph = AssetGraph.from_assets([asset1])
     instance = DagsterInstance.ephemeral()
 
     run_requests, cursor, _ = AssetDaemonContext(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_default_io_manager.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_default_io_manager.py
@@ -8,7 +8,7 @@ from dagster import (
     op,
     reconstructable,
 )
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.errors import DagsterSubprocessError
 from dagster._core.storage.fs_io_manager import PickledObjectFilesystemIOManager
 from dagster._core.test_utils import environ, instance_for_test
@@ -77,7 +77,7 @@ def foo_io_manager_asset(context):
 
 def create_asset_job():
     return define_asset_job(name="foo_io_manager_asset_job").resolve(
-        asset_graph=InternalAssetGraph.from_assets([foo_io_manager_asset])
+        asset_graph=AssetGraph.from_assets([foo_io_manager_asset])
     )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -21,7 +21,7 @@ from dagster import (
     repository,
 )
 from dagster._check import CheckError
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.time_window_partitions import TimeWindow, get_time_partitions_def
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
@@ -485,7 +485,7 @@ def test_dynamic_dimension_in_multipartitioned_asset():
 
     dynamic_multipartitioned_job = define_asset_job(
         "dynamic_multipartitioned_job", [my_asset, asset2], partitions_def=multipartitions_def
-    ).resolve(asset_graph=InternalAssetGraph.from_assets([my_asset, asset2]))
+    ).resolve(asset_graph=AssetGraph.from_assets([my_asset, asset2]))
 
     with instance_for_test() as instance:
         instance.add_dynamic_partitions("dynamic", ["1"])
@@ -538,7 +538,7 @@ def test_context_partition_time_window():
 
     multipartitioned_job = define_asset_job(
         "my_job", [my_asset], partitions_def=partitions_def
-    ).resolve(asset_graph=InternalAssetGraph.from_assets([my_asset]))
+    ).resolve(asset_graph=AssetGraph.from_assets([my_asset]))
     multipartitioned_job.execute_in_process(
         partition_key=MultiPartitionKey({"date": "2020-01-01", "static": "a"})
     )
@@ -558,7 +558,7 @@ def test_context_invalid_partition_time_window():
 
     multipartitioned_job = define_asset_job(
         "my_job", [my_asset], partitions_def=partitions_def
-    ).resolve(asset_graph=InternalAssetGraph.from_assets([my_asset]))
+    ).resolve(asset_graph=AssetGraph.from_assets([my_asset]))
     with pytest.raises(
         DagsterInvariantViolationError,
         match=(

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_reexecute.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_reexecute.py
@@ -17,9 +17,9 @@ from dagster import (
     op,
     reconstructable,
 )
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.events import Output
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.output import DynamicOut, Out
 from dagster._core.errors import DagsterExecutionStepNotFoundError
 from dagster._core.instance import DagsterInstance
@@ -574,7 +574,7 @@ def asset_job():
         ),
         executor_def=in_process_executor,
     ).resolve(
-        asset_graph=InternalAssetGraph.from_assets(
+        asset_graph=AssetGraph.from_assets(
             [
                 branching_asset,
                 echo_branching,

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
@@ -32,11 +32,11 @@ from dagster import (
     with_resources,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
     CacheableAssetsDefinition,
 )
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.no_step_launcher import no_step_launcher
@@ -323,7 +323,7 @@ def define_asset_check_job():
         yield AssetCheckResult(passed=True)
 
     return define_asset_job(name="asset_check_job", selection=[asset1]).resolve(
-        asset_graph=InternalAssetGraph.from_assets([asset1])
+        asset_graph=AssetGraph.from_assets([asset1])
     )
 
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
@@ -30,8 +30,8 @@ from dagster import (
     with_resources,
 )
 from dagster._core.definitions import AssetIn, asset, multi_asset
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.partition_mapping import UpstreamPartitionsResult
 from dagster._core.definitions.version_strategy import VersionStrategy
@@ -529,7 +529,7 @@ def test_multipartitions_fs_io_manager():
             return asset1
 
         my_job = define_asset_job("my_job", [asset1, asset2]).resolve(
-            asset_graph=InternalAssetGraph.from_assets([asset1, asset2])
+            asset_graph=AssetGraph.from_assets([asset1, asset2])
         )
 
         result = my_job.execute_in_process(partition_key=MultiPartitionKey({"a": "a", "1": "1"}))
@@ -577,7 +577,7 @@ def test_backcompat_multipartitions_fs_io_manager():
             my_job = define_asset_job(
                 "my_job", [multipartitioned, downstream_of_multipartitioned]
             ).resolve(
-                asset_graph=InternalAssetGraph.from_assets(
+                asset_graph=AssetGraph.from_assets(
                     [multipartitioned, downstream_of_multipartitioned]
                 )
             )
@@ -589,9 +589,7 @@ def test_backcompat_multipartitions_fs_io_manager():
         my_job = define_asset_job(
             "my_job", [multipartitioned, downstream_of_multipartitioned]
         ).resolve(
-            asset_graph=InternalAssetGraph.from_assets(
-                [multipartitioned, downstream_of_multipartitioned]
-            )
+            asset_graph=AssetGraph.from_assets([multipartitioned, downstream_of_multipartitioned])
         )
         result = my_job.execute_in_process(
             partition_key=MultiPartitionKey({"abc": "c", "date": "2020-04-22"}),

--- a/python_modules/dagster/dagster_tests/storage_tests/test_partition_status_cache.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_partition_status_cache.py
@@ -14,7 +14,7 @@ from dagster import (
     asset,
     define_asset_job,
 )
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.time_window_partitions import HourlyPartitionsDefinition
 from dagster._core.events import (
     AssetMaterializationPlannedData,
@@ -42,7 +42,7 @@ def test_get_cached_status_unpartitioned():
     def asset1():
         return 1
 
-    asset_graph = InternalAssetGraph.from_assets([asset1])
+    asset_graph = AssetGraph.from_assets([asset1])
     asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     asset_key = AssetKey("asset1")
@@ -86,12 +86,12 @@ def test_get_cached_partition_status_changed_time_partitions():
         return 1
 
     asset_key = AssetKey("asset1")
-    asset_graph = InternalAssetGraph.from_assets([asset1])
+    asset_graph = AssetGraph.from_assets([asset1])
     asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     def _swap_partitions_def(new_partitions_def, asset, asset_graph, asset_job):
         asset._partitions_def = new_partitions_def  # noqa: SLF001
-        asset_graph = InternalAssetGraph.from_assets([asset])
+        asset_graph = AssetGraph.from_assets([asset])
         asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
         return asset, asset_job, asset_graph
 
@@ -136,12 +136,12 @@ def test_get_cached_partition_status_by_asset():
         return 1
 
     asset_key = AssetKey("asset1")
-    asset_graph = InternalAssetGraph.from_assets([asset1])
+    asset_graph = AssetGraph.from_assets([asset1])
     asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     def _swap_partitions_def(new_partitions_def, asset, asset_graph, asset_job):
         asset._partitions_def = new_partitions_def  # noqa: SLF001
-        asset_graph = InternalAssetGraph.from_assets([asset])
+        asset_graph = AssetGraph.from_assets([asset])
         asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
         return asset, asset_job, asset_graph
 
@@ -222,7 +222,7 @@ def test_multipartition_get_cached_partition_status():
         return 1
 
     asset_key = AssetKey("asset1")
-    asset_graph = InternalAssetGraph.from_assets([asset1])
+    asset_graph = AssetGraph.from_assets([asset1])
     asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
@@ -278,7 +278,7 @@ def test_cached_status_on_wipe():
         return 1
 
     asset_key = AssetKey("asset1")
-    asset_graph = InternalAssetGraph.from_assets([asset1])
+    asset_graph = AssetGraph.from_assets([asset1])
     asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
@@ -310,7 +310,7 @@ def test_dynamic_partitions_status_not_cached():
         return 1
 
     asset_key = AssetKey("asset1")
-    asset_graph = InternalAssetGraph.from_assets([asset1])
+    asset_graph = AssetGraph.from_assets([asset1])
     asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
@@ -335,7 +335,7 @@ def test_failure_cache():
             raise Exception()
 
     asset_key = AssetKey("asset1")
-    asset_graph = InternalAssetGraph.from_assets([asset1])
+    asset_graph = AssetGraph.from_assets([asset1])
     asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
@@ -453,7 +453,7 @@ def test_failure_cache_added():
             raise Exception()
 
     asset_key = AssetKey("asset1")
-    asset_graph = InternalAssetGraph.from_assets([asset1])
+    asset_graph = AssetGraph.from_assets([asset1])
     asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
@@ -487,7 +487,7 @@ def test_failure_cache_in_progress_runs():
             raise Exception()
 
     asset_key = AssetKey("asset1")
-    asset_graph = InternalAssetGraph.from_assets([asset1])
+    asset_graph = AssetGraph.from_assets([asset1])
     define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
@@ -581,7 +581,7 @@ def test_cache_cancelled_runs():
             raise Exception()
 
     asset_key = AssetKey("asset1")
-    asset_graph = InternalAssetGraph.from_assets([asset1])
+    asset_graph = AssetGraph.from_assets([asset1])
     define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
@@ -682,7 +682,7 @@ def test_failure_cache_concurrent_materializations():
             raise Exception()
 
     asset_key = AssetKey("asset1")
-    asset_graph = InternalAssetGraph.from_assets([asset1])
+    asset_graph = AssetGraph.from_assets([asset1])
     define_asset_job("asset_job").resolve(asset_graph=asset_graph)
 
     with instance_for_test() as created_instance:
@@ -758,7 +758,7 @@ def test_failed_partitioned_asset_converted_to_multipartitioned():
         raise Exception("oops")
 
     with instance_for_test() as created_instance:
-        asset_graph = InternalAssetGraph.from_assets([my_asset])
+        asset_graph = AssetGraph.from_assets([my_asset])
         my_job = define_asset_job("asset_job", partitions_def=daily_def).resolve(
             asset_graph=asset_graph
         )
@@ -773,7 +773,7 @@ def test_failed_partitioned_asset_converted_to_multipartitioned():
                 "b": StaticPartitionsDefinition(["a", "b"]),
             }
         )
-        asset_graph = InternalAssetGraph.from_assets([my_asset])
+        asset_graph = AssetGraph.from_assets([my_asset])
         my_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
         asset_key = AssetKey("my_asset")
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
@@ -6,7 +6,7 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_interface import IAssetGraph
 
 from .asset_utils import is_non_asset_node
 from .dagster_dbt_translator import DagsterDbtTranslator
@@ -70,7 +70,7 @@ class DbtManifestAssetSelection(
             exclude=check.opt_str_param(exclude, "exclude", default=""),
         )
 
-    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
         dbt_nodes = get_dbt_resource_props_by_dbt_unique_id_from_manifest(self.manifest)
 
         keys = set()
@@ -87,7 +87,7 @@ class DbtManifestAssetSelection(
 
         return keys
 
-    def resolve_checks_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetCheckKey]:
+    def resolve_checks_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetCheckKey]:
         if not self.dagster_dbt_translator.settings.enable_asset_checks:
             return set()
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
@@ -6,7 +6,7 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
-from dagster._core.definitions.asset_graph_interface import IAssetGraph
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 
 from .asset_utils import is_non_asset_node
 from .dagster_dbt_translator import DagsterDbtTranslator
@@ -70,7 +70,7 @@ class DbtManifestAssetSelection(
             exclude=check.opt_str_param(exclude, "exclude", default=""),
         )
 
-    def resolve_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
         dbt_nodes = get_dbt_resource_props_by_dbt_unique_id_from_manifest(self.manifest)
 
         keys = set()
@@ -87,7 +87,7 @@ class DbtManifestAssetSelection(
 
         return keys
 
-    def resolve_checks_inner(self, asset_graph: IAssetGraph) -> AbstractSet[AssetCheckKey]:
+    def resolve_checks_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetCheckKey]:
         if not self.dagster_dbt_translator.settings.enable_asset_checks:
             return set()
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
@@ -16,7 +16,7 @@ from dagster import (
     file_relative_path,
 )
 from dagster._config.field_utils import EnvVar
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.test_utils import environ, instance_for_test
 from dagster_dbt import (
     DagsterDbtCloudJobInvariantViolationError,
@@ -184,7 +184,7 @@ def test_load_assets_from_dbt_cloud_job(
     materialize_cereal_assets = define_asset_job(
         name="materialize_cereal_assets",
         selection=AssetSelection.assets(*dbt_cloud_assets),
-    ).resolve(asset_graph=InternalAssetGraph.from_assets(dbt_cloud_assets))
+    ).resolve(asset_graph=AssetGraph.from_assets(dbt_cloud_assets))
 
     with instance_for_test() as instance:
         result = materialize_cereal_assets.execute_in_process(instance=instance)
@@ -298,7 +298,7 @@ def test_load_assets_from_cached_compile_run(
     materialize_cereal_assets = define_asset_job(
         name="materialize_cereal_assets",
         selection=AssetSelection.assets(*dbt_cloud_assets),
-    ).resolve(asset_graph=InternalAssetGraph.from_assets(dbt_cloud_assets))
+    ).resolve(asset_graph=AssetGraph.from_assets(dbt_cloud_assets))
 
     with instance_for_test() as instance:
         result = materialize_cereal_assets.execute_in_process(instance=instance)
@@ -536,7 +536,7 @@ def test_partitions(mocker, dbt_cloud, dbt_cloud_service):
     materialize_cereal_assets = define_asset_job(
         name="materialize_partitioned_cereal_assets",
         selection=AssetSelection.assets(*dbt_cloud_assets),
-    ).resolve(asset_graph=InternalAssetGraph.from_assets(dbt_cloud_assets))
+    ).resolve(asset_graph=AssetGraph.from_assets(dbt_cloud_assets))
 
     with instance_for_test() as instance:
         result = materialize_cereal_assets.execute_in_process(
@@ -631,7 +631,7 @@ def test_subsetting(
     materialize_cereal_assets = define_asset_job(
         name="materialize_cereal_assets",
         selection=asset_selection,
-    ).resolve(asset_graph=InternalAssetGraph.from_assets([*dbt_cloud_assets, hanger1, hanger2]))
+    ).resolve(asset_graph=AssetGraph.from_assets([*dbt_cloud_assets, hanger1, hanger2]))
 
     with instance_for_test() as instance:
         result = materialize_cereal_assets.execute_in_process(instance=instance)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_check_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_check_selection.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 import pytest
 from dagster import AssetCheckKey, AssetKey, AssetsDefinition
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster_dbt import (
     DagsterDbtTranslator,
     DagsterDbtTranslatorSettings,
@@ -27,8 +27,8 @@ def my_dbt_assets_fixture(test_asset_checks_manifest: Dict[str, Any]) -> AssetsD
 
 
 @pytest.fixture(name="asset_graph", scope="module")
-def asset_graph_fixture(my_dbt_assets: AssetsDefinition) -> InternalAssetGraph:
-    return InternalAssetGraph.from_assets([my_dbt_assets])
+def asset_graph_fixture(my_dbt_assets: AssetsDefinition) -> AssetGraph:
+    return AssetGraph.from_assets([my_dbt_assets])
 
 
 ALL_ASSET_KEYS = {
@@ -94,13 +94,13 @@ ALL_CHECK_KEYS = {
 }
 
 
-def test_all(my_dbt_assets: AssetsDefinition, asset_graph: InternalAssetGraph) -> None:
+def test_all(my_dbt_assets: AssetsDefinition, asset_graph: AssetGraph) -> None:
     asset_selection = build_dbt_asset_selection([my_dbt_assets], dbt_select="fqn:*")
     assert asset_selection.resolve(asset_graph) == ALL_ASSET_KEYS
     assert asset_selection.resolve_checks(asset_graph) == ALL_CHECK_KEYS
 
 
-def test_tag(my_dbt_assets: AssetsDefinition, asset_graph: InternalAssetGraph) -> None:
+def test_tag(my_dbt_assets: AssetsDefinition, asset_graph: AssetGraph) -> None:
     asset_selection = build_dbt_asset_selection([my_dbt_assets], dbt_select="tag:data_quality")
     assert asset_selection.resolve(asset_graph) == set()
     assert asset_selection.resolve_checks(asset_graph) == {
@@ -114,9 +114,7 @@ def test_tag(my_dbt_assets: AssetsDefinition, asset_graph: InternalAssetGraph) -
     }
 
 
-def test_selection_customers(
-    my_dbt_assets: AssetsDefinition, asset_graph: InternalAssetGraph
-) -> None:
+def test_selection_customers(my_dbt_assets: AssetsDefinition, asset_graph: AssetGraph) -> None:
     asset_selection = build_dbt_asset_selection([my_dbt_assets], dbt_select="customers")
     assert asset_selection.resolve(asset_graph) == {AssetKey(["customers"])}
     # all tests that reference model customers- includes a relationship test on orders
@@ -134,7 +132,7 @@ def test_selection_customers(
     }
 
 
-def test_excluding_tests(my_dbt_assets: AssetsDefinition, asset_graph: InternalAssetGraph) -> None:
+def test_excluding_tests(my_dbt_assets: AssetsDefinition, asset_graph: AssetGraph) -> None:
     asset_selection = build_dbt_asset_selection(
         [my_dbt_assets],
         dbt_select="customers",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Set
 
 import pytest
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
 from dagster_dbt import build_dbt_asset_selection
 from dagster_dbt.asset_decorator import dbt_assets
 
@@ -146,7 +146,7 @@ def test_dbt_asset_selection(
     @dbt_assets(manifest=test_jaffle_shop_manifest)
     def my_dbt_assets(): ...
 
-    asset_graph = InternalAssetGraph.from_assets([my_dbt_assets])
+    asset_graph = AssetGraph.from_assets([my_dbt_assets])
     asset_selection = build_dbt_asset_selection(
         [my_dbt_assets],
         dbt_select=select or "fqn:*",
@@ -183,7 +183,7 @@ def test_dbt_asset_selection_manifest_argument(
         @dbt_assets(manifest=manifest_param)
         def my_dbt_assets(): ...
 
-        asset_graph = InternalAssetGraph.from_assets([my_dbt_assets])
+        asset_graph = AssetGraph.from_assets([my_dbt_assets])
         asset_selection = build_dbt_asset_selection([my_dbt_assets], dbt_select="fqn:*")
         selected_asset_keys = asset_selection.resolve(all_assets=asset_graph)
 

--- a/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
+++ b/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
@@ -23,7 +23,7 @@ from dagster import (
     with_resources,
 )
 from dagster._config.pythonic_config import Config
-from dagster._core.definitions.internal_asset_graph import InternalAssetGraph
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.utils import DEFAULT_OUTPUT
 from dagster._utils import PICKLE_PROTOCOL, file_relative_path
 
@@ -604,7 +604,7 @@ assets = with_resources(
 def make_resolved_job(asset):
     return define_asset_job(
         name=f"{asset.key.to_user_string()}_job", selection=AssetSelection.assets(asset).upstream()
-    ).resolve(asset_graph=InternalAssetGraph.from_assets(assets))
+    ).resolve(asset_graph=AssetGraph.from_assets(assets))
 
 
 hello_world_asset_job = make_resolved_job(hello_world_asset)


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/8594

- `AssetGraph` -> `BaseAssetGraph`
- `InternalAssetGraph` -> `AssetGraph`
- `ExternalAssetGraph` -> `RemoteAssetGraph`

## How I Tested These Changes

Existing test suite.