### PR TITLE
[ui] Fix asset group border missing on lineage graph #20229

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -8,7 +8,7 @@ import {AssetKey, AssetViewParams} from './types';
 import {AssetEdges} from '../asset-graph/AssetEdges';
 import {MINIMAL_SCALE} from '../asset-graph/AssetGraphExplorer';
 import {AssetNode, AssetNodeContextMenuWrapper, AssetNodeMinimal} from '../asset-graph/AssetNode';
-import {ExpandedGroupNode} from '../asset-graph/ExpandedGroupNode';
+import {ExpandedGroupNode, GroupOutline} from '../asset-graph/ExpandedGroupNode';
 import {AssetNodeLink} from '../asset-graph/ForeignNode';
 import {GraphData, GraphNode, groupIdForNode, toGraphId} from '../asset-graph/Utils';
 import {DEFAULT_MAX_ZOOM, SVGViewport} from '../graph/SVGViewport';
@@ -88,6 +88,29 @@ export const AssetNodeLineageGraph = ({
             .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
             .sort((a, b) => a.id.length - b.id.length)
             .map((group) => (
+              <foreignObject
+                {...group.bounds}
+                key={`${group.id}-outline`}
+                onDoubleClick={(e) => {
+                  e.stopPropagation();
+                }}
+              >
+                <GroupOutline $minimal={scale < MINIMAL_SCALE} />
+              </foreignObject>
+            ))}
+
+          <AssetEdges
+            selected={null}
+            highlighted={highlighted}
+            edges={layout.edges}
+            viewportRect={viewportRect}
+            direction="horizontal"
+          />
+
+          {Object.values(layout.groups)
+            .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
+            .sort((a, b) => a.id.length - b.id.length)
+            .map((group) => (
               <foreignObject {...group.bounds} key={group.id}>
                 <ExpandedGroupNode
                   group={{
@@ -99,14 +122,6 @@ export const AssetNodeLineageGraph = ({
                 />
               </foreignObject>
             ))}
-
-          <AssetEdges
-            selected={null}
-            highlighted={highlighted}
-            edges={layout.edges}
-            viewportRect={viewportRect}
-            direction="horizontal"
-          />
 
           {Object.values(layout.nodes)
             .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))


### PR DESCRIPTION
## Summary & Motivation

Fix for https://github.com/dagster-io/dagster/issues/20229

Ideally this page would share more code with the core asset graph -- it's just different enough that it wasn't originally worth it.  I don't think it's worth refactoring at the moment because Josh's latest designs call for folding it away into the Overview (though we've put it back for the moment)

## How I Tested These Changes
