### PR TITLE
add a test that verifies that dagster dev can load the toys repo

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
+++ b/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
@@ -58,6 +58,31 @@ def test_dagster_dev_command_workspace():
                     dev_process.communicate()
 
 
+def test_dagster_dev_command_loads_toys():
+    with tempfile.TemporaryDirectory() as tempdir:
+        with environ({"DAGSTER_HOME": ""}):
+            with new_cwd(tempdir):
+                dagit_port = find_free_port()
+                dev_process = subprocess.Popen(
+                    [
+                        "dagster",
+                        "dev",
+                        "-m",
+                        "dagster_test.toys.repo",
+                        "--dagit-port",
+                        str(dagit_port),
+                        "--log-level",
+                        "debug",
+                    ],
+                    cwd=tempdir,
+                )
+                try:
+                    _wait_for_dagit_running(dagit_port)
+                finally:
+                    dev_process.send_signal(signal.SIGINT)
+                    dev_process.communicate()
+
+
 # E2E test that spins up "dagster dev", accesses dagit,
 # and waits for a schedule run to launch
 def test_dagster_dev_command_no_dagster_home():


### PR DESCRIPTION
Test Plan: This fails in 1.6.10, passes in 1.6.11

## Summary & Motivation

## How I Tested These Changes
