### PR TITLE
Bugfix: implement dbiomanager support for multiple partitions when using MultiPartitionMapping

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -202,8 +202,8 @@ class DbIOManager(IOManager):
 
                 if isinstance(context.asset_partitions_def, MultiPartitionsDefinition):
                     multi_partition_key_mappings = [
-                        partition_key.keys_by_dimension
-                        for partition_key in cast(MultiPartitionKey, context.asset_partition_keys)
+                        cast(MultiPartitionKey, partition_key).keys_by_dimension
+                        for partition_key in context.asset_partition_keys
                     ]
                     for part in context.asset_partitions_def.partitions_defs:
                         partitions = []


### PR DESCRIPTION
## Summary & Motivation
We have a job with asset A and B where B depends on A. Both are partitioned with two dimensions. We use a MultiPartitionMapping to map a Time dimension such that it includes the preceding partition (offset = -1) and the other dimension is mapped with an IdentityPartitionMapping.

This does not work because of a bug in db_iomanager.py. This PR addresses this bug.

This also fixes the following open issue: https://github.com/dagster-io/dagster/issues/17838

Feel free to modify my code as you see fit

## How I Tested These Changes

- Ran dagster unit tests for storage
- Executed our above described job which now succeeds