### PR TITLE
[ui] Add missing border on the lineage page Materialize button

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineage.tsx
@@ -72,7 +72,7 @@ export const AssetNodeLineage = ({
         <div style={{flex: 1}} />
         {Object.values(assetGraphData.nodes).length > 1 ? (
           <LaunchAssetExecutionButton
-            intent="none"
+            primary={false}
             scope={{all: Object.values(assetGraphData.nodes).map((n) => n.definition)}}
           />
         ) : (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -300,7 +300,7 @@ export const AssetView = ({assetKey, trace}: Props) => {
           <Box style={{margin: '-4px 0'}}>
             {definition && definition.isObservable ? (
               <LaunchAssetObservationButton
-                intent="primary"
+                primary
                 scope={{all: [definition], skipAllTerm: true}}
               />
             ) : definition && definition.jobNames.length > 0 && upstream ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -169,12 +169,12 @@ export const LaunchAssetExecutionButton = ({
   scope,
   preferredJobName,
   additionalDropdownOptions,
-  intent = 'primary',
+  primary = true,
   showChangedAndMissingOption = true,
 }: {
   scope: AssetsInScope;
   showChangedAndMissingOption?: boolean;
-  intent?: 'primary' | 'none';
+  primary?: boolean;
   preferredJobName?: string;
   additionalDropdownOptions?: {
     label: string;
@@ -203,7 +203,7 @@ export const LaunchAssetExecutionButton = ({
     return (
       <Tooltip content={disabledMessage} position="bottom-right">
         <Button
-          intent={intent}
+          intent={primary ? 'primary' : undefined}
           icon={<Icon name="materialization" />}
           data-testid={testId('materialize-button')}
           disabled
@@ -233,7 +233,7 @@ export const LaunchAssetExecutionButton = ({
           useDisabledButtonTooltipFix
         >
           <MaterializeButton
-            intent={intent}
+            intent={primary ? 'primary' : undefined}
             data-testid={testId('materialize-button')}
             onClick={(e) => onClick(firstOption.assetKeys, e)}
             style={{
@@ -293,7 +293,7 @@ export const LaunchAssetExecutionButton = ({
             style={{minWidth: 'initial', borderTopLeftRadius: 0, borderBottomLeftRadius: 0}}
             icon={<Icon name="arrow_drop_down" />}
             disabled={!firstOption.assetKeys.length}
-            intent={intent}
+            intent={primary ? 'primary' : undefined}
           />
         </Popover>
       </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetObservationButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetObservationButton.tsx
@@ -33,10 +33,10 @@ type ObserveAssetsState =
 export const LaunchAssetObservationButton = ({
   scope,
   preferredJobName,
-  intent = 'none',
+  primary = false,
 }: {
   scope: AssetsInScope;
-  intent?: 'primary' | 'none';
+  primary?: boolean;
   preferredJobName?: string;
 }) => {
   const {useLaunchWithTelemetry} = useLaunchPadHooks();
@@ -62,7 +62,11 @@ export const LaunchAssetObservationButton = ({
   if (!hasMaterializePermission) {
     return (
       <Tooltip content="You do not have permission to observe source assets">
-        <Button intent={intent} icon={<Icon name="observation" />} disabled>
+        <Button
+          intent={primary ? 'primary' : undefined}
+          icon={<Icon name="observation" />}
+          disabled
+        >
           {label}
         </Button>
       </Tooltip>
@@ -110,7 +114,7 @@ export const LaunchAssetObservationButton = ({
 
   return (
     <Button
-      intent={intent}
+      intent={primary ? 'primary' : undefined}
       onClick={onClick}
       icon={
         state.type === 'loading' ? <Spinner purpose="body-text" /> : <Icon name="observation" />


### PR DESCRIPTION
## Summary & Motivation

Fixes https://linear.app/dagster-labs/issue/FE-198/fix-materialize-button-on-asset-detail-page-lineage-tab

There are a few ways to fix this -- `intent="none" outlined` has the styling we're after, but `intent="primary" outlined` produces invalid output.  I couldn't pass `intent={undefined}` to the button because we still want the `primary` default prop value. I ended up moving away from the intent-ish string union to a `primary?: true` prop.

Maybe we come back and change the StyledBytton behavior, but I'm afraid that is more of a rainy day project...

## How I Tested These Changes

<img width="378" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/585132e9-1a73-46cb-8104-6283ce8d8926">
