### PR TITLE
Fix scheduler error retry logic

### DIFF
--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -645,11 +645,13 @@ def launch_scheduled_runs_for_schedule_iterator(
                     )
                     yield error_data
 
-                # Plan to run the same tick again right away
+                # Plan to run the same tick again using the schedule timestamp
+                # as both the next_iteration_timestamp and the last_iteration_timestmap
+                # (to ensure that the scheduler doesn't accidentally skip past it)
                 yield ScheduleIterationTimes(
                     cron_schedule=external_schedule.cron_schedule,
-                    next_iteration_timestamp=now_timestamp,
-                    last_iteration_timestamp=now_timestamp,
+                    next_iteration_timestamp=schedule_time.timestamp(),
+                    last_iteration_timestamp=schedule_time.timestamp(),
                 )
                 return
 


### PR DESCRIPTION
Summary:
When we added logic to track the last iteration time in memory across multiple ticks, we set it to the wrong value on the failure case when the next tick shoudl retry. It's set to the current time, not the expected schedule time - the former is typically slightly after the latter, so the next tick won't consider the correct timerange. This PR fixes that issue and adds a test case.

Test Plan: Adjusted test case that was now failing before the change here

## Summary & Motivation

## How I Tested These Changes
