### PR TITLE
[external-assets] Remove AssetLayer methods with existing AssetNode implementations

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -541,15 +541,6 @@ class AssetLayer(NamedTuple):
             assets_defs_by_check_key=assets_defs_by_check_key,
         )
 
-    def upstream_assets_for_asset(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
-        return self.asset_graph.get(asset_key).parent_keys
-
-    def downstream_assets_for_asset(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
-        # TODO: remove built-in existence check when callsites are updated to check existence
-        return (
-            self.asset_graph.get(asset_key).child_keys if self.asset_graph.has(asset_key) else set()
-        )
-
     @property
     def all_asset_keys(self) -> Iterable[AssetKey]:
         return self.asset_graph.all_asset_keys

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -967,7 +967,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         for output_key in output_keys:
             if output_key not in self.job_def.asset_layer.asset_deps:
                 continue
-            dep_keys = self.job_def.asset_layer.upstream_assets_for_asset(output_key)
+            dep_keys = self.job_def.asset_layer.get(output_key).parent_keys
             for key in dep_keys:
                 if key not in all_dep_keys and key not in output_keys:
                     all_dep_keys.append(key)

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -249,15 +249,13 @@ def _step_output_error_checked_user_event_sequence(
             ):
                 if asset_layer.has(asset_info.key):
                     assets_def = asset_layer.get(asset_info.key).assets_def
-                    all_dependent_keys = asset_layer.downstream_assets_for_asset(asset_info.key)
+                    all_dependent_keys = asset_layer.get(asset_info.key).child_keys
                     step_local_asset_keys = step_context.get_output_asset_keys()
                     step_local_dependent_keys = all_dependent_keys & step_local_asset_keys
                     for dependent_key in step_local_dependent_keys:
                         output_name = assets_def.get_output_name_for_asset_key(dependent_key)
                         # Need to skip self-dependent assets (possible with partitions)
-                        self_dep = dependent_key in asset_layer.upstream_assets_for_asset(
-                            asset_info.key
-                        )
+                        self_dep = dependent_key in asset_layer.get(asset_info.key).parent_keys
                         if not self_dep and step_context.has_seen_output(output_name):
                             raise DagsterInvariantViolationError(
                                 f'Asset "{dependent_key.to_user_string()}" was yielded before its'
@@ -705,7 +703,7 @@ def _get_input_provenance_data(
     asset_key: AssetKey, step_context: StepExecutionContext
 ) -> Mapping[AssetKey, _InputProvenanceData]:
     input_provenance: Dict[AssetKey, _InputProvenanceData] = {}
-    deps = step_context.job_def.asset_layer.upstream_assets_for_asset(asset_key)
+    deps = step_context.job_def.asset_layer.get(asset_key).parent_keys
     for key in deps:
         # For deps external to this step, this will retrieve the cached record that was stored prior
         # to step execution. For inputs internal to this step, it may trigger a query to retrieve


### PR DESCRIPTION
## Summary & Motivation

Remove a few asset layer methods with existing `AssetNode` implementations and accordingly update callsites.

## How I Tested These Changes

Existing test suite.