### PR TITLE
[BK] Add overrides arg to skip_if_no_python_changes, use to whitelist pyright dir for pyright

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -111,7 +111,7 @@ def build_repo_wide_pyright_steps() -> List[CommandStep]:
             "make pyright",
         )
         .on_test_image(AvailablePythonVersion.get_default())
-        .with_skip(skip_if_no_python_changes())
+        .with_skip(skip_if_no_python_changes(overrides=["pyright"]))
         .build(),
     ]
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -3,7 +3,7 @@ import logging
 import os
 import subprocess
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Sequence, Union
 
 import packaging.version
 import yaml
@@ -193,11 +193,16 @@ def get_commit(rev):
     return subprocess.check_output(["git", "rev-parse", "--short", rev]).decode("utf-8").strip()
 
 
-def skip_if_no_python_changes():
+def skip_if_no_python_changes(overrides: Optional[Sequence[str]] = None):
     if not is_feature_branch():
         return None
 
     if any(path.suffix == ".py" for path in ChangedFiles.all):
+        return None
+
+    if overrides and any(
+        Path(override) in path.parents for override in overrides for path in ChangedFiles.all
+    ):
         return None
 
     return "No python changes"


### PR DESCRIPTION
## Summary & Motivation

Add `overrides` to `skip_if_no_python_changes`, which allows opting out of this behavior for specified directories. Use this to run pyright steps for changes to the pyright dir.

## How I Tested These Changes

Upstack PR changes only pyright, runs pyright steps.