### PR TITLE
Make check.inst and check.opt_inst type-narrowing

### DIFF
--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -650,7 +650,7 @@ def opt_inst_param(
 
 @overload
 def opt_inst_param(
-    obj: T,
+    obj: Optional[T],
     param_name: str,
     ttype: TypeOrTupleOfTypes,
     default: Optional[T] = ...,
@@ -670,21 +670,21 @@ def opt_inst_param(
     return default if obj is None else obj
 
 
-def inst(obj: T, ttype: TypeOrTupleOfTypes, additional_message: Optional[str] = None) -> T:
+def inst(obj: object, ttype: TypeOrTupleOfTypes, additional_message: Optional[str] = None) -> T:
     if not isinstance(obj, ttype):
         raise _type_mismatch_error(obj, ttype, additional_message)
-    return obj
+    return cast(T, obj)
 
 
 def opt_inst(
-    obj: T,
+    obj: object,
     ttype: TypeOrTupleOfTypes,
     additional_message: Optional[str] = None,
     default: Optional[T] = None,
 ) -> Optional[T]:
     if obj is not None and not isinstance(obj, ttype):
         raise _type_mismatch_error(obj, ttype, additional_message)
-    return default if obj is None else obj
+    return default if obj is None else cast(T, obj)
 
 
 # ########################

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -1507,3 +1507,10 @@ def test_opt_iterable():
 
     with pytest.raises(CheckError, match="Member of iterable mismatches type"):
         check.opt_iterable_param(["atr", None], "nonedoesntcount", of_type=str)
+
+
+def test_inst_type_narrowing() -> None:
+    def _takes_any_returns_in(obj: object) -> int:
+        return check.inst(obj, int)
+
+    assert _takes_any_returns_in(1) == 1


### PR DESCRIPTION
## Summary & Motivation

We previously had a discussion about making check.inst type-narrowing. I cannot recall the exact tradeoffs but in my mind it makes no sense to have the parameter of `inst` be typed to T. `inst` should be useful for bridging the gap between typed and untyped code, or to deal with APIs where `isinstance` is required and it is ergonomic to return the value you are checking. 

Other you are forced to do patterns like

```python
# super confusing because the cast is a lie
check.inst(cast(int, untyped_value), int)
```
or
```python
check.inst(untyped_value, int)
assert isinstance(untyped_value) # appease typechecker
```

Much more satisfying is the one liner that requires no additional imports:

```python
int_value = check.inst(untyped_value, int)
```

## How I Tested These Changes

BK

Before:


![Screenshot 2024-03-12 at 8.57.42 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/be90d96f-4f96-49f9-89c8-ba4448264e4f.png)

After:

![Screenshot 2024-03-12 at 9.01.38 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/6f6fef85-772a-43b5-b102-b8b916637651.png)

