### PR TITLE
[ui] Improve wrapping on asset catalog page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
@@ -185,15 +185,19 @@ function getGreeting(timezone: string) {
 
 const CountForAssetType = ({children, assetsCount}: AssetOverviewCategoryProps) => {
   return (
-    <ColumnContainer>
-      <Box
-        flex={{direction: 'row', gap: 4, alignItems: 'center'}}
-        style={assetsCount !== 0 ? {width: '70%'} : {width: '100%'}}
-      >
+    <GridItem>
+      <Box flex={{direction: 'row', alignItems: 'center', gap: 4}} style={{overflow: 'hidden'}}>
         {children}
       </Box>
-      {assetsCount !== 0 && <AssetCount>{assetsCount} assets</AssetCount>}
-    </ColumnContainer>
+      <span
+        style={{
+          ...TextOverflowStyle,
+          ...{color: Colors.textLight(), fontSize: '14px', textAlign: 'right'},
+        }}
+      >
+        {assetsCount} assets
+      </span>
+    </GridItem>
   );
 };
 
@@ -205,18 +209,6 @@ const SectionHeader = ({sectionName}: {sectionName: string}) => {
       border="top-and-bottom"
     >
       <SectionName>{sectionName}</SectionName>
-    </Box>
-  );
-};
-
-const SectionBody = ({children}: {children: React.ReactNode}) => {
-  return (
-    <Box
-      padding={{horizontal: 24, vertical: 16}}
-      flex={{wrap: 'wrap'}}
-      style={{rowGap: '14px', columnGap: '24px'}}
-    >
-      {children}
     </Box>
   );
 };
@@ -308,7 +300,7 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
           {recentlyVisitedAssets.length > 0 && (
             <>
               <SectionHeader sectionName="Recently visited" />
-              <SectionBody>
+              <GridStyle>
                 {recentlyVisitedAssets.map((assetKey, idx) => (
                   <CountForAssetType key={idx} assetsCount={0}>
                     <Icon name="asset" />
@@ -317,13 +309,13 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                     </Link>
                   </CountForAssetType>
                 ))}
-              </SectionBody>
+              </GridStyle>
             </>
           )}
           {Object.keys(assetCountBySection.countsByOwner).length > 0 && (
             <>
               <SectionHeader sectionName="Owners" />
-              <SectionBody>
+              <GridStyle>
                 {assetCountBySection.countsByOwner.map(({owner, assetCount}) => (
                   <CountForAssetType key={owner} assetsCount={assetCount}>
                     <Link to={linkToAssetGraphOwner(owner)}>
@@ -331,13 +323,13 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                     </Link>
                   </CountForAssetType>
                 ))}
-              </SectionBody>
+              </GridStyle>
             </>
           )}
           {Object.keys(assetCountBySection.countsByComputeKind).length > 0 && (
             <>
               <SectionHeader sectionName="Compute kinds" />
-              <SectionBody>
+              <GridStyle>
                 {assetCountBySection.countsByComputeKind.map(({computeKind, assetCount}) => (
                   <CountForAssetType key={computeKind} assetsCount={assetCount}>
                     <TagIcon label={computeKind} />
@@ -346,20 +338,23 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                     </Link>
                   </CountForAssetType>
                 ))}
-              </SectionBody>
+              </GridStyle>
             </>
           )}
           {assetCountBySection.countPerAssetGroup.length > 0 && (
             <>
               <SectionHeader sectionName="Asset groups" />
-              <SectionBody>
+              <GridStyle>
                 {assetCountBySection.countPerAssetGroup.map((assetGroupCount) => (
                   <CountForAssetType
                     key={JSON.stringify(assetGroupCount.groupMetadata)}
                     assetsCount={assetGroupCount.assetCount}
                   >
                     <Icon name="asset_group" />
-                    <Link to={linkToAssetGraphGroup(assetGroupCount.groupMetadata)}>
+                    <Link
+                      to={linkToAssetGraphGroup(assetGroupCount.groupMetadata)}
+                      style={TextOverflowStyle}
+                    >
                       {assetGroupCount.groupMetadata.groupName}
                     </Link>
                     <span style={{...TextOverflowStyle, ...{color: Colors.textLighter()}}}>
@@ -370,13 +365,13 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                     </span>
                   </CountForAssetType>
                 ))}
-              </SectionBody>
+              </GridStyle>
             </>
           )}
           {assetCountBySection.countPerCodeLocation.length > 0 && (
             <>
               <SectionHeader sectionName="Code locations" />
-              <SectionBody>
+              <GridStyle>
                 {assetCountBySection.countPerCodeLocation.map((countPerCodeLocation) => (
                   <CountForAssetType
                     key={repoAddressAsHumanString(countPerCodeLocation.repoAddress)}
@@ -391,7 +386,7 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                     </Link>
                   </CountForAssetType>
                 ))}
-              </SectionBody>
+              </GridStyle>
             </>
           )}
         </Box>
