### PR TITLE
[external-assets] Convert SourceAssets used as node inputs in GraphDefinition construction

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/graph_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/graph_decorator.py
@@ -75,7 +75,7 @@ class _Graph:
             node_defs,
             config_mapping,
             positional_inputs,
-            node_input_source_assets,
+            input_assets,
         ) = do_composition(
             decorator_name="@graph",
             graph_name=self.name,
@@ -96,7 +96,7 @@ class _Graph:
             config=config_mapping,
             positional_inputs=positional_inputs,
             tags=self.tags,
-            node_input_source_assets=node_input_source_assets,
+            input_assets=input_assets,
         )
         update_wrapper(graph_def, fn)
         return graph_def

--- a/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
@@ -71,7 +71,7 @@ class _Job:
             node_defs,
             config_mapping,
             positional_inputs,
-            node_input_source_assets,
+            input_assets,
         ) = do_composition(
             decorator_name="@job",
             graph_name=self.name,
@@ -92,7 +92,7 @@ class _Job:
             config=config_mapping,
             positional_inputs=positional_inputs,
             tags=self.tags,
-            node_input_source_assets=node_input_source_assets,
+            input_assets=input_assets,
         )
 
         job_def = graph_def.to_job(

--- a/python_modules/dagster/dagster/_core/system_config/composite_descent.py
+++ b/python_modules/dagster/dagster/_core/system_config/composite_descent.py
@@ -222,7 +222,7 @@ def _apply_top_level_config_mapping(
             dependency_structure=graph_def.dependency_structure,
             resource_defs=resource_defs,
             asset_layer=job_def.asset_layer,
-            node_input_source_assets=graph_def.node_input_source_assets,
+            input_assets=graph_def.input_assets,
         )
 
         # process against that new type
@@ -290,7 +290,7 @@ def _apply_config_mapping(
         parent_handle=current_stack.handle,
         resource_defs=resource_defs,
         asset_layer=asset_layer,
-        node_input_source_assets=graph_def.node_input_source_assets,
+        input_assets=graph_def.input_assets,
     )
 
     # process against that new type

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph_source_asset_input.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph_source_asset_input.py
@@ -1,6 +1,9 @@
+from typing import Union
+
 import pytest
 from dagster import (
     AssetKey,
+    AssetsDefinition,
     DagsterInvalidDefinitionError,
     IOManager,
     IOManagerDefinition,
@@ -10,15 +13,18 @@ from dagster import (
     job,
     op,
 )
+from dagster._core.definitions.external_asset import create_external_asset_from_source_asset
 
 
-def make_io_manager(source_asset: SourceAsset, input_value=5, expected_metadata={}):
+def make_io_manager(
+    asset: Union[AssetsDefinition, SourceAsset], input_value=5, expected_metadata={}
+):
     class MyIOManager(IOManager):
         def handle_output(self, context, obj): ...
 
         def load_input(self, context):
             self.loaded_input = True
-            assert context.asset_key == source_asset.key
+            assert context.asset_key == asset.key
             for key, value in expected_metadata.items():
                 assert context.upstream_output.metadata[key] == value
             return input_value
@@ -28,6 +34,22 @@ def make_io_manager(source_asset: SourceAsset, input_value=5, expected_metadata=
 
 def test_source_asset_input_value():
     asset1 = SourceAsset("asset1", metadata={"foo": "bar"})
+
+    @op
+    def op1(input1):
+        assert input1 == 5
+
+    @graph
+    def graph1():
+        op1(asset1)
+
+    io_manager = make_io_manager(asset1, expected_metadata={"foo": "bar"})
+    assert graph1.execute_in_process(resources={"io_manager": io_manager}).success
+    assert io_manager.loaded_input
+
+
+def test_external_asset_input_value():
+    asset1 = create_external_asset_from_source_asset(SourceAsset("asset1", metadata={"foo": "bar"}))
 
     @op
     def op1(input1):

--- a/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
@@ -284,7 +284,7 @@ def test_op_config_error():
         parent_handle=None,
         resource_defs={},
         asset_layer=job_def.asset_layer,
-        node_input_source_assets={},
+        input_assets={},
     )
 
     int_solid_config_type = solid_dict_type.fields["int_config_op"].config_type


### PR DESCRIPTION
## Summary & Motivation

Currently `SourceAsset` can be passed in as inputs in `GraphDefinition` construction. This can happen either in a user-provided composition function or via the `node_input_source_assets` constructor parameter to `GraphDefinition`. This param is undocumented but nonetheless technically public.

This PR makes several changes:

- Converts `SourceAsset` passed in composition to an `AssetsDefinition` (external asset) immediately.
- Renames (with deprecation `GraphDefinition` `node_input_source_assets` param to `input_assets`
- Renames various local variables and private function params.

## How I Tested These Changes

Existing test suite.