### PR TITLE
[Asset graph] Fix branch status tag overlapping with compute kind tag

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -2,6 +2,7 @@ import * as dagre from 'dagre';
 
 import {GraphData, GraphId, GraphNode, groupIdForNode, isGroupId} from './Utils';
 import {IBounds, IPoint} from '../graph/common';
+import {ChangeReason} from '../graphql/types';
 
 export type AssetLayoutDirection = 'vertical' | 'horizontal';
 
@@ -286,6 +287,7 @@ export const getAssetNodeDimensions = (def: {
   graphName: string | null;
   description?: string | null;
   computeKind: string | null;
+  changedReasons?: ChangeReason[];
 }) => {
   const width = 320;
 
@@ -298,6 +300,9 @@ export const getAssetNodeDimensions = (def: {
     if (def.isPartitioned) {
       height += 40;
     }
+  }
+  if (def.changedReasons?.length) {
+    height += 30;
   }
 
   height += 30; // tags beneath

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -15,7 +15,7 @@ import {
 const ASYNC_LAYOUT_SOLID_COUNT = 50;
 
 // If you're working on the layout logic, set to false so hot-reloading re-computes the layout
-const CACHING_ENABLED = false;
+const CACHING_ENABLED = true;
 
 // Op Graph
 
@@ -66,7 +66,7 @@ const _assetLayoutCacheKey = (graphData: GraphData, opts: LayoutAssetGraphOption
   }
 
   return `${JSON.stringify(opts)}${JSON.stringify({
-    version: 1,
+    version: 2,
     downstream: recreateObjectWithKeysSorted(graphData.downstream),
     upstream: recreateObjectWithKeysSorted(graphData.upstream),
     nodes: Object.keys(graphData.nodes)

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -15,7 +15,7 @@ import {
 const ASYNC_LAYOUT_SOLID_COUNT = 50;
 
 // If you're working on the layout logic, set to false so hot-reloading re-computes the layout
-const CACHING_ENABLED = true;
+const CACHING_ENABLED = false;
 
 // Op Graph
 


### PR DESCRIPTION


## How I Tested These Changes

before:
<img width="401" alt="Screenshot 2024-03-14 at 6 41 35 PM" src="https://github.com/dagster-io/dagster/assets/2286579/8b92ba81-4066-4f95-aca1-3aee00eea3b9">


after:
<img width="408" alt="Screenshot 2024-03-14 at 6 42 14 PM" src="https://github.com/dagster-io/dagster/assets/2286579/f0b94d12-6a9f-4992-94ef-e667b3f46a00">
