### PR TITLE
fix: Sling asset - reading AssetSpec from stream level

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
@@ -91,7 +91,9 @@ def sling_assets(
                 description=dagster_sling_translator.get_description(stream),
                 code_version=code_version,
                 freshness_policy=dagster_sling_translator.get_freshness_policy(stream),
-                auto_materialize_policy = dagster_sling_translator.get_auto_materialize_policy(stream),
+                auto_materialize_policy=dagster_sling_translator.get_auto_materialize_policy(
+                    stream
+                ),
             )
         )
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
@@ -79,13 +79,7 @@ def sling_assets(
     """
     replication_config = validate_replication(replication_config)
     streams = get_streams_from_replication(replication_config)
-
-    group_name = dagster_sling_translator.get_group_name(replication_config)
     code_version = non_secure_md5_hash_str(str(replication_config).encode())
-    freshness_policy = dagster_sling_translator.get_freshness_policy(replication_config)
-    auto_materialize_policy = dagster_sling_translator.get_auto_materialize_policy(
-        replication_config
-    )
 
     specs: list[AssetSpec] = []
     for stream in streams:
@@ -93,10 +87,11 @@ def sling_assets(
             AssetSpec(
                 key=dagster_sling_translator.get_asset_key(stream),
                 deps=dagster_sling_translator.get_deps_asset_key(stream),
-                group_name=group_name,
+                group_name = dagster_sling_translator.get_group_name(stream),
+                description = dagster_sling_translator.get_description(stream),
                 code_version=code_version,
-                freshness_policy=freshness_policy,
-                auto_materialize_policy=auto_materialize_policy,
+                freshness_policy=dagster_sling_translator.get_freshness_policy(stream),
+                auto_materialize_policy = dagster_sling_translator.get_auto_materialize_policy(stream),
             )
         )
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
@@ -87,8 +87,8 @@ def sling_assets(
             AssetSpec(
                 key=dagster_sling_translator.get_asset_key(stream),
                 deps=dagster_sling_translator.get_deps_asset_key(stream),
-                group_name = dagster_sling_translator.get_group_name(stream),
-                description = dagster_sling_translator.get_description(stream),
+                group_name=dagster_sling_translator.get_group_name(stream),
+                description=dagster_sling_translator.get_description(stream),
                 code_version=code_version,
                 freshness_policy=dagster_sling_translator.get_freshness_policy(stream),
                 auto_materialize_policy = dagster_sling_translator.get_auto_materialize_policy(stream),


### PR DESCRIPTION
## Summary & Motivation

I wanted to use `group` and `description` for assets in **Dagster** defined in **Sling** file `replication.yaml`, but values weren't applied while `asset_key` worked fine.

**Expected**
<img width="322" alt="image" src="https://github.com/dagster-io/dagster/assets/15640266/5d02dff8-c513-4d82-a67f-496367e347c2">

**Reality**
- default group
- no description
<img width="322" alt="image" src="https://github.com/dagster-io/dagster/assets/15640266/2c9532bb-5f0d-440c-b12f-df6ba9d9f847">


**Example Configuration** (`replication.yaml`)

```yaml
source: S3_FINANCE
target: POSTGRES_PROD_FINANCE

defaults:
  mode: incremental

streams:
  s3://finance/raw_data/assets/exchanges.csv:
    object: 'raw.exchanges'
    primary_key: [code]

    meta:
      dagster:
        asset_key: "finance.exchanges"
        group: "raw_data_assets"
        description: "Exchanges RAW data"
```

## How I Tested These Changes
- setup local Dagster environment
- tested behaviour before changes - visible in **Global Asset Lineage page**
- changed affected code - `asset_decorator.py` file inside **dagster_embedded_elt / sling**.
- tested behaviour after changes
