### PR TITLE
feat(asset-overview): filter out internal metadata from integration implementations

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventMetadataEntriesTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventMetadataEntriesTable.tsx
@@ -10,7 +10,7 @@ import {
   AssetObservationFragment,
 } from './types/useRecentAssetEvents.types';
 import {Timestamp} from '../app/time/Timestamp';
-import {MetadataEntry} from '../metadata/MetadataEntry';
+import {HIDDEN_METADATA_ENTRY_LABELS, MetadataEntry} from '../metadata/MetadataEntry';
 import {isCanonicalTableSchemaEntry} from '../metadata/TableSchema';
 import {MetadataEntryFragment} from '../metadata/types/MetadataEntry.types';
 import {titleForRun} from '../runs/RunUtils';
@@ -89,9 +89,14 @@ export const AssetEventMetadataEntriesTable = ({
 
   const filteredRows = useMemo(
     () =>
-      allRows
-        .filter((row) => !filter || row.entry.label.toLowerCase().includes(filter.toLowerCase()))
-        .filter((row) => !(hideTableSchema && isCanonicalTableSchemaEntry(row.entry))),
+      allRows.filter(
+        (row) =>
+          !filter ||
+          row.entry.label.toLowerCase().includes(filter.toLowerCase()) ||
+          !HIDDEN_METADATA_ENTRY_LABELS.has(row.entry.label) ||
+          !hideTableSchema ||
+          !isCanonicalTableSchemaEntry(row.entry),
+      ),
     [allRows, filter, hideTableSchema],
   );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMetadata.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMetadata.tsx
@@ -4,7 +4,11 @@ import {Box, MetadataTable} from '@dagster-io/ui-components';
 import {AssetNodeOpMetadataFragment} from './types/AssetMetadata.types';
 import {DAGSTER_TYPE_FRAGMENT} from '../dagstertype/DagsterType';
 import {DagsterTypeFragment} from '../dagstertype/types/DagsterType.types';
-import {METADATA_ENTRY_FRAGMENT, MetadataEntry} from '../metadata/MetadataEntry';
+import {
+  HIDDEN_METADATA_ENTRY_LABELS,
+  METADATA_ENTRY_FRAGMENT,
+  MetadataEntry,
+} from '../metadata/MetadataEntry';
 import {MetadataEntryFragment} from '../metadata/types/MetadataEntry.types';
 
 export const metadataForAssetNode = (
@@ -22,12 +26,14 @@ export const AssetMetadataTable = ({
   assetMetadata: MetadataEntryFragment[];
   repoLocation: string;
 }) => {
-  const rows = assetMetadata.map((entry) => {
-    return {
-      key: entry.label,
-      value: <MetadataEntry entry={entry} repoLocation={repoLocation} />,
-    };
-  });
+  const rows = assetMetadata
+    .filter((entry) => !HIDDEN_METADATA_ENTRY_LABELS.has(entry.label))
+    .map((entry) => {
+      return {
+        key: entry.label,
+        value: <MetadataEntry entry={entry} repoLocation={repoLocation} />,
+      };
+    });
   return (
     <Box padding={{vertical: 16, horizontal: 24}} style={{overflowX: 'auto'}}>
       <MetadataTable rows={rows} />

--- a/js_modules/dagster-ui/packages/ui-core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/metadata/MetadataEntry.tsx
@@ -32,6 +32,14 @@ import {DUNDER_REPO_NAME, buildRepoAddress} from '../workspace/buildRepoAddress'
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 const TIME_FORMAT = {showSeconds: true, showTimezone: true};
+export const HIDDEN_METADATA_ENTRY_LABELS = new Set([
+  'dagster_dbt/select',
+  'dagster_dbt/exclude',
+  'dagster-dbt/select',
+  'dagster-dbt/exclude',
+  'dagster_dbt/manifest',
+  'dagster_dbt/dagster_dbt_translator',
+]);
 
 export const LogRowStructuredContentTable = ({
   rows,
@@ -73,10 +81,12 @@ export const MetadataEntries = ({
   }
   return (
     <LogRowStructuredContentTable
-      rows={entries.map((entry) => ({
-        label: entry.label,
-        item: <MetadataEntry entry={entry} expandSmallValues={expandSmallValues} />,
-      }))}
+      rows={entries
+        .filter((entry) => !HIDDEN_METADATA_ENTRY_LABELS.has(entry.label))
+        .map((entry) => ({
+          label: entry.label,
+          item: <MetadataEntry entry={entry} expandSmallValues={expandSmallValues} />,
+        }))}
     />
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/plugins/generic.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/plugins/generic.tsx
@@ -1,6 +1,7 @@
 import {Button, Dialog, DialogBody, DialogFooter, Icon} from '@dagster-io/ui-components';
 import {useEffect, useState} from 'react';
 
+import {HIDDEN_METADATA_ENTRY_LABELS} from '../metadata/MetadataEntry';
 import {IPluginSidebarProps} from '../plugins';
 
 export const SidebarComponent = (props: IPluginSidebarProps) => {
@@ -13,7 +14,7 @@ export const SidebarComponent = (props: IPluginSidebarProps) => {
   }, []);
 
   const metadata = props.definition.metadata
-    .filter((m) => m.key !== 'kind')
+    .filter((m) => m.key !== 'kind' || !HIDDEN_METADATA_ENTRY_LABELS.has(m.key))
     .sort((a, b) => a.key.localeCompare(b.key));
 
   if (metadata.length === 0) {

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -28,8 +28,10 @@ from dagster._utils.warnings import (
 )
 
 from .asset_utils import (
+    DAGSTER_DBT_EXCLUDE_METADATA_KEY,
+    DAGSTER_DBT_MANIFEST_METADATA_KEY,
+    DAGSTER_DBT_SELECT_METADATA_KEY,
     DAGSTER_DBT_TRANSLATOR_METADATA_KEY,
-    MANIFEST_METADATA_KEY,
     default_asset_check_fn,
     default_code_version_fn,
     get_deps,
@@ -320,21 +322,21 @@ def dbt_assets(
         dagster_dbt_translator=dagster_dbt_translator,
     )
 
-    if op_tags and "dagster-dbt/select" in op_tags:
+    if op_tags and DAGSTER_DBT_SELECT_METADATA_KEY in op_tags:
         raise DagsterInvalidDefinitionError(
-            "To specify a dbt selection, use the 'select' argument, not 'dagster-dbt/select'"
+            f"To specify a dbt selection, use the 'select' argument, not '{DAGSTER_DBT_SELECT_METADATA_KEY}'"
             " with op_tags"
         )
 
-    if op_tags and "dagster-dbt/exclude" in op_tags:
+    if op_tags and DAGSTER_DBT_EXCLUDE_METADATA_KEY in op_tags:
         raise DagsterInvalidDefinitionError(
-            "To specify a dbt exclusion, use the 'exclude' argument, not 'dagster-dbt/exclude'"
+            f"To specify a dbt exclusion, use the 'exclude' argument, not '{DAGSTER_DBT_EXCLUDE_METADATA_KEY}'"
             " with op_tags"
         )
 
     resolved_op_tags = {
-        **({"dagster-dbt/select": select} if select else {}),
-        **({"dagster-dbt/exclude": exclude} if exclude else {}),
+        **({DAGSTER_DBT_SELECT_METADATA_KEY: select} if select else {}),
+        **({DAGSTER_DBT_EXCLUDE_METADATA_KEY: exclude} if exclude else {}),
         **(op_tags if op_tags else {}),
     }
 
@@ -404,7 +406,7 @@ def get_dbt_multi_asset_args(
             is_required=False,
             metadata={  # type: ignore
                 **dagster_dbt_translator.get_metadata(dbt_resource_props),
-                MANIFEST_METADATA_KEY: DbtManifestWrapper(manifest=manifest),
+                DAGSTER_DBT_MANIFEST_METADATA_KEY: DbtManifestWrapper(manifest=manifest),
                 DAGSTER_DBT_TRANSLATOR_METADATA_KEY: dagster_dbt_translator,
             },
             group_name=dagster_dbt_translator.get_group_name(dbt_resource_props),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -46,8 +46,10 @@ from .utils import ASSET_RESOURCE_TYPES, dagster_name_fn
 if TYPE_CHECKING:
     from .dagster_dbt_translator import DagsterDbtTranslator, DbtManifestWrapper
 
-MANIFEST_METADATA_KEY = "dagster_dbt/manifest"
+DAGSTER_DBT_MANIFEST_METADATA_KEY = "dagster_dbt/manifest"
 DAGSTER_DBT_TRANSLATOR_METADATA_KEY = "dagster_dbt/dagster_dbt_translator"
+DAGSTER_DBT_SELECT_METADATA_KEY = "dagster_dbt/select"
+DAGSTER_DBT_EXCLUDE_METADATA_KEY = "dagster_dbt/exclude"
 
 
 def get_asset_key_for_model(dbt_assets: Sequence[AssetsDefinition], model_name: str) -> AssetKey:
@@ -304,7 +306,9 @@ def get_manifest_and_translator_from_dbt_assets(
     metadata_by_key = dbt_assets_def.metadata_by_key or {}
     first_asset_key = next(iter(dbt_assets_def.metadata_by_key.keys()))
     first_metadata = metadata_by_key.get(first_asset_key, {})
-    manifest_wrapper: Optional["DbtManifestWrapper"] = first_metadata.get(MANIFEST_METADATA_KEY)
+    manifest_wrapper: Optional["DbtManifestWrapper"] = first_metadata.get(
+        DAGSTER_DBT_MANIFEST_METADATA_KEY
+    )
     if manifest_wrapper is None:
         raise DagsterInvariantViolationError(
             f"Expected to find dbt manifest metadata on asset {first_asset_key.to_user_string()},"
@@ -696,7 +700,9 @@ def get_asset_deps(
         metadata = merge_dicts(
             dagster_dbt_translator.get_metadata(dbt_resource_props),
             {
-                MANIFEST_METADATA_KEY: DbtManifestWrapper(manifest=manifest) if manifest else None,
+                DAGSTER_DBT_MANIFEST_METADATA_KEY: DbtManifestWrapper(manifest=manifest)
+                if manifest
+                else None,
                 DAGSTER_DBT_TRANSLATOR_METADATA_KEY: dagster_dbt_translator,
             },
         )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -46,6 +46,8 @@ from pydantic import Field, validator
 from typing_extensions import Literal
 
 from ..asset_utils import (
+    DAGSTER_DBT_EXCLUDE_METADATA_KEY,
+    DAGSTER_DBT_SELECT_METADATA_KEY,
     dagster_name_fn,
     default_metadata_from_dbt_resource_props,
     get_manifest_and_translator_from_dbt_assets,
@@ -1037,8 +1039,8 @@ class DbtCliResource(ConfigurableResource):
             selection_args = get_subset_selection_for_context(
                 context=context,
                 manifest=manifest,
-                select=context.op.tags.get("dagster-dbt/select"),
-                exclude=context.op.tags.get("dagster-dbt/exclude"),
+                select=context.op.tags.get(DAGSTER_DBT_SELECT_METADATA_KEY),
+                exclude=context.op.tags.get(DAGSTER_DBT_EXCLUDE_METADATA_KEY),
                 dagster_dbt_translator=dagster_dbt_translator,
             )
         else:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -208,8 +208,8 @@ def test_selections(
     expected_asset_keys = {AssetKey(key) for key in expected_dbt_resource_names}
 
     assert my_dbt_assets.keys == expected_asset_keys
-    assert my_dbt_assets.op.tags.get("dagster-dbt/select") == select
-    assert my_dbt_assets.op.tags.get("dagster-dbt/exclude") == exclude
+    assert my_dbt_assets.op.tags.get("dagster_dbt/select") == select
+    assert my_dbt_assets.op.tags.get("dagster_dbt/exclude") == exclude
 
 
 @pytest.mark.parametrize("name", [None, "custom"])
@@ -310,7 +310,7 @@ def test_op_tags(test_jaffle_shop_manifest: Dict[str, Any]):
     assert my_dbt_assets.op.tags == {
         **op_tags,
         "kind": "dbt",
-        "dagster-dbt/select": "fqn:*",
+        "dagster_dbt/select": "fqn:*",
     }
 
     @dbt_assets(manifest=test_jaffle_shop_manifest, op_tags=op_tags, select="raw_customers+")
@@ -319,7 +319,7 @@ def test_op_tags(test_jaffle_shop_manifest: Dict[str, Any]):
     assert my_dbt_assets_with_select.op.tags == {
         **op_tags,
         "kind": "dbt",
-        "dagster-dbt/select": "raw_customers+",
+        "dagster_dbt/select": "raw_customers+",
     }
 
     @dbt_assets(manifest=test_jaffle_shop_manifest, op_tags=op_tags, exclude="raw_customers+")
@@ -328,8 +328,8 @@ def test_op_tags(test_jaffle_shop_manifest: Dict[str, Any]):
     assert my_dbt_assets_with_exclude.op.tags == {
         **op_tags,
         "kind": "dbt",
-        "dagster-dbt/select": "fqn:*",
-        "dagster-dbt/exclude": "raw_customers+",
+        "dagster_dbt/select": "fqn:*",
+        "dagster_dbt/exclude": "raw_customers+",
     }
 
     @dbt_assets(
@@ -343,35 +343,35 @@ def test_op_tags(test_jaffle_shop_manifest: Dict[str, Any]):
     assert my_dbt_assets_with_select_and_exclude.op.tags == {
         **op_tags,
         "kind": "dbt",
-        "dagster-dbt/select": "raw_customers+",
-        "dagster-dbt/exclude": "customers",
+        "dagster_dbt/select": "raw_customers+",
+        "dagster_dbt/exclude": "customers",
     }
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=(
-            "To specify a dbt selection, use the 'select' argument, not 'dagster-dbt/select'"
+            "To specify a dbt selection, use the 'select' argument, not 'dagster_dbt/select'"
             " with op_tags"
         ),
     ):
 
         @dbt_assets(
             manifest=test_jaffle_shop_manifest,
-            op_tags={"dagster-dbt/select": "raw_customers+"},
+            op_tags={"dagster_dbt/select": "raw_customers+"},
         )
         def select_tag(): ...
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=(
-            "To specify a dbt exclusion, use the 'exclude' argument, not 'dagster-dbt/exclude'"
+            "To specify a dbt exclusion, use the 'exclude' argument, not 'dagster_dbt/exclude'"
             " with op_tags"
         ),
     ):
 
         @dbt_assets(
             manifest=test_jaffle_shop_manifest,
-            op_tags={"dagster-dbt/exclude": "raw_customers+"},
+            op_tags={"dagster_dbt/exclude": "raw_customers+"},
         )
         def exclude_tag(): ...
 


### PR DESCRIPTION
## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/16851.

More shenanigans -- filter out metadata that's specific to integration logic (e.g. `dagster-dbt`) in the frontend. Not particularly happy with this implementation since it's prone to error if we forget to filter any component that displays metadata in our app, but we can decide on another longer-term solution in the future (e.g. a `HiddenMetadataEntry` type?)



## How I Tested These Changes
See `dagster_dbt/manifest` and `dagster_dbt/dagster_dbt_translator` omitted from the asset overview metadata.

<img width="1429" alt="Screenshot 2024-03-14 at 6 32 15 PM" src="https://github.com/dagster-io/dagster/assets/16431325/ca66ef74-1712-4024-93fc-39fd6bd96060">

