### PR TITLE
TableMetadataEntries

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/metadata/TableSchema.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/metadata/TableSchema.tsx
@@ -31,7 +31,7 @@ interface ITableSchemaProps {
 export const isCanonicalTableSchemaEntry = (
   m: Pick<MaterializationEvent['metadataEntries'][0], '__typename' | 'label'>,
 ): m is TableSchemaMetadataEntry =>
-  m.__typename === 'TableSchemaMetadataEntry' && m.label === 'columns';
+  m.__typename === 'TableSchemaMetadataEntry' && m.label === 'dagster/column_schema';
 
 export const TableSchema = ({
   schema,

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -1164,21 +1164,20 @@ class NamespacedMetadataEntries(ABC, BaseModel, frozen=True):
     def _strip_namespace_from_key(key: str) -> str:
         return key.split("/", 1)[1]
 
-    def dict(self):
-        return {self._namespaced_key(key): getattr(self, key) for key in self.__fields__.keys()}
-
     def keys(self) -> AbstractSet[str]:
         return {
             self._namespaced_key(key)
             for key in self.__fields__.keys()
+            # getattr returns the pydantic property on the subclass
             if getattr(self, key) is not None
         }
 
     def __getitem__(self, key: str) -> Any:
+        # getattr returns the pydantic property on the subclass
         return getattr(self, self._strip_namespace_from_key(key))
 
     @classmethod
-    def from_dict(
+    def extract(
         cls: Type[T_NamespacedMetadataEntries], metadata_dict: Mapping[str, Any]
     ) -> T_NamespacedMetadataEntries:
         kwargs = {}

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -1178,10 +1178,28 @@ class NamespacedMetadataEntries(ABC, BaseModel, frozen=True):
 
     @classmethod
     def extract(
-        cls: Type[T_NamespacedMetadataEntries], metadata_dict: Mapping[str, Any]
+        cls: Type[T_NamespacedMetadataEntries], metadata: Mapping[str, Any]
     ) -> T_NamespacedMetadataEntries:
+        """Extracts entries from the provided metadata dictionary into an instance of this class.
+
+        Ignores any entries in the metadata dictionary whose keys don't correspond to fields on this
+        class.
+
+        In general, the following should always pass:
+
+        .. code-block:: python
+
+            class MyMetadataEntries(NamedspacedMetadataEntries):
+                ...
+
+            metadata_entries: MyMetadataEntries  = ...
+            assert MyMetadataEntries.extract(dict(metadata_entries)) == metadata_entries
+
+        Args:
+            metadata (Mapping[str, Any]): A dictionary of metadata entries.
+        """
         kwargs = {}
-        for namespaced_key, value in metadata_dict.items():
+        for namespaced_key, value in metadata.items():
             splits = namespaced_key.split("/")
             if len(splits) == 2:
                 namespace, key = splits

--- a/python_modules/dagster/dagster_tests/definitions_tests/metadata_tests/test_table_metadata_entries.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/metadata_tests/test_table_metadata_entries.py
@@ -1,0 +1,15 @@
+from dagster import AssetMaterialization, TableSchema
+from dagster._core.definitions.metadata import TableMetadataEntries
+
+
+def test_table_metadata_entries():
+    assert dict(TableMetadataEntries()) == {}
+    assert TableMetadataEntries.from_dict(dict(TableMetadataEntries())) == TableMetadataEntries()
+
+    column_schema = TableSchema(columns=[])
+    table_metadata_entries = TableMetadataEntries(column_schema=column_schema)
+    assert dict(table_metadata_entries) == {"dagster/column_schema": column_schema}
+    assert {**table_metadata_entries} == {"dagster/column_schema": column_schema}
+    assert TableMetadataEntries.from_dict(dict(table_metadata_entries)) == table_metadata_entries
+
+    AssetMaterialization(asset_key="a", metadata=dict(table_metadata_entries))

--- a/python_modules/dagster/dagster_tests/definitions_tests/metadata_tests/test_table_metadata_entries.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/metadata_tests/test_table_metadata_entries.py
@@ -1,15 +1,12 @@
+import pytest
 from dagster import AssetMaterialization, TableColumn, TableSchema
 from dagster._core.definitions.metadata import TableMetadataEntries
+from dagster._core.errors import DagsterInvalidMetadata
 
 
 def test_table_metadata_entries():
     column_schema = TableSchema(columns=[TableColumn("foo", "str")])
     table_metadata_entries = TableMetadataEntries(column_schema=column_schema)
-
-    table_metadata_entries_dict = table_metadata_entries.dict()
-    assert table_metadata_entries_dict == {"dagster/column_schema": column_schema}
-    assert isinstance(table_metadata_entries_dict["dagster/column_schema"], TableSchema)
-    AssetMaterialization(asset_key="a", metadata=table_metadata_entries_dict)
 
     dict_table_metadata_entries = dict(table_metadata_entries)
     assert dict_table_metadata_entries == {"dagster/column_schema": column_schema}
@@ -21,5 +18,9 @@ def test_table_metadata_entries():
     assert isinstance(splat_table_metadata_entries["dagster/column_schema"], TableSchema)
     AssetMaterialization(asset_key="a", metadata=splat_table_metadata_entries)
 
+    table_metadata_entries_dict = table_metadata_entries.dict()
+    with pytest.raises(DagsterInvalidMetadata):
+        AssetMaterialization(asset_key="a", metadata=table_metadata_entries_dict)
+
     assert dict(TableMetadataEntries()) == {}
-    assert TableMetadataEntries.from_dict(dict(TableMetadataEntries())) == TableMetadataEntries()
+    assert TableMetadataEntries.extract(dict(TableMetadataEntries())) == TableMetadataEntries()

--- a/python_modules/dagster/dagster_tests/definitions_tests/metadata_tests/test_table_metadata_entries.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/metadata_tests/test_table_metadata_entries.py
@@ -1,15 +1,25 @@
-from dagster import AssetMaterialization, TableSchema
+from dagster import AssetMaterialization, TableColumn, TableSchema
 from dagster._core.definitions.metadata import TableMetadataEntries
 
 
 def test_table_metadata_entries():
+    column_schema = TableSchema(columns=[TableColumn("foo", "str")])
+    table_metadata_entries = TableMetadataEntries(column_schema=column_schema)
+
+    table_metadata_entries_dict = table_metadata_entries.dict()
+    assert table_metadata_entries_dict == {"dagster/column_schema": column_schema}
+    assert isinstance(table_metadata_entries_dict["dagster/column_schema"], TableSchema)
+    AssetMaterialization(asset_key="a", metadata=table_metadata_entries_dict)
+
+    dict_table_metadata_entries = dict(table_metadata_entries)
+    assert dict_table_metadata_entries == {"dagster/column_schema": column_schema}
+    assert isinstance(dict_table_metadata_entries["dagster/column_schema"], TableSchema)
+    AssetMaterialization(asset_key="a", metadata=dict_table_metadata_entries)
+
+    splat_table_metadata_entries = {**table_metadata_entries}
+    assert splat_table_metadata_entries == {"dagster/column_schema": column_schema}
+    assert isinstance(splat_table_metadata_entries["dagster/column_schema"], TableSchema)
+    AssetMaterialization(asset_key="a", metadata=splat_table_metadata_entries)
+
     assert dict(TableMetadataEntries()) == {}
     assert TableMetadataEntries.from_dict(dict(TableMetadataEntries())) == TableMetadataEntries()
-
-    column_schema = TableSchema(columns=[])
-    table_metadata_entries = TableMetadataEntries(column_schema=column_schema)
-    assert dict(table_metadata_entries) == {"dagster/column_schema": column_schema}
-    assert {**table_metadata_entries} == {"dagster/column_schema": column_schema}
-    assert TableMetadataEntries.from_dict(dict(table_metadata_entries)) == table_metadata_entries
-
-    AssetMaterialization(asset_key="a", metadata=dict(table_metadata_entries))

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -367,20 +367,18 @@ def default_metadata_from_dbt_resource_props(
     metadata: Dict[str, Any] = {}
     columns = dbt_resource_props.get("columns", {})
     if len(columns) > 0:
-        return dict(
-            TableMetadataEntries(
-                column_schema=TableSchema(
-                    columns=[
-                        TableColumn(
-                            name=column_name,
-                            type=column_info.get("data_type") or "?",
-                            description=column_info.get("description"),
-                        )
-                        for column_name, column_info in columns.items()
-                    ]
-                )
+        return TableMetadataEntries(
+            column_schema=TableSchema(
+                columns=[
+                    TableColumn(
+                        name=column_name,
+                        type=column_info.get("data_type") or "?",
+                        description=column_info.get("description"),
+                    )
+                    for column_name, column_info in columns.items()
+                ]
             )
-        )
+        ).dict()
     return metadata
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -25,7 +25,6 @@ from dagster import (
     DefaultScheduleStatus,
     FreshnessPolicy,
     In,
-    MetadataValue,
     Nothing,
     Out,
     RunConfig,
@@ -38,6 +37,7 @@ from dagster import (
 from dagster._core.definitions.decorators.asset_decorator import (
     _validate_and_assign_output_names_to_check_specs,
 )
+from dagster._core.definitions.metadata import TableMetadataEntries
 from dagster._utils.merger import merge_dicts
 from dagster._utils.warnings import deprecation_warning
 
@@ -367,16 +367,18 @@ def default_metadata_from_dbt_resource_props(
     metadata: Dict[str, Any] = {}
     columns = dbt_resource_props.get("columns", {})
     if len(columns) > 0:
-        metadata["columns"] = MetadataValue.table_schema(
-            TableSchema(
-                columns=[
-                    TableColumn(
-                        name=column_name,
-                        type=column_info.get("data_type") or "?",
-                        description=column_info.get("description"),
-                    )
-                    for column_name, column_info in columns.items()
-                ]
+        return dict(
+            TableMetadataEntries(
+                column_schema=TableSchema(
+                    columns=[
+                        TableColumn(
+                            name=column_name,
+                            type=column_info.get("data_type") or "?",
+                            description=column_info.get("description"),
+                        )
+                        for column_name, column_info in columns.items()
+                    ]
+                )
             )
         )
     return metadata

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -51,7 +51,7 @@ def test_columns_metadata(test_metadata_manifest: Dict[str, Any]) -> None:
         }
 
         for output in output_by_dbt_unique_id.values():
-            assert TableMetadataEntries.from_dict(output.metadata).column_schema is not None
+            assert TableMetadataEntries.extract(output.metadata).column_schema is not None
 
         customers_output = output_by_dbt_unique_id["model.test_dagster_metadata.customers"]
         assert (
@@ -66,7 +66,7 @@ def test_columns_metadata(test_metadata_manifest: Dict[str, Any]) -> None:
                     TableColumn("customer_lifetime_value", type="DOUBLE"),
                 ]
             )
-            == TableMetadataEntries.from_dict(customers_output.metadata).column_schema
+            == TableMetadataEntries.extract(customers_output.metadata).column_schema
         )
 
         yield from events

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -10,6 +10,7 @@ from dagster import (
     TableSchema,
     materialize,
 )
+from dagster._core.definitions.metadata import TableMetadataEntries
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.core.resources_v2 import DbtCliResource
 
@@ -50,7 +51,7 @@ def test_columns_metadata(test_metadata_manifest: Dict[str, Any]) -> None:
         }
 
         for output in output_by_dbt_unique_id.values():
-            assert "columns" in output.metadata
+            assert TableMetadataEntries.from_dict(output.metadata).column_schema is not None
 
         customers_output = output_by_dbt_unique_id["model.test_dagster_metadata.customers"]
         assert (
@@ -65,7 +66,7 @@ def test_columns_metadata(test_metadata_manifest: Dict[str, Any]) -> None:
                     TableColumn("customer_lifetime_value", type="DOUBLE"),
                 ]
             )
-            == customers_output.metadata["columns"].value
+            == TableMetadataEntries.from_dict(customers_output.metadata).column_schema
         )
 
         yield from events


### PR DESCRIPTION
## Summary & Motivation

A la part of the proposal in [this PR](https://github.com/dagster-io/dagster/pull/20077), adds a class that holds a set of standard metadata entries that apply to assets that are tables.

The main impacts of this PR:
- The "columns" metadata key has been renamed to "dagster/column_schema".
  - Went with "dagster/column_schema" instead of "dagster/columns" because the latter could be interpreted as a list of column names, while "column_schema" implies that types are included.
- The magic string "columns" and "dagster/column_schema" no longer exist in Python. Instead, a typed attribute on the `TableMetadataEntries` class is used.

While the idea would be to expose `TableMetadataEntries` publicly eventually, this PR doesn't include any public-facing API changes. It modifies the dbt integration to use the private API.

Previous versions of this proposal had used "dagster.table" instead of "dagster", but there's not actually a package named "dagster.table", so stuck with "dagster".

## How I Tested These Changes
