### PR TITLE
[docs] fix responsive design of getting started buttons

### DIFF
--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -12,7 +12,7 @@ Dagster is designed to be used at every stage of the data development lifecycle,
 
 **New to Dagster**? Check out the **Quickstart**, learn with some hands-on **Tutorials**, or dive into **Concepts**. For an in-depth learning experience, enroll in **Dagster University**.
 
-<div className="inline-flex flex-row space-x-4">
+<div className="w-full inline-flex flex-col space-y-2 md:space-y-0 md:flex-row md:space-x-4">
   <Button link="/getting-started/quickstart">Quickstart</Button>
   <Button link="/tutorial" style="secondary">
     View Tutorials


### PR DESCRIPTION
## Summary & Motivation

- Getting started buttons were improperly rendered on smaller devices.
- Made buttons `flex-col` on `md` size and smaller, `flex-row` with `space-x-4` on larger

## How I Tested These Changes

iPhone 12:
<img width="399" alt="image" src="https://github.com/dagster-io/dagster/assets/5807118/31d16c0e-5275-4fe6-b0ac-83b64f3a3ae9">

iPad:
<img width="1026" alt="image" src="https://github.com/dagster-io/dagster/assets/5807118/8f0b9739-6b19-44ff-8ed9-42cc9babf4ee">
