### PR TITLE
remove __del__ from event storage and poller

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/test_polling_event_watcher.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_polling_event_watcher.py
@@ -1,7 +1,7 @@
 import tempfile
 import time
 from contextlib import contextmanager
-from typing import Any, Callable, Mapping, Union
+from typing import Any, Callable, Mapping, Optional
 
 import dagster._check as check
 from dagster._core.events import DagsterEvent, DagsterEventType, EngineEventData
@@ -21,10 +21,9 @@ class SqlitePollingEventLogStorage(SqliteEventLogStorage):
     observe runs.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(SqlitePollingEventLogStorage, self).__init__(*args, **kwargs)
-        self._watcher = SqlPollingEventWatcher(self)
-        self._disposed = False
+        self._watcher: Optional[SqlPollingEventWatcher] = None
 
     @classmethod
     def from_config_value(
@@ -33,25 +32,33 @@ class SqlitePollingEventLogStorage(SqliteEventLogStorage):
         return cls(inst_data=inst_data, **config_value)
 
     def watch(
-        self, run_id: str, cursor: Union[str, int], callback: Callable[[EventLogEntry], None]
+        self,
+        run_id: str,
+        cursor: Optional[str],
+        callback: Callable[[EventLogEntry, str], None],
     ):
         check.str_param(run_id, "run_id")
         check.opt_str_param(cursor, "cursor")
         check.callable_param(callback, "callback")
+        if self._watcher is None:
+            self._watcher = SqlPollingEventWatcher(self)
+
         self._watcher.watch_run(run_id, cursor, callback)
 
-    def end_watch(self, run_id: str, handler: Callable[[EventLogEntry], None]):
+    def end_watch(
+        self,
+        run_id: str,
+        handler: Callable[[EventLogEntry, str], None],
+    ):
         check.str_param(run_id, "run_id")
         check.callable_param(handler, "handler")
-        self._watcher.unwatch_run(run_id, handler)
+        if self._watcher:
+            self._watcher.unwatch_run(run_id, handler)
 
-    def __del__(self):
-        self.dispose()
-
-    def dispose(self):
-        if not self._disposed:
-            self._disposed = True
+    def dispose(self) -> None:
+        if self._watcher:
             self._watcher.close()
+            self._watcher = None
 
 
 RUN_ID = make_new_run_id()

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -58,9 +58,7 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def __init__(self, mysql_url: str, inst_data: Optional[ConfigurableClassData] = None):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.mysql_url = check.str_param(mysql_url, "mysql_url")
-        self._disposed = False
-
-        self._event_watcher = SqlPollingEventWatcher(self)
+        self._event_watcher: Optional[SqlPollingEventWatcher] = None
 
         # Default to not holding any connections open to prevent accumulating connections per DagsterInstance
         self._engine = create_engine(
@@ -200,22 +198,20 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def watch(self, run_id: str, cursor: Optional[str], callback: EventHandlerFn) -> None:
         if cursor and EventLogCursor.parse(cursor).is_offset_cursor():
             check.failed("Cannot call `watch` with an offset cursor")
+
+        if self._event_watcher is None:
+            self._event_watcher = SqlPollingEventWatcher(self)
+
         self._event_watcher.watch_run(run_id, cursor, callback)
 
     def end_watch(self, run_id: str, handler: EventHandlerFn) -> None:
-        self._event_watcher.unwatch_run(run_id, handler)
-
-    @property
-    def event_watcher(self) -> SqlPollingEventWatcher:
-        return self._event_watcher
-
-    def __del__(self) -> None:
-        self.dispose()
+        if self._event_watcher:
+            self._event_watcher.unwatch_run(run_id, handler)
 
     def dispose(self) -> None:
-        if not self._disposed:
-            self._disposed = True
+        if self._event_watcher:
             self._event_watcher.close()
+            self._event_watcher = None
 
     def alembic_version(self) -> AlembicVersion:
         alembic_config = mysql_alembic_config(__file__)

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_event_log.py
@@ -1,6 +1,9 @@
+import gc
 import time
+from contextlib import contextmanager
 from urllib.parse import urlparse
 
+import objgraph
 import pytest
 import yaml
 from dagster._core.storage.event_log.base import EventLogCursor
@@ -15,74 +18,86 @@ from dagster_tests.storage_tests.utils.event_log_storage import (
 )
 
 
+@contextmanager
+def _clean_storage(conn_string):
+    storage = MySQLEventLogStorage.create_clean_storage(conn_string)
+    assert storage
+    try:
+        yield storage
+    finally:
+        storage.dispose()
+
+
 class TestMySQLEventLogStorage(TestEventLogStorage):
     __test__ = True
 
     @pytest.fixture(scope="function", name="storage")
     def event_log_storage(self, conn_string):
-        storage = MySQLEventLogStorage.create_clean_storage(conn_string)
-        assert storage
-        try:
+        with _clean_storage(conn_string) as storage:
             yield storage
-        finally:
-            storage.dispose()
 
-    def test_event_log_storage_two_watchers(self, storage):
-        run_id = make_new_run_id()
-        watched_1 = []
-        watched_2 = []
+    def test_event_log_storage_two_watchers(self, conn_string):
+        with _clean_storage(conn_string) as storage:
+            run_id = make_new_run_id()
+            watched_1 = []
+            watched_2 = []
 
-        def watch_one(event, _cursor):
-            watched_1.append(event)
+            def watch_one(event, _cursor):
+                watched_1.append(event)
 
-        def watch_two(event, _cursor):
-            watched_2.append(event)
+            def watch_two(event, _cursor):
+                watched_2.append(event)
 
-        assert len(storage.get_logs_for_run(run_id)) == 0
+            assert len(storage.get_logs_for_run(run_id)) == 0
 
-        storage.store_event(create_test_event_log_record(str(1), run_id=run_id))
-        assert len(storage.get_logs_for_run(run_id)) == 1
-        assert len(watched_1) == 0
+            storage.store_event(create_test_event_log_record(str(1), run_id=run_id))
+            assert len(storage.get_logs_for_run(run_id)) == 1
+            assert len(watched_1) == 0
 
-        storage.watch(run_id, str(EventLogCursor.from_storage_id(1)), watch_one)
+            storage.watch(run_id, str(EventLogCursor.from_storage_id(1)), watch_one)
 
-        storage.store_event(create_test_event_log_record(str(2), run_id=run_id))
-        storage.store_event(create_test_event_log_record(str(3), run_id=run_id))
+            storage.store_event(create_test_event_log_record(str(2), run_id=run_id))
+            storage.store_event(create_test_event_log_record(str(3), run_id=run_id))
 
-        storage.watch(run_id, str(EventLogCursor.from_storage_id(3)), watch_two)
-        storage.store_event(create_test_event_log_record(str(4), run_id=run_id))
+            storage.watch(run_id, str(EventLogCursor.from_storage_id(3)), watch_two)
+            storage.store_event(create_test_event_log_record(str(4), run_id=run_id))
 
-        attempts = 10
-        while (len(watched_1) < 3 or len(watched_2) < 1) and attempts > 0:
-            time.sleep(0.1)
-            attempts -= 1
+            attempts = 10
+            while (len(watched_1) < 3 or len(watched_2) < 1) and attempts > 0:
+                time.sleep(0.1)
+                attempts -= 1
 
-        assert len(storage.get_logs_for_run(run_id)) == 4
-        assert len(watched_1) == 3
-        assert len(watched_2) == 1
+            assert len(storage.get_logs_for_run(run_id)) == 4
+            assert len(watched_1) == 3
+            assert len(watched_2) == 1
 
-        storage.end_watch(run_id, watch_one)
-        time.sleep(0.3)  # this value scientifically selected from a range of attractive values
-        storage.store_event(create_test_event_log_record(str(5), run_id=run_id))
+            storage.end_watch(run_id, watch_one)
+            time.sleep(0.3)  # this value scientifically selected from a range of attractive values
+            storage.store_event(create_test_event_log_record(str(5), run_id=run_id))
 
-        attempts = 10
-        while len(watched_2) < 2 and attempts > 0:
-            time.sleep(0.1)
-            attempts -= 1
-        storage.end_watch(run_id, watch_two)
+            attempts = 10
+            while len(watched_2) < 2 and attempts > 0:
+                time.sleep(0.1)
+                attempts -= 1
+            storage.end_watch(run_id, watch_two)
 
-        assert len(storage.get_logs_for_run(run_id)) == 5
-        assert len(watched_1) == 3
-        assert len(watched_2) == 2
+            assert len(storage.get_logs_for_run(run_id)) == 5
+            assert len(watched_1) == 3
+            assert len(watched_2) == 2
 
-        storage.delete_events(run_id)
+            storage.delete_events(run_id)
 
-        assert len(storage.get_logs_for_run(run_id)) == 0
-        assert len(watched_1) == 3
-        assert len(watched_2) == 2
+            assert len(storage.get_logs_for_run(run_id)) == 0
+            assert len(watched_1) == 3
+            assert len(watched_2) == 2
 
-        assert [int(evt.message) for evt in watched_1] == [2, 3, 4]
-        assert [int(evt.message) for evt in watched_2] == [4, 5]
+            assert [int(evt.message) for evt in watched_1] == [2, 3, 4]
+            assert [int(evt.message) for evt in watched_2] == [4, 5]
+            assert len(objgraph.by_type("SqlPollingEventWatcher")) == 1
+
+        # ensure we clean up poller on exit
+        gc.collect()
+        assert len(objgraph.by_type("SqlPollingEventWatcher")) == 0
 
     def test_load_from_config(self, conn_string):
         parse_result = urlparse(conn_string)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -85,14 +85,11 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             should_autocreate_tables, "should_autocreate_tables"
         )
 
-        self._disposed = False
-
         # Default to not holding any connections open to prevent accumulating connections per DagsterInstance
         self._engine = create_engine(
             self.postgres_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool
         )
-
-        self._event_watcher = SqlPollingEventWatcher(self)
+        self._event_watcher: Optional[SqlPollingEventWatcher] = None
 
         self._secondary_index_cache = {}
 
@@ -344,6 +341,8 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     ) -> None:
         if cursor and EventLogCursor.parse(cursor).is_offset_cursor():
             check.failed("Cannot call `watch` with an offset cursor")
