### PR TITLE
feat(dbt): add parameter toggle to emit column dependency metadata

### DIFF
--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -611,6 +611,22 @@ snapshots:
     - "{{ dagster.log_column_level_metadata() }}"
 ```
 
+Column dependencies can be removed from materialization metadata by disabling the collection of parent relation metadata. This can be done by setting the `enable_parent_relation_metadata_collection` argument to `False` in the `dagster.log_column_level_metadata()` macro:
+
+```yaml
+models:
+  +post-hook:
+    - "{{ dagster.log_column_level_metadata(enable_parent_relation_metadata_collection=false) }}"
+
+seeds:
+  +post-hook:
+    - "{{ dagster.log_column_level_metadata(enable_parent_relation_metadata_collection=false) }}"
+
+snapshots:
+  +post-hook:
+    - "{{ dagster.log_column_level_metadata(enable_parent_relation_metadata_collection=false) }}"
+```
+
 ---
 
 ## Defining dependencies

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/dbt_project.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/dbt_project.yml
@@ -21,7 +21,7 @@ require-dbt-version: [">=1.0.0", "<2.0.0"]
 
 models:
   +post-hook:
-    - "{{ dagster.log_column_level_metadata() }}"
+    - "{{ dagster.log_column_level_metadata(enable_parent_relation_metadata_collection=var('dagster_enable_parent_relation_metadata_collection', 'true')) }}"
   test_dagster_metadata:
     materialized: table
     staging:
@@ -29,4 +29,4 @@ models:
 
 seeds:
   +post-hook:
-    - "{{ dagster.log_column_level_metadata() }}"
+    - "{{ dagster.log_column_level_metadata(enable_parent_relation_metadata_collection=var('dagster_enable_parent_relation_metadata_collection', 'true')) }}"


### PR DESCRIPTION
## Summary & Motivation
Allow the collection of column schema metadata for a dbt node's parents to be enabled or disabled. Disabling this collection prevents column dependencies from being emitted in the dbt node's materialization.

## How I Tested These Changes
pytest, added docs
