### PR TITLE
[fix] Add current time to cron-based test

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
@@ -79,7 +79,7 @@ cron_scenarios = [
             auto_materialize_policy=AutoMaterializePolicy(
                 rules={AutoMaterializeRule.skip_on_parent_missing()}
             )
-        ),
+        ).with_current_time("2023-11-11T11:11"),
         execution_fn=lambda state: state.evaluate_tick()
         .assert_requested_runs()
         # rule added after the first tick, should capture that this asset was not materialized


### PR DESCRIPTION
## Summary & Motivation

If you executed this test within 60 seconds of an hour boundary, it would fail as there would be a new cron tick. This fixes the current time at the start of the test such that there's no time-dependence.

## How I Tested These Changes