+        if self._event_watcher is None:
+            self._event_watcher = SqlPollingEventWatcher(self)
 
         self._event_watcher.watch_run(run_id, cursor, callback)
 
@@ -357,16 +356,13 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             return deserialize_value(cursor_res.scalar(), EventLogEntry)  # type: ignore
 
     def end_watch(self, run_id: str, handler: EventHandlerFn) -> None:
-        self._event_watcher.unwatch_run(run_id, handler)
-
-    def __del__(self) -> None:
-        # Keep the inherent limitations of __del__ in Python in mind!
-        self.dispose()
+        if self._event_watcher:
+            self._event_watcher.unwatch_run(run_id, handler)
 
     def dispose(self) -> None:
-        if not self._disposed:
-            self._disposed = True
+        if self._event_watcher:
             self._event_watcher.close()
+            self._event_watcher = None
 
     def alembic_version(self) -> AlembicVersion:
         alembic_config = pg_alembic_config(__file__)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
@@ -1,5 +1,8 @@
+import gc
 import time
+from contextlib import contextmanager
 
+import objgraph
 import pytest
 import yaml
 from dagster._core.storage.event_log.base import EventLogCursor
@@ -14,75 +17,87 @@ from dagster_tests.storage_tests.utils.event_log_storage import (
 )
 
 
