### PR TITLE
Revert "Fix bootstrapping behavior of MaterializeOnCron (#20020)"

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
@@ -72,38 +72,6 @@ cron_scenarios = [
         .assert_requested_runs(),
     ),
     AssetDaemonScenario(
-        id="basic_hourly_cron_unpartitioned_rule_added_later",
-        initial_state=one_asset.with_asset_properties(
-            # this policy will never materialize the asset
-            auto_materialize_policy=AutoMaterializePolicy(
-                rules={AutoMaterializeRule.skip_on_parent_missing()}
-            )
-        ),
-        execution_fn=lambda state: state.evaluate_tick()
-        .assert_requested_runs()
-        # rule added after the first tick, should capture that this asset was not materialized
-        # since the previous tick
-        .with_asset_properties(auto_materialize_policy=get_cron_policy(basic_hourly_cron_schedule))
-        .evaluate_tick()
-        .assert_requested_runs(run_request(["A"]))
-        .with_not_started_runs()
-        # back to the original policy which never materializes
-        .with_current_time_advanced(seconds=30)
-        .with_asset_properties(
-            auto_materialize_policy=AutoMaterializePolicy(
-                rules={AutoMaterializeRule.skip_on_parent_missing()}
-            )
-        )
-        .evaluate_tick()
-        .assert_requested_runs()
-        # now we add the policy back in, but it's already been materialized since the previous tick
-        # so it shouldn't execute again
-        .with_current_time_advanced(seconds=30)
-        .with_asset_properties(auto_materialize_policy=get_cron_policy(basic_hourly_cron_schedule))
-        .evaluate_tick()
-        .assert_requested_runs(),
-    ),
-    AssetDaemonScenario(
         id="basic_hourly_cron_unpartitioned_multi_asset",
         initial_spec=three_assets_not_subsettable.with_asset_properties(
             auto_materialize_policy=get_cron_policy(basic_hourly_cron_schedule)


### PR DESCRIPTION
## Summary & Motivation

#20020 borked master. This reverts the change.


## How I Tested These Changes

On master:

```
(dagster-3.11.5-2024-02-25) ➜  dagster git:(master) ✗ pytest python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
WARNING:root:Unable to detect CI environment.  No test analytics will be sent.
====================================================================== test session starts =======================================================================
platform darwin -- Python 3.11.5, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/schrockn/code/dagster-io/dagster
configfile: pyproject.toml
plugins: syrupy-4.6.1, cases-3.8.2, anyio-4.3.0, time-machine-2.13.0, dependency-0.5.1, typeguard-4.1.5, mock-3.3.1, requests-mock-1.11.0, cov-2.10.1, xdist-3.3.1, buildkite-test-collector-0.1.7, hypothesis-6.98.12, rerunfailures-10.0
collected 0 items / 1 error

============================================================================= ERRORS =============================================================================
______________________ ERROR collecting python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py _______________________
python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py:62: in <module>
    from .updated_scenarios.cron_scenarios import (
python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py:74: in <module>
    AssetDaemonScenario(
E   TypeError: AssetDaemonScenario.__new__() got an unexpected keyword argument 'initial_state'
==================================================================== short test summary info =====================================================================
ERROR python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py - TypeError: AssetDaemonScenario.__new__() got an unexpected keyword argument 'initial_state'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
======================================================================== 1 error in 0.37s =======================================================================
```

On revert branch:

```
(dagster-3.11.5-2024-02-25) ➜  dagster git:(revert-20020) ✗ pytest python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
WARNING:root:Unable to detect CI environment.  No test analytics will be sent.
====================================================================== test session starts =======================================================================
platform darwin -- Python 3.11.5, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/schrockn/code/dagster-io/dagster
configfile: pyproject.toml
plugins: syrupy-4.6.1, cases-3.8.2, anyio-4.3.0, time-machine-2.13.0, dependency-0.5.1, typeguard-4.1.5, mock-3.3.1, requests-mock-1.11.0, cov-2.10.1, xdist-3.3.1, buildkite-test-collector-0.1.7, hypothesis-6.98.12, rerunfailures-10.0
collected 69 items

python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py ................................
```