### PR TITLE
[ui] Fix owners filter error

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useAssetOwnerFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useAssetOwnerFilter.tsx
@@ -49,12 +49,14 @@ export function useAssetOwnersForAssets(
     () =>
       Array.from(
         new Set(
-          assets.flatMap(
-            (a) =>
-              a.definition?.owners.flatMap((o) =>
-                o.__typename === 'TeamAssetOwner' ? o.team : o.email,
-              ),
-          ),
+          assets
+            .flatMap(
+              (a) =>
+                a.definition?.owners.flatMap((o) =>
+                  o.__typename === 'TeamAssetOwner' ? o.team : o.email,
+                ),
+            )
+            .filter((o) => o),
         ),
       ) as string[],
     [assets],


### PR DESCRIPTION
Fixes https://linear.app/dagster-labs/issue/PLUS-1026/owners-filter-without-experimental-feature-flag-is-broken

The cause of the issue is attempting to render owners of assets without definitions. This PR adds filtering to remove these undefined objects.