### PR TITLE
adding dagster_cloud.yaml to the tutorial example

### DIFF
--- a/examples/tutorial/dagster_cloud.yaml
+++ b/examples/tutorial/dagster_cloud.yaml
@@ -1,0 +1,4 @@
+locations:
+  - location_name: tutorial
+    code_source:
+      package_name: tutorial


### PR DESCRIPTION
## Summary & Motivation

Earlier this year, in the cloud nux, we replaced one of the less-maintained example projects with the tutorial project. but just found out that the tutorial was missing a dagster_cloud.yaml which the cloud NUX assumes the project iwll have.

Adding this to the project

## How I Tested These Changes
