### PR TITLE
[ui] Fix user-select style warning

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
@@ -9,7 +9,7 @@ export const HeaderCell = ({
   ...rest
 }: React.ComponentProps<typeof CellBox>) => {
   // no text select
-  const clickStyle = onClick ? {cursor: 'pointer', 'user-select': 'none'} : {};
+  const clickStyle = onClick ? {cursor: 'pointer', userSelect: 'none'} : {};
 
   return (
     <CellBox


### PR DESCRIPTION
## Summary & Motivation

Fix a warning related to invalid style key.

## How I Tested These Changes

Verify that the warning goes away when rendering a virtualized table with clickable headers.