### PR TITLE
asset definition tags: dict-based python APIs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_out.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_out.py
@@ -16,8 +16,11 @@ from dagster._core.definitions.output import Out
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster._core.types.dagster_type import DagsterType, resolve_dagster_type
 
+from .utils import validate_definition_tags
+
 
 @experimental_param(param="owners")
+@experimental_param(param="tags")
 class AssetOut(
     NamedTuple(
         "_AssetOut",
@@ -35,6 +38,7 @@ class AssetOut(
             ("auto_materialize_policy", PublicAttr[Optional[AutoMaterializePolicy]]),
             ("backfill_policy", PublicAttr[Optional[BackfillPolicy]]),
             ("owners", PublicAttr[Optional[Sequence[str]]]),
+            ("tags", PublicAttr[Optional[Mapping[str, str]]]),
         ],
     )
 ):
@@ -69,6 +73,8 @@ class AssetOut(
         owners (Optional[Sequence[str]]): A list of strings representing owners of the asset. Each
             string can be a user's email address, or a team name prefixed with `team:`,
             e.g. `team:finops`.
+        tags (Optional[Mapping[str, str]]): Tags for filtering and organizing. These tags are not
+            attached to runs of the asset.
     """
 
     def __new__(
@@ -86,6 +92,7 @@ class AssetOut(
         auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
         backfill_policy: Optional[BackfillPolicy] = None,
         owners: Optional[Sequence[str]] = None,
+        tags: Optional[Mapping[str, str]] = None,
     ):
         if isinstance(key_prefix, str):
             key_prefix = [key_prefix]
@@ -117,6 +124,7 @@ class AssetOut(
                 backfill_policy, "backfill_policy", BackfillPolicy
             ),
             owners=check.opt_sequence_param(owners, "owners", of_type=str),
+            tags=validate_definition_tags(tags),
         )
 
     def to_out(self) -> Out:

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -328,18 +328,28 @@ class AssetSelection(ABC, BaseModel, frozen=True):
         return SubtractAssetSelection(left=self, right=other)
 
     def resolve(
-        self, all_assets: Union[Iterable[Union[AssetsDefinition, SourceAsset]], BaseAssetGraph]
+        self,
+        all_assets: Union[Iterable[Union[AssetsDefinition, SourceAsset]], BaseAssetGraph],
+        allow_missing: bool = False,
     ) -> AbstractSet[AssetKey]:
+        """Returns the set of asset keys in all_assets that match this selection.
+
+        Args:
+            allow_missing (bool): If False, will raise an error if any of the leaf selections in the
+                asset selection target entities that don't exist in the set of provided assets.
+        """
         if isinstance(all_assets, BaseAssetGraph):
             asset_graph = all_assets
         else:
             check.iterable_param(all_assets, "all_assets", (AssetsDefinition, SourceAsset))
             asset_graph = AssetGraph.from_assets(all_assets)
 
-        return self.resolve_inner(asset_graph)
+        return self.resolve_inner(asset_graph, allow_missing=allow_missing)
 
     @abstractmethod
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
         raise NotImplementedError()
 
     def resolve_checks(self, asset_graph: AssetGraph) -> AbstractSet[AssetCheckKey]:
@@ -353,37 +363,38 @@ class AssetSelection(ABC, BaseModel, frozen=True):
         asset_keys = self.resolve(asset_graph)
         return {handle for handle in asset_graph.asset_check_keys if handle.asset_key in asset_keys}
 
-    @staticmethod
-    def _selection_from_string(string: str) -> "AssetSelection":
-        from dagster._core.definitions import AssetSelection
-
+    @classmethod
+    def from_string(cls, string: str) -> "AssetSelection":
         if string == "*":
-            return AssetSelection.all()
+            return cls.all()
 
         parts = parse_clause(string)
-        if not parts:
-            check.failed(f"Invalid selection string: {string}")
-        u, item, d = parts
+        if parts is not None:
+            key_selection = cls.keys(parts.item_name)
+            if parts.up_depth and parts.down_depth:
+                selection = key_selection.upstream(parts.up_depth) | key_selection.downstream(
+                    parts.down_depth
+                )
+            elif parts.up_depth:
+                selection = key_selection.upstream(parts.up_depth)
+            elif parts.down_depth:
+                selection = key_selection.downstream(parts.down_depth)
+            else:
+                selection = key_selection
+            return selection
 
-        selection: AssetSelection = AssetSelection.keys(item)
-        if u:
-            selection = selection.upstream(u)
-        if d:
-            selection = selection.downstream(d)
-        return selection
+        check.failed(f"Invalid selection string: {string}")
 
     @classmethod
     def from_coercible(cls, selection: CoercibleToAssetSelection) -> "AssetSelection":
         if isinstance(selection, str):
-            return cls._selection_from_string(selection)
+            return cls.from_string(selection)
         elif isinstance(selection, AssetSelection):
             return selection
         elif isinstance(selection, collections.abc.Sequence) and all(
             isinstance(el, str) for el in selection
         ):
-            return reduce(
-                operator.or_, [cls._selection_from_string(cast(str, s)) for s in selection]
-            )
+            return reduce(operator.or_, [cls.from_string(cast(str, s)) for s in selection])
         elif isinstance(selection, collections.abc.Sequence) and all(
             isinstance(el, (AssetsDefinition, SourceAsset)) for el in selection
         ):
@@ -431,7 +442,9 @@ class AssetSelection(ABC, BaseModel, frozen=True):
 class AllSelection(AssetSelection, frozen=True):
     include_sources: Optional[bool] = None
 
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
         return (
             asset_graph.all_asset_keys
             if self.include_sources
@@ -447,7 +460,9 @@ class AllSelection(AssetSelection, frozen=True):
 
 @whitelist_for_serdes
 class AllAssetCheckSelection(AssetSelection, frozen=True):
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
         return set()
 
     def resolve_checks_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetCheckKey]:
@@ -464,7 +479,9 @@ class AllAssetCheckSelection(AssetSelection, frozen=True):
 class AssetChecksForAssetKeysSelection(AssetSelection, frozen=True):
     selected_asset_keys: Sequence[AssetKey]
 
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
         return set()
 
     def resolve_checks_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetCheckKey]:
@@ -482,7 +499,9 @@ class AssetChecksForAssetKeysSelection(AssetSelection, frozen=True):
 class AssetCheckKeysSelection(AssetSelection, frozen=True):
     selected_asset_check_keys: Sequence[AssetCheckKey]
 
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
         return set()
 
     def resolve_checks_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetCheckKey]:
@@ -504,9 +523,15 @@ class AndAssetSelection(
 ):
     operands: Sequence[AssetSelection]
 
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
         return reduce(
-            operator.and_, (selection.resolve_inner(asset_graph) for selection in self.operands)
+            operator.and_,
+            (
+                selection.resolve_inner(asset_graph, allow_missing=allow_missing)
+                for selection in self.operands
+            ),
         )
 
     def resolve_checks_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetCheckKey]:
@@ -537,9 +562,15 @@ class OrAssetSelection(
 ):
     operands: Sequence[AssetSelection]
 
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
         return reduce(
-            operator.or_, (selection.resolve_inner(asset_graph) for selection in self.operands)
+            operator.or_,
+            (
+                selection.resolve_inner(asset_graph, allow_missing=allow_missing)
+                for selection in self.operands
+            ),
         )
 
     def resolve_checks_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetCheckKey]:
@@ -571,8 +602,12 @@ class SubtractAssetSelection(
     left: AssetSelection
     right: AssetSelection
 
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
-        return self.left.resolve_inner(asset_graph) - self.right.resolve_inner(asset_graph)
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
+        return self.left.resolve_inner(
+            asset_graph, allow_missing=allow_missing
+        ) - self.right.resolve_inner(asset_graph, allow_missing=allow_missing)
 
     def resolve_checks_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetCheckKey]:
         return self.left.resolve_checks_inner(asset_graph) - self.right.resolve_checks_inner(
@@ -600,8 +635,10 @@ class SinksAssetSelection(
 ):
     child: AssetSelection
 
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
-        selection = self.child.resolve_inner(asset_graph)
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
+        selection = self.child.resolve_inner(asset_graph, allow_missing=allow_missing)
         return fetch_sinks(asset_graph.asset_dep_graph, selection)
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
@@ -616,8 +653,10 @@ class RequiredNeighborsAssetSelection(
 ):
     child: AssetSelection
 
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
-        selection = self.child.resolve_inner(asset_graph)
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
+        selection = self.child.resolve_inner(asset_graph, allow_missing=allow_missing)
         output = set(selection)
         for asset_key in selection:
             output.update(asset_graph.get(asset_key).execution_set_asset_keys)
@@ -635,8 +674,10 @@ class RootsAssetSelection(
 ):
     child: AssetSelection
 
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
-        selection = self.child.resolve_inner(asset_graph)
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
+        selection = self.child.resolve_inner(asset_graph, allow_missing=allow_missing)
         return fetch_sources(asset_graph.asset_dep_graph, selection)
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
@@ -653,8 +694,10 @@ class DownstreamAssetSelection(
     depth: Optional[int]
     include_self: bool
 
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
-        selection = self.child.resolve_inner(asset_graph)
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
+        selection = self.child.resolve_inner(asset_graph, allow_missing=allow_missing)
         return operator.sub(
             reduce(
                 operator.or_,
@@ -681,7 +724,9 @@ class GroupsAssetSelection(AssetSelection, frozen=True):
     selected_groups: Sequence[str]
     include_sources: bool
 
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.all_asset_keys
             if self.include_sources
@@ -708,30 +753,38 @@ class GroupsAssetSelection(AssetSelection, frozen=True):
 class KeysAssetSelection(AssetSelection, frozen=True):
     selected_keys: Sequence[AssetKey]
 
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
         specified_keys = set(self.selected_keys)
-        invalid_keys = {key for key in specified_keys if key not in asset_graph.all_asset_keys}
+        missing_keys = {key for key in specified_keys if key not in asset_graph.all_asset_keys}
 
-        # Arbitrary limit to avoid huge error messages
-        keys_to_suggest = list(invalid_keys)[:4]
-        suggestions = ""
-        for invalid_key in keys_to_suggest:
-            similar_names = resolve_similar_asset_names(invalid_key, asset_graph.all_asset_keys)
-            if similar_names:
-                # Arbitrarily limit to 10 similar names to avoid a huge error message
-                subset_similar_names = similar_names[:10]
-                similar_to_string = ", ".join(
-                    (similar.to_string() for similar in subset_similar_names)
+        if not allow_missing:
+            # Arbitrary limit to avoid huge error messages
+            keys_to_suggest = list(missing_keys)[:4]
+            suggestions = ""
+            for invalid_key in keys_to_suggest:
+                similar_names = resolve_similar_asset_names(invalid_key, asset_graph.all_asset_keys)
+                if similar_names:
+                    # Arbitrarily limit to 10 similar names to avoid a huge error message
+                    subset_similar_names = similar_names[:10]
+                    similar_to_string = ", ".join(
+                        (similar.to_string() for similar in subset_similar_names)
+                    )
+                    suggestions += (
+                        f"\n\nFor selected asset {invalid_key.to_string()}, did you mean one of "
+                        f"the following?\n\t{similar_to_string}"
+                    )
+
+            if missing_keys:
+                raise DagsterInvalidSubsetError(
+                    f"AssetKey(s) {[k.to_user_string() for k in missing_keys]} were selected, but "
+                    "no AssetsDefinition objects supply these keys. Make sure all keys are spelled "
+                    "correctly, and all AssetsDefinitions are correctly added to the "
+                    f"`Definitions`.{suggestions}"
                 )
-                suggestions += f"\n\nFor selected asset {invalid_key.to_string()}, did you mean one of the following?\n\t{similar_to_string}"
 
-        if invalid_keys:
-            raise DagsterInvalidSubsetError(
-                f"AssetKey(s) {invalid_keys} were selected, but no AssetsDefinition objects supply "
-                "these keys. Make sure all keys are spelled correctly, and all AssetsDefinitions "
-                f"are correctly added to the `Definitions`.{suggestions}"
-            )
-        return specified_keys
+        return specified_keys - missing_keys
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return self
@@ -751,7 +804,9 @@ class KeyPrefixesAssetSelection(AssetSelection, frozen=True):
     selected_key_prefixes: Sequence[Sequence[str]]
     include_sources: bool
 
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
         base_set = (
             asset_graph.all_asset_keys
             if self.include_sources
@@ -809,8 +864,10 @@ class UpstreamAssetSelection(
     depth: Optional[int]
     include_self: bool
 
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
-        selection = self.child.resolve_inner(asset_graph)
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
+        selection = self.child.resolve_inner(asset_graph, allow_missing=allow_missing)
         if len(selection) == 0:
             return selection
         all_upstream = _fetch_all_upstream(selection, asset_graph, self.depth, self.include_self)
@@ -841,8 +898,10 @@ class ParentSourcesAssetSelection(
 ):
     child: AssetSelection
 
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
-        selection = self.child.resolve_inner(asset_graph)
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
+        selection = self.child.resolve_inner(asset_graph, allow_missing=allow_missing)
         if len(selection) == 0:
             return selection
         all_upstream = _fetch_all_upstream(selection, asset_graph)

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -12,6 +12,7 @@ from .events import (
 )
 from .freshness_policy import FreshnessPolicy
 from .metadata import RawMetadataMapping
+from .utils import validate_definition_tags
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_dep import AssetDep, CoercibleToAssetDep
@@ -55,6 +56,7 @@ class AssetExecutionType(Enum):
 
 
 @experimental_param(param="owners")
+@experimental_param(param="tags")
 class AssetSpec(
     NamedTuple(
         "_AssetSpec",
@@ -69,6 +71,7 @@ class AssetSpec(
             ("freshness_policy", PublicAttr[Optional[FreshnessPolicy]]),
             ("auto_materialize_policy", PublicAttr[Optional[AutoMaterializePolicy]]),
             ("owners", PublicAttr[Optional[Sequence[str]]]),
+            ("tags", PublicAttr[Optional[Mapping[str, str]]]),
         ],
     )
 ):
@@ -97,6 +100,8 @@ class AssetSpec(
         owners (Optional[Sequence[str]]): A list of strings representing owners of the asset. Each
             string can be a user's email address, or a team name prefixed with `team:`,
             e.g. `team:finops`.
+        tags (Optional[Mapping[str, str]]): Tags for filtering and organizing. These tags are not
+            attached to runs of the asset.
     """
 
     def __new__(
@@ -112,6 +117,7 @@ class AssetSpec(
         freshness_policy: Optional[FreshnessPolicy] = None,
         auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
         owners: Optional[Sequence[str]] = None,
+        tags: Optional[Mapping[str, str]] = None,
     ):
         from dagster._core.definitions.asset_dep import coerce_to_deps_and_check_duplicates
 
@@ -138,4 +144,5 @@ class AssetSpec(
                 AutoMaterializePolicy,
             ),
             owners=check.opt_sequence_param(owners, "owners", of_type=str),
+            tags=validate_definition_tags(tags),
         )

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -17,7 +17,6 @@ from typing import (
     Optional,
     Sequence,
     Set,
-    Tuple,
     TypeVar,
 )
 
@@ -282,7 +281,13 @@ def fetch_connected_assets_definitions(
     return frozenset(name_to_definition_map[n] for n in connected_names)
 
 
-def parse_clause(clause: str) -> Optional[Tuple[int, str, int]]:
+class GraphSelectionClause(NamedTuple):
+    up_depth: int
+    item_name: str
+    down_depth: int
+
+
+def parse_clause(clause: str) -> Optional[GraphSelectionClause]:
     def _get_depth(part: str) -> int:
         if part == "":
             return 0
@@ -303,7 +308,7 @@ def parse_clause(clause: str) -> Optional[Tuple[int, str, int]]:
     up_depth = _get_depth(ancestor_part)
     down_depth = _get_depth(descendant_part)
 
-    return (up_depth, item_name, down_depth)
+    return GraphSelectionClause(up_depth, item_name, down_depth)
 
 
 def parse_items_from_selection(selection: Sequence[str]) -> Sequence[str]:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -533,7 +533,9 @@ def test_all_asset_selection_subclasses_serializable():
 
 def test_to_serializable_asset_selection():
     class UnserializableAssetSelection(AssetSelection, frozen=True):
-        def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
+        def resolve_inner(
+            self, asset_graph: BaseAssetGraph, allow_missing: bool
+        ) -> AbstractSet[AssetKey]:
             return asset_graph.materializable_asset_keys - {AssetKey("asset2")}
 
     @asset

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2188,3 +2188,39 @@ def test_asset_spec_with_metadata():
         AssetKey(["a"]): {"foo": "1"},
         AssetKey(["b"]): {"bar": "2"},
     }
+
+
+def test_asset_with_tags():
+    @asset(tags={"a": "b"})
+    def asset1(): ...
+
+    assert asset1.tags_by_key[asset1.key] == {"a": "b"}
+
+    with pytest.raises(DagsterInvalidDefinitionError, match="Invalid tag key"):
+
+        @asset(tags={"a%": "b"})  # key has illegal character
+        def asset2(): ...
+
+
+def test_asset_spec_with_tags():
+    @multi_asset(specs=[AssetSpec("asset1", tags={"a": "b"})])
+    def assets(): ...
+
+    assert assets.tags_by_key[AssetKey("asset1")] == {"a": "b"}
+
+    with pytest.raises(DagsterInvalidDefinitionError, match="Invalid tag key"):
+
+        @multi_asset(specs=[AssetSpec("asset1", tags={"a%": "b"})])  # key has illegal character
+        def assets(): ...
+
+
+def test_asset_out_with_tags():
+    @multi_asset(outs={"asset1": AssetOut(tags={"a": "b"})})
+    def assets(): ...
+
+    assert assets.tags_by_key[AssetKey("asset1")] == {"a": "b"}
+
+    with pytest.raises(DagsterInvalidDefinitionError, match="Invalid tag key"):
+
+        @multi_asset(outs={"asset1": AssetOut(tags={"a%": "b"})})  # key has illegal character
+        def assets(): ...

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_materialize_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_materialize_command.py
@@ -97,13 +97,13 @@ def test_partition_option_with_non_partitioned_asset():
 def test_asset_key_missing():
     with instance_for_test():
         result = invoke_materialize("nonexistent_asset")
-        assert "No qualified assets to execute found" in str(result.exception)
+        assert "no AssetsDefinition objects supply these keys" in str(result.exception)
 
 
 def test_one_of_the_asset_keys_missing():
     with instance_for_test():
         result = invoke_materialize("asset1,nonexistent_asset")
-        assert "No qualified assets to execute found" in str(result.exception)
+        assert "no AssetsDefinition objects supply these keys" in str(result.exception)
 
 
 def test_conflicting_partitions():

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_sensor_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_sensor_data.py
@@ -25,7 +25,9 @@ def test_unserializable_asset_selection():
     def asset2(): ...
 
     class MySpecialAssetSelection(AssetSelection, frozen=True):
-        def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
+        def resolve_inner(
+            self, asset_graph: BaseAssetGraph, allow_missing: bool
+        ) -> AbstractSet[AssetKey]:
             return asset_graph.materializable_asset_keys - {AssetKey("asset2")}
 
     @sensor(asset_selection=MySpecialAssetSelection())

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
@@ -634,9 +634,7 @@ def test_bad_coerce():
 
 
 def test_bad_resolve():
-    with pytest.raises(
-        DagsterInvalidSubsetError, match=r"AssetKey\(s\) {AssetKey\(\['foo'\]\)} were selected"
-    ):
+    with pytest.raises(DagsterInvalidSubsetError, match=r"AssetKey\(s\) \['foo'\] were selected"):
 
         @repository
         def _fails():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_utils.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_utils.py
@@ -1,0 +1,36 @@
+from dagster._core.definitions.utils import (
+    is_valid_definition_tag_key,
+    is_valid_definition_tag_value,
+)
+
+
+def test_is_valid_definition_tag_key():
+    assert is_valid_definition_tag_key("abc") is True
+    assert is_valid_definition_tag_key("abc.xhz") is True
+    assert is_valid_definition_tag_key("abc-xhz") is True
+    assert is_valid_definition_tag_key("abc/xyz") is True
+    assert is_valid_definition_tag_key("afdjkl.fdskj.-fsdj_lk") is True
+    assert is_valid_definition_tag_key("abc/xyz/fdjks") is False
+    assert is_valid_definition_tag_key("/xyzfdjks") is False
+    assert is_valid_definition_tag_key("xyzfdjks/") is False
+    assert is_valid_definition_tag_key("") is False
+    assert is_valid_definition_tag_key("a" * 63) is True
+    assert is_valid_definition_tag_key("a" * 64) is False
+    assert is_valid_definition_tag_key("a" * 63 + "/" + "b" * 63) is True
+    assert is_valid_definition_tag_key("a" * 64 + "/" + "b" * 63) is False
+
+
+def test_is_valid_definition_tag_value():
+    assert is_valid_definition_tag_value("abc") is True
+    assert is_valid_definition_tag_value("abc.xhz") is True
+    assert is_valid_definition_tag_value("abc-xhz") is True
+    assert is_valid_definition_tag_value("abc/xyz") is False
+    assert is_valid_definition_tag_value("afdjkl.fdskj.-fsdj_lk") is True
+    assert is_valid_definition_tag_value("abc/xyz/fdjks") is False
+    assert is_valid_definition_tag_value("/xyzfdjks") is False
+    assert is_valid_definition_tag_value("xyzfdjks/") is False
+    assert is_valid_definition_tag_value("") is True
+    assert is_valid_definition_tag_value("a" * 63) is True
+    assert is_valid_definition_tag_value("a" * 64) is False
+    assert is_valid_definition_tag_value("a" * 63 + "/" + "b" * 63) is False
+    assert is_valid_definition_tag_value("a" * 64 + "/" + "b" * 63) is False

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
@@ -70,7 +70,9 @@ class DbtManifestAssetSelection(
             exclude=check.opt_str_param(exclude, "exclude", default=""),
         )
 
-    def resolve_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing=False
+    ) -> AbstractSet[AssetKey]:
         dbt_nodes = get_dbt_resource_props_by_dbt_unique_id_from_manifest(self.manifest)
 
         keys = set()


### PR DESCRIPTION
## Summary & Motivation

A la [this RFC](https://github.com/dagster-io/internal/discussions/8544), adds tags to asset definitions. I.e. to `@asset`, `AssetSpec`, and `AssetOut`.

`is_valid_definition_tag_key` and `is_valid_definition_tag_value` enforce a similar set of rules to those applied to Kubernetes labels: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set. Differences between Dagster's constraints and Kubernetes' constraints:
- In Dagster, all allowed characters except "/" can be starting and ending characters. In k8s, starting and ending characters must be alphanumeric
- In Dagster, namespaces aren't expected to be URLs, and are limited to 63 characters, not 253 characters

This does not yet implement the string representation of tags that's in the linked proposal. However, it makes room for it by restricting "=" from being a valid character in a tag key.

## How I Tested These Changes
