### PR TITLE
[graphql] Omit run from inProgressRunIds once a materialization has occurred

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -206,6 +206,19 @@ def get_assets_latest_info(
         for asset_record in asset_records
     }
 
+    # Build a lookup table of asset keys to last materialization run IDs. We will filter these
+    # run IDs out of the "in progress" run lists that are generated below since they have already
+    # emitted an output for the run.
+    latest_materialization_run_id_by_asset: Dict[AssetKey, Optional[str]] = {
+        asset_record.asset_entry.asset_key: (
+            asset_record.asset_entry.last_materialization.run_id
+            if asset_record.asset_entry.last_materialization
+            and asset_record.asset_entry.asset_key in step_keys_by_asset
+            else None
+        )
+        for asset_record in asset_records
+    }
+
     latest_run_ids_by_asset: Dict[
         AssetKey, str
     ] = {  # last_run_id column is written to upon run creation (via ASSET_MATERIALIZATION_PLANNED event)
@@ -227,7 +240,12 @@ def get_assets_latest_info(
     (
         in_progress_run_ids_by_asset,
         unstarted_run_ids_by_asset,
-    ) = _get_in_progress_runs_for_assets(graphene_info, in_progress_records, step_keys_by_asset)
+    ) = _get_in_progress_runs_for_assets(
+        graphene_info,
+        in_progress_records,
+        step_keys_by_asset,
+        latest_materialization_run_id_by_asset,
+    )
 
     from .fetch_assets import get_unique_asset_id
 
@@ -263,6 +281,7 @@ def _get_in_progress_runs_for_assets(
     graphene_info: "ResolveInfo",
     in_progress_records: Sequence[RunRecord],
     step_keys_by_asset: Mapping[AssetKey, Sequence[str]],
+    latest_materialization_run_id_by_asset: Dict[AssetKey, Optional[str]],
 ) -> Tuple[Mapping[AssetKey, AbstractSet[str]], Mapping[AssetKey, AbstractSet[str]]]:
     # Build mapping of step key to the assets it generates
     asset_key_by_step_key = defaultdict(set)
@@ -297,6 +316,8 @@ def _get_in_progress_runs_for_assets(
                     step_stats_by_asset[asset_key].append(step_stat)
 
             for asset in selected_assets:
+                if latest_materialization_run_id_by_asset.get(asset) == run.run_id:
+                    continue
                 asset_step_stats = step_stats_by_asset.get(asset)
                 if asset_step_stats:
                     # asset_step_stats will contain all steps that are in progress or complete
@@ -313,6 +334,8 @@ def _get_in_progress_runs_for_assets(
         else:
             # the run never began execution, all steps are unstarted
             for asset in selected_assets:
+                if latest_materialization_run_id_by_asset.get(asset) == run.run_id:
+                    continue
                 unstarted_run_ids_by_asset[asset].add(record.dagster_run.run_id)
 
     return in_progress_run_ids_by_asset, unstarted_run_ids_by_asset

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
@@ -590,7 +590,231 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.51942e62cef26febc51e5192cd1fefba7b856916": {
+        "Shape.62edccaf30696e25335ae92685bdc41e204e30e6": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "dummy_io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "hanging_asset_resource",
+              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {}}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.811a60b4c43530c3d6100304f377dbd2d3045291": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "hanging_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "my_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "never_runs_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.811a60b4c43530c3d6100304f377dbd2d3045291",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "file",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.bc8cd50dda2a812117fc13b85d227c8d38193ef2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"downstream_dynamic_partitioned_asset\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"never_runs_asset\": {}, \"output_then_hang_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}, \"upstream_dynamic_partitioned_asset\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.c7272640d3971d0239f1518d61e4193c378d65e9"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": true,
+              "name": "resources",
+              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.bc8cd50dda2a812117fc13b85d227c8d38193ef2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.c7272640d3971d0239f1518d61e4193c378d65e9": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -832,6 +1056,15 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "output_then_hang_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
               "default_value_as_json_str": "{\"config\": {}}",
               "description": null,
               "is_required": false,
@@ -912,231 +1145,7 @@
             }
           ],
           "given_name": null,
-          "key": "Shape.51942e62cef26febc51e5192cd1fefba7b856916",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.62edccaf30696e25335ae92685bdc41e204e30e6": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "dummy_io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "hanging_asset_resource",
-              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {}}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.811a60b4c43530c3d6100304f377dbd2d3045291": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "hanging_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "my_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "never_runs_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.811a60b4c43530c3d6100304f377dbd2d3045291",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "file",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.a4f106a4f8bd570ece0fcb2d629cd593752ab958": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"downstream_dynamic_partitioned_asset\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"never_runs_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}, \"upstream_dynamic_partitioned_asset\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.51942e62cef26febc51e5192cd1fefba7b856916"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": true,
-              "name": "resources",
-              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.a4f106a4f8bd570ece0fcb2d629cd593752ab958",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
+          "key": "Shape.c7272640d3971d0239f1518d61e4193c378d65e9",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -1730,6 +1739,14 @@
           "__class__": "SolidInvocationSnap",
           "input_dep_snaps": [],
           "is_dynamic_mapped": false,
+          "solid_def_name": "output_then_hang_asset",
+          "solid_name": "output_then_hang_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
           "solid_def_name": "subsettable_checked_multi_asset",
           "solid_name": "subsettable_checked_multi_asset",
           "tags": {}
@@ -1894,7 +1911,7 @@
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.a4f106a4f8bd570ece0fcb2d629cd593752ab958"
+        "root_config_key": "Shape.bc8cd50dda2a812117fc13b85d227c8d38193ef2"
       }
     ],
     "name": "__ASSET_JOB_0",
@@ -2889,6 +2906,35 @@
             }
           ],
           "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "output_then_hang_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [
+            "hanging_asset_resource"
+          ],
           "tags": {}
         },
         {
@@ -8819,56 +8865,6 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.369eb128583ce77ca481e7ee6d631dc90fe1932c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"executable_asset\": {}, \"fail_partition_materialization\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"hanging_partition_asset\": {}, \"never_runs_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}, \"yield_partition_materialization\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.ea1d226bbbbb97576c56cfd54f26dcbae2794d9a"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": true,
-              "name": "resources",
-              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.369eb128583ce77ca481e7ee6d631dc90fe1932c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
         "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -8970,194 +8966,7 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "dummy_io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "hanging_asset_resource",
-              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {}}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.811a60b4c43530c3d6100304f377dbd2d3045291": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "hanging_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "my_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "never_runs_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.811a60b4c43530c3d6100304f377dbd2d3045291",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "file",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.ea1d226bbbbb97576c56cfd54f26dcbae2794d9a": {
+        "Shape.72c7c7672122cde99157e5b1d190830250f8668d": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -9408,6 +9217,15 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "output_then_hang_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
               "default_value_as_json_str": "{\"config\": {}}",
               "description": null,
               "is_required": false,
@@ -9488,7 +9306,244 @@
             }
           ],
           "given_name": null,
-          "key": "Shape.ea1d226bbbbb97576c56cfd54f26dcbae2794d9a",
+          "key": "Shape.72c7c7672122cde99157e5b1d190830250f8668d",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "dummy_io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "hanging_asset_resource",
+              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {}}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.811a60b4c43530c3d6100304f377dbd2d3045291": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "hanging_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "my_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "never_runs_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.811a60b4c43530c3d6100304f377dbd2d3045291",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "file",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.bebb6738b1a459d594b06bc216f4af2ffdbecd87": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"executable_asset\": {}, \"fail_partition_materialization\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"hanging_partition_asset\": {}, \"never_runs_asset\": {}, \"output_then_hang_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}, \"yield_partition_materialization\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.72c7c7672122cde99157e5b1d190830250f8668d"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": true,
+              "name": "resources",
+              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.bebb6738b1a459d594b06bc216f4af2ffdbecd87",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -10041,6 +10096,14 @@
           "__class__": "SolidInvocationSnap",
           "input_dep_snaps": [],
           "is_dynamic_mapped": false,
+          "solid_def_name": "output_then_hang_asset",
+          "solid_name": "output_then_hang_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
           "solid_def_name": "subsettable_checked_multi_asset",
           "solid_name": "subsettable_checked_multi_asset",
           "tags": {}
@@ -10205,7 +10268,7 @@
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.369eb128583ce77ca481e7ee6d631dc90fe1932c"
+        "root_config_key": "Shape.bebb6738b1a459d594b06bc216f4af2ffdbecd87"
       }
     ],
     "name": "__ASSET_JOB_5",
