### PR TITLE
sentinel for tags without values

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -559,6 +559,7 @@ from dagster._core.storage.partition_status_cache import (
 from dagster._core.storage.tags import (
     MAX_RUNTIME_SECONDS_TAG as MAX_RUNTIME_SECONDS_TAG,
     MEMOIZED_RUN_TAG as MEMOIZED_RUN_TAG,
+    TAG_NO_VALUE as TAG_NO_VALUE,
 )
 from dagster._core.storage.upath_io_manager import UPathIOManager as UPathIOManager
 from dagster._core.types.config_schema import (

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -19,6 +19,7 @@ from dagster._core.selector.subset_selector import (
     fetch_sources,
     parse_clause,
 )
+from dagster._core.storage.tags import TAG_NO_VALUE
 from dagster._serdes.serdes import whitelist_for_serdes
 
 from .asset_check_spec import AssetCheckKey
@@ -195,8 +196,16 @@ class AssetSelection(ABC, BaseModel, frozen=True):
             include_sources (bool): If True, then include source assets matching the group in the
                 selection.
         """
-        key, value = string.split("=")
-        return TagAssetSelection(key=key, value=value, include_sources=include_sources)
+        split_by_equals_segments = string.split("=")
+        if len(split_by_equals_segments) == 1:
+            return TagAssetSelection(
+                key=string, value=TAG_NO_VALUE, include_sources=include_sources
+            )
+        elif len(split_by_equals_segments) == 2:
+            key, value = split_by_equals_segments
+            return TagAssetSelection(key=key, value=value, include_sources=include_sources)
+        else:
+            check.failed(f"Invalid tag selection string: {string}. Must have no more than one '='.")
 
     @public
     @staticmethod

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -85,6 +85,9 @@ USER_EDITABLE_SYSTEM_TAGS = [
 ]
 
 
+TAG_NO_VALUE = "__dagster_no_value"
+
+
 class TagType(Enum):
     # Custom tag provided by a user
     USER_PROVIDED = "USER_PROVIDED"

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -43,6 +43,7 @@ from dagster._core.definitions.asset_selection import (
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.events import AssetKey
+from dagster._core.storage.tags import TAG_NO_VALUE
 from dagster._serdes import deserialize_value
 from dagster._serdes.serdes import _WHITELIST_MAP
 from pydantic import ValidationError
@@ -711,6 +712,7 @@ def test_deserialize_old_all_asset_selection():
 
 def test_from_string_tag():
     assert AssetSelection.from_string("tag:foo=bar") == AssetSelection.tag("foo", "bar")
+    assert AssetSelection.from_string("tag:foo") == AssetSelection.tag("foo", TAG_NO_VALUE)
 
 
 def test_tag():
@@ -736,10 +738,18 @@ def test_tag_string():
             AssetSpec("asset2", tags={"foo": "fooval2"}),
             AssetSpec("asset3", tags={"foo": "fooval", "bar": "barval"}),
             AssetSpec("asset4", tags={"bar": "barval"}),
+            AssetSpec("asset5", tags={"baz": TAG_NO_VALUE}),
+            AssetSpec("asset6", tags={"baz": TAG_NO_VALUE, "bar": "barval"}),
         ]
     )
     def assets(): ...
 
     assert AssetSelection.tag_string("foo=fooval").resolve([assets]) == {
-        AssetKey(k) for k in ["asset1", "asset3"]
+        AssetKey("asset1"),
+        AssetKey("asset3"),
+    }
+    assert AssetSelection.tag_string("foo").resolve([assets]) == set()
+    assert AssetSelection.tag_string("baz").resolve([assets]) == {
+        AssetKey("asset5"),
+        AssetKey("asset6"),
     }


### PR DESCRIPTION
## Summary & Motivation

Adds a special sentinel value for tags that indicates "this tag is just a string, not a key-value pair". How this sentinel will be used:
- In the CLI, when a selection like `--select tag:foo` is provided, we'll interpret it as `AssetSelection.tag("foo", "__dagster_novalue")` (implemented in this PR)
- The dbt integration will provide this value for all tags (because dbt tags are strings).
- In the UI, we'll hide this sentinel value. I.e. a tags dict like `{"foo":  "fooval", "bar": "__dagster_novalue"}` will be rendered as "foo=fooval, bar" in the UI.

## How I Tested These Changes
