### PR TITLE
[asset-checks] Stub out AssetChecksDefinition

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_checks.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_checks.py
@@ -28,7 +28,7 @@ def test_execute(defs):
 
 def test_factory():
     checks = [make_check(check_blob) for check_blob in check_blobs]
-    assert [c.spec.key for c in checks] == [
+    assert [next(iter(c.check_keys)) for c in checks] == [
         AssetCheckKey(
             AssetKey(["orders"]),
             "orders_id_has_no_nulls",

--- a/python_modules/dagster/dagster/_core/definitions/asset_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_checks.py
@@ -1,193 +1,71 @@
 from typing import (
-    TYPE_CHECKING,
     Any,
-    Dict,
-    Iterable,
-    Iterator,
     Mapping,
-    NamedTuple,
     Optional,
     Sequence,
-    Set,
 )
 
 from dagster import _check as check
-from dagster._annotations import experimental, public
-from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSpec
-from dagster._core.definitions.events import (
-    AssetKey,
-    CoercibleToAssetKeyPrefix,
-)
-from dagster._core.definitions.node_definition import NodeDefinition
+from dagster._annotations import experimental
+from dagster._core.definitions.asset_check_spec import AssetCheckSpec
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.resource_definition import ResourceDefinition
-from dagster._core.definitions.resource_requirement import (
-    RequiresResources,
-    ResourceAddable,
-    ResourceRequirement,
-    merge_resource_defs,
-)
 from dagster._core.errors import DagsterAssetCheckFailedError
 from dagster._core.types.dagster_type import Nothing
 
-if TYPE_CHECKING:
-    from dagster._core.definitions.assets import AssetsDefinition
 
-
-@experimental
-class AssetChecksDefinitionInputOutputProps(NamedTuple):
-    asset_check_keys_by_output_name: Mapping[str, AssetCheckKey]
-    asset_keys_by_input_name: Mapping[str, AssetKey]
-
-    def with_asset_key_prefix(
-        self, prefix: CoercibleToAssetKeyPrefix
-    ) -> "AssetChecksDefinitionInputOutputProps":
-        return self._replace(
-            asset_check_keys_by_output_name={
-                output_name: check_key.with_asset_key_prefix(prefix)
-                for output_name, check_key in self.asset_check_keys_by_output_name.items()
-            },
-            asset_keys_by_input_name={
-                input_name: asset_key.with_prefix(prefix)
-                for input_name, asset_key in self.asset_keys_by_input_name.items()
-            },
-        )
-
-
-@experimental
-class AssetChecksDefinition(ResourceAddable, RequiresResources):
+class AssetChecksDefinition(AssetsDefinition):
     """Defines a set of checks that are produced by the same op or op graph.
 
-    AssetChecksDefinition are typically not instantiated directly, but rather produced using a
-    decorator like :py:func:`@asset_check <asset>`.
+    AssetChecksDefinition should not be instantiated directly, but rather produced using the `@asset_check` decorator or `AssetChecksDefinition.create` method.
     """
 
-    def __init__(
-        self,
+    @staticmethod
+    def create(
         *,
-        node_def: NodeDefinition,
-        resource_defs: Mapping[str, ResourceDefinition],
-        specs: Sequence[AssetCheckSpec],
-        input_output_props: AssetChecksDefinitionInputOutputProps,
-        # if adding new fields, make sure to handle them in the get_attributes_dict method
+        keys_by_input_name: Mapping[str, AssetKey],
+        node_def: OpDefinition,
+        check_specs_by_output_name: Mapping[str, AssetCheckSpec],
+        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     ):
-        self._node_def = node_def
-        self._resource_defs = resource_defs
-        self._specs = check.sequence_param(specs, "specs", of_type=AssetCheckSpec)
-        self._input_output_props = check.inst_param(
-            input_output_props, "input_output_props", AssetChecksDefinitionInputOutputProps
-        )
-        self._specs_by_handle = {spec.key: spec for spec in specs}
-        self._specs_by_output_name = {
-            output_name: self._specs_by_handle[check_key]
-            for output_name, check_key in input_output_props.asset_check_keys_by_output_name.items()
-        }
-
-    @public
-    @property
-    def node_def(self) -> NodeDefinition:
-        """The op or op graph that can be executed to check the assets."""
-        return self._node_def
-
-    @public
-    @property
-    def name(self) -> str:
-        return self.spec.name
-
-    @public
-    @property
-    def description(self) -> Optional[str]:
-        return self.spec.description
-
-    @public
-    @property
-    def asset_key(self) -> AssetKey:
-        return self.spec.asset_key
-
-    @public
-    @property
-    def spec(self) -> AssetCheckSpec:
-        if len(self._specs_by_output_name) > 1:
-            check.failed(
-                "Tried to retrieve single-check property from a checks definition with multiple"
-                " checks: " + ", ".join(spec.name for spec in self._specs_by_output_name.values()),
-            )
-
-        return next(iter(self.specs))
-
-    @public
-    @property
-    def specs(self) -> Iterable[AssetCheckSpec]:
-        return self._specs_by_output_name.values()
-
-    @property
-    def keys(self) -> Iterable[AssetCheckKey]:
-        return self._specs_by_handle.keys()
-
-    @property
-    def specs_by_output_name(self) -> Mapping[str, AssetCheckSpec]:
-        return self._specs_by_output_name
-
-    @property
-    def asset_keys_by_input_name(self) -> Mapping[str, AssetKey]:
-        return self._input_output_props.asset_keys_by_input_name
-
-    def get_resource_requirements(self) -> Iterator[ResourceRequirement]:
-        yield from self.node_def.get_resource_requirements()  # type: ignore[attr-defined]
-        for source_key, resource_def in self._resource_defs.items():
-            yield from resource_def.get_resource_requirements(outer_context=source_key)
-
-    def get_spec_for_check_key(self, asset_check_key: AssetCheckKey) -> AssetCheckSpec:
-        return self._specs_by_handle[asset_check_key]
-
-    @public
-    @property
-    def required_resource_keys(self) -> Set[str]:
-        """Set[str]: The set of keys for resources that must be provided to this AssetsDefinition."""
-        return {requirement.key for requirement in self.get_resource_requirements()}
-
-    @property
-    def resource_defs(self) -> Mapping[str, ResourceDefinition]:
-        return self._resource_defs
-
-    def with_resources(
-        self, resource_defs: Mapping[str, ResourceDefinition]
-    ) -> "AssetChecksDefinition":
-        attributes_dict = self.get_attributes_dict()
-        attributes_dict["resource_defs"] = merge_resource_defs(
-            old_resource_defs=self._resource_defs,
-            resource_defs_to_merge_in=resource_defs,
-            requires_resources=self,
-        )
-        return self.__class__(**attributes_dict)
-
-    def get_attributes_dict(self) -> Dict[str, Any]:
-        return dict(
-            node_def=self._node_def,
-            resource_defs=self._resource_defs,
-            specs=self._specs,
-            input_output_props=self._input_output_props,
+        """Create an AssetChecksDefinition."""
+        return AssetChecksDefinition(
+            keys_by_input_name=keys_by_input_name,
+            keys_by_output_name={},
+            node_def=node_def,
+            partitions_def=None,
+            partition_mappings=None,
+            asset_deps=None,
+            selected_asset_keys=None,
+            can_subset=False,
+            resource_defs=resource_defs,
+            group_names_by_key=None,
+            metadata_by_key=None,
+            tags_by_key=None,
+            freshness_policies_by_key=None,
+            auto_materialize_policies_by_key=None,
+            backfill_policy=None,
+            descriptions_by_key=None,
+            check_specs_by_output_name=check_specs_by_output_name,
+            selected_asset_check_keys=None,
+            is_subset=False,
+            owners_by_key=None,
         )
 
-    def with_attributes(
-        self,
-        asset_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
-    ) -> "AssetChecksDefinition":
-        attributes_dict = self.get_attributes_dict()
-        if asset_key_prefix is not None:
-            attributes_dict["specs"] = [
-                spec.with_asset_key_prefix(asset_key_prefix) for spec in self._specs
-            ]
-            attributes_dict["input_output_props"] = self._input_output_props.with_asset_key_prefix(
-                asset_key_prefix
-            )
 
-        return AssetChecksDefinition(**attributes_dict)
+# This is still needed in a few places where we need to handle normal AssetsDefinition and
+# AssetChecksDefinition differently, but eventually those areas should be refactored and this should
+# be removed.
+def has_only_asset_checks(assets_def: AssetsDefinition) -> bool:
+    return len(assets_def.keys) == 0 and len(assets_def.check_keys) > 0
 
 
 @experimental
 def build_asset_with_blocking_check(
     asset_def: "AssetsDefinition",
-    checks: Sequence[AssetChecksDefinition],
+    checks: Sequence["AssetsDefinition"],
 ) -> "AssetsDefinition":
     from dagster import AssetIn, In, OpExecutionContext, Output, op
     from dagster._core.definitions.decorators.asset_decorator import graph_asset_no_defaults
@@ -195,7 +73,7 @@ def build_asset_with_blocking_check(
 
     check_specs = []
     for c in checks:
-        check_specs.extend(c.specs)
+        check_specs.extend(c.check_specs)
 
     check_output_names = [c.get_python_identifier() for c in check_specs]
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -3,7 +3,6 @@ from typing import AbstractSet, Iterable, Mapping, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
-from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_layer import subset_assets_defs
 from dagster._core.definitions.asset_spec import (
     SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET,
@@ -135,37 +134,24 @@ class AssetNode(BaseAssetNode):
 
 
 class AssetGraph(BaseAssetGraph[AssetNode]):
-    # maps asset check keys to the definition where it is computed
-    _asset_check_compute_defs_by_key: Mapping[
-        AssetCheckKey, Union[AssetsDefinition, AssetChecksDefinition]
-    ]
+    _asset_check_defs_by_key: Mapping[AssetCheckKey, AssetsDefinition]
 
     def __init__(
         self,
         asset_nodes_by_key: Mapping[AssetKey, AssetNode],
-        asset_check_compute_defs_by_key: Mapping[
-            AssetCheckKey, Union[AssetsDefinition, AssetChecksDefinition]
-        ],
+        asset_check_defs_by_key: Mapping[AssetCheckKey, AssetsDefinition],
     ):
         self._asset_nodes_by_key = asset_nodes_by_key
-        self._asset_check_compute_defs_by_key = asset_check_compute_defs_by_key
+        self._asset_check_defs_by_key = asset_check_defs_by_key
         self._asset_nodes_by_check_key = {
-            **{
-                check_key: asset
-                for asset in asset_nodes_by_key.values()
-                for check_key in asset.check_keys
-            },
-            **{
-                key: asset_nodes_by_key[acd.asset_key]
-                for key, acd in asset_check_compute_defs_by_key.items()
-                if isinstance(acd, AssetChecksDefinition) and acd.asset_key in asset_nodes_by_key
-            },
+            check_key: asset
+            for asset in asset_nodes_by_key.values()
+            for check_key in asset.check_keys
         }
 
     @staticmethod
     def normalize_assets(
         assets: Iterable[Union[AssetsDefinition, SourceAsset]],
-        checks_defs: Optional[Iterable[AssetChecksDefinition]] = None,
     ) -> Sequence[AssetsDefinition]:
         """Normalize a mixed list of AssetsDefinition and SourceAsset to a list of AssetsDefinition.
 
@@ -181,8 +167,6 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
             create_external_asset_from_source_asset,
             external_asset_from_spec,
         )
-
-        checks_defs = checks_defs or []
 
         # Convert any source assets to external assets
         assets_defs = [
@@ -207,8 +191,7 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
         # Create unexecutable external assets definitions for any referenced keys for which no
         # definition was provided.
         all_referenced_asset_keys = {
-            *(key for asset_def in assets_defs for key in asset_def.dependency_keys),
-            *(checks_def.asset_key for checks_def in checks_defs),
+            key for assets_def in assets_defs for key in assets_def.dependency_keys
         }
         for key in all_referenced_asset_keys.difference(all_keys):
             assets_defs.append(
@@ -222,10 +205,8 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
     def from_assets(
         cls,
         assets: Iterable[Union[AssetsDefinition, SourceAsset]],
-        asset_checks: Optional[Sequence[AssetChecksDefinition]] = None,
     ) -> "AssetGraph":
-        asset_checks = asset_checks or []
-        assets_defs = cls.normalize_assets(assets, asset_checks)
+        assets_defs = cls.normalize_assets(assets)
 
         # Build the set of AssetNodes. Each node holds key rather than object references to parent
         # and child nodes.
@@ -237,22 +218,20 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
                 child_keys=dep_graph["downstream"][key],
                 assets_def=ad,
                 check_keys={
-                    *ad.check_keys,
-                    *(ck for cd in asset_checks if cd.asset_key == key for ck in cd.keys),
+                    *(ck for ad in assets_defs for ck in ad.check_keys if ck.asset_key == key),
                 },
             )
             for ad in assets_defs
             for key in ad.keys
         }
 
-        asset_check_compute_defs_by_key = {
-            **{key: checks_def for checks_def in (asset_checks or []) for key in checks_def.keys},
-            **{key: assets_def for assets_def in assets_defs for key in assets_def.check_keys},
+        asset_check_defs_by_key = {
+            key: assets_def for assets_def in assets_defs for key in assets_def.check_keys
         }
 
         return AssetGraph(
             asset_nodes_by_key=asset_nodes_by_key,
-            asset_check_compute_defs_by_key=asset_check_compute_defs_by_key,
+            asset_check_defs_by_key=asset_check_defs_by_key,
         )
 
     def get_execution_set_asset_and_check_keys(
@@ -260,12 +239,7 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
     ) -> AbstractSet[AssetKeyOrCheckKey]:
         if isinstance(asset_or_check_key, AssetKey):
             return self.get(asset_or_check_key).execution_set_asset_and_check_keys
-        # all AssetsCheckDefinition can emit only as subset of keys
-        elif isinstance(
-            self._asset_check_compute_defs_by_key[asset_or_check_key], AssetChecksDefinition
-        ):
-            return {asset_or_check_key}
-        else:
+        else:  # AssetCheckKey
             asset_node = self._asset_nodes_by_check_key[asset_or_check_key]
             asset_unit_keys = asset_node.execution_set_asset_and_check_keys
             return (
@@ -277,11 +251,7 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
         return list(
             {
                 *(asset.assets_def for asset in self.asset_nodes),
-                *(
-                    ad
-                    for ad in self._asset_check_compute_defs_by_key.values()
-                    if isinstance(ad, AssetsDefinition)
-                ),
+                *(ad for ad in self._asset_check_defs_by_key.values()),
             }
         )
 
@@ -293,28 +263,15 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
                 *[self.get(key).assets_def for key in keys if isinstance(key, AssetKey)],
                 *[
                     ad
-                    for k, ad in self._asset_check_compute_defs_by_key.items()
+                    for k, ad in self._asset_check_defs_by_key.items()
                     if k in keys and isinstance(ad, AssetsDefinition)
                 ],
             }
         )
 
-    @property
-    def asset_checks_defs(self) -> Sequence[AssetChecksDefinition]:
-        return list(
-            {
-                acd
-                for acd in self._asset_check_compute_defs_by_key.values()
-                if isinstance(acd, AssetChecksDefinition)
-            }
-        )
-
     @cached_property
     def asset_check_keys(self) -> AbstractSet[AssetCheckKey]:
-        return {
-            *(key for ad in self.assets_defs for key in ad.check_keys),
-            *(key for acd in self.asset_checks_defs for key in acd.keys),
-        }
+        return {key for ad in self.assets_defs for key in ad.check_keys}
 
     def get_subset(
         self,
@@ -348,13 +305,4 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
             for unexecutable_ad in create_unexecutable_external_assets_from_assets_def(ad)
         ]
 
-        # ignore check keys that don't correspond to an AssetChecksDefinition
-        asset_checks_defs = list(
-            {
-                acd
-                for key, acd in self._asset_check_compute_defs_by_key.items()
-                if key in (asset_check_keys or []) and isinstance(acd, AssetChecksDefinition)
-            }
-        )
-
-        return self.from_assets([*executable_assets_defs, *loadable_assets_defs], asset_checks_defs)
+        return self.from_assets([*executable_assets_defs, *loadable_assets_defs])

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -19,7 +19,6 @@ from typing import (
 
 import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSpec
-from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.metadata import (
     RawMetadataValue,
@@ -392,17 +391,16 @@ class AssetLayer(NamedTuple):
     # See AssetLayer.downstream_dep_assets for more information
     dep_asset_keys_by_node_output_handle: Mapping[NodeOutputHandle, Set[AssetKey]]
     partition_mappings_by_asset_dep: Mapping[Tuple[NodeHandle, AssetKey], "PartitionMapping"]
-    asset_checks_defs_by_node_handle: Mapping[NodeHandle, "AssetChecksDefinition"]
     node_output_handles_by_asset_check_key: Mapping[AssetCheckKey, NodeOutputHandle]
     check_names_by_asset_key_by_node_handle: Mapping[
         NodeHandle, Mapping[AssetKey, AbstractSet[str]]
     ]
+    assets_defs_by_check_key: Mapping[AssetCheckKey, "AssetsDefinition"]
 
     @staticmethod
     def from_graph_and_assets_node_mapping(
         graph_def: GraphDefinition,
         assets_defs_by_outer_node_handle: Mapping[NodeHandle, "AssetsDefinition"],
-        asset_checks_defs_by_node_handle: Mapping[NodeHandle, "AssetChecksDefinition"],
         asset_graph: "AssetGraph",
     ) -> "AssetLayer":
         """Generate asset info from a GraphDefinition and a mapping from nodes in that graph to the
@@ -438,6 +436,7 @@ class AssetLayer(NamedTuple):
 
         node_output_handles_by_asset_check_key: Mapping[AssetCheckKey, NodeOutputHandle] = {}
         check_names_by_asset_key_by_node_handle: Dict[NodeHandle, Dict[AssetKey, Set[str]]] = {}
+        assets_defs_by_check_key: Dict[AssetCheckKey, "AssetsDefinition"] = {}
 
         for node_handle, assets_def in assets_defs_by_outer_node_handle.items():
             for key in assets_def.keys:
@@ -517,33 +516,12 @@ class AssetLayer(NamedTuple):
                     )
                     check_key_by_output[node_output_handle] = check_spec.key
 
+                assets_defs_by_check_key.update({k: assets_def for k in assets_def.check_keys})
+
         dep_asset_keys_by_node_output_handle = defaultdict(set)
         for asset_key, node_output_handles in dep_node_output_handles_by_asset_key.items():
             for node_output_handle in node_output_handles:
                 dep_asset_keys_by_node_output_handle[node_output_handle].add(asset_key)
-
-        for node_handle, checks_def in asset_checks_defs_by_node_handle.items():
-            check_names_by_asset_key_by_node_handle[node_handle] = defaultdict(set)
-            for output_name, check_spec in checks_def.specs_by_output_name.items():
-                inner_output_def, inner_node_handle = checks_def.node_def.resolve_output_to_origin(
-                    output_name, handle=node_handle
-                )
-                node_output_handle = NodeOutputHandle(
-                    check.not_none(inner_node_handle), inner_output_def.name
-                )
-                node_output_handles_by_asset_check_key[check_spec.key] = node_output_handle
-                check_names_by_asset_key_by_node_handle[node_handle][check_spec.asset_key].add(
-                    check_spec.name
-                )
-                check_key_by_output[node_output_handle] = check_spec.key
-
-            for input_name, asset_key in checks_def.asset_keys_by_input_name.items():
-                input_handle = NodeInputHandle(node_handle, input_name)
-                asset_key_by_input[input_handle] = asset_key
-                # resolve graph input to list of op inputs that consume it
-                node_input_handles = checks_def.node_def.resolve_input_to_destinations(input_handle)
-                for node_input_handle in node_input_handles:
-                    asset_key_by_input[node_input_handle] = asset_key
 
         assets_defs_by_node_handle: Dict[NodeHandle, "AssetsDefinition"] = {
             # nodes for assets
@@ -571,9 +549,9 @@ class AssetLayer(NamedTuple):
             dependency_node_handles_by_asset_key=dep_node_handles_by_asset_key,
             dep_asset_keys_by_node_output_handle=dep_asset_keys_by_node_output_handle,
             partition_mappings_by_asset_dep=partition_mappings_by_asset_dep,
-            asset_checks_defs_by_node_handle=asset_checks_defs_by_node_handle,
             node_output_handles_by_asset_check_key=node_output_handles_by_asset_check_key,
             check_names_by_asset_key_by_node_handle=check_names_by_asset_key_by_node_handle,
+            assets_defs_by_check_key=assets_defs_by_check_key,
         )
 
     def upstream_assets_for_asset(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
@@ -596,10 +574,6 @@ class AssetLayer(NamedTuple):
     @property
     def assets_defs(self) -> Sequence["AssetsDefinition"]:
         return self.asset_graph.assets_defs
-
-    @property
-    def has_asset_check_defs(self) -> bool:
-        return len(self.asset_checks_defs_by_node_handle) > 0
 
     def get(self, asset_key: AssetKey) -> "AssetNode":
         return self.asset_graph.get(asset_key)
@@ -630,36 +604,13 @@ class AssetLayer(NamedTuple):
 
     def asset_check_specs_for_node(self, node_handle: NodeHandle) -> Sequence[AssetCheckSpec]:
         assets_def_for_node = self.assets_def_for_node(node_handle)
-        checks_def_for_node = self.asset_checks_def_for_node(node_handle)
-
-        if assets_def_for_node is not None:
-            check.invariant(checks_def_for_node is None)
-            return list(assets_def_for_node.check_specs)
-        elif checks_def_for_node is not None:
-            return list(checks_def_for_node.specs)
-        else:
-            return []
+        return list(assets_def_for_node.check_specs) if assets_def_for_node else []
 
     def get_spec_for_asset_check(
         self, node_handle: NodeHandle, asset_check_key: AssetCheckKey
     ) -> Optional[AssetCheckSpec]:
-        asset_checks_def_or_assets_def = self.asset_checks_defs_by_node_handle.get(
-            node_handle
-        ) or self.assets_defs_by_node_handle.get(node_handle)
-        return (
-            asset_checks_def_or_assets_def.get_spec_for_check_key(asset_check_key)
-            if asset_checks_def_or_assets_def
-            else None
-        )
-
-    def asset_checks_def_for_node(
-        self, node_handle: NodeHandle
-    ) -> Optional["AssetChecksDefinition"]:
-        return self.asset_checks_defs_by_node_handle.get(node_handle)
-
-    @property
-    def asset_checks_defs(self) -> Iterable[AssetChecksDefinition]:
-        return self.asset_graph.asset_checks_defs
+        assets_def = self.assets_defs_by_node_handle.get(node_handle)
+        return assets_def.get_spec_for_check_key(asset_check_key) if assets_def else None
 
     def get_output_name_for_asset_check(self, asset_check_key: AssetCheckKey) -> str:
         """Output name in the leaf op."""
@@ -738,7 +689,6 @@ class AssetLayer(NamedTuple):
 def build_asset_selection_job(
     name: str,
     assets: Iterable["AssetsDefinition"],
-    asset_checks: Iterable["AssetChecksDefinition"],
     executor_def: Optional[ExecutorDefinition] = None,
     config: Optional[Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig"]] = None,
     partitions_def: Optional["PartitionsDefinition"] = None,
@@ -762,7 +712,6 @@ def build_asset_selection_job(
         # no selections, include everything
         included_assets = list(assets)
         excluded_assets = []
-        included_checks_defs = list(asset_checks)
     else:
         # Filter to assets that match either selected assets or include a selected check.
         # E.g. a multi asset can be included even if it's not in asset_selection, if it has a selected check
@@ -770,23 +719,6 @@ def build_asset_selection_job(
         (included_assets, excluded_assets) = subset_assets_defs(
             assets, asset_selection or set(), asset_check_selection
         )
-
-        if asset_check_selection is None:
-            # If assets were selected and checks are None, then include all checks on the selected assets.
-            # Note: once we start explicitly passing in asset checks instead of None from the front end,
-            # we can remove this logic.
-            included_checks_defs = [
-                asset_check
-                for asset_check in asset_checks
-                if asset_check.asset_key in check.not_none(asset_selection)
-            ]
-        else:
-            # Otherwise, filter to explicitly selected checks defs
-            included_checks_defs = [
-                asset_check
-                for asset_check in asset_checks
-                if [spec for spec in asset_check.specs if spec.key in asset_check_selection]
-            ]
 
     if partitions_def:
         for asset in included_assets:
@@ -806,10 +738,7 @@ def build_asset_selection_job(
         )
         for unexecutable_ad in create_unexecutable_external_assets_from_assets_def(ad)
     ]
-    asset_graph = AssetGraph.from_assets(
-        [*executable_assets_defs, *unexecutable_assets_defs], included_checks_defs
-    )
-
+    asset_graph = AssetGraph.from_assets([*executable_assets_defs, *unexecutable_assets_defs])
     return build_assets_job(
         name=name,
         asset_graph=asset_graph,
@@ -841,7 +770,7 @@ def subset_assets_defs(
     excluded_assets: Set[AssetsDefinition] = set()
 
     # Do not match any assets with no keys
-    for asset in set(a for a in assets if a.has_keys):
+    for asset in set(a for a in assets if a.has_keys or a.has_check_keys):
         # intersection
         selected_subset = selected_asset_keys & asset.keys
 
@@ -851,7 +780,7 @@ def subset_assets_defs(
         # if no checks were selected, filter to checks that target selected assets
         else:
             selected_check_subset = {
-                key for key in asset.check_keys if key.asset_key in selected_subset
+                key for key in asset.check_keys if key.asset_key in selected_asset_keys
             }
 
         # all assets in this def are selected

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -10,7 +10,6 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._annotations import deprecated, experimental_param, public
-from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.resolved_asset_deps import resolve_similar_asset_names
 from dagster._core.errors import DagsterInvalidSubsetError
@@ -182,14 +181,10 @@ class AssetSelection(ABC, BaseModel, frozen=True):
 
     @public
     @staticmethod
-    def checks(*asset_checks: AssetChecksDefinition) -> "AssetCheckKeysSelection":
+    def checks(*assets_defs: AssetsDefinition) -> "AssetCheckKeysSelection":
         """Returns a selection that includes all of the provided asset checks."""
         return AssetCheckKeysSelection(
-            selected_asset_check_keys=[
-                AssetCheckKey(asset_key=AssetKey.from_coercible(spec.asset_key), name=spec.name)
-                for checks_def in asset_checks
-                for spec in checks_def.specs
-            ]
+            selected_asset_check_keys=[key for ad in assets_defs for key in ad.check_keys]
         )
 
     @public

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -17,6 +17,7 @@ from typing import (
 from toposort import CircularDependencyError, toposort
 
 import dagster._check as check
+from dagster._core.definitions.asset_checks import has_only_asset_checks
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.policy import RetryPolicy
@@ -24,7 +25,6 @@ from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.selector.subset_selector import AssetSelectionData
 from dagster._utils.merger import merge_dicts
 
-from .asset_checks import AssetChecksDefinition
 from .asset_layer import AssetLayer
 from .assets import AssetsDefinition
 from .config import ConfigMapping
@@ -157,28 +157,21 @@ def build_assets_job(
         asset_graph.assets_defs_for_keys(asset_graph.executable_asset_keys)
     )
 
-    deps, assets_defs_by_node_handle, asset_checks_defs_by_node_handle = build_node_deps(
-        asset_graph,
-    )
+    deps, assets_defs_by_node_handle = build_node_deps(asset_graph)
 
     # attempt to resolve cycles using multi-asset subsetting
     if _has_cycles(deps):
         asset_graph = _attempt_resolve_node_cycles(asset_graph)
-        deps, assets_defs_by_node_handle, asset_checks_defs_by_node_handle = build_node_deps(
-            asset_graph,
-        )
+        deps, assets_defs_by_node_handle = build_node_deps(asset_graph)
 
     node_defs = [
-        *(
-            asset.node_def
-            for asset in asset_graph.assets_defs_for_keys(
-                [
-                    *asset_graph.executable_asset_keys,
-                    *asset_graph.asset_check_keys,
-                ]
-            )
-        ),
-        *(asset_check.node_def for asset_check in asset_graph.asset_checks_defs),
+        asset.node_def
+        for asset in asset_graph.assets_defs_for_keys(
+            [
+                *asset_graph.executable_asset_keys,
+                *asset_graph.asset_check_keys,
+            ]
+        )
     ]
 
     graph = GraphDefinition(
@@ -193,7 +186,6 @@ def build_assets_job(
 
     asset_layer = AssetLayer.from_graph_and_assets_node_mapping(
         graph_def=graph,
-        asset_checks_defs_by_node_handle=asset_checks_defs_by_node_handle,
         assets_defs_by_outer_node_handle=assets_defs_by_node_handle,
         asset_graph=asset_graph,
     )
@@ -263,7 +255,7 @@ def _key_for_asset(asset: Union[AssetsDefinition, SourceAsset]) -> AssetKey:
 
 
 def _get_blocking_asset_check_output_handles_by_asset_key(
-    assets_defs_by_node_handle, asset_checks_defs_by_node_handle
+    assets_defs_by_node_handle: Mapping[NodeHandle, AssetsDefinition],
 ) -> Mapping[AssetKey, AbstractSet[NodeOutputHandle]]:
     """For each asset key, returns the set of node output handles that correspond to asset check
     specs that should block the execution of downstream assets if they fail.
@@ -272,12 +264,6 @@ def _get_blocking_asset_check_output_handles_by_asset_key(
 
     for node_handle, assets_def in assets_defs_by_node_handle.items():
         for output_name, check_spec in assets_def.check_specs_by_output_name.items():
-            check_specs_by_node_output_handle[
-                NodeOutputHandle(node_handle, output_name=output_name)
-            ] = check_spec
-
-    for node_handle, asset_checks_def in asset_checks_defs_by_node_handle.items():
-        for output_name, check_spec in asset_checks_def.specs_by_output_name.items():
             check_specs_by_node_output_handle[
                 NodeOutputHandle(node_handle, output_name=output_name)
             ] = check_spec
@@ -299,11 +285,9 @@ def build_node_deps(
 ) -> Tuple[
     DependencyMapping[NodeInvocation],
     Mapping[NodeHandle, AssetsDefinition],
-    Mapping[NodeHandle, AssetChecksDefinition],
 ]:
     # sort so that nodes get a consistent name
     assets_defs = sorted(asset_graph.assets_defs, key=lambda ad: (sorted((ak for ak in ad.keys))))
-    asset_checks_defs = asset_graph.asset_checks_defs
 
     # if the same graph/op is used in multiple assets_definitions, their invocations must have
     # different names. we keep track of definitions that share a name and add a suffix to their
@@ -325,15 +309,9 @@ def build_node_deps(
         for output_name, key in assets_def.keys_by_output_name.items():
             node_alias_and_output_by_asset_key[key] = (node_alias, output_name)
 
-    asset_checks_defs_by_node_handle: Dict[NodeHandle, AssetChecksDefinition] = {}
-    for asset_checks_def in asset_checks_defs:
-        node_def_name = asset_checks_def.node_def.name
-        node_key = NodeInvocation(node_def_name)
-        asset_checks_defs_by_node_handle[NodeHandle(node_def_name, parent=None)] = asset_checks_def
-
     blocking_asset_check_output_handles_by_asset_key = (
         _get_blocking_asset_check_output_handles_by_asset_key(
-            assets_defs_by_node_handle, asset_checks_defs_by_node_handle
+            assets_defs_by_node_handle,
         )
     )
 
@@ -345,21 +323,37 @@ def build_node_deps(
         node_key = NodeInvocation(node_def_name, alias=alias)
         deps[node_key] = {}
 
+        # TODO: We should be able to remove this after a refactor of `AssetsDefinition` and just use
+        # a single method. At present using `keys_by_input_name` for asset checks only will exclude
+        # `additional_deps`, so we need to use `node_keys_by_input_name`. But using
+        # `node_keys_by_input_name` breaks cycle resolution on subsettable multi-assets.
+        inputs_map = (
+            assets_def.node_keys_by_input_name
+            if has_only_asset_checks(assets_def)
+            else assets_def.keys_by_input_name
+        )
+
         # connect each input of this AssetsDefinition to the proper upstream node
-        for input_name, upstream_asset_key in assets_def.keys_by_input_name.items():
+        for input_name, upstream_asset_key in inputs_map.items():
             # ignore self-deps
             if upstream_asset_key in assets_def.keys:
                 continue
 
-            blocking_asset_check_output_handles = (
-                blocking_asset_check_output_handles_by_asset_key.get(upstream_asset_key)
-            )
-            asset_check_deps = [
-                DependencyDefinition(
-                    node_output_handle.node_handle.name, node_output_handle.output_name
+            # if this assets def itself performs checks on an upstream key, exempt it from being
+            # blocked on other checks
+            if upstream_asset_key not in {ck.asset_key for ck in assets_def.check_keys}:
+                blocking_asset_check_output_handles = (
+                    blocking_asset_check_output_handles_by_asset_key.get(upstream_asset_key)
                 )
-                for node_output_handle in blocking_asset_check_output_handles or []
-            ]
+                asset_check_deps = [
+                    DependencyDefinition(
+                        node_output_handle.node_handle.name, node_output_handle.output_name
+                    )
+                    for node_output_handle in blocking_asset_check_output_handles or []
+                ]
+            else:
+                blocking_asset_check_output_handles = set()
+                asset_check_deps = []
 
             if upstream_asset_key in node_alias_and_output_by_asset_key:
                 upstream_node_alias, upstream_output_name = node_alias_and_output_by_asset_key[
@@ -377,25 +371,7 @@ def build_node_deps(
                 deps[node_key][input_name] = BlockingAssetChecksDependencyDefinition(
                     asset_check_dependencies=asset_check_deps, other_dependency=None
                 )
-
-    # put asset checks downstream of the assets they're checking
-    asset_checks_defs_by_node_handle: Dict[NodeHandle, AssetChecksDefinition] = {}
-    for asset_checks_def in asset_checks_defs:
-        node_def_name = asset_checks_def.node_def.name
-        node_key = NodeInvocation(node_def_name)
-        deps[node_key] = {}
-        asset_checks_defs_by_node_handle[NodeHandle(node_def_name, parent=None)] = asset_checks_def
-
-        for input_name, asset_key in asset_checks_def.asset_keys_by_input_name.items():
-            if asset_key in node_alias_and_output_by_asset_key:
-                upstream_node_alias, upstream_output_name = node_alias_and_output_by_asset_key[
-                    asset_key
-                ]
-                deps[node_key][input_name] = DependencyDefinition(
-                    upstream_node_alias, upstream_output_name
-                )
-
-    return deps, assets_defs_by_node_handle, asset_checks_defs_by_node_handle
+    return deps, assets_defs_by_node_handle
 
 
 def _has_cycles(
@@ -478,7 +454,7 @@ def _attempt_resolve_node_cycles(asset_graph: AssetGraph) -> AssetGraph:
                     assets_def.subset_for(asset_keys, selected_asset_check_keys=None)
                 )
 
-    return AssetGraph.from_assets(subsetted_assets_defs, asset_graph.asset_checks_defs)
+    return AssetGraph.from_assets(subsetted_assets_defs)
 
 
 def _ensure_resources_dont_conflict(
@@ -527,11 +503,6 @@ def check_resources_satisfy_requirements(
             merge_dicts(resource_defs, assets_def.resource_defs),
             list(assets_def.get_resource_requirements()),
         )
-    for asset_checks_def in asset_graph.asset_checks_defs:
-        ensure_requirements_satisfied(
-            merge_dicts(resource_defs, asset_checks_def.resource_defs),
-            list(asset_checks_def.get_resource_requirements()),
-        )
 
 
 def get_all_resource_defs(
@@ -544,8 +515,5 @@ def get_all_resource_defs(
     all_resource_defs = dict(resource_defs)
     for assets_def in asset_graph.assets_defs:
         all_resource_defs = merge_dicts(all_resource_defs, assets_def.resource_defs)
-
-    for asset_checks_def in asset_graph.asset_checks_defs:
-        all_resource_defs = merge_dicts(all_resource_defs, asset_checks_def.resource_defs)
 
     return all_resource_defs

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -7,10 +7,7 @@ from dagster._annotations import experimental
 from dagster._config import UserConfigSchema
 from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
-from dagster._core.definitions.asset_checks import (
-    AssetChecksDefinition,
-    AssetChecksDefinitionInputOutputProps,
-)
+from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_dep import CoercibleToAssetDep
 from dagster._core.definitions.asset_in import AssetIn
 from dagster._core.definitions.assets import AssetsDefinition
@@ -232,19 +229,14 @@ def asset_check(
             retry_policy=retry_policy,
         )(fn)
 
-        checks_def = AssetChecksDefinition(
+        return AssetChecksDefinition.create(
+            keys_by_input_name={
+                input_tuple[0]: asset_key
+                for asset_key, input_tuple in input_tuples_by_asset_key.items()
+            },
             node_def=op_def,
             resource_defs=wrap_resources_for_execution(resource_defs),
-            specs=[spec],
-            input_output_props=AssetChecksDefinitionInputOutputProps(
-                asset_keys_by_input_name={
-                    input_tuple[0]: asset_key
-                    for asset_key, input_tuple in input_tuples_by_asset_key.items()
-                },
-                asset_check_keys_by_output_name={op_def.output_defs[0].name: spec.key},
-            ),
+            check_specs_by_output_name={op_def.output_defs[0].name: spec},
         )
-
-        return checks_def
 
     return inner

--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -24,7 +24,6 @@ from dagster._core.definitions.metadata import (
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
 
-from ..asset_checks import AssetChecksDefinition
 from ..executor_definition import ExecutorDefinition
 from ..graph_definition import GraphDefinition
 from ..job_definition import JobDefinition
@@ -136,7 +135,6 @@ class _Repository:
                         AssetsDefinition,
                         SourceAsset,
                         UnresolvedAssetJobDefinition,
-                        AssetChecksDefinition,
                     ),
                 ):
                     bad_defns.append((i, type(definition)))

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -825,7 +825,6 @@ class JobDefinition(IHasInternalInit):
             asset_check_selection=asset_check_selection,
             asset_selection_data=asset_selection_data,
             config=self.config_mapping or self.partitioned_config,
-            asset_checks=self.asset_layer.asset_checks_defs,
         )
         return new_job
 
@@ -1258,10 +1257,10 @@ def _infer_asset_layer_from_source_asset_deps(job_graph_def: GraphDefinition) ->
         dependency_node_handles_by_asset_key={},
         dep_asset_keys_by_node_output_handle={},
         partition_mappings_by_asset_dep={},
-        asset_checks_defs_by_node_handle={},
         node_output_handles_by_asset_check_key={},
         check_names_by_asset_key_by_node_handle={},
         check_key_by_node_output_handle={},
+        assets_defs_by_check_key={},
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/load_asset_checks_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_asset_checks_from_modules.py
@@ -1,23 +1,29 @@
 import inspect
 from importlib import import_module
 from types import ModuleType
-from typing import Iterable, Optional, Sequence
+from typing import Iterable, Optional, Sequence, cast
 
 import dagster._check as check
+from dagster._core.definitions.assets import AssetsDefinition
 
-from .asset_checks import AssetChecksDefinition
+from .asset_checks import AssetChecksDefinition, has_only_asset_checks
 from .asset_key import (
     CoercibleToAssetKeyPrefix,
     check_opt_coercible_to_asset_key_prefix_param,
 )
-from .load_assets_from_modules import find_modules_in_package, find_objects_in_module_of_types
+from .load_assets_from_modules import (
+    find_modules_in_package,
+    find_objects_in_module_of_types,
+    prefix_assets,
+)
 
 
 def _checks_from_modules(modules: Iterable[ModuleType]) -> Sequence[AssetChecksDefinition]:
     checks = []
     for module in modules:
-        for c in find_objects_in_module_of_types(module, AssetChecksDefinition):
-            checks.append(c)
+        for c in find_objects_in_module_of_types(module, AssetsDefinition):
+            if has_only_asset_checks(c):
+                checks.append(cast(AssetChecksDefinition, c))
     return checks
 
 
@@ -26,13 +32,11 @@ def _checks_with_attributes(
     asset_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
 ) -> Sequence[AssetChecksDefinition]:
     modified_checks = []
-    for c in checks_defs:
-        modified_checks.append(
-            c.with_attributes(
-                asset_key_prefix=asset_key_prefix,
-            )
-        )
-    return modified_checks
+    if asset_key_prefix:
+        modified_checks, _ = prefix_assets(checks_defs, asset_key_prefix, [], None)
+        return cast(Sequence[AssetChecksDefinition], modified_checks)
+    else:
+        return checks_defs
 
 
 def load_asset_checks_from_modules(
@@ -55,7 +59,6 @@ def load_asset_checks_from_modules(
     asset_key_prefix = check_opt_coercible_to_asset_key_prefix_param(
         asset_key_prefix, "asset_key_prefix"
     )
-
     return _checks_with_attributes(_checks_from_modules(modules), asset_key_prefix=asset_key_prefix)
 
 

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -396,6 +396,9 @@ def prefix_assets(
 
     """
     asset_keys = {asset_key for assets_def in assets_defs for asset_key in assets_def.keys}
+    check_target_keys = {
+        key.asset_key for assets_def in assets_defs for key in assets_def.check_keys
+    }
     source_asset_keys = {source_asset.key for source_asset in source_assets}
 
     if isinstance(key_prefix, str):
@@ -408,8 +411,8 @@ def prefix_assets(
             asset_key: AssetKey([*key_prefix, *asset_key.path]) for asset_key in assets_def.keys
         }
         input_asset_key_replacements = {}
-        for dep_asset_key in assets_def.dependency_keys:
-            if dep_asset_key in asset_keys:
+        for dep_asset_key in assets_def.keys_by_input_name.values():
+            if dep_asset_key in asset_keys or dep_asset_key in check_target_keys:
                 input_asset_key_replacements[dep_asset_key] = AssetKey(
                     [*key_prefix, *dep_asset_key.path]
                 )

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data.py
@@ -16,7 +16,6 @@ from typing import (
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
-from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.graph_definition import SubselectedGraphDefinition
@@ -33,6 +32,7 @@ from .valid_definitions import RepositoryListDefinition
 
 if TYPE_CHECKING:
     from dagster._core.definitions import AssetsDefinition
+    from dagster._core.definitions.asset_checks import AssetChecksDefinition
     from dagster._core.definitions.partitioned_schedule import (
         UnresolvedPartitionedAssetScheduleDefinition,
     )
@@ -275,7 +275,7 @@ class CachingRepositoryData(RepositoryData):
             asset_checks_defs_by_key,
             "assets_checks_defs_by_key",
             key_type=AssetCheckKey,
-            value_type=AssetChecksDefinition,
+            value_type=AssetsDefinition,
         )
         check.mapping_param(
             top_level_resources, "top_level_resources", key_type=str, value_type=ResourceDefinition

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -219,45 +219,42 @@ def build_caching_repository_data_from_list(
                 )
             # we can only resolve these once we have all assets
             unresolved_jobs[definition.name] = definition
+        elif isinstance(definition, AssetChecksDefinition):
+            for key in definition.check_keys:
+                if key in asset_check_keys:
+                    raise DagsterInvalidDefinitionError(f"Duplicate asset check key: {key}")
+            asset_check_keys.update(definition.check_keys)
+            asset_checks_defs.append(definition)
         elif isinstance(definition, AssetsDefinition):
             for key in definition.keys:
                 if key in asset_keys:
                     raise DagsterInvalidDefinitionError(f"Duplicate asset key: {key}")
+            for key in definition.check_keys:
+                if key in asset_check_keys:
+                    raise DagsterInvalidDefinitionError(f"Duplicate asset check key: {key}")
 
             asset_keys.update(definition.keys)
+            asset_check_keys.update(definition.check_keys)
             assets_defs.append(definition)
         elif isinstance(definition, SourceAsset):
             source_assets.append(definition)
             asset_keys.add(definition.key)
-        elif isinstance(definition, AssetChecksDefinition):
-            for key in definition.keys:
-                if key in asset_check_keys:
-                    raise DagsterInvalidDefinitionError(f"Duplicate asset check key: {key}")
-            asset_check_keys.update(definition.keys)
-            asset_checks_defs.append(definition)
         else:
             check.failed(f"Unexpected repository entry {definition}")
 
-    asset_graph = AssetGraph.from_assets(
-        [*assets_defs, *source_assets], asset_checks=asset_checks_defs
-    )
-    if assets_defs or source_assets or asset_checks_defs:
+    asset_graph = AssetGraph.from_assets([*assets_defs, *asset_checks_defs, *source_assets])
+    source_assets_by_key = {source_asset.key: source_asset for source_asset in source_assets}
+    assets_defs_by_key = {key: asset for asset in assets_defs for key in asset.keys}
+    asset_checks_defs_by_key = {
+        key: checks_def for checks_def in asset_checks_defs for key in checks_def.check_keys
+    }
+    if assets_defs or asset_checks_defs or source_assets:
         for job_def in get_base_asset_jobs(
             asset_graph=asset_graph,
             executor_def=default_executor_def,
             resource_defs=top_level_resources,
         ):
             jobs[job_def.name] = job_def
-
-        source_assets_by_key = {source_asset.key: source_asset for source_asset in source_assets}
-        assets_defs_by_key = {key: asset for asset in assets_defs for key in asset.keys}
-        asset_checks_defs_by_key = {
-            key: checks_def for checks_def in asset_checks_defs for key in checks_def.keys
-        }
-    else:
-        source_assets_by_key = {}
-        assets_defs_by_key = {}
-        asset_checks_defs_by_key = {}
 
     for name, sensor_def in sensors.items():
         if sensor_def.has_loadable_targets():

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -411,10 +411,10 @@ class RepositoryDefinition:
     def asset_graph(self) -> AssetGraph:
         return AssetGraph.from_assets(
             [
-                *list(dict.fromkeys(self.assets_defs_by_key.values())),
+                *list(set(self.assets_defs_by_key.values())),
                 *self.source_assets_by_key.values(),
+                *list(set(self.asset_checks_defs_by_key.values())),
             ],
-            list(dict.fromkeys(self.asset_checks_defs_by_key.values())),
         )
 
     # If definition comes from the @repository decorator, then the __call__ method will be

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/valid_definitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/valid_definitions.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, TypeVar, Union
 
 from typing_extensions import TypeAlias
 
-from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.schedule_definition import ScheduleDefinition
@@ -34,7 +33,6 @@ T_RepositoryLevelDefinition = TypeVar(
 
 RepositoryListDefinition: TypeAlias = Union[
     "AssetsDefinition",
-    AssetChecksDefinition,
     GraphDefinition,
     JobDefinition,
     ScheduleDefinition,

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -226,9 +226,8 @@ def get_inputs_field(
         if inp.input_manager_key:
             input_field = get_input_manager_input_field(node, inp, resource_defs)
         elif (
-            # if you have executable assets defs, input will be loaded from the source asset
-            asset_layer.executable_asset_keys
-            or asset_layer.has_asset_check_defs
+            # if you have assets defs, input will be loaded from the source asset
+            asset_layer.assets_defs
             and asset_layer.asset_key_for_input(handle, name)
             and not has_upstream
         ):

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -221,7 +221,6 @@ class UnresolvedAssetJobDefinition(
         return build_asset_selection_job(
             name=self.name,
             assets=assets,
-            asset_checks=asset_graph.asset_checks_defs,
             config=self.config,
             description=self.description,
             tags=self.tags,

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -931,10 +931,10 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
     @property
     def is_asset_check_step(self) -> bool:
-        """Whether this step corresponds to an asset check."""
-        return (
-            self.job_def.asset_layer.asset_checks_defs_by_node_handle.get(self.node_handle)
-            is not None
+        """Whether this step corresponds to at least one asset check."""
+        return any(
+            self.job_def.asset_layer.asset_check_key_for_output(self.node_handle, output.name)
+            for output in self.step.step_outputs
         )
 
     def set_data_version(self, asset_key: AssetKey, data_version: "DataVersion") -> None:
@@ -1097,6 +1097,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
         return (
             upstream_asset_key is not None
+            and asset_layer.has(upstream_asset_key)
             and asset_layer.get(upstream_asset_key).partitions_def is not None
         )
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -762,9 +762,12 @@ def test_required_assets_and_checks_by_key_check_decorator(
     @asset_check(asset=asset0)
     def check0(): ...
 
-    asset_graph = asset_graph_from_assets([asset0], asset_checks=[check0])
+    asset_graph = asset_graph_from_assets([asset0, check0])
     assert asset_graph.get_execution_set_asset_and_check_keys(asset0.key) == {asset0.key}
-    assert asset_graph.get_execution_set_asset_and_check_keys(check0.spec.key) == {check0.spec.key}
+    assert (
+        asset_graph.get_execution_set_asset_and_check_keys(next(iter(check0.check_keys)))
+        == check0.check_keys
+    )
 
 
 def test_required_assets_and_checks_by_key_asset_decorator(
@@ -779,13 +782,16 @@ def test_required_assets_and_checks_by_key_asset_decorator(
     @asset_check(asset=asset0)
     def check0(): ...
 
-    asset_graph = asset_graph_from_assets([asset0], asset_checks=[check0])
+    asset_graph = asset_graph_from_assets([asset0, check0])
 
     grouped_keys = [asset0.key, foo_check.key, bar_check.key]
     for key in grouped_keys:
         assert asset_graph.get_execution_set_asset_and_check_keys(key) == set(grouped_keys)
 
-    assert asset_graph.get_execution_set_asset_and_check_keys(check0.spec.key) == {check0.spec.key}
+    assert (
+        asset_graph.get_execution_set_asset_and_check_keys(next(iter(check0.check_keys)))
+        == check0.check_keys
+    )
 
 
 def test_required_assets_and_checks_by_key_multi_asset(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -547,7 +547,7 @@ def test_to_serializable_asset_selection():
     @asset_check(asset=asset1)
     def check1(): ...
 
-    asset_graph = AssetGraph.from_assets([asset1, asset2], asset_checks=[check1])
+    asset_graph = AssetGraph.from_assets([asset1, asset2, check1])
 
     def assert_serializable_same(asset_selection: AssetSelection) -> None:
         assert asset_selection.to_serializable_asset_selection(asset_graph) == asset_selection

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -122,7 +122,6 @@ def test_calculate_data_time_unpartitioned(ignore_asset_tags, runs_to_expected_d
                 asset_selection=AssetSelection.keys(*(AssetKey(c) for c in to_materialize)).resolve(
                     all_assets
                 ),
-                asset_checks=[],
             ).execute_in_process(instance=instance)
 
             assert result.success

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_check_tests/test_load_from_modules.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_check_tests/test_load_from_modules.py
@@ -19,8 +19,11 @@ def test_load_asset_checks_from_modules():
     checks = load_asset_checks_from_modules([checks_module])
     assert len(checks) == 1
 
-    assert checks[0].spec.asset_key == asset_check_1.asset_key
-    assert checks[0].spec.name == asset_check_1.name
+    asset_check_1_key = next(iter(asset_check_1.check_keys))
+
+    check_key = next(iter(checks[0].check_keys))
+    assert check_key.asset_key == asset_check_1_key.asset_key
+    assert check_key.name == asset_check_1_key.name
 
     result = execute_assets_and_checks(
         asset_checks=checks, assets=load_assets_from_modules([checks_module])
@@ -29,19 +32,19 @@ def test_load_asset_checks_from_modules():
 
     assert len(result.get_asset_check_evaluations()) == 1
     assert result.get_asset_check_evaluations()[0].passed
-    assert result.get_asset_check_evaluations()[0].asset_key == asset_check_1.asset_key
-    assert result.get_asset_check_evaluations()[0].check_name == "asset_check_1"
+    assert result.get_asset_check_evaluations()[0].asset_key == asset_check_1_key.asset_key
+    assert result.get_asset_check_evaluations()[0].check_name == asset_check_1_key.name
 
 
 def test_load_asset_checks_from_modules_prefix():
     from . import checks_module
-    from .checks_module import asset_check_1
 
     checks = load_asset_checks_from_modules([checks_module], asset_key_prefix="foo")
     assert len(checks) == 1
 
-    assert checks[0].spec.asset_key == AssetKey(["foo", "asset_1"])
-    assert checks[0].spec.name == asset_check_1.name
+    check_key = next(iter(checks[0].check_keys))
+    assert check_key.asset_key == AssetKey(["foo", "asset_1"])
+    assert check_key.name == "asset_check_1"
 
     result = execute_assets_and_checks(
         asset_checks=checks, assets=load_assets_from_modules([checks_module], key_prefix="foo")
@@ -62,8 +65,9 @@ def check_in_current_module():
 def test_load_asset_checks_from_current_module():
     checks = load_asset_checks_from_current_module(asset_key_prefix="foo")
     assert len(checks) == 1
-    assert checks[0].name == "check_in_current_module"
-    assert checks[0].asset_key == AssetKey(["foo", "asset_1"])
+    check_key = next(iter(checks[0].check_keys))
+    assert check_key.name == "check_in_current_module"
+    assert check_key.asset_key == AssetKey(["foo", "asset_1"])
 
 
 @pytest.mark.parametrize(
@@ -78,7 +82,9 @@ def test_load_asset_checks_from_package(load_fn):
 
     checks = load_fn(checks_module, asset_key_prefix="foo")
     assert len(checks) == 2
-    assert checks[0].name == "asset_check_1"
-    assert checks[0].asset_key == AssetKey(["foo", "asset_1"])
-    assert checks[1].name == "submodule_check"
-    assert checks[1].asset_key == AssetKey(["foo", "asset_1"])
+    check_key_0 = next(iter(checks[0].check_keys))
+    assert check_key_0.name == "asset_check_1"
+    assert check_key_0.asset_key == AssetKey(["foo", "asset_1"])
+    check_key_1 = next(iter(checks[1].check_keys))
+    assert check_key_1.name == "submodule_check"
+    assert check_key_1.asset_key == AssetKey(["foo", "asset_1"])

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -193,7 +193,7 @@ class AssetReconciliationScenario(
             or isinstance(a, SourceAsset)
             for a in assets
         ):
-            asset_graph = AssetGraph.from_assets(assets, asset_checks=asset_checks)
+            asset_graph = AssetGraph.from_assets([*assets, *(asset_checks or [])])
             auto_materialize_asset_keys = (
                 asset_selection.resolve(asset_graph)
                 if asset_selection is not None

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
@@ -42,9 +42,10 @@ def test_asset_check_decorator():
     def check1():
         return AssetCheckResult(passed=True)
 
-    assert check1.name == "check1"
-    assert check1.description == "desc"
-    assert check1.asset_key == AssetKey("asset1")
+    spec = check1.get_spec_for_check_key(AssetCheckKey(AssetKey(["asset1"]), "check1"))
+    assert spec.name == "check1"
+    assert spec.description == "desc"
+    assert spec.asset_key == AssetKey("asset1")
 
 
 def test_asset_check_decorator_name():
@@ -52,7 +53,8 @@ def test_asset_check_decorator_name():
     def _check():
         return AssetCheckResult(passed=True)
 
-    assert _check.name == "check1"
+    spec = _check.get_spec_for_check_key(AssetCheckKey(AssetKey(["asset1"]), "check1"))
+    assert spec.name == "check1"
 
 
 def test_asset_check_with_prefix():
@@ -63,7 +65,10 @@ def test_asset_check_with_prefix():
     def my_check():
         return AssetCheckResult(passed=True)
 
-    assert my_check.asset_key == AssetKey(["prefix", "asset1"])
+    spec = my_check.get_spec_for_check_key(
+        AssetCheckKey(AssetKey(["prefix", "asset1"]), "my_check")
+    )
+    assert spec.asset_key == AssetKey(["prefix", "asset1"])
 
 
 def test_asset_check_input_with_prefix():
@@ -74,7 +79,10 @@ def test_asset_check_input_with_prefix():
     def my_check(asset1):
         return AssetCheckResult(passed=True)
 
-    assert my_check.asset_key == AssetKey(["prefix", "asset1"])
+    spec = my_check.get_spec_for_check_key(
+        AssetCheckKey(AssetKey(["prefix", "asset1"]), "my_check")
+    )
+    assert spec.asset_key == AssetKey(["prefix", "asset1"])
 
 
 def test_execute_asset_and_check():
@@ -84,10 +92,9 @@ def test_execute_asset_and_check():
     @asset_check(asset=asset1, description="desc")
     def check1(context: AssetExecutionContext):
         assert context.asset_key_for_input("asset1") == asset1.key
-        asset_check_spec = context.asset_check_spec
         return AssetCheckResult(
-            asset_key=asset_check_spec.asset_key,
-            check_name=asset_check_spec.name,
+            asset_key=asset1.key,
+            check_name="check1",
             passed=True,
             metadata={"foo": "bar"},
         )
@@ -162,10 +169,9 @@ def test_execute_check_and_asset_in_separate_run():
     @asset_check(asset=asset1, description="desc")
     def check1(context: AssetExecutionContext):
         assert context.asset_key_for_input("asset1") == asset1.key
-        asset_check_spec = context.asset_check_spec
         return AssetCheckResult(
-            asset_key=asset_check_spec.asset_key,
-            check_name=asset_check_spec.name,
+            asset_key=asset1.key,
+            check_name="check1",
             passed=True,
             metadata={"foo": "bar"},
         )
@@ -537,8 +543,9 @@ def test_managed_input():
 
         def handle_output(self, context, obj): ...
 
-    assert check1.name == "check1"
-    assert check1.asset_key == asset1.key
+    spec = check1.get_spec_for_check_key(AssetCheckKey(AssetKey(["asset1"]), "check1"))
+    assert spec.name == "check1"
+    assert spec.asset_key == asset1.key
 
     assert execute_assets_and_checks(
         assets=[asset1], asset_checks=[check1], resources={"io_manager": MyIOManager()}
@@ -570,8 +577,9 @@ def test_managed_input_with_context():
         assert asset1 == 4
         return AssetCheckResult(passed=True)
 
-    assert check1.name == "check1"
-    assert check1.asset_key == asset1.key
+    spec = check1.get_spec_for_check_key(AssetCheckKey(AssetKey(["asset1"]), "check1"))
+    assert spec.name == "check1"
+    assert spec.asset_key == asset1.key
 
     execute_assets_and_checks(assets=[asset1], asset_checks=[check1])
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator_secondary_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator_secondary_assets.py
@@ -9,6 +9,8 @@ from dagster import (
     asset,
     asset_check,
 )
+from dagster._core.definitions.asset_check_spec import AssetCheckKey
+from dagster._core.definitions.events import AssetKey
 
 from .test_asset_check_decorator import execute_assets_and_checks
 
@@ -34,7 +36,8 @@ def test_additional_deps():
         return AssetCheckResult(passed=True)
 
     assert len(check1.node_def.input_defs) == 2
-    assert check1.spec.additional_deps == [AssetDep(asset2.key)]
+    spec = check1.get_spec_for_check_key(AssetCheckKey(AssetKey(["asset1"]), "check1"))
+    assert spec.additional_deps == [AssetDep(asset2.key)]
 
     execute_assets_and_checks(assets=[asset1, asset2], asset_checks=[check1])
 
@@ -46,7 +49,8 @@ def test_additional_deps_with_managed_input():
         return AssetCheckResult(passed=True)
 
     assert len(check1.node_def.input_defs) == 2
-    assert check1.spec.additional_deps == [AssetDep(asset2.key)]
+    spec = check1.get_spec_for_check_key(AssetCheckKey(AssetKey(["asset1"]), "check1"))
+    assert spec.additional_deps == [AssetDep(asset2.key)]
 
     execute_assets_and_checks(assets=[asset1, asset2], asset_checks=[check1])
 
@@ -120,7 +124,8 @@ def test_additional_ins():
         return AssetCheckResult(passed=True)
 
     assert len(check1.node_def.input_defs) == 2
-    assert check1.spec.additional_deps == [AssetDep(asset2.key)]
+    spec = check1.get_spec_for_check_key(AssetCheckKey(AssetKey(["asset1"]), "check1"))
+    assert spec.additional_deps == [AssetDep(asset2.key)]
 
     execute_assets_and_checks(assets=[asset1, asset2], asset_checks=[check1])
 
@@ -132,7 +137,8 @@ def test_additional_ins_primary_asset_not_a_param():
         return AssetCheckResult(passed=True)
 
     assert len(check1.node_def.input_defs) == 2
-    assert check1.spec.additional_deps == [AssetDep(asset2.key)]
+    spec = check1.get_spec_for_check_key(AssetCheckKey(AssetKey(["asset1"]), "check1"))
+    assert spec.additional_deps == [AssetDep(asset2.key)]
 
     execute_assets_and_checks(assets=[asset1, asset2], asset_checks=[check1])
 
@@ -145,7 +151,8 @@ def test_additional_ins_and_deps():
         return AssetCheckResult(passed=True)
 
     assert len(check1.node_def.input_defs) == 3
-    assert sorted(check1.spec.additional_deps) == [AssetDep(asset2.key), AssetDep(asset3.key)]
+    spec = check1.get_spec_for_check_key(AssetCheckKey(AssetKey(["asset1"]), "check1"))
+    assert sorted(spec.additional_deps) == [AssetDep(asset2.key), AssetDep(asset3.key)]
 
     execute_assets_and_checks(assets=[asset1, asset2], asset_checks=[check1])
 
@@ -159,11 +166,11 @@ def test_check_waits_for_additional_deps():
     def my_fail_asset():
         raise Exception("foobar")
 
-    @asset_check(asset=asset1, additional_deps=[my_fail_asset])
+    @asset_check(asset=my_asset, additional_deps=[my_fail_asset])
     def check_with_dep():
         return AssetCheckResult(passed=True)
 
-    @asset_check(asset=asset1)
+    @asset_check(asset=my_asset)
     def check_without_dep():
         return AssetCheckResult(passed=True)
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
@@ -664,7 +664,7 @@ def test_assets_checks():
     def my_repo():
         return [foo, foo_check]
 
-    assert my_repo.asset_checks_defs_by_key[next(iter(foo_check.keys))] == foo_check
+    assert my_repo.asset_checks_defs_by_key[next(iter(foo_check.check_keys))] == foo_check
 
 
 def test_direct_assets():


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/8711

Implement `@asset_check` in terms of `AssetsDefinition` and convert `AssetChecksDefinition` to a trivial subclass of `AssetsDefinition`. This allows the consolidation of many internal codepaths and is closer to the way we handle asset observation routines (i.e. there is no `AssetsObserveDefinition`).

The repository/definition-level API is left in place in this PR, though we may wish to change it in the future. `AssetChecksDefinition` are now in a similar position to `SourceAsset`, where the symbol remains part of our public API but is not used in the guts of our system.

## How I Tested These Changes

Existing test suite.