### PR TITLE
Update owners_by_key when output keys overriden via with_attributes

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1186,6 +1186,11 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             for key, metadata in metadata_by_key.items()
         }
 
+        replaced_owners_by_key = {
+            output_asset_key_replacements.get(key, key): owners
+            for key, owners in self.owners_by_key.items()
+        }
+
         replaced_attributes = dict(
             keys_by_input_name={
                 input_name: input_asset_key_replacements.get(key, key)
@@ -1221,6 +1226,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
                 **self._metadata_by_key,
                 **replaced_metadata_by_key,
             },
+            owners_by_key=replaced_owners_by_key,
             freshness_policies_by_key=replaced_freshness_policies_by_key,
             auto_materialize_policies_by_key=replaced_auto_materialize_policies_by_key,
             backfill_policy=backfill_policy if backfill_policy else self.backfill_policy,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2140,6 +2140,30 @@ def test_multi_asset_owners():
     }
 
 
+def test_replace_asset_keys_for_asset_with_owners():
+    @multi_asset(
+        outs={
+            "out1": AssetOut(owners=["user@dagsterlabs.com"]),
+            "out2": AssetOut(owners=["user@dagsterlabs.com"]),
+        }
+    )
+    def my_multi_asset():
+        pass
+
+    assert my_multi_asset.owners_by_key == {
+        AssetKey("out1"): [UserAssetOwner("user@dagsterlabs.com")],
+        AssetKey("out2"): [UserAssetOwner("user@dagsterlabs.com")],
+    }
+
+    prefixed_asset = my_multi_asset.with_attributes(
+        output_asset_key_replacements={AssetKey(["out1"]): AssetKey(["prefix", "out1"])}
+    )
+    assert prefixed_asset.owners_by_key == {
+        AssetKey(["prefix", "out1"]): [UserAssetOwner("user@dagsterlabs.com")],
+        AssetKey("out2"): [UserAssetOwner("user@dagsterlabs.com")],
+    }
+
+
 def test_asset_spec_with_code_versions():
     @multi_asset(specs=[AssetSpec(key="a", code_version="1"), AssetSpec(key="b", code_version="2")])
     def multi_asset_with_versions():


### PR DESCRIPTION
As the title.

This enables owners to be fetched correctly from an assets definition after its asset keys are prefixed via `load_assets_from_package_modules` etc.