### PR TITLE
fix: remove input path logging causing false positives on source assets thinking they are updated

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -255,7 +255,6 @@ class UPathIOManager(MemoizableIOManager):
             else:
                 raise e
 
-        context.add_input_metadata({"path": MetadataValue.path(str(path))})
         return obj
 
     def _load_partition_from_path(


### PR DESCRIPTION
## Summary & Motivation
The UPathIOManager adds for no reason the path on the input asset, if the input asset is a source asset now it will have an additional observation causing a false positive across your asset lineage thinking all the assets are now outdated even though the source asset did not get a new version.

If you have an auto materialize policy this will cause all your assets to be updated in an infinite loop..
