### PR TITLE
[search ui] Add asset filter fields to search index

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav.tsx
@@ -180,7 +180,7 @@ export const AppTopNav = ({
             <div style={{width: '0px', height: '30px'}} />
           </ShortcutHandler>
         ) : null}
-        <SearchDialog searchPlaceholder={searchPlaceholder} />
+        <SearchDialog searchPlaceholder={searchPlaceholder} isAssetSearch={false} />
         {children}
       </Box>
     </AppTopNavContainer>

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav.tsx
@@ -180,7 +180,7 @@ export const AppTopNav = ({
             <div style={{width: '0px', height: '30px'}} />
           </ShortcutHandler>
         ) : null}
-        <SearchDialog searchPlaceholder={searchPlaceholder} isAssetSearch={false} />
+        <SearchDialog searchPlaceholder={searchPlaceholder} />
         {children}
       </Box>
     </AppTopNavContainer>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
@@ -32,7 +32,7 @@ type AssetCountsResult = {
   countPerCodeLocation: CountPerCodeLocation[];
 };
 
-type GroupMetadata = {
+export type GroupMetadata = {
   groupName: string;
   repositoryLocationName: string;
   repositoryName: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
@@ -8,7 +8,6 @@ import styled from 'styled-components';
 import {AssetGlobalLineageButton, AssetPageHeader} from './AssetPageHeader';
 import {ASSET_CATALOG_TABLE_QUERY} from './AssetsCatalogTable';
 import {fetchRecentlyVisitedAssetsFromLocalStorage} from './RecentlyVisitedAssetsStorage';
-import {AssetTableFragment} from './types/AssetTableFragment.types';
 import {
   AssetCatalogTableQuery,
   AssetCatalogTableQueryVariables,
@@ -68,8 +67,6 @@ export function buildAssetCountBySection(assets: AssetDefinitionMetadata[]): Ass
   const assetCountByComputeKind: Record<string, number> = {};
   const assetCountByGroup: Record<string, number> = {};
   const assetCountByCodeLocation: Record<string, number> = {};
-
-  // TODO guard against the query data not containing the above fields?
 
   assets
     .filter((asset) => asset.definition)

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
@@ -186,7 +186,7 @@ const linkToAssetGraphComputeKind = (computeKind: string) => {
   })}`;
 };
 
-const linkToCodeLocation = (repoAddress: RepoAddress) => {
+export const linkToCodeLocation = (repoAddress: RepoAddress) => {
   return `/locations/${repoAddressAsURLString(repoAddress)}/assets`;
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
@@ -49,11 +49,27 @@ type CountPerCodeLocation = {
   assetCount: number;
 };
 
-function buildAssetCountBySection(assets: AssetTableFragment[]): AssetCountsResult {
+type AssetDefinitionMetadata = {
+  definition: {
+    owners: Array<
+      {__typename: 'UserAssetOwner'; email: string} | {__typename: 'TeamAssetOwner'; team: string}
+    >;
+    computeKind: string | null;
+    groupName: string | null;
+    repository: {
+      name: string;
+      location: {name: string};
+    };
+  } | null;
+};
+
+export function buildAssetCountBySection(assets: AssetDefinitionMetadata[]): AssetCountsResult {
   const assetCountByOwner: Record<string, number> = {};
   const assetCountByComputeKind: Record<string, number> = {};
   const assetCountByGroup: Record<string, number> = {};
   const assetCountByCodeLocation: Record<string, number> = {};
+
+  // TODO guard against the query data not containing the above fields?
 
   assets
     .filter((asset) => asset.definition)

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components';
 import {AssetGlobalLineageButton, AssetPageHeader} from './AssetPageHeader';
 import {ASSET_CATALOG_TABLE_QUERY} from './AssetsCatalogTable';
 import {fetchRecentlyVisitedAssetsFromLocalStorage} from './RecentlyVisitedAssetsStorage';
+import {AssetTableDefinitionFragment} from './types/AssetTableFragment.types';
 import {
   AssetCatalogTableQuery,
   AssetCatalogTableQueryVariables,
@@ -49,17 +50,10 @@ type CountPerCodeLocation = {
 };
 
 type AssetDefinitionMetadata = {
-  definition: {
-    owners: Array<
-      {__typename: 'UserAssetOwner'; email: string} | {__typename: 'TeamAssetOwner'; team: string}
-    >;
-    computeKind: string | null;
-    groupName: string | null;
-    repository: {
-      name: string;
-      location: {name: string};
-    };
-  } | null;
+  definition: Pick<
+    AssetTableDefinitionFragment,
+    'owners' | 'computeKind' | 'groupName' | 'repository'
+  > | null;
 };
 
 export function buildAssetCountBySection(assets: AssetDefinitionMetadata[]): AssetCountsResult {

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -130,11 +130,7 @@ export const SearchDialog = ({
         dispatch({
           type: 'complete-secondary',
           queryString: queryStringForResults,
-          results: results.filter(
-            (result) =>
-              result.item.type === SearchResultType.Asset ||
-              result.item.type === SearchResultType.AssetGroup,
-          ),
+          results: results.filter((result) => result.item.type === SearchResultType.Asset), // Only return asset results
         });
       } else {
         dispatch({type: 'complete-secondary', queryString: queryStringForResults, results});

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
@@ -4,9 +4,9 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
-import {SearchResult, SearchResultType} from './types';
+import {AssetFilterSearchResultType, SearchResult, SearchResultType} from './types';
 
-const iconForType = (type: SearchResultType): IconName => {
+const iconForType = (type: SearchResultType | AssetFilterSearchResultType): IconName => {
   switch (type) {
     case SearchResultType.Asset:
       return 'asset';

--- a/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
@@ -22,6 +22,7 @@ export type SearchResult = {
   href: string;
   type: SearchResultType;
   tags?: string;
+  numResults?: number;
 };
 
 export type ReadyResponse = {type: 'ready'};

--- a/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
@@ -23,17 +23,6 @@ export enum AssetFilterSearchResultType {
   AssetGroup = 'AssetFilterSearchResultType.AssetGroup',
 }
 
-export function isAssetFilterSearchResultType(
-  type: SearchResultType | AssetFilterSearchResultType,
-): type is AssetFilterSearchResultType {
-  return (
-    type === AssetFilterSearchResultType.AssetGroup ||
-    type === AssetFilterSearchResultType.CodeLocation ||
-    type === AssetFilterSearchResultType.ComputeKind ||
-    type === AssetFilterSearchResultType.Owner
-  );
-}
-
 export type SearchResult = {
   label: string;
   description: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
@@ -12,15 +12,33 @@ export enum SearchResultType {
   Sensor,
   Solid,
   Resource,
-  ComputeKind,
-  CodeLocation,
+}
+
+export enum AssetFilterSearchResultType {
+  // Add types with corresponding strings to distinguish
+  // between SearchResultType.AssetGroup
+  ComputeKind = 'AssetFilterSearchResultType.ComputeKind',
+  CodeLocation = 'AssetFilterSearchResultType.CodeLocation',
+  Owner = 'AssetFilterSearchResultType.Owner',
+  AssetGroup = 'AssetFilterSearchResultType.AssetGroup',
+}
+
+export function isAssetFilterSearchResultType(
+  type: SearchResultType | AssetFilterSearchResultType,
+): type is AssetFilterSearchResultType {
+  return (
+    type === AssetFilterSearchResultType.AssetGroup ||
+    type === AssetFilterSearchResultType.CodeLocation ||
+    type === AssetFilterSearchResultType.ComputeKind ||
+    type === AssetFilterSearchResultType.Owner
+  );
 }
 
 export type SearchResult = {
   label: string;
   description: string;
   href: string;
-  type: SearchResultType;
+  type: SearchResultType | AssetFilterSearchResultType;
   tags?: string;
   numResults?: number;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
@@ -12,6 +12,8 @@ export enum SearchResultType {
   Sensor,
   Solid,
   Resource,
+  ComputeKind,
+  CodeLocation,
 }
 
 export type SearchResult = {

--- a/js_modules/dagster-ui/packages/ui-core/src/search/types/useGlobalSearch.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/types/useGlobalSearch.types.ts
@@ -76,6 +76,10 @@ export type SearchSecondaryQuery = {
             id: string;
             computeKind: string | null;
             groupName: string | null;
+            owners: Array<
+              | {__typename: 'TeamAssetOwner'; team: string}
+              | {__typename: 'UserAssetOwner'; email: string}
+            >;
             repository: {
               __typename: 'Repository';
               id: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/search/types/useGlobalSearch.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/types/useGlobalSearch.types.ts
@@ -71,7 +71,18 @@ export type SearchSecondaryQuery = {
           __typename: 'Asset';
           id: string;
           key: {__typename: 'AssetKey'; path: Array<string>};
-          definition: {__typename: 'AssetNode'; id: string} | null;
+          definition: {
+            __typename: 'AssetNode';
+            id: string;
+            computeKind: string | null;
+            groupName: string | null;
+            repository: {
+              __typename: 'Repository';
+              id: string;
+              name: string;
+              location: {__typename: 'RepositoryLocation'; id: string; name: string};
+            };
+          } | null;
         }>;
       }
     | {__typename: 'PythonError'};

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -2,7 +2,7 @@ import {gql} from '@apollo/client';
 import {useCallback, useEffect, useRef} from 'react';
 
 import {QueryResponse, WorkerSearchResult, createSearchWorker} from './createSearchWorker';
-import {SearchResult, SearchResultType} from './types';
+import {AssetFilterSearchResultType, SearchResult, SearchResultType} from './types';
 import {
   SearchPrimaryQuery,
   SearchPrimaryQueryVariables,
@@ -155,8 +155,8 @@ const secondaryDataToSearchResults = (input: {data?: SearchSecondaryQuery}) => {
     countsBySection.countsByComputeKind,
   ).map(([computeKind, count]) => ({
     label: computeKind,
-    description: 'Compute kind',
-    type: SearchResultType.ComputeKind,
+    description: '',
+    type: AssetFilterSearchResultType.ComputeKind,
     // TODO display correct link once https://github.com/dagster-io/dagster/pull/20342 lands
     href: '/assets',
     numResults: count,
@@ -168,8 +168,8 @@ const secondaryDataToSearchResults = (input: {data?: SearchSecondaryQuery}) => {
         codeLocationAssetCount.repoAddress.name,
         codeLocationAssetCount.repoAddress.location,
       ),
-      description: 'Code location',
-      type: SearchResultType.CodeLocation,
+      description: '',
+      type: AssetFilterSearchResultType.CodeLocation,
       // TODO display correct link once https://github.com/dagster-io/dagster/pull/20342 lands
       href: '/assets',
       numResults: codeLocationAssetCount.assetCount,
@@ -179,21 +179,19 @@ const secondaryDataToSearchResults = (input: {data?: SearchSecondaryQuery}) => {
   const groupResults: SearchResult[] = countsBySection.countPerAssetGroup.map(
     (groupAssetCount) => ({
       label: groupAssetCount.groupMetadata.groupName,
-      description: `Asset group in ${buildRepoPathForHuman(
-        groupAssetCount.groupMetadata.repositoryName,
-        groupAssetCount.groupMetadata.repositoryLocationName,
-      )}`,
-      type: SearchResultType.AssetGroup,
+      description: '',
+      type: AssetFilterSearchResultType.AssetGroup,
       // TODO display correct link once https://github.com/dagster-io/dagster/pull/20342 lands
       href: '/assets',
+      numResults: groupAssetCount.assetCount,
     }),
   );
 
   const ownerResults: SearchResult[] = Object.entries(countsBySection.countsByOwner).map(
     ([owner, count]) => ({
       label: owner,
-      description: 'Owner',
-      type: SearchResultType.Asset,
+      description: '',
+      type: AssetFilterSearchResultType.Owner,
       // TODO display correct link once https://github.com/dagster-io/dagster/pull/20342 lands
       href: '/assets',
       numResults: count,
@@ -202,12 +200,15 @@ const secondaryDataToSearchResults = (input: {data?: SearchSecondaryQuery}) => {
 
   const assets = nodes
     .filter(({definition}) => definition !== null)
-    .map(({key}) => {
+    .map(({key, definition}) => {
       return {
         label: displayNameForAssetKey(key),
         href: assetDetailsPathForKey(key),
         segments: key.path,
-        description: 'Asset',
+        description: `Asset in ${buildRepoPathForHuman(
+          definition!.repository.name,
+          definition!.repository.location.name,
+        )}`,
         type: SearchResultType.Asset,
       };
     });

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -1,4 +1,5 @@
 import {gql} from '@apollo/client';
+import qs from 'qs';
 import {useCallback, useEffect, useRef} from 'react';
 
 import {QueryResponse, WorkerSearchResult, createSearchWorker} from './createSearchWorker';
@@ -12,10 +13,20 @@ import {
 import {useIndexedDBCachedQuery} from './useIndexedDBCachedQuery';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Utils';
-import {buildAssetCountBySection} from '../assets/AssetsOverview';
+import {GroupMetadata, buildAssetCountBySection} from '../assets/AssetsOverview';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 import {workspacePath} from '../workspace/workspacePath';
+
+const linkToAssetTableWithGroupFilter = (groupMetadata: GroupMetadata) => {
+  return `/assets?${qs.stringify({groups: JSON.stringify([groupMetadata])})}`;
+};
+
+const linkToAssetTableWithComputeKindFilter = (computeKind: string) => {
+  return `/assets?${qs.stringify({
+    computeKindTags: JSON.stringify([computeKind]),
+  })}`;
+};
 
 const primaryDataToSearchResults = (input: {data?: SearchPrimaryQuery}) => {
   const {data} = input;
@@ -178,8 +189,7 @@ const secondaryDataToSearchResults = (
       label: computeKind,
       description: '',
       type: AssetFilterSearchResultType.ComputeKind,
-      // TODO display correct link once https://github.com/dagster-io/dagster/pull/20342 lands
-      href: '/assets',
+      href: linkToAssetTableWithComputeKindFilter(computeKind),
       numResults: count,
     }));
 
@@ -202,8 +212,7 @@ const secondaryDataToSearchResults = (
         label: groupAssetCount.groupMetadata.groupName,
         description: '',
         type: AssetFilterSearchResultType.AssetGroup,
-        // TODO display correct link once https://github.com/dagster-io/dagster/pull/20342 lands
-        href: '/assets',
+        href: linkToAssetTableWithGroupFilter(groupAssetCount.groupMetadata),
         numResults: groupAssetCount.assetCount,
       }),
     );

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -259,6 +259,11 @@ type IndexBuffer = {
   cancel: () => void;
 };
 
+// This is the version of the secondary query, used as part of the cache key.
+// When the data in the cache must be invalidated, this version should be bumped to prevent
+// fetching stale data.
+export const SEARCH_SECONDARY_DATA_VERSION = 'v1;';
+
 /**
  * Perform global search populated by two lazy queries, to be initialized upon some
  * interaction with the search input. Each query result list is packaged and sent to a worker
@@ -292,7 +297,7 @@ export const useGlobalSearch = ({includeAssetFilters}: {includeAssetFilters: boo
     loading: secondaryDataLoading,
   } = useIndexedDBCachedQuery<SearchSecondaryQuery, SearchSecondaryQueryVariables>({
     query: SEARCH_SECONDARY_QUERY,
-    key: 'SearchSecondary',
+    key: `SearchSecondary:${SEARCH_SECONDARY_DATA_VERSION}`,
   });
 
   const consumeBufferEffect = useCallback(

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -259,10 +259,11 @@ type IndexBuffer = {
   cancel: () => void;
 };
 
-// This is the version of the secondary query, used as part of the cache key.
-// When the data in the cache must be invalidated, this version should be bumped to prevent
-// fetching stale data.
-export const SEARCH_SECONDARY_DATA_VERSION = 'v1;';
+// These are the versions of the primary and secondary data queries. They are used to
+// version the cache in indexedDB. When the data in the cache must be invalidated, this version
+// should be bumped to prevent fetching stale data.
+export const SEARCH_PRIMARY_DATA_VERSION = 1;
+export const SEARCH_SECONDARY_DATA_VERSION = 1;
 
 /**
  * Perform global search populated by two lazy queries, to be initialized upon some
@@ -289,6 +290,7 @@ export const useGlobalSearch = ({includeAssetFilters}: {includeAssetFilters: boo
   } = useIndexedDBCachedQuery<SearchPrimaryQuery, SearchPrimaryQueryVariables>({
     query: SEARCH_PRIMARY_QUERY,
     key: 'SearchPrimary',
+    version: SEARCH_PRIMARY_DATA_VERSION,
   });
 
   const {
@@ -297,7 +299,8 @@ export const useGlobalSearch = ({includeAssetFilters}: {includeAssetFilters: boo
     loading: secondaryDataLoading,
   } = useIndexedDBCachedQuery<SearchSecondaryQuery, SearchSecondaryQueryVariables>({
     query: SEARCH_SECONDARY_QUERY,
-    key: `SearchSecondary:${SEARCH_SECONDARY_DATA_VERSION}`,
+    key: 'SearchSecondary',
+    version: SEARCH_SECONDARY_DATA_VERSION,
   });
 
   const consumeBufferEffect = useCallback(

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -13,7 +13,11 @@ import {
 import {useIndexedDBCachedQuery} from './useIndexedDBCachedQuery';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Utils';
-import {GroupMetadata, buildAssetCountBySection} from '../assets/AssetsOverview';
+import {
+  GroupMetadata,
+  buildAssetCountBySection,
+  linkToCodeLocation,
+} from '../assets/AssetsOverview';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 import {workspacePath} from '../workspace/workspacePath';
@@ -25,6 +29,12 @@ const linkToAssetTableWithGroupFilter = (groupMetadata: GroupMetadata) => {
 const linkToAssetTableWithComputeKindFilter = (computeKind: string) => {
   return `/assets?${qs.stringify({
     computeKindTags: JSON.stringify([computeKind]),
+  })}`;
+};
+
+const linkToAssetTableWithOwnerFilter = (owner: string) => {
+  return `/assets?${qs.stringify({
+    owners: JSON.stringify([owner]),
   })}`;
 };
 
@@ -201,8 +211,7 @@ const secondaryDataToSearchResults = (
         ),
         description: '',
         type: AssetFilterSearchResultType.CodeLocation,
-        // TODO display correct link once https://github.com/dagster-io/dagster/pull/20342 lands
-        href: '/assets',
+        href: linkToCodeLocation(codeLocationAssetCount.repoAddress),
         numResults: codeLocationAssetCount.assetCount,
       }),
     );
@@ -222,8 +231,7 @@ const secondaryDataToSearchResults = (
         label: owner,
         description: '',
         type: AssetFilterSearchResultType.Owner,
-        // TODO display correct link once https://github.com/dagster-io/dagster/pull/20342 lands
-        href: '/assets',
+        href: linkToAssetTableWithOwnerFilter(owner),
         numResults: count,
       }),
     );


### PR DESCRIPTION
This PR enables adds the following asset filters to the search index results:
- asset owner
- compute kind
- code location
- asset group

This involves:
1. Querying for these fields per-asset on `SECONDARY_SEARCH_QUERY`
2. Grouping by field to determine the # of assets per filter
3. Adding each filter to the list of possible search results

Open questions:
- Perf impact of fetching these additional fields for each asset in graphQL?