### PR TITLE
Fix incorrect assumption about whether "full jobs" need parent snapshots

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -1415,9 +1415,7 @@ def external_repository_data_from_def(
     else:
         job_datas = sorted(
             list(
-                map(
-                    lambda job: external_job_data_from_def(job, include_parent_snapshot=False), jobs
-                )
+                map(lambda job: external_job_data_from_def(job, include_parent_snapshot=True), jobs)
             ),
             key=lambda pd: pd.name,
         )

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -794,7 +794,7 @@ class DagsterApiServer(DagsterApiServicer):
 
             job_def = self._get_repo_for_origin(repository_origin).get_job(request.job_name)
             ser_job_data = serialize_value(
-                external_job_data_from_def(job_def, include_parent_snapshot=False)
+                external_job_data_from_def(job_def, include_parent_snapshot=True)
             )
             return api_pb2.ExternalJobReply(serialized_job_data=ser_job_data)
         except Exception:


### PR DESCRIPTION
Summary:
If you have a job that is defined by an op or asset selection, it's still a 'full job' but also has a parent snapshot

## Summary & Motivation

## How I Tested These Changes
