### PR TITLE
[external-assets] Consolidate asset job construction

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
@@ -17642,29 +17642,6 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Selector.2571019f1a5201853d11032145ac3e534067f214": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "env",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.2571019f1a5201853d11032145ac3e534067f214",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
         "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -17948,73 +17925,41 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851": {
+        "Shape.22ef5f214708cb30cd4940652ff6f8f900c765d6": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
           "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "dummy_io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": false,
               "default_value_as_json_str": null,
               "description": null,
-              "is_required": false,
-              "name": "base_dir",
-              "type_key": "StringSourceType"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.430bb6ff8d203ca0ff0a224523b286e0109da95e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"output_then_hang_asset\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.e04fad9a05c90983540f9c3eb316ede838d946e2"
+              "is_required": true,
+              "name": "hanging_asset_resource",
+              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
             },
             {
               "__class__": "ConfigFieldSnap",
               "default_provided": false,
               "default_value_as_json_str": null,
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": true,
-              "name": "resources",
-              "type_key": "Shape.fe21c8e7bb74501f89b285a2b35a543f648db2c8"
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
             }
           ],
           "given_name": null,
-          "key": "Shape.430bb6ff8d203ca0ff0a224523b286e0109da95e",
+          "key": "Shape.22ef5f214708cb30cd4940652ff6f8f900c765d6",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -18047,29 +17992,6 @@
           ],
           "given_name": null,
           "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f2a71367507edd1b8e64f739222c4312b3691b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -18168,6 +18090,56 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
+        "Shape.cb9d09e190ef60d4174654b8fc26e7574f87d657": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"output_then_hang_asset\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.e04fad9a05c90983540f9c3eb316ede838d946e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": true,
+              "name": "resources",
+              "type_key": "Shape.22ef5f214708cb30cd4940652ff6f8f900c765d6"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.cb9d09e190ef60d4174654b8fc26e7574f87d657",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
         "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -18227,47 +18199,6 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.fe21c8e7bb74501f89b285a2b35a543f648db2c8": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "dummy_io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "hanging_asset_resource",
-              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.fe21c8e7bb74501f89b285a2b35a543f648db2c8",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
         "String": {
           "__class__": "ConfigTypeSnap",
           "description": "",
@@ -18282,22 +18213,6 @@
             "__enum__": "ConfigScalarKind.STRING"
           },
           "type_param_keys": null
-        },
-        "StringSourceType": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "StringSourceType",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.2571019f1a5201853d11032145ac3e534067f214"
-          ]
         }
       }
     },
@@ -18460,18 +18375,18 @@
             "__class__": "ResourceDefSnap",
             "config_field_snap": {
               "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
+              "default_provided": false,
+              "default_value_as_json_str": null,
               "description": null,
               "is_required": false,
               "name": "config",
-              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
+              "type_key": "Any"
             },
             "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.430bb6ff8d203ca0ff0a224523b286e0109da95e"
+        "root_config_key": "Shape.cb9d09e190ef60d4174654b8fc26e7574f87d657"
       }
     ],
     "name": "output_then_hang_job",
