### PR TITLE
[concurreny] fix pending claim check sleep intervals

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/active.py
@@ -270,7 +270,7 @@ class ActiveExecution:
             self._executable.append(key)
             del self._waiting_to_retry[key]
 
-    def sleep_interval(self):
+    def sleep_interval(self) -> float:
         now = time.time()
         intervals = []
         if self._waiting_to_retry:


### PR DESCRIPTION
from scanning the code, it appeared we would always end up sleeping `0` for concurrency checks which leads to busy waiting / slamming the DB 

## How I Tested These Changes

existing coverage