### PR TITLE
[embedded-elt][sling] add asset key prefix unit test

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
@@ -1,4 +1,5 @@
 import re
+from dataclasses import dataclass
 from typing import Any, Iterable, Mapping, Optional
 
 from dagster import (
@@ -10,6 +11,7 @@ from dagster import (
 from dagster._annotations import public
 
 
+@dataclass
 class DagsterSlingTranslator:
     target_prefix: str = "target"
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
@@ -1,5 +1,4 @@
 import re
-from dataclasses import dataclass
 from typing import Any, Iterable, Mapping, Optional
 
 from dagster import (
@@ -11,7 +10,6 @@ from dagster import (
 from dagster._annotations import public
 
 
-@dataclass
 class DagsterSlingTranslator:
     target_prefix: str = "target"
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
@@ -196,3 +196,24 @@ def test_base_with_meta_config_translator():
         AssetKey(["target", "public", "transactions"])
         in my_sling_assets.auto_materialize_policies_by_key
     )
+
+
+def test_base_with_custom_asset_key_prefix():
+    class CustomPrefixDagsterSlingTranslator(DagsterSlingTranslator):
+        target_prefix: str = "custom"
+
+    @sling_assets(
+        replication_config=file_relative_path(
+            __file__, "replication_configs/base_config/replication.yaml"
+        ),
+        dagster_sling_translator=CustomPrefixDagsterSlingTranslator(),
+    )
+    def my_sling_assets(): ...
+
+    assert my_sling_assets.keys == {
+        AssetKey(["custom", "public", "users"]),
+        AssetKey(["custom", "public", "accounts"]),
+        AssetKey(["custom", "public", "all_users"]),
+        AssetKey(["custom", "departments"]),
+        AssetKey(["custom", "public", "transactions"]),
+    }

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
@@ -199,14 +199,11 @@ def test_base_with_meta_config_translator():
 
 
 def test_base_with_custom_asset_key_prefix():
-    class CustomPrefixDagsterSlingTranslator(DagsterSlingTranslator):
-        target_prefix: str = "custom"
-
     @sling_assets(
         replication_config=file_relative_path(
             __file__, "replication_configs/base_config/replication.yaml"
         ),
-        dagster_sling_translator=CustomPrefixDagsterSlingTranslator(),
+        dagster_sling_translator=DagsterSlingTranslator(target_prefix="custom"),
     )
     def my_sling_assets(): ...
 


### PR DESCRIPTION
## Summary & Motivation

~~By defining `DagsterSlingTranslator` as a `@dataclass`, when a user overrides this class, they would need to specify the same decorator, otherwise the `target_prefix` attribute will not be recognized.~~

~~I don't believe having it as a _dataclass_ is providing us any benefit, as I've removed it in this PR, and the tests continue to pass. I've also introduced a test for the `target_prefix`.~~

Resolves https://github.com/dagster-io/dagster/issues/20485