@@ -18515,7 +18430,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[123]
-  '4b80803d1f02acb0a6b7b3872f69b4fb84ecc372'
+  '557106a5e60ddca8f667e9daae445616f1f6a120'
 # ---
 # name: test_all_snapshot_ids[124]
   '''
@@ -82479,29 +82394,6 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Selector.2571019f1a5201853d11032145ac3e534067f214": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "env",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.2571019f1a5201853d11032145ac3e534067f214",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
         "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -82785,23 +82677,41 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851": {
+        "Shape.22ef5f214708cb30cd4940652ff6f8f900c765d6": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
           "fields": [
             {
               "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "dummy_io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
               "default_provided": false,
               "default_value_as_json_str": null,
               "description": null,
+              "is_required": true,
+              "name": "hanging_asset_resource",
+              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
               "is_required": false,
-              "name": "base_dir",
-              "type_key": "StringSourceType"
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
             }
           ],
           "given_name": null,
-          "key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851",
+          "key": "Shape.22ef5f214708cb30cd4940652ff6f8f900c765d6",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -82834,29 +82744,6 @@
           ],
           "given_name": null,
           "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f2a71367507edd1b8e64f739222c4312b3691b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -82973,7 +82860,30 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.a326b823cd55ceb4ff54d05110b5a151ccb88256": {
+        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.d2db998e4d71c26f79f25441c3708db8054e80ad": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -83012,34 +82922,11 @@
               "description": "Configure how shared resources are implemented within a run.",
               "is_required": true,
               "name": "resources",
-              "type_key": "Shape.fe21c8e7bb74501f89b285a2b35a543f648db2c8"
+              "type_key": "Shape.22ef5f214708cb30cd4940652ff6f8f900c765d6"
             }
           ],
           "given_name": null,
-          "key": "Shape.a326b823cd55ceb4ff54d05110b5a151ccb88256",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
+          "key": "Shape.d2db998e4d71c26f79f25441c3708db8054e80ad",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -83082,47 +82969,6 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.fe21c8e7bb74501f89b285a2b35a543f648db2c8": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "dummy_io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "hanging_asset_resource",
-              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.fe21c8e7bb74501f89b285a2b35a543f648db2c8",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
         "String": {
           "__class__": "ConfigTypeSnap",
           "description": "",
@@ -83137,22 +82983,6 @@
             "__enum__": "ConfigScalarKind.STRING"
           },
           "type_param_keys": null
-        },
-        "StringSourceType": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "StringSourceType",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.2571019f1a5201853d11032145ac3e534067f214"
-          ]
         }
       }
     },
@@ -83364,18 +83194,18 @@
             "__class__": "ResourceDefSnap",
             "config_field_snap": {
               "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
+              "default_provided": false,
+              "default_value_as_json_str": null,
               "description": null,
               "is_required": false,
               "name": "config",
-              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
+              "type_key": "Any"
             },
             "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.a326b823cd55ceb4ff54d05110b5a151ccb88256"
+        "root_config_key": "Shape.d2db998e4d71c26f79f25441c3708db8054e80ad"
       }
     ],
     "name": "hanging_job",
@@ -83494,7 +83324,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[67]
-  '7fc9ecf0bc0dbc8402952dc97591120430ac6420'
+  '065b896532a7dc8172d7865d74f08375cb96ce96'
 # ---
 # name: test_all_snapshot_ids[68]
   '''
@@ -83651,29 +83481,6 @@
           ],
           "given_name": null,
           "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.2571019f1a5201853d11032145ac3e534067f214": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "env",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.2571019f1a5201853d11032145ac3e534067f214",
           "kind": {
             "__enum__": "ConfigTypeKind.SELECTOR"
           },
@@ -83963,23 +83770,41 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851": {
+        "Shape.22ef5f214708cb30cd4940652ff6f8f900c765d6": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
           "fields": [
             {
               "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "dummy_io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
               "default_provided": false,
               "default_value_as_json_str": null,
               "description": null,
+              "is_required": true,
+              "name": "hanging_asset_resource",
+              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
               "is_required": false,
-              "name": "base_dir",
-              "type_key": "StringSourceType"
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
             }
           ],
           "given_name": null,
-          "key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851",
+          "key": "Shape.22ef5f214708cb30cd4940652ff6f8f900c765d6",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -84018,29 +83843,6 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.44f2a71367507edd1b8e64f739222c4312b3691b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
         "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -84058,6 +83860,56 @@
           ],
           "given_name": null,
           "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.61075519d5493bc5cb6d2b807c37dbbdf5eb7336": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"hanging_partition_asset\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.7ea9921167c0a52e9ed3dfad987582ffc796e7eb"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": true,
