### PR TITLE
[bugfix] Fix regression in ExternalAssetNode metadata

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -1239,7 +1239,9 @@ class ExternalAssetNode(
         auto_observe_interval_minutes: Optional[float] = None,
         owners: Optional[Sequence[str]] = None,
     ):
-        metadata = normalize_metadata(check.opt_mapping_param(metadata, "metadata", key_type=str))
+        metadata = normalize_metadata(
+            check.opt_mapping_param(metadata, "metadata", key_type=str), allow_invalid=True
+        )
 
         # backcompat logic for execution type specified via metadata
         if SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE in metadata:


### PR DESCRIPTION
## Summary & Motivation

A previous refactor introduced a regression by failing to normalize `ExternalAssetNode` metadata with `allow_invalid=True`. This fixes the regression.

## How I Tested These Changes

Existing test suite.