### PR TITLE
[AssetCondition] Create AssetConditionScenarioState class

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
@@ -1,0 +1,92 @@
+import dataclasses
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import dagster._check as check
+from dagster import AssetKey
+from dagster._core.definitions.asset_condition.asset_condition import (
+    AndAssetCondition,
+    AssetCondition,
+    AssetConditionEvaluationState,
+    AssetConditionResult,
+)
+from dagster._core.definitions.asset_condition.asset_condition_evaluation_context import (
+    AssetConditionEvaluationContext,
+)
+from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
+from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
+from dagster._core.definitions.data_time import CachingDataTimeResolver
+from dagster._core.definitions.events import CoercibleToAssetKey
+from dagster._seven.compat.pendulum import pendulum_freeze_time
+from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
+
+from ..scenario_state import ScenarioState
+
+
+class FalseAssetCondition(AssetCondition):
+    """Always returns the empty subset."""
+
+    def description(self) -> str:
+        return ""
+
+    def evaluate(self, context: AssetConditionEvaluationContext) -> AssetConditionResult:
+        return AssetConditionResult.create(context, true_subset=context.empty_subset())
+
+
+@dataclass(frozen=True)
+class AssetConditionScenarioState(ScenarioState):
+    asset_condition: Optional[AssetCondition] = None
+    previous_evaluation_state: Optional[AssetConditionEvaluationState] = None
+
+    def evaluate(
+        self, asset: CoercibleToAssetKey
+    ) -> Tuple["AssetConditionScenarioState", AssetConditionResult]:
+        asset_key = AssetKey.from_coercible(asset)
+        # ensure that the top level condition never returns any asset partitions, as otherwise the
+        # next evaluation will assume that those asset partitions were requested by the machinery
+        asset_condition = AndAssetCondition(
+            children=[check.not_none(self.asset_condition), FalseAssetCondition()]
+        )
+
+        with pendulum_freeze_time(self.current_time):
+            instance_queryer = CachingInstanceQueryer(
+                instance=self.instance, asset_graph=self.asset_graph
+            )
+            context = AssetConditionEvaluationContext.create(
+                asset_key=asset_key,
+                condition=asset_condition,
+                previous_evaluation_state=self.previous_evaluation_state,
+                instance_queryer=instance_queryer,
+                data_time_resolver=CachingDataTimeResolver(instance_queryer),
+                evaluation_state_by_key={},
+                expected_data_time_mapping={},
+                daemon_context=AssetDaemonContext(
+                    evaluation_id=1,
+                    instance=self.instance,
+                    asset_graph=self.asset_graph,
+                    cursor=AssetDaemonCursor.empty(),
+                    materialize_run_tags={},
+                    observe_run_tags={},
+                    auto_observe_asset_keys=None,
+                    auto_materialize_asset_keys=None,
+                    respect_materialization_data_versions=False,
+                    logger=self.logger,
+                    evaluation_time=self.current_time,
+                ),
+            )
+
+            full_result = asset_condition.evaluate(context)
+            new_state = dataclasses.replace(
+                self,
+                previous_evaluation_state=AssetConditionEvaluationState.create(
+                    context, full_result
+                ),
+            )
+
+        return new_state, full_result.child_results[0]
+
+    def without_previous_evaluation_state(self) -> "AssetConditionScenarioState":
+        """Removes the previous evaluation state from the state. This is useful for testing
+        re-evaluating this data "from scratch" after much computation has occurred.
+        """
+        return dataclasses.replace(self, previous_evaluation_state=None)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/missing_tests.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/missing_tests.py
@@ -1,0 +1,56 @@
+from dagster._core.definitions.asset_condition.asset_condition import AssetCondition
+
+from ..base_scenario import run_request
+from ..scenario_specs import (
+    daily_partitions_def,
+    day_partition_key,
+    one_asset,
+    time_partitions_start_datetime,
+)
+from .asset_condition_scenario import AssetConditionScenarioState
+
+
+def test_missing_unpartitioned() -> None:
+    state = AssetConditionScenarioState(one_asset, asset_condition=AssetCondition.missing())
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+    # still true
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+    # after a run of A it's now False
+    state, result = state.with_runs(run_request("A")).evaluate("A")
+    assert result.true_subset.size == 0
+
+    # if we evaluate from scratch, it's also False
+    _, result = state.without_previous_evaluation_state().evaluate("A")
+    assert result.true_subset.size == 0
+
+
+def test_missing_time_partitioned() -> None:
+    state = (
+        AssetConditionScenarioState(one_asset, asset_condition=AssetCondition.missing())
+        .with_asset_properties(partitions_def=daily_partitions_def)
+        .with_current_time(time_partitions_start_datetime)
+        .with_current_time_advanced(days=6, minutes=1)
+    )
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 6
+
+    # still true
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 6
+
+    # after two runs of A those partitions are now False
+    state, result = state.with_runs(
+        run_request("A", day_partition_key(time_partitions_start_datetime, 1)),
+        run_request("A", day_partition_key(time_partitions_start_datetime, 3)),
+    ).evaluate("A")
+    assert result.true_subset.size == 4
+
+    # if we evaluate from scratch, they're still False
+    _, result = state.without_previous_evaluation_state().evaluate("A")
+    assert result.true_subset.size == 4

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_specs.py
@@ -1,5 +1,7 @@
+import datetime
+
 import pendulum
