### PR TITLE
Retrieve assets targeted by checks

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -257,6 +257,7 @@ def build_assets_job(
         source_assets=resolved_source_assets,
         assets_defs_by_outer_node_handle=assets_defs_by_node_handle,
         observable_source_assets_by_node_handle=observable_source_assets_by_node_handle,
+        loadable_assets=loadable_assets,
     )
 
     all_resource_defs = get_all_resource_defs(


### PR DESCRIPTION
If checks are running in a job without the assets which target them, those assets are currently inaccessible off the context. This makes it so that the aforementioned asset definitons or source assets are available on the context. 

This becomes useful for anomaly detection stuff.