### PR TITLE
[ui] Repair "Show JSON" dialog stacking

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/CellTruncationProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/CellTruncationProvider.tsx
@@ -1,8 +1,6 @@
-import {Button, Icon} from '@dagster-io/ui-components';
+import {Button, Dialog, DialogFooter, Icon} from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled from 'styled-components';
-
-import {showCustomAlert} from '../app/CustomAlertProvider';
 
 const OverflowFade = styled.div`
   position: absolute;
@@ -31,10 +29,11 @@ export class CellTruncationProvider extends React.Component<
     onExpand?: () => void;
     forceExpandability?: boolean;
   },
-  {isOverflowing: boolean}
+  {isOverflowing: boolean; showDialog: boolean}
 > {
   state = {
     isOverflowing: false,
+    showDialog: false,
   };
 
   private contentContainerRef: React.RefObject<HTMLDivElement> = React.createRef();
@@ -62,18 +61,18 @@ export class CellTruncationProvider extends React.Component<
     }
   }
 
-  defaultExpand() {
+  dialogContents() {
     const message =
       this.contentContainerRef.current && this.contentContainerRef.current.textContent;
-    message &&
-      showCustomAlert({
-        body: <div style={{whiteSpace: 'pre-wrap'}}>{message}</div>,
-      });
+    if (message) {
+      return <div style={{whiteSpace: 'pre-wrap'}}>{message}</div>;
+    }
+    return null;
   }
 
   onView = () => {
     const {onExpand} = this.props;
-    onExpand ? onExpand() : this.defaultExpand();
+    onExpand ? onExpand() : this.setState({showDialog: true});
   };
 
   render() {
@@ -90,6 +89,21 @@ export class CellTruncationProvider extends React.Component<
                 View full message
               </Button>
             </OverflowButtonContainer>
+            {this.props.onExpand ? null : (
+              <Dialog
+                canEscapeKeyClose
+                canOutsideClickClose
+                isOpen={this.state.showDialog}
+                onClose={() => this.setState({showDialog: false})}
+              >
+                <div>{this.dialogContents()}</div>
+                <DialogFooter topBorder>
+                  <Button intent="primary" onClick={() => this.setState({showDialog: false})}>
+                    Done
+                  </Button>
+                </DialogFooter>
+              </Dialog>
+            )}
           </>
         )}
       </div>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRow.tsx
@@ -1,6 +1,7 @@
 import {gql} from '@apollo/client';
-import {Box} from '@dagster-io/ui-components';
+import {Box, Button, Dialog, DialogBody, DialogFooter} from '@dagster-io/ui-components';
 import * as React from 'react';
+import {useMemo, useState} from 'react';
 
 import {CellTruncationProvider} from './CellTruncationProvider';
 import {
@@ -28,16 +29,13 @@ interface StructuredProps {
   highlighted: boolean;
 }
 
-interface StructuredState {
-  expanded: boolean;
-}
+export const Structured = (props: StructuredProps) => {
+  const {node, metadata, style, highlighted} = props;
+  const [expanded, setExpanded] = useState(false);
 
-export class Structured extends React.Component<StructuredProps, StructuredState> {
-  onExpand = () => {
-    const {node, metadata} = this.props;
-
+  const {title, body, dialogStyle} = useMemo(() => {
     if (node.__typename === 'ExecutionStepFailureEvent') {
-      showCustomAlert({
+      return {
         title: 'Error',
         body: (
           <PythonErrorInfo
@@ -46,46 +44,60 @@ export class Structured extends React.Component<StructuredProps, StructuredState
             errorSource={node.errorSource}
           />
         ),
-      });
-    } else if (node.__typename === 'ExecutionStepUpForRetryEvent') {
-      showCustomAlert({
+      };
+    }
+
+    if (node.__typename === 'ExecutionStepUpForRetryEvent') {
+      return {
         title: 'Step Retry',
         body: <PythonErrorInfo error={node.error ? node.error : node} />,
-      });
-    } else if (
+      };
+    }
+
+    if (
       (node.__typename === 'EngineEvent' && node.error) ||
       (node.__typename === 'RunFailureEvent' && node.error) ||
       node.__typename === 'HookErroredEvent' ||
       node.__typename === 'ResourceInitFailureEvent'
     ) {
-      showCustomAlert({
+      return {
         title: 'Error',
         body: <PythonErrorInfo error={node.error ? node.error : node} />,
-      });
-    } else {
-      showCustomAlert({
-        title: node.stepKey || 'Info',
-        body: (
-          <StructuredContent>
-            <LogsRowStructuredContent node={node} metadata={metadata} />
-          </StructuredContent>
-        ),
-      });
+      };
     }
-  };
 
-  render() {
-    return (
-      <CellTruncationProvider style={this.props.style} onExpand={this.onExpand}>
-        <StructuredMemoizedContent
-          node={this.props.node}
-          metadata={this.props.metadata}
-          highlighted={this.props.highlighted}
-        />
-      </CellTruncationProvider>
-    );
-  }
-}
+    return {
+      title: node.stepKey || 'Info',
+      body: (
+        <StructuredContent>
+          <LogsRowStructuredContent node={node} metadata={metadata} />
+        </StructuredContent>
+      ),
+      dialogStyle: {width: '80vw', minWidth: '600px', maxWidth: '1000px'},
+    };
+  }, [metadata, node]);
+
+  return (
+    <CellTruncationProvider style={style} onExpand={() => setExpanded(true)}>
+      <StructuredMemoizedContent node={node} metadata={metadata} highlighted={highlighted} />
+      <Dialog
+        title={title}
+        isOpen={expanded}
+        canEscapeKeyClose
+        canOutsideClickClose
+        onClose={() => setExpanded(false)}
+        style={dialogStyle}
+      >
+        <DialogBody>{body}</DialogBody>
+        <DialogFooter topBorder>
+          <Button intent="primary" onClick={() => setExpanded(false)}>
+            Done
+          </Button>
+        </DialogFooter>
+      </Dialog>
+    </CellTruncationProvider>
+  );
+};
 
 export const LOGS_ROW_STRUCTURED_FRAGMENT = gql`
   fragment LogsRowStructuredFragment on DagsterRunEvent {


### PR DESCRIPTION
## Summary & Motivation

Reimplement the log expansion dialog to use `Dialog` directly, instead of `showCustomAlert`. This allows us to show the "Show JSON" dialog on top of it correctly when opened from the expansing dialog.

https://github.com/dagster-io/dagster/assets/2823852/6832c44f-fb0c-4092-a34e-0c7c4c13b0f8

## How I Tested These Changes

Find a log that needs to be expanded. Click on it, then click "Show JSON". Verify correct dialog stacking.