### PR TITLE
Support AssetCheckKey in AssetSelection.checks

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -51,6 +51,9 @@ class AssetCheckKey(NamedTuple):
     def with_asset_key_prefix(self, prefix: CoercibleToAssetKeyPrefix) -> "AssetCheckKey":
         return self._replace(asset_key=self.asset_key.with_prefix(prefix))
 
+    def to_user_string(self) -> str:
+        return f"{self.asset_key.to_user_string()}:{self.name}"
+
 
 @experimental
 class AssetCheckSpec(

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -362,13 +362,17 @@ class AssetSelection(ABC, BaseModel, frozen=True):
     ) -> AbstractSet[AssetKey]:
         raise NotImplementedError()
 
-    def resolve_checks(self, asset_graph: AssetGraph) -> AbstractSet[AssetCheckKey]:
+    def resolve_checks(
+        self, asset_graph: AssetGraph, allow_missing: bool = False
+    ) -> AbstractSet[AssetCheckKey]:
         """We don't need this method currently, but it makes things consistent with resolve_inner. Currently
         we don't store checks in the RemoteAssetGraph, so we only support AssetGraph.
         """
-        return self.resolve_checks_inner(asset_graph)
+        return self.resolve_checks_inner(asset_graph, allow_missing=allow_missing)
 
-    def resolve_checks_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetCheckKey]:
+    def resolve_checks_inner(
+        self, asset_graph: AssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetCheckKey]:
         """By default, resolve to checks that target the selected assets. This is overriden for particular selections."""
         asset_keys = self.resolve(asset_graph)
         return {handle for handle in asset_graph.asset_check_keys if handle.asset_key in asset_keys}
@@ -475,7 +479,9 @@ class AllAssetCheckSelection(AssetSelection, frozen=True):
     ) -> AbstractSet[AssetKey]:
         return set()
 
-    def resolve_checks_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetCheckKey]:
+    def resolve_checks_inner(
+        self, asset_graph: AssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetCheckKey]:
         return asset_graph.asset_check_keys
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
@@ -494,7 +500,9 @@ class AssetChecksForAssetKeysSelection(AssetSelection, frozen=True):
     ) -> AbstractSet[AssetKey]:
         return set()
 
-    def resolve_checks_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetCheckKey]:
+    def resolve_checks_inner(
+        self, asset_graph: AssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetCheckKey]:
         return {
             handle
             for handle in asset_graph.asset_check_keys
@@ -514,12 +522,20 @@ class AssetCheckKeysSelection(AssetSelection, frozen=True):
     ) -> AbstractSet[AssetKey]:
         return set()
 
-    def resolve_checks_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetCheckKey]:
-        return {
-            handle
-            for handle in asset_graph.asset_check_keys
-            if handle in self.selected_asset_check_keys
-        }
+    def resolve_checks_inner(
+        self, asset_graph: AssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetCheckKey]:
+        specified_keys = set(self.selected_asset_check_keys)
+        missing_keys = {key for key in specified_keys if key not in asset_graph.asset_check_keys}
+
+        if not allow_missing and missing_keys:
+            raise DagsterInvalidSubsetError(
+                f"AssetCheckKey(s) {[k.to_user_string() for k in missing_keys]} were selected, but "
+                "no definitions supply these keys. Make sure all keys are spelled "
+                "correctly, and all definitions are correctly added to the "
+                f"`Definitions`."
+            )
+        return specified_keys & asset_graph.asset_check_keys
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return self
@@ -544,10 +560,15 @@ class AndAssetSelection(
             ),
         )
 
-    def resolve_checks_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetCheckKey]:
+    def resolve_checks_inner(
+        self, asset_graph: AssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetCheckKey]:
         return reduce(
             operator.and_,
-            (selection.resolve_checks_inner(asset_graph) for selection in self.operands),
+            (
+                selection.resolve_checks_inner(asset_graph, allow_missing=allow_missing)
+                for selection in self.operands
+            ),
         )
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
@@ -583,10 +604,15 @@ class OrAssetSelection(
             ),
         )
 
-    def resolve_checks_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetCheckKey]:
+    def resolve_checks_inner(
+        self, asset_graph: AssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetCheckKey]:
         return reduce(
             operator.or_,
-            (selection.resolve_checks_inner(asset_graph) for selection in self.operands),
+            (
+                selection.resolve_checks_inner(asset_graph, allow_missing=allow_missing)
+                for selection in self.operands
+            ),
         )
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
@@ -619,10 +645,12 @@ class SubtractAssetSelection(
             asset_graph, allow_missing=allow_missing
         ) - self.right.resolve_inner(asset_graph, allow_missing=allow_missing)
 
