### PR TITLE
[ui] Don’t show partition summary for partitioned observable source assets #19614

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
@@ -6,6 +6,7 @@ import {AssetEventSystemTags} from './AssetEventSystemTags';
 import {AssetLineageElements} from './AssetLineageElements';
 import {AssetMaterializationUpstreamData} from './AssetMaterializationUpstreamData';
 import {RunlessEventTag} from './RunlessEventTag';
+import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {isRunlessEvent} from './isRunlessEvent';
 import {
   AssetMaterializationFragment,
@@ -24,9 +25,11 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 export const AssetEventDetail = ({
   event,
   assetKey,
+  hidePartitionLinks = false,
 }: {
   assetKey: AssetKeyInput;
   event: AssetMaterializationFragment | AssetObservationFragment;
+  hidePartitionLinks?: boolean;
 }) => {
   const run = event.runOrError?.__typename === 'Run' ? event.runOrError : null;
   const repositoryOrigin = run?.repositoryOrigin;
@@ -66,7 +69,18 @@ export const AssetEventDetail = ({
         {event.partition && (
           <Box flex={{gap: 4, direction: 'column'}}>
             <Subheading>Partition</Subheading>
-            <Link to={`?view=partitions&partition=${event.partition}`}>{event.partition}</Link>
+            {hidePartitionLinks ? (
+              event.partition
+            ) : (
+              <Link
+                to={assetDetailsPathForKey(assetKey, {
+                  view: 'partitions',
+                  partition: event.partition,
+                })}
+              >
+                {event.partition}
+              </Link>
+            )}
           </Box>
         )}
         <Box flex={{gap: 4, direction: 'column'}} style={{minHeight: 64}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
@@ -66,7 +66,11 @@ export const AssetEvents = ({
     (json) => ({types: json?.types || ALL_EVENT_TYPES}),
   );
 
+  // Source assets never have materializations, so we don't want to show the type filter
   const hideFilters = assetNode?.isSource;
+  // Source assets never have a partitions tab, so we shouldn't allow links to it
+  const hidePartitionLinks = assetNode?.isSource;
+
   const grouped = useGroupedEvents(
     xAxis,
     hideFilters || filters.types.includes('materialization') ? materializations : [],
@@ -212,7 +216,11 @@ export const AssetEvents = ({
                 <AssetPartitionDetailEmpty />
               )
             ) : focused?.latest ? (
-              <AssetEventDetail assetKey={assetKey} event={focused.latest} />
+              <AssetEventDetail
+                assetKey={assetKey}
+                event={focused.latest}
+                hidePartitionLinks={hidePartitionLinks}
+              />
             ) : (
               <AssetEventDetailEmpty />
             )}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -1,7 +1,7 @@
 import {gql, useQuery} from '@apollo/client';
 import {Alert, Box, ErrorBoundary, NonIdealState, Spinner, Tag} from '@dagster-io/ui-components';
 import {useContext, useEffect, useMemo} from 'react';
-import {Link, useLocation} from 'react-router-dom';
+import {Link, Redirect, useLocation} from 'react-router-dom';
 
 import {AssetEvents} from './AssetEvents';
 import {AssetFeatureContext} from './AssetFeatureContext';
@@ -26,6 +26,7 @@ import {LaunchAssetObservationButton} from './LaunchAssetObservationButton';
 import {OverdueTag} from './OverdueTag';
 import {UNDERLYING_OPS_ASSET_NODE_FRAGMENT} from './UnderlyingOpsOrGraph';
 import {AssetChecks} from './asset-checks/AssetChecks';
+import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {AssetKey, AssetViewParams} from './types';
 import {
   AssetViewDefinitionNodeFragment,
@@ -166,6 +167,10 @@ export const AssetView = ({assetKey, trace}: Props) => {
     if (definitionQueryResult.loading && !definitionQueryResult.previousData) {
       return <AssetLoadingDefinitionState />;
     }
+    if (definition?.isSource) {
+      return <Redirect to={assetDetailsPathForKey(assetKey, {view: 'events'})} />;
+    }
+
     return (
       <AssetPartitions
         assetKey={assetKey}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -143,7 +143,7 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
           </RowCell>
         ) : null}
         <RowCell>
-          {definition?.partitionDefinition ? (
+          {definition?.partitionDefinition && !definition?.isSource ? (
             <Box flex={{direction: 'column', alignItems: 'flex-start', gap: 4}}>
               <PartitionCountLabels partitionStats={liveData?.partitionStats} />
               <Caption>{partitionCountString(liveData?.partitionStats?.numPartitions)}</Caption>


### PR DESCRIPTION

## Summary & Motivation

Fixes #19614


The asset list now shows the same status line that is shown in the asset DAG:

<img width="1391" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/1a22938c-2620-487c-a6a3-0141a46f5beb">

The events tab's "partition" value is no longer a clickable link to the (non-existent) partitions tab:

<img width="400" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/f57dfa1c-e80f-496e-8e59-fc6b2a9916c4">

If you somehow still manage to land on view=partitions for a source asset, a new check redirects you back to events

## How I Tested These Changes

Tested manually with an observable source asset for now.