### PR TITLE
[Asset checks] Add back warnings for different gql errors

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -21,7 +21,13 @@ import React, {useContext} from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
-import {ASSET_CHECK_DETAILS_QUERY, MetadataCell} from './AssetCheckDetailModal';
+import {
+  ASSET_CHECK_DETAILS_QUERY,
+  AgentUpgradeRequired,
+  MetadataCell,
+  MigrationRequired,
+  NeedsUserCodeUpgrade,
+} from './AssetCheckDetailModal';
 import {AssetCheckStatusTag} from './AssetCheckStatusTag';
 import {
   EXECUTE_CHECKS_BUTTON_ASSET_NODE_FRAGMENT,
@@ -115,6 +121,17 @@ export const AssetChecks = ({
 
   if (!data) {
     return null;
+  }
+
+  if (data.assetNodeOrError.__typename === 'AssetNode') {
+    switch (data.assetNodeOrError.assetChecksOrError.__typename) {
+      case 'AssetCheckNeedsAgentUpgradeError':
+        return <AgentUpgradeRequired />;
+      case 'AssetCheckNeedsMigrationError':
+        return <MigrationRequired />;
+      case 'AssetCheckNeedsUserCodeUpgrade':
+        return <NeedsUserCodeUpgrade />;
+    }
   }
 
   if (!checks.length || !selectedCheck || !assetNode) {


### PR DESCRIPTION
## Summary & Motivation

tested with storybook:

![Screenshot 2024-03-06 at 5 48 28 PM](https://github.com/dagster-io/dagster/assets/2286579/5530ab08-7dca-4e29-972a-90e093f06419)
![Screenshot 2024-03-06 at 5 50 12 PM](https://github.com/dagster-io/dagster/assets/2286579/659a7c24-7a0b-4231-a49c-05ecd47491d3)
![Screenshot 2024-03-06 at 5 50 07 PM](https://github.com/dagster-io/dagster/assets/2286579/187ba2b5-fa08-4829-a4d0-6f464e448a41)