@@ -11222,6 +11285,35 @@
             }
           ],
           "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "output_then_hang_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [
+            "hanging_asset_resource"
+          ],
           "tags": {}
         },
         {
@@ -16353,7 +16445,7 @@
   'd65a072229c6e8fc80db02c8d06067f3b0b48305'
 # ---
 # name: test_all_snapshot_ids[11]
-  '96e4cced37a2bfebe95cdb652d031275e65a0577'
+  'e5ac3743cbfc741199017e8d2ec8bff52bbbef4e'
 # ---
 # name: test_all_snapshot_ids[120]
   '''
@@ -17879,6 +17971,1042 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
+        "Shape.430bb6ff8d203ca0ff0a224523b286e0109da95e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"output_then_hang_asset\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.e04fad9a05c90983540f9c3eb316ede838d946e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": true,
+              "name": "resources",
+              "type_key": "Shape.fe21c8e7bb74501f89b285a2b35a543f648db2c8"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.430bb6ff8d203ca0ff0a224523b286e0109da95e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f2a71367507edd1b8e64f739222c4312b3691b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "file",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e04fad9a05c90983540f9c3eb316ede838d946e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "output_then_hang_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e04fad9a05c90983540f9c3eb316ede838d946e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.fe21c8e7bb74501f89b285a2b35a543f648db2c8": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "dummy_io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "hanging_asset_resource",
+              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.fe21c8e7bb74501f89b285a2b35a543f648db2c8",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        },
+        "StringSourceType": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "StringSourceType",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.2571019f1a5201853d11032145ac3e534067f214"
+          ]
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "output_then_hang_asset",
+          "solid_name": "output_then_hang_asset",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "output_then_hang_job",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": null,
+            "name": "dummy_io_manager"
+          },
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            },
+            "description": null,
+            "name": "hanging_asset_resource"
+          },
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.430bb6ff8d203ca0ff0a224523b286e0109da95e"
+      }
+    ],
+    "name": "output_then_hang_job",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "output_then_hang_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [
+            "hanging_asset_resource"
+          ],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[123]
+  '4b80803d1f02acb0a6b7b3872f69b4fb84ecc372'
+# ---
+# name: test_all_snapshot_ids[124]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.2571019f1a5201853d11032145ac3e534067f214": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "env",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.2571019f1a5201853d11032145ac3e534067f214",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "base_dir",
+              "type_key": "StringSourceType"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
         "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -18420,10 +19548,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[123]
+# name: test_all_snapshot_ids[125]
   'd006ed500ce7bd68754d2c5ef1ad29ca176a0e69'
 # ---
-# name: test_all_snapshot_ids[124]
+# name: test_all_snapshot_ids[126]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -19277,10 +20405,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[125]
+# name: test_all_snapshot_ids[127]
   '88c326b7e07c8c537ecd8086fd6429436a46c66f'
 # ---
-# name: test_all_snapshot_ids[126]
+# name: test_all_snapshot_ids[128]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -20180,913 +21308,8 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[127]
-  'a73f4941b2735f3a261d9617abaaed09a88aaebc'
-# ---
-# name: test_all_snapshot_ids[128]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.13e52aa6878a8e9f6b5fea1f6086cb52486e3c95": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "R1",
-              "type_key": "Shape.fe2c8a3955b895767072f0aa1d243b6e1714df90"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.13e52aa6878a8e9f6b5fea1f6086cb52486e3c95",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.1f049499585829308eb97bdfcb96ec7cad460ad6": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"op_with_required_resource\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.e184cc449eaa96b4c59f30cbdf34d7efa47bb273"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": true,
-              "name": "resources",
-              "type_key": "Shape.13e52aa6878a8e9f6b5fea1f6086cb52486e3c95"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1f049499585829308eb97bdfcb96ec7cad460ad6",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e184cc449eaa96b4c59f30cbdf34d7efa47bb273": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "op_with_required_resource",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e184cc449eaa96b4c59f30cbdf34d7efa47bb273",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.fe2c8a3955b895767072f0aa1d243b6e1714df90": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.fe2c8a3955b895767072f0aa1d243b6e1714df90",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "op_with_required_resource",
-          "solid_name": "op_with_required_resource",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "required_resource_config_job",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Int"
-            },
-            "description": null,
-            "name": "R1"
-          },
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.1f049499585829308eb97bdfcb96ec7cad460ad6"
-      }
-    ],
-    "name": "required_resource_config_job",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "op_with_required_resource",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [
-            "R1"
-          ],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
 # name: test_all_snapshot_ids[129]
-  '11f4785f61153adc6cca6935748af3807b59eee9'
+  'a73f4941b2735f3a261d9617abaaed09a88aaebc'
 # ---
 # name: test_all_snapshot_ids[12]
   '''
@@ -21702,56 +21925,6 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.63e92c9bfb76f4eabb010fbb660141728852d18e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"downstream_time_partitioned_asset\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"never_runs_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}, \"upstream_time_partitioned_asset\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.759dc59f975b8489cb2a1ae61168e3c9d6a4c905"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": true,
-              "name": "resources",
-              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.63e92c9bfb76f4eabb010fbb660141728852d18e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
         "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -21816,7 +21989,48 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.759dc59f975b8489cb2a1ae61168e3c9d6a4c905": {
+        "Shape.811a60b4c43530c3d6100304f377dbd2d3045291": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "hanging_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "my_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "never_runs_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.811a60b4c43530c3d6100304f377dbd2d3045291",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.82be1cb119c0afb98cbceb79868d6b94195f0507": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -22058,6 +22272,15 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "output_then_hang_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
               "default_value_as_json_str": "{\"config\": {}}",
               "description": null,
               "is_required": false,
@@ -22138,14 +22361,14 @@
             }
           ],
           "given_name": null,
-          "key": "Shape.759dc59f975b8489cb2a1ae61168e3c9d6a4c905",
+          "key": "Shape.82be1cb119c0afb98cbceb79868d6b94195f0507",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.811a60b4c43530c3d6100304f377dbd2d3045291": {
+        "Shape.8c2318d782183897dedc85d2cd27e8c5eef1bac8": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -22153,33 +22376,42 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
               "is_required": false,
-              "name": "hanging_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
             },
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
               "default_value_as_json_str": "{}",
-              "description": null,
+              "description": "Configure how loggers emit messages within a run.",
               "is_required": false,
-              "name": "my_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
             },
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
+              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"downstream_time_partitioned_asset\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"never_runs_asset\": {}, \"output_then_hang_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}, \"upstream_time_partitioned_asset\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
               "is_required": false,
-              "name": "never_runs_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+              "name": "ops",
+              "type_key": "Shape.82be1cb119c0afb98cbceb79868d6b94195f0507"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": true,
+              "name": "resources",
+              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
             }
           ],
           "given_name": null,
-          "key": "Shape.811a60b4c43530c3d6100304f377dbd2d3045291",
+          "key": "Shape.8c2318d782183897dedc85d2cd27e8c5eef1bac8",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -22819,6 +23051,14 @@
           "__class__": "SolidInvocationSnap",
           "input_dep_snaps": [],
           "is_dynamic_mapped": false,
+          "solid_def_name": "output_then_hang_asset",
+          "solid_name": "output_then_hang_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
           "solid_def_name": "subsettable_checked_multi_asset",
           "solid_name": "subsettable_checked_multi_asset",
           "tags": {}
@@ -22983,7 +23223,7 @@
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.63e92c9bfb76f4eabb010fbb660141728852d18e"
+        "root_config_key": "Shape.8c2318d782183897dedc85d2cd27e8c5eef1bac8"
       }
     ],
     "name": "__ASSET_JOB_6",
