### PR TITLE
Remove test_airflow_2 extra from dagster-airflow automation install

### DIFF
--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -11,7 +11,7 @@ deps =
   -e ../dagster-graphql
   -e ../libraries/dagster-managed-elements
   -e ../libraries/dagster-airbyte
-  -e ../libraries/dagster-airflow[test_airflow_2]
+  -e ../libraries/dagster-airflow
   -e ../libraries/dagster-aws
   -e ../libraries/dagster-celery
   -e ../libraries/dagster-celery-docker


### PR DESCRIPTION
## Summary & Motivation

For some reason the presence of this extra started crashing uv during build of the tox env, and removing it seems to have no impact on the tests.