### PR TITLE
Short circuit PartitionsSet operations regardless of order

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -972,10 +972,16 @@ class PartitionsSubset(ABC, Generic[T_str]):
     def __or__(self, other: "PartitionsSubset") -> "PartitionsSubset[T_str]":
         if self is other:
             return self
+        # Anything | AllPartitionsSubset = AllPartitionsSubset
+        if isinstance(other, AllPartitionsSubset):
+            return cast(PartitionsSubset[T_str], other)  # Is this safe?
         return self.with_partition_keys(other.get_partition_keys())
 
     def __sub__(self, other: "PartitionsSubset") -> "PartitionsSubset[T_str]":
         if self is other:
+            return self.empty_subset()
+        # Anything - AllPartitionsSubset = Empty
+        if isinstance(other, AllPartitionsSubset):
             return self.empty_subset()
         return self.empty_subset().with_partition_keys(
             set(self.get_partition_keys()).difference(set(other.get_partition_keys()))
@@ -983,6 +989,9 @@ class PartitionsSubset(ABC, Generic[T_str]):
 
     def __and__(self, other: "PartitionsSubset") -> "PartitionsSubset[T_str]":
         if self is other:
+            return self
+        # Anything & AllPartitionsSubset = Anything
+        if isinstance(other, AllPartitionsSubset):
             return self
         return self.empty_subset().with_partition_keys(
             set(self.get_partition_keys()) & set(other.get_partition_keys())

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -969,15 +969,15 @@ class PartitionsSubset(ABC, Generic[T_str]):
             )
         )
 
-    def __or__(self, other: "PartitionsSubset") -> "PartitionsSubset[T_str]":
+    def __or__(self, other: "PartitionsSubset") -> "PartitionsSubset":
         if self is other:
             return self
         # Anything | AllPartitionsSubset = AllPartitionsSubset
         if isinstance(other, AllPartitionsSubset):
-            return cast(PartitionsSubset[T_str], other)  # Is this safe?
+            return other
         return self.with_partition_keys(other.get_partition_keys())
 
-    def __sub__(self, other: "PartitionsSubset") -> "PartitionsSubset[T_str]":
+    def __sub__(self, other: "PartitionsSubset") -> "PartitionsSubset":
         if self is other:
             return self.empty_subset()
         # Anything - AllPartitionsSubset = Empty
@@ -987,7 +987,7 @@ class PartitionsSubset(ABC, Generic[T_str]):
             set(self.get_partition_keys()).difference(set(other.get_partition_keys()))
         )
 
-    def __and__(self, other: "PartitionsSubset") -> "PartitionsSubset[T_str]":
+    def __and__(self, other: "PartitionsSubset") -> "PartitionsSubset":
         if self is other:
             return self
         # Anything & AllPartitionsSubset = Anything


### PR DESCRIPTION
## Summary & Motivation

Owen made the sensible suggestion (https://github.com/dagster-io/dagster/pull/20312#discussion_r1516977615) to take advantage of native partition set features to avoid materializing partition keys with the AllPartitionsSubset is involved. This required changing operation order.

Instead, this PR proposes to also special case the base class operators when "other" is AllPartitionsSubset so we don't have to think about order.


## How I Tested These Changes

BK
