### PR TITLE
[Asset graph] allow filtering by changed reason

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/CloudOSSContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/CloudOSSContext.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const CloudOSSContext = React.createContext<{
+  isBranchDeployment: boolean;
+}>({
+  isBranchDeployment: false,
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -166,7 +166,6 @@ export const ASSET_NODE_LIVE_FRAGMENT = gql`
         }
       }
     }
-    changedReasons
     freshnessInfo {
       ...AssetNodeLiveFreshnessInfo
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetLiveDataProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetLiveDataProvider.types.ts
@@ -27,7 +27,6 @@ export type AssetNodeLiveFragment = {
   __typename: 'AssetNode';
   id: string;
   opNames: Array<string>;
-  changedReasons: Array<Types.ChangeReason>;
   staleStatus: Types.StaleStatus | null;
   repository: {__typename: 'Repository'; id: string};
   assetKey: {__typename: 'AssetKey'; path: Array<string>};
@@ -120,7 +119,6 @@ export type AssetGraphLiveQuery = {
     __typename: 'AssetNode';
     id: string;
     opNames: Array<string>;
-    changedReasons: Array<Types.ChangeReason>;
     staleStatus: Types.StaleStatus | null;
     repository: {__typename: 'Repository'; id: string};
     assetKey: {__typename: 'AssetKey'; path: Array<string>};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -71,14 +71,14 @@ type AssetNode = AssetNodeForGraphQueryFragment;
 type OptionalFilters =
   | {
       filters: {
-        groups: AssetGroupSelector[];
-        computeKindTags: string[];
-        changedInBranch: ChangeReason[];
+        groups?: AssetGroupSelector[];
+        computeKindTags?: string[];
+        changedInBranch?: ChangeReason[];
       };
       setFilters: (updates: {
-        groups: AssetGroupSelector[];
-        computeKindTags: string[];
-        changedInBranch: ChangeReason[];
+        groups?: AssetGroupSelector[];
+        computeKindTags?: string[];
+        changedInBranch?: ChangeReason[];
       }) => void;
     }
   | {filters?: null; setFilters?: null};
@@ -122,6 +122,29 @@ export const AssetGraphExplorer = (props: Props) => {
 
   const {explorerPath, onChangeExplorerPath} = props;
 
+  const setComputeKindTags = React.useCallback(
+    (tags: string[]) =>
+      props.setFilters?.({
+        ...props.filters,
+        computeKindTags: tags,
+      }),
+    [props],
+  );
+
+  const setGroupFilters = React.useCallback(
+    (groups: AssetGroupSelector[]) => props.setFilters?.({...props.filters, groups}),
+    [props],
+  );
+
+  const setChangedInBranch = React.useCallback(
+    (changedInBranch: ChangeReason[]) =>
+      props.setFilters?.({
+        ...props.filters,
+        changedInBranch,
+      }),
+    [props],
+  );
+
   const {button, filterBar} = useAssetGraphExplorerFilters({
     nodes: React.useMemo(
       () => (fullAssetGraphData ? Object.values(fullAssetGraphData.nodes) : []),
@@ -129,31 +152,14 @@ export const AssetGraphExplorer = (props: Props) => {
     ),
     assetGroups,
     visibleAssetGroups: React.useMemo(() => props.filters?.groups || [], [props.filters?.groups]),
-    setGroupFilters: React.useCallback(
-      (groups: AssetGroupSelector[]) => props.setFilters?.({...props.filters, groups}),
-      [props],
-    ),
+    setGroupFilters: props.filters?.groups ? setGroupFilters : undefined,
     computeKindTags: props.filters?.computeKindTags || emptyArray,
-    setComputeKindTags: React.useCallback(
-      (tags: string[]) =>
-        props.setFilters?.({
-          ...props.filters,
-          computeKindTags: tags,
-        }),
-      [props],
-    ),
+    setComputeKindTags: props.filters?.computeKindTags ? setComputeKindTags : undefined,
     changedInBranch: React.useMemo(
       () => props.filters?.changedInBranch || [],
       [props.filters?.changedInBranch],
     ),
-    setChangedInBranch: React.useCallback(
-      (changedInBranch: ChangeReason[]) =>
-        props.setFilters?.({
-          ...props.filters,
-          changedInBranch,
-        }),
-      [props],
-    ),
+    setChangedInBranch: props.filters?.changedInBranch ? setChangedInBranch : undefined,
     explorerPath: explorerPath.opsQuery,
     clearExplorerPath: React.useCallback(() => {
       onChangeExplorerPath(

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -50,7 +50,7 @@ import {AssetKey} from '../assets/types';
 import {DEFAULT_MAX_ZOOM, SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
 import {closestNodeInDirection, isNodeOffscreen} from '../graph/common';
-import {AssetGroupSelector} from '../graphql/types';
+import {AssetGroupSelector, ChangeReason} from '../graphql/types';
 import {useQueryAndLocalStoragePersistedState} from '../hooks/useQueryAndLocalStoragePersistedState';
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {PageLoadTrace} from '../performance';
@@ -73,8 +73,13 @@ type OptionalFilters =
       filters: {
         groups: AssetGroupSelector[];
         computeKindTags: string[];
+        changedInBranch: ChangeReason[];
       };
-      setFilters: (updates: {groups: AssetGroupSelector[]; computeKindTags: string[]}) => void;
+      setFilters: (updates: {
+        groups: AssetGroupSelector[];
+        computeKindTags: string[];
+        changedInBranch: ChangeReason[];
+      }) => void;
     }
   | {filters?: null; setFilters?: null};
 
@@ -134,6 +139,18 @@ export const AssetGraphExplorer = (props: Props) => {
         props.setFilters?.({
           ...props.filters,
           computeKindTags: tags,
+        }),
+      [props],
+    ),
+    changedInBranch: React.useMemo(
+      () => props.filters?.changedInBranch || [],
+      [props.filters?.changedInBranch],
+    ),
+    setChangedInBranch: React.useCallback(
+      (changedInBranch: ChangeReason[]) =>
+        props.setFilters?.({
+          ...props.filters,
+          changedInBranch,
         }),
       [props],
     ),

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -152,6 +152,7 @@ export const AssetGraphExplorer = (props: Props) => {
       () => (fullAssetGraphData ? Object.values(fullAssetGraphData.nodes) : []),
       [fullAssetGraphData],
     ),
+    isGlobalGraph,
     assetGroups,
     visibleAssetGroups: React.useMemo(() => props.filters?.groups || [], [props.filters?.groups]),
     setGroupFilters: props.filters?.groups ? setGroupFilters : undefined,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -122,27 +122,29 @@ export const AssetGraphExplorer = (props: Props) => {
 
   const {explorerPath, onChangeExplorerPath} = props;
 
+  const {filters, setFilters} = props;
+
   const setComputeKindTags = React.useCallback(
     (tags: string[]) =>
-      props.setFilters?.({
-        ...props.filters,
+      setFilters?.({
+        ...filters,
         computeKindTags: tags,
       }),
-    [props],
+    [setFilters, filters],
   );
 
   const setGroupFilters = React.useCallback(
-    (groups: AssetGroupSelector[]) => props.setFilters?.({...props.filters, groups}),
-    [props],
+    (groups: AssetGroupSelector[]) => setFilters?.({...filters, groups}),
+    [filters, setFilters],
   );
 
   const setChangedInBranch = React.useCallback(
     (changedInBranch: ChangeReason[]) =>
-      props.setFilters?.({
-        ...props.filters,
+      setFilters?.({
+        ...filters,
         changedInBranch,
       }),
-    [props],
+    [filters, setFilters],
   );
 
   const {button, filterBar} = useAssetGraphExplorerFilters({

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -152,7 +152,7 @@ export const AssetGraphExplorer = (props: Props) => {
       () => (fullAssetGraphData ? Object.values(fullAssetGraphData.nodes) : []),
       [fullAssetGraphData],
     ),
-    isGlobalGraph,
+    isGlobalGraph: !!props.isGlobalGraph,
     assetGroups,
     visibleAssetGroups: React.useMemo(() => props.filters?.groups || [], [props.filters?.groups]),
     setGroupFilters: props.filters?.groups ? setGroupFilters : undefined,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
@@ -69,7 +69,7 @@ export function useAssetGraphExplorerFilters({
     menuWidth: '300px',
     renderLabel: ({value}) => (
       <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-        <Icon name="repo" />
+        <Icon name="new_in_branch" />
         <TruncatedTextWithFullTextOnHover
           tooltipText={value}
           text={

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
@@ -194,7 +194,7 @@ export function useAssetGraphExplorerFilters({
     filters.push(kindTagsFilter);
   }
   const {button, activeFiltersJsx} = useFilters({filters});
-  if (allRepos.length <= 1 && !assetGroups) {
+  if (!filters.length) {
     return {button: null, activeFiltersJsx: null};
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
@@ -1,7 +1,8 @@
 import {Box, Icon} from '@dagster-io/ui-components';
-import {useContext, useMemo} from 'react';
+import React, {useContext, useMemo} from 'react';
 
 import {GraphNode} from './Utils';
+import {CloudOSSContext} from '../app/CloudOSSContext';
 import {FeatureFlag, featureEnabled} from '../app/Flags';
 import {AssetGroupSelector, ChangeReason} from '../graphql/types';
 import {TruncatedTextWithFullTextOnHover} from '../nav/getLeftNavItemsForOption';
@@ -178,7 +179,13 @@ export function useAssetGraphExplorerFilters({
   if (assetGroups) {
     filters.push(groupsFilter);
   }
-  if (changedInBranch && featureEnabled(FeatureFlag.flagExperimentalBranchDiff)) {
+
+  const {isBranchDeployment} = React.useContext(CloudOSSContext);
+  if (
+    changedInBranch &&
+    featureEnabled(FeatureFlag.flagExperimentalBranchDiff) &&
+    isBranchDeployment
+  ) {
     filters.push(changedFilter);
   }
   filters.push(kindTagsFilter);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
@@ -24,11 +24,11 @@ type OptionalFilters =
       setChangedInBranch?: null;
     }
   | {
-      assetGroups: AssetGroupSelector[];
-      visibleAssetGroups: AssetGroupSelector[];
-      setGroupFilters: (groups: AssetGroupSelector[]) => void;
-      computeKindTags: string[];
-      setComputeKindTags: (s: string[]) => void;
+      assetGroups?: AssetGroupSelector[];
+      visibleAssetGroups?: AssetGroupSelector[];
+      setGroupFilters?: (groups: AssetGroupSelector[]) => void;
+      computeKindTags?: string[];
+      setComputeKindTags?: (s: string[]) => void;
       changedInBranch?: ChangeReason[];
       setChangedInBranch?: (s: ChangeReason[]) => void;
     };
@@ -179,7 +179,6 @@ export function useAssetGraphExplorerFilters({
   if (assetGroups) {
     filters.push(groupsFilter);
   }
-
   const {isBranchDeployment} = React.useContext(CloudOSSContext);
   if (
     changedInBranch &&

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
@@ -173,10 +173,13 @@ export function useAssetGraphExplorerFilters({
   });
 
   const filters: FilterObject[] = [];
-  if (allRepos.length > 1) {
+
+  // This is kind of odd, but rely on group filtering being enabled for
+  // showing the locations filter since the locationsFilter is controlled by app-wide context
+  if (allRepos.length > 1 && setGroupFilters) {
     filters.push(reposFilter);
   }
-  if (assetGroups) {
+  if (assetGroups && setGroupFilters) {
     filters.push(groupsFilter);
   }
   const {isBranchDeployment} = React.useContext(CloudOSSContext);
@@ -187,7 +190,9 @@ export function useAssetGraphExplorerFilters({
   ) {
     filters.push(changedFilter);
   }
-  filters.push(kindTagsFilter);
+  if (setComputeKindTags) {
+    filters.push(kindTagsFilter);
+  }
   const {button, activeFiltersJsx} = useFilters({filters});
   if (allRepos.length <= 1 && !assetGroups) {
     return {button: null, activeFiltersJsx: null};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
@@ -37,12 +37,14 @@ type Props = {
   nodes: GraphNode[];
   clearExplorerPath: () => void;
   explorerPath: string;
+  isGlobalGraph: boolean;
 } & OptionalFilters;
 
 const emptyArray: any[] = [];
 
 export function useAssetGraphExplorerFilters({
   nodes,
+  isGlobalGraph,
   assetGroups,
   visibleAssetGroups,
   setGroupFilters,
@@ -174,9 +176,7 @@ export function useAssetGraphExplorerFilters({
 
   const filters: FilterObject[] = [];
 
-  // This is kind of odd, but rely on group filtering being enabled for
-  // showing the locations filter since the locationsFilter is controlled by app-wide context
-  if (allRepos.length > 1 && setGroupFilters) {
+  if (allRepos.length > 1 && isGlobalGraph) {
     filters.push(reposFilter);
   }
   if (assetGroups && setGroupFilters) {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -38,7 +38,7 @@ export const AssetNode = React.memo(({definition, selected}: Props) => {
       <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}>
         <StaleReasonsTag liveData={liveData} assetKey={definition.assetKey} include="upstream" />
         <ChangedReasonsTag
-          changedReasons={liveData?.changedReasons}
+          changedReasons={definition.changedReasons}
           assetKey={definition.assetKey}
         />
       </Box>
@@ -176,7 +176,7 @@ export const AssetNodeMinimal = ({
   const {border, background} = buildAssetNodeStatusContent({assetKey, definition, liveData});
   const displayName = assetKey.path[assetKey.path.length - 1]!;
 
-  const isChanged = liveData?.changedReasons?.length;
+  const isChanged = definition.changedReasons.length;
   const isStale = isAssetStale(liveData);
 
   return (
@@ -196,7 +196,7 @@ export const AssetNodeMinimal = ({
           >
             {isChanged ? (
               <MinimalNodeChangedDot
-                changedReasons={liveData.changedReasons!}
+                changedReasons={definition.changedReasons}
                 assetKey={assetKey}
               />
             ) : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -286,6 +286,7 @@ const SIDEBAR_ASSET_FRAGMENT = gql`
         }
       }
     }
