### PR TITLE
feat(asset-search): sort sections alphabetically

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
@@ -13,6 +13,7 @@ import {
   AssetCatalogTableQuery,
   AssetCatalogTableQueryVariables,
 } from './types/AssetsCatalogTable.types';
+import {COMMON_COLLATOR} from '../app/Util';
 import {useTrackPageView} from '../app/analytics';
 import {TimeContext} from '../app/time/TimeContext';
 import {browserTimezone} from '../app/time/browserTimezone';
@@ -28,8 +29,8 @@ import {repoAddressFromPath} from '../workspace/repoAddressFromPath';
 import {RepoAddress} from '../workspace/types';
 
 type AssetCountsResult = {
-  countsByOwner: Record<string, number>;
-  countsByComputeKind: Record<string, number>;
+  countsByOwner: CountByOwner[];
+  countsByComputeKind: CountByComputeKind[];
   countPerAssetGroup: CountPerGroupName[];
   countPerCodeLocation: CountPerCodeLocation[];
 };
@@ -38,6 +39,16 @@ export type GroupMetadata = {
   groupName: string;
   repositoryLocationName: string;
   repositoryName: string;
+};
+
+type CountByOwner = {
+  owner: string;
+  assetCount: number;
+};
+
+type CountByComputeKind = {
+  computeKind: string;
+  assetCount: number;
 };
 
 type CountPerGroupName = {
@@ -96,18 +107,55 @@ export function buildAssetCountBySection(assets: AssetDefinitionMetadata[]): Ass
         (assetCountByCodeLocation[stringifiedCodeLocation] || 0) + 1;
     });
 
-  const countPerAssetGroup = Object.entries(assetCountByGroup).map(([groupIdentifier, count]) => ({
-    assetCount: count,
-    groupMetadata: JSON.parse(groupIdentifier),
-  }));
+  const countsByOwner = Object.entries(assetCountByOwner)
+    .map(([owner, count]) => ({
+      owner,
+      assetCount: count,
+    }))
+    .sort(({owner: ownerA}, {owner: ownerB}) => COMMON_COLLATOR.compare(ownerA, ownerB));
+  const countsByComputeKind = Object.entries(assetCountByComputeKind)
+    .map(([computeKind, count]) => ({
+      computeKind,
+      assetCount: count,
+    }))
+    .sort(({computeKind: computeKindA}, {computeKind: computeKindB}) =>
+      COMMON_COLLATOR.compare(computeKindA, computeKindB),
+    );
+  const countPerAssetGroup = Object.entries(assetCountByGroup)
+    .map(([groupIdentifier, count]) => ({
+      assetCount: count,
+      groupMetadata: JSON.parse(groupIdentifier),
+    }))
+    .sort(
+      ({groupMetadata: groupMetadataA}, {groupMetadata: groupMetadataB}) =>
+        COMMON_COLLATOR.compare(
+          repoAddressAsHumanString({
+            name: groupMetadataA.repositoryName,
+            location: groupMetadataA.repositoryLocationName,
+          }),
+          repoAddressAsHumanString({
+            name: groupMetadataB.repositoryName,
+            location: groupMetadataB.repositoryLocationName,
+          }),
+        ) || COMMON_COLLATOR.compare(groupMetadataA.groupName, groupMetadataB.groupName),
+    );
+  const countPerCodeLocation = Object.entries(assetCountByCodeLocation)
+    .map(([key, count]) => ({
+      repoAddress: repoAddressFromPath(key)!,
+      assetCount: count,
+    }))
+    .sort(({repoAddress: repoAddressA}, {repoAddress: repoAddressB}) =>
+      COMMON_COLLATOR.compare(
+        repoAddressAsHumanString(repoAddressA),
+        repoAddressAsHumanString(repoAddressB),
+      ),
+    );
 
   return {
-    countsByOwner: assetCountByOwner,
-    countsByComputeKind: assetCountByComputeKind,
+    countsByOwner,
+    countsByComputeKind,
     countPerAssetGroup,
-    countPerCodeLocation: Object.entries(assetCountByCodeLocation).map(([key, count]) => {
-      return {repoAddress: repoAddressFromPath(key)!, assetCount: count};
-    }),
+    countPerCodeLocation,
   };
 }
 