+              "name": "resources",
+              "type_key": "Shape.22ef5f214708cb30cd4940652ff6f8f900c765d6"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.61075519d5493bc5cb6d2b807c37dbbdf5eb7336",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -84192,97 +84044,6 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
-        "Shape.fb6432983a93b4ab0b9e56382730add4bfd61acf": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"hanging_partition_asset\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.7ea9921167c0a52e9ed3dfad987582ffc796e7eb"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": true,
-              "name": "resources",
-              "type_key": "Shape.fe21c8e7bb74501f89b285a2b35a543f648db2c8"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.fb6432983a93b4ab0b9e56382730add4bfd61acf",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.fe21c8e7bb74501f89b285a2b35a543f648db2c8": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "dummy_io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "hanging_asset_resource",
-              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.fe21c8e7bb74501f89b285a2b35a543f648db2c8",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
         "String": {
           "__class__": "ConfigTypeSnap",
           "description": "",
@@ -84297,22 +84058,6 @@
             "__enum__": "ConfigScalarKind.STRING"
           },
           "type_param_keys": null
-        },
-        "StringSourceType": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "StringSourceType",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.2571019f1a5201853d11032145ac3e534067f214"
-          ]
         }
       }
     },
@@ -84475,18 +84220,18 @@
             "__class__": "ResourceDefSnap",
             "config_field_snap": {
               "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
+              "default_provided": false,
+              "default_value_as_json_str": null,
               "description": null,
               "is_required": false,
               "name": "config",
-              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
+              "type_key": "Any"
             },
             "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.fb6432983a93b4ab0b9e56382730add4bfd61acf"
+        "root_config_key": "Shape.61075519d5493bc5cb6d2b807c37dbbdf5eb7336"
       }
     ],
     "name": "hanging_partition_asset_job",
