### PR TITLE
chore(pyright): rebuild pyright pins on each buildkite build

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -107,7 +107,9 @@ def build_repo_wide_pyright_steps() -> List[CommandStep]:
         CommandStepBuilder(":pyright: pyright")
         .run(
             "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y",
-            "pip install uv -e python_modules/dagster[pyright] -e python_modules/dagster-pipes",
+            "pip install -U uv",
+            "make install_pyright",
+            "make rebuild_pyright_pins",
             "make pyright",
         )
         .on_test_image(AvailablePythonVersion.get_default())

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ pyright:
 	python scripts/run-pyright.py --all
 
 install_pyright:
-	pip install -e 'python_modules/dagster[pyright]'
+	pip install -e 'python_modules/dagster[pyright]' -e 'python_modules/dagster-pipes'
 
 rebuild_pyright:
 	python scripts/run-pyright.py --all --rebuild


### PR DESCRIPTION
## Summary & Motivation
Prevent errors like https://github.com/dagster-io/dagster/pull/20406 from happening by always attempting to regenerate the pyright pins on each build.

I could put this in a separate step and scope it down to only run if any `requirements.txt` has changed in the `pyright/` subdirectory, but want to see if the build time difference is negligible because of `uv` first.

## How I Tested These Changes
bk
