### PR TITLE
strict_dataclass

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_strict_dataclass.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_strict_dataclass.py
@@ -1,0 +1,17 @@
+from dagster._core.utils import strict_dataclass
+
+
+def test_frozen():
+    pass
+
+
+def test_positional_arguments():
+    pass
+
+
+def test_too_many_positional_arguments():
+    @strict_dataclass()
+    def MyClass():
+        a: int
+
+    MyClass(5, 6)

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_strict_dataclass.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_strict_dataclass.py
@@ -1,17 +1,95 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
 from dagster._core.utils import strict_dataclass
+from pydantic import ValidationError
+
+
+def test_kwargs():
+    @strict_dataclass()
+    class MyClass:
+        a: int
+        b: str
+
+    foo = MyClass(a=5, b="x")
+    assert foo.a == 5
+    assert foo.b == "x"
+
+
+def test_kwargs_extras():
+    @strict_dataclass()
+    class MyClass:
+        a: int
+        b: str
+
+    with pytest.raises(ValidationError):
+        MyClass(a=5, b="x", c=5)
 
 
 def test_frozen():
-    pass
+    @strict_dataclass()
+    class MyClass:
+        a: int
+        b: str
+
+    foo = MyClass(a=5, b="x")
+
+    with pytest.raises(FrozenInstanceError):
+        foo.a = 6
 
 
-def test_positional_arguments():
-    pass
+def test_positional_args_default():
+    @strict_dataclass()
+    class MyClass:
+        a: int
+        b: str
+
+    with pytest.raises(TypeError):
+        MyClass(5, "x")
+
+
+def test_positional_args_override_init():
+    @strict_dataclass(positional_args={"a"})
+    class MyClass:
+        a: int
+        b: str
+
+    foo = MyClass(5, b="x")
+    assert foo.a == 5
+    assert foo.b == "x"
+
+    with pytest.raises(TypeError):
+        MyClass(5, "x")
+
+
+def test_type_validation():
+    @strict_dataclass()
+    class MyClass:
+        a: int
+        b: str
+
+    with pytest.raises(ValidationError):
+        MyClass(a=5, b=6)
 
 
 def test_too_many_positional_arguments():
-    @strict_dataclass()
-    def MyClass():
+    @strict_dataclass(positional_args={"a"})
+    class MyClass:
         a: int
 
-    MyClass(5, 6)
+    with pytest.raises(TypeError):
+        MyClass(5, 6)
+
+
+def test_inheritance():
+    @strict_dataclass()
+    class MyClass:
+        a: int
+
+    @strict_dataclass()
+    class MySubClass(MyClass):
+        b: str
+
+    foo = MySubClass(a=5, b="x")
+    assert foo.a == 5
+    assert foo.b == "x"


### PR DESCRIPTION
## Summary & Motivation

This one was a doozy.

Introduces a `@strict_dataclass` decorator, with the aim of replacing our usage of `NamedTuple` and `pydantic.BaseModel`.

#### Why not `pydantic.BaseModel`?

1. This would require remembering to use `frozen=True`, which is annoying and error-prone.
1. It doesn't work with positional arguments. Even if we declare positional arguments bad for new classes, many of our existing NamedTuples are public APIs that will need to support positional arguments for the forseeable future.

#### Why not `@pydantic.dataclass(frozen=True, config=dict(extra="forbid"))`

This would require remembering to use `frozen=True, config=dict(extra="forbid")`, which is annoying and error-prone.

## How I Tested These Changes
