### PR TITLE
[fix] Resolve submodules using prefix instead of dirname

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -339,8 +339,7 @@ def load_assets_from_package_name(
 
 def find_modules_in_package(package_module: ModuleType) -> Iterable[ModuleType]:
     yield package_module
-    package_path = package_module.__file__
-    if package_path:
+    if package_module.__file__:
         for _, modname, is_pkg in pkgutil.walk_packages(
             package_module.__path__, prefix=package_module.__name__ + "."
         ):

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -1,5 +1,4 @@
 import inspect
-import os
 import pkgutil
 from importlib import import_module
 from types import ModuleType
@@ -342,8 +341,10 @@ def find_modules_in_package(package_module: ModuleType) -> Iterable[ModuleType]:
     yield package_module
     package_path = package_module.__file__
     if package_path:
-        for _, modname, is_pkg in pkgutil.walk_packages([os.path.dirname(package_path)]):
-            submodule = import_module(f"{package_module.__name__}.{modname}")
+        for _, modname, is_pkg in pkgutil.walk_packages(
+            package_module.__path__, prefix=package_module.__name__ + "."
+        ):
+            submodule = import_module(modname)
             if is_pkg:
                 yield from find_modules_in_package(submodule)
             else:


### PR DESCRIPTION
## Summary & Motivation

Resolves bug in https://github.com/dagster-io/dagster/issues/20422

## How I Tested These Changes

After editing this dagster library code in locally, this works in the minimal repro here: https://github.com/dagster-io/dagster-quickstart/compare/main...CSRessel:dagster-bug-repro:main

And this fix also works within my own work as well