+    changedReasons
 
     ...AssetNodeConfigFragment
     ...AssetNodeOpMetadataFragment

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -165,7 +165,6 @@ export interface LiveDataForNode {
 
 export const MISSING_LIVE_DATA: LiveDataForNode = {
   unstartedRunIds: [],
-  changedReasons: [],
   inProgressRunIds: [],
   runWhichFailedToMaterialize: null,
   freshnessInfo: null,
@@ -218,7 +217,6 @@ export const buildLiveDataForNode = (
 
   return {
     lastMaterialization,
-    changedReasons: assetNode.changedReasons,
     lastMaterializationRunStatus:
       latestRunForAsset && lastMaterialization?.runId === latestRunForAsset?.id
         ? latestRunForAsset.status

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -14,7 +14,7 @@ import {
   AssetNodeLiveMaterializationFragment,
   AssetNodeLiveObservationFragment,
 } from '../asset-data/types/AssetLiveDataProvider.types';
-import {ChangeReason, RunStatus, StaleStatus} from '../graphql/types';
+import {RunStatus, StaleStatus} from '../graphql/types';
 
 /**
  * IMPORTANT: This file is used by the WebWorker so make sure we don't indirectly import React or anything that relies on window/document
@@ -154,7 +154,6 @@ export interface LiveDataForNode {
   staleStatus: StaleStatus | null;
   staleCauses: AssetGraphLiveQuery['assetNodes'][0]['staleCauses'];
   assetChecks: AssetCheckLiveFragment[];
-  changedReasons?: Array<ChangeReason>;
   partitionStats: {
     numMaterialized: number;
     numMaterializing: number;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -103,12 +103,6 @@ export const AssetNodeFragmentPartitioned: AssetNodeFragment = buildAssetNode({
 export const LiveDataForNodeRunStartedNotMaterializing: LiveDataForNode = {
   stepKey: 'asset2',
   unstartedRunIds: ['ABCDEF'],
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   inProgressRunIds: [],
   lastMaterialization: null,
   lastMaterializationRunStatus: null,
@@ -125,12 +119,6 @@ export const LiveDataForNodeRunStartedNotMaterializing: LiveDataForNode = {
 export const LiveDataForNodeRunStartedMaterializing: LiveDataForNode = {
   stepKey: 'asset3',
   unstartedRunIds: [],
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   inProgressRunIds: ['ABCDEF'],
   lastMaterialization: null,
   lastMaterializationRunStatus: null,
@@ -147,12 +135,6 @@ export const LiveDataForNodeRunStartedMaterializing: LiveDataForNode = {
 export const LiveDataForNodeRunFailed: LiveDataForNode = {
   stepKey: 'asset4',
   unstartedRunIds: [],
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   inProgressRunIds: [],
   lastMaterialization: null,
   lastMaterializationRunStatus: null,
@@ -175,12 +157,6 @@ export const LiveDataForNodeNeverMaterialized: LiveDataForNode = {
   stepKey: 'asset5',
   unstartedRunIds: [],
   inProgressRunIds: [],
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   lastMaterialization: null,
   lastMaterializationRunStatus: null,
   lastObservation: null,
@@ -196,12 +172,6 @@ export const LiveDataForNodeNeverMaterialized: LiveDataForNode = {
 export const LiveDataForNodeMaterialized: LiveDataForNode = {
   stepKey: 'asset6',
   unstartedRunIds: [],
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   inProgressRunIds: [],
   lastMaterialization: buildMaterializationEvent({
     runId: 'ABCDEF',
@@ -220,12 +190,6 @@ export const LiveDataForNodeMaterialized: LiveDataForNode = {
 
 export const LiveDataForNodeMaterializedWithChecks: LiveDataForNode = {
   stepKey: 'asset7',
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: buildMaterializationEvent({
@@ -303,12 +267,6 @@ export const LiveDataForNodeMaterializedWithChecksOk: LiveDataForNode = {
 
 export const LiveDataForNodeMaterializedAndStale: LiveDataForNode = {
   stepKey: 'asset8',
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: buildMaterializationEvent({
@@ -328,12 +286,6 @@ export const LiveDataForNodeMaterializedAndStale: LiveDataForNode = {
 
 export const LiveDataForNodeMaterializedAndStaleAndOverdue: LiveDataForNode = {
   stepKey: 'asset9',
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: buildMaterializationEvent({
@@ -356,12 +308,7 @@ export const LiveDataForNodeMaterializedAndStaleAndOverdue: LiveDataForNode = {
 
 export const LiveDataForNodeMaterializedAndStaleAndFresh: LiveDataForNode = {
   stepKey: 'asset10',
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
+
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: buildMaterializationEvent({
@@ -384,12 +331,6 @@ export const LiveDataForNodeMaterializedAndStaleAndFresh: LiveDataForNode = {
 
 export const LiveDataForNodeMaterializedAndFresh: LiveDataForNode = {
   stepKey: 'asset11',
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: buildMaterializationEvent({
@@ -412,12 +353,6 @@ export const LiveDataForNodeMaterializedAndFresh: LiveDataForNode = {
 
 export const LiveDataForNodeMaterializedAndOverdue: LiveDataForNode = {
   stepKey: 'asset12',
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: buildMaterializationEvent({
@@ -443,12 +378,6 @@ export const LiveDataForNodeFailedAndOverdue: LiveDataForNode = {
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterializationRunStatus: null,
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   lastObservation: null,
   lastMaterialization: null,
   runWhichFailedToMaterialize: buildRun({
@@ -470,12 +399,6 @@ export const LiveDataForNodeSourceNeverObserved: LiveDataForNode = {
   stepKey: 'source_asset2',
   unstartedRunIds: [],
   inProgressRunIds: [],
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   lastMaterialization: null,
   lastMaterializationRunStatus: null,
   lastObservation: null,
@@ -493,12 +416,6 @@ export const LiveDataForNodeSourceObservationRunning: LiveDataForNode = {
   stepKey: 'source_asset3',
   unstartedRunIds: [],
   inProgressRunIds: ['ABCDEF'],
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   lastMaterialization: null,
   lastMaterializationRunStatus: null,
   lastObservation: null,
@@ -524,12 +441,6 @@ export const LiveDataForNodeSourceObservedUpToDate: LiveDataForNode = {
   runWhichFailedToMaterialize: null,
   staleStatus: StaleStatus.FRESH,
   staleCauses: [],
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   assetChecks: [],
   freshnessInfo: null,
   opNames: [],
@@ -548,12 +459,6 @@ export const LiveDataForNodePartitionedSomeMissing: LiveDataForNode = {
   lastMaterializationRunStatus: null,
   lastObservation: null,
   runWhichFailedToMaterialize: null,
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   staleStatus: StaleStatus.FRESH,
   staleCauses: [],
   assetChecks: [],
@@ -576,12 +481,6 @@ export const LiveDataForNodePartitionedSomeFailed: LiveDataForNode = {
     runId: 'ABCDEF',
     timestamp: TIMESTAMP,
   },
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   lastMaterializationRunStatus: null,
   lastObservation: null,
   runWhichFailedToMaterialize: null,
@@ -610,12 +509,6 @@ export const LiveDataForNodePartitionedNoneMissing: LiveDataForNode = {
   lastMaterializationRunStatus: null,
   lastObservation: null,
   runWhichFailedToMaterialize: null,
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   staleStatus: StaleStatus.FRESH,
   staleCauses: [],
   assetChecks: [],
@@ -634,12 +527,6 @@ export const LiveDataForNodePartitionedNeverMaterialized: LiveDataForNode = {
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: null,
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   lastMaterializationRunStatus: null,
   lastObservation: null,
   runWhichFailedToMaterialize: null,
@@ -668,12 +555,6 @@ export const LiveDataForNodePartitionedMaterializing: LiveDataForNode = {
   staleCauses: [],
   assetChecks: [],
   freshnessInfo: null,
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   partitionStats: {
     numMaterialized: 0,
     numMaterializing: 5,
@@ -698,12 +579,6 @@ export const LiveDataForNodePartitionedStale: LiveDataForNode = {
   staleStatus: StaleStatus.STALE,
   staleCauses: [MockStaleReasonData],
   assetChecks: [],
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   freshnessInfo: null,
   partitionStats: {
     numMaterialized: 1500,
@@ -717,12 +592,6 @@ export const LiveDataForNodePartitionedStale: LiveDataForNode = {
 export const LiveDataForNodePartitionedOverdue: LiveDataForNode = {
   stepKey: 'asset23',
   unstartedRunIds: [],
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   inProgressRunIds: [],
   lastMaterialization: {
     __typename: 'MaterializationEvent',
@@ -774,22 +643,10 @@ export const LiveDataForNodePartitionedFresh: LiveDataForNode = {
     numFailed: 0,
   },
   opNames: [],
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
 };
 
 export const LiveDataForNodePartitionedLatestRunFailed: LiveDataForNode = {
   stepKey: 'asset25',
-  changedReasons: [
-    ChangeReason.NEW,
-    ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
-    ChangeReason.PARTITIONS_DEFINITION,
-  ],
   unstartedRunIds: [],
   inProgressRunIds: [],
   lastMaterialization: null,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
@@ -1,6 +1,8 @@
 import {MockedProvider} from '@apollo/client/testing';
 import {Box} from '@dagster-io/ui-components';
+import React from 'react';
 
+import {FeatureFlag, setFeatureFlags} from '../../app/Flags';
 import {AssetLiveDataProvider, factory} from '../../asset-data/AssetLiveDataProvider';
 import {KNOWN_TAGS} from '../../graph/OpTags';
 import {buildAssetKey} from '../../graphql/types';
@@ -64,6 +66,10 @@ export const LiveStates = () => {
       </>
     );
   };
+
+  React.useEffect(() => {
+    setFeatureFlags([FeatureFlag.flagExperimentalBranchDiff]);
+  }, []);
 
   return (
     <MockedProvider>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -11,12 +11,17 @@ import {
   AutoMaterializeDecisionType,
   AutoMaterializePolicyType,
   RunStatus,
-  buildAssetChecks,
   buildAssetNode,
   buildAutoMaterializePolicy,
   buildAutoMaterializeRule,
+  buildCompositeConfigType,
   buildFreshnessPolicy,
+  buildRegularDagsterType,
+  buildRepository,
+  buildRepositoryLocation,
+  buildSolidDefinition,
 } from '../../graphql/types';
+import {buildQueryMock} from '../../testing/mocking';
 import {WorkspaceProvider} from '../../workspace/WorkspaceContext';
 import {SIDEBAR_ASSET_QUERY, SidebarAssetInfo} from '../SidebarAssetInfo';
 import {GraphNode} from '../Utils';
@@ -28,12 +33,12 @@ export default {
   component: SidebarAssetInfo,
 };
 
-const MockRepo = {
+const MockRepo = buildRepository({
   __typename: 'Repository',
   id: 'test.py.repo',
   name: 'test.py',
-  location: {__typename: 'RepositoryLocation', id: 'repo', name: 'repo'},
-} as const;
+  location: buildRepositoryLocation({id: 'repo', name: 'repo'}),
+});
 
 const MockAssetKey = {__typename: 'AssetKey' as const, path: ['asset1']};
 
@@ -56,35 +61,26 @@ const buildGraphNodeMock = (definitionOverrides: Partial<AssetNode>): GraphNode 
 
 const buildSidebarQueryMock = (
   overrides: Partial<SidebarAssetQuery['assetNodeOrError']> = {},
-): MockedResponse<SidebarAssetQuery> => ({
-  request: {
+): MockedResponse<SidebarAssetQuery> =>
+  buildQueryMock({
     query: SIDEBAR_ASSET_QUERY,
     variables: {
       assetKey: {
         path: ['asset1'],
       },
     },
-  },
-  result: {
     data: {
-      __typename: 'Query',
-      assetNodeOrError: {
-        __typename: 'AssetNode',
+      assetNodeOrError: buildAssetNode({
         id: 'test.py.repo.["asset1"]',
         description: null,
-        backfillPolicy: null,
-        configField: null,
         metadataEntries: [],
-        assetChecksOrError: buildAssetChecks(),
         jobNames: ['test_job'],
-        autoMaterializePolicy: null,
-        freshnessPolicy: null,
-        partitionDefinition: null,
         assetKey: {
           path: ['asset1'],
           __typename: 'AssetKey',
         },
-        op: {
+        // @ts-expect-error not sure why the types dont match up, investigate later
+        op: buildSolidDefinition({
           name: 'asset1',
           description: null,
           metadata: [
@@ -99,9 +95,9 @@ const buildSidebarQueryMock = (
               __typename: 'MetadataItemDefinition',
             },
           ],
-          __typename: 'SolidDefinition',
-        },
+        }),
         opVersion: null,
+        // @ts-expect-error not sure why the types dont match up, investigate later
         repository: MockRepo,
         requiredResources: [
           {
@@ -121,7 +117,8 @@ const buildSidebarQueryMock = (
             resourceKey: 'just_another_resource',
           },
         ],
-        type: {
+        // @ts-expect-error not sure why the types dont match up, investigate later
+        type: buildRegularDagsterType({
           key: 'Any',
           name: 'Any',
           displayName: 'Any',
@@ -131,24 +128,21 @@ const buildSidebarQueryMock = (
           isBuiltin: true,
           isNothing: false,
           metadataEntries: [],
-          inputSchemaType: {
-            __typename: 'CompositeConfigType',
+          inputSchemaType: buildCompositeConfigType({
             key: 'Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4',
             description: null,
             isSelector: true,
             typeParamKeys: [],
             fields: [],
             recursiveConfigTypes: [],
-          },
+          }),
           outputSchemaType: null,
-          __typename: 'RegularDagsterType',
           innerTypes: [],
-        },
+        }),
         ...overrides,
-      },
+      }),
     },
-  },
-});
+  });
 
 const buildEventsMock = ({reported}: {reported: boolean}): MockedResponse<AssetEventsQuery> => ({
   request: {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/SidebarAssetInfo.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/SidebarAssetInfo.types.ts
@@ -8,6 +8,7 @@ export type SidebarAssetFragment = {
   description: string | null;
   opVersion: string | null;
   jobNames: Array<string>;
+  changedReasons: Array<Types.ChangeReason>;
   metadataEntries: Array<
     | {
         __typename: 'AssetMetadataEntry';
@@ -15675,6 +15676,7 @@ export type SidebarAssetQuery = {
         description: string | null;
         opVersion: string | null;
         jobNames: Array<string>;
+        changedReasons: Array<Types.ChangeReason>;
         metadataEntries: Array<
           | {
               __typename: 'AssetMetadataEntry';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useAssetGraphData.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useAssetGraphData.types.ts
@@ -14,10 +14,10 @@ export type AssetGraphQuery = {
     id: string;
     groupName: string | null;
     isExecutable: boolean;
+    changedReasons: Array<Types.ChangeReason>;
     hasMaterializePermission: boolean;
     graphName: string | null;
     jobNames: Array<string>;
-    changedReasons: Array<Types.ChangeReason>;
     opNames: Array<string>;
     opVersion: string | null;
     description: string | null;
@@ -42,10 +42,10 @@ export type AssetNodeForGraphQueryFragment = {
   id: string;
   groupName: string | null;
   isExecutable: boolean;
+  changedReasons: Array<Types.ChangeReason>;
   hasMaterializePermission: boolean;
   graphName: string | null;
   jobNames: Array<string>;
-  changedReasons: Array<Types.ChangeReason>;
   opNames: Array<string>;
   opVersion: string | null;
   description: string | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -201,6 +201,7 @@ export const ASSET_GRAPH_QUERY = gql`
     id
     groupName
     isExecutable
+    changedReasons
     hasMaterializePermission
     repository {
       id

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
@@ -101,7 +101,12 @@ export const AssetGroupRoot = ({
 
   const setFilters = React.useCallback(({changedInBranch}: {changedInBranch?: ChangeReason[]}) => {
     if (changedInBranch) {
-      setChangeInBranchFilters(changedInBranch);
+      setChangeInBranchFilters((previousChangedInBranch) => {
+        if (JSON.stringify(previousChangedInBranch) !== JSON.stringify(changedInBranch)) {
+          return changedInBranch;
+        }
+        return previousChangedInBranch;
+      });
     } else {
       setChangeInBranchFilters([]);
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
@@ -63,7 +63,10 @@ export const AssetGroupRoot = ({
 
   const onChangeExplorerPath = useCallback(
     (path: ExplorerPath, mode: 'push' | 'replace') => {
-      history[mode](`${groupPath}/${explorerPathToString(path)}`);
+      history[mode]({
+        pathname: `${groupPath}/${explorerPathToString(path)}`,
+        search: history.location.search,
+      });
     },
     [groupPath, history],
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
@@ -112,6 +112,15 @@ export const AssetGroupRoot = ({
     [groupSelector, hideNodesMatchingInLineage],
   );
 
+  const lineageOptions = React.useMemo(
+    () => ({preferAssetRendering: true, explodeComposites: true}),
+    [],
+  );
+  const lineageFilters = React.useMemo(
+    () => ({changedInBranch: changedInBranchFilters}),
+    [changedInBranchFilters],
+  );
+
   return (
     <Page style={{display: 'flex', flexDirection: 'column', paddingBottom: 0}}>
       <PageHeader
@@ -134,11 +143,11 @@ export const AssetGroupRoot = ({
       {tab === 'lineage' ? (
         <AssetGraphExplorer
           fetchOptions={fetchOptions}
-          options={{preferAssetRendering: true, explodeComposites: true}}
+          options={lineageOptions}
           explorerPath={explorerPathFromString(path || 'lineage/')}
           onChangeExplorerPath={onChangeExplorerPath}
           onNavigateToSourceAssetNode={onNavigateToSourceAssetNode}
-          filters={{changedInBranch: changedInBranchFilters}}
+          filters={lineageFilters}
           setFilters={setFilters}
         />
       ) : (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
@@ -1,10 +1,8 @@
 import {gql, useQuery} from '@apollo/client';
 import {Box, Heading, Page, PageHeader, Tabs, Tag} from '@dagster-io/ui-components';
-import isEqual from 'lodash/isEqual';
 import React, {useCallback, useMemo} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
-import {buildAssetGroupSelector} from './AssetGroupSuggest';
 import {AssetGlobalLineageLink} from './AssetPageHeader';
 import {AssetsCatalogTable} from './AssetsCatalogTable';
 import {useAutoMaterializeSensorFlag} from './AutoMaterializeSensorFlag';
@@ -89,17 +87,14 @@ export const AssetGroupRoot = ({
   );
 
   const [filters, setFilters] = useQueryPersistedState<{
-    groups?: AssetGroupSelector[];
     computeKindTags?: string[];
     changedInBranch?: ChangeReason[];
   }>({
-    encode: ({groups, computeKindTags, changedInBranch}) => ({
-      groups: groups?.length ? JSON.stringify(groups) : undefined,
+    encode: ({computeKindTags, changedInBranch}) => ({
       computeKindTags: computeKindTags?.length ? JSON.stringify(computeKindTags) : undefined,
       changedInBranch: changedInBranch?.length ? JSON.stringify(changedInBranch) : undefined,
     }),
     decode: (qs) => ({
-      groups: qs.groups ? JSON.parse(qs.groups) : [],
       computeKindTags: qs.computeKindTags ? JSON.parse(qs.computeKindTags) : [],
       changedInBranch: qs.changedInBranch ? JSON.parse(qs.changedInBranch) : [],
     }),
@@ -116,12 +111,6 @@ export const AssetGroupRoot = ({
         )
       ) {
         return true;
-      }
-      if (filters.groups?.length) {
-        const nodeGroup = buildAssetGroupSelector({definition: node});
-        if (!filters.groups.some((g) => isEqual(g, nodeGroup))) {
-          return true;
-        }
       }
 
       if (filters.changedInBranch?.length) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
@@ -35,7 +35,7 @@ import {AssetObservationFragment} from './types/useRecentAssetEvents.types';
 import {ASSET_MATERIALIZATION_FRAGMENT, ASSET_OBSERVATION_FRAGMENT} from './useRecentAssetEvents';
 import {Timestamp} from '../app/time/Timestamp';
 import {LiveDataForNode, isHiddenAssetGroupJob, stepKeyForAsset} from '../asset-graph/Utils';
-import {RunStatus, StaleStatus} from '../graphql/types';
+import {ChangeReason, RunStatus, StaleStatus} from '../graphql/types';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {RunStatusWithStats} from '../runs/RunStatusDots';
 import {linkToRunEvent, titleForRun} from '../runs/RunUtils';
@@ -193,7 +193,7 @@ export const AssetPartitionDetail = ({
   stepKey?: string;
   staleCauses?: LiveDataForNode['staleCauses'];
   staleStatus?: LiveDataForNode['staleStatus'];
-  changedReasons?: LiveDataForNode['changedReasons'];
+  changedReasons?: ChangeReason[];
 }) => {
   const {latest, partition, all} = group;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -121,6 +121,7 @@ export const AssetSidebarActivitySummary = ({
                   assetKey={asset.assetKey}
                   latest={displayedEvent}
                   liveData={liveData}
+                  definition={asset}
                 />
               </div>
             ) : loading ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -539,7 +539,7 @@ const AssetViewPageHeaderTags = ({
               onClick={onShowUpstream}
             />
             <ChangedReasonsTag
-              changedReasons={liveData?.changedReasons}
+              changedReasons={definition.changedReasons}
               assetKey={definition.assetKey}
             />
           </>
@@ -586,7 +586,7 @@ const AssetViewPageHeaderTags = ({
             onClick={onShowUpstream}
           />
           <ChangedReasonsTag
-            changedReasons={liveData?.changedReasons}
+            changedReasons={definition.changedReasons}
             assetKey={definition.assetKey}
           />
           <AssetComputeKindTag style={{position: 'relative'}} definition={definition} reduceColor />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
@@ -30,14 +30,14 @@ export const AssetsGroupsGlobalGraphRoot = () => {
   const history = useHistory();
 
   const [filters, setFilters] = useQueryPersistedState<{
-    groups: AssetGroupSelector[];
-    computeKindTags: string[];
-    changedInBranch: ChangeReason[];
+    groups?: AssetGroupSelector[];
+    computeKindTags?: string[];
+    changedInBranch?: ChangeReason[];
   }>({
     encode: ({groups, computeKindTags, changedInBranch}) => ({
-      groups: groups.length ? JSON.stringify(groups) : undefined,
-      computeKindTags: computeKindTags.length ? JSON.stringify(computeKindTags) : undefined,
-      changedInBranch: changedInBranch.length ? JSON.stringify(changedInBranch) : undefined,
+      groups: groups?.length ? JSON.stringify(groups) : undefined,
+      computeKindTags: computeKindTags?.length ? JSON.stringify(computeKindTags) : undefined,
+      changedInBranch: changedInBranch?.length ? JSON.stringify(changedInBranch) : undefined,
     }),
     decode: (qs) => ({
       groups: qs.groups ? JSON.parse(qs.groups) : [],
@@ -86,8 +86,8 @@ export const AssetsGroupsGlobalGraphRoot = () => {
           }
         }
 
-        if (filters.changedInBranch.length) {
-          if (node.changedReasons.find((reason) => filters.changedInBranch.includes(reason))) {
+        if (filters.changedInBranch?.length) {
+          if (node.changedReasons.find((reason) => filters.changedInBranch!.includes(reason))) {
             return false;
           }
           return true;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
@@ -12,7 +12,7 @@ import {
 import {AssetGraphExplorer} from '../asset-graph/AssetGraphExplorer';
 import {AssetGraphFetchScope} from '../asset-graph/useAssetGraphData';
 import {AssetLocation} from '../asset-graph/useFindAssetLocation';
-import {AssetGroupSelector} from '../graphql/types';
+import {AssetGroupSelector, ChangeReason} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {usePageLoadTrace} from '../performance';
@@ -32,14 +32,17 @@ export const AssetsGroupsGlobalGraphRoot = () => {
   const [filters, setFilters] = useQueryPersistedState<{
     groups: AssetGroupSelector[];
     computeKindTags: string[];
+    changedInBranch: ChangeReason[];
   }>({
-    encode: ({groups, computeKindTags}) => ({
+    encode: ({groups, computeKindTags, changedInBranch}) => ({
       groups: groups.length ? JSON.stringify(groups) : undefined,
       computeKindTags: computeKindTags.length ? JSON.stringify(computeKindTags) : undefined,
+      changedInBranch: changedInBranch.length ? JSON.stringify(changedInBranch) : undefined,
     }),
     decode: (qs) => ({
       groups: qs.groups ? JSON.parse(qs.groups) : [],
       computeKindTags: qs.computeKindTags ? JSON.parse(qs.computeKindTags) : [],
+      changedInBranch: qs.changedInBranch ? JSON.parse(qs.changedInBranch) : [],
     }),
   });
 
@@ -83,11 +86,18 @@ export const AssetsGroupsGlobalGraphRoot = () => {
           }
         }
 
+        if (filters.changedInBranch.length) {
+          if (node.changedReasons.find((reason) => filters.changedInBranch.includes(reason))) {
+            return false;
+          }
+          return true;
+        }
+
         return false;
       },
     };
     return options;
-  }, [filters.groups, visibleRepos]);
+  }, [filters, visibleRepos]);
 
   return (
     <Page style={{display: 'flex', flexDirection: 'column', paddingBottom: 0}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LastMaterializationMetadata.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LastMaterializationMetadata.tsx
@@ -6,6 +6,7 @@ import {AssetLineageElements} from './AssetLineageElements';
 import {ChangedReasonsTag} from './ChangedReasons';
 import {StaleReasonsTag} from './Stale';
 import {isRunlessEvent} from './isRunlessEvent';
+import {AssetViewDefinitionNodeFragment} from './types/AssetView.types';
 import {
   AssetMaterializationFragment,
   AssetObservationFragment,
@@ -25,10 +26,12 @@ export const LatestMaterializationMetadata = ({
   assetKey,
   latest,
   liveData,
+  definition,
 }: {
   assetKey: AssetKeyInput;
   latest: AssetObservationFragment | AssetMaterializationFragment | undefined;
   liveData: LiveDataForNode | undefined;
+  definition: Pick<AssetViewDefinitionNodeFragment, 'changedReasons'>;
 }) => {
   const latestRun = latest?.runOrError.__typename === 'Run' ? latest?.runOrError : null;
   const repositoryOrigin = latestRun?.repositoryOrigin;
@@ -122,7 +125,7 @@ export const LatestMaterializationMetadata = ({
                     <>
                       <StaleReasonsTag assetKey={assetKey} liveData={liveData} />
                       <ChangedReasonsTag
-                        changedReasons={liveData?.changedReasons}
+                        changedReasons={definition.changedReasons}
                         assetKey={assetKey}
                       />
                     </>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
@@ -20,13 +20,12 @@ import styled from 'styled-components';
 
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {LiveDataForNode, displayNameForAssetKey} from '../asset-graph/Utils';
-import {AssetKeyInput, ChangeReason, StaleCauseCategory, StaleStatus} from '../graphql/types';
+import {AssetKeyInput, StaleCauseCategory, StaleStatus} from '../graphql/types';
 import {numberFormatter} from '../ui/formatters';
 
 type StaleDataForNode = {
   staleCauses?: LiveDataForNode['staleCauses'];
   staleStatus?: LiveDataForNode['staleStatus'];
-  changedReasons?: ChangeReason[];
 };
 export const isAssetMissing = (liveData?: Pick<StaleDataForNode, 'staleStatus'>) =>
   liveData && liveData.staleStatus === StaleStatus.MISSING;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
@@ -20,13 +20,13 @@ import styled from 'styled-components';
 
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {LiveDataForNode, displayNameForAssetKey} from '../asset-graph/Utils';
-import {AssetKeyInput, StaleCauseCategory, StaleStatus} from '../graphql/types';
+import {AssetKeyInput, ChangeReason, StaleCauseCategory, StaleStatus} from '../graphql/types';
 import {numberFormatter} from '../ui/formatters';
 
 type StaleDataForNode = {
   staleCauses?: LiveDataForNode['staleCauses'];
   staleStatus?: LiveDataForNode['staleStatus'];
-  changedReasons?: LiveDataForNode['changedReasons'];
+  changedReasons?: ChangeReason[];
 };
 export const isAssetMissing = (liveData?: Pick<StaleDataForNode, 'staleStatus'>) =>
   liveData && liveData.staleStatus === StaleStatus.MISSING;


### PR DESCRIPTION
## Summary & Motivation
<img width="321" alt="Screenshot 2024-03-07 at 11 11 34 AM" src="https://github.com/dagster-io/dagster/assets/2286579/0d2f0cec-c843-451b-8f9e-0225d8c647c3">
<img width="337" alt="Screenshot 2024-03-07 at 11 11 27 AM" src="https://github.com/dagster-io/dagster/assets/2286579/6a239123-f052-4d7c-8bb5-72d45a1b1dee">
<img width="296" alt="Screenshot 2024-03-07 at 11 11 23 AM" src="https://github.com/dagster-io/dagster/assets/2286579/a1ad791f-fa6b-47ae-837d-14fdc1d35a36">



## How I Tested These Changes

locally tested with hacked data, needs more testing with real data