### PR TITLE
Refactor useRefreshAtInterval out of useQueryRefreshAtInterval

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
@@ -53,7 +53,7 @@ export function useQueryRefreshAtInterval(
   }
 
   const {nextFireMs, nextFireDelay, refetch} = useRefreshAtInterval({
-    refreshFunction: useCallback(async () => {
+    refresh: useCallback(async () => {
       return await queryResult?.refetch();
     }, [queryResult]),
     intervalMs,
@@ -74,11 +74,11 @@ export function useQueryRefreshAtInterval(
 }
 
 export function useRefreshAtInterval<T>({
-  refreshFunction,
+  refresh,
   intervalMs,
   enabled,
 }: {
-  refreshFunction: () => Promise<T>;
+  refresh: () => Promise<T>;
   intervalMs: number;
   enabled?: boolean;
 }) {
@@ -99,10 +99,10 @@ export function useRefreshAtInterval<T>({
 
   const refresh = useCallback(async () => {
     setLoading(true);
-    const result = await refreshFunction();
+    const result = await refresh();
     setLoading(false);
     return result;
-  }, [refreshFunction]);
+  }, [refresh]);
 
   useEffect(() => {
     if (!enabled) {

--- a/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
@@ -15,7 +15,7 @@ export interface QueryRefreshState {
   refetch: ObservableQuery['refetch'];
 }
 
-export interface RefreshState<T> {
+export interface RefreshState<T = void> {
   nextFireMs: number | null | undefined;
   nextFireDelay: number; // seconds
   refetch: () => Promise<T>;
@@ -73,7 +73,7 @@ export function useQueryRefreshAtInterval(
   );
 }
 
-export function useRefreshAtInterval<T>({
+export function useRefreshAtInterval<T = void>({
   refresh,
   intervalMs,
   enabled,
@@ -97,7 +97,7 @@ export function useRefreshAtInterval<T>({
 
   const [loading, setLoading] = useState(false);
 
-  const refresh = useCallback(async () => {
+  const refreshFn = useCallback(async () => {
     setLoading(true);
     const result = await refresh();
     setLoading(false);
@@ -113,11 +113,11 @@ export function useRefreshAtInterval<T>({
       !searchVisible &&
       (searchVisibilityDidInterrupt.current || documentVisiblityDidInterrupt.current)
     ) {
-      refresh();
+      refreshFn();
       documentVisiblityDidInterrupt.current = false;
       searchVisibilityDidInterrupt.current = false;
     }
-  }, [documentVisible, enabled, searchVisible, refresh]);
+  }, [documentVisible, enabled, searchVisible, refreshFn]);
 
   useEffect(() => {
     clearTimeout(timer.current);
@@ -156,13 +156,13 @@ export function useRefreshAtInterval<T>({
         searchVisibilityDidInterrupt.current = true;
         return;
       }
-      refresh();
+      refreshFn();
     }, adjustedIntervalMs);
 
     return () => {
       clearTimeout(timer.current);
     };
-  }, [loading, intervalMs, enabled, refresh]);
+  }, [loading, intervalMs, enabled, refreshFn]);
 
   // Expose the next fire time both as a unix timstamp and as a "seconds" interval
   // so the <QueryRefreshCountdown> can display the number easily.
@@ -174,9 +174,9 @@ export function useRefreshAtInterval<T>({
     () => ({
       nextFireMs,
       nextFireDelay,
-      refetch: refresh,
+      refetch: refreshFn,
     }),
-    [nextFireMs, nextFireDelay, refresh],
+    [nextFireMs, nextFireDelay, refreshFn],
   );
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
@@ -1,8 +1,7 @@
 import {NetworkStatus, ObservableQuery, QueryResult} from '@apollo/client';
 import {RefreshableCountdown, useCountdown} from '@dagster-io/ui-components';
-import {useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
-import {useConstantCallback} from '../hooks/useConstantCallback';
 import {useDocumentVisibility} from '../hooks/useDocumentVisibility';
 import {isSearchVisible, useSearchVisibility} from '../search/useSearchVisibility';
 
@@ -54,9 +53,9 @@ export function useQueryRefreshAtInterval(
   }
 
   const {nextFireMs, nextFireDelay, refetch} = useRefreshAtInterval({
-    async refreshFunction() {
+    refreshFunction: useCallback(async () => {
       return await queryResult?.refetch();
-    },
+    }, [queryResult]),
     intervalMs,
     enabled,
   });
@@ -98,12 +97,12 @@ export function useRefreshAtInterval<T>({
 
   const [loading, setLoading] = useState(false);
 
-  const refresh = useConstantCallback(async () => {
+  const refresh = useCallback(async () => {
     setLoading(true);
     const result = await refreshFunction();
     setLoading(false);
     return result;
-  });
+  }, [refreshFunction]);
 
   useEffect(() => {
     if (!enabled) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -133,7 +133,7 @@ const GlobalAutomaterializationRoot = () => {
     () => {
       const ticks = data?.autoMaterializeTicks;
       return (
-        ticks?.map((tick, index) => {
+        ticks?.slice(100).map((tick, index) => {
           const nextTick = ticks[index - 1];
           // For ticks that get stuck in "Started" state without an endTimestamp.
           if (nextTick && isStuckStartedTick(tick, index)) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -140,7 +140,7 @@ const GlobalAutomaterializationRoot = () => {
         }) ?? []
       );
     },
-    // The allTicks array changes every 2 seconds because we we query every 2 seconds.
+    // The allTicks array changes every 2 seconds because we query every 2 seconds.
     // This would cause everything to re-render, to avoid that we memoize the ticks array that we pass around
     // using the ID and status of the ticks.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -121,10 +121,7 @@ const GlobalAutomaterializationRoot = () => {
   const data = queryResult.data ?? queryResult.previousData;
 
   const allTicks = useMemo(() => {
-    if (data?.sensorOrError.__typename === 'Sensor') {
-      return data.sensorOrError.sensorState.ticks;
-    }
-    return [];
+    return data?.autoMaterializeTicks || [];
   }, [data]);
 
   const ticks = useMemo(
@@ -143,8 +140,9 @@ const GlobalAutomaterializationRoot = () => {
         }) ?? []
       );
     },
+    // memoize by id/status of ticks
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(allTicks)],
+    [JSON.stringify(allTicks.map((tick) => `${tick.id}:${tick.status}`))],
   );
 
   const onHoverTick = useCallback(

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -140,7 +140,9 @@ const GlobalAutomaterializationRoot = () => {
         }) ?? []
       );
     },
-    // memoize by id/status of ticks
+    // The allTicks array changes every 2 seconds because we we query every 2 seconds.
+    // This would cause everything to re-render, to avoid that we memoize the ticks array that we pass around
+    // using the ID and status of the ticks.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [JSON.stringify(allTicks.map((tick) => `${tick.id}:${tick.status}`))],
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -29,7 +29,6 @@ import {useRefreshAtInterval} from '../../app/QueryRefresh';
 import {assertUnreachable} from '../../app/Util';
 import {useTrackPageView} from '../../app/analytics';
 import {InstigationTickStatus} from '../../graphql/types';
-import {useConstantCallback} from '../../hooks/useConstantCallback';
 import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
 import {LiveTickTimeline} from '../../instigation/LiveTickTimeline2';
 import {isStuckStartedTick} from '../../instigation/util';
@@ -93,7 +92,10 @@ const GlobalAutomaterializationRoot = () => {
     fetch({variables: getVariables()});
   }, [fetch, getVariables]);
 
-  const refresh = useConstantCallback(async () => await fetch({variables: getVariables()}));
+  const refresh = useCallback(
+    async () => await fetch({variables: getVariables()}),
+    [fetch, getVariables],
+  );
 
   useRefreshAtInterval({
     refresh,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -122,9 +122,10 @@ const GlobalAutomaterializationRoot = () => {
 
   const ids = data ? data.autoMaterializeTicks.map((tick) => `${tick.id}:${tick.status}`) : [];
   while (ids.length < 100) {
-    // Super hacky but we need to keep the memo args length the same...
-    // And the memo below prevents us from changing the ticks reference every second
-    // which avoids a bunch of re-rendering
+    // Because we refresh this query every 2 seconds, the array changes every 2 seconds.
+    // To avoid re-rendering the whole page every 2 seconds we use the tickID and tickStatus
+    // of the first 100 ticks in order to memoize the ticks array we pass around so that it only
+    // changes if a tick changes or is added/removed.
     ids.push('');
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -65,9 +65,6 @@ const GlobalAutomaterializationRoot = () => {
 
   const {permissions: {canToggleAutoMaterialize} = {}} = useUnscopedPermissions();
 
-  const [fetch, queryResult] = useLazyQuery<AssetDaemonTicksQuery, AssetDaemonTicksQueryVariables>(
-    ASSET_DAEMON_TICKS_QUERY,
-  );
   const [isPaused, setIsPaused] = useState(false);
   const [statuses, setStatuses] = useState<undefined | InstigationTickStatus[]>(undefined);
   const [timeRange, setTimerange] = useState<undefined | [number, number]>(undefined);
@@ -83,14 +80,18 @@ const GlobalAutomaterializationRoot = () => {
       afterTimestamp: (Date.now() - TWENTY_MINUTES) / 1000,
     };
   }, [statuses, timeRange]);
-  function fetchData() {
-    fetch({
-      variables,
-    });
-  }
+
+  const [fetch, queryResult] = useLazyQuery<AssetDaemonTicksQuery, AssetDaemonTicksQueryVariables>(
+    ASSET_DAEMON_TICKS_QUERY,
+    {variables},
+  );
+
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useLayoutEffect(fetchData, [variables]);
-  useQueryRefreshAtInterval(queryResult, 2 * 1000, !isPaused && !timeRange && !statuses, fetchData);
+  useLayoutEffect(() => {
+    fetch({variables});
+  }, [fetch, variables]);
+
+  useQueryRefreshAtInterval(queryResult, 2 * 1000, !isPaused && !timeRange && !statuses);
 
   const [selectedTick, setSelectedTick] = useState<AssetDaemonTickFragment | null>(null);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useConstantCallback.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useConstantCallback.tsx
@@ -1,0 +1,12 @@
+import {useCallback} from 'react';
+
+import {useUpdatingRef} from './useUpdatingRef';
+
+/**
+ * Useful when you want to use a callback inside of a useEffect
+ * but you don't want the callback changing to cause the useEffect to cleanup and rerun the effect.
+ */
+export function useConstantCallback<T extends (...args: any[]) => any>(callback: T): T {
+  const callbackRef = useUpdatingRef(callback);
+  return useCallback((...args: Parameters<T>) => callbackRef.current(...args), [callbackRef]);
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useConstantCallback.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useConstantCallback.tsx
@@ -8,5 +8,5 @@ import {useUpdatingRef} from './useUpdatingRef';
  */
 export function useConstantCallback<T extends (...args: any[]) => any>(callback: T): T {
   const callbackRef = useUpdatingRef(callback);
-  return useCallback((...args: Parameters<T>) => callbackRef.current(...args), [callbackRef]);
+  return useCallback((...args: any[]) => callbackRef.current(...args), [callbackRef]) as T;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
@@ -110,7 +110,10 @@ export const SensorPageAutomaterialize = (props: Props) => {
     return [];
   }, [data]);
 
-  const ids = useMemo(() => allTicks.map((tick) => `${tick.id}:${tick.status}`), [allTicks]);
+  const ids = useMemo(
+    () => allTicks.slice(100).map((tick) => `${tick.id}:${tick.status}`),
+    [allTicks],
+  );
 
   while (ids.length < 100) {
     // Because we refresh this query every 2 seconds, the array changes every 2 seconds.
@@ -137,7 +140,7 @@ export const SensorPageAutomaterialize = (props: Props) => {
       );
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [...ids.slice(0, 100)],
+    ids,
   );
 
   const onHoverTick = useCallback(

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
@@ -126,7 +126,7 @@ export const SensorPageAutomaterialize = (props: Props) => {
         }) ?? []
       );
     },
-    // The allTicks array changes every 2 seconds because we we query every 2 seconds.
+    // The allTicks array changes every 2 seconds because we query every 2 seconds.
     // This would cause everything to re-render, to avoid that we memoize the ticks array that we pass around
     // using the ID and status of the ticks.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
@@ -113,9 +113,10 @@ export const SensorPageAutomaterialize = (props: Props) => {
   const ids = useMemo(() => allTicks.map((tick) => `${tick.id}:${tick.status}`), [allTicks]);
 
   while (ids.length < 100) {
-    // Super hacky but we need to keep the memo args length the same...
-    // And the memo below prevents us from changing the ticks reference every second
-    // which avoids a bunch of re-rendering
+    // Because we refresh this query every 2 seconds, the array changes every 2 seconds.
+    // To avoid re-rendering the whole page every 2 seconds we use the tickID and tickStatus
+    // of the first 100 ticks in order to memoize the ticks array we pass around so that it only
+    // changes if a tick changes or is added/removed.
     ids.push('');
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
@@ -126,7 +126,7 @@ export const SensorPageAutomaterialize = (props: Props) => {
   const ticks = useMemo(
     () => {
       return (
-        allTicks.map((tick, index) => {
+        allTicks.slice(100).map((tick, index) => {
           const nextTick = allTicks[index - 1];
           // For ticks that get stuck in "Started" state without an endTimestamp.
           if (nextTick && isStuckStartedTick(tick, index)) {

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
@@ -110,23 +110,10 @@ export const SensorPageAutomaterialize = (props: Props) => {
     return [];
   }, [data]);
 
-  const ids = useMemo(
-    () => allTicks.slice(100).map((tick) => `${tick.id}:${tick.status}`),
-    [allTicks],
-  );
-
-  while (ids.length < 100) {
-    // Because we refresh this query every 2 seconds, the array changes every 2 seconds.
-    // To avoid re-rendering the whole page every 2 seconds we use the tickID and tickStatus
-    // of the first 100 ticks in order to memoize the ticks array we pass around so that it only
-    // changes if a tick changes or is added/removed.
-    ids.push('');
-  }
-
   const ticks = useMemo(
     () => {
       return (
-        allTicks.slice(100).map((tick, index) => {
+        allTicks.map((tick, index) => {
           const nextTick = allTicks[index - 1];
           // For ticks that get stuck in "Started" state without an endTimestamp.
           if (nextTick && isStuckStartedTick(tick, index)) {
@@ -140,7 +127,7 @@ export const SensorPageAutomaterialize = (props: Props) => {
       );
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    ids,
+    [JSON.stringify(allTicks)],
   );
 
   const onHoverTick = useCallback(

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
@@ -15,7 +15,6 @@ import {AutomaterializeRunHistoryTable} from '../assets/auto-materialization/Aut
 import {SensorAutomaterializationEvaluationHistoryTable} from '../assets/auto-materialization/SensorAutomaterializationEvaluationHistoryTable';
 import {AssetDaemonTickFragment} from '../assets/auto-materialization/types/AssetDaemonTicksQuery.types';
 import {InstigationTickStatus} from '../graphql/types';
-import {useConstantCallback} from '../hooks/useConstantCallback';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {LiveTickTimeline} from '../instigation/LiveTickTimeline2';
 import {isStuckStartedTick} from '../instigation/util';
@@ -76,7 +75,10 @@ export const SensorPageAutomaterialize = (props: Props) => {
     fetch({variables: getVariables()});
   }, [fetch, getVariables]);
 
-  const refresh = useConstantCallback(async () => await fetch({variables: getVariables()}));
+  const refresh = useCallback(
+    async () => await fetch({variables: getVariables()}),
+    [fetch, getVariables],
+  );
 
   useRefreshAtInterval({
     refresh,

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
@@ -126,7 +126,9 @@ export const SensorPageAutomaterialize = (props: Props) => {
         }) ?? []
       );
     },
-    // memoize by id/status of ticks
+    // The allTicks array changes every 2 seconds because we we query every 2 seconds.
+    // This would cause everything to re-render, to avoid that we memoize the ticks array that we pass around
+    // using the ID and status of the ticks.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [JSON.stringify(allTicks.map((tick) => `${tick.id}:${tick.status}`))],
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
@@ -126,8 +126,9 @@ export const SensorPageAutomaterialize = (props: Props) => {
         }) ?? []
       );
     },
+    // memoize by id/status of ticks
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(allTicks)],
+    [JSON.stringify(allTicks.map((tick) => `${tick.id}:${tick.status}`))],
   );
 
   const onHoverTick = useCallback(

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
@@ -41,10 +41,6 @@ export const SensorPageAutomaterialize = (props: Props) => {
   const [statuses, setStatuses] = useState<undefined | InstigationTickStatus[]>(undefined);
   const [timeRange, setTimerange] = useState<undefined | [number, number]>(undefined);
 
-  const [fetch, queryResult] = useLazyQuery<AssetSensorTicksQuery, AssetSensorTicksQueryVariables>(
-    ASSET_SENSOR_TICKS_QUERY,
-  );
-
   const variables: AssetSensorTicksQueryVariables = useMemo(() => {
     if (timeRange || statuses) {
       return {
@@ -68,15 +64,18 @@ export const SensorPageAutomaterialize = (props: Props) => {
     };
   }, [sensor, repoAddress, statuses, timeRange]);
 
-  function fetchData() {
-    fetch({
+  const [fetch, queryResult] = useLazyQuery<AssetSensorTicksQuery, AssetSensorTicksQueryVariables>(
+    ASSET_SENSOR_TICKS_QUERY,
+    {
       variables,
-    });
-  }
+    },
+  );
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useLayoutEffect(fetchData, [variables]);
-  useQueryRefreshAtInterval(queryResult, 2 * 1000, !isPaused && !timeRange && !statuses, fetchData);
+  useLayoutEffect(() => {
+    fetch({variables});
+  }, [fetch, variables]);
+
+  useQueryRefreshAtInterval(queryResult, 2 * 1000, !isPaused && !timeRange && !statuses);
 
   const [selectedTick, setSelectedTick] = useState<AssetDaemonTickFragment | null>(null);
 


### PR DESCRIPTION
## Summary & Motivation

The refresh functionality inside useQueryRefreshAtInterval is generally useful and I want to reuse it outside of the context of apollo queries (in my case it's for webworkers) so I'm moving that functionality into a separate hook 

## How I Tested These Changes

I tested it locally though we should really write a jest test for this file. I visited the SensorAMP and global AMP pages they both refreshed fine.

![Screenshot 2024-03-14 at 12 35 02 PM](https://github.com/dagster-io/dagster/assets/2286579/bfa95e8c-eea3-4fed-9109-36d499c06c6a)
