### PR TITLE
[1.7] deprecate invalid tag keys

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -6,7 +6,7 @@ import requests.exceptions
 from dagster import DagsterRunStatus
 from dagster._annotations import deprecated, public
 from dagster._core.definitions.run_config import RunConfig, convert_config_input
-from dagster._core.definitions.utils import validate_tags
+from dagster._core.definitions.utils import validate_and_normalize_tags
 from gql import Client, gql
 from gql.transport import Transport
 from gql.transport.requests import RequestsHTTPTransport
@@ -143,7 +143,7 @@ class DagsterGraphQLClient:
             "Either a mode and run_config or a preset must be specified in order to "
             f"submit the pipeline {pipeline_name} for execution",
         )
-        tags = validate_tags(tags)
+        tags = validate_and_normalize_tags(tags).tags
 
         pipeline_or_job = "Job" if is_using_job_op_graph_apis else "Pipeline"
 

--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -6,7 +6,7 @@ import requests.exceptions
 from dagster import DagsterRunStatus
 from dagster._annotations import deprecated, public
 from dagster._core.definitions.run_config import RunConfig, convert_config_input
-from dagster._core.definitions.utils import validate_and_normalize_tags
+from dagster._core.definitions.utils import normalize_tags
 from gql import Client, gql
 from gql.transport import Transport
 from gql.transport.requests import RequestsHTTPTransport
@@ -143,7 +143,7 @@ class DagsterGraphQLClient:
             "Either a mode and run_config or a preset must be specified in order to "
             f"submit the pipeline {pipeline_name} for execution",
         )