@@ -23984,6 +24224,35 @@
           "__class__": "SolidDefSnap",
           "config_field_snap": {
             "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "output_then_hang_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [
+            "hanging_asset_resource"
+          ],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
             "default_provided": true,
             "default_value_as_json_str": "{}",
             "description": null,
@@ -24276,6 +24545,911 @@
   '''
 # ---
 # name: test_all_snapshot_ids[130]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.13e52aa6878a8e9f6b5fea1f6086cb52486e3c95": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "R1",
+              "type_key": "Shape.fe2c8a3955b895767072f0aa1d243b6e1714df90"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.13e52aa6878a8e9f6b5fea1f6086cb52486e3c95",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1f049499585829308eb97bdfcb96ec7cad460ad6": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"op_with_required_resource\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.e184cc449eaa96b4c59f30cbdf34d7efa47bb273"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": true,
+              "name": "resources",
+              "type_key": "Shape.13e52aa6878a8e9f6b5fea1f6086cb52486e3c95"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1f049499585829308eb97bdfcb96ec7cad460ad6",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e184cc449eaa96b4c59f30cbdf34d7efa47bb273": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "op_with_required_resource",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e184cc449eaa96b4c59f30cbdf34d7efa47bb273",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.fe2c8a3955b895767072f0aa1d243b6e1714df90": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.fe2c8a3955b895767072f0aa1d243b6e1714df90",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "op_with_required_resource",
+          "solid_name": "op_with_required_resource",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "required_resource_config_job",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Int"
+            },
+            "description": null,
+            "name": "R1"
+          },
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.1f049499585829308eb97bdfcb96ec7cad460ad6"
+      }
+    ],
+    "name": "required_resource_config_job",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "op_with_required_resource",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [
+            "R1"
+          ],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[131]
+  '11f4785f61153adc6cca6935748af3807b59eee9'
+# ---
+# name: test_all_snapshot_ids[132]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -25177,10 +26351,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[131]
+# name: test_all_snapshot_ids[133]
   '2b43566d7b3de2138b12c91b6953d6f1ddde0140'
 # ---
-# name: test_all_snapshot_ids[132]
+# name: test_all_snapshot_ids[134]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -26317,10 +27491,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[133]
+# name: test_all_snapshot_ids[135]
   'b07b89c1664d4a248bc1a39974a91b31d8956c54'
 # ---
-# name: test_all_snapshot_ids[134]
+# name: test_all_snapshot_ids[136]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -27479,10 +28653,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[135]
+# name: test_all_snapshot_ids[137]
   '9a9a09da6b3a1dbab13bfde5e155c0f097dd22a5'
 # ---
-# name: test_all_snapshot_ids[136]
+# name: test_all_snapshot_ids[138]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -28450,10 +29624,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[137]
+# name: test_all_snapshot_ids[139]
   'b131f0bc1872f377636fbf002a3ad86049c1e8af'
 # ---
-# name: test_all_snapshot_ids[138]
+# name: test_all_snapshot_ids[13]
+  'c7692c22ea80315f2d23aac853f3f19262a1cf70'
+# ---
+# name: test_all_snapshot_ids[140]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -29439,13 +30616,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[139]
+# name: test_all_snapshot_ids[141]
   'ca68b52613bfcadc230b3dc1ec7e1045f9bc5836'
 # ---
-# name: test_all_snapshot_ids[13]
-  '101218d0aa7d12af14bbacabc9f7edf945942a79'
-# ---
-# name: test_all_snapshot_ids[140]
+# name: test_all_snapshot_ids[142]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -30299,10 +31473,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[141]
+# name: test_all_snapshot_ids[143]
   '4fbe2b21985de715173a8d630c5d1506a0c7f040'
 # ---
-# name: test_all_snapshot_ids[142]
+# name: test_all_snapshot_ids[144]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -31156,10 +32330,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[143]
+# name: test_all_snapshot_ids[145]
   'c58bbee5967b5e43b907f2ee09bfa26b5b017899'
 # ---
-# name: test_all_snapshot_ids[144]
+# name: test_all_snapshot_ids[146]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -32013,10 +33187,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[145]
+# name: test_all_snapshot_ids[147]
   '9109ebc6447db70cdcd17a7bf8b90ec61ffd02fe'
 # ---
-# name: test_all_snapshot_ids[146]
+# name: test_all_snapshot_ids[148]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -32870,10 +34044,3243 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[147]
+# name: test_all_snapshot_ids[149]
   '673ec5c1c0fce5ffec0506edd32bcdbd018e79bb'
 # ---
-# name: test_all_snapshot_ids[148]
+# name: test_all_snapshot_ids[14]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.2571019f1a5201853d11032145ac3e534067f214": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "env",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.2571019f1a5201853d11032145ac3e534067f214",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "base_dir",
+              "type_key": "StringSourceType"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.35d3e42b53e66506c5867f04644849cd03763bc6": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}",
+              "description": null,
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.811a60b4c43530c3d6100304f377dbd2d3045291"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.35d3e42b53e66506c5867f04644849cd03763bc6",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f2a71367507edd1b8e64f739222c4312b3691b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.62edccaf30696e25335ae92685bdc41e204e30e6": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "dummy_io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "hanging_asset_resource",
+              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {}}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.8065bf110a1aa152aa025e3f9332ea39b40973b3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_1",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_1_my_check",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_2",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_3",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_one",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_two",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "asset_yields_observation",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "bar",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "baz",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "check_in_op_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "downstream_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "executable_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "first_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "foo",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "foo_bar",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "fresh_diamond_bottom",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "fresh_diamond_left",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "fresh_diamond_right",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "fresh_diamond_top",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "grouped_asset_1",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "grouped_asset_2",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "grouped_asset_4",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "hanging_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}",
+              "description": null,
+              "is_required": false,
+              "name": "hanging_graph",
+              "type_key": "Shape.35d3e42b53e66506c5867f04644849cd03763bc6"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "never_runs_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "output_then_hang_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "single_run_backfill_policy_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {}}",
+              "description": null,
+              "is_required": false,
+              "name": "subsettable_checked_multi_asset",
+              "type_key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "typed_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {}}",
+              "description": null,
+              "is_required": false,
+              "name": "typed_multi_asset",
+              "type_key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "unconnected",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "ungrouped_asset_3",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "ungrouped_asset_5",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "unpartitioned_upstream_of_partitioned",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "untyped_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "upstream_daily_partitioned_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.8065bf110a1aa152aa025e3f9332ea39b40973b3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.811a60b4c43530c3d6100304f377dbd2d3045291": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "hanging_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "my_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "never_runs_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.811a60b4c43530c3d6100304f377dbd2d3045291",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "file",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.ec380ad19fb2e34793ca8937d73ffe6d351a53fa": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"never_runs_asset\": {}, \"output_then_hang_asset\": {}, \"single_run_backfill_policy_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}, \"upstream_daily_partitioned_asset\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.8065bf110a1aa152aa025e3f9332ea39b40973b3"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": true,
+              "name": "resources",
+              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.ec380ad19fb2e34793ca8937d73ffe6d351a53fa",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        },
+        "StringSourceType": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "StringSourceType",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.2571019f1a5201853d11032145ac3e534067f214"
+          ]
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_1",
+          "solid_name": "asset_1",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "asset_1",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "asset_1"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_1_my_check",
+          "solid_name": "asset_1_my_check",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "asset_1",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "asset_1"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_2",
+          "solid_name": "asset_2",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "asset_2",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "asset_2"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_3",
+          "solid_name": "asset_3",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_one",
+          "solid_name": "asset_one",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "asset_one",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "asset_one"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_two",
+          "solid_name": "asset_two",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "asset_yields_observation",
+          "solid_name": "asset_yields_observation",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "bar",
+          "solid_name": "bar",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "foo_bar",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "foo_bar"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "baz",
+          "solid_name": "baz",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "check_in_op_asset",
+          "solid_name": "check_in_op_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "hanging_graph",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "hanging_graph"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "downstream_asset",
+          "solid_name": "downstream_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "unexecutable_asset",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": []
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "executable_asset",
+          "solid_name": "executable_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "dummy_source_asset",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": []
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "first_asset",
+          "solid_name": "first_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "foo",
+          "solid_name": "foo",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "bar",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "bar"
+                }
+              ]
+            },
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "foo",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "foo"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "foo_bar",
+          "solid_name": "foo_bar",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "fresh_diamond_left",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "fresh_diamond_left"
+                }
+              ]
+            },
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "fresh_diamond_right",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "fresh_diamond_right"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "fresh_diamond_bottom",
+          "solid_name": "fresh_diamond_bottom",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "fresh_diamond_top",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "fresh_diamond_top"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "fresh_diamond_left",
+          "solid_name": "fresh_diamond_left",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "fresh_diamond_top",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "fresh_diamond_top"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "fresh_diamond_right",
+          "solid_name": "fresh_diamond_right",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "diamond_source",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": []
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "fresh_diamond_top",
+          "solid_name": "fresh_diamond_top",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "grouped_asset_1",
+          "solid_name": "grouped_asset_1",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "grouped_asset_2",
+          "solid_name": "grouped_asset_2",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "grouped_asset_4",
+          "solid_name": "grouped_asset_4",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "first_asset",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "first_asset"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "hanging_asset",
+          "solid_name": "hanging_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "hanging_graph",
+          "solid_name": "hanging_graph",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "hanging_asset",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "hanging_asset"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "never_runs_asset",
+          "solid_name": "never_runs_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "output_then_hang_asset",
+          "solid_name": "output_then_hang_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "single_run_backfill_policy_asset",
+          "solid_name": "single_run_backfill_policy_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "subsettable_checked_multi_asset",
+          "solid_name": "subsettable_checked_multi_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "int_asset",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "int_asset",
+                  "solid_name": "typed_multi_asset"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "typed_asset",
+          "solid_name": "typed_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "typed_multi_asset",
+          "solid_name": "typed_multi_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "unconnected",
+          "solid_name": "unconnected",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "ungrouped_asset_3",
+          "solid_name": "ungrouped_asset_3",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "ungrouped_asset_5",
+          "solid_name": "ungrouped_asset_5",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "unpartitioned_upstream_of_partitioned",
+          "solid_name": "unpartitioned_upstream_of_partitioned",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "typed_asset",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "typed_asset"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "untyped_asset",
+          "solid_name": "untyped_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "unpartitioned_upstream_of_partitioned",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "unpartitioned_upstream_of_partitioned"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "upstream_daily_partitioned_asset",
+          "solid_name": "upstream_daily_partitioned_asset",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "__ASSET_JOB_7",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": null,
+            "name": "dummy_io_manager"
+          },
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            },
+            "description": null,
+            "name": "hanging_asset_resource"
+          },
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.ec380ad19fb2e34793ca8937d73ffe6d351a53fa"
+      }
+    ],
+    "name": "__ASSET_JOB_7",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [
+        {
+          "__class__": "CompositeSolidDefSnap",
+          "config_field_snap": null,
+          "dep_structure_snapshot": {
+            "__class__": "DependencyStructureSnapshot",
+            "solid_invocation_snaps": [
+              {
+                "__class__": "SolidInvocationSnap",
+                "input_dep_snaps": [
+                  {
+                    "__class__": "InputDependencySnap",
+                    "input_name": "my_op",
+                    "is_dynamic_collect": false,
+                    "upstream_output_snaps": [
+                      {
+                        "__class__": "OutputHandleSnap",
+                        "output_name": "result",
+                        "solid_name": "my_op"
+                      }
+                    ]
+                  }
+                ],
+                "is_dynamic_mapped": false,
+                "solid_def_name": "hanging_op",
+                "solid_name": "hanging_op",
+                "tags": {}
+              },
+              {
+                "__class__": "SolidInvocationSnap",
+                "input_dep_snaps": [],
+                "is_dynamic_mapped": false,
+                "solid_def_name": "my_op",
+                "solid_name": "my_op",
+                "tags": {}
+              },
+              {
+                "__class__": "SolidInvocationSnap",
+                "input_dep_snaps": [
+                  {
+                    "__class__": "InputDependencySnap",
+                    "input_name": "hanging_op",
+                    "is_dynamic_collect": false,
+                    "upstream_output_snaps": [
+                      {
+                        "__class__": "OutputHandleSnap",
+                        "output_name": "result",
+                        "solid_name": "hanging_op"
+                      }
+                    ]
+                  }
+                ],
+                "is_dynamic_mapped": false,
+                "solid_def_name": "never_runs_op",
+                "solid_name": "never_runs_op",
+                "tags": {}
+              }
+            ]
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "input_mapping_snaps": [],
+          "name": "hanging_graph",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "output_mapping_snaps": [
+            {
+              "__class__": "OutputMappingSnap",
+              "external_output_name": "result",
+              "mapped_output_name": "result",
+              "mapped_solid_name": "never_runs_op"
+            }
+          ],
+          "tags": {}
+        }
+      ],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "asset_1",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "asset_1"
+            }
+          ],
+          "name": "asset_1_my_check",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Nothing",
+              "description": null,
+              "name": "asset_1"
+            }
+          ],
+          "name": "asset_2",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Nothing",
+              "description": null,
+              "name": "asset_2"
+            }
+          ],
+          "name": "asset_3",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "asset_one",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "asset_one"
+            }
+          ],
+          "name": "asset_two",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "asset_yields_observation",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "bar",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "foo_bar"
+            }
+          ],
+          "name": "baz",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "check_in_op_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "check_in_op_asset_my_check"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "hanging_graph"
+            }
+          ],
+          "name": "downstream_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "unexecutable_asset"
+            }
+          ],
+          "name": "executable_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Nothing",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "dummy_source_asset"
+            }
+          ],
+          "name": "first_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "foo",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "bar"
+            },
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "foo"
+            }
+          ],
+          "name": "foo_bar",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "fresh_diamond_left"
+            },
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "fresh_diamond_right"
+            }
+          ],
+          "name": "fresh_diamond_bottom",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "fresh_diamond_top"
+            }
+          ],
+          "name": "fresh_diamond_left",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "fresh_diamond_top"
+            }
+          ],
+          "name": "fresh_diamond_right",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Nothing",
+              "description": null,
+              "name": "diamond_source"
+            }
+          ],
+          "name": "fresh_diamond_top",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "grouped_asset_1",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "grouped_asset_2",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "grouped_asset_4",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": "Asset that hangs forever, used to test in-progress ops.",
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "first_asset"
+            }
+          ],
+          "name": "hanging_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [
+            "hanging_asset_resource"
+          ],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "my_op"
+            }
+          ],
+          "name": "hanging_op",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [
+            "hanging_asset_resource"
+          ],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "my_op",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "hanging_asset"
+            }
+          ],
+          "name": "never_runs_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "hanging_op"
+            }
+          ],
+          "name": "never_runs_op",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "output_then_hang_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [
+            "hanging_asset_resource"
+          ],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "single_run_backfill_policy_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "subsettable_checked_multi_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": false,
+              "name": "one"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": false,
+              "name": "two"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": false,
+              "name": "one_my_check"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": false,
+              "name": "one_my_other_check"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "int_asset"
+            }
+          ],
+          "name": "typed_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Int",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "typed_multi_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Int",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "int_asset"
+            },
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "String",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "str_asset"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "unconnected",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "ungrouped_asset_3",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "ungrouped_asset_5",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "unpartitioned_upstream_of_partitioned",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "typed_asset"
+            }
+          ],
+          "name": "untyped_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "unpartitioned_upstream_of_partitioned"
+            }
+          ],
+          "name": "upstream_daily_partitioned_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[150]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -34114,3197 +38521,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[149]
+# name: test_all_snapshot_ids[151]
   '91aa79ab9d26309c5caa7ea69daa1741fda34362'
 # ---
-# name: test_all_snapshot_ids[14]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.2571019f1a5201853d11032145ac3e534067f214": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "env",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.2571019f1a5201853d11032145ac3e534067f214",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "base_dir",
-              "type_key": "StringSourceType"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.35d3e42b53e66506c5867f04644849cd03763bc6": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}",
-              "description": null,
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.811a60b4c43530c3d6100304f377dbd2d3045291"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.35d3e42b53e66506c5867f04644849cd03763bc6",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f2a71367507edd1b8e64f739222c4312b3691b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.62edccaf30696e25335ae92685bdc41e204e30e6": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "dummy_io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "hanging_asset_resource",
-              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {}}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.7c69ef3a8e6b7346ecb1b5e965def0559aca46b5": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"never_runs_asset\": {}, \"single_run_backfill_policy_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}, \"upstream_daily_partitioned_asset\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.8353a3e5f257cef7ac8ab4b6a7f24acfc1bcb46e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": true,
-              "name": "resources",
-              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.7c69ef3a8e6b7346ecb1b5e965def0559aca46b5",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.811a60b4c43530c3d6100304f377dbd2d3045291": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "hanging_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "my_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "never_runs_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.811a60b4c43530c3d6100304f377dbd2d3045291",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.8353a3e5f257cef7ac8ab4b6a7f24acfc1bcb46e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "asset_1",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "asset_1_my_check",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "asset_2",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "asset_3",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "asset_one",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "asset_two",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "asset_yields_observation",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "bar",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "baz",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "check_in_op_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "downstream_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "executable_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "first_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "foo",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "foo_bar",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "fresh_diamond_bottom",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "fresh_diamond_left",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "fresh_diamond_right",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "fresh_diamond_top",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "grouped_asset_1",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "grouped_asset_2",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "grouped_asset_4",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "hanging_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}",
-              "description": null,
-              "is_required": false,
-              "name": "hanging_graph",
-              "type_key": "Shape.35d3e42b53e66506c5867f04644849cd03763bc6"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "never_runs_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "single_run_backfill_policy_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {}}",
-              "description": null,
-              "is_required": false,
-              "name": "subsettable_checked_multi_asset",
-              "type_key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "typed_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {}}",
-              "description": null,
-              "is_required": false,
-              "name": "typed_multi_asset",
-              "type_key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "unconnected",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "ungrouped_asset_3",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "ungrouped_asset_5",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "unpartitioned_upstream_of_partitioned",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "untyped_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "upstream_daily_partitioned_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.8353a3e5f257cef7ac8ab4b6a7f24acfc1bcb46e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "file",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        },
-        "StringSourceType": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "StringSourceType",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.2571019f1a5201853d11032145ac3e534067f214"
-          ]
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "asset_1",
-          "solid_name": "asset_1",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "asset_1",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "asset_1"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "asset_1_my_check",
-          "solid_name": "asset_1_my_check",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "asset_1",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "asset_1"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "asset_2",
-          "solid_name": "asset_2",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "asset_2",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "asset_2"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "asset_3",
-          "solid_name": "asset_3",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "asset_one",
-          "solid_name": "asset_one",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "asset_one",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "asset_one"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "asset_two",
-          "solid_name": "asset_two",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "asset_yields_observation",
-          "solid_name": "asset_yields_observation",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "bar",
-          "solid_name": "bar",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "foo_bar",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "foo_bar"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "baz",
-          "solid_name": "baz",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "check_in_op_asset",
-          "solid_name": "check_in_op_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "hanging_graph",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "hanging_graph"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "downstream_asset",
-          "solid_name": "downstream_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "unexecutable_asset",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": []
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "executable_asset",
-          "solid_name": "executable_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "dummy_source_asset",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": []
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "first_asset",
-          "solid_name": "first_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "foo",
-          "solid_name": "foo",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "bar",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "bar"
-                }
-              ]
-            },
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "foo",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "foo"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "foo_bar",
-          "solid_name": "foo_bar",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "fresh_diamond_left",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "fresh_diamond_left"
-                }
-              ]
-            },
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "fresh_diamond_right",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "fresh_diamond_right"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "fresh_diamond_bottom",
-          "solid_name": "fresh_diamond_bottom",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "fresh_diamond_top",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "fresh_diamond_top"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "fresh_diamond_left",
-          "solid_name": "fresh_diamond_left",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "fresh_diamond_top",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "fresh_diamond_top"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "fresh_diamond_right",
-          "solid_name": "fresh_diamond_right",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "diamond_source",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": []
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "fresh_diamond_top",
-          "solid_name": "fresh_diamond_top",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "grouped_asset_1",
-          "solid_name": "grouped_asset_1",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "grouped_asset_2",
-          "solid_name": "grouped_asset_2",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "grouped_asset_4",
-          "solid_name": "grouped_asset_4",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "first_asset",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "first_asset"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "hanging_asset",
-          "solid_name": "hanging_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "hanging_graph",
-          "solid_name": "hanging_graph",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "hanging_asset",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "hanging_asset"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "never_runs_asset",
-          "solid_name": "never_runs_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "single_run_backfill_policy_asset",
-          "solid_name": "single_run_backfill_policy_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "subsettable_checked_multi_asset",
-          "solid_name": "subsettable_checked_multi_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "int_asset",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "int_asset",
-                  "solid_name": "typed_multi_asset"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "typed_asset",
-          "solid_name": "typed_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "typed_multi_asset",
-          "solid_name": "typed_multi_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "unconnected",
-          "solid_name": "unconnected",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "ungrouped_asset_3",
-          "solid_name": "ungrouped_asset_3",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "ungrouped_asset_5",
-          "solid_name": "ungrouped_asset_5",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "unpartitioned_upstream_of_partitioned",
-          "solid_name": "unpartitioned_upstream_of_partitioned",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "typed_asset",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "typed_asset"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "untyped_asset",
-          "solid_name": "untyped_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "unpartitioned_upstream_of_partitioned",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "unpartitioned_upstream_of_partitioned"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "upstream_daily_partitioned_asset",
-          "solid_name": "upstream_daily_partitioned_asset",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "__ASSET_JOB_7",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": null,
-            "name": "dummy_io_manager"
-          },
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
-            },
-            "description": null,
-            "name": "hanging_asset_resource"
-          },
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.7c69ef3a8e6b7346ecb1b5e965def0559aca46b5"
-      }
-    ],
-    "name": "__ASSET_JOB_7",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [
-        {
-          "__class__": "CompositeSolidDefSnap",
-          "config_field_snap": null,
-          "dep_structure_snapshot": {
-            "__class__": "DependencyStructureSnapshot",
-            "solid_invocation_snaps": [
-              {
-                "__class__": "SolidInvocationSnap",
-                "input_dep_snaps": [
-                  {
-                    "__class__": "InputDependencySnap",
-                    "input_name": "my_op",
-                    "is_dynamic_collect": false,
-                    "upstream_output_snaps": [
-                      {
-                        "__class__": "OutputHandleSnap",
-                        "output_name": "result",
-                        "solid_name": "my_op"
-                      }
-                    ]
-                  }
-                ],
-                "is_dynamic_mapped": false,
-                "solid_def_name": "hanging_op",
-                "solid_name": "hanging_op",
-                "tags": {}
-              },
-              {
-                "__class__": "SolidInvocationSnap",
-                "input_dep_snaps": [],
-                "is_dynamic_mapped": false,
-                "solid_def_name": "my_op",
-                "solid_name": "my_op",
-                "tags": {}
-              },
-              {
-                "__class__": "SolidInvocationSnap",
-                "input_dep_snaps": [
-                  {
-                    "__class__": "InputDependencySnap",
-                    "input_name": "hanging_op",
-                    "is_dynamic_collect": false,
-                    "upstream_output_snaps": [
-                      {
-                        "__class__": "OutputHandleSnap",
-                        "output_name": "result",
-                        "solid_name": "hanging_op"
-                      }
-                    ]
-                  }
-                ],
-                "is_dynamic_mapped": false,
-                "solid_def_name": "never_runs_op",
-                "solid_name": "never_runs_op",
-                "tags": {}
-              }
-            ]
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "input_mapping_snaps": [],
-          "name": "hanging_graph",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "output_mapping_snaps": [
-            {
-              "__class__": "OutputMappingSnap",
-              "external_output_name": "result",
-              "mapped_output_name": "result",
-              "mapped_solid_name": "never_runs_op"
-            }
-          ],
-          "tags": {}
-        }
-      ],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "asset_1",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "asset_1"
-            }
-          ],
-          "name": "asset_1_my_check",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Nothing",
-              "description": null,
-              "name": "asset_1"
-            }
-          ],
-          "name": "asset_2",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Nothing",
-              "description": null,
-              "name": "asset_2"
-            }
-          ],
-          "name": "asset_3",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "asset_one",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "asset_one"
-            }
-          ],
-          "name": "asset_two",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "asset_yields_observation",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "bar",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "foo_bar"
-            }
-          ],
-          "name": "baz",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "check_in_op_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            },
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "check_in_op_asset_my_check"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "hanging_graph"
-            }
-          ],
-          "name": "downstream_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "unexecutable_asset"
-            }
-          ],
-          "name": "executable_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Nothing",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "dummy_source_asset"
-            }
-          ],
-          "name": "first_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "foo",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "bar"
-            },
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "foo"
-            }
-          ],
-          "name": "foo_bar",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "fresh_diamond_left"
-            },
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "fresh_diamond_right"
-            }
-          ],
-          "name": "fresh_diamond_bottom",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "fresh_diamond_top"
-            }
-          ],
-          "name": "fresh_diamond_left",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "fresh_diamond_top"
-            }
-          ],
-          "name": "fresh_diamond_right",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Nothing",
-              "description": null,
-              "name": "diamond_source"
-            }
-          ],
-          "name": "fresh_diamond_top",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "grouped_asset_1",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "grouped_asset_2",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "grouped_asset_4",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": "Asset that hangs forever, used to test in-progress ops.",
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "first_asset"
-            }
-          ],
-          "name": "hanging_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [
-            "hanging_asset_resource"
-          ],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "my_op"
-            }
-          ],
-          "name": "hanging_op",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [
-            "hanging_asset_resource"
-          ],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "my_op",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "hanging_asset"
-            }
-          ],
-          "name": "never_runs_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "hanging_op"
-            }
-          ],
-          "name": "never_runs_op",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "single_run_backfill_policy_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "subsettable_checked_multi_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": false,
-              "name": "one"
-            },
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": false,
-              "name": "two"
-            },
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": false,
-              "name": "one_my_check"
-            },
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": false,
-              "name": "one_my_other_check"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "int_asset"
-            }
-          ],
-          "name": "typed_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Int",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "typed_multi_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Int",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "int_asset"
-            },
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "String",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "str_asset"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "unconnected",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "ungrouped_asset_3",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "ungrouped_asset_5",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "unpartitioned_upstream_of_partitioned",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "typed_asset"
-            }
-          ],
-          "name": "untyped_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "unpartitioned_upstream_of_partitioned"
-            }
-          ],
-          "name": "upstream_daily_partitioned_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
-# name: test_all_snapshot_ids[150]
+# name: test_all_snapshot_ids[152]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -38158,10 +39378,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[151]
+# name: test_all_snapshot_ids[153]
   '927cbfcff5af3bd40ebed1cae3eed1baf4c3547f'
 # ---
-# name: test_all_snapshot_ids[152]
+# name: test_all_snapshot_ids[154]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -39017,10 +40237,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[153]
+# name: test_all_snapshot_ids[155]
   '8e516c94a1e0d32aabc7ea8d8fc27d68afdb45cf'
 # ---
-# name: test_all_snapshot_ids[154]
+# name: test_all_snapshot_ids[156]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -40115,10 +41335,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[155]
+# name: test_all_snapshot_ids[157]
   'cf5f6596eead075696e683b33db56a830ea834d4'
 # ---
-# name: test_all_snapshot_ids[156]
+# name: test_all_snapshot_ids[158]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -41213,10 +42433,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[157]
+# name: test_all_snapshot_ids[159]
   'a273aada46419892fdf5bbc48d0878f0e1eecba7'
 # ---
-# name: test_all_snapshot_ids[158]
+# name: test_all_snapshot_ids[15]
+  '0f764ee99fd4ca113e99db6fcbf035b92120ca4e'
+# ---
+# name: test_all_snapshot_ids[160]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -42196,13 +43419,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[159]
+# name: test_all_snapshot_ids[161]
   '4b4b18dca82ef0567492f476ff2bcbbf7392206d'
 # ---
-# name: test_all_snapshot_ids[15]
-  '99392647c3920344c3a8d4a6c43b057dcc7dbba6'
-# ---
-# name: test_all_snapshot_ids[160]
+# name: test_all_snapshot_ids[162]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -43392,7 +44612,7 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[161]
+# name: test_all_snapshot_ids[163]
   '1e553a1a3208ae523ef9d8257bcdf009fab236d2'
 # ---
 # name: test_all_snapshot_ids[16]
@@ -43862,56 +45082,6 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.16d7dd1c4cdc6af7eb5ea1740b53d007ee00a32e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"downstream_weekly_partitioned_asset\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"never_runs_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.c17890fb660fe12813f55128eec3be3d26e8308a"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": true,
-              "name": "resources",
-              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.16d7dd1c4cdc6af7eb5ea1740b53d007ee00a32e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
         "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -44164,53 +45334,7 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "file",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.c17890fb660fe12813f55128eec3be3d26e8308a": {
+        "Shape.90f35acb12f7fb1e13ba4db2c4cd9f5894920fb1": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -44452,6 +45576,15 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "output_then_hang_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
               "default_value_as_json_str": "{\"config\": {}}",
               "description": null,
               "is_required": false,
@@ -44523,7 +45656,103 @@
             }
           ],
           "given_name": null,
-          "key": "Shape.c17890fb660fe12813f55128eec3be3d26e8308a",
+          "key": "Shape.90f35acb12f7fb1e13ba4db2c4cd9f5894920fb1",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "file",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.9f5f188daa95ac1ffd53a9e0b83f932c3d12362c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"downstream_weekly_partitioned_asset\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"never_runs_asset\": {}, \"output_then_hang_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.90f35acb12f7fb1e13ba4db2c4cd9f5894920fb1"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": true,
+              "name": "resources",
+              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.9f5f188daa95ac1ffd53a9e0b83f932c3d12362c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -45111,6 +46340,14 @@
           "__class__": "SolidInvocationSnap",
           "input_dep_snaps": [],
           "is_dynamic_mapped": false,
+          "solid_def_name": "output_then_hang_asset",
+          "solid_name": "output_then_hang_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
           "solid_def_name": "subsettable_checked_multi_asset",
           "solid_name": "subsettable_checked_multi_asset",
           "tags": {}
@@ -45267,7 +46504,7 @@
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.16d7dd1c4cdc6af7eb5ea1740b53d007ee00a32e"
+        "root_config_key": "Shape.9f5f188daa95ac1ffd53a9e0b83f932c3d12362c"
       }
     ],
     "name": "__ASSET_JOB_8",
@@ -46268,6 +47505,35 @@
           "__class__": "SolidDefSnap",
           "config_field_snap": {
             "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "output_then_hang_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [
+            "hanging_asset_resource"
+          ],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
             "default_provided": true,
             "default_value_as_json_str": "{}",
             "description": null,
@@ -46533,7 +47799,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[17]
-  'fd24f07895615ca57e9ebf4ed51482b15ddb998d'
+  '76a04c6a8a1c071a35a7bf78860ceb23d296aa02'
 # ---
 # name: test_all_snapshot_ids[18]
   '''
@@ -47300,57 +48566,7 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.ba93297730221cc8298ae7f6f81da8fd93163dc1": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"multi_run_backfill_policy_asset\": {}, \"never_runs_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.c133960c694991c0274019483b0bc6e15260ef69"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": true,
-              "name": "resources",
-              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.ba93297730221cc8298ae7f6f81da8fd93163dc1",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.c133960c694991c0274019483b0bc6e15260ef69": {
+        "Shape.b691b4f6a95d97c56c8cd62eff15a51d63195f44": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -47592,6 +48808,15 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "output_then_hang_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
               "default_value_as_json_str": "{\"config\": {}}",
               "description": null,
               "is_required": false,
@@ -47663,7 +48888,7 @@
             }
           ],
           "given_name": null,
