### PR TITLE
RFC: Code Location API

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,6 +1,8 @@
 # from typing import Iterable
+from typing import Mapping
+
 from dagster import Definitions, asset
-from dagster._core.definitions.code_server import CodeLocation, CodeServer  # , ICodeServer
+from dagster._core.definitions.code_server import CodeLocation, MultiDefinitionsCodeLocation
 
 
 @asset
@@ -9,10 +11,13 @@ def an_asset_a() -> None:
 
 
 class ACodeLocation(CodeLocation):
-    name = "a_code_location"
-
+    # could put metadata here
+    # team = "some team name"
     def load_definitions(self) -> Definitions:
         return Definitions([an_asset_a])
+
+
+code_location = ACodeLocation()
 
 
 @asset
@@ -20,14 +25,12 @@ def an_asset_b() -> None:
     pass
 
 
-class BCodeLocation(CodeLocation):
-    name = "b_code_location"
-
-    def load_definitions(self) -> Definitions:
-        return Definitions([an_asset_b])
+class ABCodeLocation(MultiDefinitionsCodeLocation):
+    def load_definitions_dict(self) -> Mapping[str, Definitions]:
+        return {"a_defs": Definitions([an_asset_a]), "b_defs": Definitions([an_asset_b])}
 
 
-code_server = CodeServer(code_locations=[ACodeLocation(), BCodeLocation()])
+code_location = ABCodeLocation()
 
 # class CustomCodeServer(ICodeServer):
 #     def load_code_locations(self) -> Iterable[CodeLocation]:

--- a/example.py
+++ b/example.py
@@ -1,9 +1,10 @@
+# from typing import Iterable
 from dagster import Definitions, asset
-from dagster._core.definitions.code_server import CodeLocation, CodeServer
+from dagster._core.definitions.code_server import CodeLocation, CodeServer  # , ICodeServer
 
 
 @asset
-def an_asset() -> None:
+def an_asset_a() -> None:
     pass
 
 
@@ -11,7 +12,38 @@ class ACodeLocation(CodeLocation):
     name = "a_code_location"
 
     def load_definitions(self) -> Definitions:
-        return Definitions([an_asset])
+        return Definitions([an_asset_a])
 
 
-code_server = CodeServer(code_locations=[ACodeLocation()])
+@asset
+def an_asset_b() -> None:
+    pass
+
+
+class BCodeLocation(CodeLocation):
+    name = "b_code_location"
+
+    def load_definitions(self) -> Definitions:
+        return Definitions([an_asset_b])
+
+
+code_server = CodeServer(code_locations=[ACodeLocation(), BCodeLocation()])
+
+# class CustomCodeServer(ICodeServer):
+#     def load_code_locations(self) -> Iterable[CodeLocation]:
+#         return [
+#             ACodeLocationWithDefsBuiltFromPersistedState()
+#         ]
+
+# class ACodeLocationWithDefsBuiltFromPersistedState(CodeLocation):
+#     name = "a_code_location"
+
+#     def load_definitions(self) -> Definitions:
+#         return Definitions(
+#             build_assets_defs(
+#                 get_serialized_representation_of_assets_from_storage()
+#             )
+#         )
+
+
+# code_server = CustomCodeServer()

--- a/example.py
+++ b/example.py
@@ -6,8 +6,10 @@ from dagster._core.definitions.code_server import CodeLocation, CodeServer
 def an_asset() -> None:
     pass
 
+
 class ACodeLocation(CodeLocation):
     name = "a_code_location"
+
     def load_definitions(self) -> Definitions:
         return Definitions([an_asset])
 

--- a/example.py
+++ b/example.py
@@ -1,0 +1,15 @@
+from dagster import Definitions, asset
+from dagster._core.definitions.code_server import CodeLocation, CodeServer
+
+
+@asset
+def an_asset() -> None:
+    pass
+
+class ACodeLocation(CodeLocation):
+    name = "a_code_location"
+    def load_definitions(self) -> Definitions:
+        return Definitions([an_asset])
+
+
+code_server = CodeServer(code_locations=[ACodeLocation()])

--- a/python_modules/dagster/dagster/_core/definitions/code_server.py
+++ b/python_modules/dagster/dagster/_core/definitions/code_server.py
@@ -1,17 +1,27 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import Iterable, List
 
 from dagster._core.definitions.definitions_class import Definitions
 
 
-class CodeServer:
+class ICodeServer(ABC):
+    # User can override this method to perform any necessary setup when the code server starts
+    def on_code_server_start(self) -> None: ...
+
+    @abstractmethod
+    def load_code_locations(self) -> Iterable["CodeLocation"]: ...
+
+
+class CodeServer(ICodeServer):
     code_locations: List["CodeLocation"]
 
     def __init__(self, code_locations: List["CodeLocation"]):
         self.code_locations = code_locations
 
-    # User can override this method to perform any necessary setup when the code server starts
     def on_code_server_start(self) -> None: ...
+
+    def load_code_locations(self) -> Iterable["CodeLocation"]:
+        return self.code_locations
 
 
 class CodeLocation(ABC):

--- a/python_modules/dagster/dagster/_core/definitions/code_server.py
+++ b/python_modules/dagster/dagster/_core/definitions/code_server.py
@@ -10,8 +10,9 @@ class CodeServer:
     def __init__(self, code_locations: List["CodeLocation"]):
         self.code_locations = code_locations
 
