### PR TITLE
[external-assets] Make external_asset_nodes_from_defs take list

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1412,7 +1412,7 @@ def external_repository_data_from_def(
     resource_datas = repository_def.get_top_level_resources()
     asset_graph = external_asset_nodes_from_defs(
         jobs,
-        assets_defs_by_key=repository_def.assets_defs_by_key,
+        assets_defs=repository_def.asset_graph.assets_defs,
     )
 
     nested_resource_map = _get_nested_resources_map(
@@ -1566,7 +1566,7 @@ def external_asset_checks_from_defs(
 
 def external_asset_nodes_from_defs(
     job_defs: Sequence[JobDefinition],
-    assets_defs_by_key: Mapping[AssetKey, AssetsDefinition],
+    assets_defs: Iterable[AssetsDefinition],
 ) -> Sequence[ExternalAssetNode]:
     node_defs_by_asset_key: Dict[AssetKey, List[Tuple[NodeOutputHandle, JobDefinition]]] = (
         defaultdict(list)
@@ -1733,7 +1733,7 @@ def external_asset_nodes_from_defs(
         )
 
     # Ensure any external assets that are have no nodes in any job are included in the asset graph
-    for asset in assets_defs_by_key.values():
+    for asset in assets_defs:
         for key in [key for key in asset.keys if key not in node_defs_by_asset_key]:
             # This is in place to preserve an implicit behavior in the Dagster UI where stub
             # dependencies were rendered as if they weren't part of the default asset group.

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -53,7 +53,7 @@ def to_external_asset_graph(assets, asset_checks=None) -> AssetGraph:
         return assets + (asset_checks or [])
 
     external_asset_nodes = external_asset_nodes_from_defs(
-        repo.get_all_jobs(), repo.assets_defs_by_key
+        repo.get_all_jobs(), repo.asset_graph.assets_defs
     )
     return ExternalAssetGraph.from_repository_handles_and_external_asset_nodes(
         [(MagicMock(), asset_node) for asset_node in external_asset_nodes],

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -710,7 +710,7 @@ def external_asset_graph_from_assets_by_repo_name(
 
         external_asset_nodes = external_asset_nodes_from_defs(
             repo.get_all_jobs(),
-            repo.assets_defs_by_key,
+            repo.asset_graph.assets_defs,
         )
         repo_handle = MagicMock(repository_name=repo_name)
         from_repository_handles_and_external_asset_nodes.extend(

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -54,7 +54,7 @@ def _get_external_asset_nodes_from_definitions(
     defs: Definitions,
 ) -> Sequence[ExternalAssetNode]:
     repo = defs.get_repository_def()
-    return external_asset_nodes_from_defs(repo.get_all_jobs(), repo.assets_defs_by_key)
+    return external_asset_nodes_from_defs(repo.get_all_jobs(), repo.asset_graph.assets_defs)
 
 
 def test_single_asset_job():


### PR DESCRIPTION
## Summary & Motivation

Make `external_asset_nodes_from_defs` take a sequence of assets defs instead of a dict by key. This is how it is used internally anyway and supports an upstack PR.

## How I Tested These Changes

BK