### PR TITLE
[external-assets] Remove SourceAsset from AssetLayer

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -770,10 +770,7 @@ class JobDefinition(IHasInternalInit):
         check.opt_set_param(asset_check_selection, "asset_check_selection", AssetCheckKey)
 
         nonexistent_assets = [
-            asset
-            for asset in asset_selection
-            if asset not in self.asset_layer.asset_keys
-            and asset not in self.asset_layer.source_assets_by_key
+            asset for asset in asset_selection if asset not in self.asset_layer.asset_keys
         ]
         nonexistent_asset_strings = [
             asset_str
@@ -818,7 +815,7 @@ class JobDefinition(IHasInternalInit):
         new_job = build_asset_selection_job(
             name=self.name,
             assets=self.asset_layer.assets_defs,
-            source_assets=self.asset_layer.source_assets_by_key.values(),
+            source_assets=[],
             executor_def=self.executor_def,
             resource_defs=self.resource_defs,
             description=self.description,
@@ -1219,6 +1216,10 @@ def _infer_asset_layer_from_source_asset_deps(job_graph_def: GraphDefinition) ->
     """For non-asset jobs that have some inputs that are fed from SourceAssets, constructs an
     AssetLayer that includes those SourceAssets.
     """
+    from dagster._core.definitions.external_asset import (
+        create_external_asset_from_source_asset,
+    )
+
     asset_keys_by_node_input_handle: Dict[NodeInputHandle, AssetKey] = {}
     source_assets_list = []
     source_asset_keys_set = set()
@@ -1257,9 +1258,8 @@ def _infer_asset_layer_from_source_asset_deps(job_graph_def: GraphDefinition) ->
         asset_info_by_node_output_handle={},
         asset_deps={},
         dependency_node_handles_by_asset_key={},
-        assets_defs_by_key={},
-        source_assets_by_key={
-            source_asset.key: source_asset for source_asset in source_assets_list
+        assets_defs_by_key={
+            sa.key: create_external_asset_from_source_asset(sa) for sa in source_assets_list
         },
         io_manager_keys_by_asset_key=io_manager_keys_by_asset_key,
         dep_asset_keys_by_node_output_handle={},

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -299,22 +299,14 @@ class RepositoryDefinition:
         """
         if self.has_job(ASSET_BASE_JOB_PREFIX):
             base_job = self.get_job(ASSET_BASE_JOB_PREFIX)
-            if all(
-                key in base_job.asset_layer.assets_defs_by_key
-                or base_job.asset_layer.is_observable_for_asset(key)
-                for key in asset_keys
-            ):
+            if all(base_job.asset_layer.is_executable_for_asset(key) for key in asset_keys):
                 return base_job
         else:
             i = 0
             while self.has_job(f"{ASSET_BASE_JOB_PREFIX}_{i}"):
                 base_job = self.get_job(f"{ASSET_BASE_JOB_PREFIX}_{i}")
 
-                if all(
-                    key in base_job.asset_layer.assets_defs_by_key
-                    or base_job.asset_layer.is_observable_for_asset(key)
-                    for key in asset_keys
-                ):
+                if all(base_job.asset_layer.is_executable_for_asset(key) for key in asset_keys):
                     return base_job
 
                 i += 1

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -899,8 +899,6 @@ def _log_materialization_or_observation_events_for_asset(
         assets_def = asset_layer.assets_def_for_node(step_context.node_handle)
         if assets_def is not None:
             execution_type = assets_def.execution_type
-        elif asset_key in asset_layer.source_assets_by_key:
-            execution_type = asset_layer.source_assets_by_key[asset_key].execution_type
         else:
             # This is a situation that shouldn't really ever occur, but appears to be able to happen
             # when multiple output names point to the same asset key, which also shouldn't occur,

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -1643,7 +1643,7 @@ def external_asset_nodes_from_defs(
                     downstream_asset_key=output_key
                 )
 
-        for assets_def in asset_layer.assets_defs:
+        for assets_def in [ad for ad in asset_layer.assets_defs if ad.is_executable]:
             metadata_by_asset_key.update(assets_def.metadata_by_key)
             freshness_policy_by_asset_key.update(assets_def.freshness_policies_by_key)
             auto_materialize_policy_by_asset_key.update(assets_def.auto_materialize_policies_by_key)
@@ -1703,7 +1703,6 @@ def external_asset_nodes_from_defs(
         while node_handle.parent:
             node_handle = node_handle.parent
             graph_name = node_handle.name
-
         asset_nodes.append(
             ExternalAssetNode(
                 asset_key=asset_key,

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph_source_asset_input.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph_source_asset_input.py
@@ -19,7 +19,8 @@ def make_io_manager(source_asset: SourceAsset, input_value=5, expected_metadata=
         def load_input(self, context):
             self.loaded_input = True
             assert context.asset_key == source_asset.key
-            assert context.upstream_output.metadata == expected_metadata
+            for key, value in expected_metadata.items():
+                assert context.upstream_output.metadata[key] == value
             return input_value
 
     return MyIOManager()


### PR DESCRIPTION
## Summary & Motivation

Remove `SourceAsset` from `AssetLayer`, replacing any source assets passed in to `AssetLayer` construction with externals. This also entails a few `AssetLayer` callsite changes, as the existence of an assets def for a key in the `AssetLayer` was being used as an indication that it is executable, which is no longer true after this change.

This should be seen as a stepping stone to passing an `AssetGraph` in to the `AssetLayer`.

## How I Tested These Changes

Existing test suite.