### PR TITLE
Revert "feat(declarative-instigator-status): delete unloadable instigators in the scheduler daemon (#19988)"

### DIFF
--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -310,7 +310,6 @@ def execute_sensor_iteration(
     tick_retention_settings = instance.get_tick_retention_settings(InstigatorType.SENSOR)
 
     sensors: Dict[str, ExternalSensor] = {}
-
     for location_entry in workspace_snapshot.values():
         code_location = location_entry.code_location
         if code_location:

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -1202,9 +1202,6 @@ def test_bad_load_sensor_repository(
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(invalid_state.instigator_origin_id, invalid_state.selector_id)
         assert len(ticks) == 0
-        assert instance.get_instigator_state(
-            invalid_state.instigator_origin_id, invalid_state.selector_id
-        )
 
 
 def test_bad_load_sensor(executor, instance, workspace_context, external_repo):
@@ -1237,9 +1234,6 @@ def test_bad_load_sensor(executor, instance, workspace_context, external_repo):
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(invalid_state.instigator_origin_id, invalid_state.selector_id)
         assert len(ticks) == 0
-        assert instance.get_instigator_state(
-            invalid_state.instigator_origin_id, invalid_state.selector_id
-        )
 
 
 def test_error_sensor(caplog, executor, instance, workspace_context, external_repo):

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -2231,9 +2231,6 @@ class TestSchedulerRun:
             )
 
             assert len(ticks) == 0
-            assert not scheduler_instance.get_instigator_state(
-                schedule_state.instigator_origin_id, schedule_state.selector_id
-            )
 
     @pytest.mark.parametrize("executor", get_schedule_executors())
     def test_bad_load_schedule(
@@ -2273,9 +2270,6 @@ class TestSchedulerRun:
             )
 
             assert len(ticks) == 0
-            assert not scheduler_instance.get_instigator_state(
-                schedule_state.instigator_origin_id, schedule_state.selector_id
-            )
 
     @pytest.mark.parametrize("executor", get_schedule_executors())
     def test_load_code_location_not_in_workspace(
@@ -2329,9 +2323,6 @@ class TestSchedulerRun:
             )
 
             assert len(ticks) == 0
-            assert not scheduler_instance.get_instigator_state(
-                schedule_state.instigator_origin_id, schedule_state.selector_id
-            )
 
     @pytest.mark.parametrize("executor", get_schedule_executors())
     def test_multiple_schedules_on_different_time_ranges(


### PR DESCRIPTION
## Summary & Motivation
There's some race condition happening with the daemon's copy of the workspace vs what's written in the db.

Reverting this change and investigating further later.

## How I Tested These Changes
bk
