### PR TITLE
[external-assets] Ensure assets defs are present for all asset checks in AssetGraph

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -242,9 +242,9 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
             self.asset_dep_graph, self.observable_asset_keys | self.materializable_asset_keys
         )
 
-    @cached_property
-    def asset_check_keys(self) -> AbstractSet[AssetCheckKey]:
-        return {key for asset in self.asset_nodes for key in asset.check_keys}
+    @property
+    @abstractmethod
+    def asset_check_keys(self) -> AbstractSet[AssetCheckKey]: ...
 
     @cached_property
     def all_partitions_defs(self) -> Sequence[PartitionsDefinition]:

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -336,6 +336,10 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
     def asset_checks(self) -> Sequence["ExternalAssetCheck"]:
         return list(dict.fromkeys(self._asset_checks_by_key.values()))
 
+    @cached_property
+    def asset_check_keys(self) -> AbstractSet[AssetCheckKey]:
+        return {key for asset in self.asset_nodes for key in asset.check_keys}
+
     def asset_keys_for_job(self, job_name: str) -> AbstractSet[AssetKey]:
         return {node.key for node in self.asset_nodes if job_name in node.job_names}
 


### PR DESCRIPTION
## Summary & Motivation

There is a bug in the asset graph that I surfaced in an upstack PR, which is that the `AssetsDefinition` for an asset check isn't available from the asset graph if an `AssetsDefinition` has been subsetted to only a check with no assets. This refactors `AssetGraph` to support this niche case, which opens the door to using `AssetGraph` as the basis for `AssetLayer`.

## How I Tested These Changes

Existing test suite. The "new" functionality is tested upstack by #20405 