### PR TITLE
[useQueryRefreshAtInterval] Remove unused custom refetch logic that was used for chunking/batching fetches

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
@@ -38,7 +38,6 @@ export function useQueryRefreshAtInterval(
   queryResult: Pick<QueryResult<any, any>, 'refetch' | 'loading' | 'networkStatus'>,
   intervalMs: number,
   enabled = true,
-  customRefetch?: () => void,
 ) {
   const timer = useRef<number>();
   const loadingStartMs = useRef<number>();
@@ -46,9 +45,6 @@ export function useQueryRefreshAtInterval(
 
   const queryResultRef = useRef(queryResult);
   queryResultRef.current = queryResult;
-
-  const customRefetchRef = useRef(customRefetch);
-  customRefetchRef.current = customRefetch;
 
   // Sanity check - don't use this hook alongside a useQuery pollInterval
   if (queryResult.networkStatus === NetworkStatus.poll) {
@@ -75,7 +71,7 @@ export function useQueryRefreshAtInterval(
       !searchVisible &&
       (searchVisibilityDidInterrupt.current || documentVisiblityDidInterrupt.current)
     ) {
-      customRefetchRef.current ? customRefetchRef.current() : queryResultRef.current?.refetch();
+      queryResultRef.current?.refetch();
       documentVisiblityDidInterrupt.current = false;
       searchVisibilityDidInterrupt.current = false;
     }
@@ -118,7 +114,7 @@ export function useQueryRefreshAtInterval(
         searchVisibilityDidInterrupt.current = true;
         return;
       }
-      customRefetchRef.current ? customRefetchRef.current() : queryResultRef.current?.refetch();
+      queryResultRef.current?.refetch();
     }, adjustedIntervalMs);
 
     return () => {
@@ -137,11 +133,7 @@ export function useQueryRefreshAtInterval(
       nextFireMs,
       nextFireDelay,
       networkStatus: queryResult.networkStatus,
-      refetch: (...props) => {
-        return customRefetchRef.current
-          ? (customRefetchRef.current() as any)
-          : queryResult.refetch(...props);
-      },
+      refetch: queryResult.refetch,
     }),
     [nextFireMs, nextFireDelay, queryResult],
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -90,7 +90,7 @@ const GlobalAutomaterializationRoot = () => {
   }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useLayoutEffect(fetchData, [variables]);
-  useQueryRefreshAtInterval(queryResult, 2 * 1000, !isPaused && !timeRange && !statuses, fetchData);
+  useQueryRefreshAtInterval(queryResult, 2 * 1000, !isPaused && !timeRange && !statuses);
 
   const [selectedTick, setSelectedTick] = useState<AssetDaemonTickFragment | null>(null);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -65,9 +65,6 @@ const GlobalAutomaterializationRoot = () => {
 
   const {permissions: {canToggleAutoMaterialize} = {}} = useUnscopedPermissions();
 
-  const [fetch, queryResult] = useLazyQuery<AssetDaemonTicksQuery, AssetDaemonTicksQueryVariables>(
-    ASSET_DAEMON_TICKS_QUERY,
-  );
   const [isPaused, setIsPaused] = useState(false);
   const [statuses, setStatuses] = useState<undefined | InstigationTickStatus[]>(undefined);
   const [timeRange, setTimerange] = useState<undefined | [number, number]>(undefined);
@@ -83,6 +80,10 @@ const GlobalAutomaterializationRoot = () => {
       afterTimestamp: (Date.now() - TWENTY_MINUTES) / 1000,
     };
   }, [statuses, timeRange]);
+  const [fetch, queryResult] = useLazyQuery<AssetDaemonTicksQuery, AssetDaemonTicksQueryVariables>(
+    ASSET_DAEMON_TICKS_QUERY,
+    {variables},
+  );
   function fetchData() {
     fetch({
       variables,

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
@@ -76,7 +76,7 @@ export const SensorPageAutomaterialize = (props: Props) => {
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useLayoutEffect(fetchData, [variables]);
-  useQueryRefreshAtInterval(queryResult, 2 * 1000, !isPaused && !timeRange && !statuses, fetchData);
+  useQueryRefreshAtInterval(queryResult, 2 * 1000, !isPaused && !timeRange && !statuses);
 
   const [selectedTick, setSelectedTick] = useState<AssetDaemonTickFragment | null>(null);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
@@ -41,10 +41,6 @@ export const SensorPageAutomaterialize = (props: Props) => {
   const [statuses, setStatuses] = useState<undefined | InstigationTickStatus[]>(undefined);
   const [timeRange, setTimerange] = useState<undefined | [number, number]>(undefined);
 
-  const [fetch, queryResult] = useLazyQuery<AssetSensorTicksQuery, AssetSensorTicksQueryVariables>(
-    ASSET_SENSOR_TICKS_QUERY,
-  );
-
   const variables: AssetSensorTicksQueryVariables = useMemo(() => {
     if (timeRange || statuses) {
       return {
@@ -67,6 +63,11 @@ export const SensorPageAutomaterialize = (props: Props) => {
       afterTimestamp: (Date.now() - TWENTY_MINUTES) / 1000,
     };
   }, [sensor, repoAddress, statuses, timeRange]);
+
+  const [fetch, queryResult] = useLazyQuery<AssetSensorTicksQuery, AssetSensorTicksQueryVariables>(
+    ASSET_SENSOR_TICKS_QUERY,
+    {variables},
+  );
 
   function fetchData() {
     fetch({


### PR DESCRIPTION
## Summary & Motivation

The special custom refetch logic in this hook was added in https://github.com/dagster-io/dagster/pull/16523/files to chunk/batch asset fetching. We don't need this custom logic anymore since we have AssetLiveDataProvider now.

## How I Tested These Changes

check AMP page and made sure auto refreshing still works.

lint