### PR TITLE
remove AssetDaemonContext._verbose_log_fn

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
@@ -447,11 +447,11 @@ class RuleCondition(
         return self.rule.description
 
     def evaluate(self, context: "AssetConditionEvaluationContext") -> AssetConditionResult:
-        context.root_context.daemon_context._verbose_log_fn(  # noqa
+        context.root_context.daemon_context.logger.debug(
             f"Evaluating rule: {self.rule.to_snapshot()}"
         )
         evaluation_result = self.rule.evaluate_for_asset(context)
-        context.root_context.daemon_context._verbose_log_fn(  # noqa
+        context.root_context.daemon_context.logger.debug(
             f"Rule returned {evaluation_result.true_subset.size} partitions "
             f"({evaluation_result.end_timestamp - evaluation_result.start_timestamp:.2f} seconds)"
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-import os
 import time
 from collections import defaultdict
 from typing import (
@@ -109,12 +108,12 @@ class AssetDaemonContext:
         self._respect_materialization_data_versions = respect_materialization_data_versions
         self._logger = logger
 
-        self._verbose_log_fn = (
-            self._logger.info if os.getenv("ASSET_DAEMON_VERBOSE_LOGS") else self._logger.debug
-        )
-
         # cache data before the tick starts
         self.prefetch()
+
+    @property
+    def logger(self) -> logging.Logger:
+        return self._logger
 
     @property
     def instance_queryer(self) -> "CachingInstanceQueryer":
@@ -234,7 +233,7 @@ class AssetDaemonContext:
 
             num_checked_assets = num_checked_assets + 1
             start_time = time.time()
-            self._verbose_log_fn(
+            self._logger.debug(
                 "Evaluating asset"
                 f" {asset_key.to_user_string()} ({num_checked_assets}/{num_auto_materialize_asset_keys})"
             )


### PR DESCRIPTION
Summary:
This was a hack to paper over my inability to understand python log configuration, I have now achieved a basic enough understand of python log configuration that it can be removed.

Test Plan:
Run daemon with debug logging and info logging

## Summary & Motivation

## How I Tested These Changes
