### PR TITLE
ScheduleDefinition: Unhelpful `DeprecatedWarning`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -608,6 +608,7 @@ class ScheduleDefinition(IHasInternalInit):
         self._environment_vars = check.opt_mapping_param(
             environment_vars, "environment_vars", key_type=str, value_type=str
         )
+        self._environment_vars = self._environment_vars or None
 
         self._execution_timezone = check.opt_str_param(execution_timezone, "execution_timezone")
 
@@ -820,7 +821,7 @@ class ScheduleDefinition(IHasInternalInit):
         additional_warn_text="Setting this property no longer has any effect.",
     )
     @property
-    def environment_vars(self) -> Mapping[str, str]:
+    def environment_vars(self) -> Optional[Mapping[str, str]]:
         """Mapping[str, str]: Environment variables to export to the cron schedule."""
         return self._environment_vars
 

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -605,10 +605,9 @@ class ScheduleDefinition(IHasInternalInit):
 
         self._description = check.opt_str_param(description, "description")
 
-        self._environment_vars = check.opt_mapping_param(
+        self._environment_vars = check.opt_nullable_mapping_param(
             environment_vars, "environment_vars", key_type=str, value_type=str
         )
-        self._environment_vars = self._environment_vars or None
 
         self._execution_timezone = check.opt_str_param(execution_timezone, "execution_timezone")
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_schedule.py
@@ -447,15 +447,3 @@ def test_vixie_cronstring_schedule():
     assert execution_data.run_requests
     assert len(execution_data.run_requests) == 1
     assert execution_data.run_requests[0].tags.get("foo") == "FOO"
-
-
-def test__empty_schedule_definition__no_raise_DepreciationWarning() -> None:
-    """Test that ScheduleDefinition() does not raise a DeprecationWarning.
-    
-    This test ensures that the warning is not raised when the `environment_vars` 
-    argument is not passed, thus adhering to the deprecation policy.
-    """
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-
-        ScheduleDefinition()

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_schedule.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import re
+import warnings
 from datetime import datetime
 
 import pendulum
@@ -446,3 +447,15 @@ def test_vixie_cronstring_schedule():
     assert execution_data.run_requests
     assert len(execution_data.run_requests) == 1
     assert execution_data.run_requests[0].tags.get("foo") == "FOO"
+
+
+def test__empty_schedule_definition__no_raise_DepreciationWarning() -> None:
+    """Test that ScheduleDefinition() does not raise a DeprecationWarning.
+    
+    This test ensures that the warning is not raised when the `environment_vars` 
+    argument is not passed, thus adhering to the deprecation policy.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+
+        ScheduleDefinition()

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_schedule.py
@@ -1,7 +1,6 @@
 import inspect
 import json
 import re
-import warnings
 from datetime import datetime
 
 import pendulum


### PR DESCRIPTION
## Summary & Motivation
There is a `DepreciationWarning` for the `ScheduleDefinition` constructor that triggers regardless of the inputs given. 

Given the `DepreciationWarning` indicates the depreciation of the use of `environment_vars` in the constructor, expected use would no emitting of the warning when the `environment_vars` is unused.

**Cause**: `check.opt_mapping_param` returns `dict()` when the object passed into it is `None`. This is counter to to the `@deprecated` decorator which required a value of `None` to not emit the warning.

## How I Tested These Changes

This showed up in our local usage of dagster in an attempt to find `DeprecationWarning`s across the codebase, in which this one we are unable to resolve due to the inconsistent behavior mentioned above. 

This PR includes a `test__empty_schedule_definition__no_raise_DepreciationWarning` which fails upon any `DeprecationWarning` raised when constructing an empty `ScheduleDefinition`.
