### PR TITLE
Fix sqlite logging

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -118,6 +118,8 @@ if TYPE_CHECKING:
 MIN_ASSET_ROWS = 25
 DEFAULT_MAX_LIMIT_EVENT_RECORDS = 10000
 
+# Limit logs to 1GB, has to be less than INT_MAX
+MAX_SERIALIZED_EVENT_LENGTH = 1024*1024*1024
 
 def get_max_event_records_limit() -> int:
     max_value = os.getenv("MAX_LIMIT_GET_EVENT_RECORDS")

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -203,10 +203,14 @@ class SqlEventLogStorage(EventLogStorage):
             if event.dagster_event.partition:
                 partition = event.dagster_event.partition
 
+        serialized_event = serialize_value(event)
+        if len(serialized_event) > MAX_SERIALIZED_EVENT_LENGTH:
+            serialized_event = serialized_event[:MAX_SERIALIZED_EVENT_LENGTH-3] + "..."
+
         # https://stackoverflow.com/a/54386260/324449
         return SqlEventLogStorageTable.insert().values(
             run_id=event.run_id,
-            event=serialize_value(event),
+            event=serialized_event,
             dagster_event_type=dagster_event_type,
             timestamp=self._event_insert_timestamp(event),
             step_key=step_key,


### PR DESCRIPTION
## Summary & Motivation
If a task generates long output that is included in a log event, it might overflow sqlite limits and fail.
See real-world stacktrace at the end of the description.

## How I Tested These Changes
Ran the failing scenario again.

## Real world stack trace:
```
dagster._core.errors.DagsterSubprocessError: During multiprocess execution errors occurred in child processes:
In process 610244: OverflowError: string longer than INT_MAX bytes

Stack Trace:
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/dagster/_core/executor/child_process_executor.py", line 79, in _execute_command_in_child_process
    for step_event in command.execute():
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/dagster/_core/executor/multiprocess.py", line 98, in execute
    yield from execute_plan_iterator(
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/dagster/_core/execution/api.py", line 878, in __iter__
    yield from self.iterator(
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/dagster/_core/execution/plan/execute_plan.py", line 121, in inner_plan_execution_iterator
    for step_event in check.generator(
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/dagster/_core/execution/plan/execute_plan.py", line 341, in dagster_event_sequence_for_step
    yield step_failure_event_from_exc_info(
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/dagster/_core/execution/plan/objects.py", line 130, in step_failure_event_from_exc_info
    return DagsterEvent.step_failure_event(
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/dagster/_core/events/__init__.py", line 858, in step_failure_event
    return DagsterEvent.from_step(
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/dagster/_core/events/__init__.py", line 430, in from_step
    log_step_event(step_context, event)
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/dagster/_core/events/__init__.py", line 309, in log_step_event
    step_context.log.log_dagster_event(
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/dagster/_core/log_manager.py", line 407, in log_dagster_event
    self.log(level=level, msg=msg, extra={DAGSTER_META_KEY: dagster_event})
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/dagster/_core/log_manager.py", line 422, in log
    self._log(level, msg, args, **kwargs)
  File "/pagaya/python310/lib/python3.10/logging/__init__.py", line 1628, in _log
    self.handle(record)
  File "/pagaya/python310/lib/python3.10/logging/__init__.py", line 1638, in handle
    self.callHandlers(record)
  File "/pagaya/python310/lib/python3.10/logging/__init__.py", line 1700, in callHandlers
    hdlr.handle(record)
  File "/pagaya/python310/lib/python3.10/logging/__init__.py", line 972, in handle
    self.emit(record)
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/dagster/_core/log_manager.py", line 288, in emit
    handler.handle(dagster_record)
  File "/pagaya/python310/lib/python3.10/logging/__init__.py", line 972, in handle
    self.emit(record)
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/dagster/_core/instance/__init__.py", line 229, in emit
    self._instance.handle_new_event(event)
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/dagster/_core/instance/__init__.py", line 2254, in handle_new_event
    self._event_storage.store_event(event)
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py", line 243, in store_event
    conn.execute(insert_event_statement)
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1385, in execute
    return meth(self, multiparams, params, _EMPTY_EXECUTION_OPTS)
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/sqlalchemy/sql/elements.py", line 334, in _execute_on_connection
    return connection._execute_clauseelement(
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1577, in _execute_clauseelement
    ret = self._execute_context(
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1953, in _execute_context
    self._handle_dbapi_exception(
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 2138, in _handle_dbapi_exception
    util.raise_(exc_info[1], with_traceback=exc_info[2])
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1910, in _execute_context
    self.dialect.do_execute(
  File "/home/datajobs/workspaces/data/venv/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
```