@@ -173,6 +221,10 @@ const SectionBody = ({children}: {children: React.ReactNode}) => {
 
 const linkToAssetGraphGroup = (groupMetadata: GroupMetadata) => {
   return `/asset-groups?${qs.stringify({groups: JSON.stringify([groupMetadata])})}`;
+};
+
+const linkToAssetGraphOwner = (owner: string) => {
+  return `/asset-groups?${qs.stringify({owners: JSON.stringify([owner])})}`;
 };
 
 const linkToAssetGraphComputeKind = (computeKind: string) => {
@@ -269,9 +321,11 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
             <>
               <SectionHeader sectionName="Owners" />
               <SectionBody>
-                {Object.entries(assetCountBySection.countsByOwner).map(([label, count]) => (
-                  <CountForAssetType key={label} assetsCount={count}>
-                    <UserDisplay email={label} />
+                {assetCountBySection.countsByOwner.map(({owner, assetCount}) => (
+                  <CountForAssetType key={owner} assetsCount={assetCount}>
+                    <Link to={linkToAssetGraphOwner(owner)}>
+                      <UserDisplay email={owner} />
+                    </Link>
                   </CountForAssetType>
                 ))}
               </SectionBody>
@@ -281,10 +335,10 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
             <>
               <SectionHeader sectionName="Compute kinds" />
               <SectionBody>
-                {Object.entries(assetCountBySection.countsByComputeKind).map(([label, count]) => (
-                  <CountForAssetType key={label} assetsCount={count}>
-                    <TagIcon label={label} />
-                    <Link to={linkToAssetGraphComputeKind(label)}>{label}</Link>
+                {assetCountBySection.countsByComputeKind.map(({computeKind, assetCount}) => (
+                  <CountForAssetType key={computeKind} assetsCount={assetCount}>
+                    <TagIcon label={computeKind} />
+                    <Link to={linkToAssetGraphComputeKind(computeKind)}>{computeKind}</Link>
                   </CountForAssetType>
                 ))}
               </SectionBody>
@@ -304,7 +358,10 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                       {assetGroupCount.groupMetadata.groupName}
                     </Link>
                     <span style={{color: Colors.textLighter()}}>
-                      {assetGroupCount.groupMetadata.repositoryLocationName}
+                      {repoAddressAsHumanString({
+                        name: assetGroupCount.groupMetadata.repositoryName,
+                        location: assetGroupCount.groupMetadata.repositoryLocationName,
+                      })}
                     </span>
                   </CountForAssetType>
                 ))}

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -193,15 +193,15 @@ const secondaryDataToSearchResults = (
   } else {
     const countsBySection = buildAssetCountBySection(nodes);
 
-    const computeKindResults: SearchResult[] = Object.entries(
-      countsBySection.countsByComputeKind,
-    ).map(([computeKind, count]) => ({
-      label: computeKind,
-      description: '',
-      type: AssetFilterSearchResultType.ComputeKind,
-      href: linkToAssetTableWithComputeKindFilter(computeKind),
-      numResults: count,
-    }));
+    const computeKindResults: SearchResult[] = countsBySection.countsByComputeKind.map(
+      ({computeKind, assetCount}) => ({
+        label: computeKind,
+        description: '',
+        type: AssetFilterSearchResultType.ComputeKind,
+        href: linkToAssetTableWithComputeKindFilter(computeKind),
+        numResults: assetCount,
+      }),
+    );
 
     const codeLocationResults: SearchResult[] = countsBySection.countPerCodeLocation.map(
       (codeLocationAssetCount) => ({
@@ -226,13 +226,13 @@ const secondaryDataToSearchResults = (
       }),
     );
 
-    const ownerResults: SearchResult[] = Object.entries(countsBySection.countsByOwner).map(
-      ([owner, count]) => ({
+    const ownerResults: SearchResult[] = countsBySection.countsByOwner.map(
+      ({owner, assetCount}) => ({
         label: owner,
         description: '',
         type: AssetFilterSearchResultType.Owner,
         href: linkToAssetTableWithOwnerFilter(owner),
-        numResults: count,
+        numResults: assetCount,
       }),
     );
     return [


### PR DESCRIPTION
## Summary & Motivation
- Sort sections (owners/compute kind/asset group/code location) to have some consistency
- Add links from owners to the asset graph

After doing this, it looks like the asset group section should be incorporated into the code location section, as both sections are displaying information from the same hierarchy (grouped by code location, then further scoped down by group name).

Later on, we could have different other sorts (e.g. by count, by specific field attribute) as a toggle for the user.

Sorting also shows that the way that this information layout feels a bit odd -- the ordering happens row-wise. With rows consisting of three columns, it's not immediate to see that ordering is the ordering column-wise or row-wise. I don't recall other parts of our UI where we take an approach like this, as we always render one logical item per row, and columns are organized by the same type of item.

## How I Tested These Changes
local

**Sorted asset search page**
<img width="2056" alt="Screenshot 2024-03-15 at 11 00 12 AM" src="https://github.com/dagster-io/dagster/assets/16431325/b81f8538-363c-4d2b-8fe0-d9aacdb5f375">

**See link when hovering over owner**
<img width="2080" alt="Screenshot 2024-03-15 at 11 00 16 AM" src="https://github.com/dagster-io/dagster/assets/16431325/ff08ed3d-2a33-491d-9faa-e61fb8f06001">

