### PR TITLE
[external-assets] asset checks dup check

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/valid_definitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/valid_definitions.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, TypeVar, Union
 
 from typing_extensions import TypeAlias
 
+from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.schedule_definition import ScheduleDefinition
@@ -33,6 +34,7 @@ T_RepositoryLevelDefinition = TypeVar(
 
 RepositoryListDefinition: TypeAlias = Union[
     "AssetsDefinition",
+    AssetChecksDefinition,
     GraphDefinition,
     JobDefinition,
     ScheduleDefinition,

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
@@ -380,7 +380,7 @@ def test_definitions_conflicting_checks():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='Detected conflicting node definitions with the same name "asset1_check1"',
+        match="Duplicate asset check key.+asset1.+check1",
     ):
         Definitions(asset_checks=[make_check(), make_check()])
 


### PR DESCRIPTION
## Summary & Motivation

In the status quo, duplicate asset check keys are only caught during asset job construction. This moves the duplicate check to the definitions layer (where we catch dup asset keys).

## How I Tested These Changes

Updated existing unit test.