### PR TITLE
Asset tags in the UI

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeDefinition.tsx
@@ -335,6 +335,10 @@ export const ASSET_NODE_DEFINITION_FRAGMENT = gql`
     jobNames
     isSource
     isExecutable
+    tags {
+      key
+      value
+    }
     owners {
       __typename
       ... on TeamAssetOwner {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -227,6 +227,17 @@ export const AssetNodeOverview = ({
           <AssetComputeKindTag style={{position: 'relative'}} definition={assetNode} reduceColor />
         )}
       </AttributeAndValue>
+      <AttributeAndValue label="Tags">
+        {assetNode.tags && assetNode.tags.length > 0 && (
+          <Box flex={{gap: 4, alignItems: 'center', wrap: 'wrap'}}>
+            {assetNode.tags.map((tag, idx) => (
+              <Tag key={idx}>
+                {tag.key}={tag.value}
+              </Tag>
+            ))}
+          </Box>
+        )}
+      </AttributeAndValue>
     </Box>
   );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetNodeDefinition.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetNodeDefinition.types.ts
@@ -18,6 +18,7 @@ export type AssetNodeDefinitionFragment = {
   computeKind: string | null;
   isPartitioned: boolean;
   isObservable: boolean;
+  tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
   owners: Array<
     {__typename: 'TeamAssetOwner'; team: string} | {__typename: 'UserAssetOwner'; email: string}
   >;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
@@ -70,6 +70,7 @@ export type AssetViewDefinitionQuery = {
                 };
               }
           >;
+          tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
           owners: Array<
             | {__typename: 'TeamAssetOwner'; team: string}
             | {__typename: 'UserAssetOwner'; email: string}
@@ -15896,6 +15897,7 @@ export type AssetViewDefinitionNodeFragment = {
         };
       }
   >;
+  tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
   owners: Array<
     {__typename: 'TeamAssetOwner'; team: string} | {__typename: 'UserAssetOwner'; email: string}
   >;

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -675,6 +675,7 @@ type AssetNode {
   assetPartitionStatuses: AssetPartitionStatuses!
   partitionStats: PartitionStats
   metadataEntries: [MetadataEntry!]!
+  tags: [DefinitionTag!]!
   op: SolidDefinition
   opName: String
   opNames: [String!]!
@@ -827,6 +828,11 @@ type PartitionStats {
   numPartitions: Int!
   numFailed: Int!
   numMaterializing: Int!
+}
+
+type DefinitionTag {
+  key: String!
+  value: String!
 }
 
 type PartitionDefinition {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -473,6 +473,7 @@ export type AssetNode = {
   staleCausesByPartition: Maybe<Array<Array<StaleCause>>>;
   staleStatus: Maybe<StaleStatus>;
   staleStatusByPartition: Array<StaleStatus>;
+  tags: Array<DefinitionTag>;
   targetingInstigators: Array<Instigator>;
   type: Maybe<ListDagsterType | NullableDagsterType | RegularDagsterType>;
 };
@@ -1074,6 +1075,12 @@ export type DefaultPartitionStatuses = {
   materializedPartitions: Array<Scalars['String']['output']>;
   materializingPartitions: Array<Scalars['String']['output']>;
   unmaterializedPartitions: Array<Scalars['String']['output']>;
+};
+
+export type DefinitionTag = {
+  __typename: 'DefinitionTag';
+  key: Scalars['String']['output'];
+  value: Scalars['String']['output'];
 };
 
 export type DeletePipelineRunResult =
@@ -6292,6 +6299,7 @@ export const buildAssetNode = (
       overrides && overrides.hasOwnProperty('staleStatusByPartition')
         ? overrides.staleStatusByPartition!
         : [],
+    tags: overrides && overrides.hasOwnProperty('tags') ? overrides.tags! : [],
     targetingInstigators:
       overrides && overrides.hasOwnProperty('targetingInstigators')
         ? overrides.targetingInstigators!
@@ -7158,6 +7166,19 @@ export const buildDefaultPartitionStatuses = (
       overrides && overrides.hasOwnProperty('unmaterializedPartitions')
         ? overrides.unmaterializedPartitions!
         : [],
+  };
+};
+
+export const buildDefinitionTag = (
+  overrides?: Partial<DefinitionTag>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'DefinitionTag'} & DefinitionTag => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('DefinitionTag');
+  return {
+    __typename: 'DefinitionTag',
+    key: overrides && overrides.hasOwnProperty('key') ? overrides.key! : 'itaque',
+    value: overrides && overrides.hasOwnProperty('value') ? overrides.value! : 'consequatur',
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -61,6 +61,7 @@ from dagster_graphql.schema.solids import (
     GrapheneResourceRequirement,
     GrapheneSolidDefinition,
 )
+from dagster_graphql.schema.tags import GrapheneDefinitionTag
 
 from ..implementation.fetch_assets import (
     build_partition_statuses,
@@ -303,6 +304,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     assetPartitionStatuses = graphene.NonNull(GrapheneAssetPartitionStatuses)
     partitionStats = graphene.Field(GraphenePartitionStats)
     metadata_entries = non_null_list(GrapheneMetadataEntry)
+    tags = non_null_list(GrapheneDefinitionTag)
     op = graphene.Field(GrapheneSolidDefinition)
     opName = graphene.String()
     opNames = non_null_list(graphene.String)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1192,6 +1192,12 @@ class GrapheneAssetNode(graphene.ObjectType):
     ) -> Sequence[GrapheneMetadataEntry]:
         return list(iterate_metadata_entries(self._external_asset_node.metadata))
 
+    def resolve_tags(self, _graphene_info: ResolveInfo) -> Sequence[GrapheneDefinitionTag]:
+        return [
+            GrapheneDefinitionTag(key, value)
+            for key, value in (self._external_asset_node.tags or {}).items()
+        ]
+
     def resolve_op(
         self, _graphene_info: ResolveInfo
     ) -> Optional[Union[GrapheneSolidDefinition, GrapheneCompositeSolidDefinition]]:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/tags.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/tags.py
@@ -34,6 +34,17 @@ class GrapheneEventTag(graphene.ObjectType):
         super().__init__(key=key, value=value)
 
 
+class GrapheneDefinitionTag(graphene.ObjectType):
+    key = graphene.NonNull(graphene.String)
+    value = graphene.NonNull(graphene.String)
+
+    class Meta:
+        name = "DefinitionTag"
+
+    def __init__(self, key, value):
+        super().__init__(key=key, value=value)
+
+
 class GraphenePipelineTagAndValues(graphene.ObjectType):
     class Meta:
         description = """A run tag and the free-form values that have been associated

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -1195,6 +1195,7 @@ class ExternalAssetNode(
             ("output_name", Optional[str]),
             ("output_description", Optional[str]),
             ("metadata", Mapping[str, MetadataValue]),
+            ("tags", Optional[Mapping[str, str]]),
             ("group_name", Optional[str]),
             ("freshness_policy", Optional[FreshnessPolicy]),
             ("is_source", bool),
@@ -1234,6 +1235,7 @@ class ExternalAssetNode(
         output_name: Optional[str] = None,
         output_description: Optional[str] = None,
         metadata: Optional[Mapping[str, MetadataValue]] = None,
+        tags: Optional[Mapping[str, str]] = None,
         group_name: Optional[str] = None,
         freshness_policy: Optional[FreshnessPolicy] = None,
         is_source: Optional[bool] = None,
@@ -1313,6 +1315,7 @@ class ExternalAssetNode(
             output_name=check.opt_str_param(output_name, "output_name"),
             output_description=check.opt_str_param(output_description, "output_description"),
             metadata=metadata,
+            tags=check.opt_mapping_param(tags, "tags", key_type=str, value_type=str),
             group_name=check.opt_str_param(group_name, "group_name"),
             freshness_policy=check.opt_inst_param(
                 freshness_policy, "freshness_policy", FreshnessPolicy
@@ -1586,6 +1589,7 @@ def external_asset_nodes_from_defs(
     asset_info_by_asset_key: Dict[AssetKey, AssetOutputInfo] = dict()
     freshness_policy_by_asset_key: Dict[AssetKey, FreshnessPolicy] = dict()
     metadata_by_asset_key: Dict[AssetKey, RawMetadataMapping] = dict()
+    tags_by_asset_key: Dict[AssetKey, Mapping[str, str]] = dict()
     auto_materialize_policy_by_asset_key: Dict[AssetKey, AutoMaterializePolicy] = dict()
     backfill_policy_by_asset_key: Dict[AssetKey, Optional[BackfillPolicy]] = dict()
 
@@ -1645,6 +1649,7 @@ def external_asset_nodes_from_defs(
 
         for assets_def in [ad for ad in asset_layer.assets_defs if ad.is_executable]:
             metadata_by_asset_key.update(assets_def.metadata_by_key)
+            tags_by_asset_key.update(assets_def.tags_by_key)
             freshness_policy_by_asset_key.update(assets_def.freshness_policies_by_key)
             auto_materialize_policy_by_asset_key.update(assets_def.auto_materialize_policies_by_key)
             backfill_policy_by_asset_key.update(
@@ -1723,6 +1728,7 @@ def external_asset_nodes_from_defs(
                 partitions_def_data=partitions_def_data,
                 output_name=output_def.name,
                 metadata=asset_metadata,
+                tags=tags_by_asset_key.get(asset_key),
                 is_source=execution_types_by_asset_key.get(asset_key)
                 != AssetExecutionType.MATERIALIZATION,
                 is_observable=is_observable_by_key.get(asset_key, False),


### PR DESCRIPTION
## Summary & Motivation

This PR passes tags up through graphql to the UI and displays them on the asset overview page. It doesn't yet support the no-value tags introduced in this PR: https://github.com/dagster-io/dagster/pull/20388.

Stacks on top of https://github.com/dagster-io/dagster/pull/20351.

<img width="1167" alt="image" src="https://github.com/dagster-io/dagster/assets/654855/97bcb447-06e6-4cd1-a0f2-4fdfffdd1d0d">

## How I Tested These Changes