@@ -84530,7 +84275,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[69]
-  '49dfd6286f91dfab3f7d37ea95b6ffa0d3f662be'
+  'd0700b0d774bc626fd21c3e043778dc00e050e9b'
 # ---
 # name: test_all_snapshot_ids[6]
   '''

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -992,9 +992,10 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
         assert result.data["launchPipelineExecution"]["__typename"] == "InvalidSubsetError"
         assert (
             result.data["launchPipelineExecution"]["message"]
-            == "dagster._core.errors.DagsterInvalidSubsetError: Asset checks provided in"
-            " asset_check_selection argument AssetCheckKey(asset_key=AssetKey(['asset_1']),"
-            " name='non-existent-check') do not exist in parent asset group or job.\n"
+            == "dagster._core.errors.DagsterInvalidSubsetError: AssetCheckKey(s)"
+            " ['asset_1:non-existent-check'] were selected, but no definitions supply these keys."
+            " Make sure all keys are spelled correctly, and all definitions are correctly added to"
+            " the `Definitions`.\n"
         )
 
     def test_launch_subset_asset_no_check(self, graphql_context: WorkspaceRequestContext):

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
-    Any,
     Callable,
     Dict,
     Iterable,
@@ -13,40 +12,28 @@ from typing import (
     Sequence,
     Set,
     Tuple,
-    Union,
     cast,
 )
 
 import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSpec
-from dagster._core.definitions.hook_definition import HookDefinition
-from dagster._core.definitions.metadata import (
-    RawMetadataValue,
-)
-from dagster._core.selector.subset_selector import AssetSelectionData
 
 from ..errors import (
-    DagsterInvalidSubsetError,
     DagsterInvariantViolationError,
 )
-from .config import ConfigMapping
 from .dependency import NodeHandle, NodeInputHandle, NodeOutput, NodeOutputHandle
 from .events import AssetKey
-from .executor_definition import ExecutorDefinition
 from .graph_definition import GraphDefinition
 from .node_definition import NodeDefinition
-from .policy import RetryPolicy
-from .resource_definition import ResourceDefinition
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_graph import AssetGraph, AssetNode
-    from dagster._core.definitions.assets import AssetsDefinition, SourceAsset
+    from dagster._core.definitions.assets import AssetsDefinition
     from dagster._core.definitions.base_asset_graph import AssetKeyOrCheckKey
-    from dagster._core.definitions.job_definition import JobDefinition
     from dagster._core.definitions.partition_mapping import PartitionMapping
     from dagster._core.execution.context.output import OutputContext
 
-    from .partition import PartitionedConfig, PartitionsDefinition
+    from .partition import PartitionsDefinition
 
 
 class AssetOutputInfo(
@@ -684,144 +671,3 @@ class AssetLayer(NamedTuple):
         return self.dep_asset_keys_by_node_output_handle.get(
             NodeOutputHandle(node_handle, output_name), set()
         )
-
-
-def build_asset_selection_job(
-    name: str,
-    assets: Iterable["AssetsDefinition"],
-    executor_def: Optional[ExecutorDefinition] = None,
-    config: Optional[Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig"]] = None,
-    partitions_def: Optional["PartitionsDefinition"] = None,
-    resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
-    description: Optional[str] = None,
-    tags: Optional[Mapping[str, Any]] = None,
-    metadata: Optional[Mapping[str, RawMetadataValue]] = None,
-    asset_selection: Optional[AbstractSet[AssetKey]] = None,
-    asset_check_selection: Optional[AbstractSet[AssetCheckKey]] = None,
-    asset_selection_data: Optional[AssetSelectionData] = None,
-    hooks: Optional[AbstractSet[HookDefinition]] = None,
-    op_retry_policy: Optional[RetryPolicy] = None,
-) -> "JobDefinition":
-    from dagster._core.definitions.asset_graph import AssetGraph
-    from dagster._core.definitions.assets_job import build_assets_job
-    from dagster._core.definitions.external_asset import (
-        create_unexecutable_external_assets_from_assets_def,
-    )
-
-    if asset_selection is None and asset_check_selection is None:
-        # no selections, include everything
-        included_assets = list(assets)
-        excluded_assets = []
-    else:
-        # Filter to assets that match either selected assets or include a selected check.
-        # E.g. a multi asset can be included even if it's not in asset_selection, if it has a selected check
-        # defined with check_specs
-        (included_assets, excluded_assets) = subset_assets_defs(
-            assets, asset_selection or set(), asset_check_selection
-        )
-
-    if partitions_def:
-        for asset in included_assets:
-            check.invariant(
-                asset.partitions_def == partitions_def or asset.partitions_def is None,
-                f"Assets defined for node '{asset.node_def.name}' have a partitions_def of "
-                f"{asset.partitions_def}, but job '{name}' has non-matching partitions_def of "
-                f"{partitions_def}.",
-            )
-
-    executable_assets_defs = [asset for asset in included_assets if asset.is_executable]
-    unexecutable_assets_defs = [
-        unexecutable_ad
-        for ad in (
-            *(asset for asset in included_assets if not asset.is_executable),
-            *excluded_assets,
-        )
-        for unexecutable_ad in create_unexecutable_external_assets_from_assets_def(ad)
-    ]
-    asset_graph = AssetGraph.from_assets([*executable_assets_defs, *unexecutable_assets_defs])
-    return build_assets_job(
-        name=name,
-        asset_graph=asset_graph,
-        config=config,
-        resource_defs=resource_defs,
-        executor_def=executor_def,
-        partitions_def=partitions_def,
-        description=description,
-        tags=tags,
-        metadata=metadata,
-        hooks=hooks,
-        op_retry_policy=op_retry_policy,
-        _asset_selection_data=asset_selection_data,
-    )
-
-
-def subset_assets_defs(
-    assets: Iterable["AssetsDefinition"],
-    selected_asset_keys: AbstractSet[AssetKey],
-    selected_asset_check_keys: Optional[AbstractSet[AssetCheckKey]],
-) -> Tuple[
-    Sequence["AssetsDefinition"],
-    Sequence["AssetsDefinition"],
-]:
-    """Given a list of asset key selection queries, generate a set of AssetsDefinition objects
-    representing the included/excluded definitions.
-    """
-    included_assets: Set[AssetsDefinition] = set()
-    excluded_assets: Set[AssetsDefinition] = set()
-
-    # Do not match any assets with no keys
-    for asset in set(a for a in assets if a.has_keys or a.has_check_keys):
-        # intersection
-        selected_subset = selected_asset_keys & asset.keys
-
-        # if specific checks were selected, only include those
-        if selected_asset_check_keys is not None:
-            selected_check_subset = selected_asset_check_keys & asset.check_keys
-        # if no checks were selected, filter to checks that target selected assets
-        else:
-            selected_check_subset = {
-                key for key in asset.check_keys if key.asset_key in selected_asset_keys
-            }
-
-        # all assets in this def are selected
-        if selected_subset == asset.keys and selected_check_subset == asset.check_keys:
-            included_assets.add(asset)
-        # no assets in this def are selected
-        elif len(selected_subset) == 0 and len(selected_check_subset) == 0:
-            excluded_assets.add(asset)
-        elif asset.can_subset:
-            # subset of the asset that we want
-            subset_asset = asset.subset_for(selected_asset_keys, selected_check_subset)
-            included_assets.add(subset_asset)
-            # subset of the asset that we don't want
-            excluded_assets.add(
-                asset.subset_for(
-                    selected_asset_keys=asset.keys - subset_asset.keys,
-                    selected_asset_check_keys=(asset.check_keys - subset_asset.check_keys),
-                )
-            )
-        else:
-            raise DagsterInvalidSubsetError(
-                f"When building job, the AssetsDefinition '{asset.node_def.name}' "
-                f"contains asset keys {sorted(list(asset.keys))} and check keys "
-                f"{sorted(list(asset.check_keys))}, but "
-                f"attempted to select only {sorted(list(selected_subset))}. "
-                "This AssetsDefinition does not support subsetting. Please select all "
-                "asset keys produced by this asset.\n\nIf using an AssetSelection, you may "
-                "use required_multi_asset_neighbors() to select any remaining assets, for "
-                "example:\nAssetSelection.keys('my_asset').required_multi_asset_neighbors()"
-            )
-
-    return (
-        list(included_assets),
-        list(excluded_assets),
-    )
-
-
-def _subset_source_assets(
-    source_assets: Iterable["SourceAsset"],
-    selected_asset_keys: AbstractSet[AssetKey],
-) -> Sequence["SourceAsset"]:
-    return [
-        source_asset for source_asset in source_assets if source_asset.key in selected_asset_keys
-    ]

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -195,14 +195,6 @@ class AssetSelection(ABC, BaseModel, frozen=True):
         )
 
     @public
-    @staticmethod
-    def check_keys(*assets_defs: AssetsDefinition) -> "AssetCheckKeysSelection":
-        """Returns a selection that includes all of the provided asset checks."""
-        return AssetCheckKeysSelection(
-            selected_asset_check_keys=[key for ad in assets_defs for key in ad.check_keys]
-        )
-
-    @public
     def downstream(
         self, depth: Optional[int] = None, include_self: bool = True
     ) -> "DownstreamAssetSelection":

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -31,6 +31,7 @@ from dagster._core.definitions.asset_spec import (
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPolicyType
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.graph_definition import SubselectedGraphDefinition
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.op_invocation import direct_invocation_result
@@ -1299,7 +1300,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         self,
         selected_asset_keys: AbstractSet[AssetKey],
         selected_asset_check_keys: AbstractSet[AssetCheckKey],
-    ):
+    ) -> SubselectedGraphDefinition:
         from dagster._core.definitions.graph_definition import GraphDefinition
 
         if not isinstance(self.node_def, GraphDefinition):
@@ -1389,7 +1390,6 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
                 out_asset_key: set(self._keys_by_input_name.values())
                 for out_asset_key in subsetted_keys_by_output_name.values()
             }
-
             replaced_attributes = dict(
                 keys_by_input_name=subsetted_keys_by_input_name,
                 keys_by_output_name=subsetted_keys_by_output_name,

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -98,17 +98,15 @@ class AssetSelectionData(
 
     def __new__(
         cls,
-        asset_selection: AbstractSet[AssetKey],
+        asset_selection: Optional[AbstractSet[AssetKey]],
         asset_check_selection: Optional[AbstractSet[AssetCheckKey]],
         parent_job_def: "JobDefinition",
     ):
         from dagster._core.definitions.job_definition import JobDefinition
 
-        check.opt_set_param(asset_check_selection, "asset_check_selection", AssetCheckKey)
-
         return super(AssetSelectionData, cls).__new__(
             cls,
-            asset_selection=check.set_param(asset_selection, "asset_selection", AssetKey),
+            asset_selection=check.opt_set_param(asset_selection, "asset_selection", AssetKey),
             asset_check_selection=asset_check_selection,
             parent_job_def=check.inst_param(parent_job_def, "parent_job_def", JobDefinition),
         )

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_execution_plan.py
@@ -18,7 +18,9 @@ def test_execution_plan_error_grpc(instance: DagsterInstance):
 
         with pytest.raises(
             DagsterUserCodeProcessError,
-            match=re.escape('Assets provided in asset_selection argument ["fake"] do not exist'),
+            match=re.escape(
+                "AssetKey(s) ['fake'] were selected, but no AssetsDefinition objects supply these keys."
+            ),
         ):
             sync_get_external_execution_plan_grpc(
                 api_client,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -366,7 +366,6 @@ def test_define_selection_job(job_selection, expected_assets, use_multi, prefixe
 
     # now build the subset job
     job = create_test_asset_job(final_assets, selection=job_selection)
-
     with instance_for_test() as instance:
         result = job.execute_in_process(instance=instance)
         planned_asset_keys = {

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -1316,9 +1316,8 @@ def test_external_time_window_valid_partition_key():
 def test_external_assets_def_to_external_asset_graph() -> None:
     asset_one = next(iter(external_assets_from_specs([AssetSpec("asset_one")])))
 
-    assets_job = define_asset_job("assets_job", [asset_one])
     external_asset_nodes = _get_external_asset_nodes_from_definitions(
-        Definitions(assets=[asset_one], jobs=[assets_job])
+        Definitions(assets=[asset_one])
     )
 
     assert len(external_asset_nodes) == 1

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -18,7 +18,6 @@ from dagster import (
     repository,
 )
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.asset_layer import build_asset_selection_job
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.data_version import DataVersion
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
@@ -27,6 +26,7 @@ from dagster._core.definitions.materialize import materialize_to_memory
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition
 from dagster._core.event_api import EventRecordsFilter
+from dagster._core.test_utils import create_test_asset_job
 from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_freeze_time
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
@@ -116,12 +116,9 @@ def test_calculate_data_time_unpartitioned(ignore_asset_tags, runs_to_expected_d
             runs_to_expected_data_times_index
         ):
             # materialize selected assets
-            result = build_asset_selection_job(
-                "materialize_job",
-                assets=all_assets,
-                asset_selection=AssetSelection.keys(*(AssetKey(c) for c in to_materialize)).resolve(
-                    all_assets
-                ),
+            result = create_test_asset_job(
+                all_assets,
+                selection=AssetSelection.keys(*(AssetKey(c) for c in to_materialize)),
             ).execute_in_process(instance=instance)
 
             assert result.success


### PR DESCRIPTION
## Summary & Motivation

Refactor `AssetGraph` subsetting and consolidate construction of asset jobs.

- Delete `AssetGraph.get_subset` and replace with function `get_asset_graph_for_job`. The reasoning here is that the `get_subset` method on `AssetGraph` imposed subsetting constraints and transfromed the underlying assets defs in a way that only makes sense for jobs.
- Delete `build_asset_selection_job`. It had two callsites in `JobDefinition.get_subset` and `UnresolvedAssetJobDefinition.resolve`. These now directly invoke `build_assets_job`.
- Refactor/condense some of the validation logic for asset jobs.

These changes unify asset job code paths and make asset job construction much more straightforward. Asset jobs are now constructed by:

- Building an `AssetGraph` for the job by calling `get_job_asset_graph(<repo_asset_graph>, selection)`
- Passing the built `AssetGraph` to `build_assets_job`

## How I Tested These Changes

Existing test suite. A few GQL snapshots were amended due to slimming the number of upstream assets used in asset job construction to only what is loaded from.