-        tags = validate_and_normalize_tags(tags).tags
+        tags = normalize_tags(tags).tags
 
         pipeline_or_job = "Job" if is_using_job_op_graph_apis else "Pipeline"
 

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -30,7 +30,7 @@ from dagster._cli.workspace.cli_target import (
 from dagster._core.definitions import JobDefinition
 from dagster._core.definitions.reconstruct import ReconstructableJob
 from dagster._core.definitions.selector import JobSubsetSelector
-from dagster._core.definitions.utils import validate_and_normalize_tags
+from dagster._core.definitions.utils import normalize_tags
 from dagster._core.errors import DagsterBackfillFailedError
 from dagster._core.execution.api import create_execution_plan, execute_job
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
@@ -577,7 +577,7 @@ def _check_execute_external_job_args(
 
     return (
         run_config,
-        validate_and_normalize_tags(tags).tags,
+        normalize_tags(tags).tags,
         op_selection,
     )
 

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -30,7 +30,7 @@ from dagster._cli.workspace.cli_target import (
 from dagster._core.definitions import JobDefinition
 from dagster._core.definitions.reconstruct import ReconstructableJob
 from dagster._core.definitions.selector import JobSubsetSelector
-from dagster._core.definitions.utils import validate_tags
+from dagster._core.definitions.utils import validate_and_normalize_tags
 from dagster._core.errors import DagsterBackfillFailedError
 from dagster._core.execution.api import create_execution_plan, execute_job
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
@@ -577,7 +577,7 @@ def _check_execute_external_job_args(
 
     return (
         run_config,
-        validate_tags(tags),
+        validate_and_normalize_tags(tags).tags,
         op_selection,
     )
 

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_sensor_definition.py
@@ -5,7 +5,7 @@ from dagster._core.definitions.asset_selection import CoercibleToAssetSelection
 
 from .asset_selection import AssetSelection
 from .sensor_definition import DefaultSensorStatus, SensorDefinition, SensorType
-from .utils import check_valid_name, validate_and_normalize_tags
+from .utils import check_valid_name, normalize_tags
 
 
 @experimental
@@ -36,7 +36,7 @@ class AutoMaterializeSensorDefinition(SensorDefinition):
         minimum_interval_seconds: Optional[int] = None,
         description: Optional[str] = None,
     ):
-        self._run_tags = validate_and_normalize_tags(run_tags).tags
+        self._run_tags = normalize_tags(run_tags).tags
 
         def evaluation_fn(context):
             raise NotImplementedError(

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_sensor_definition.py
@@ -5,7 +5,7 @@ from dagster._core.definitions.asset_selection import CoercibleToAssetSelection
 
 from .asset_selection import AssetSelection
 from .sensor_definition import DefaultSensorStatus, SensorDefinition, SensorType
-from .utils import check_valid_name, validate_tags
+from .utils import check_valid_name, validate_and_normalize_tags
 
 
 @experimental
@@ -36,7 +36,7 @@ class AutoMaterializeSensorDefinition(SensorDefinition):
         minimum_interval_seconds: Optional[int] = None,
         description: Optional[str] = None,
     ):
-        self._run_tags = validate_tags(run_tags)
+        self._run_tags = validate_and_normalize_tags(run_tags).tags
 
         def evaluation_fn(context):
             raise NotImplementedError(

--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -51,7 +51,7 @@ from .node_definition import NodeDefinition
 from .output import OutputDefinition, OutputMapping
 from .policy import RetryPolicy
 from .resource_definition import ResourceDefinition
-from .utils import check_valid_name, validate_tags
+from .utils import NormalizedTags, check_valid_name, validate_and_normalize_tags
 from .version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
@@ -645,7 +645,7 @@ class PendingNodeInvocation(Generic[T_NodeDefinition]):
 
     @public
     def tag(self, tags: Optional[Mapping[str, str]]) -> "PendingNodeInvocation[T_NodeDefinition]":
-        tags = validate_tags(tags)
+        tags = validate_and_normalize_tags(tags).tags
         return PendingNodeInvocation(
             node_def=self.node_def,
             given_alias=self.given_alias,
@@ -686,7 +686,7 @@ class PendingNodeInvocation(Generic[T_NodeDefinition]):
         description: Optional[str] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         config: Optional[Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig"]] = None,
-        tags: Optional[Mapping[str, Any]] = None,
+        tags: Union[NormalizedTags, Optional[Mapping[str, Any]]] = None,
         logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
         executor_def: Optional["ExecutorDefinition"] = None,
         hooks: Optional[AbstractSet[HookDefinition]] = None,
@@ -701,7 +701,7 @@ class PendingNodeInvocation(Generic[T_NodeDefinition]):
                 "constructed using the `@graph` decorator support this method."
             )
 
-        tags = check.opt_mapping_param(tags, "tags", key_type=str)
+        tags = validate_and_normalize_tags(tags)
         hooks = check.opt_set_param(hooks, "hooks", HookDefinition)
         input_values = check.opt_mapping_param(input_values, "input_values")
         op_retry_policy = check.opt_inst_param(op_retry_policy, "op_retry_policy", RetryPolicy)
@@ -713,7 +713,7 @@ class PendingNodeInvocation(Generic[T_NodeDefinition]):
             description=description,
             resource_defs=resource_defs,
             config=config,
-            tags={**(self.tags or {}), **tags},
+            tags=NormalizedTags(self.tags or {}).with_normalized_tags(tags),
             logger_defs=logger_defs,
             executor_def=executor_def,
             hooks=job_hooks,

--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -51,7 +51,7 @@ from .node_definition import NodeDefinition
 from .output import OutputDefinition, OutputMapping
 from .policy import RetryPolicy
 from .resource_definition import ResourceDefinition
-from .utils import NormalizedTags, check_valid_name, validate_and_normalize_tags
+from .utils import NormalizedTags, check_valid_name, normalize_tags
 from .version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
@@ -645,7 +645,7 @@ class PendingNodeInvocation(Generic[T_NodeDefinition]):
 
     @public
     def tag(self, tags: Optional[Mapping[str, str]]) -> "PendingNodeInvocation[T_NodeDefinition]":
-        tags = validate_and_normalize_tags(tags).tags
+        tags = normalize_tags(tags).tags
         return PendingNodeInvocation(
             node_def=self.node_def,
             given_alias=self.given_alias,
@@ -701,7 +701,7 @@ class PendingNodeInvocation(Generic[T_NodeDefinition]):
                 "constructed using the `@graph` decorator support this method."
             )
 
-        tags = validate_and_normalize_tags(tags)
+        tags = normalize_tags(tags)
         hooks = check.opt_set_param(hooks, "hooks", HookDefinition)
         input_values = check.opt_mapping_param(input_values, "input_values")
         op_retry_policy = check.opt_inst_param(op_retry_policy, "op_retry_policy", RetryPolicy)

--- a/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
@@ -13,6 +13,7 @@ from ..logger_definition import LoggerDefinition
 from ..metadata import RawMetadataValue
 from ..policy import RetryPolicy
 from ..resource_definition import ResourceDefinition
+from ..utils import validate_and_normalize_tags
 from ..version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
@@ -44,7 +45,7 @@ class _Job:
 
         self.name = name
         self.description = description
-        self.tags = tags
+        self.tags = validate_and_normalize_tags(tags, warning_stacklevel=5)
         self.metadata = metadata
         self.resource_defs = resource_defs
         self.config = convert_config_input(config)

--- a/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
@@ -13,7 +13,7 @@ from ..logger_definition import LoggerDefinition
 from ..metadata import RawMetadataValue
 from ..policy import RetryPolicy
 from ..resource_definition import ResourceDefinition
-from ..utils import validate_and_normalize_tags
+from ..utils import normalize_tags
 from ..version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
@@ -45,7 +45,7 @@ class _Job:
 
         self.name = name
         self.description = description
-        self.tags = validate_and_normalize_tags(tags, warning_stacklevel=5)
+        self.tags = normalize_tags(tags, warning_stacklevel=5)
         self.metadata = metadata
         self.resource_defs = resource_defs
         self.config = convert_config_input(config)

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -35,7 +35,7 @@ from ..schedule_definition import (
     validate_and_get_schedule_resource_dict,
 )
 from ..target import ExecutableDefinition
-from ..utils import validate_tags
+from ..utils import validate_and_normalize_tags
 
 
 def schedule(
@@ -113,7 +113,9 @@ def schedule(
                 " to ScheduleDefinition. Must provide only one of the two."
             )
         elif tags:
-            validated_tags = validate_tags(tags, allow_reserved_tags=False)
+            validated_tags = validate_and_normalize_tags(
+                tags, allow_reserved_tags=False, warning_stacklevel=3
+            )
 
         context_param_name = get_context_param_name(fn)
         resource_arg_names: Set[str] = {arg.name for arg in get_resource_args(fn)}
@@ -149,7 +151,12 @@ def schedule(
                     evaluated_run_config = copy.deepcopy(result)
                     evaluated_tags = (
                         validated_tags
-                        or (tags_fn and validate_tags(tags_fn(context), allow_reserved_tags=False))
+                        or (
+                            tags_fn
+                            and validate_and_normalize_tags(
+                                tags_fn(context), allow_reserved_tags=False
+                            )
+                        )
                         or None
                     )
                     yield RunRequest(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -35,7 +35,7 @@ from ..schedule_definition import (
     validate_and_get_schedule_resource_dict,
 )
 from ..target import ExecutableDefinition
-from ..utils import validate_and_normalize_tags
+from ..utils import normalize_tags
 
 
 def schedule(
@@ -113,9 +113,7 @@ def schedule(
                 " to ScheduleDefinition. Must provide only one of the two."
             )
         elif tags:
-            validated_tags = validate_and_normalize_tags(
-                tags, allow_reserved_tags=False, warning_stacklevel=3
-            )
+            validated_tags = normalize_tags(tags, allow_reserved_tags=False, warning_stacklevel=3)
 
         context_param_name = get_context_param_name(fn)
         resource_arg_names: Set[str] = {arg.name for arg in get_resource_args(fn)}
@@ -151,12 +149,7 @@ def schedule(
                     evaluated_run_config = copy.deepcopy(result)
                     evaluated_tags = (
                         validated_tags
-                        or (
-                            tags_fn
-                            and validate_and_normalize_tags(
-                                tags_fn(context), allow_reserved_tags=False
-                            )
-                        )
+                        or (tags_fn and normalize_tags(tags_fn(context), allow_reserved_tags=False))
                         or None
                     )
                     yield RunRequest(

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -35,7 +35,7 @@ from dagster._utils import hash_collection
 from .hook_definition import HookDefinition
 from .input import FanInInputPointer, InputDefinition, InputMapping, InputPointer
 from .output import OutputDefinition
-from .utils import DEFAULT_OUTPUT, struct_to_string, validate_and_normalize_tags
+from .utils import DEFAULT_OUTPUT, normalize_tags, struct_to_string
 
 if TYPE_CHECKING:
     from dagster._core.definitions.op_definition import OpDefinition
@@ -144,7 +144,7 @@ class Node(ABC):
             "graph_definition",
             GraphDefinition,
         )
-        self._additional_tags = validate_and_normalize_tags(tags).tags
+        self._additional_tags = normalize_tags(tags).tags
         self._hook_defs = check.opt_set_param(hook_defs, "hook_defs", of_type=HookDefinition)
         self._retry_policy = check.opt_inst_param(retry_policy, "retry_policy", RetryPolicy)
 

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -35,7 +35,7 @@ from dagster._utils import hash_collection
 from .hook_definition import HookDefinition
 from .input import FanInInputPointer, InputDefinition, InputMapping, InputPointer
 from .output import OutputDefinition
-from .utils import DEFAULT_OUTPUT, struct_to_string, validate_tags
+from .utils import DEFAULT_OUTPUT, struct_to_string, validate_and_normalize_tags
 
 if TYPE_CHECKING:
     from dagster._core.definitions.op_definition import OpDefinition
@@ -144,7 +144,7 @@ class Node(ABC):
             "graph_definition",
             GraphDefinition,
         )
-        self._additional_tags = validate_tags(tags)
+        self._additional_tags = validate_and_normalize_tags(tags).tags
         self._hook_defs = check.opt_set_param(hook_defs, "hook_defs", of_type=HookDefinition)
         self._retry_policy = check.opt_inst_param(retry_policy, "retry_policy", RetryPolicy)
 

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -52,6 +52,7 @@ from .node_container import create_execution_structure, normalize_dependency_dic
 from .node_definition import NodeDefinition
 from .output import OutputDefinition, OutputMapping
 from .resource_requirement import ResourceRequirement
+from .utils import NormalizedTags
 from .version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
@@ -207,7 +208,7 @@ class GraphDefinition(NodeDefinition):
         input_mappings: Optional[Sequence[InputMapping]] = None,
         output_mappings: Optional[Sequence[OutputMapping]] = None,
         config: Optional[ConfigMapping] = None,
-        tags: Optional[Mapping[str, str]] = None,
+        tags: Union[NormalizedTags, Optional[Mapping[str, str]]] = None,
         node_input_source_assets: Optional[Mapping[str, Mapping[str, "SourceAsset"]]] = None,
         input_assets: Optional[
             Mapping[str, Mapping[str, Union["AssetsDefinition", "SourceAsset"]]]
@@ -596,7 +597,7 @@ class GraphDefinition(NodeDefinition):
         config: Optional[
             Union["RunConfig", ConfigMapping, Mapping[str, object], "PartitionedConfig"]
         ] = None,
-        tags: Optional[Mapping[str, str]] = None,
+        tags: Union[NormalizedTags, Optional[Mapping[str, str]]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
         executor_def: Optional["ExecutorDefinition"] = None,

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -80,7 +80,7 @@ from .metadata import MetadataValue, RawMetadataValue, normalize_metadata
 from .partition import PartitionedConfig, PartitionsDefinition
 from .resource_definition import ResourceDefinition
 from .run_request import RunRequest
-from .utils import DEFAULT_IO_MANAGER_KEY, NormalizedTags, validate_and_normalize_tags
+from .utils import DEFAULT_IO_MANAGER_KEY, NormalizedTags, normalize_tags
 from .version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
@@ -174,7 +174,7 @@ class JobDefinition(IHasInternalInit):
         # tags and description can exist on graph as well, but since
         # same graph may be in multiple jobs, keep separate layer
         self._description = check.opt_str_param(description, "description")
-        self._tags = validate_and_normalize_tags(tags).tags
+        self._tags = normalize_tags(tags).tags
         self._metadata = normalize_metadata(
             check.opt_mapping_param(metadata, "metadata", key_type=str)
         )

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -80,7 +80,7 @@ from .metadata import MetadataValue, RawMetadataValue, normalize_metadata
 from .partition import PartitionedConfig, PartitionsDefinition
 from .resource_definition import ResourceDefinition
 from .run_request import RunRequest
-from .utils import DEFAULT_IO_MANAGER_KEY, validate_tags
+from .utils import DEFAULT_IO_MANAGER_KEY, NormalizedTags, validate_and_normalize_tags
 from .version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
@@ -131,7 +131,7 @@ class JobDefinition(IHasInternalInit):
         ] = None,
         description: Optional[str] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
-        tags: Optional[Mapping[str, Any]] = None,
+        tags: Union[NormalizedTags, Optional[Mapping[str, Any]]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         hook_defs: Optional[AbstractSet[HookDefinition]] = None,
         op_retry_policy: Optional[RetryPolicy] = None,
@@ -174,7 +174,7 @@ class JobDefinition(IHasInternalInit):
         # tags and description can exist on graph as well, but since
         # same graph may be in multiple jobs, keep separate layer
         self._description = check.opt_str_param(description, "description")
-        self._tags = validate_tags(tags)
+        self._tags = validate_and_normalize_tags(tags).tags
         self._metadata = normalize_metadata(
             check.opt_mapping_param(metadata, "metadata", key_type=str)
         )
@@ -266,7 +266,7 @@ class JobDefinition(IHasInternalInit):
         ],
         description: Optional[str],
         partitions_def: Optional[PartitionsDefinition],
-        tags: Optional[Mapping[str, Any]],
+        tags: Union[NormalizedTags, Optional[Mapping[str, Any]]],
         metadata: Optional[Mapping[str, RawMetadataValue]],
         hook_defs: Optional[AbstractSet[HookDefinition]],
         op_retry_policy: Optional[RetryPolicy],

--- a/python_modules/dagster/dagster/_core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/node_definition.py
@@ -17,7 +17,7 @@ from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.errors import DagsterInvariantViolationError
 
 from .hook_definition import HookDefinition
-from .utils import NormalizedTags, check_valid_name, validate_and_normalize_tags
+from .utils import NormalizedTags, check_valid_name, normalize_tags
 
 if TYPE_CHECKING:
     from dagster._core.types.dagster_type import DagsterType
@@ -53,7 +53,7 @@ class NodeDefinition(NamedConfigurableDefinition):
     ):
         self._name = check_valid_name(name)
         self._description = check.opt_str_param(description, "description")
-        self._tags = validate_and_normalize_tags(tags).tags
+        self._tags = normalize_tags(tags).tags
         self._input_defs = input_defs
         self._input_dict = {input_def.name: input_def for input_def in input_defs}
         check.invariant(len(self._input_defs) == len(self._input_dict), "Duplicate input def names")
@@ -204,7 +204,7 @@ class NodeDefinition(NamedConfigurableDefinition):
         return PendingNodeInvocation(
             node_def=self,
             given_alias=given_alias,
-            tags=validate_and_normalize_tags(tags).tags if tags else None,
+            tags=normalize_tags(tags).tags if tags else None,
             hook_defs=hook_defs,
             retry_policy=retry_policy,
         )

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -48,7 +48,7 @@ from ..errors import (
     DagsterUnknownPartitionError,
 )
 from .config import ConfigMapping
-from .utils import validate_and_normalize_tags
+from .utils import normalize_tags
 
 DEFAULT_DATE_FORMAT = "%Y-%m-%d"
 
@@ -726,7 +726,7 @@ class PartitionedConfig(Generic[T_PartitionsDefinition]):
             user_tags = self._tags_for_partition_key_fn(partition_key)
         else:
             user_tags = {}
-        user_tags = validate_and_normalize_tags(user_tags, allow_reserved_tags=False).tags
+        user_tags = normalize_tags(user_tags, allow_reserved_tags=False).tags
 
         system_tags = {
             **self.partitions_def.get_tags_for_partition_key(partition_key),

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -48,7 +48,7 @@ from ..errors import (
     DagsterUnknownPartitionError,
 )
 from .config import ConfigMapping
-from .utils import validate_tags
+from .utils import validate_and_normalize_tags
 
 DEFAULT_DATE_FORMAT = "%Y-%m-%d"
 
@@ -726,7 +726,7 @@ class PartitionedConfig(Generic[T_PartitionsDefinition]):
             user_tags = self._tags_for_partition_key_fn(partition_key)
         else:
             user_tags = {}
-        user_tags = validate_tags(user_tags, allow_reserved_tags=False)
+        user_tags = validate_and_normalize_tags(user_tags, allow_reserved_tags=False).tags
 
         system_tags = {
             **self.partitions_def.get_tags_for_partition_key(partition_key),

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -19,7 +19,7 @@ from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluatio
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey, AssetMaterialization, AssetObservation
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.utils import validate_tags
+from dagster._core.definitions.utils import NormalizedTags, validate_and_normalize_tags
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.tags import (
@@ -165,7 +165,7 @@ class RunRequest(
         cls,
         run_key: Optional[str] = None,
         run_config: Optional[Union["RunConfig", Mapping[str, Any]]] = None,
-        tags: Optional[Mapping[str, Any]] = None,
+        tags: Union[NormalizedTags, Optional[Mapping[str, Any]]] = None,
         job_name: Optional[str] = None,
         asset_selection: Optional[Sequence[AssetKey]] = None,
         stale_assets_only: bool = False,
@@ -180,7 +180,7 @@ class RunRequest(
             run_config=check.opt_mapping_param(
                 convert_config_input(run_config), "run_config", key_type=str
             ),
-            tags=validate_tags(check.opt_mapping_param(tags, "tags", key_type=str)),
+            tags=validate_and_normalize_tags(tags).tags,
             job_name=check.opt_str_param(job_name, "job_name"),
             asset_selection=check.opt_nullable_sequence_param(
                 asset_selection, "asset_selection", of_type=AssetKey

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -19,7 +19,7 @@ from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluatio
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey, AssetMaterialization, AssetObservation
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.utils import NormalizedTags, validate_and_normalize_tags
+from dagster._core.definitions.utils import NormalizedTags, normalize_tags
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.tags import (
@@ -180,7 +180,7 @@ class RunRequest(
             run_config=check.opt_mapping_param(
                 convert_config_input(run_config), "run_config", key_type=str
             ),
-            tags=validate_and_normalize_tags(tags).tags,
+            tags=normalize_tags(tags).tags,
             job_name=check.opt_str_param(job_name, "job_name"),
             asset_selection=check.opt_nullable_sequence_param(
                 asset_selection, "asset_selection", of_type=AssetKey

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -50,7 +50,7 @@ from .job_definition import JobDefinition
 from .run_request import RunRequest, SkipReason
 from .target import DirectTarget, ExecutableDefinition, RepoRelativeTarget
 from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition
-from .utils import NormalizedTags, check_valid_name, validate_and_normalize_tags
+from .utils import NormalizedTags, check_valid_name, normalize_tags
 
 if TYPE_CHECKING:
     from dagster import ResourceDefinition
@@ -645,7 +645,7 @@ class ScheduleDefinition(IHasInternalInit):
                     " to ScheduleDefinition. Must provide only one of the two."
                 )
             elif tags:
-                tags = validate_and_normalize_tags(tags, allow_reserved_tags=False).tags
+                tags = normalize_tags(tags, allow_reserved_tags=False).tags
                 tags_fn = lambda _context: tags
             else:
                 tags_fn = check.opt_callable_param(
@@ -688,9 +688,7 @@ class ScheduleDefinition(IHasInternalInit):
                     ScheduleExecutionError,
                     lambda: f"Error occurred during the execution of tags_fn for schedule {name}",
                 ):
-                    evaluated_tags = validate_and_normalize_tags(
-                        tags_fn(context), allow_reserved_tags=False
-                    )
+                    evaluated_tags = normalize_tags(tags_fn(context), allow_reserved_tags=False)
 
                 yield RunRequest(
                     run_key=None,

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -50,7 +50,7 @@ from .job_definition import JobDefinition
 from .run_request import RunRequest, SkipReason
 from .target import DirectTarget, ExecutableDefinition, RepoRelativeTarget
 from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition
-from .utils import check_valid_name, validate_tags
+from .utils import NormalizedTags, check_valid_name, validate_and_normalize_tags
 
 if TYPE_CHECKING:
     from dagster import ResourceDefinition
@@ -559,7 +559,7 @@ class ScheduleDefinition(IHasInternalInit):
         job_name: Optional[str] = None,
         run_config: Optional[Any] = None,
         run_config_fn: Optional[ScheduleRunConfigFunction] = None,
-        tags: Optional[Mapping[str, str]] = None,
+        tags: Union[NormalizedTags, Optional[Mapping[str, str]]] = None,
         tags_fn: Optional[ScheduleTagsFunction] = None,
         should_execute: Optional[ScheduleShouldExecuteFunction] = None,
         environment_vars: Optional[Mapping[str, str]] = None,
@@ -645,7 +645,7 @@ class ScheduleDefinition(IHasInternalInit):
                     " to ScheduleDefinition. Must provide only one of the two."
                 )
             elif tags:
-                tags = validate_tags(tags, allow_reserved_tags=False)
+                tags = validate_and_normalize_tags(tags, allow_reserved_tags=False).tags
                 tags_fn = lambda _context: tags
             else:
                 tags_fn = check.opt_callable_param(
@@ -688,7 +688,9 @@ class ScheduleDefinition(IHasInternalInit):
                     ScheduleExecutionError,
                     lambda: f"Error occurred during the execution of tags_fn for schedule {name}",
                 ):
-                    evaluated_tags = validate_tags(tags_fn(context), allow_reserved_tags=False)
+                    evaluated_tags = validate_and_normalize_tags(
+                        tags_fn(context), allow_reserved_tags=False
+                    )
 
                 yield RunRequest(
                     run_key=None,

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -99,15 +99,17 @@ class NormalizedTags(NamedTuple):
         return NormalizedTags({**self.tags, **normalized_tags.tags})
 
 
-def validate_tags() -> int: ...
-
-
-def validate_and_normalize_tags(
+def normalize_tags(
     tags: Union[NormalizedTags, Optional[Mapping[str, Any]]],
     allow_reserved_tags: bool = True,
     warn_on_deprecated_tags: bool = True,
     warning_stacklevel: int = 4,
 ) -> NormalizedTags:
+    """Normalizes JSON-object tags into string tags and warns on deprecated tags.
+
+    New tags properties should _not_ use this function, because it doesn't hard error on tags that
+    are no longer supported.
+    """
     if isinstance(tags, NormalizedTags):
         return tags
 

--- a/python_modules/dagster/dagster/_core/execution/plan/step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/step.py
@@ -16,7 +16,7 @@ from typing import (
 from typing_extensions import TypeGuard
 
 import dagster._check as check
-from dagster._core.definitions.utils import validate_and_normalize_tags
+from dagster._core.definitions.utils import normalize_tags
 from dagster._serdes.serdes import EnumSerializer, whitelist_for_serdes
 from dagster._utils.merger import merge_dicts
 
@@ -154,7 +154,7 @@ class ExecutionStep(
                 so.name: so
                 for so in check.sequence_param(step_outputs, "step_outputs", of_type=StepOutput)
             },
-            tags=validate_and_normalize_tags(
+            tags=normalize_tags(
                 check.opt_mapping_param(tags, "tags", key_type=str), warn_on_deprecated_tags=False
             ).tags,
             logging_tags=merge_dicts(

--- a/python_modules/dagster/dagster/_core/execution/plan/step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/step.py
@@ -16,7 +16,7 @@ from typing import (
 from typing_extensions import TypeGuard
 
 import dagster._check as check
-from dagster._core.definitions.utils import validate_tags
+from dagster._core.definitions.utils import validate_and_normalize_tags
 from dagster._serdes.serdes import EnumSerializer, whitelist_for_serdes
 from dagster._utils.merger import merge_dicts
 
@@ -154,7 +154,9 @@ class ExecutionStep(
                 so.name: so
                 for so in check.sequence_param(step_outputs, "step_outputs", of_type=StepOutput)
             },
-            tags=validate_tags(check.opt_mapping_param(tags, "tags", key_type=str)),
+            tags=validate_and_normalize_tags(
+                check.opt_mapping_param(tags, "tags", key_type=str), warn_on_deprecated_tags=False
+            ).tags,
             logging_tags=merge_dicts(
                 {
                     "step_key": handle.to_key(),

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1486,7 +1486,7 @@ class DagsterInstance(DynamicPartitionsStore):
         asset_job_partitions_def: Optional["PartitionsDefinition"] = None,
     ) -> DagsterRun:
         from dagster._core.definitions.asset_check_spec import AssetCheckKey
-        from dagster._core.definitions.utils import validate_and_normalize_tags
+        from dagster._core.definitions.utils import normalize_tags
         from dagster._core.remote_representation.origin import ExternalJobOrigin
         from dagster._core.snap import ExecutionPlanSnapshot, JobSnapshot
 
@@ -1499,7 +1499,7 @@ class DagsterInstance(DynamicPartitionsStore):
         check.opt_inst_param(status, "status", DagsterRunStatus)
         check.opt_mapping_param(tags, "tags", key_type=str)
 
-        validated_tags = validate_and_normalize_tags(tags, warn_on_deprecated_tags=False).tags
+        validated_tags = normalize_tags(tags, warn_on_deprecated_tags=False).tags
 
         check.opt_str_param(root_run_id, "root_run_id")
         check.opt_str_param(parent_run_id, "parent_run_id")

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1486,7 +1486,7 @@ class DagsterInstance(DynamicPartitionsStore):
         asset_job_partitions_def: Optional["PartitionsDefinition"] = None,
     ) -> DagsterRun:
         from dagster._core.definitions.asset_check_spec import AssetCheckKey
-        from dagster._core.definitions.utils import validate_tags
+        from dagster._core.definitions.utils import validate_and_normalize_tags
         from dagster._core.remote_representation.origin import ExternalJobOrigin
         from dagster._core.snap import ExecutionPlanSnapshot, JobSnapshot
 
@@ -1499,7 +1499,7 @@ class DagsterInstance(DynamicPartitionsStore):
         check.opt_inst_param(status, "status", DagsterRunStatus)
         check.opt_mapping_param(tags, "tags", key_type=str)
 
-        validated_tags = validate_tags(tags)
+        validated_tags = validate_and_normalize_tags(tags, warn_on_deprecated_tags=False).tags
 
         check.opt_str_param(root_run_id, "root_run_id")
         check.opt_str_param(parent_run_id, "parent_run_id")

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -35,7 +35,7 @@ from dagster._core.definitions.sensor_definition import (
     DefaultSensorStatus,
     SensorType,
 )
-from dagster._core.definitions.utils import validate_and_normalize_tags
+from dagster._core.definitions.utils import normalize_tags
 from dagster._core.errors import DagsterError
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.code_location import CodeLocation
@@ -982,7 +982,7 @@ def _create_sensor_run(
     )
     execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
 
-    job_tags = validate_and_normalize_tags(
+    job_tags = normalize_tags(
         external_job.tags or {}, allow_reserved_tags=False, warn_on_deprecated_tags=False
     ).tags
     tags = merge_dicts(

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -35,7 +35,7 @@ from dagster._core.definitions.sensor_definition import (
     DefaultSensorStatus,
     SensorType,
 )
-from dagster._core.definitions.utils import validate_tags
+from dagster._core.definitions.utils import validate_and_normalize_tags
 from dagster._core.errors import DagsterError
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.code_location import CodeLocation
@@ -982,7 +982,9 @@ def _create_sensor_run(
     )
     execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
 
-    job_tags = validate_tags(external_job.tags or {}, allow_reserved_tags=False)
+    job_tags = validate_and_normalize_tags(
+        external_job.tags or {}, allow_reserved_tags=False, warn_on_deprecated_tags=False
+    ).tags
     tags = merge_dicts(
         merge_dicts(job_tags, run_request.tags),
         # this gets applied in the sensor definition too, but we apply it here for backcompat

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -27,7 +27,7 @@ import dagster._check as check
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.schedule_definition import DefaultScheduleStatus
 from dagster._core.definitions.selector import JobSubsetSelector
-from dagster._core.definitions.utils import validate_tags
+from dagster._core.definitions.utils import validate_and_normalize_tags
 from dagster._core.errors import (
     DagsterCodeLocationLoadError,
     DagsterUserCodeUnreachableError,
@@ -926,7 +926,10 @@ def _create_scheduler_run(
     execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
 
     tags = merge_dicts(
-        validate_tags(external_job.tags, allow_reserved_tags=False) or {},
+        validate_and_normalize_tags(
+            external_job.tags, allow_reserved_tags=False, warn_on_deprecated_tags=False
+        ).tags
+        or {},
         schedule_tags,
     )
 

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -27,7 +27,7 @@ import dagster._check as check
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.schedule_definition import DefaultScheduleStatus
 from dagster._core.definitions.selector import JobSubsetSelector
-from dagster._core.definitions.utils import validate_and_normalize_tags
+from dagster._core.definitions.utils import normalize_tags
 from dagster._core.errors import (
     DagsterCodeLocationLoadError,
     DagsterUserCodeUnreachableError,
@@ -926,7 +926,7 @@ def _create_scheduler_run(
     execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
 
     tags = merge_dicts(
-        validate_and_normalize_tags(
+        normalize_tags(
             external_job.tags, allow_reserved_tags=False, warn_on_deprecated_tags=False
         ).tags
         or {},

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
@@ -8,7 +8,7 @@ from dagster import (
     ResourceDefinition,
     _check as check,
 )
-from dagster._core.definitions.utils import validate_tags
+from dagster._core.definitions.utils import validate_and_normalize_tags
 from dagster._core.instance import IS_AIRFLOW_INGEST_PIPELINE_STR
 
 from dagster_airflow.airflow_dag_converter import get_graph_definition_args
@@ -77,7 +77,7 @@ def make_dagster_job_from_airflow_dag(
     if IS_AIRFLOW_INGEST_PIPELINE_STR not in tags:
         mutated_tags[IS_AIRFLOW_INGEST_PIPELINE_STR] = "true"
 
-    mutated_tags = validate_tags(mutated_tags)
+    mutated_tags = validate_and_normalize_tags(mutated_tags)
 
     node_dependencies, node_defs = get_graph_definition_args(dag=dag)
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
@@ -8,7 +8,7 @@ from dagster import (
     ResourceDefinition,
     _check as check,
 )
-from dagster._core.definitions.utils import validate_and_normalize_tags
+from dagster._core.definitions.utils import normalize_tags
 from dagster._core.instance import IS_AIRFLOW_INGEST_PIPELINE_STR
 
 from dagster_airflow.airflow_dag_converter import get_graph_definition_args
@@ -77,7 +77,7 @@ def make_dagster_job_from_airflow_dag(
     if IS_AIRFLOW_INGEST_PIPELINE_STR not in tags:
         mutated_tags[IS_AIRFLOW_INGEST_PIPELINE_STR] = "true"
 
-    mutated_tags = validate_and_normalize_tags(mutated_tags)
+    mutated_tags = normalize_tags(mutated_tags)
 
     node_dependencies, node_defs = get_graph_definition_args(dag=dag)
 

--- a/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
@@ -19,7 +19,7 @@ from dagster import (
 from dagster._config.pythonic_config import Config, infer_schema_from_config_class
 from dagster._config.pythonic_config.type_check_utils import safe_is_subclass
 from dagster._core.definitions.events import CoercibleToAssetKey, CoercibleToAssetKeyPrefix
-from dagster._core.definitions.utils import validate_tags
+from dagster._core.definitions.utils import validate_and_normalize_tags
 from dagster._core.execution.context.compute import OpExecutionContext
 
 from dagstermill.factory import _clean_path_for_windows, execute_notebook
@@ -172,7 +172,7 @@ def define_dagstermill_asset(
         io_manager_key, "io_manager_key", default="output_notebook_io_manager"
     )
 
-    user_tags = validate_tags(op_tags)
+    user_tags = validate_and_normalize_tags(op_tags).tags
     if op_tags is not None:
         check.invariant(
             "notebook_path" not in op_tags,

--- a/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
@@ -19,7 +19,7 @@ from dagster import (
 from dagster._config.pythonic_config import Config, infer_schema_from_config_class
 from dagster._config.pythonic_config.type_check_utils import safe_is_subclass
 from dagster._core.definitions.events import CoercibleToAssetKey, CoercibleToAssetKeyPrefix
-from dagster._core.definitions.utils import validate_and_normalize_tags
+from dagster._core.definitions.utils import normalize_tags
 from dagster._core.execution.context.compute import OpExecutionContext
 
 from dagstermill.factory import _clean_path_for_windows, execute_notebook
@@ -172,7 +172,7 @@ def define_dagstermill_asset(
         io_manager_key, "io_manager_key", default="output_notebook_io_manager"
     )
 
-    user_tags = validate_and_normalize_tags(op_tags).tags
+    user_tags = normalize_tags(op_tags).tags
     if op_tags is not None:
         check.invariant(
             "notebook_path" not in op_tags,

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -21,7 +21,7 @@ from dagster._config.pythonic_config.type_check_utils import safe_is_subclass
 from dagster._core.definitions.events import AssetMaterialization, Failure, RetryRequested
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.reconstruct import ReconstructableJob
-from dagster._core.definitions.utils import validate_and_normalize_tags
+from dagster._core.definitions.utils import normalize_tags
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.execution.context.input import build_input_context
 from dagster._core.execution.context.system import StepExecutionContext
@@ -414,7 +414,7 @@ def define_dagstermill_op(
     default_description = f"This op is backed by the notebook at {notebook_path}"
     description = check.opt_str_param(description, "description", default=default_description)
 
-    user_tags = validate_and_normalize_tags(tags).tags
+    user_tags = normalize_tags(tags).tags
     if tags is not None:
         check.invariant(
             "notebook_path" not in tags,

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -21,7 +21,7 @@ from dagster._config.pythonic_config.type_check_utils import safe_is_subclass
 from dagster._core.definitions.events import AssetMaterialization, Failure, RetryRequested
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.reconstruct import ReconstructableJob
-from dagster._core.definitions.utils import validate_tags
+from dagster._core.definitions.utils import validate_and_normalize_tags
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.execution.context.input import build_input_context
 from dagster._core.execution.context.system import StepExecutionContext
@@ -414,7 +414,7 @@ def define_dagstermill_op(
     default_description = f"This op is backed by the notebook at {notebook_path}"
     description = check.opt_str_param(description, "description", default=default_description)
 
-    user_tags = validate_tags(tags)
+    user_tags = validate_and_normalize_tags(tags).tags
     if tags is not None:
         check.invariant(
             "notebook_path" not in tags,


### PR DESCRIPTION
# Summary & Motivation

The asset definitions tag PR introduces a restricted set of keys and values that are allowed for asset tags.

This PR starts raising deprecation warnings on construction of jobs, schedules, ops, run requests, and graphs, when tags have keys that don't match the constraints.

It punts on doing the same for tag values, because non-matching values are currently the only way to pass JSON blobs to systems like Kubernetes.  In the long run, these should probably be passed via run metadata instead of tags, but don't want to raise deprecation warnings without an alternative.

To avoid warning multiple times on bad tag, this PR introduces a `NormalizedTags` class. When a API that validates tags invokes another API that validates tags, it passes down a `NormalizedTags` object so that the invoked API won't warn again.

## How I Tested These Changes

Unit tests verify that warnings occur exactly once and point to the user code line, not an internal line