-from dagster import AssetSpec, StaticPartitionsDefinition
+from dagster import AssetSpec, MultiPartitionKey, StaticPartitionsDefinition
 from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.partition import DynamicPartitionsDefinition
@@ -10,7 +12,7 @@ from dagster._core.definitions.time_window_partitions import (
     HourlyPartitionsDefinition,
 )
 
-from ..scenario_state import MultiAssetSpec, ScenarioSpec
+from .scenario_state import MultiAssetSpec, ScenarioSpec
 
 ############
 # PARTITIONS
@@ -96,3 +98,23 @@ two_assets_in_sequence_fan_out_partitions = two_assets_in_sequence.with_asset_pr
     deps=[AssetDep("A", partition_mapping=StaticPartitionMapping({"1": ["1", "2", "3"]}))],
 )
 dynamic_partitions_def = DynamicPartitionsDefinition(name="dynamic")
+
+
+###########
+# UTILITIES
+###########
+
+
+def day_partition_key(time: datetime.datetime, delta: int = 0) -> str:
+    """Returns the partition key of a day partition delta days from the initial time."""
+    return (time + datetime.timedelta(days=delta - 1)).strftime("%Y-%m-%d")
+
+
+def hour_partition_key(time: datetime.datetime, delta: int = 0) -> str:
+    """Returns the partition key of a day partition delta days from the initial time."""
+    return (time + datetime.timedelta(hours=delta - 1)).strftime("%Y-%m-%d-%H:00")
+
+
+def multi_partition_key(**kwargs) -> MultiPartitionKey:
+    """Returns a MultiPartitionKey based off of the given kwargs."""
+    return MultiPartitionKey(kwargs)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_state.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_state.py
@@ -1,6 +1,7 @@
 import dataclasses
 import datetime
 import json
+import logging
 import os
 import sys
 from collections import namedtuple
@@ -231,6 +232,7 @@ class ScenarioState:
 
     scenario_spec: ScenarioSpec
     instance: DagsterInstance = field(default_factory=lambda: DagsterInstance.ephemeral())
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger(__name__))
 
     @property
     def current_time(self) -> datetime.datetime:

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -46,17 +46,17 @@ from dagster._serdes.serdes import serialize_value
 
 from dagster_tests.definitions_tests.auto_materialize_tests.scenario_state import ScenarioSpec
 
-from .asset_daemon_scenario import (
-    AssetDaemonScenario,
-    AssetRuleEvaluationSpec,
-)
 from .base_scenario import (
     run_request,
 )
