### PR TITLE
Make repository definition available on step execution context

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_base.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_base.py
@@ -6,6 +6,7 @@ from dagster._core.definitions.events import AssetKey
 
 if TYPE_CHECKING:
     from .job_definition import JobDefinition
+    from .repository_definition import RepositoryDefinition
 
 
 class IJob(ABC):
@@ -17,6 +18,10 @@ class IJob(ABC):
 
     @abstractmethod
     def get_definition(self) -> "JobDefinition":
+        pass
+
+    @abstractmethod
+    def get_repository_definition(self) -> "RepositoryDefinition":
         pass
 
     @abstractmethod
@@ -53,11 +58,16 @@ class InMemoryJob(IJob):
     def __init__(
         self,
         job_def: "JobDefinition",
+        repository_def: "RepositoryDefinition",
     ):
         self._job_def = job_def
+        self._repository_def = repository_def
 
     def get_definition(self) -> "JobDefinition":
         return self._job_def
+
+    def get_repository_definition(self) -> "RepositoryDefinition":
+        return self._repository_def
 
     def get_subset(
         self,
@@ -72,7 +82,8 @@ class InMemoryJob(IJob):
                 op_selection=op_selection,
                 asset_selection=asset_selection,
                 asset_check_selection=asset_check_selection,
-            )
+            ),
+            self._repository_def,
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -265,6 +265,10 @@ class ReconstructableJob(
             self.asset_check_selection,
         )
 
+    @lru_cache(maxsize=1)
+    def get_repository_definition(self) -> "RepositoryDefinition":
+        return self.repository.get_definition()
+
     def get_reconstructable_repository(self) -> ReconstructableRepository:
         return self.repository
 

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -579,6 +579,10 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         self._requires_typed_event_stream = False
         self._typed_event_stream_error_message = None
 
+    @property
+    def repository_def(self):
+        return self.plan_data.job.get_repository_definition()
+
     # In this mode no conversion is done on returned values and missing but expected outputs are not
     # allowed.
     @property

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps_error_informative.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps_error_informative.py
@@ -12,16 +12,14 @@ from dagster._core.errors import DagsterInvalidDefinitionError
 @pytest.mark.parametrize("asset_key_prefix", [[], ["my_prefix"]])
 def test_typo_upstream_asset_one_similar(group_name, asset_key_prefix) -> None:
     @asset(group_name=group_name, key_prefix=asset_key_prefix)
-    def asset1():
-        ...
+    def asset1(): ...
 
     @asset(
         group_name=group_name,
         key_prefix=asset_key_prefix,
         ins={"asst1": AssetIn(asset_key_prefix + ["asst1"])},
     )
-    def asset2(asst1):
-        ...
+    def asset2(asst1): ...
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
@@ -36,12 +34,10 @@ def test_typo_upstream_asset_one_similar(group_name, asset_key_prefix) -> None:
 
 def test_typo_upstream_asset_no_similar() -> None:
     @asset
-    def asset1():
-        ...
+    def asset1(): ...
 
     @asset
-    def asset2(not_close_to_asset1):
-        ...
+    def asset2(not_close_to_asset1): ...
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
@@ -55,20 +51,16 @@ def test_typo_upstream_asset_no_similar() -> None:
 
 def test_typo_upstream_asset_many_similar() -> None:
     @asset
-    def asset1():
-        ...
+    def asset1(): ...
 
     @asset
-    def assets1():
-        ...
+    def assets1(): ...
 
     @asset
-    def asst():
-        ...
+    def asst(): ...
 
     @asset
-    def asset2(asst1):
-        ...
+    def asset2(asst1): ...
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
@@ -85,12 +77,10 @@ def test_typo_upstream_asset_many_similar() -> None:
 
 def test_typo_upstream_asset_wrong_prefix() -> None:
     @asset(key_prefix=["my", "prefix"])
-    def asset1():
-        ...
+    def asset1(): ...
 
     @asset(ins={"asset1": AssetIn(key=AssetKey(["my", "prfix", "asset1"]))})
-    def asset2(asset1):
-        ...
+    def asset2(asset1): ...
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
@@ -107,12 +97,10 @@ def test_typo_upstream_asset_wrong_prefix_and_wrong_key() -> None:
     # In the case that the user has a typo in the key and the prefix, we don't suggest the asset since it's too different.
 
     @asset(key_prefix=["my", "prefix"])
-    def asset1():
-        ...
+    def asset1(): ...
 
     @asset(ins={"asset1": AssetIn(key=AssetKey(["my", "prfix", "asset4"]))})