-    def on_code_server_start(self) -> None:
-        ...
+    # User can override this method to perform any necessary setup when the code server starts
+    def on_code_server_start(self) -> None: ...
+
 
 class CodeLocation(ABC):
     name: str

--- a/python_modules/dagster/dagster/_core/definitions/code_server.py
+++ b/python_modules/dagster/dagster/_core/definitions/code_server.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+from dagster._core.definitions.definitions_class import Definitions
+
+
+class CodeServer:
+    code_locations: List["CodeLocation"]
+
+    def __init__(self, code_locations: List["CodeLocation"]):
+        self.code_locations = code_locations
+
+    def on_code_server_start(self) -> None:
+        ...
+
+class CodeLocation(ABC):
+    name: str
+
+    @abstractmethod
+    def load_definitions(self) -> Definitions: ...

--- a/python_modules/dagster/dagster/_core/definitions/code_server.py
+++ b/python_modules/dagster/dagster/_core/definitions/code_server.py
@@ -1,31 +1,30 @@
 from abc import ABC, abstractmethod
-from typing import Iterable, List
+from typing import Mapping
 
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.repository_definition.valid_definitions import (
+    SINGLETON_REPOSITORY_NAME,
+)
 
 
-class ICodeServer(ABC):
+class ICodeLocation(ABC):
     # User can override this method to perform any necessary setup when the code server starts
-    def on_code_server_start(self) -> None: ...
+    def on_start(self) -> None: ...
 
     @abstractmethod
-    def load_code_locations(self) -> Iterable["CodeLocation"]: ...
+    def load_definitions_dict(self) -> Mapping[str, Definitions]: ...
 
 
-class CodeServer(ICodeServer):
-    code_locations: List["CodeLocation"]
+class CodeLocation(ICodeLocation, ABC):
+    def on_start(self) -> None: ...
 
-    def __init__(self, code_locations: List["CodeLocation"]):
-        self.code_locations = code_locations
-
-    def on_code_server_start(self) -> None: ...
-
-    def load_code_locations(self) -> Iterable["CodeLocation"]:
-        return self.code_locations
-
-
-class CodeLocation(ABC):
-    name: str
+    def load_definitions_dict(self) -> Mapping[str, Definitions]:
+        return {SINGLETON_REPOSITORY_NAME: self.load_definitions()}
 
     @abstractmethod
     def load_definitions(self) -> Definitions: ...
+
+
+class MultiDefinitionsCodeLocation(ICodeLocation):
+    @abstractmethod
+    def load_definitions_dict(self) -> Mapping[str, Definitions]: ...


### PR DESCRIPTION
## Summary & Motivation

I am not sure of the status of the project to build some asset checks from persisted state, but just wanted to throw something out there that has stewed in my head since we chatted about it.

In order to implement that feature successfully, I believe we will need to iterate on our APIs to be a little more flexible. Along the way, I think we can build a more transparent API for users that understand code servers, code locations, and Definitions objects and want to use them for more advanced use cases. This is no way eliminates the current user experience of `defs = Definitions(...)`. It builds on that when it is not sufficient.

The idea here is pretty simple. We add two new classes to our public-facing API: `CodeServer` and `CodeLocation`.

A `CodeServer` contains a `List[CodeLocation]`. 

`CodeLocation` has an explicit `name` attribute, and an abstract method that returns a `Definitions` object. This is key as it allows a `Definitions` object to be lazily loaded and it enables a first-class API for specifying multiple named code locations within a single code server (as opposed to using `create_repository_using_definitions_args`)

```python
@asset
def an_asset_a() -> None:
    pass


class ACodeLocation(CodeLocation):
    name = "a_code_location"

    def load_definitions(self) -> Definitions:
        return Definitions([an_asset_a])

@asset
def an_asset_b() -> None:
    pass

class BCodeLocation(CodeLocation):
    name = "b_code_location"

    def load_definitions(self) -> Definitions:
        return Definitions([an_asset_b])

code_server = CodeServer(code_locations=[ACodeLocation(), BCodeLocation()])
```

This is much more explicit that we have today, and leaks our core ontology in a good way, in my opinion. It would require a slight change in our vocabulary: we use code location and code server interchangeable today, which is a source of confusion. We would completely remove the vocabulary of "repository", even for advanced use cases. Instead one would have multiple, named code locations per code server to handle that use case.

Where this gets more interesting is if we do more surgery and take advantage of lazily constructed definitions. Consider the case where we want to build Definitions based on persisted state. E.g. UI-driven checks or assets definitions. `CodeServer` enables that:

```class CustomCodeServer(ICodeServer):
    def load_code_locations(self) -> Iterable[CodeLocation]:
        return [
            ACodeLocationWithDefsBuiltFromPersistedState()
        ]

class ACodeLocationWithDefsBuiltFromPersistedState(CodeLocation):
    name = "a_code_location"

    def load_definitions(self) -> Definitions:
        return Definitions(
            build_assets_defs(
                get_serialized_representation_of_assets_from_storage()
            )
        )


code_server = CustomCodeServer()
```

We would then add a grpc method to invoke `load_definitions` on a CodeLocation _without_ requiring code server restart, dramatically improving iteration speed. 

I also think this would serve as a successor to `CacheableAssetsDefinition`. Definitions that require interaction with storage or an API would happen after the code server has successfully loaded.

## How I Tested These Changes

I did not.