-from .updated_scenarios.asset_daemon_scenario_states import (
+from .scenario_specs import (
     one_asset,
     two_assets_in_sequence,
     two_partitions_def,
+)
+from .updated_scenarios.asset_daemon_scenario import (
+    AssetDaemonScenario,
+    AssetRuleEvaluationSpec,
 )
 from .updated_scenarios.basic_scenarios import basic_scenarios
 from .updated_scenarios.cron_scenarios import (

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_scenarios.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .asset_daemon_scenario import AssetDaemonScenario
+from .updated_scenarios.asset_daemon_scenario import AssetDaemonScenario
 from .updated_scenarios.basic_scenarios import basic_scenarios
 from .updated_scenarios.cron_scenarios import cron_scenarios
 from .updated_scenarios.cursor_migration_scenarios import cursor_migration_scenarios

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario.py
@@ -1,7 +1,5 @@
 import dataclasses
-import datetime
 import itertools
-import logging
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from typing import (
@@ -19,7 +17,6 @@ import dagster._check as check
 from dagster import (
     AssetKey,
     DagsterInstance,
-    MultiPartitionKey,
     RunRequest,
     RunsFilter,
 )
@@ -48,14 +45,9 @@ from dagster._core.host_representation.origin import (
     ExternalInstigatorOrigin,
     ExternalRepositoryOrigin,
 )
-from dagster._core.scheduler.instigation import (
-    SensorInstigatorData,
-    TickStatus,
-)
+from dagster._core.scheduler.instigation import SensorInstigatorData, TickStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
-from dagster._core.test_utils import (
-    wait_for_futures,
-)
+from dagster._core.test_utils import wait_for_futures
 from dagster._daemon.asset_daemon import (
     _PRE_SENSOR_AUTO_MATERIALIZE_ORIGIN_ID,
     _PRE_SENSOR_AUTO_MATERIALIZE_SELECTOR_ID,
@@ -64,34 +56,11 @@ from dagster._daemon.asset_daemon import (
     asset_daemon_cursor_from_instigator_serialized_cursor,
     get_current_evaluation_id,
 )
-from dagster._serdes.serdes import (
-    DeserializationError,
-    deserialize_value,
-    serialize_value,
-)
+from dagster._serdes.serdes import DeserializationError, deserialize_value, serialize_value
 from dagster._seven.compat.pendulum import pendulum_freeze_time
 
-from .base_scenario import run_request
-from .scenario_state import (
-    ScenarioSpec,
-    ScenarioState,
-    get_code_location_origin,
-)
-
-
-def day_partition_key(time: datetime.datetime, delta: int = 0) -> str:
-    """Returns the partition key of a day partition delta days from the initial time."""
-    return (time + datetime.timedelta(days=delta - 1)).strftime("%Y-%m-%d")
-
-
-def hour_partition_key(time: datetime.datetime, delta: int = 0) -> str:
-    """Returns the partition key of a day partition delta days from the initial time."""
-    return (time + datetime.timedelta(hours=delta - 1)).strftime("%Y-%m-%d-%H:00")
-
-
-def multi_partition_key(**kwargs) -> MultiPartitionKey:
-    """Returns a MultiPartitionKey based off of the given kwargs."""
-    return MultiPartitionKey(kwargs)
+from ..base_scenario import run_request
+from ..scenario_state import ScenarioSpec, ScenarioState, get_code_location_origin
 
 
 class AssetRuleEvaluationSpec(NamedTuple):
@@ -161,7 +130,6 @@ class AssetDaemonScenarioState(ScenarioState):
     run_requests: Sequence[RunRequest] = field(default_factory=list)
     serialized_cursor: str = field(default=serialize_value(AssetDaemonCursor.empty(0)))
     evaluations: Sequence[AssetConditionEvaluation] = field(default_factory=list)
-    logger: logging.Logger = field(default=logging.getLogger("dagster.amp"))
     tick_index: int = 1
 
     # set by scenario runner

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/basic_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/basic_scenarios.py
@@ -3,19 +3,19 @@ from dagster._core.definitions.auto_materialize_rule_evaluation import (
     ParentUpdatedRuleEvaluationData,
 )
 
-from ..asset_daemon_scenario import (
-    AssetDaemonScenario,
-    AssetRuleEvaluationSpec,
-)
 from ..base_scenario import run_request
-from ..scenario_state import ScenarioSpec
-from .asset_daemon_scenario_states import (
+from ..scenario_specs import (
     diamond,
     one_asset,
     one_asset_depends_on_two,
     three_assets_in_sequence,
     two_assets_depend_on_one,
     two_assets_in_sequence,
+)
+from ..scenario_state import ScenarioSpec
+from .asset_daemon_scenario import (
+    AssetDaemonScenario,
+    AssetRuleEvaluationSpec,
 )
 
 basic_scenarios = [

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
@@ -5,11 +5,11 @@ from dagster._core.definitions.auto_materialize_rule import (
     WaitingOnAssetsRuleEvaluationData,
 )
 
-from ..asset_daemon_scenario import AssetDaemonScenario, AssetRuleEvaluationSpec, hour_partition_key
 from ..base_scenario import run_request
-from .asset_daemon_scenario_states import (
+from ..scenario_specs import (
     daily_partitions_def,
     dynamic_partitions_def,
+    hour_partition_key,
     hourly_partitions_def,
     one_asset,
     one_asset_depends_on_two,
@@ -17,6 +17,7 @@ from .asset_daemon_scenario_states import (
     time_partitions_start_str,
     two_partitions_def,
 )
+from .asset_daemon_scenario import AssetDaemonScenario, AssetRuleEvaluationSpec
 
 
 def get_cron_policy(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cursor_migration_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cursor_migration_scenarios.py
@@ -7,22 +7,19 @@ from dagster_tests.definitions_tests.auto_materialize_tests.updated_scenarios.cr
     get_cron_policy,
 )
 
-from ..asset_daemon_scenario import (
-    AssetDaemonScenario,
-    AssetRuleEvaluationSpec,
-    day_partition_key,
-    hour_partition_key,
-)
 from ..base_scenario import (
     run_request,
 )
-from .asset_daemon_scenario_states import (
+from ..scenario_specs import (
     daily_partitions_def,
+    day_partition_key,
+    hour_partition_key,
     hourly_partitions_def,
     one_asset,
     three_assets_in_sequence,
     time_partitions_start_str,
 )
+from .asset_daemon_scenario import AssetDaemonScenario, AssetRuleEvaluationSpec
 
 cursor_migration_scenarios = [
     AssetDaemonScenario(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
@@ -2,11 +2,11 @@ from dagster import AutoMaterializeRule
 from dagster._core.definitions.asset_condition.asset_condition import AssetCondition, RuleCondition
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 
-from ..asset_daemon_scenario import (
+from ..base_scenario import run_request
+from ..scenario_specs import one_asset, two_assets_in_sequence
+from .asset_daemon_scenario import (
     AssetDaemonScenario,
 )
-from ..base_scenario import run_request
-from .asset_daemon_scenario_states import one_asset, two_assets_in_sequence
 
 custom_condition_scenarios = [
     AssetDaemonScenario(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/freshness_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/freshness_policy_scenarios.py
@@ -3,13 +3,10 @@ from dagster._core.definitions.asset_spec import AssetSpec
 
 from dagster_tests.definitions_tests.auto_materialize_tests.scenario_state import ScenarioSpec
 
-from ..asset_daemon_scenario import (
-    AssetDaemonScenario,
-    day_partition_key,
-)
 from ..base_scenario import run_request
-from .asset_daemon_scenario_states import (
+from ..scenario_specs import (
     daily_partitions_def,
+    day_partition_key,
     diamond,
     one_asset,
     one_asset_depends_on_two,
@@ -17,6 +14,7 @@ from .asset_daemon_scenario_states import (
     two_assets_depend_on_one,
     two_assets_in_sequence,
 )
+from .asset_daemon_scenario import AssetDaemonScenario
 
 freshness_30m = FreshnessPolicy(maximum_lag_minutes=30)
 freshness_60m = FreshnessPolicy(maximum_lag_minutes=60)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/latest_materialization_run_tag_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/latest_materialization_run_tag_scenarios.py
@@ -1,12 +1,12 @@
 from dagster import AutoMaterializeAssetPartitionsFilter, AutoMaterializePolicy, AutoMaterializeRule
 
-from ..asset_daemon_scenario import AssetDaemonScenario
 from ..base_scenario import run_request
-from .asset_daemon_scenario_states import (
+from ..scenario_specs import (
     one_asset_depends_on_two,
     three_assets_in_sequence,
     two_assets_in_sequence,
 )
+from .asset_daemon_scenario import AssetDaemonScenario
 
 filter_latest_run_tag_key_policy = (
     AutoMaterializePolicy.eager()

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
@@ -11,21 +11,15 @@ from dagster import (
 )
 from dagster._core.definitions.auto_materialize_rule import DiscardOnMaxMaterializationsExceededRule
 
-from ..asset_daemon_scenario import (
-    AssetDaemonScenario,
-    AssetRuleEvaluationSpec,
-    day_partition_key,
-    hour_partition_key,
-    multi_partition_key,
-)
-from ..base_scenario import (
-    run_request,
-)
-from .asset_daemon_scenario_states import (
+from ..base_scenario import run_request
+from ..scenario_specs import (
     daily_partitions_def,
+    day_partition_key,
     dynamic_partitions_def,
+    hour_partition_key,
     hourly_partitions_def,
     hourly_to_daily,
+    multi_partition_key,
     one_asset,
     one_asset_depends_on_two,
     one_asset_self_dependency,
@@ -42,6 +36,7 @@ from .asset_daemon_scenario_states import (
     two_assets_in_sequence_fan_out_partitions,
     two_partitions_def,
 )
+from .asset_daemon_scenario import AssetDaemonScenario, AssetRuleEvaluationSpec
 
 partition_scenarios = [
     AssetDaemonScenario(


### PR DESCRIPTION
## Summary & Motivation

As we create more AssetConditions, it is increasingly useful to be able to test them in isolation, rather than as part of a larger policy. This builds off of previous work to split out the old AssetDaemonScenarion test framework into something more reusable. Most of this PR is just shifting existing functions around between files / folders.

Also added in a few tests for `AssetCondition.missing()` to demonstrate how this would be used.

## How I Tested These Changes
