### PR TITLE
[search ui] Display asset search on asset landing page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Text.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Text.tsx
@@ -82,6 +82,12 @@ export const CaptionSubtitle = styled(Text)`
   line-height: 16px;
 `;
 
+export const CaptionBolded = styled(Text)`
+  font-family: ${FontFamily.default};
+  font-size: 12px;
+  font-weight: 900;
+`;
+
 export const Code = styled(Text)`
   background-color: ${Colors.backgroundBlue()};
   border-radius: 2px;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
@@ -246,7 +246,7 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                 <AssetGlobalLineageButton />
               </Box>
             </Box>
-            <SearchDialog searchPlaceholder="blah" isAssetSearch={true} displayAsOverlay={false} />
+            <SearchDialog isAssetSearch={true} displayAsOverlay={false} />
           </Box>
         </Box>
         <Box flex={{direction: 'column'}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
@@ -20,7 +20,7 @@ import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {TagIcon} from '../graph/OpTags';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
-import {SearchDialog} from '../search/SearchDialog';
+import {AssetSearch} from '../search/AssetSearch';
 import {ReloadAllButton} from '../workspace/ReloadAllButton';
 import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString, repoAddressAsURLString} from '../workspace/repoAddressAsString';
@@ -246,7 +246,7 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                 <AssetGlobalLineageButton />
               </Box>
             </Box>
-            <SearchDialog isAssetSearch={true} displayAsOverlay={false} />
+            <AssetSearch />
           </Box>
         </Box>
         <Box flex={{direction: 'column'}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
@@ -1,5 +1,5 @@
 import {useQuery} from '@apollo/client';
-import {Box, Colors, Heading, Icon, Page, Spinner, TextInput} from '@dagster-io/ui-components';
+import {Box, Colors, Heading, Icon, Page, Spinner} from '@dagster-io/ui-components';
 import qs from 'qs';
 import {useContext} from 'react';
 import {Link, useParams} from 'react-router-dom';
@@ -20,6 +20,7 @@ import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {TagIcon} from '../graph/OpTags';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
+import {SearchDialog} from '../search/SearchDialog';
 import {ReloadAllButton} from '../workspace/ReloadAllButton';
 import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString, repoAddressAsURLString} from '../workspace/repoAddressAsString';
@@ -234,7 +235,7 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
       />
       <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'auto'}}>
         <Box padding={64} flex={{justifyContent: 'center', alignItems: 'center'}}>
-          <Box style={{width: '60%'}} flex={{direction: 'column', gap: 16}}>
+          <Box style={{width: '60%', minWidth: '600px'}} flex={{direction: 'column', gap: 16}}>
             <Box flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}>
               <Heading>
                 {getGreeting(timezone)}
@@ -245,7 +246,7 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                 <AssetGlobalLineageButton />
               </Box>
             </Box>
-            <TextInput />
+            <SearchDialog searchPlaceholder="blah" isAssetSearch={true} displayAsOverlay={false} />
           </Box>
         </Box>
         <Box flex={{direction: 'column'}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/search/AssetSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/AssetSearch.tsx
@@ -1,0 +1,204 @@
+import {Colors, Icon, Spinner} from '@dagster-io/ui-components';
+import Fuse from 'fuse.js';
+import debounce from 'lodash/debounce';
+import * as React from 'react';
+import {useHistory} from 'react-router-dom';
+import styled from 'styled-components';
+
+import {SearchBox, SearchInput} from './SearchDialog';
+import {SearchResults} from './SearchResults';
+import {SearchResult, SearchResultType, isAssetFilterSearchResultType} from './types';
+import {useGlobalSearch} from './useGlobalSearch';
+import {Trace, createTrace} from '../performance';
+
+const MAX_ASSET_RESULTS = 50;
+const MAX_FILTER_RESULTS = 25;
+
+type State = {
+  queryString: string;
+  searching: boolean;
+  secondaryResults: Fuse.FuseResult<SearchResult>[];
+  highlight: number;
+  loaded: boolean;
+};
+
+type Action =
+  | {type: 'highlight'; highlight: number}
+  | {type: 'change-query'; queryString: string}
+  | {type: 'complete-secondary'; queryString: string; results: Fuse.FuseResult<SearchResult>[]};
+
+const reducer = (state: State, action: Action) => {
+  switch (action.type) {
+    case 'highlight':
+      return {...state, highlight: action.highlight};
+    case 'change-query':
+      return {...state, queryString: action.queryString, searching: true, highlight: 0};
+    case 'complete-secondary':
+      // If the received results match the current querystring, use them. Otherwise discard.
+      const secondaryResults =
+        action.queryString === state.queryString ? action.results : state.secondaryResults;
+      return {...state, secondaryResults, searching: false};
+    default:
+      return state;
+  }
+};
+
+const initialState: State = {
+  queryString: '',
+  searching: false,
+  secondaryResults: [],
+  highlight: 0,
+  loaded: false,
+};
+
+const DEBOUNCE_MSEC = 100;
+
+type SearchResultGroups = {
+  assetResults: Fuse.FuseResult<SearchResult>[];
+  assetFilterResults: Fuse.FuseResult<SearchResult>[];
+};
+
+function groupSearchResults(secondaryResults: Fuse.FuseResult<SearchResult>[]): SearchResultGroups {
+  return {
+    assetResults: secondaryResults.filter((result) => result.item.type === SearchResultType.Asset),
+    assetFilterResults: secondaryResults.filter((result) =>
+      isAssetFilterSearchResultType(result.item.type),
+    ),
+  };
+}
+
+export const AssetSearch = () => {
+  const history = useHistory();
+  const {loading, searchSecondary} = useGlobalSearch({
+    includeAssetFilters: true,
+  });
+
+  const [state, dispatch] = React.useReducer(reducer, initialState);
+  const {queryString, secondaryResults, highlight} = state;
+
+  const {assetResults, assetFilterResults} = groupSearchResults(secondaryResults);
+
+  const renderedAssetResults = assetResults.slice(0, MAX_ASSET_RESULTS);
+  const renderedFilterResults = assetFilterResults.slice(0, MAX_FILTER_RESULTS);
+
+  const renderedResults = [...renderedAssetResults, ...renderedFilterResults];
+  const numRenderedResults = renderedResults.length;
+
+  const isFirstSearch = React.useRef(true);
+  const firstSearchTrace = React.useRef<null | Trace>(null);
+
+  React.useEffect(() => {
+    if (!loading && secondaryResults) {
+      firstSearchTrace.current?.endTrace();
+    }
+  }, [loading, secondaryResults]);
+
+  const searchAndHandleSecondary = React.useCallback(
+    async (queryString: string) => {
+      const {queryString: queryStringForResults, results} = await searchSecondary(queryString);
+      dispatch({type: 'complete-secondary', queryString: queryStringForResults, results});
+    },
+    [searchSecondary],
+  );
+
+  const debouncedSearch = React.useMemo(() => {
+    const debouncedSearch = debounce(async (queryString: string) => {
+      searchAndHandleSecondary(queryString);
+    }, DEBOUNCE_MSEC);
+    return (queryString: string) => {
+      if (!firstSearchTrace.current && isFirstSearch.current) {
+        isFirstSearch.current = false;
+        const trace = createTrace('SearchDialog:FirstSearch');
+        firstSearchTrace.current = trace;
+        trace.startTrace();
+      }
+      return debouncedSearch(queryString);
+    };
+  }, [searchAndHandleSecondary]);
+
+  const onChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    dispatch({type: 'change-query', queryString: newValue});
+    debouncedSearch(newValue);
+  };
+
+  const onClickResult = React.useCallback(
+    (result: Fuse.FuseResult<SearchResult>) => {
+      history.push(result.item.href);
+    },
+    [history],
+  );
+
+  const highlightedResult = renderedResults[highlight] || null;
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    const {key} = e;
+
+    if (!numRenderedResults) {
+      return;
+    }
+
+    const lastResult = numRenderedResults - 1;
+
+    switch (key) {
+      case 'ArrowUp':
+        e.preventDefault();
+        dispatch({
+          type: 'highlight',
+          highlight: highlight === 0 ? lastResult : highlight - 1,
+        });
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        dispatch({
+          type: 'highlight',
+          highlight: highlight === lastResult ? 0 : highlight + 1,
+        });
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (highlightedResult) {
+          history.push(highlightedResult.item.href);
+        }
+    }
+  };
+
+  return (
+    <SearchInputWrapper>
+      <SearchBox hasQueryString={!!queryString.length}>
+        <Icon name="search" color={Colors.accentGray()} size={20} />
+        <SearchInput
+          data-search-input="1"
+          autoFocus
+          spellCheck={false}
+          onChange={onChange}
+          onKeyDown={onKeyDown}
+          placeholder="Search assets"
+          type="text"
+          value={queryString}
+        />
+        {loading ? <Spinner purpose="body-text" /> : null}
+      </SearchBox>
+      <SearchResultsWrapper>
+        <SearchResults
+          highlight={highlight}
+          queryString={queryString}
+          results={renderedAssetResults}
+          filterResults={renderedFilterResults}
+          onClickResult={onClickResult}
+        />
+      </SearchResultsWrapper>
+    </SearchInputWrapper>
+  );
+};
+
+const SearchInputWrapper = styled.div`
+  position: relative;
+`;
+
+const SearchResultsWrapper = styled.div`
+  top: 60px;
+  position: absolute;
+  z-index: 1;
+  width: 100%;
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/search/AssetSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/AssetSearch.tsx
@@ -19,7 +19,6 @@ type State = {
   searching: boolean;
   secondaryResults: Fuse.FuseResult<SearchResult>[];
   highlight: number;
-  loaded: boolean;
 };
 
 type Action =
