### PR TITLE
[external-assets] Make stub assets part of default group

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -50,7 +50,7 @@ const buildGraphNodeMock = (definitionOverrides: Partial<AssetNode>): GraphNode 
     assetKey: MockAssetKey,
     jobNames: ['__ASSET_JOB_1'],
     opNames: ['asset1'],
-    groupName: null,
+    groupName: 'default',
     graphName: null,
     isPartitioned: false,
     isObservable: false,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useAssetGraphData.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useAssetGraphData.types.ts
@@ -12,7 +12,7 @@ export type AssetGraphQuery = {
   assetNodes: Array<{
     __typename: 'AssetNode';
     id: string;
-    groupName: string | null;
+    groupName: string;
     isExecutable: boolean;
     changedReasons: Array<Types.ChangeReason>;
     hasMaterializePermission: boolean;
@@ -40,7 +40,7 @@ export type AssetGraphQuery = {
 export type AssetNodeForGraphQueryFragment = {
   __typename: 'AssetNode';
   id: string;
-  groupName: string | null;
+  groupName: string;
   isExecutable: boolean;
   changedReasons: Array<Types.ChangeReason>;
   hasMaterializePermission: boolean;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useFindAssetLocation.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useFindAssetLocation.types.ts
@@ -17,7 +17,7 @@ export type AssetForNavigationQuery = {
           id: string;
           opNames: Array<string>;
           jobNames: Array<string>;
-          groupName: string | null;
+          groupName: string;
           repository: {
             __typename: 'Repository';
             id: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/types/AutomaterializationTickDetailDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/types/AutomaterializationTickDetailDialog.types.ts
@@ -15,7 +15,7 @@ export type AssetGroupAndLocationQuery = {
         definition: {
           __typename: 'AssetNode';
           id: string;
-          groupName: string | null;
+          groupName: string;
           repository: {
             __typename: 'Repository';
             id: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetNodeDefinition.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetNodeDefinition.types.ts
@@ -6,7 +6,7 @@ export type AssetNodeDefinitionFragment = {
   __typename: 'AssetNode';
   id: string;
   description: string | null;
-  groupName: string | null;
+  groupName: string;
   graphName: string | null;
   opNames: Array<string>;
   opVersion: string | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetTableFragment.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetTableFragment.types.ts
@@ -6,7 +6,7 @@ export type AssetTableDefinitionFragment = {
   __typename: 'AssetNode';
   id: string;
   changedReasons: Array<Types.ChangeReason>;
-  groupName: string | null;
+  groupName: string;
   opNames: Array<string>;
   isSource: boolean;
   isObservable: boolean;
@@ -34,7 +34,7 @@ export type AssetTableFragment = {
     __typename: 'AssetNode';
     id: string;
     changedReasons: Array<Types.ChangeReason>;
-    groupName: string | null;
+    groupName: string;
     opNames: Array<string>;
     isSource: boolean;
     isObservable: boolean;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
@@ -21,7 +21,7 @@ export type AssetViewDefinitionQuery = {
         definition: {
           __typename: 'AssetNode';
           id: string;
-          groupName: string | null;
+          groupName: string;
           description: string | null;
           graphName: string | null;
           opNames: Array<string>;
@@ -15926,7 +15926,7 @@ export type AssetViewDefinitionQuery = {
 export type AssetViewDefinitionNodeFragment = {
   __typename: 'AssetNode';
   id: string;
-  groupName: string | null;
+  groupName: string;
   description: string | null;
   graphName: string | null;
   opNames: Array<string>;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetsCatalogTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetsCatalogTable.types.ts
@@ -17,7 +17,7 @@ export type AssetCatalogTableQuery = {
             __typename: 'AssetNode';
             id: string;
             changedReasons: Array<Types.ChangeReason>;
-            groupName: string | null;
+            groupName: string;
             opNames: Array<string>;
             isSource: boolean;
             isObservable: boolean;
@@ -61,7 +61,7 @@ export type AssetCatalogGroupTableQuery = {
     __typename: 'AssetNode';
     id: string;
     changedReasons: Array<Types.ChangeReason>;
-    groupName: string | null;
+    groupName: string;
     opNames: Array<string>;
     isSource: boolean;
     isObservable: boolean;
@@ -87,7 +87,7 @@ export type AssetCatalogGroupTableNodeFragment = {
   __typename: 'AssetNode';
   id: string;
   changedReasons: Array<Types.ChangeReason>;
-  groupName: string | null;
+  groupName: string;
   opNames: Array<string>;
   isSource: boolean;
   isObservable: boolean;

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -661,7 +661,7 @@ type AssetNode {
   freshnessPolicy: FreshnessPolicy
   autoMaterializePolicy: AutoMaterializePolicy
   graphName: String
-  groupName: String
+  groupName: String!
   owners: [AssetOwner!]!
   id: ID!
   isExecutable: Boolean!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -430,7 +430,7 @@ export type AssetNode = {
   freshnessInfo: Maybe<AssetFreshnessInfo>;
   freshnessPolicy: Maybe<FreshnessPolicy>;
   graphName: Maybe<Scalars['String']['output']>;
-  groupName: Maybe<Scalars['String']['output']>;
+  groupName: Scalars['String']['output'];
   hasAssetChecks: Scalars['Boolean']['output'];
   hasMaterializePermission: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];

--- a/js_modules/dagster-ui/packages/ui-core/src/search/types/useGlobalSearch.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/types/useGlobalSearch.types.ts
@@ -75,7 +75,7 @@ export type SearchSecondaryQuery = {
             __typename: 'AssetNode';
             id: string;
             computeKind: string | null;
-            groupName: string | null;
+            groupName: string;
             owners: Array<
               | {__typename: 'TeamAssetOwner'; team: string}
               | {__typename: 'UserAssetOwner'; email: string}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedRepoAssetTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedRepoAssetTable.types.ts
@@ -5,7 +5,7 @@ import * as Types from '../../graphql/types';
 export type RepoAssetTableFragment = {
   __typename: 'AssetNode';
   id: string;
-  groupName: string | null;
+  groupName: string;
   changedReasons: Array<Types.ChangeReason>;
   opNames: Array<string>;
   isSource: boolean;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceAssetsRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceAssetsRoot.types.ts
@@ -26,7 +26,7 @@ export type WorkspaceAssetsQuery = {
         assetNodes: Array<{
           __typename: 'AssetNode';
           id: string;
-          groupName: string | null;
+          groupName: string;
           changedReasons: Array<Types.ChangeReason>;
           opNames: Array<string>;
           isSource: boolean;

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -287,7 +287,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     freshnessPolicy = graphene.Field(GrapheneFreshnessPolicy)
     autoMaterializePolicy = graphene.Field(GrapheneAutoMaterializePolicy)
     graphName = graphene.String()
-    groupName = graphene.String()
+    groupName = graphene.NonNull(graphene.String)
     owners = non_null_list(GrapheneAssetOwner)
     id = graphene.NonNull(graphene.ID)
     isExecutable = graphene.NonNull(graphene.Boolean)

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -94,6 +94,7 @@ from dagster._core.definitions.sensor_definition import (
     SensorType,
 )
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
+from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.snap import JobSnapshot
 from dagster._core.snap.mode import ResourceDefSnap, build_resource_def_snap
@@ -1188,7 +1189,7 @@ class ExternalAssetNode(
             ("output_description", Optional[str]),
             ("metadata", Mapping[str, MetadataValue]),
             ("tags", Optional[Mapping[str, str]]),
-            ("group_name", Optional[str]),
+            ("group_name", str),
             ("freshness_policy", Optional[FreshnessPolicy]),
             ("is_source", bool),
             ("is_observable", bool),
@@ -1310,7 +1311,9 @@ class ExternalAssetNode(
             output_description=check.opt_str_param(output_description, "output_description"),
             metadata=metadata,
             tags=check.opt_mapping_param(tags, "tags", key_type=str, value_type=str),
-            group_name=check.opt_str_param(group_name, "group_name"),
+            # Newer code always passes a string group name when constructing these, but we assign
+            # the default here for backcompat.
+            group_name=check.opt_str_param(group_name, "group_name") or DEFAULT_GROUP_NAME,
             freshness_policy=check.opt_inst_param(
                 freshness_policy, "freshness_policy", FreshnessPolicy
             ),
@@ -1629,10 +1632,6 @@ def external_asset_nodes_from_defs(
             output_name = None
             required_top_level_resources = []
 
-        # This is in place to preserve an implicit behavior in the Dagster UI where stub
-        # dependencies were rendered as if they weren't part of the default asset group.
-        group_name = None if asset_node.assets_def.is_auto_created_stub else asset_node.group_name
-
         # Partition mappings are only exposed on the ExternalAssetNode if at least one asset is
         # partitioned and the partition mapping is one of the builtin types.
         partition_mappings: Dict[AssetKey, Optional[PartitionMapping]] = {}
@@ -1671,7 +1670,7 @@ def external_asset_nodes_from_defs(
                 output_name=output_name,
                 metadata=asset_node.metadata,
                 tags=asset_node.tags,
-                group_name=group_name,
+                group_name=asset_node.group_name,
                 freshness_policy=asset_node.freshness_policy,
                 is_source=asset_node.is_external,
                 is_observable=asset_node.is_observable,


### PR DESCRIPTION
## Summary & Motivation

Assets specified via `deps` currently have a default `group_name` of `None`. This leads to a situation where they display as "outside of the group" (`foo_source` in below image) when viewing the default asset group, whereas when they are specified as `SourceAsset` or explicitly as external assets they get a default group name of `DEFAULT_GROUP_NAME` (and are shown like `bar_source` in the below image).

![image](https://github.com/dagster-io/dagster/assets/1531373/cee51481-31c6-4b07-99eb-b63591da17b6)

This PR makes it so that all assets, no matter how they are specified, get a default group name of `DEFAULT_GROUP_NAME`. It also changes the GQL schema to always return a string (instead of nullable string for `groupName`).

cc @bengotow re this comment: https://github.com/dagster-io/dagster/pull/20474#pullrequestreview-1936853177

## How I Tested These Changes

Existing test suite.