-          "key": "Shape.c133960c694991c0274019483b0bc6e15260ef69",
+          "key": "Shape.b691b4f6a95d97c56c8cd62eff15a51d63195f44",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -47677,6 +48902,56 @@
           "fields": [],
           "given_name": null,
           "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.dfbcb7fb9bb9f88e3754afb9440a66047a540d60": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"multi_run_backfill_policy_asset\": {}, \"never_runs_asset\": {}, \"output_then_hang_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.b691b4f6a95d97c56c8cd62eff15a51d63195f44"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": true,
+              "name": "resources",
+              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.dfbcb7fb9bb9f88e3754afb9440a66047a540d60",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -48244,6 +49519,14 @@
           "__class__": "SolidInvocationSnap",
           "input_dep_snaps": [],
           "is_dynamic_mapped": false,
+          "solid_def_name": "output_then_hang_asset",
+          "solid_name": "output_then_hang_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
           "solid_def_name": "subsettable_checked_multi_asset",
           "solid_name": "subsettable_checked_multi_asset",
           "tags": {}
@@ -48400,7 +49683,7 @@
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.ba93297730221cc8298ae7f6f81da8fd93163dc1"
+        "root_config_key": "Shape.dfbcb7fb9bb9f88e3754afb9440a66047a540d60"
       }
     ],
     "name": "__ASSET_JOB_9",
