### PR TITLE
[ui] Automation root

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
@@ -6,6 +6,7 @@ import {AssetFeatureProvider} from '../assets/AssetFeatureContext';
 
 const WorkspaceRoot = lazy(() => import('../workspace/WorkspaceRoot'));
 const OverviewRoot = lazy(() => import('../overview/OverviewRoot'));
+const AutomationRoot = lazy(() => import('../automation/AutomationRoot'));
 const FallthroughRoot = lazy(() => import('./FallthroughRoot'));
 const AssetsCatalogRoot = lazy(() => import('../assets/AssetsCatalogRoot'));
 const AssetsGroupsGlobalGraphRoot = lazy(() => import('../assets/AssetsGroupsGlobalGraphRoot'));
@@ -97,6 +98,11 @@ export const ContentRoot = memo(() => {
           <Route path="/overview">
             <Suspense fallback={<div />}>
               <OverviewRoot />
+            </Suspense>
+          </Route>
+          <Route path="/automation">
+            <Suspense fallback={<div />}>
+              <AutomationRoot />
             </Suspense>
           </Route>
           <Route path="/settings">

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -1,0 +1,36 @@
+import {Heading, Page, PageHeader} from '@dagster-io/ui-components';
+import {Redirect} from 'react-router-dom';
+
+import {GlobalAutomaterializationContent} from './GlobalAutomaterializationContent';
+import {assertUnreachable} from '../../app/Util';
+import {useTrackPageView} from '../../app/analytics';
+import {useDocumentTitle} from '../../hooks/useDocumentTitle';
+import {OverviewTabs} from '../../overview/OverviewTabs';
+import {useAutoMaterializeSensorFlag} from '../AutoMaterializeSensorFlag';
+
+// Determine whether the user is flagged to see automaterialize policies as
+// sensors. If so, redirect to the Sensors overview.
+export const AutomaterializationRoot = () => {
+  const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
+  switch (automaterializeSensorsFlagState) {
+    case 'unknown':
+      return <div />; // Waiting for result
+    case 'has-global-amp':
+      return <GlobalAutomaterializationRoot />;
+    case 'has-sensor-amp':
+      return <Redirect to="/overview/sensors" />;
+    default:
+      assertUnreachable(automaterializeSensorsFlagState);
+  }
+};
+
+const GlobalAutomaterializationRoot = () => {
+  useTrackPageView();
+  useDocumentTitle('Overview | Auto-materialize');
+  return (
+    <Page>
+      <PageHeader title={<Heading>Overview</Heading>} tabs={<OverviewTabs tab="amp" />} />
+      <GlobalAutomaterializationContent />
+    </Page>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializeDot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializeDot.tsx
@@ -1,0 +1,10 @@
+import {Colors} from '@dagster-io/ui-components';
+import styled from 'styled-components';
+
+export const AutomaterializeDot = styled.div<{$paused: boolean | undefined}>`
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: ${({$paused}) =>
+    $paused === false ? Colors.accentBlue() : Colors.accentGray()};
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/GlobalAutomaterializationContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/GlobalAutomaterializationContent.tsx
@@ -1,18 +1,6 @@
 import {useLazyQuery} from '@apollo/client';
-import {
-  Alert,
-  Box,
-  Checkbox,
-  Colors,
-  Heading,
-  Page,
-  PageHeader,
-  Spinner,
-  Subtitle2,
-  Table,
-} from '@dagster-io/ui-components';
+import {Alert, Box, Checkbox, Colors, Spinner, Subtitle2, Table} from '@dagster-io/ui-components';
 import {useCallback, useMemo, useState} from 'react';
-import {Redirect} from 'react-router-dom';
 
 import {ASSET_DAEMON_TICKS_QUERY} from './AssetDaemonTicksQuery';
 import {AutomaterializationTickDetailDialog} from './AutomaterializationTickDetailDialog';
@@ -26,14 +14,10 @@ import {
 import {useConfirmation} from '../../app/CustomConfirmationProvider';
 import {useUnscopedPermissions} from '../../app/Permissions';
 import {useRefreshAtInterval} from '../../app/QueryRefresh';
-import {assertUnreachable} from '../../app/Util';
-import {useTrackPageView} from '../../app/analytics';
 import {InstigationTickStatus} from '../../graphql/types';
 import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
 import {LiveTickTimeline} from '../../instigation/LiveTickTimeline2';
 import {isStuckStartedTick} from '../../instigation/util';
-import {OverviewTabs} from '../../overview/OverviewTabs';
-import {useAutoMaterializeSensorFlag} from '../AutoMaterializeSensorFlag';
 import {useAutomaterializeDaemonStatus} from '../useAutomaterializeDaemonStatus';
 
 const MINUTE = 60 * 1000;
@@ -41,25 +25,7 @@ const THREE_MINUTES = 3 * MINUTE;
 const FIVE_MINUTES = 5 * MINUTE;
 const TWENTY_MINUTES = 20 * MINUTE;
 
-// Determine whether the user is flagged to see automaterialize policies as
-// sensors. If so, redirect to the Sensors overview.
-export const AutomaterializationRoot = () => {
-  const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
-  switch (automaterializeSensorsFlagState) {
-    case 'unknown':
-      return <div />; // Waiting for result
-    case 'has-global-amp':
-      return <GlobalAutomaterializationRoot />;
-    case 'has-sensor-amp':
-      return <Redirect to="/overview/sensors" />;
-    default:
-      assertUnreachable(automaterializeSensorsFlagState);
-  }
-};
-
-const GlobalAutomaterializationRoot = () => {
-  useTrackPageView();
-
+export const GlobalAutomaterializationContent = () => {
   const automaterialize = useAutomaterializeDaemonStatus();
   const confirm = useConfirmation();
 
@@ -152,8 +118,7 @@ const GlobalAutomaterializationRoot = () => {
   );
 
   return (
-    <Page>
-      <PageHeader title={<Heading>Overview</Heading>} tabs={<OverviewTabs tab="amp" />} />
+    <>
       <Box padding={{vertical: 12, horizontal: 24}} flex={{direction: 'column', gap: 12}}>
         <Alert
           intent="info"
@@ -249,6 +214,6 @@ const GlobalAutomaterializationRoot = () => {
           )}
         </>
       )}
-    </Page>
+    </>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationAutomaterializeRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationAutomaterializeRoot.tsx
@@ -1,0 +1,36 @@
+import {Heading, Page, PageHeader} from '@dagster-io/ui-components';
+import {Redirect} from 'react-router-dom';
+
+import {AutomationTabs} from './AutomationTabs';
+import {assertUnreachable} from '../app/Util';
+import {useTrackPageView} from '../app/analytics';
+import {useAutoMaterializeSensorFlag} from '../assets/AutoMaterializeSensorFlag';
+import {GlobalAutomaterializationContent} from '../assets/auto-materialization/GlobalAutomaterializationContent';
+import {useDocumentTitle} from '../hooks/useDocumentTitle';
+
+// Determine whether the user is flagged to see automaterialize policies as
+// sensors. If so, redirect to the Sensors overview.
+export const AutomationAutomaterializeRoot = () => {
+  const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
+  switch (automaterializeSensorsFlagState) {
+    case 'unknown':
+      return <div />; // Waiting for result
+    case 'has-global-amp':
+      return <GlobalAutomationAutomaterializeRoot />;
+    case 'has-sensor-amp':
+      return <Redirect to="/automation/sensors" />;
+    default:
+      assertUnreachable(automaterializeSensorsFlagState);
+  }
+};
+
+const GlobalAutomationAutomaterializeRoot = () => {
+  useTrackPageView();
+  useDocumentTitle('Automation | Auto-materialize');
+  return (
+    <Page>
+      <PageHeader title={<Heading>Automation</Heading>} tabs={<AutomationTabs tab="amp" />} />
+      <GlobalAutomaterializationContent />
+    </Page>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationBackfillsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationBackfillsRoot.tsx
@@ -1,0 +1,18 @@
+import {Heading, Page, PageHeader} from '@dagster-io/ui-components';
+
+import {AutomationTabs} from './AutomationTabs';
+import {useTrackPageView} from '../app/analytics';
+import {useDocumentTitle} from '../hooks/useDocumentTitle';
+import {InstanceBackfills} from '../instance/InstanceBackfills';
+
+export const AutomationBackfillsRoot = () => {
+  useTrackPageView();
+  useDocumentTitle('Automation | Backfills');
+
+  return (
+    <Page>
+      <PageHeader title={<Heading>Automation</Heading>} tabs={<AutomationTabs tab="backfills" />} />
+      <InstanceBackfills />
+    </Page>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationRoot.tsx
@@ -1,0 +1,34 @@
+import {Redirect, Route, Switch} from 'react-router-dom';
+
+import {AutomationAutomaterializeRoot} from './AutomationAutomaterializeRoot';
+import {AutomationBackfillsRoot} from './AutomationBackfillsRoot';
+import {AutomationSchedulesRoot} from './AutomationSchedulesRoot';
+import {AutomationSensorsRoot} from './AutomationSensorsRoot';
+import {BackfillPage} from '../instance/backfill/BackfillPage';
+
+export const AutomationRoot = () => {
+  return (
+    <Switch>
+      <Route path="/automation/schedules">
+        <AutomationSchedulesRoot />
+      </Route>
+      <Route path="/automation/sensors">
+        <AutomationSensorsRoot />
+      </Route>
+      <Route path="/automation/backfills/:backfillId">
+        <BackfillPage />
+      </Route>
+      <Route path="/automation/backfills" exact>
+        <AutomationBackfillsRoot />
+      </Route>
+      <Route path="/automation/auto-materialize" exact>
+        <AutomationAutomaterializeRoot />
+      </Route>
+      <Route path="*" render={() => <Redirect to="/automation/schedules" />} />
+    </Switch>
+  );
+};
+
+// Imported via React.lazy, which requires a default export.
+// eslint-disable-next-line import/no-default-export
+export default AutomationRoot;

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationSchedulesRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationSchedulesRoot.tsx
@@ -1,0 +1,18 @@
+import {Box, Heading, PageHeader} from '@dagster-io/ui-components';
+
+import {AutomationTabs} from './AutomationTabs';
+import {useTrackPageView} from '../app/analytics';
+import {useDocumentTitle} from '../hooks/useDocumentTitle';
+import {OverviewSchedules} from '../overview/OverviewSchedules';
+
+export const AutomationSchedulesRoot = () => {
+  useTrackPageView();
+  useDocumentTitle('Automation | Schedules');
+
+  return (
+    <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
+      <PageHeader title={<Heading>Automation</Heading>} tabs={<AutomationTabs tab="schedules" />} />
+      <OverviewSchedules />
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationSensorsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationSensorsRoot.tsx
@@ -1,0 +1,18 @@
+import {Box, Heading, PageHeader} from '@dagster-io/ui-components';
+
+import {AutomationTabs} from './AutomationTabs';
+import {useTrackPageView} from '../app/analytics';
+import {useDocumentTitle} from '../hooks/useDocumentTitle';
+import {OverviewSensors} from '../overview/OverviewSensors';
+
+export const AutomationSensorsRoot = () => {
+  useTrackPageView();
+  useDocumentTitle('Automation | Sensors');
+
+  return (
+    <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
+      <PageHeader title={<Heading>Automation</Heading>} tabs={<AutomationTabs tab="sensors" />} />
+      <OverviewSensors />
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationTabs.tsx
@@ -1,0 +1,43 @@
+import {Box, Spinner, Tabs} from '@dagster-io/ui-components';
+
+import {useAutoMaterializeSensorFlag} from '../assets/AutoMaterializeSensorFlag';
+import {AutomaterializeDot} from '../assets/auto-materialization/AutomaterializeDot';
+import {useAutomaterializeDaemonStatus} from '../assets/useAutomaterializeDaemonStatus';
+import {TabLink} from '../ui/TabLink';
+
+interface Props {
+  tab: string;
+}
+
+export const AutomationTabs = (props: Props) => {
+  const {tab} = props;
+
+  const automaterialize = useAutomaterializeDaemonStatus();
+  const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
+
+  return (
+    <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
+      <Tabs selectedTabId={tab}>
+        <TabLink id="schedules" title="Schedules" to="/automation/schedules" />
+        <TabLink id="sensors" title="Sensors" to="/automation/sensors" />
+        {automaterializeSensorsFlagState === 'has-global-amp' ? (
+          <TabLink
+            id="amp"
+            title={
+              <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+                <div>Auto-materialize</div>
+                {automaterialize.loading ? (
+                  <Spinner purpose="body-text" />
+                ) : (
+                  <AutomaterializeDot $paused={automaterialize.paused} />
+                )}
+              </Box>
+            }
+            to="/automation/auto-materialize"
+          />
+        ) : null}
+        <TabLink id="backfills" title="Backfills" to="/automation/backfills" />
+      </Tabs>
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
@@ -3,10 +3,7 @@ import {
   Box,
   Colors,
   CursorPaginationControls,
-  Heading,
   NonIdealState,
-  Page,
-  PageHeader,
   Spinner,
 } from '@dagster-io/ui-components';
 
@@ -20,11 +17,14 @@ import {
 } from './types/InstanceBackfills.types';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
-import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {
+  FIFTEEN_SECONDS,
+  QueryRefreshCountdown,
+  useQueryRefreshAtInterval,
+} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {BulkActionStatus} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
-import {OverviewTabs} from '../overview/OverviewTabs';
 import {DaemonNotRunningAlertBody} from '../partitions/BackfillMessaging';
 import {useCursorPaginatedQuery} from '../runs/useCursorPaginatedQuery';
 import {useFilters} from '../ui/Filters';
@@ -170,19 +170,19 @@ export const InstanceBackfills = () => {
   };
 
   return (
-    <Page>
-      <PageHeader
-        title={<Heading>Overview</Heading>}
-        tabs={<OverviewTabs tab="backfills" refreshState={refreshState} />}
-      />
-      <Box padding={{vertical: 12, horizontal: 20}}>
+    <>
+      <Box
+        padding={{vertical: 12, horizontal: 20}}
+        flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
+      >
         <Box flex={{direction: 'column', gap: 8}}>
           <div>{button}</div>
           {activeFiltersJsx}
         </Box>
+        <QueryRefreshCountdown refreshState={refreshState} />
       </Box>
       {content()}
-    </Page>
+    </>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfillsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfillsRoot.tsx
@@ -1,0 +1,18 @@
+import {Heading, Page, PageHeader} from '@dagster-io/ui-components';
+
+import {InstanceBackfills} from './InstanceBackfills';
+import {useTrackPageView} from '../app/analytics';
+import {useDocumentTitle} from '../hooks/useDocumentTitle';
+import {OverviewTabs} from '../overview/OverviewTabs';
+
+export const InstanceBackfillsRoot = () => {
+  useTrackPageView();
+  useDocumentTitle('Overview | Backfills');
+
+  return (
+    <Page>
+      <PageHeader title={<Heading>Overview</Heading>} tabs={<OverviewTabs tab="backfills" />} />
+      <InstanceBackfills />
+    </Page>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
@@ -3,10 +3,10 @@ import {Redirect, Route, Switch} from 'react-router-dom';
 import {OverviewActivityRoot} from './OverviewActivityRoot';
 import {OverviewJobsRoot} from './OverviewJobsRoot';
 import {OverviewResourcesRoot} from './OverviewResourcesRoot';
-import {OverviewSchedulesRoot} from './OverviewSchedules';
-import {OverviewSensorsRoot} from './OverviewSensors';
-import {AutomaterializationRoot} from '../assets/auto-materialization/GlobalAutomaterializationContent';
-import {InstanceBackfills} from '../instance/InstanceBackfills';
+import {OverviewSchedulesRoot} from './OverviewSchedulesRoot';
+import {OverviewSensorsRoot} from './OverviewSensorsRoot';
+import {AutomaterializationRoot} from '../assets/auto-materialization/AutomaterializationRoot';
+import {InstanceBackfillsRoot} from '../instance/InstanceBackfillsRoot';
 import {BackfillPage} from '../instance/backfill/BackfillPage';
 
 export const OverviewRoot = () => {
@@ -31,7 +31,7 @@ export const OverviewRoot = () => {
         <BackfillPage />
       </Route>
       <Route path="/overview/backfills" exact>
-        <InstanceBackfills />
+        <InstanceBackfillsRoot />
       </Route>
       <Route path="/overview/resources">
         <OverviewResourcesRoot />

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSchedules.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSchedules.tsx
@@ -1,19 +1,9 @@
 import {gql, useQuery} from '@apollo/client';
-import {
-  Box,
-  Colors,
-  Heading,
-  NonIdealState,
-  PageHeader,
-  Spinner,
-  TextInput,
-  Tooltip,
-} from '@dagster-io/ui-components';
+import {Box, Colors, NonIdealState, Spinner, TextInput, Tooltip} from '@dagster-io/ui-components';
 import {useContext, useMemo} from 'react';
 
 import {BASIC_INSTIGATION_STATE_FRAGMENT} from './BasicInstigationStateFragment';
 import {OverviewScheduleTable} from './OverviewSchedulesTable';
-import {OverviewTabs} from './OverviewTabs';
 import {sortRepoBuckets} from './sortRepoBuckets';
 import {BasicInstigationStateFragment} from './types/BasicInstigationStateFragment.types';
 import {
@@ -23,8 +13,6 @@ import {
 import {visibleRepoKeys} from './visibleRepoKeys';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
-import {useTrackPageView} from '../app/analytics';
-import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {useSelectionReducer} from '../hooks/useSelectionReducer';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
@@ -42,10 +30,7 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
-export const OverviewSchedulesRoot = () => {
-  useTrackPageView();
-  useDocumentTitle('Overview | Schedules');
-
+export const OverviewSchedules = () => {
   const {allRepos, visibleRepos, loading: workspaceLoading} = useContext(WorkspaceContext);
   const repoCount = allRepos.length;
   const [searchValue, setSearchValue] = useQueryPersistedState<string>({
@@ -239,11 +224,7 @@ export const OverviewSchedulesRoot = () => {
   const showSearchSpinner = (workspaceLoading && !repoCount) || (loading && !data);
 
   return (
-    <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
-      <PageHeader
-        title={<Heading>Overview</Heading>}
-        tabs={<OverviewTabs tab="schedules" refreshState={refreshState} />}
-      />
+    <>
       <Box
         padding={{horizontal: 24, vertical: 16}}
         flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
@@ -301,7 +282,7 @@ export const OverviewSchedulesRoot = () => {
           {content()}
         </>
       )}
-    </Box>
+    </>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSchedulesRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSchedulesRoot.tsx
@@ -1,0 +1,18 @@
+import {Box, Heading, PageHeader} from '@dagster-io/ui-components';
+
+import {OverviewSchedules} from './OverviewSchedules';
+import {OverviewTabs} from './OverviewTabs';
+import {useTrackPageView} from '../app/analytics';
+import {useDocumentTitle} from '../hooks/useDocumentTitle';
+
+export const OverviewSchedulesRoot = () => {
+  useTrackPageView();
+  useDocumentTitle('Overview | Schedules');
+
+  return (
+    <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
+      <PageHeader title={<Heading>Overview</Heading>} tabs={<OverviewTabs tab="schedules" />} />
+      <OverviewSchedules />
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSensors.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSensors.tsx
@@ -1,28 +1,20 @@
 import {gql, useQuery} from '@apollo/client';
-import {
-  Box,
-  Colors,
-  Heading,
-  NonIdealState,
-  PageHeader,
-  Spinner,
-  TextInput,
-  Tooltip,
-} from '@dagster-io/ui-components';
+import {Box, Colors, NonIdealState, Spinner, TextInput, Tooltip} from '@dagster-io/ui-components';
 import {useContext, useMemo, useState} from 'react';
 
 import {BASIC_INSTIGATION_STATE_FRAGMENT} from './BasicInstigationStateFragment';
 import {OverviewSensorTable} from './OverviewSensorsTable';
-import {OverviewTabs} from './OverviewTabs';
 import {sortRepoBuckets} from './sortRepoBuckets';
 import {BasicInstigationStateFragment} from './types/BasicInstigationStateFragment.types';
 import {OverviewSensorsQuery, OverviewSensorsQueryVariables} from './types/OverviewSensors.types';
 import {visibleRepoKeys} from './visibleRepoKeys';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
-import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
-import {useTrackPageView} from '../app/analytics';
+import {
+  FIFTEEN_SECONDS,
+  QueryRefreshCountdown,
+  useQueryRefreshAtInterval,
+} from '../app/QueryRefresh';
 import {SensorType} from '../graphql/types';
-import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {useSelectionReducer} from '../hooks/useSelectionReducer';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
@@ -61,10 +53,7 @@ const SENSOR_TYPE_TO_FILTER: Partial<Record<SensorType, ReturnType<typeof toSetF
 };
 const ALL_SENSOR_TYPE_FILTERS = Object.values(SENSOR_TYPE_TO_FILTER);
 
-export const OverviewSensorsRoot = () => {
-  useTrackPageView();
-  useDocumentTitle('Overview | Sensors');
-
+export const OverviewSensors = () => {
   const {allRepos, visibleRepos, loading: workspaceLoading} = useContext(WorkspaceContext);
   const repoCount = allRepos.length;
   const [searchValue, setSearchValue] = useQueryPersistedState<string>({
@@ -281,11 +270,7 @@ export const OverviewSensorsRoot = () => {
   const showSearchSpinner = (workspaceLoading && !repoCount) || (loading && !data);
 
   return (
-    <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
-      <PageHeader
-        title={<Heading>Overview</Heading>}
-        tabs={<OverviewTabs tab="sensors" refreshState={refreshState} />}
-      />
+    <>
       <Box
         padding={{horizontal: 24, vertical: 16}}
         flex={{
@@ -311,14 +296,17 @@ export const OverviewSensorsRoot = () => {
             style={{width: '340px'}}
           />
         </Box>
-        <Tooltip
-          content="You do not have permission to start or stop these schedules"
-          canShow={anySensorsVisible && !viewerHasAnyInstigationPermission}
-          placement="top-end"
-          useDisabledButtonTooltipFix
-        >
-          <SensorBulkActionMenu sensors={checkedSensors} onDone={() => refreshState.refetch()} />
-        </Tooltip>
+        <Box flex={{direction: 'row', gap: 12, alignItems: 'center'}}>
+          <QueryRefreshCountdown refreshState={refreshState} />
+          <Tooltip
+            content="You do not have permission to start or stop these schedules"
+            canShow={anySensorsVisible && !viewerHasAnyInstigationPermission}
+            placement="top-end"
+            useDisabledButtonTooltipFix
+          >
+            <SensorBulkActionMenu sensors={checkedSensors} onDone={() => refreshState.refetch()} />
+          </Tooltip>
+        </Box>
       </Box>
       {activeFiltersJsx.length ? (
         <Box
@@ -343,7 +331,7 @@ export const OverviewSensorsRoot = () => {
           {content()}
         </>
       )}
-    </Box>
+    </>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSensorsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSensorsRoot.tsx
@@ -1,0 +1,18 @@
+import {Box, Heading, PageHeader} from '@dagster-io/ui-components';
+
+import {OverviewSensors} from './OverviewSensors';
+import {OverviewTabs} from './OverviewTabs';
+import {useTrackPageView} from '../app/analytics';
+import {useDocumentTitle} from '../hooks/useDocumentTitle';
+
+export const OverviewSensorsRoot = () => {
+  useTrackPageView();
+  useDocumentTitle('Overview | Sensors');
+
+  return (
+    <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
+      <PageHeader title={<Heading>Overview</Heading>} tabs={<OverviewTabs tab="sensors" />} />
+      <OverviewSensors />
+    </Box>
+  );
+};


### PR DESCRIPTION
## Summary & Motivation

Create the "Automation" page, a step toward breaking apart "Overview" for the new navigation structure.

The content for each of these tabs is now shared by the "Overview" section and this "Automation" section, with each of them using their own distinct tabs, document title, etc.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/04l624FRNbtX4kJhQyXR/3e8f4c71-279d-4f32-ab9b-a6d96e30045b.png)

This route is not publicly visible yet, but can be accessed at `/automation`.

## How I Tested These Changes

View `/automation`, verify that the tabs and pages work correctly. View `/overview`, verify same.

Verify also that all tabs are properly scrollable, since the root containers are changing.