### PR TITLE
Rename reserved word column in snowflake quickstart

### DIFF
--- a/examples/quickstart_snowflake/quickstart_snowflake/assets/hackernews.py
+++ b/examples/quickstart_snowflake/quickstart_snowflake/assets/hackernews.py
@@ -36,6 +36,9 @@ def hackernews_topstories(
 
     df = pd.DataFrame(results)
 
+    # Rename the column to avoid conflict with the reserved keyword "by"
+    df.rename(columns={"by": "by_"}, inplace=True)
+
     # Dagster supports attaching arbitrary metadata to asset materializations. This metadata will be
     # shown in the run logs and also be displayed on the "Activity" tab of the "Asset Details" page in the UI.
     # This metadata would be useful for monitoring and maintaining the asset as you iterate.


### PR DESCRIPTION
Snowflake serialization failed for me because of the reserved keyword "by"

The SnowflakeIOManager does not quote identifiers (apparently on purpose)

## Summary & Motivation
Out of the box, a cloned copy of this quickstart failed for me on Dagster cloud.

## How I Tested These Changes
I ran the updated quickstart on dagster cloud.