@@ -49394,6 +50677,35 @@
           "__class__": "SolidDefSnap",
           "config_field_snap": {
             "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "output_then_hang_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [
+            "hanging_asset_resource"
+          ],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
             "default_provided": true,
             "default_value_as_json_str": "{}",
             "description": null,
@@ -49659,10 +50971,10 @@
   '''
 # ---
 # name: test_all_snapshot_ids[19]
-  '9213b41d455f227d5a3416c5d7ccbb1c81d2a400'
+  '79cbf979acc4920cb3a4366fb410e4d5dcfc13ed'
 # ---
 # name: test_all_snapshot_ids[1]
-  '6055af087296224ffbe75b13d80e1965a27272b0'
+  '17092da9c23db2c90f88e6bd3fd2876fd5faa1be'
 # ---
 # name: test_all_snapshot_ids[20]
   '''
@@ -55102,6 +56414,56 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
+        "Shape.457fa32d1d4bac4f6aeac5cf6dba845dc2dadd7b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"never_runs_asset\": {}, \"no_multipartitions_1\": {}, \"output_then_hang_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.87cc36faa592faae5266afc61041dc7ed48a2cb1"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": true,
+              "name": "resources",
+              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.457fa32d1d4bac4f6aeac5cf6dba845dc2dadd7b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
         "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -55125,7 +56487,135 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.5e54764609297533a7e03f4c04b07d07a7545d49": {
+        "Shape.62edccaf30696e25335ae92685bdc41e204e30e6": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "dummy_io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "hanging_asset_resource",
+              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {}}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.811a60b4c43530c3d6100304f377dbd2d3045291": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "hanging_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "my_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "never_runs_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.811a60b4c43530c3d6100304f377dbd2d3045291",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.87cc36faa592faae5266afc61041dc7ed48a2cb1": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -55367,6 +56857,15 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "output_then_hang_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
               "default_value_as_json_str": "{\"config\": {}}",
               "description": null,
               "is_required": false,
@@ -55438,135 +56937,7 @@
             }
           ],
           "given_name": null,
