### PR TITLE
Dagster University: Remove redundant MetadataValue in Dagster Essentials Course

### DIFF
--- a/docs/dagster-university/pages/dagster-essentials/extra-credit/coding-practice-metadata-taxi-zones-file.md
+++ b/docs/dagster-university/pages/dagster-essentials/extra-credit/coding-practice-metadata-taxi-zones-file.md
@@ -31,7 +31,7 @@ def taxi_zones_file():
 
     with open(constants.TAXI_ZONES_FILE_PATH, "wb") as output_file:
         output_file.write(raw_taxi_zones.content)
-    num_rows = MetadataValue.int(len(pd.read_csv(constants.TAXI_ZONES_FILE_PATH)))
+    num_rows = len(pd.read_csv(constants.TAXI_ZONES_FILE_PATH))
 
     return MaterializeResult(
         metadata={


### PR DESCRIPTION
## Summary & Motivation
In "Extra credit: Metadata" of the Dagster Essentials course, the row count is being wrapped in a MetadataValue twice, once when the rows are counted, and once in the MaterializeResult definition, resulting in this error:

`Param "value" is not a int.`
`Got IntMetadataValue(value=263) which is type <class 'dagster._core.definitions.metadata.IntMetadataValue'>.`

## How I Tested These Changes
Ran the example with the redundant MetadataValue removed
