### PR TITLE
[external-assets] Add AssetGraph subsetting, make build_asset_job use AssetGraph

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_observable_source_asset.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_observable_source_asset.py
@@ -5,6 +5,7 @@ from dagster._core.definitions.data_version import (
 )
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.instance_for_test import instance_for_test
+from dagster._core.test_utils import create_test_asset_job
 from docs_snippets.concepts.assets.observable_source_assets import (
     foo_source_asset,
     observation_job,
@@ -13,11 +14,7 @@ from docs_snippets.concepts.assets.observable_source_assets import (
 
 
 def test_observable_source_asset():
-    @repository
-    def repo():
-        return [foo_source_asset]
-
-    job_def = build_assets_job("test_job", [], [foo_source_asset])
+    job_def = create_test_asset_job([foo_source_asset])
     result = job_def.execute_in_process()
     assert result.success
 

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1112,7 +1112,6 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             Union[AutoMaterializePolicy, Mapping[AssetKey, AutoMaterializePolicy]]
         ] = None,
         backfill_policy: Optional[BackfillPolicy] = None,
-        is_subset: bool = False,
         check_specs_by_output_name: Optional[Mapping[str, AssetCheckSpec]] = None,
         selected_asset_check_keys: Optional[AbstractSet[AssetCheckKey]] = None,
     ) -> "AssetsDefinition":
@@ -1277,7 +1276,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
                 **self._descriptions_by_key,
                 **replaced_descriptions_by_key,
             },
-            is_subset=is_subset,
+            is_subset=self.is_subset,
             check_specs_by_output_name=check_specs_by_output_name
             if check_specs_by_output_name
             else self.check_specs_by_output_name,

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -198,6 +198,10 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
         return {node.key for node in self.asset_nodes if node.is_executable}
 
     @cached_property