-          "key": "Shape.5e54764609297533a7e03f4c04b07d07a7545d49",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.62edccaf30696e25335ae92685bdc41e204e30e6": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "dummy_io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "hanging_asset_resource",
-              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {}}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.811a60b4c43530c3d6100304f377dbd2d3045291": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "hanging_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "my_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "never_runs_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.811a60b4c43530c3d6100304f377dbd2d3045291",
+          "key": "Shape.87cc36faa592faae5266afc61041dc7ed48a2cb1",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -55590,56 +56961,6 @@
           ],
           "given_name": null,
           "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.a562f26e14d5619dd1458187bfbf992c0fcc685b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"never_runs_asset\": {}, \"no_multipartitions_1\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.5e54764609297533a7e03f4c04b07d07a7545d49"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": true,
-              "name": "resources",
-              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.a562f26e14d5619dd1458187bfbf992c0fcc685b",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -56243,6 +57564,14 @@
           "__class__": "SolidInvocationSnap",
           "input_dep_snaps": [],
           "is_dynamic_mapped": false,
+          "solid_def_name": "output_then_hang_asset",
+          "solid_name": "output_then_hang_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
           "solid_def_name": "subsettable_checked_multi_asset",
           "solid_name": "subsettable_checked_multi_asset",
           "tags": {}
