### PR TITLE
[ui] "Copy asset key" button is not needed on Assets page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.tsx
@@ -70,14 +70,16 @@ export const AssetPageHeader = ({assetKey, ...extra}: Props) => {
               </Heading>
             )}
           />
-          <Tooltip placement="bottom" content="Copy asset key">
-            <CopyButton onClick={performCopy}>
-              <Icon
-                name={didCopy ? 'copy_to_clipboard_done' : 'copy_to_clipboard'}
-                color={Colors.accentGray()}
-              />
-            </CopyButton>
-          </Tooltip>
+          {copyableString ? (
+            <Tooltip placement="bottom" content="Copy asset key">
+              <CopyButton onClick={performCopy}>
+                <Icon
+                  name={didCopy ? 'copy_to_clipboard_done' : 'copy_to_clipboard'}
+                  color={Colors.accentGray()}
+                />
+              </CopyButton>
+            </Tooltip>
+          ) : undefined}
         </Box>
       }
       {...extra}


### PR DESCRIPTION
## Summary & Motivation
Fix for https://github.com/dagster-io/dagster/issues/20093

## How I Tested These Changes