+    def unexecutable_asset_keys(self) -> AbstractSet[AssetKey]:
+        return {node.key for node in self.asset_nodes if not node.is_executable}
+
+    @cached_property
     def toposorted_asset_keys(self) -> Sequence[AssetKey]:
         """Return topologically sorted asset keys in graph. Keys with the same topological level are
         sorted alphabetically to provide stability.

--- a/python_modules/dagster/dagster/_core/definitions/external_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset.py
@@ -181,3 +181,14 @@ def create_external_asset_from_source_asset(source_asset: SourceAsset) -> Assets
             return return_value
 
     return _shim_assets_def
+
+
+# Create unexecutable assets defs for each asset key in the provided assets def. This is used to
+# make a materializable assets def available only for loading in a job.
+def create_unexecutable_external_assets_from_assets_def(
+    assets_def: AssetsDefinition,
+) -> Sequence[AssetsDefinition]:
+    if not assets_def.is_executable:
+        return [assets_def]
+    else:
+        return [create_external_asset_from_source_asset(sa) for sa in assets_def.to_source_assets()]

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -815,7 +815,6 @@ class JobDefinition(IHasInternalInit):
         new_job = build_asset_selection_job(
             name=self.name,
             assets=self.asset_layer.assets_defs,
-            source_assets=[],
             executor_def=self.executor_def,
             resource_defs=self.resource_defs,
             description=self.description,

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -223,7 +223,6 @@ class UnresolvedAssetJobDefinition(
             assets=assets,
             asset_checks=asset_graph.asset_checks_defs,
             config=self.config,
-            source_assets=[],
             description=self.description,
             tags=self.tags,
             metadata=self.metadata,

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -32,7 +32,6 @@ if TYPE_CHECKING:
     from dagster._core.definitions.assets import AssetsDefinition
     from dagster._core.definitions.graph_definition import GraphDefinition
     from dagster._core.definitions.job_definition import JobDefinition
-    from dagster._core.definitions.source_asset import SourceAsset
 
 MAX_NUM = sys.maxsize
 
@@ -116,7 +115,7 @@ class AssetSelectionData(
 
 
 def generate_asset_dep_graph(
-    assets_defs: Iterable["AssetsDefinition"], source_assets: Iterable["SourceAsset"]
+    assets_defs: Iterable["AssetsDefinition"],
 ) -> DependencyGraph[AssetKey]:
     upstream: Dict[AssetKey, Set[AssetKey]] = {}
     downstream: Dict[AssetKey, Set[AssetKey]] = {}
@@ -483,7 +482,7 @@ def parse_asset_selection(
     if len(asset_selection) == 1 and asset_selection[0] == "*":
         return {key for ad in assets_defs for key in ad.keys}
 
-    graph = generate_asset_dep_graph(assets_defs, [])
+    graph = generate_asset_dep_graph(assets_defs)
     assets_set: Set[AssetKey] = set()
 
     # loop over clauses

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -737,11 +737,9 @@ def create_test_asset_job(
     resources: Mapping[str, object] = {},
     **kwargs: Any,
 ) -> JobDefinition:
-    assets_defs = [a for a in assets if isinstance(a, AssetsDefinition)]
-    source_assets = [a for a in assets if isinstance(a, SourceAsset)]
-    selection = selection or assets_defs
+    selection = selection or [a for a in assets if a.is_executable]
     return Definitions(
-        assets=[*assets_defs, *source_assets],
+        assets=assets,
         jobs=[define_asset_job(name, selection, **kwargs)],
         resources=resources,
     ).get_job_def(name)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -53,7 +53,7 @@ from dagster._core.errors import (
 )
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.mem_io_manager import InMemoryIOManager
-from dagster._core.test_utils import instance_for_test
+from dagster._core.test_utils import create_test_asset_job, instance_for_test
 from dagster._core.types.dagster_type import Nothing
 
 
@@ -1274,14 +1274,10 @@ def test_graph_backed_asset_subset_context(
         out_2, out_3 = add_one(reused_output)
         return {"asset_one": out_1, "asset_two": out_2, "asset_three": out_3}
 
-    asset_job = define_asset_job("yay").resolve(
-        asset_graph=AssetGraph.from_assets(
-            [AssetsDefinition.from_graph(three, can_subset=True)],
-        )
-    )
+    job_def = create_test_asset_job([AssetsDefinition.from_graph(three, can_subset=True)])
 
     with instance_for_test() as instance:
-        result = asset_job.execute_in_process(asset_selection=asset_selection, instance=instance)
+        result = job_def.execute_in_process(asset_selection=asset_selection, instance=instance)
         assert result.success
         assert (
             get_num_events(instance, result.run_id, DagsterEventType.ASSET_MATERIALIZATION)

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -119,7 +119,6 @@ def test_calculate_data_time_unpartitioned(ignore_asset_tags, runs_to_expected_d
             result = build_asset_selection_job(
                 "materialize_job",
                 assets=all_assets,
-                source_assets=[],
                 asset_selection=AssetSelection.keys(*(AssetKey(c) for c in to_materialize)).resolve(
                     all_assets
                 ),


### PR DESCRIPTION
## Summary & Motivation

Cluster of related changes that allow for using `AssetGraph` as our general representation of "collection of assets", which allows it to be used as the source of truth for an asset job.

- Add `AssetGraph.get_subset`. This returns a new `AssetGraph`. You pass a set of executable asset keys and asset check keys to get a subset-- the result will automatically include any parent assets as unexecutable.
- Add a `create_unexecutable_external_assets_from_assets_def` function. This is fulfilling the same role as `AssetsDefinition.to_source_assets`. It would be cleaner to create a single unexecutable `AssetsDefinition` from the passed-in one, but for now we are returning multiple `AssetsDefinition` (once for each key) since this can be implemented in terms of the existing `.to_source_assets`.
- Change `build_assets_job` to accept an `AssetGraph` instead of separate lists of executable and loadable assets definitions. Modify the two callsites to pass an `AssetGraph`.

 The next step is composing this with `AssetLayer`.

## How I Tested These Changes

Existing test suite.