+@contextmanager
+def _clean_storage(conn_string):
+    storage = PostgresEventLogStorage.create_clean_storage(conn_string)
+    assert storage
+    try:
+        yield storage
+    finally:
+        storage.dispose()
+
+
 class TestPostgresEventLogStorage(TestEventLogStorage):
     __test__ = True
 
     @pytest.fixture(scope="function", name="storage")
     def event_log_storage(self, conn_string):
-        storage = PostgresEventLogStorage.create_clean_storage(conn_string)
-        assert storage
-        try:
+        with _clean_storage(conn_string) as storage:
             yield storage
-        finally:
-            storage.dispose()
 
-    def test_event_log_storage_two_watchers(self, storage):
-        run_id = make_new_run_id()
-        watched_1 = []
-        watched_2 = []
+    def test_event_log_storage_two_watchers(self, conn_string):
+        with _clean_storage(conn_string) as storage:
+            run_id = make_new_run_id()
+            watched_1 = []
+            watched_2 = []
 
-        def watch_one(event, _cursor):
-            watched_1.append(event)
+            def watch_one(event, _cursor):
+                watched_1.append(event)
 
-        def watch_two(event, _cursor):
-            watched_2.append(event)
+            def watch_two(event, _cursor):
+                watched_2.append(event)
 
-        assert len(storage.get_logs_for_run(run_id)) == 0
+            assert len(storage.get_logs_for_run(run_id)) == 0
 
