### PR TITLE
[external-assets] Update AssetLayer property access callsites to use AssetNode

### DIFF
--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -66,7 +66,7 @@ def execute_materialize_command(instance: DagsterInstance, kwargs: Mapping[str, 
     if partition:
         partitions_def = implicit_job_def.partitions_def
         if partitions_def is None or all(
-            implicit_job_def.asset_layer.partitions_def_for_asset(asset_key) is None
+            implicit_job_def.asset_layer.get(asset_key).partitions_def is None
             for asset_key in asset_keys
         ):
             check.failed("Provided '--partition' option, but none of the assets are partitioned")

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -30,6 +30,7 @@ from dagster._core.definitions.resource_requirement import (
     OutputManagerRequirement,
     ResourceRequirement,
 )
+from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
     DagsterInvalidInvocationError,
@@ -427,7 +428,11 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             elif asset_layer and handle:
                 input_asset_key = asset_layer.asset_key_for_input(handle, input_def.name)
                 if input_asset_key:
-                    io_manager_key = asset_layer.io_manager_key_for_asset(input_asset_key)
+                    io_manager_key = (
+                        asset_layer.get(input_asset_key).io_manager_key
+                        if asset_layer.has(input_asset_key)
+                        else DEFAULT_IO_MANAGER_KEY
+                    )
                     yield InputManagerRequirement(
                         key=io_manager_key,
                         node_description=node_description,

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -299,14 +299,20 @@ class RepositoryDefinition:
         """
         if self.has_job(ASSET_BASE_JOB_PREFIX):
             base_job = self.get_job(ASSET_BASE_JOB_PREFIX)
-            if all(base_job.asset_layer.is_executable_for_asset(key) for key in asset_keys):
+            asset_layer = base_job.asset_layer
+            if all(
+                asset_layer.has(key) and asset_layer.get(key).is_executable for key in asset_keys
+            ):
                 return base_job
         else:
             i = 0
             while self.has_job(f"{ASSET_BASE_JOB_PREFIX}_{i}"):
                 base_job = self.get_job(f"{ASSET_BASE_JOB_PREFIX}_{i}")
-
-                if all(base_job.asset_layer.is_executable_for_asset(key) for key in asset_keys):
+                asset_layer = base_job.asset_layer
+                if all(
+                    asset_layer.has(key) and asset_layer.get(key).is_executable
+                    for key in asset_keys
+                ):
                     return base_job
 
                 i += 1

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1034,9 +1034,7 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
 
         """
         asset_key = self.asset_key_for_output(output_name)
-        result = self._step_execution_context.job_def.asset_layer.partitions_def_for_asset(
-            asset_key
-        )
+        result = self._step_execution_context.job_def.asset_layer.get(asset_key).partitions_def
         if result is None:
             raise DagsterInvariantViolationError(
                 f"Attempting to access partitions def for asset {asset_key}, but it is not"
@@ -1074,9 +1072,7 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
 
         """
         asset_key = self.asset_key_for_input(input_name)
-        result = self._step_execution_context.job_def.asset_layer.partitions_def_for_asset(
-            asset_key
-        )
+        result = self._step_execution_context.job_def.asset_layer.get(asset_key).partitions_def
         if result is None:
             raise DagsterInvariantViolationError(
                 f"Attempting to access partitions def for asset {asset_key}, but it is not"

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -328,7 +328,7 @@ class OutputContext:
     def asset_partitions_def(self) -> "PartitionsDefinition":
         """The PartitionsDefinition on the asset corresponding to this output."""
         asset_key = self.asset_key
-        result = self.step_context.job_def.asset_layer.partitions_def_for_asset(asset_key)
+        result = self.step_context.job_def.asset_layer.get(asset_key).partitions_def
         if result is None:
             raise DagsterInvariantViolationError(
                 f"Attempting to access partitions def for asset {asset_key}, but it is not"
@@ -751,7 +751,7 @@ def get_output_context(
         node_handle=node_handle, output_name=step_output.name
     )
     if asset_info is not None:
-        metadata = job_def.asset_layer.metadata_for_asset(asset_info.key) or output_def.metadata
+        metadata = job_def.asset_layer.get(asset_info.key).metadata or output_def.metadata
     else:
         metadata = output_def.metadata
 

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -703,7 +703,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         )
 
         asset_partitions_def = (
-            self.job_def.asset_layer.partitions_def_for_asset(asset_key) if asset_key else None
+            self.job_def.asset_layer.get(asset_key).partitions_def if asset_key else None
         )
         return InputContext(
             job_name=self.job_def.name,
@@ -1020,7 +1020,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         asset_layer = self.job_def.asset_layer
         upstream_asset_key = asset_layer.asset_key_for_input(self.node_handle, input_name)
         if upstream_asset_key:
-            upstream_asset_partitions_def = asset_layer.partitions_def_for_asset(upstream_asset_key)
+            upstream_asset_partitions_def = asset_layer.get(upstream_asset_key).partitions_def
             assets_def = asset_layer.assets_def_for_node(self.node_handle)
             partitions_def = assets_def.partitions_def if assets_def else None
             explicit_partition_mapping = self.job_def.asset_layer.partition_mapping_for_node_input(
@@ -1097,7 +1097,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
         return (
             upstream_asset_key is not None
-            and asset_layer.partitions_def_for_asset(upstream_asset_key) is not None
+            and asset_layer.get(upstream_asset_key).partitions_def is not None
         )
 
     def asset_partition_key_range_for_input(self, input_name: str) -> PartitionKeyRange:
@@ -1108,7 +1108,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             asset_layer.asset_key_for_input(self.node_handle, input_name)
         )
         upstream_asset_partitions_def = check.not_none(
-            asset_layer.partitions_def_for_asset(upstream_asset_key)
+            asset_layer.get(upstream_asset_key).partitions_def
         )
 
         partition_key_ranges = subset.get_partition_key_ranges(
@@ -1132,7 +1132,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         upstream_asset_key = asset_layer.asset_key_for_input(self.node_handle, input_name)
 
         if upstream_asset_key is not None:
-            upstream_asset_partitions_def = asset_layer.partitions_def_for_asset(upstream_asset_key)
+            upstream_asset_partitions_def = asset_layer.get(upstream_asset_key).partitions_def
 
             if upstream_asset_partitions_def is not None:
                 partitions_def = assets_def.partitions_def if assets_def else None
@@ -1264,7 +1264,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         if upstream_asset_key is None:
             raise ValueError("The input has no corresponding asset")
 
-        upstream_asset_partitions_def = asset_layer.partitions_def_for_asset(upstream_asset_key)
+        upstream_asset_partitions_def = asset_layer.get(upstream_asset_key).partitions_def
 
         if not upstream_asset_partitions_def:
             raise ValueError(
@@ -1311,7 +1311,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         asset_key = asset_layer.asset_key_for_output(self.node_handle, output_name)
         if asset_key is None:
             return False
-        return asset_layer.is_observable_for_asset(asset_key)
+        return asset_layer.get(asset_key).is_observable
 
 
 class TypeCheckContext:

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -245,10 +245,10 @@ def _step_output_error_checked_user_event_sequence(
             if (
                 asset_info is not None
                 and asset_info.is_required
-                and asset_layer.has_assets_def_for_asset(asset_info.key)
+                and asset_layer.has(asset_info.key)
             ):
-                assets_def = asset_layer.assets_def_for_asset(asset_info.key)
-                if assets_def is not None:
+                if asset_layer.has(asset_info.key):
+                    assets_def = asset_layer.get(asset_info.key).assets_def
                     all_dependent_keys = asset_layer.downstream_assets_for_asset(asset_info.key)
                     step_local_asset_keys = step_context.get_output_asset_keys()
                     step_local_dependent_keys = all_dependent_keys & step_local_asset_keys
@@ -311,9 +311,7 @@ def _step_output_error_checked_user_event_sequence(
                 step_context.node_handle, step_output_def.name
             )
             # We require explicitly returned/yielded for asset observations
-            is_observable_asset = asset_key is not None and asset_layer.is_observable_for_asset(
-                asset_key
-            )
+            is_observable_asset = asset_key is not None and asset_layer.get(asset_key).is_observable
 
             if step_output_def.dagster_type.is_nothing and not is_observable_asset:
                 step_context.log.info(
@@ -693,7 +691,7 @@ def _get_output_asset_events(
 
 def _get_code_version(asset_key: AssetKey, step_context: StepExecutionContext) -> str:
     return (
-        step_context.job_def.asset_layer.code_version_for_asset(asset_key)
+        step_context.job_def.asset_layer.get(asset_key).code_version
         or step_context.dagster_run.run_id
     )
 

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -1626,9 +1626,7 @@ def external_asset_nodes_from_defs(
             all_upstream_asset_keys.update(upstream_asset_keys)
             node_defs_by_asset_key[output_key].append((node_output_handle, job_def))
             asset_info_by_asset_key[output_key] = asset_info
-            execution_types_by_asset_key[output_key] = asset_layer.execution_type_for_asset(
-                output_key
-            )
+            execution_types_by_asset_key[output_key] = asset_layer.get(output_key).execution_type
 
             for upstream_key in upstream_asset_keys:
                 partition_mapping = asset_layer.partition_mapping_for_node_input(
@@ -1670,7 +1668,7 @@ def external_asset_nodes_from_defs(
                 execution_set_identifiers[assets_def.key] = assets_def.unique_id
 
         group_name_by_asset_key.update(
-            {k: asset_layer.group_name_for_asset(k) for k in asset_layer.all_asset_keys}
+            {k: asset_layer.get(k).group_name for k in asset_layer.all_asset_keys}
         )
 
     asset_nodes: List[ExternalAssetNode] = []


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/8718

`AssetLayer` has several methods for accessing individual properties of assets. This PR deletes these methods in favor of having callers retrieve the `AssetNode` for the target asset and access the property from there.

## How I Tested These Changes

Existing test suite.