@@ -410,33 +405,24 @@ const SectionName = styled.span`
   font-size: 12px;
 `;
 
-const AssetCount = styled.span`
-  color: ${Colors.textLight()};
-  font-size: 14px;
-
-  width: 30%;
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  text-align: right;
-`;
-
 const TextOverflowStyle: React.CSSProperties = {
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
-  width: '100%',
 };
 
-const ColumnContainer = styled.div`
-  width: calc(33% - 16px);
-  @media (max-width: 800px) {
-    width: calc(100% - 16px);
-  }
+const GridStyle = styled.div`
+  padding: 16px 12px;
 
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const GridItem = styled.div`
+  padding: 6px 12px;
+  display: grid;
+  grid-template-columns: auto auto;
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
@@ -189,7 +189,9 @@ const CountForAssetType = ({children, assetsCount}: AssetOverviewCategoryProps) 
       flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
       style={{width: 'calc(33% - 16px)'}}
     >
-      <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>{children}</Box>
+      <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}} style={{width: '70%'}}>
+        {children}
+      </Box>
       {assetsCount !== 0 && <AssetCount>{assetsCount} assets</AssetCount>}
     </Box>
   );
@@ -310,7 +312,7 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                 {recentlyVisitedAssets.map((assetKey, idx) => (
                   <CountForAssetType key={idx} assetsCount={0}>
                     <Icon name="asset" />
-                    <Link to={`/assets/${assetKey.path.join('/')}`}>
+                    <Link to={`/assets/${assetKey.path.join('/')}`} style={TextOverflowStyle}>
                       {displayNameForAssetKey(assetKey)}
                     </Link>
                   </CountForAssetType>
@@ -339,7 +341,9 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                 {assetCountBySection.countsByComputeKind.map(({computeKind, assetCount}) => (
                   <CountForAssetType key={computeKind} assetsCount={assetCount}>
                     <TagIcon label={computeKind} />
-                    <Link to={linkToAssetGraphComputeKind(computeKind)}>{computeKind}</Link>
+                    <Link to={linkToAssetGraphComputeKind(computeKind)} style={TextOverflowStyle}>
+                      {computeKind}
+                    </Link>
                   </CountForAssetType>
                 ))}
               </SectionBody>
@@ -379,7 +383,10 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                     assetsCount={countPerCodeLocation.assetCount}
                   >
                     <Icon name="folder" />
-                    <Link to={linkToCodeLocation(countPerCodeLocation.repoAddress)}>
+                    <Link
+                      to={linkToCodeLocation(countPerCodeLocation.repoAddress)}
+                      style={TextOverflowStyle}
+                    >
                       {repoAddressAsHumanString(countPerCodeLocation.repoAddress)}
                     </Link>
                   </CountForAssetType>
@@ -406,4 +413,18 @@ const SectionName = styled.span`
 const AssetCount = styled.span`
   color: ${Colors.textLight()};
   font-size: 14px;
+
+  width: 30%;
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
 `;
