### PR TITLE
[Asset graph] Gate unsynced status tag on upstream staleCauses

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -177,7 +177,7 @@ export const AssetNodeMinimal = ({
   const displayName = assetKey.path[assetKey.path.length - 1]!;
 
   const isChanged = definition.changedReasons.length;
-  const isStale = isAssetStale(liveData);
+  const isStale = isAssetStale(assetKey, liveData, 'upstream');
 
   return (
     <AssetInsetForHoverEffect>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/CalculateChangedAndMissingDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/CalculateChangedAndMissingDialog.tsx
@@ -55,7 +55,7 @@ export const CalculateChangedAndMissingDialog = React.memo(
     const staleOrMissing = React.useMemo(
       () =>
         data?.assetNodes
-          .filter((node) => isAssetStale(node) || isAssetMissing(node))
+          .filter((node) => isAssetStale(node.assetKey, node, 'all') || isAssetMissing(node))
           .map(asAssetKeyInput),
       [data],
     );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
@@ -125,10 +125,12 @@ export const StaleReasonsTag = ({
   include?: 'all' | 'upstream' | 'self';
   onClick?: () => void;
 }) => {
-  if (!isAssetStale(assetKey, liveData, 'upstream') || !liveData?.staleCauses?.length) {
+  const grouped = groupedCauses(assetKey, include, liveData);
+  const totalCauses = Object.values(grouped).reduce((s, g) => s + g.length, 0);
+  if (!totalCauses) {
     return <div />;
   }
-  const label = <Caption>Unsynced ({numberFormatter.format(liveData.staleCauses.length)})</Caption>;
+  const label = <Caption>Unsynced ({numberFormatter.format(totalCauses)})</Caption>;
   return (
     <Box
       flex={{gap: 4, alignItems: 'center', justifyContent: 'space-between'}}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
@@ -79,7 +79,9 @@ export const StaleReasonsLabel = ({
   include: 'all' | 'upstream' | 'self';
   liveData?: StaleDataForNode;
 }) => {
-  if (!isAssetStale(liveData) || !liveData?.staleCauses?.length) {
+  const grouped = groupedCauses(assetKey, include, liveData);
+  const totalCauses = Object.values(grouped).reduce((s, g) => s + g.length, 0);
+  if (!isAssetStale(liveData) || !totalCauses) {
     return null;
   }
 
@@ -191,10 +193,10 @@ const StaleCausesPopoverSummary = ({
   include?: 'all' | 'upstream' | 'self';
 }) => {
   const grouped = groupedCauses(assetKey, include, liveData);
-  const totalCauses = liveData?.staleCauses?.length;
+  const totalCauses = Object.values(grouped).reduce((s, g) => s + g.length, 0);
 
   if (!totalCauses) {
-    // Should never happen since the parent of this component should check that the asset is stale before rendering the popover
+    // Can happen if the parent didn't checked the grouped causes
     return <div />;
   }
   return (


### PR DESCRIPTION
## Summary & Motivation

We're currently showing Unsynced tags with empty popovers. This is due to a bug where the popover logic counts staleCauses.length while the popover body uses the `groupedCauses` function to filter out causes that aren't due to immediate upstream dependencies and ends up rendering an empty dialog

## How I Tested These Changes

shadow dagit:

<img width="690" alt="Screenshot 2024-03-14 at 11 55 39 PM" src="https://github.com/dagster-io/dagster/assets/2286579/a36ca27a-95c3-4d08-9ec2-ae0a50af4731">
