### PR TITLE
[ui] Fix asset catalog search input dark mode display

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -326,6 +326,7 @@ export const SearchInput = styled.input`
   margin-left: 4px;
   outline: none;
   width: 100%;
+  background-color: transparent;
 
   &::placeholder {
     color: ${Colors.textLighter()};


### PR DESCRIPTION
Previously:

![image](https://github.com/dagster-io/dagster/assets/29110579/7b9215b1-591f-415f-8a18-2196ce861726)


Now:

<img width="1792" alt="image" src="https://github.com/dagster-io/dagster/assets/29110579/a8dec7c4-f2e6-43ca-bcf1-1792dfe7212c">
