### PR TITLE
[external-assets] Make BaseAssetNode.group_name always return str

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -24,6 +24,7 @@ from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.resolved_asset_deps import ResolvedAssetDependencies
 from dagster._core.definitions.source_asset import SourceAsset
+from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster._core.selector.subset_selector import (
     generate_asset_dep_graph,
 )
@@ -45,8 +46,8 @@ class AssetNode(BaseAssetNode):
         self._check_keys = check_keys
 
     @property
-    def group_name(self) -> Optional[str]:
-        return self.assets_def.group_names_by_key.get(self.key)
+    def group_name(self) -> str:
+        return self.assets_def.group_names_by_key.get(self.key, DEFAULT_GROUP_NAME)
 
     @property
     def is_materializable(self) -> bool:

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -82,7 +82,7 @@ class BaseAssetNode(ABC):
 
     @property
     @abstractmethod
-    def group_name(self) -> Optional[str]: ...
+    def group_name(self) -> str: ...
 
     @property
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -22,6 +22,7 @@ from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.assets_job import ASSET_BASE_JOB_PREFIX
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
+from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster._core.remote_representation.external import ExternalRepository
 from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.workspace.workspace import IWorkspace
@@ -62,8 +63,8 @@ class RemoteAssetNode(BaseAssetNode):
     ##### COMMON ASSET NODE INTERFACE
 
     @property
-    def group_name(self) -> Optional[str]:
-        return self._priority_node.group_name
+    def group_name(self) -> str:
+        return self._priority_node.group_name or DEFAULT_GROUP_NAME
 
     @cached_property
     def is_materializable(self) -> bool:


### PR DESCRIPTION
## Summary & Motivation

Normalize return value of `BaseAssetNode.group_name` to a string (returns default group name for None).

## How I Tested These Changes

Existing test suite.