### PR TITLE
Support tags in asset selections

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -67,6 +67,10 @@ class AssetNode(BaseAssetNode):
         return self.assets_def.metadata_by_key.get(self.key, {})
 
     @property
+    def tags(self) -> Mapping[str, str]:
+        return self.assets_def.tags_by_key.get(self.key, {})
+
+    @property
     def is_partitioned(self) -> bool:
         return self.assets_def.partitions_def is not None
 


### PR DESCRIPTION
## Summary & Motivation

- Adds `AssetSelection.tag` (public, experimental), which accepts a key and a value
- Adds `AssetSelection.tag_string` (internal for now), which accepts a string interprets it as a key-value pair
- Adds support in the asset CLI for `--select tag:foo=fooval`

## How I Tested These Changes

added tests