### PR TITLE
[ui] Nav to assets catalog page from top nav

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav.tsx
@@ -36,7 +36,7 @@ export const AppTopNav = ({
   allowGlobalReload = false,
 }: Props) => {
   const history = useHistory();
-  const {flagSettingsPage} = useFeatureFlags();
+  const {flagSettingsPage, flagUseNewOverviewPage} = useFeatureFlags();
 
   const navLinks = () => {
     return [
@@ -80,7 +80,7 @@ export const AppTopNav = ({
             shortcutFilter={(e) => e.altKey && e.code === 'Digit3'}
           >
             <TopNavLink
-              to="/assets"
+              to={flagUseNewOverviewPage ? '/assets-overview' : '/assets'}
               data-cy="AppTopNav_AssetsLink"
               isActive={(_, location) => {
                 const {pathname} = location;


### PR DESCRIPTION
In the top nav, when clicking on "Assets" you should go to the new catalog page if the feature gate is enabled.

Use the prior behavior and navigate to the assets table view if the feature gate isn't enabled.