@@ -56399,7 +57728,7 @@
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.a562f26e14d5619dd1458187bfbf992c0fcc685b"
+        "root_config_key": "Shape.457fa32d1d4bac4f6aeac5cf6dba845dc2dadd7b"
       }
     ],
     "name": "__ASSET_JOB_1",
@@ -57387,6 +58716,35 @@
             }
           ],
           "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "output_then_hang_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [
+            "hanging_asset_resource"
+          ],
           "tags": {}
         },
         {
@@ -63039,7 +64397,7 @@
   'a28dd9e490e08f05fab6ab1309de27da5cd3eb0f'
 # ---
 # name: test_all_snapshot_ids[3]
-  '2def11101a7aeeee1809bac7334e0ef2ebbee0a7'
+  'dab69732d7ded7444284aefd080b68da18e7eb9e'
 # ---
 # name: test_all_snapshot_ids[40]
   '''
@@ -68826,7 +70184,162 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.70b536f2e50ba1728b343ba609af79d8159e0e0b": {
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "dummy_io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "hanging_asset_resource",
+              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {}}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.76be1feac3022d3b6a868958e5a800025921ece7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"multipartitions_1\": {}, \"multipartitions_2\": {}, \"multipartitions_fail\": {}, \"never_runs_asset\": {}, \"output_then_hang_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.8caee7d48d3f3259dd8e33ba141384b4f833db10"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": true,
+              "name": "resources",
+              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.76be1feac3022d3b6a868958e5a800025921ece7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.811a60b4c43530c3d6100304f377dbd2d3045291": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "hanging_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "my_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "never_runs_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.811a60b4c43530c3d6100304f377dbd2d3045291",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.8caee7d48d3f3259dd8e33ba141384b4f833db10": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -69086,6 +70599,15 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "output_then_hang_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
               "default_value_as_json_str": "{\"config\": {}}",
               "description": null,
               "is_required": false,
@@ -69157,162 +70679,7 @@
             }
           ],
           "given_name": null,
-          "key": "Shape.70b536f2e50ba1728b343ba609af79d8159e0e0b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "dummy_io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "hanging_asset_resource",
-              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {}}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.811a60b4c43530c3d6100304f377dbd2d3045291": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "hanging_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "my_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "never_runs_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.811a60b4c43530c3d6100304f377dbd2d3045291",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.998e674112882b32439894fa206cec9bdedefa64": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"multipartitions_1\": {}, \"multipartitions_2\": {}, \"multipartitions_fail\": {}, \"never_runs_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.70b536f2e50ba1728b343ba609af79d8159e0e0b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": true,
-              "name": "resources",
-              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.998e674112882b32439894fa206cec9bdedefa64",
+          "key": "Shape.8caee7d48d3f3259dd8e33ba141384b4f833db10",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -69968,6 +71335,14 @@
           "__class__": "SolidInvocationSnap",
           "input_dep_snaps": [],
           "is_dynamic_mapped": false,
+          "solid_def_name": "output_then_hang_asset",
+          "solid_name": "output_then_hang_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
           "solid_def_name": "subsettable_checked_multi_asset",
           "solid_name": "subsettable_checked_multi_asset",
           "tags": {}
@@ -70124,7 +71499,7 @@
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.998e674112882b32439894fa206cec9bdedefa64"
+        "root_config_key": "Shape.76be1feac3022d3b6a868958e5a800025921ece7"
       }
     ],
     "name": "__ASSET_JOB_2",
@@ -71173,6 +72548,35 @@
             }
           ],
           "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "output_then_hang_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [
+            "hanging_asset_resource"
+          ],
           "tags": {}
         },
         {
@@ -77071,7 +78475,7 @@
   '18148f4a4dffa80180e9d70b389fdd2952275a82'
 # ---
 # name: test_all_snapshot_ids[5]
-  'b90753d74008998bb4787744d0f84a8d83a683f8'
+  '8bd95363c7c1c2494a686c3fbaca2cc3d3a84a0b'
 # ---
 # name: test_all_snapshot_ids[60]
   '''
@@ -83719,6 +85123,56 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
+        "Shape.4d6cabc028e11f5e433a1de845c5ad08884716bb": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"dynamic_in_multipartitions_fail\": {}, \"dynamic_in_multipartitions_success\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"never_runs_asset\": {}, \"output_then_hang_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.a5acc1306bcb26a4cdcb28e790c3ba9ecf4f2303"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": true,
+              "name": "resources",
+              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4d6cabc028e11f5e433a1de845c5ad08884716bb",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
         "Shape.62edccaf30696e25335ae92685bdc41e204e30e6": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -83870,80 +85324,7 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.bc8253101a831980159cb674a03998f3017bff34": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"dynamic_in_multipartitions_fail\": {}, \"dynamic_in_multipartitions_success\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"never_runs_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.d834395f76d63eb508382a1ce1365f31fabb0044"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": true,
-              "name": "resources",
-              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.bc8253101a831980159cb674a03998f3017bff34",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.d834395f76d63eb508382a1ce1365f31fabb0044": {
+        "Shape.a5acc1306bcb26a4cdcb28e790c3ba9ecf4f2303": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -84194,6 +85575,15 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "output_then_hang_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
               "default_value_as_json_str": "{\"config\": {}}",
               "description": null,
               "is_required": false,
@@ -84265,7 +85655,30 @@
             }
           ],
           "given_name": null,
-          "key": "Shape.d834395f76d63eb508382a1ce1365f31fabb0044",
+          "key": "Shape.a5acc1306bcb26a4cdcb28e790c3ba9ecf4f2303",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -84867,6 +86280,14 @@
           "__class__": "SolidInvocationSnap",
           "input_dep_snaps": [],
           "is_dynamic_mapped": false,
+          "solid_def_name": "output_then_hang_asset",
+          "solid_name": "output_then_hang_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
           "solid_def_name": "subsettable_checked_multi_asset",
           "solid_name": "subsettable_checked_multi_asset",
           "tags": {}
@@ -85023,7 +86444,7 @@
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.bc8253101a831980159cb674a03998f3017bff34"
+        "root_config_key": "Shape.4d6cabc028e11f5e433a1de845c5ad08884716bb"
       }
     ],
     "name": "__ASSET_JOB_3",
