### PR TITLE
[ui] Allow more asset metadata plots [arbitrary cap for perf] #19305

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMaterializationGraphs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMaterializationGraphs.tsx
@@ -26,7 +26,7 @@ export const AssetMaterializationGraphs = (props: {
   }, [props.groups]);
 
   const graphDataByMetadataLabel = extractNumericData(reversed, props.xAxis);
-  const graphLabels = Object.keys(graphDataByMetadataLabel).slice(0, 20).sort();
+  const graphLabels = Object.keys(graphDataByMetadataLabel).slice(0, 100).sort();
 
   if (process.env.NODE_ENV === 'test') {
     return <span />; // chartjs and our useViewport hook don't play nicely with jest


### PR DESCRIPTION
Fixes https://github.com/dagster-io/dagster/issues/19305

## Summary & Motivation

Note: This entire page is likely going away soon and once it's merged into asset overview, there will be a search bar for finding the plot you want, so I'm not too worried about this being a temporary solution


## How I Tested These Changes
