### PR TITLE
Fix Concepts documentation typo

### DIFF
--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -51,7 +51,7 @@ An asset is an object in persistent storage, such as a table, file, or persisted
 
 ## Automation
 
-Dagster offers several ways to run data pipelines without manual intervation, including traditional scheduling and event-based triggers.
+Dagster offers several ways to run data pipelines without manual intervention, including traditional scheduling and event-based triggers.
 
 <ArticleList>
   <ArticleListItem


### PR DESCRIPTION
## Summary & Motivation
There's a little typo in the Concepts documentation.

## How I Tested These Changes