-    def asset2(asset1):
-        ...
+    def asset2(asset1): ...
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
@@ -126,13 +114,11 @@ def test_typo_upstream_asset_wrong_prefix_and_wrong_key() -> None:
 
 def test_one_off_component_prefix() -> None:
     @asset(key_prefix=["my", "prefix"])
-    def asset1():
-        ...
+    def asset1(): ...
 
     # One more component in the prefix
     @asset(ins={"asset1": AssetIn(key=AssetKey(["my", "prefix", "nested", "asset1"]))})
-    def asset2(asset1):
-        ...
+    def asset2(asset1): ...
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
@@ -146,8 +132,7 @@ def test_one_off_component_prefix() -> None:
 
     # One fewer component in the prefix
     @asset(ins={"asset1": AssetIn(key=AssetKey(["my", "asset1"]))})
-    def asset3(asset1):
-        ...
+    def asset3(asset1): ...
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
@@ -162,13 +147,11 @@ def test_one_off_component_prefix() -> None:
 
 def test_accidentally_using_slashes() -> None:
     @asset(key_prefix=["my", "prefix"])
-    def asset1():
-        ...
+    def asset1(): ...
 
     # Use slashes instead of list
     @asset(ins={"asset1": AssetIn(key=AssetKey(["my/prefix/asset1"]))})
-    def asset2(asset1):
-        ...
+    def asset2(asset1): ...
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
@@ -192,8 +175,7 @@ def test_perf() -> None:
     for i in range(NUM_ASSETS_TO_TEST_PERF):
 
         @asset(name="asset_" + str(i))
-        def my_asset():
-            ...
+        def my_asset(): ...
 
         assets.append(my_asset.key)
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection_error_informative.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection_error_informative.py
@@ -9,8 +9,7 @@ from dagster._core.errors import DagsterInvalidSubsetError
 @pytest.mark.parametrize("asset_key_prefix", [[], ["my_prefix"]])
 def test_typo_asset_selection_one_similar(group_name, asset_key_prefix) -> None:
     @asset(group_name=group_name, key_prefix=asset_key_prefix)
-    def asset1():
-        ...
+    def asset1(): ...
 
     my_job = define_asset_job("my_job", selection=AssetSelection.keys(asset_key_prefix + ["asst1"]))
 
@@ -24,8 +23,7 @@ def test_typo_asset_selection_one_similar(group_name, asset_key_prefix) -> None:
 
 def test_typo_asset_selection_no_similar() -> None:
     @asset
-    def asset1():
-        ...
+    def asset1(): ...
 
     my_job = define_asset_job("my_job", selection=AssetSelection.keys("not_close_to_asset1"))
 
@@ -39,16 +37,13 @@ def test_typo_asset_selection_no_similar() -> None:
 
 def test_typo_asset_selection_many_similar() -> None:
     @asset
-    def asset1():
-        ...
+    def asset1(): ...
 
     @asset
-    def assets1():
-        ...
+    def assets1(): ...
 
     @asset
-    def asst():
-        ...
+    def asst(): ...
 
     my_job = define_asset_job("my_job", selection=AssetSelection.keys("asst1"))
 
@@ -66,8 +61,7 @@ def test_typo_asset_selection_many_similar() -> None:
 
 def test_typo_asset_selection_wrong_prefix() -> None:
     @asset(key_prefix=["my", "prefix"])
-    def asset1():
-        ...
+    def asset1(): ...
 
     my_job = define_asset_job("my_job", selection=AssetSelection.keys(["my", "prfix", "asset1"]))
 
@@ -83,8 +77,7 @@ def test_typo_asset_selection_wrong_prefix_and_wrong_key() -> None:
     # In the case that the user has a typo in the key and the prefix, we don't suggest the asset since it's too different.
 
     @asset(key_prefix=["my", "prefix"])
-    def asset1():
-        ...
+    def asset1(): ...
 
     my_job = define_asset_job("my_job", selection=AssetSelection.keys(["my", "prfix", "asset4"]))
 
@@ -98,8 +91,7 @@ def test_typo_asset_selection_wrong_prefix_and_wrong_key() -> None:
 
 def test_one_off_component_prefix() -> None:
     @asset(key_prefix=["my", "prefix"])
-    def asset1():
-        ...
+    def asset1(): ...
 
     # One more component in the prefix
     my_job = define_asset_job(


### PR DESCRIPTION
There are various asset check methods that require us to introspect from the repository-wide asset graph. This PR makes the repository definition easily available (but not public) so that we can retrieve them.