+
+const TextOverflowStyle: React.CSSProperties = {
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  width: '100%',
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
@@ -1,5 +1,5 @@
 import {useQuery} from '@apollo/client';
-import {Box, Colors, Heading, Icon, Page, Spinner} from '@dagster-io/ui-components';
+import {Box, Colors, Heading, Icon, MiddleTruncate, Page, Spinner} from '@dagster-io/ui-components';
 import qs from 'qs';
 import {useContext} from 'react';
 import {Link, useParams} from 'react-router-dom';
@@ -186,7 +186,10 @@ function getGreeting(timezone: string) {
 const CountForAssetType = ({children, assetsCount}: AssetOverviewCategoryProps) => {
   return (
     <GridItem>
-      <Box flex={{direction: 'row', alignItems: 'center', gap: 4}} style={{overflow: 'hidden'}}>
+      <Box
+        flex={{direction: 'row', alignItems: 'center', gap: 4}}
+        style={{overflow: 'hidden', color: Colors.textLighter()}}
+      >
         {children}
       </Box>
       <span
@@ -357,12 +360,12 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                     >
                       {assetGroupCount.groupMetadata.groupName}
                     </Link>
-                    <span style={{...TextOverflowStyle, ...{color: Colors.textLighter()}}}>
-                      {repoAddressAsHumanString({
+                    <MiddleTruncate
+                      text={repoAddressAsHumanString({
                         name: assetGroupCount.groupMetadata.repositoryName,
                         location: assetGroupCount.groupMetadata.repositoryLocationName,
                       })}
-                    </span>
+                    />
                   </CountForAssetType>
                 ))}
               </GridStyle>
@@ -415,14 +418,14 @@ const GridStyle = styled.div`
   padding: 16px 12px;
 
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
   @media (max-width: 768px) {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 `;
 
 const GridItem = styled.div`
   padding: 6px 12px;
-  display: grid;
-  grid-template-columns: auto auto;
+  display: flex;
+  justify-content: space-between;
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
@@ -185,15 +185,15 @@ function getGreeting(timezone: string) {
 
 const CountForAssetType = ({children, assetsCount}: AssetOverviewCategoryProps) => {
   return (
-    <Box
-      flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
-      style={{width: 'calc(33% - 16px)'}}
-    >
-      <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}} style={{width: '70%'}}>
+    <ColumnContainer>
+      <Box
+        flex={{direction: 'row', gap: 4, alignItems: 'center'}}
+        style={assetsCount !== 0 ? {width: '70%'} : {width: '100%'}}
+      >
         {children}
       </Box>
       {assetsCount !== 0 && <AssetCount>{assetsCount} assets</AssetCount>}
-    </Box>
+    </ColumnContainer>
   );
 };
 
@@ -362,7 +362,7 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                     <Link to={linkToAssetGraphGroup(assetGroupCount.groupMetadata)}>
                       {assetGroupCount.groupMetadata.groupName}
                     </Link>
-                    <span style={{color: Colors.textLighter()}}>
+                    <span style={{...TextOverflowStyle, ...{color: Colors.textLighter()}}}>
                       {repoAddressAsHumanString({
                         name: assetGroupCount.groupMetadata.repositoryName,
                         location: assetGroupCount.groupMetadata.repositoryLocationName,
@@ -428,3 +428,15 @@ const TextOverflowStyle: React.CSSProperties = {
   textOverflow: 'ellipsis',
   width: '100%',
 };
+
+const ColumnContainer = styled.div`
+  width: calc(33% - 16px);
+  @media (max-width: 800px) {
+    width: calc(100% - 16px);
+  }
+
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;


### PR DESCRIPTION
Improve wrapping for smaller screen sizes on the asset catalog page. Linear ticket: https://linear.app/dagster-labs/issue/FE-244/handle-long-strings-in-asset-catalog-page

Adds:
- Ellipsis when text overflows
- When screen size is below 800px, switch to rows instead of 3-column layout

<img width="1128" alt="image" src="https://github.com/dagster-io/dagster/assets/29110579/d3e39f5a-562a-47eb-9df9-8af93bbada86">
<img width="703" alt="image" src="https://github.com/dagster-io/dagster/assets/29110579/03d8fa11-5f87-4948-b2eb-3d29449ac88a">

