### PR TITLE
[dagster-dask] Make dagster-dask support 2024.3.0

### DIFF
--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -28,7 +28,7 @@ def normalize_names(names):
         name = camel_to_snake1.sub(r"\1_\2", name)
         return camel_to_snake2.sub(r"\1_\2", name).lower()
 
-    return map(normalize, names)
+    return [normalize(n) for n in names]
 
 
 DataFrameUtilities = {


### PR DESCRIPTION
## Summary & Motivation

`dask==2024.3.0` was just released and broke one of our tests, this fixes it by changing a `map()` to a list comprehension (`map` returns an iterator).

## How I Tested These Changes

Existing test suite.