### PR TITLE
AssetCheckResult.description

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckDetailModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckDetailModal.tsx
@@ -58,6 +58,7 @@ export const ASSET_CHECK_EXECUTION_FRAGMENT = gql`
     evaluation {
       severity
       timestamp
+      description
       targetMaterialization {
         timestamp
         runId

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -295,6 +295,11 @@ export const AssetChecks = ({
               headerWrapperProps={headerWrapperProps}
               arrowSide="right"
             >
+              {lastExecution?.evaluation?.description ? (
+                <Box padding={{top: 12}} flex={{gap: 12, direction: 'column'}}>
+                  <Body2>{lastExecution.evaluation.description}</Body2>
+                </Box>
+              ) : null}
               <Box padding={{top: 12}} flex={{direction: 'column', gap: 12}}>
                 <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 24}}>
                   <Box flex={{direction: 'column', gap: 6}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetCheckDetailModal.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetCheckDetailModal.types.ts
@@ -13,6 +13,7 @@ export type AssetCheckExecutionFragment = {
     __typename: 'AssetCheckEvaluation';
     severity: Types.AssetCheckSeverity;
     timestamp: number;
+    description: string | null;
     targetMaterialization: {
       __typename: 'AssetCheckEvaluationTargetMaterializationData';
       timestamp: number;
@@ -163,6 +164,7 @@ export type AssetCheckDetailsQuery = {
       __typename: 'AssetCheckEvaluation';
       severity: Types.AssetCheckSeverity;
       timestamp: number;
+      description: string | null;
       targetMaterialization: {
         __typename: 'AssetCheckEvaluationTargetMaterializationData';
         timestamp: number;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
@@ -35,6 +35,7 @@ export type AssetChecksQuery = {
                     __typename: 'AssetCheckEvaluation';
                     severity: Types.AssetCheckSeverity;
                     timestamp: number;
+                    description: string | null;
                     targetMaterialization: {
                       __typename: 'AssetCheckEvaluationTargetMaterializationData';
                       timestamp: number;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/VirtualizedAssetCheckTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/VirtualizedAssetCheckTable.types.ts
@@ -18,6 +18,7 @@ export type AssetCheckTableFragment = {
       __typename: 'AssetCheckEvaluation';
       severity: Types.AssetCheckSeverity;
       timestamp: number;
+      description: string | null;
       targetMaterialization: {
         __typename: 'AssetCheckEvaluationTargetMaterializationData';
         timestamp: number;

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -927,6 +927,7 @@ type AssetCheckEvaluation {
   targetMaterialization: AssetCheckEvaluationTargetMaterializationData
   metadataEntries: [MetadataEntry!]!
   severity: AssetCheckSeverity!
+  description: String
   success: Boolean!
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -163,6 +163,7 @@ export type AssetCheckEvaluation = {
   __typename: 'AssetCheckEvaluation';
   assetKey: AssetKey;
   checkName: Scalars['String']['output'];
+  description: Maybe<Scalars['String']['output']>;
   metadataEntries: Array<
     | AssetMetadataEntry
     | BoolMetadataEntry
@@ -5670,6 +5671,8 @@ export const buildAssetCheckEvaluation = (
         ? ({} as AssetKey)
         : buildAssetKey({}, relationshipsToOmit),
     checkName: overrides && overrides.hasOwnProperty('checkName') ? overrides.checkName! : 'sed',
+    description:
+      overrides && overrides.hasOwnProperty('description') ? overrides.description! : 'quia',
     metadataEntries:
       overrides && overrides.hasOwnProperty('metadataEntries') ? overrides.metadataEntries! : [],
     severity:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -59,6 +59,7 @@ class GrapheneAssetCheckEvaluation(graphene.ObjectType):
     targetMaterialization = graphene.Field(GrapheneAssetCheckEvaluationTargetMaterializationData)
     metadataEntries = non_null_list(GrapheneMetadataEntry)
     severity = graphene.NonNull(GrapheneAssetCheckSeverity)
+    description = graphene.String()
 
     # NOTE: this should be renamed passed
     success = graphene.NonNull(graphene.Boolean)
@@ -85,6 +86,7 @@ class GrapheneAssetCheckEvaluation(graphene.ObjectType):
         self.success = evaluation_data.passed
         self.checkName = evaluation_data.check_name
         self.assetKey = evaluation_data.asset_key
+        self.description = evaluation_data.description
 
 
 class GrapheneAssetCheckExecution(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -87,6 +87,7 @@ query GetAssetChecksQuery($assetKey: AssetKeyInput!, $checkName: String!) {
             metadataEntries {
                 label
             }
+            description
         }
     }
 }
@@ -475,6 +476,7 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                         storage_id=42, run_id="bizbuz", timestamp=3.3
                     ),
                     severity=AssetCheckSeverity.ERROR,
+                    description="evaluation description",
                 ),
                 timestamp=evaluation_timestamp,
             )
@@ -501,6 +503,7 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                         "metadataEntries": [
                             {"label": "foo"},
                         ],
+                        "description": "evaluation description",
                     },
                 }
             ],

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_evaluation.py
@@ -66,6 +66,7 @@ class AssetCheckEvaluation(
                 Optional[AssetCheckEvaluationTargetMaterializationData],
             ),
             ("severity", AssetCheckSeverity),
+            ("description", Optional[str]),
         ],
     )
 ):
@@ -86,6 +87,8 @@ class AssetCheckEvaluation(
             The latest materialization at execution time of the check.
         severity (AssetCheckSeverity):
             Severity of the check result.
+        description (Optional[str]):
+            A text description of the result of the check evaluation.
     """
 
     def __new__(
@@ -96,6 +99,7 @@ class AssetCheckEvaluation(
         metadata: Mapping[str, MetadataValue],
         target_materialization_data: Optional[AssetCheckEvaluationTargetMaterializationData] = None,
         severity: AssetCheckSeverity = AssetCheckSeverity.ERROR,
+        description: Optional[str] = None,
     ):
         return super(AssetCheckEvaluation, cls).__new__(
             cls,
@@ -109,6 +113,7 @@ class AssetCheckEvaluation(
                 AssetCheckEvaluationTargetMaterializationData,
             ),
             severity=check.inst_param(severity, "severity", AssetCheckSeverity),
+            description=check.opt_str_param(description, "description"),
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
@@ -30,6 +30,7 @@ class AssetCheckResult(
             ("check_name", PublicAttr[Optional[str]]),
             ("metadata", PublicAttr[Mapping[str, MetadataValue]]),
             ("severity", PublicAttr[AssetCheckSeverity]),
+            ("description", PublicAttr[Optional[str]]),
         ],
     )
 ):
@@ -48,7 +49,8 @@ class AssetCheckResult(
             list, and one of the data classes returned by a MetadataValue static method.
         severity (AssetCheckSeverity):
             Severity of the check. Defaults to ERROR.
-
+        description (Optional[str]):
+            A text description of the result of the check evaluation.
     """
 
     def __new__(
@@ -59,6 +61,7 @@ class AssetCheckResult(
         check_name: Optional[str] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         severity: AssetCheckSeverity = AssetCheckSeverity.ERROR,
+        description: Optional[str] = None,
     ):
         normalized_metadata = normalize_metadata(
             check.opt_mapping_param(metadata, "metadata", key_type=str),
@@ -70,6 +73,7 @@ class AssetCheckResult(
             passed=check.bool_param(passed, "passed"),
             metadata=normalized_metadata,
             severity=check.inst_param(severity, "severity", AssetCheckSeverity),
+            description=check.opt_str_param(description, "description"),
         )
 
     def to_asset_check_evaluation(
@@ -149,6 +153,7 @@ class AssetCheckResult(
             metadata=self.metadata,
             target_materialization_data=target_materialization_data,
             severity=self.severity,
+            description=self.description,
         )
 
     def get_spec_python_identifier(


### PR DESCRIPTION
## Summary & Motivation

Adds an optional description field to `AssetCheckResult`.

Here's an evaluation where the description is "The check failed"

<img width="1163" alt="image" src="https://github.com/dagster-io/dagster/assets/654855/54055dfc-bea9-4808-9ec7-69702e975d1c">

Followup work would be to include it in the execution history table somehow.

## How I Tested These Changes
