### PR TITLE
fix(dbt): read dbt `+meta` from `+config` when present

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -339,7 +339,10 @@ def default_asset_key_fn(dbt_resource_props: Mapping[str, Any]) -> AssetKey:
         dbt models: a dbt model's key is the union of its model name and any schema configured on
             the model itself.
     """
-    dagster_metadata = dbt_resource_props.get("meta", {}).get("dagster", {})
+    dbt_meta = dbt_resource_props.get("config", {}).get("meta", {}) or dbt_resource_props.get(
+        "meta", {}
+    )
+    dagster_metadata = dbt_meta.get("dagster", {})
     asset_key_config = dagster_metadata.get("asset_key", [])
     if asset_key_config:
         return AssetKey(asset_key_config)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_duplicate_source_asset_key/dbt_project.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_duplicate_source_asset_key/dbt_project.yml
@@ -24,3 +24,8 @@ models:
     materialized: table
     staging:
       materialized: view
+
+sources:
+  +meta:
+    dagster:
+      asset_key: ["duplicate"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_duplicate_source_asset_key/models/sources.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_duplicate_source_asset_key/models/sources.yml
@@ -4,16 +4,5 @@ sources:
   - name: jaffle_shop
     tables:
       - name: raw_customers
-        meta:
-          dagster:
-            asset_key: ["duplicate"]
-
       - name: raw_orders
-        meta:
-          dagster:
-            asset_key: ["duplicate"]
-
       - name: raw_payments
-        meta:
-          dagster:
-            asset_key: ["duplicate"]


### PR DESCRIPTION
## Summary & Motivation
From https://docs.getdbt.com/reference/resource-configs/meta:

> Depending on the resource you're configuring, meta may be available within the config property, and/or as a top-level key. (For backwards compatibility, meta is often (but not always) supported as a top-level key, though without the capabilities of config inheritance.)

This affects sources, as `+meta` config inheritance is applied in the top level `+config` field, rather than in the top level `+meta` field.

This change reads from `+config` when present to read `+meta`. Otherwise, we fall back to reading from the top level `+meta` field.

## How I Tested These Changes
pytest