@@ -48,7 +47,6 @@ const initialState: State = {
   searching: false,
   secondaryResults: [],
   highlight: 0,
-  loaded: false,
 };
 
 const DEBOUNCE_MSEC = 100;
@@ -69,7 +67,7 @@ function groupSearchResults(secondaryResults: Fuse.FuseResult<SearchResult>[]): 
 
 export const AssetSearch = () => {
   const history = useHistory();
-  const {loading, searchSecondary} = useGlobalSearch({
+  const {loading, searchSecondary, initialize} = useGlobalSearch({
     includeAssetFilters: true,
   });
 
@@ -88,10 +86,11 @@ export const AssetSearch = () => {
   const firstSearchTrace = React.useRef<null | Trace>(null);
 
   React.useEffect(() => {
+    initialize();
     if (!loading && secondaryResults) {
       firstSearchTrace.current?.endTrace();
     }
-  }, [loading, secondaryResults]);
+  }, [loading, secondaryResults, initialize]);
 
   const searchAndHandleSecondary = React.useCallback(
     async (queryString: string) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/search/AssetSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/AssetSearch.tsx
@@ -107,7 +107,7 @@ export const AssetSearch = () => {
     return (queryString: string) => {
       if (!firstSearchTrace.current && isFirstSearch.current) {
         isFirstSearch.current = false;
-        const trace = createTrace('SearchDialog:FirstSearch');
+        const trace = createTrace('AssetSearch:FirstSearch');
         firstSearchTrace.current = trace;
         trace.startTrace();
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -312,74 +312,18 @@ export const SearchDialog = ({
           transitionDuration={100}
         >
           <Container>
-<<<<<<< HEAD
             {searchInput}
             {searchResults}
-=======
-            <SearchBox hasQueryString={!!queryString.length}>
-              <Icon name="search" color={Colors.accentGray()} size={20} />
-              <SearchInput
-                data-search-input="1"
-                autoFocus
-                spellCheck={false}
-                onChange={onChange}
-                onKeyDown={onKeyDown}
-                placeholder={
-                  isAssetSearch ? 'Search assets' : 'Search assets, jobs, schedules, sensors…'
-                }
-                type="text"
-                value={queryString}
-              />
-              {loading ? <Spinner purpose="body-text" /> : null}
-            </SearchBox>
-            <SearchResults
-              highlight={highlight}
-              queryString={queryString}
-              results={renderedResults}
-              onClickResult={onClickResult}
-              filterResults={[]}
-            />
->>>>>>> 60e496c9bd (display filter results & bold matches)
           </Container>
         </Overlay>
       </>
     );
   } else {
     return (
-<<<<<<< HEAD
       <SearchInputWrapper>
         {searchInput}
         <SearchResultsWrapper>{searchResults}</SearchResultsWrapper>
       </SearchInputWrapper>
-=======
-      <InPageSearchContainer>
-        <SearchBox hasQueryString={!!queryString.length}>
-          <Icon name="search" color={Colors.accentGray()} size={20} />
-          <SearchInput
-            data-search-input="1"
-            autoFocus
-            spellCheck={false}
-            onChange={onChange}
-            onKeyDown={onKeyDown}
-            placeholder={
-              isAssetSearch ? 'Search assets' : 'Search assets, jobs, schedules, sensors…'
-            }
-            type="text"
-            value={queryString}
-          />
-          {loading ? <Spinner purpose="body-text" /> : null}
-        </SearchBox>
-        <SearchResultsWrapper>
-          <SearchResults
-            highlight={highlight}
-            queryString={queryString}
-            results={renderedResults}
-            filterResults={assetFilterResults}
-            onClickResult={onClickResult}
-          />
-        </SearchResultsWrapper>
-      </InPageSearchContainer>
->>>>>>> 60e496c9bd (display filter results & bold matches)
     );
   }
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -312,18 +312,74 @@ export const SearchDialog = ({
           transitionDuration={100}
         >
           <Container>
+<<<<<<< HEAD
             {searchInput}
             {searchResults}
+=======
+            <SearchBox hasQueryString={!!queryString.length}>
+              <Icon name="search" color={Colors.accentGray()} size={20} />
+              <SearchInput
+                data-search-input="1"
+                autoFocus
+                spellCheck={false}
+                onChange={onChange}
+                onKeyDown={onKeyDown}
+                placeholder={
+                  isAssetSearch ? 'Search assets' : 'Search assets, jobs, schedules, sensors…'
+                }
+                type="text"
+                value={queryString}
+              />
+              {loading ? <Spinner purpose="body-text" /> : null}
+            </SearchBox>
+            <SearchResults
+              highlight={highlight}
+              queryString={queryString}
+              results={renderedResults}
+              onClickResult={onClickResult}
+              filterResults={[]}
+            />
+>>>>>>> 60e496c9bd (display filter results & bold matches)
           </Container>
         </Overlay>
       </>
     );
   } else {
     return (
+<<<<<<< HEAD
       <SearchInputWrapper>
         {searchInput}
         <SearchResultsWrapper>{searchResults}</SearchResultsWrapper>
       </SearchInputWrapper>
+=======
+      <InPageSearchContainer>
+        <SearchBox hasQueryString={!!queryString.length}>
+          <Icon name="search" color={Colors.accentGray()} size={20} />
+          <SearchInput
+            data-search-input="1"
+            autoFocus
+            spellCheck={false}
+            onChange={onChange}
+            onKeyDown={onKeyDown}
+            placeholder={
+              isAssetSearch ? 'Search assets' : 'Search assets, jobs, schedules, sensors…'
+            }
+            type="text"
+            value={queryString}
+          />
+          {loading ? <Spinner purpose="body-text" /> : null}
+        </SearchBox>
+        <SearchResultsWrapper>
+          <SearchResults
+            highlight={highlight}
+            queryString={queryString}
+            results={renderedResults}
+            filterResults={assetFilterResults}
+            onClickResult={onClickResult}
+          />
+        </SearchResultsWrapper>
+      </InPageSearchContainer>
+>>>>>>> 60e496c9bd (display filter results & bold matches)
     );
   }
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -8,7 +8,7 @@ import {useHistory} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {SearchResults} from './SearchResults';
-import {SearchResult} from './types';
+import {SearchResult, SearchResultType} from './types';
 import {useGlobalSearch} from './useGlobalSearch';
 import {__updateSearchVisibility} from './useSearchVisibility';
 import {ShortcutHandler} from '../app/ShortcutHandler';
@@ -72,7 +72,50 @@ const initialState: State = {
 
 const DEBOUNCE_MSEC = 100;
 
-export const SearchDialog = ({searchPlaceholder}: {searchPlaceholder: string}) => {
+type SearchResultGroups = {
+  primaryResults: Fuse.FuseResult<SearchResult>[];
+  assetResults: Fuse.FuseResult<SearchResult>[];
+  assetFilterResults: Fuse.FuseResult<SearchResult>[];
+};
+
+function groupSearchResults(
+  primaryResults: Fuse.FuseResult<SearchResult>[],
+  secondaryResults: Fuse.FuseResult<SearchResult>[],
+  isAssetSearch: boolean,
+): SearchResultGroups {
+  if (isAssetSearch) {
+    return {
+      primaryResults: [],
+      assetResults: secondaryResults.filter(
+        (result) => result.item.type === SearchResultType.Asset,
+      ),
+      assetFilterResults: secondaryResults.filter(
+        (result) =>
+          result.item.type === SearchResultType.AssetGroup ||
+          result.item.type === SearchResultType.ComputeKind ||
+          result.item.type === SearchResultType.CodeLocation,
+      ),
+    };
+  } else {
+    return {
+      primaryResults,
+      assetResults: secondaryResults.filter(
+        (result) => result.item.type === SearchResultType.Asset,
+      ),
+      assetFilterResults: [],
+    };
+  }
+}
+
+export const SearchDialog = ({
+  searchPlaceholder,
+  isAssetSearch,
+  displayAsOverlay = true,
+}: {
+  searchPlaceholder: string;
+  isAssetSearch: boolean;
+  displayAsOverlay?: boolean;
+}) => {
   const history = useHistory();
   const {initialize, loading, searchPrimary, searchSecondary} = useGlobalSearch({
     includeAssetFilters: false,
@@ -82,7 +125,13 @@ export const SearchDialog = ({searchPlaceholder}: {searchPlaceholder: string}) =
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const {shown, queryString, primaryResults, secondaryResults, highlight} = state;
 
-  const results = [...primaryResults, ...secondaryResults];
+  const {
+    primaryResults: primaryResultsGroup,
+    assetResults,
+    assetFilterResults,
+  } = groupSearchResults(primaryResults, secondaryResults, isAssetSearch);
+  const results = [...primaryResultsGroup, ...assetResults, ...assetFilterResults];
+
   const renderedResults = results.slice(0, MAX_DISPLAYED_RESULTS);
   const numRenderedResults = renderedResults.length;
 
@@ -208,60 +257,93 @@ export const SearchDialog = ({searchPlaceholder}: {searchPlaceholder: string}) =
     }
   };
 
-  return (
-    <>
-      <ShortcutHandler onShortcut={openSearch} shortcutLabel="/" shortcutFilter={shortcutFilter}>
-        <SearchTrigger onClick={openSearch} data-search-trigger="1">
-          <Box flex={{justifyContent: 'space-between', alignItems: 'center'}}>
-            <Box flex={{alignItems: 'center', gap: 4}}>
-              <div
-                style={{
-                  height: '24px',
-                  width: '24px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                <Icon name="search" color={Colors.navTextHover()} />
-              </div>
-              <div>{searchPlaceholder}</div>
+  if (displayAsOverlay) {
+    return (
+      <>
+        <ShortcutHandler onShortcut={openSearch} shortcutLabel="/" shortcutFilter={shortcutFilter}>
+          <SearchTrigger onClick={openSearch} data-search-trigger="1">
+            <Box flex={{justifyContent: 'space-between', alignItems: 'center'}}>
+              <Box flex={{alignItems: 'center', gap: 4}}>
+                <div
+                  style={{
+                    height: '24px',
+                    width: '24px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Icon name="search" color={Colors.navTextHover()} />
+                </div>
+                <div>{searchPlaceholder}</div>
+              </Box>
+              <SlashShortcut>/</SlashShortcut>
             </Box>
-            <SlashShortcut>/</SlashShortcut>
-          </Box>
-        </SearchTrigger>
-      </ShortcutHandler>
-      <Overlay
-        backdropProps={{style: {backgroundColor: Colors.dialogBackground()}}}
-        isOpen={shown}
-        onClose={() => dispatch({type: 'hide-dialog'})}
-        transitionDuration={100}
-      >
-        <Container>
-          <SearchBox hasQueryString={!!queryString.length}>
-            <Icon name="search" color={Colors.accentGray()} size={20} />
-            <SearchInput
-              data-search-input="1"
-              autoFocus
-              spellCheck={false}
-              onChange={onChange}
-              onKeyDown={onKeyDown}
-              placeholder="Search assets, jobs, schedules, sensors…"
-              type="text"
-              value={queryString}
+          </SearchTrigger>
+        </ShortcutHandler>
+        <Overlay
+          backdropProps={{style: {backgroundColor: Colors.dialogBackground()}}}
+          isOpen={shown}
+          onClose={() => dispatch({type: 'hide-dialog'})}
+          transitionDuration={100}
+        >
+          <Container>
+            <SearchBox hasQueryString={!!queryString.length}>
+              <Icon name="search" color={Colors.accentGray()} size={20} />
+              <SearchInput
+                data-search-input="1"
+                autoFocus
+                spellCheck={false}
+                onChange={onChange}
+                onKeyDown={onKeyDown}
+                placeholder={
+                  isAssetSearch ? 'Search assets' : 'Search assets, jobs, schedules, sensors…'
+                }
+                type="text"
+                value={queryString}
+              />
+              {loading ? <Spinner purpose="body-text" /> : null}
+            </SearchBox>
+            <SearchResults
+              highlight={highlight}
+              queryString={queryString}
+              results={renderedResults}
+              onClickResult={onClickResult}
             />
-            {loading ? <Spinner purpose="body-text" /> : null}
-          </SearchBox>
+          </Container>
+        </Overlay>
+      </>
+    );
+  } else {
+    return (
+      <InPageSearchContainer>
+        <SearchBox hasQueryString={!!queryString.length}>
+          <Icon name="search" color={Colors.accentGray()} size={20} />
+          <SearchInput
+            data-search-input="1"
+            autoFocus
+            spellCheck={false}
+            onChange={onChange}
+            onKeyDown={onKeyDown}
+            placeholder={
+              isAssetSearch ? 'Search assets' : 'Search assets, jobs, schedules, sensors…'
+            }
+            type="text"
+            value={queryString}
+          />
+          {loading ? <Spinner purpose="body-text" /> : null}
+        </SearchBox>
+        <SearchResultsWrapper>
           <SearchResults
             highlight={highlight}
             queryString={queryString}
             results={renderedResults}
             onClickResult={onClickResult}
           />
-        </Container>
-      </Overlay>
-    </>
-  );
+        </SearchResultsWrapper>
+      </InPageSearchContainer>
+    );
+  }
 };
 
 const SearchTrigger = styled.button`
@@ -302,11 +384,25 @@ const Container = styled.div`
   }
 `;
 
+const InPageSearchContainer = styled.div`
+  position: relative;
+`;
+
+const SearchResultsWrapper = styled.div`
+  top: 60px;
+  position: absolute;
+  z-index: 1;
+  width: 100%;
+`;
+
 interface SearchBoxProps {
   readonly hasQueryString: boolean;
 }
 
 const SearchBox = styled.div<SearchBoxProps>`
+  border-radius: 12px;
+  box-shadow: 2px 2px 8px ${Colors.shadowDefault()};
+
   align-items: center;
   border-bottom: ${({hasQueryString}) =>
     hasQueryString ? `1px solid ${Colors.keylineDefault()}` : 'none'};

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -130,7 +130,7 @@ export const SearchDialog = ({
     assetResults,
     assetFilterResults,
   } = groupSearchResults(primaryResults, secondaryResults, isAssetSearch);
-  const results = [...primaryResultsGroup, ...assetResults, ...assetFilterResults];
+  const results = [...primaryResultsGroup, ...assetResults];
 
   const renderedResults = results.slice(0, MAX_DISPLAYED_RESULTS);
   const numRenderedResults = renderedResults.length;
@@ -309,6 +309,7 @@ export const SearchDialog = ({
               queryString={queryString}
               results={renderedResults}
               onClickResult={onClickResult}
+              filterResults={[]}
             />
           </Container>
         </Overlay>
@@ -338,6 +339,7 @@ export const SearchDialog = ({
             highlight={highlight}
             queryString={queryString}
             results={renderedResults}
+            filterResults={assetFilterResults}
             onClickResult={onClickResult}
           />
         </SearchResultsWrapper>

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -8,7 +8,7 @@ import {useHistory} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {SearchResults} from './SearchResults';
-import {SearchResult, SearchResultType} from './types';
+import {SearchResult, SearchResultType, isAssetFilterSearchResultType} from './types';
 import {useGlobalSearch} from './useGlobalSearch';
 import {__updateSearchVisibility} from './useSearchVisibility';
 import {ShortcutHandler} from '../app/ShortcutHandler';
@@ -89,11 +89,8 @@ function groupSearchResults(
       assetResults: secondaryResults.filter(
         (result) => result.item.type === SearchResultType.Asset,
       ),
-      assetFilterResults: secondaryResults.filter(
-        (result) =>
-          result.item.type === SearchResultType.AssetGroup ||
-          result.item.type === SearchResultType.ComputeKind ||
-          result.item.type === SearchResultType.CodeLocation,
+      assetFilterResults: secondaryResults.filter((result) =>
+        isAssetFilterSearchResultType(result.item.type),
       ),
     };
   } else {
@@ -112,7 +109,7 @@ export const SearchDialog = ({
   isAssetSearch,
   displayAsOverlay = true,
 }: {
-  searchPlaceholder: string;
+  searchPlaceholder?: string;
   isAssetSearch: boolean;
   displayAsOverlay?: boolean;
 }) => {
@@ -257,6 +254,33 @@ export const SearchDialog = ({
     }
   };
 
+  const searchResults = (
+    <SearchResults
+      highlight={highlight}
+      queryString={queryString}
+      results={renderedResults}
+      filterResults={assetFilterResults}
+      onClickResult={onClickResult}
+    />
+  );
+
+  const searchInput = (
+    <SearchBox hasQueryString={!!queryString.length}>
+      <Icon name="search" color={Colors.accentGray()} size={20} />
+      <SearchInput
+        data-search-input="1"
+        autoFocus
+        spellCheck={false}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        placeholder={isAssetSearch ? 'Search assets' : 'Search assets, jobs, schedules, sensors…'}
+        type="text"
+        value={queryString}
+      />
+      {loading ? <Spinner purpose="body-text" /> : null}
+    </SearchBox>
+  );
+
   if (displayAsOverlay) {
     return (
       <>
@@ -288,62 +312,18 @@ export const SearchDialog = ({
           transitionDuration={100}
         >
           <Container>
-            <SearchBox hasQueryString={!!queryString.length}>
-              <Icon name="search" color={Colors.accentGray()} size={20} />
-              <SearchInput
-                data-search-input="1"
-                autoFocus
-                spellCheck={false}
-                onChange={onChange}
-                onKeyDown={onKeyDown}
-                placeholder={
-                  isAssetSearch ? 'Search assets' : 'Search assets, jobs, schedules, sensors…'
-                }
-                type="text"
-                value={queryString}
-              />
-              {loading ? <Spinner purpose="body-text" /> : null}
-            </SearchBox>
-            <SearchResults
-              highlight={highlight}
-              queryString={queryString}
-              results={renderedResults}
-              onClickResult={onClickResult}
-              filterResults={[]}
-            />
+            {searchInput}
+            {searchResults}
           </Container>
         </Overlay>
       </>
     );
   } else {
     return (
-      <InPageSearchContainer>
-        <SearchBox hasQueryString={!!queryString.length}>
-          <Icon name="search" color={Colors.accentGray()} size={20} />
-          <SearchInput
-            data-search-input="1"
-            autoFocus
-            spellCheck={false}
-            onChange={onChange}
-            onKeyDown={onKeyDown}
-            placeholder={
-              isAssetSearch ? 'Search assets' : 'Search assets, jobs, schedules, sensors…'
-            }
-            type="text"
-            value={queryString}
-          />
-          {loading ? <Spinner purpose="body-text" /> : null}
-        </SearchBox>
-        <SearchResultsWrapper>
-          <SearchResults
-            highlight={highlight}
-            queryString={queryString}
-            results={renderedResults}
-            filterResults={assetFilterResults}
-            onClickResult={onClickResult}
-          />
-        </SearchResultsWrapper>
-      </InPageSearchContainer>
+      <SearchInputWrapper>
+        {searchInput}
+        <SearchResultsWrapper>{searchResults}</SearchResultsWrapper>
+      </SearchInputWrapper>
     );
   }
 };
@@ -386,7 +366,7 @@ const Container = styled.div`
   }
 `;
 
-const InPageSearchContainer = styled.div`
+const SearchInputWrapper = styled.div`
   position: relative;
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
@@ -135,33 +135,26 @@ const SearchResultItem = React.memo(({isHighlight, onClickResult, result}: ItemP
   return (
     <Item isHighlight={isHighlight} ref={element}>
       <ResultLink to={item.href} onMouseDown={onClick}>
-        <Box
-          flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
-          style={{width: '100%'}}
-        >
-          <Box flex={{direction: 'row', alignItems: 'center'}}>
-            <StyledTag
-              $fillColor={Colors.backgroundGray()}
-              $interactive={false}
-              $textColor={Colors.textDefault()}
-            >
-              <Icon
-                name={iconForType(item.type)}
-                color={isHighlight ? Colors.textDefault() : Colors.textLight()}
-              />
-              {isAssetFilterSearchResultType(item.type) ? (
-                <SearchResultLabel>{assetFilterPrefixString(item.type)}:&nbsp;</SearchResultLabel>
-              ) : (
-                <></>
-              )}
-              {labelComponents.map((component) => component)}
-            </StyledTag>
-            <div style={{marginLeft: '8px'}}>
-              <Description isHighlight={isHighlight}>
-                {item.numResults ? `${item.numResults} assets` : item.description}
-              </Description>
-            </div>
-          </Box>
+        <Box flex={{direction: 'row', alignItems: 'center'}} style={{width: '100%'}}>
+          <StyledTag
+            $fillColor={Colors.backgroundGray()}
+            $interactive={false}
+            $textColor={Colors.textDefault()}
+          >
+            <Icon
+              name={iconForType(item.type)}
+              color={isHighlight ? Colors.textDefault() : Colors.textLight()}
+            />
+            {isAssetFilterSearchResultType(item.type) && (
+              <SearchResultLabel>{assetFilterPrefixString(item.type)}:&nbsp;</SearchResultLabel>
+            )}
+            {labelComponents.map((component) => component)}
+          </StyledTag>
+          <div style={{marginLeft: '8px'}}>
+            <Description isHighlight={isHighlight}>
+              {item.numResults ? `${item.numResults} assets` : item.description}
+            </Description>
+          </div>
         </Box>
       </ResultLink>
     </Item>

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
@@ -118,6 +118,9 @@ const List = styled.ul<ListProps>`
   padding: ${({hasResults}) => (hasResults ? '4px 0' : 'none')};
   list-style: none;
   overflow-y: auto;
+  background-color: ${Colors.backgroundDefault()};
+  box-shadow: 2px 2px 8px ${Colors.shadowDefault()};
+  border-radius: 4px;
 `;
 
 interface HighlightableTextProps {
@@ -126,7 +129,8 @@ interface HighlightableTextProps {
 
 const Item = styled.li<HighlightableTextProps>`
   align-items: center;
-  background-color: ${({isHighlight}) => (isHighlight ? Colors.backgroundLight() : 'transparent')};
+  background-color: ${({isHighlight}) =>
+    isHighlight ? Colors.backgroundLight() : Colors.backgroundDefault()};
   box-shadow: ${({isHighlight}) => (isHighlight ? Colors.accentLime() : 'transparent')} 4px 0 0
     inset;
   color: ${Colors.textLight()};

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
@@ -1,4 +1,12 @@
-import {Box, Colors, Icon, IconName, StyledTag} from '@dagster-io/ui-components';
+import {
+  Box,
+  Caption,
+  CaptionBolded,
+  Colors,
+  Icon,
+  IconName,
+  StyledTag,
+} from '@dagster-io/ui-components';
 import Fuse from 'fuse.js';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
@@ -95,16 +103,16 @@ function buildSearchLabel(result: Fuse.FuseResult<SearchResult>): JSX.Element[] 
   let parsedString = '';
   mergedIndices.forEach((indices) => {
     const stringBeforeMatch = result.item.label.slice(parsedString.length, indices[0]);
-    labelComponents.push(<SearchResultLabel>{stringBeforeMatch}</SearchResultLabel>);
+    labelComponents.push(<Caption>{stringBeforeMatch}</Caption>);
     parsedString += stringBeforeMatch;
 
     const match = result.item.label.slice(indices[0], indices[1] + 1);
-    labelComponents.push(<SearchResultBoldedLabel>{match}</SearchResultBoldedLabel>);
+    labelComponents.push(<CaptionBolded>{match}</CaptionBolded>);
     parsedString += match;
   });
 
   const stringAfterMatch = result.item.label.substring(parsedString.length);
-  labelComponents.push(<SearchResultLabel>{stringAfterMatch}</SearchResultLabel>);
+  labelComponents.push(<Caption>{stringAfterMatch}</Caption>);
   parsedString += stringAfterMatch;
 
   return labelComponents;
@@ -135,7 +143,7 @@ const SearchResultItem = React.memo(({isHighlight, onClickResult, result}: ItemP
   return (
     <Item isHighlight={isHighlight} ref={element}>
       <ResultLink to={item.href} onMouseDown={onClick}>
-        <Box flex={{direction: 'row', alignItems: 'center'}} style={{width: '100%'}}>
+        <Box flex={{direction: 'row', alignItems: 'center', grow: 1}}>
           <StyledTag
             $fillColor={Colors.backgroundGray()}
             $interactive={false}
@@ -146,7 +154,7 @@ const SearchResultItem = React.memo(({isHighlight, onClickResult, result}: ItemP
               color={isHighlight ? Colors.textDefault() : Colors.textLight()}
             />
             {isAssetFilterSearchResultType(item.type) && (
-              <SearchResultLabel>{assetFilterPrefixString(item.type)}:&nbsp;</SearchResultLabel>
+              <Caption>{assetFilterPrefixString(item.type)}:&nbsp;</Caption>
             )}
             {labelComponents.map((component) => component)}
           </StyledTag>
@@ -236,14 +244,6 @@ const MatchingFiltersHeader = styled.li`
   border-bottom: 1px solid ${Colors.backgroundGray()};
   color: ${Colors.textLight()};
   font-weight: 500;
-`;
-
-const SearchResultBoldedLabel = styled.span`
-  font-weight: 800;
-`;
-
-const SearchResultLabel = styled.span`
-  font-weight: 300;
 `;
 
 const Item = styled.li<HighlightableTextProps>`

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
@@ -1,10 +1,15 @@
-import {Colors, Icon, IconName, StyledTag} from '@dagster-io/ui-components';
+import {Box, Colors, Icon, IconName, StyledTag} from '@dagster-io/ui-components';
 import Fuse from 'fuse.js';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
-import {AssetFilterSearchResultType, SearchResult, SearchResultType} from './types';
+import {
+  AssetFilterSearchResultType,
+  SearchResult,
+  SearchResultType,
+  isAssetFilterSearchResultType,
+} from './types';
 
 const iconForType = (type: SearchResultType | AssetFilterSearchResultType): IconName => {
   switch (type) {
@@ -27,8 +32,29 @@ const iconForType = (type: SearchResultType | AssetFilterSearchResultType): Icon
       return 'op';
     case SearchResultType.Resource:
       return 'resource';
+    case AssetFilterSearchResultType.CodeLocation:
+      return 'folder';
+    case AssetFilterSearchResultType.Owner:
+      return 'account_circle';
+    case AssetFilterSearchResultType.AssetGroup:
+      return 'asset_group';
     default:
       return 'source';
+  }
+};
+
+const assetFilterPrefixString = (type: AssetFilterSearchResultType): string => {
+  switch (type) {
+    case AssetFilterSearchResultType.CodeLocation:
+      return 'Code location';
+    case AssetFilterSearchResultType.ComputeKind:
+      return 'Compute kind';
+    case AssetFilterSearchResultType.Owner:
+      return 'Owner';
+    case AssetFilterSearchResultType.AssetGroup:
+      return 'Group';
+    default:
+      return '';
   }
 };
 
@@ -39,24 +65,23 @@ interface ItemProps {
 }
 
 function buildSearchLabel(result: Fuse.FuseResult<SearchResult>): JSX.Element[] {
-  const labelComponents = [];
-  let parsedString = '';
+  // Fuse provides indices of the label that match the query string.
+  // Use these match indices to display the label with the matching parts bolded.
+
   // Match indices can overlap, i.e. [0, 4] and [1, 1] can both be matches
   // So we merge them to be non-overlapping
   const mergedIndices: Fuse.RangeTuple[] = [];
-
   if (result.matches && result.matches.length > 0) {
     const match = result.matches[0]!; // Only one match per row, since we only match by label
 
     // The indices should be returned in sorted order, but we sort just in case
     const sortedIndices = Array.from(match.indices).sort((a, b) => (a[0] < b[0] ? -1 : 1));
+    // Merge overlapping indices
     if (sortedIndices.length > 0) {
       mergedIndices.push(sortedIndices[0]!);
-
       for (let i = 1; i < sortedIndices.length; i++) {
         const last = mergedIndices[mergedIndices.length - 1]!;
         const current = sortedIndices[i]!;
-
         if (current[0] <= last[1]) {
           last[1] = Math.max(last[1], current[1]);
         } else {
@@ -66,6 +91,8 @@ function buildSearchLabel(result: Fuse.FuseResult<SearchResult>): JSX.Element[] 
     }
   }
 
+  const labelComponents = [];
+  let parsedString = '';
   mergedIndices.forEach((indices) => {
     const stringBeforeMatch = result.item.label.slice(parsedString.length, indices[0]);
     labelComponents.push(<SearchResultLabel>{stringBeforeMatch}</SearchResultLabel>);
@@ -108,20 +135,34 @@ const SearchResultItem = React.memo(({isHighlight, onClickResult, result}: ItemP
   return (
     <Item isHighlight={isHighlight} ref={element}>
       <ResultLink to={item.href} onMouseDown={onClick}>
-        <StyledTag
-          $fillColor={Colors.backgroundGray()}
-          $interactive={false}
-          $textColor={Colors.textDefault()}
+        <Box
+          flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
+          style={{width: '100%'}}
         >
-          <Icon
-            name={iconForType(item.type)}
-            color={isHighlight ? Colors.textDefault() : Colors.textLight()}
-          />
-          {labelComponents.map((component) => component)}
-        </StyledTag>
-        <div style={{marginLeft: '12px'}}>
-          <Description isHighlight={isHighlight}>{item.description}</Description>
-        </div>
+          <Box flex={{direction: 'row', alignItems: 'center'}}>
+            <StyledTag
+              $fillColor={Colors.backgroundGray()}
+              $interactive={false}
+              $textColor={Colors.textDefault()}
+            >
+              <Icon
+                name={iconForType(item.type)}
+                color={isHighlight ? Colors.textDefault() : Colors.textLight()}
+              />
+              {isAssetFilterSearchResultType(item.type) ? (
+                <SearchResultLabel>{assetFilterPrefixString(item.type)}:&nbsp;</SearchResultLabel>
+              ) : (
+                <></>
+              )}
+              {labelComponents.map((component) => component)}
+            </StyledTag>
+            <div style={{marginLeft: '8px'}}>
+              <Description isHighlight={isHighlight}>
+                {item.numResults ? `${item.numResults} assets` : item.description}
+              </Description>
+            </div>
+          </Box>
+        </Box>
       </ResultLink>
     </Item>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
@@ -23,6 +23,17 @@ export enum AssetFilterSearchResultType {
   AssetGroup = 'AssetFilterSearchResultType.AssetGroup',
 }
 
+export function isAssetFilterSearchResultType(
+  type: SearchResultType | AssetFilterSearchResultType,
+): type is AssetFilterSearchResultType {
+  return (
+    type === AssetFilterSearchResultType.AssetGroup ||
+    type === AssetFilterSearchResultType.CodeLocation ||
+    type === AssetFilterSearchResultType.ComputeKind ||
+    type === AssetFilterSearchResultType.Owner
+  );
+}
+
 export type SearchResult = {
   label: string;
   description: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -249,6 +249,7 @@ const fuseOptions = {
   keys: ['label', 'segments', 'tags', 'type'],
   threshold: 0.3,
   useExtendedSearch: true,
+  includeMatches: true,
 };
 
 const EMPTY_RESPONSE = {queryString: '', results: []};


### PR DESCRIPTION
Walkthrough of the UI: https://www.loom.com/share/182595e3ba40415694343c6d786720d7?sid=ecb71bf9-0a87-44e4-bb78-4673d6d06495

Changes included:
- Allows the `SearchDialog` to accept a prop indicating whether the search displays as an overlay, or on the page
- Displays the fuzzy matches in the label in bold
- Displays filter results, alongside the # of assets

Next steps:
- Handle typeaheads (i.e. `asset is:`/`sensor is:`/etc)