### PR TITLE
removing a du starter project from the master venv

### DIFF
--- a/pyright/master/requirements.txt
+++ b/pyright/master/requirements.txt
@@ -113,7 +113,6 @@ dbt-core<1.6
 -e examples/docs_snippets[full]
 -e examples/feature_graph_backed_assets
 # -e examples/project_fully_featured
--e examples/project_du_dbt_starter
 # -e examples/quickstart_aws  # (analyzed but not installed)
 # -e examples/quickstart_etl  # (analyzed but not installed)
 # -e examples/quickstart_gcp  # (analyzed but not installed)


### PR DESCRIPTION
## Summary & Motivation

DU Starter projects are pinned to explicit Dagster versions so the content matches the API state, but that conflicts with the `dagster==1!0+dev` req for everything else on pyright. Dropping it from the master venv.

## How I Tested These Changes