-        storage.store_event(create_test_event_log_record(str(1), run_id=run_id))
-        assert len(storage.get_logs_for_run(run_id)) == 1
-        assert len(watched_1) == 0
+            storage.store_event(create_test_event_log_record(str(1), run_id=run_id))
+            assert len(storage.get_logs_for_run(run_id)) == 1
+            assert len(watched_1) == 0
 
-        storage.watch(run_id, str(EventLogCursor.from_storage_id(1)), watch_one)
+            storage.watch(run_id, str(EventLogCursor.from_storage_id(1)), watch_one)
 
-        storage.store_event(create_test_event_log_record(str(2), run_id=run_id))
-        storage.store_event(create_test_event_log_record(str(3), run_id=run_id))
+            storage.store_event(create_test_event_log_record(str(2), run_id=run_id))
+            storage.store_event(create_test_event_log_record(str(3), run_id=run_id))
 
-        storage.watch(run_id, str(EventLogCursor.from_storage_id(3)), watch_two)
-        storage.store_event(create_test_event_log_record(str(4), run_id=run_id))
+            storage.watch(run_id, str(EventLogCursor.from_storage_id(3)), watch_two)
+            storage.store_event(create_test_event_log_record(str(4), run_id=run_id))
 
-        attempts = 10
-        while (len(watched_1) < 3 or len(watched_2) < 1) and attempts > 0:
-            time.sleep(0.5)
-            attempts -= 1
-        assert len(watched_1) == 3
-        assert len(watched_2) == 1
+            attempts = 10
+            while (len(watched_1) < 3 or len(watched_2) < 1) and attempts > 0:
+                time.sleep(0.5)
+                attempts -= 1
+            assert len(watched_1) == 3
+            assert len(watched_2) == 1
 
-        assert len(storage.get_logs_for_run(run_id)) == 4
+            assert len(storage.get_logs_for_run(run_id)) == 4
 
-        storage.end_watch(run_id, watch_one)
-        time.sleep(0.3)  # this value scientifically selected from a range of attractive values
-        storage.store_event(create_test_event_log_record(str(5), run_id=run_id))
+            storage.end_watch(run_id, watch_one)
+            time.sleep(0.3)  # this value scientifically selected from a range of attractive values
+            storage.store_event(create_test_event_log_record(str(5), run_id=run_id))
 
-        attempts = 10
-        while len(watched_2) < 2 and attempts > 0:
-            time.sleep(0.5)
-            attempts -= 1
-        assert len(watched_1) == 3
-        assert len(watched_2) == 2
+            attempts = 10
+            while len(watched_2) < 2 and attempts > 0:
+                time.sleep(0.5)
+                attempts -= 1
+            assert len(watched_1) == 3
+            assert len(watched_2) == 2
 
-        storage.end_watch(run_id, watch_two)
+            storage.end_watch(run_id, watch_two)
 
-        assert len(storage.get_logs_for_run(run_id)) == 5
+            assert len(storage.get_logs_for_run(run_id)) == 5
 
-        storage.delete_events(run_id)
+            storage.delete_events(run_id)
 
-        assert len(storage.get_logs_for_run(run_id)) == 0
-        assert len(watched_1) == 3
-        assert len(watched_2) == 2
+            assert len(storage.get_logs_for_run(run_id)) == 0
+            assert len(watched_1) == 3
+            assert len(watched_2) == 2
 
-        assert [int(evt.message) for evt in watched_1] == [2, 3, 4]
-        assert [int(evt.message) for evt in watched_2] == [4, 5]
+            assert [int(evt.message) for evt in watched_1] == [2, 3, 4]
+            assert [int(evt.message) for evt in watched_2] == [4, 5]
+            assert len(objgraph.by_type("SqlPollingEventWatcher")) == 1
+
+        # ensure we clean up poller on exit
+        gc.collect()
+        assert len(objgraph.by_type("SqlPollingEventWatcher")) == 0
 
     def test_load_from_config(self, hostname):
         url_cfg = f"""


### PR DESCRIPTION
`__del__` is bad vibes. 

This was originally added long ago before we got disciplined about using context managers for handling the life cycle of `DagsterInstance`. That should ensure proper shutdown in the vast majority of important callsites. 

Additional I have updated the `event_watcher` set-up to lazy instantiate and clear itself on disposal. This further reduces the conditions where `__del__` might have helped to only callsites that dont use a context manager but are subscribing to the event stream for a run using this non-public APIs. 

## How I Tested These Changes

updated postgres and mysql tests