@@ -86045,6 +87466,35 @@
             }
           ],
           "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "output_then_hang_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [
+            "hanging_asset_resource"
+          ],
           "tags": {}
         },
         {
@@ -90805,7 +92255,7 @@
   '643e2b02ca69b0087d15b448a9108d39d5b35036'
 # ---
 # name: test_all_snapshot_ids[7]
-  '11cd8fe3cd920eec840dacb875d80fd31ed0354f'
+  '57b5a17a320c174c4eed18f1f6491d0e3d6ed058'
 # ---
 # name: test_all_snapshot_ids[80]
   '''
@@ -95994,56 +97444,6 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.4e27d4826586293046fcae41fd620d553876812f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"downstream_static_partitioned_asset\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"middle_static_partitioned_asset_1\": {}, \"middle_static_partitioned_asset_2\": {}, \"never_runs_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}, \"upstream_static_partitioned_asset\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.f8aba75e4637ab6bacf06528a151d00eed9afb92"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": true,
-              "name": "resources",
-              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4e27d4826586293046fcae41fd620d553876812f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
         "Shape.62edccaf30696e25335ae92685bdc41e204e30e6": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -96195,66 +97595,7 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.f8aba75e4637ab6bacf06528a151d00eed9afb92": {
+        "Shape.abe25a4061e4b9541a8b95fd5739124488ac788e": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -96514,6 +97855,15 @@
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "output_then_hang_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
               "default_value_as_json_str": "{\"config\": {}}",
               "description": null,
               "is_required": false,
@@ -96594,7 +97944,116 @@
             }
           ],
           "given_name": null,
-          "key": "Shape.f8aba75e4637ab6bacf06528a151d00eed9afb92",
+          "key": "Shape.abe25a4061e4b9541a8b95fd5739124488ac788e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b05ed70257fef9c6542ffee0f3c0fa6089cbe7fd": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"downstream_asset\": {}, \"downstream_static_partitioned_asset\": {}, \"executable_asset\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"middle_static_partitioned_asset_1\": {}, \"middle_static_partitioned_asset_2\": {}, \"never_runs_asset\": {}, \"output_then_hang_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}, \"upstream_static_partitioned_asset\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.abe25a4061e4b9541a8b95fd5739124488ac788e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": true,
+              "name": "resources",
+              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b05ed70257fef9c6542ffee0f3c0fa6089cbe7fd",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -97206,6 +98665,14 @@
           "__class__": "SolidInvocationSnap",
           "input_dep_snaps": [],
           "is_dynamic_mapped": false,
+          "solid_def_name": "output_then_hang_asset",
+          "solid_name": "output_then_hang_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
           "solid_def_name": "subsettable_checked_multi_asset",
           "solid_name": "subsettable_checked_multi_asset",
           "tags": {}
@@ -97370,7 +98837,7 @@
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.4e27d4826586293046fcae41fd620d553876812f"
+        "root_config_key": "Shape.b05ed70257fef9c6542ffee0f3c0fa6089cbe7fd"
       }
     ],
     "name": "__ASSET_JOB_4",
@@ -98439,6 +99906,35 @@
             }
           ],
           "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "output_then_hang_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [
+            "hanging_asset_resource"
+          ],
           "tags": {}
         },
         {
@@ -103320,5 +104816,5 @@
   '10cfd966244a4e4064ff00517d3e012ad6ce4c7d'
 # ---
 # name: test_all_snapshot_ids[9]
-  'a89d9701f9c6b6a345507e3e4729945df95acfbb'
+  '6d78f488993e79dba49bfe51a5b28bafc0f1344b'
 # ---

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_assets.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_assets.ambr
@@ -329,6 +329,13 @@
         dict({
           'key': dict({
             'path': list([
+              'output_then_hang_asset',
+            ]),
+          }),
+        }),
+        dict({
+          'key': dict({
+            'path': list([
               'single_run_backfill_policy_asset',
             ]),
           }),
@@ -680,6 +687,11 @@
         'freshnessInfo': None,
         'freshnessPolicy': None,
         'id': 'test.test_repo.["one"]',
+      }),
+      dict({
+        'freshnessInfo': None,
+        'freshnessPolicy': None,
+        'id': 'test.test_repo.["output_then_hang_asset"]',
       }),
       dict({
         'freshnessInfo': None,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_solids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_solids.ambr
@@ -3950,6 +3950,102 @@
         dict({
           '__typename': 'UsedSolid',
           'definition': dict({
+            'name': 'output_then_hang_asset',
+          }),
+          'invocations': list([
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_0',
+              }),
+              'solidHandle': dict({
+                'handleID': 'output_then_hang_asset',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_1',
+              }),
+              'solidHandle': dict({
+                'handleID': 'output_then_hang_asset',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_2',
+              }),
+              'solidHandle': dict({
+                'handleID': 'output_then_hang_asset',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_3',
+              }),
+              'solidHandle': dict({
+                'handleID': 'output_then_hang_asset',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_4',
+              }),
+              'solidHandle': dict({
+                'handleID': 'output_then_hang_asset',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_5',
+              }),
+              'solidHandle': dict({
+                'handleID': 'output_then_hang_asset',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_6',
+              }),
+              'solidHandle': dict({
+                'handleID': 'output_then_hang_asset',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_7',
+              }),
+              'solidHandle': dict({
+                'handleID': 'output_then_hang_asset',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_8',
+              }),
+              'solidHandle': dict({
+                'handleID': 'output_then_hang_asset',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': '__ASSET_JOB_9',
+              }),
+              'solidHandle': dict({
+                'handleID': 'output_then_hang_asset',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': 'output_then_hang_job',
+              }),
+              'solidHandle': dict({
+                'handleID': 'output_then_hang_asset',
+              }),
+            }),
+          ]),
+        }),
+        dict({
+          '__typename': 'UsedSolid',
+          'definition': dict({
             'name': 'passthrough',
           }),
           'invocations': list([

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1318,7 +1318,7 @@ def first_asset(dummy_source_asset):
 def hanging_asset(context, first_asset):
     """Asset that hangs forever, used to test in-progress ops."""
     with open(context.resources.hanging_asset_resource, "w", encoding="utf8") as ff:
-        ff.write("yup")
+        ff.write("yup")  # signals test to terminate run
 
     while True:
         time.sleep(0.1)
@@ -1332,6 +1332,21 @@ def never_runs_asset(hanging_asset):
 hanging_job = define_asset_job(
     name="hanging_job",
     selection=[first_asset, hanging_asset, never_runs_asset],
+)
+
+
+@asset(io_manager_key="dummy_io_manager", required_resource_keys={"hanging_asset_resource"})
+def output_then_hang_asset(context):
+    yield Output(5)
+    with open(context.resources.hanging_asset_resource, "w", encoding="utf8") as ff:
+        ff.write("yup")  # signals test to terminate run
+    while True:
+        time.sleep(0.1)
+
+
+output_then_hang_job = define_asset_job(
+    name="output_then_hang_job",
+    selection=[output_then_hang_asset],
 )
 
 
@@ -1920,6 +1935,7 @@ def define_asset_jobs() -> Sequence[UnresolvedAssetJobDefinition]:
         hanging_graph_asset_job,
         hanging_job,
         hanging_partition_asset_job,
+        output_then_hang_job,
         multi_partitions_fail_job,
         multi_partitions_job,
         named_groups_job,
@@ -2018,6 +2034,7 @@ def define_assets():
         dummy_source_asset,
         hanging_partition_asset,
         hanging_graph_asset,
+        output_then_hang_asset,
         downstream_asset,
         subsettable_checked_multi_asset,
         check_in_op_asset,


### PR DESCRIPTION
## Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/18792

Given the hypothetical asset below, we want it to switch from "Materializing..." to "Materialized" as soon as the output is yielded, not at the end of step execution 100s later.

```

@asset()
def test_asset():
    yield Output(value=1, output_name="result", metadata={"num_rows": 50})
    time.sleep(100)
```

I think the easiest way to do this is to omit the run from `AssetLatestInfo.inProgressRunIds` if the `AssetLatestInfo.latestMaterialization` is from that run ID. This doesn't handle the edge case where multiple runs are in-flight and both have already materialized, but also doesn't require loading any more data than we already have!

I put this in python as opposed to JS because there is already other logic considered in the resolver and I didn't want to hide additional logic in the front-end.

## How I Tested These Changes

I added a new test case for this! The hanging asset trick in the tests is pretty slick, kudos to whoever came up with that :-) 