-    def resolve_checks_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetCheckKey]:
-        return self.left.resolve_checks_inner(asset_graph) - self.right.resolve_checks_inner(
-            asset_graph
-        )
+    def resolve_checks_inner(
+        self, asset_graph: AssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetCheckKey]:
+        return self.left.resolve_checks_inner(
+            asset_graph, allow_missing=allow_missing
+        ) - self.right.resolve_checks_inner(asset_graph, allow_missing=allow_missing)
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return self.replace(

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -181,7 +181,22 @@ class AssetSelection(ABC, BaseModel, frozen=True):
 
     @public
     @staticmethod
-    def checks(*assets_defs: AssetsDefinition) -> "AssetCheckKeysSelection":
+    def checks(
+        *assets_defs_or_check_keys: Union[AssetsDefinition, AssetCheckKey],
+    ) -> "AssetCheckKeysSelection":
+        """Returns a selection that includes all of the provided asset checks or check keys."""
+        assets_defs = [ad for ad in assets_defs_or_check_keys if isinstance(ad, AssetsDefinition)]
+        check_keys = [key for key in assets_defs_or_check_keys if isinstance(key, AssetCheckKey)]
+        return AssetCheckKeysSelection(
+            selected_asset_check_keys=[
+                *(key for ad in assets_defs for key in ad.check_keys),
+                *check_keys,
+            ]
+        )
+
+    @public
+    @staticmethod
+    def check_keys(*assets_defs: AssetsDefinition) -> "AssetCheckKeysSelection":
         """Returns a selection that includes all of the provided asset checks."""
         return AssetCheckKeysSelection(
             selected_asset_check_keys=[key for ad in assets_defs for key in ad.check_keys]

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_selection.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_selection.py
@@ -201,3 +201,14 @@ def test_checks_on_asset():
         AssetCheckKey(asset_with_checks.key, "check1"),
         AssetCheckKey(asset_with_checks.key, "check2"),
     }
+
+
+def test_keys_selection():
+    assets = [asset1, asset2]
+    asset_checks = [asset1_check1, asset1_check2, asset2_check1]
+    defs = Definitions(assets=assets, asset_checks=asset_checks)
+    keys = {
+        AssetCheckKey(asset_key=asset1.key, name="asset1_check1"),
+        AssetCheckKey(asset_key=asset1.key, name="asset1_check2"),
+    }
+    assert AssetSelection.checks(*keys).resolve_checks(defs.get_asset_graph()) == keys

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_selection.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_selection.py
@@ -1,3 +1,4 @@
+import pytest
 from dagster import (
     AssetCheckResult,
     AssetSelection,
@@ -10,6 +11,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSpec
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
+from dagster._core.errors import DagsterInvalidSubsetError
 
 
 @asset
@@ -203,12 +205,22 @@ def test_checks_on_asset():
     }
 
 
-def test_keys_selection():
+def test_check_keys_selection():
     assets = [asset1, asset2]
     asset_checks = [asset1_check1, asset1_check2, asset2_check1]
     defs = Definitions(assets=assets, asset_checks=asset_checks)
+    asset_graph = defs.get_asset_graph()
     keys = {
         AssetCheckKey(asset_key=asset1.key, name="asset1_check1"),
         AssetCheckKey(asset_key=asset1.key, name="asset1_check2"),
     }
-    assert AssetSelection.checks(*keys).resolve_checks(defs.get_asset_graph()) == keys
+    assert AssetSelection.checks(*keys).resolve_checks(asset_graph) == keys
+
+    fake_key = AssetCheckKey(asset_key=asset1.key, name="fake")
+    assert AssetSelection.checks(fake_key).resolve_checks(asset_graph, allow_missing=True) == set()
+
+    with pytest.raises(
+        DagsterInvalidSubsetError,
+        match=r"AssetCheckKey\(s\) \['asset1:fake'\] were selected, but no definitions supply these keys..*",
+    ):
+        AssetSelection.checks(fake_key).resolve_checks(asset_graph)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
@@ -71,7 +71,7 @@ class DbtManifestAssetSelection(
         )
 
     def resolve_inner(
-        self, asset_graph: BaseAssetGraph, allow_missing=False
+        self, asset_graph: BaseAssetGraph, allow_missing: bool = False
     ) -> AbstractSet[AssetKey]:
         dbt_nodes = get_dbt_resource_props_by_dbt_unique_id_from_manifest(self.manifest)
 
@@ -89,7 +89,9 @@ class DbtManifestAssetSelection(
 
         return keys
 
-    def resolve_checks_inner(self, asset_graph: BaseAssetGraph) -> AbstractSet[AssetCheckKey]:
+    def resolve_checks_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetCheckKey]:
         if not self.dagster_dbt_translator.settings.enable_asset_checks:
             return set()
 


### PR DESCRIPTION
## Summary & Motivation

Add support for `AssetCheckKey` on `AssetSelection.checks`. Also adds `allow_missing` arg for resolving checks to match resolution for regular keys.

## How I Tested These Changes

New unit tests.