### PR TITLE
[perf] external_asset_nodes_from_defs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -634,6 +634,10 @@ class AssetLayer(NamedTuple):
         return len(self.assets_defs_by_key) > 0
 
     @property
+    def assets_defs(self) -> Set["AssetsDefinition"]:
+        return set(assets_def for assets_def in self.assets_defs_by_key.values())
+
+    @property
     def has_asset_check_defs(self) -> bool:
         return len(self.asset_checks_defs_by_node_handle) > 0
 

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -817,7 +817,7 @@ class JobDefinition(IHasInternalInit):
 
         new_job = build_asset_selection_job(
             name=self.name,
-            assets=set(self.asset_layer.assets_defs_by_key.values()),
+            assets=self.asset_layer.assets_defs,
             source_assets=self.asset_layer.source_assets_by_key.values(),
             executor_def=self.executor_def,
             resource_defs=self.resource_defs,

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -1639,7 +1639,7 @@ def external_asset_nodes_from_defs(
                     downstream_asset_key=output_key
                 )
 
-        for assets_def in asset_layer.assets_defs_by_key.values():
+        for assets_def in asset_layer.assets_defs:
             metadata_by_asset_key.update(assets_def.metadata_by_key)
             freshness_policy_by_asset_key.update(assets_def.freshness_policies_by_key)
             auto_materialize_policy_by_asset_key.update(assets_def.auto_materialize_policies_by_key)


### PR DESCRIPTION
A user with a large number of assets sent over a profile showing we were spending over a minute in `external_asset_nodes_from_defs`
![Screenshot 2024-03-07 at 1 34 56 PM](https://github.com/dagster-io/dagster/assets/202219/fa6afa28-4b97-40ed-94fe-eda6aa7c6cdf)



accumulated in Left Heavy, the stand-out is this dict comprehension  (the were on `1.6.6`)
https://github.com/dagster-io/dagster/blame/1.6.6/python_modules/dagster/dagster/_core/host_representation/external_data.py#L1635

Using https://gist.github.com/alangenfeld/edfd98a1a72e806ea20c95463b3cf6e1 to repro a large `multi_asset` it revealed the real underlying problem was 

```
for assets_def in asset_layer.assets_defs_by_key.values():
```

which was causing us to the same work over and over again as `assets_defs_by_key.values()` returns the same `AssetsDefinitions` for each key it that maps to it, an enormous amount of wasted work for large `@multi_asset`s 

I also 
* cached unique_id
* changed a merge_dicts to {**, **}

as they were what showed up in the initial after profiling. 

## How I Tested These Changes

existing coverage

using repro gist from summary reduce repo snapshot time for large multi asset from 1 minute to 1 second 

