### PR TITLE
remove optionality of get_run_tags tag_keys arg

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -66,7 +66,7 @@ def get_run_tag_keys(graphene_info: "ResolveInfo") -> "GrapheneRunTagKeys":
 
 def get_run_tags(
     graphene_info: "ResolveInfo",
-    tag_keys: Optional[List[str]] = None,
+    tag_keys: List[str],
     value_prefix: Optional[str] = None,
     limit: Optional[int] = None,
 ) -> "GrapheneRunTags":

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -803,7 +803,7 @@ class GrapheneQuery(graphene.ObjectType):
     def resolve_runTagsOrError(
         self,
         graphene_info: ResolveInfo,
-        tagKeys: Optional[List[str]] = None,
+        tagKeys: List[str],
         valuePrefix: Optional[str] = None,
         limit: Optional[int] = None,
     ):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -78,19 +78,6 @@ mutation DeleteRun($runId: String!) {
 }
 """
 
-ALL_TAGS_QUERY = """
-{
-  runTagsOrError {
-    ... on RunTags {
-      tags {
-        key
-        values
-      }
-    }
-  }
-}
-"""
-
 ALL_TAG_KEYS_QUERY = """
 {
   runTagKeysOrError {
@@ -351,12 +338,6 @@ class TestGetRuns(ExecutingGraphQLContextTestMatrix):
         # check presence rather than set equality since we might have extra tags in cloud
         assert "fruit" in tag_keys
         assert "veggie" in tag_keys
-
-        all_tags_result = execute_dagster_graphql(read_context, ALL_TAGS_QUERY)
-        tags = all_tags_result.data["runTagsOrError"]["tags"]
-        tags_dict = {item["key"]: item["values"] for item in tags}
-        assert tags_dict["fruit"] == ["apple"]
-        assert tags_dict["veggie"] == ["carrot"]
 
         filtered_tags_result = execute_dagster_graphql(
             read_context, FILTERED_TAGS_QUERY, variables={"tagKeys": ["fruit"]}

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1089,7 +1089,7 @@ class DagsterInstance(DynamicPartitionsStore):
     @traced
     def get_run_tags(
         self,
-        tag_keys: Optional[Sequence[str]] = None,
+        tag_keys: Sequence[str],
         value_prefix: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> Sequence[Tuple[str, Set[str]]]:

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -240,7 +240,7 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
 
     def get_run_tags(
         self,
-        tag_keys: Optional[Sequence[str]] = None,
+        tag_keys: Sequence[str],
         value_prefix: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> Sequence[Tuple[str, Set[str]]]:

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -161,14 +161,14 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
     @abstractmethod
     def get_run_tags(
         self,
-        tag_keys: Optional[Sequence[str]] = None,
+        tag_keys: Sequence[str],
         value_prefix: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> Sequence[Tuple[str, Set[str]]]:
         """Get a list of tag keys and the values that have been associated with them.
 
         Args:
-            tag_keys (Optional[Sequence[str]]): tag keys to filter by.
+            tag_keys (Sequence[str]): tag keys to filter by.
 
         Returns:
             List[Tuple[str, Set[str]]]

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -438,7 +438,7 @@ class SqlRunStorage(RunStorage):
 
     def get_run_tags(
         self,
-        tag_keys: Optional[Sequence[str]] = None,
+        tag_keys: Sequence[str],
         value_prefix: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> Sequence[Tuple[str, Set[str]]]:
@@ -447,9 +447,8 @@ class SqlRunStorage(RunStorage):
             db_select([RunTagsTable.c.key, RunTagsTable.c.value])
             .distinct()
             .order_by(RunTagsTable.c.key, RunTagsTable.c.value)
+            .where(RunTagsTable.c.key.in_(tag_keys))
         )
-        if tag_keys:
-            query = query.where(RunTagsTable.c.key.in_(tag_keys))
         if value_prefix:
             query = query.where(RunTagsTable.c.value.startswith(value_prefix))
         if limit:

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -3,6 +3,7 @@ import tempfile
 import time
 import unittest
 from datetime import datetime, timedelta
+from typing import Optional
 
 import pendulum
 import pytest
@@ -52,7 +53,7 @@ from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_freeze
 win_py36 = _seven.IS_WINDOWS and sys.version_info[0] == 3 and sys.version_info[1] == 6
 
 
-def _get_run_by_id(storage, run_id):
+def _get_run_by_id(storage, run_id) -> Optional[DagsterRun]:
     records = storage.get_run_records(RunsFilter(run_ids=[run_id]))
     if not records:
         return None
@@ -240,7 +241,7 @@ class TestRunStorage:
         assert len(runs_b) == 1
         assert runs_b[0].run_id == two
 
-    def test_add_run_tags(self, storage):
+    def test_add_run_tags(self, storage: RunStorage):
         assert storage
         one = make_new_run_id()
         two = make_new_run_id()
@@ -248,24 +249,28 @@ class TestRunStorage:
         storage.add_run(TestRunStorage.build_run(run_id=one, job_name="foo"))
         storage.add_run(TestRunStorage.build_run(run_id=two, job_name="bar"))
 
-        assert storage.get_run_tags() == []
+        assert storage.get_run_tags(tag_keys=["tag1", "tag2"]) == []
 
         storage.add_run_tags(one, {"tag1": "val1", "tag2": "val2"})
         storage.add_run_tags(two, {"tag1": "val1"})
 
-        assert storage.get_run_tags() == [("tag1", {"val1"}), ("tag2", {"val2"})]
+        assert storage.get_run_tags(tag_keys=["tag1", "tag2"]) == [
+            ("tag1", {"val1"}),
+            ("tag2", {"val2"}),
+        ]
 
         # Adding both existing tags and a new tag
         storage.add_run_tags(one, {"tag1": "val2", "tag3": "val3"})
 
         test_run = _get_run_by_id(storage, one)
+        assert test_run
 
         assert len(test_run.tags) == 3
         assert test_run.tags["tag1"] == "val2"
         assert test_run.tags["tag2"] == "val2"
         assert test_run.tags["tag3"] == "val3"
 
-        assert storage.get_run_tags() == [
+        assert storage.get_run_tags(tag_keys=["tag1", "tag2", "tag3"]) == [
             ("tag1", {"val1", "val2"}),
             ("tag2", {"val2"}),
             ("tag3", {"val3"}),
@@ -275,13 +280,13 @@ class TestRunStorage:
         storage.add_run_tags(one, {"tag1": "val3"})
 
         test_run = _get_run_by_id(storage, one)
-
+        assert test_run
         assert len(test_run.tags) == 3
         assert test_run.tags["tag1"] == "val3"
         assert test_run.tags["tag2"] == "val2"
         assert test_run.tags["tag3"] == "val3"
 
-        assert storage.get_run_tags() == [
+        assert storage.get_run_tags(tag_keys=["tag1", "tag2", "tag3"]) == [
             ("tag1", {"val1", "val3"}),
             ("tag2", {"val2"}),
             ("tag3", {"val3"}),
@@ -291,6 +296,7 @@ class TestRunStorage:
         storage.add_run_tags(one, {"tag4": "val4"})
 
         test_run = _get_run_by_id(storage, one)
+        assert test_run
 
         assert len(test_run.tags) == 4
         assert test_run.tags["tag1"] == "val3"
@@ -298,7 +304,7 @@ class TestRunStorage:
         assert test_run.tags["tag3"] == "val3"
         assert test_run.tags["tag4"] == "val4"
 
-        assert storage.get_run_tags() == [
+        assert storage.get_run_tags(tag_keys=["tag1", "tag2", "tag3", "tag4"]) == [
             ("tag1", {"val1", "val3"}),
             ("tag2", {"val2"}),
             ("tag3", {"val3"}),
@@ -306,6 +312,7 @@ class TestRunStorage:
         ]
 
         test_run = _get_run_by_id(storage, one)
+        assert test_run
         assert len(test_run.tags) == 4
         assert test_run.tags["tag1"] == "val3"
         assert test_run.tags["tag2"] == "val2"
@@ -330,7 +337,7 @@ class TestRunStorage:
             "tag4": "val4",
         }
 
-    def test_get_run_tags(self, storage):
+    def test_get_run_tags(self, storage: RunStorage):
         one = make_new_run_id()
         two = make_new_run_id()
         storage.add_run(TestRunStorage.build_run(run_id=one, job_name="foo"))
@@ -361,16 +368,19 @@ class TestRunStorage:
         ]
 
         # test getting run tags with prefix
-        assert storage.get_run_tags(value_prefix="x_") == [
+        assert storage.get_run_tags(tag_keys=["x_1", "x_2"], value_prefix="x_") == [
             ("x_1", {"x_1"}),
             ("x_2", {"x_2"}),
         ]
 
         # test getting run tags with limit
-        assert storage.get_run_tags(limit=3) == [
+        assert storage.get_run_tags(tag_keys=["tag1", "tag2"], limit=3) == [
             ("tag1", {"val1", "val3"}),
             ("tag2", {"val2"}),
         ]
+
+        # empty tag_keys implies nothing instead of everything
+        assert storage.get_run_tags(tag_keys=[]) == []
 
     def test_fetch_by_filter(self, storage):
         assert storage
@@ -526,7 +536,7 @@ class TestRunStorage:
         assert count == 4
         assert run_ids == [four, three, two, one]
 
-    def test_fetch_count_by_tag(self, storage):
+    def test_fetch_count_by_tag(self, storage: RunStorage):
         assert storage
         one = make_new_run_id()
         two = make_new_run_id()
@@ -559,7 +569,10 @@ class TestRunStorage:
         run_count = storage.get_runs_count()
         assert run_count == 3
 
-        assert storage.get_run_tags() == [("mytag", {"hello", "goodbye"}), ("mytag2", {"world"})]
+        assert storage.get_run_tags(tag_keys=["mytag", "mytag2"]) == [
+            ("mytag", {"hello", "goodbye"}),
+            ("mytag2", {"world"}),
+        ]
 
     def test_fetch_by_tags(self, storage):
         assert storage
@@ -900,7 +913,7 @@ class TestRunStorage:
         storage.delete_run(run_id)
         assert list(storage.get_runs()) == []
 
-    def test_delete_with_tags(self, storage):
+    def test_delete_with_tags(self, storage: RunStorage):
         if not self.can_delete_runs():
             pytest.skip("storage cannot delete runs")
 
@@ -914,10 +927,10 @@ class TestRunStorage:
             )
         )
         assert len(storage.get_runs()) == 1
-        assert run_id in [key for key, value in storage.get_run_tags()]
+        assert run_id in [key for key, value in storage.get_run_tags(tag_keys=[run_id])]
         storage.delete_run(run_id)
         assert list(storage.get_runs()) == []
-        assert run_id not in [key for key, value in storage.get_run_tags()]
+        assert run_id not in [key for key, value in storage.get_run_tags(tag_keys=[run_id])]
 
     def test_wipe_tags(self, storage: RunStorage):
         if not self.can_delete_runs():
@@ -929,11 +942,11 @@ class TestRunStorage:
         storage.add_run(run)
 
         assert _get_run_by_id(storage, run_id) == run
-        assert dict(storage.get_run_tags()) == {"foo": {"bar"}}
+        assert dict(storage.get_run_tags(tag_keys=["foo"])) == {"foo": {"bar"}}
 
         storage.wipe()
         assert list(storage.get_runs()) == []
-        assert dict(storage.get_run_tags()) == {}
+        assert dict(storage.get_run_tags(tag_keys=["foo"])) == {}
 
     def test_write_conflicting_run_id(self, storage: RunStorage):
         double_run_id = "double_run_id"


### PR DESCRIPTION
We have no internal call sites that do not specify tag_keys and omitting it can easily create incredibly expensive DB queries. 

## How I Tested These Changes

updated test suite
