### PR TITLE
Clean up some old methods on HookContext

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/_core/execution/context/hook.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import TYPE_CHECKING, AbstractSet, Any, Dict, Mapping, Optional, Set, Union
 
 import dagster._check as check
@@ -89,14 +88,6 @@ class HookContext:
         """The op instance associated with the hook."""
         return self._step_execution_context.op
 
-    @property
-    def step(self) -> ExecutionStep:
-        warnings.warn(
-            "The step property of HookContext has been deprecated, and will be removed "
-            "in a future release."
-        )
-        return self._step_execution_context.step
-
     @public
     @property
     def step_key(self) -> str:
@@ -115,18 +106,14 @@ class HookContext:
         """Resources available in the hook context."""
         return self._resources
 
-    @property
-    def solid_config(self) -> Any:
-        solid_config = self._step_execution_context.resolved_run_config.ops.get(
-            str(self._step_execution_context.step.node_handle)
-        )
-        return solid_config.config if solid_config else None
-
     @public
     @property
     def op_config(self) -> Any:
         """The parsed config specific to this op."""
-        return self.solid_config
+        op_config = self._step_execution_context.resolved_run_config.ops.get(
+            str(self._step_execution_context.step.node_handle)
+        )
+        return op_config.config if op_config else None
 
     # Because of the fact that we directly use the log manager of the step, if a user calls
     # hook_context.log.with_tags, then they will end up mutating the step's logging tags as well.
@@ -136,15 +123,6 @@ class HookContext:
     def log(self) -> DagsterLogManager:
         """Centralized log dispatch from user code."""
         return self._step_execution_context.log
-
-    @property
-    def solid_exception(self) -> Optional[BaseException]:
-        """The thrown exception in a failed solid.
-
-        Returns:
-            Optional[BaseException]: the exception object, None if the solid execution succeeds.
-        """
-        return self.op_exception
 
     @public
     @property
@@ -157,8 +135,9 @@ class HookContext:
 
         return exc
 
+    @public
     @property
-    def solid_output_values(self) -> Mapping[str, Union[Any, Mapping[str, Any]]]:
+    def op_output_values(self) -> Mapping[str, Union[Any, Mapping[str, Any]]]:
         """The computed output values.
 
         Returns a dictionary where keys are output names and the values are:
@@ -184,12 +163,6 @@ class HookContext:
                 results[step_output_handle.output_name] = value
 
         return results
-
-    @public
-    @property
-    def op_output_values(self):
-        """Computed output values in an op."""
-        return self.solid_output_values
 
     @public
     @property
@@ -316,8 +289,8 @@ class UnboundHookContext(HookContext):
         return self._resources
 
     @property
-    def solid_config(self) -> Any:
-        raise DagsterInvalidPropertyError(_property_msg("solid_config", "property"))
+    def op_config(self) -> Any:
+        raise DagsterInvalidPropertyError(_property_msg("op_config", "property"))
 
     @property
     def log(self) -> DagsterLogManager:
@@ -328,14 +301,14 @@ class UnboundHookContext(HookContext):
         return self._op_exception
 
     @property
-    def solid_output_values(self) -> Mapping[str, Union[Any, Mapping[str, Any]]]:
+    def op_output_values(self) -> Mapping[str, Union[Any, Mapping[str, Any]]]:
         """The computed output values.
 
         Returns a dictionary where keys are output names and the values are:
             * the output values in the normal case
             * a dictionary from mapping key to corresponding value in the mapped case
         """
-        raise DagsterInvalidPropertyError(_property_msg("solid_output_values", "method"))
+        raise DagsterInvalidPropertyError(_property_msg("op_output_values", "method"))
 
     @property
     def op_output_metadata(self) -> Mapping[str, Union[Any, Mapping[str, Any]]]:
@@ -418,8 +391,8 @@ class BoundHookContext(HookContext):
         return self._resources
 
     @property
-    def solid_config(self) -> Any:
-        raise DagsterInvalidPropertyError(_property_msg("solid_config", "property"))
+    def op_config(self) -> Any:
+        raise DagsterInvalidPropertyError(_property_msg("op_config", "property"))
 
     @property
     def log(self) -> DagsterLogManager:
@@ -430,14 +403,14 @@ class BoundHookContext(HookContext):
         return self._op_exception
 
     @property
-    def solid_output_values(self) -> Mapping[str, Union[Any, Mapping[str, Any]]]:
+    def op_output_values(self) -> Mapping[str, Union[Any, Mapping[str, Any]]]:
         """The computed output values.
 
         Returns a dictionary where keys are output names and the values are:
             * the output values in the normal case
             * a dictionary from mapping key to corresponding value in the mapped case
         """
-        raise DagsterInvalidPropertyError(_property_msg("solid_output_values", "method"))
+        raise DagsterInvalidPropertyError(_property_msg("op_output_values", "method"))
 
     @property
     def op_output_metadata(self) -> Mapping[str, Union[Any, Mapping[str, Any]]]:


### PR DESCRIPTION
## Summary & Motivation

Clean up old "solid" references and a deprecated method that should've been removed in 1.0.

## How I Tested These Changes

Existing test suite.