### PR TITLE
[CachingInstanceQueryer] make run_has_tags handle missing run

### DIFF
--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -383,7 +383,12 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         return None
 
     def run_has_tag(self, run_id: str, tag_key: str, tag_value: Optional[str]) -> bool:
-        run_tags = cast(DagsterRun, self._get_run_by_id(run_id)).tags
+        run = self._get_run_by_id(run_id)
+        if run is None:
+            return False
+
+        run_tags = run.tags
+
         if tag_value is None:
             return tag_key in run_tags
         else:


### PR DESCRIPTION
observed an error with stack trace

```
AttributeError: 'NoneType' object has no attribute 'tags'

  File "/dagster/dagster/_daemon/backfill.py", line 49, in execute_backfill_jobs
    yield from execute_asset_backfill_iteration(
  File "/dagster/dagster/_core/execution/asset_backfill.py", line 917, in execute_asset_backfill_iteration
    for result in execute_asset_backfill_iteration_inner(
  File "/dagster/dagster/_core/execution/asset_backfill.py", line 1217, in execute_asset_backfill_iteration_inner
    for updated_materialized_subset in get_asset_backfill_iteration_materialized_partitions(
  File "/dagster/dagster/_core/execution/asset_backfill.py", line 1119, in get_asset_backfill_iteration_materialized_partitions
    records_in_backfill = [
                          ^
  File "/dagster/dagster/_core/execution/asset_backfill.py", line 1122, in <listcomp>
    if instance_queryer.run_has_tag(
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/dagster/dagster/_utils/caching_instance_queryer.py", line 386, in run_has_tag
    run_tags = cast(DagsterRun, self._get_run_by_id(run_id)).tags

```

so instead of casting and assuming we will get a run, actually check it

## How I Tested These Changes

bk, eyes
