### PR TITLE
[embedded-elt][sling] passing translator and replication config from decorator using metadata

### DIFF
--- a/docs/content/integrations/embedded-elt.mdx
+++ b/docs/content/integrations/embedded-elt.mdx
@@ -139,10 +139,7 @@ sling_resource = SlingResource(connections=[...])  # Add connections here
     dagster_sling_translator=DagsterSlingTranslator(),
 )
 def my_assets(context, sling: SlingResource):
-    yield from sling.replicate(
-        context=context,
-        replication_config=replication_config,
-    )
+    yield from sling.replicate(context=context)
     for row in sling.stream_raw_logs():
         context.log.info(row)
 
@@ -220,9 +217,7 @@ replication_config = {
     dagster_sling_translator=DagsterSlingTranslator(),
 )
 def my_assets(context, sling: SlingResource):
-    yield from sling.replicate(
-        replication_config=replication_config,
-    )
+    yield from sling.replicate(context=context)
 ```
 
 ## Example 2: File to Database
@@ -258,9 +253,7 @@ replication_config = {
     dagster_sling_translator=DagsterSlingTranslator(),
 )
 def my_assets(context, sling: SlingResource):
-    yield from sling.replicate(
-        replication_config=replication_config,
-    )
+    yield from sling.replicate(context=context)
 ```
 
 ---

--- a/docs/content/integrations/embedded-elt.mdx
+++ b/docs/content/integrations/embedded-elt.mdx
@@ -123,7 +123,6 @@ Each stream will render two assets, one for the source stream and one for the ta
 
 ```python file=/integrations/embedded_elt/sling_dagster_translator.py
 from dagster_embedded_elt.sling import (
-    DagsterSlingTranslator,
     SlingResource,
     sling_assets,
 )
@@ -134,10 +133,7 @@ replication_config = file_relative_path(__file__, "../sling_replication.yaml")
 sling_resource = SlingResource(connections=[...])  # Add connections here
 
 
-@sling_assets(
-    replication_config=replication_config,
-    dagster_sling_translator=DagsterSlingTranslator(),
-)
+@sling_assets(replication_config=replication_config)
 def my_assets(context, sling: SlingResource):
     yield from sling.replicate(context=context)
     for row in sling.stream_raw_logs():

--- a/docs/content/integrations/embedded-elt.mdx
+++ b/docs/content/integrations/embedded-elt.mdx
@@ -122,7 +122,6 @@ Now you can define a Sling asset using the <PyObject module="dagster_embedded_el
 Each stream will render two assets, one for the source stream and one for the target destination. You may override how assets are named by passing in a custom <PyObject module="dagster_embedded_elt.sling" object="DagsterSlingTranslator" /> object.
 
 ```python file=/integrations/embedded_elt/sling_dagster_translator.py
-from dagster_embedded_elt import sling
 from dagster_embedded_elt.sling import (
     DagsterSlingTranslator,
     SlingResource,
@@ -135,11 +134,14 @@ replication_config = file_relative_path(__file__, "../sling_replication.yaml")
 sling_resource = SlingResource(connections=[...])  # Add connections here
 
 
-@sling_assets(replication_config=replication_config)
+@sling_assets(
+    replication_config=replication_config,
+    dagster_sling_translator=DagsterSlingTranslator(),
+)
 def my_assets(context, sling: SlingResource):
     yield from sling.replicate(
+        context=context,
         replication_config=replication_config,
-        dagster_sling_translator=DagsterSlingTranslator(),
     )
     for row in sling.stream_raw_logs():
         context.log.info(row)
@@ -213,11 +215,13 @@ replication_config = {
 }
 
 
-@sling_assets(replication_config=replication_config)
+@sling_assets(
+    replication_config=replication_config,
+    dagster_sling_translator=DagsterSlingTranslator(),
+)
 def my_assets(context, sling: SlingResource):
     yield from sling.replicate(
         replication_config=replication_config,
-        dagster_sling_translator=DagsterSlingTranslator(),
     )
 ```
 
@@ -249,11 +253,13 @@ replication_config = {
 }
 
 
-@sling_assets(replication_config=replication_config)
+@sling_assets(
+    replication_config=replication_config,
+    dagster_sling_translator=DagsterSlingTranslator(),
+)
 def my_assets(context, sling: SlingResource):
     yield from sling.replicate(
         replication_config=replication_config,
-        dagster_sling_translator=DagsterSlingTranslator(),
     )
 ```
 

--- a/docs/content/integrations/embedded-elt.mdx
+++ b/docs/content/integrations/embedded-elt.mdx
@@ -162,7 +162,6 @@ This is an example of how to setup a Sling sync between two databases such as Po
 
 ```python file=/integrations/embedded_elt/postgres_snowflake.py
 from dagster_embedded_elt.sling import (
-    DagsterSlingTranslator,
     SlingConnectionResource,
     SlingResource,
     sling_assets,
@@ -208,10 +207,7 @@ replication_config = {
 }
 
 
-@sling_assets(
-    replication_config=replication_config,
-    dagster_sling_translator=DagsterSlingTranslator(),
-)
+@sling_assets(replication_config=replication_config)
 def my_assets(context, sling: SlingResource):
     yield from sling.replicate(context=context)
 ```
@@ -244,10 +240,7 @@ replication_config = {
 }
 
 
-@sling_assets(
-    replication_config=replication_config,
-    dagster_sling_translator=DagsterSlingTranslator(),
-)
+@sling_assets(replication_config=replication_config)
 def my_assets(context, sling: SlingResource):
     yield from sling.replicate(context=context)
 ```

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/postgres_snowflake.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/postgres_snowflake.py
@@ -48,9 +48,11 @@ replication_config = {
 }
 
 
-@sling_assets(replication_config=replication_config)
+@sling_assets(
+    replication_config=replication_config,
+    dagster_sling_translator=DagsterSlingTranslator(),
+)
 def my_assets(context, sling: SlingResource):
     yield from sling.replicate(
         replication_config=replication_config,
-        dagster_sling_translator=DagsterSlingTranslator(),
     )

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/postgres_snowflake.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/postgres_snowflake.py
@@ -53,6 +53,4 @@ replication_config = {
     dagster_sling_translator=DagsterSlingTranslator(),
 )
 def my_assets(context, sling: SlingResource):
-    yield from sling.replicate(
-        replication_config=replication_config,
-    )
+    yield from sling.replicate(context=context)

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/postgres_snowflake.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/postgres_snowflake.py
@@ -2,7 +2,6 @@
 # pyright: reportOptionalMemberAccess=none
 
 from dagster_embedded_elt.sling import (
-    DagsterSlingTranslator,
     SlingConnectionResource,
     SlingResource,
     sling_assets,
@@ -48,9 +47,6 @@ replication_config = {
 }
 
 
-@sling_assets(
-    replication_config=replication_config,
-    dagster_sling_translator=DagsterSlingTranslator(),
-)
+@sling_assets(replication_config=replication_config)
 def my_assets(context, sling: SlingResource):
     yield from sling.replicate(context=context)

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/s3_snowflake.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/s3_snowflake.py
@@ -50,9 +50,7 @@ replication_config = {
     dagster_sling_translator=DagsterSlingTranslator(),
 )
 def my_assets(context, sling: SlingResource):
-    yield from sling.replicate(
-        replication_config=replication_config,
-    )
+    yield from sling.replicate(context=context)
 
 
 # end_storage_config

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/s3_snowflake.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/s3_snowflake.py
@@ -45,11 +45,13 @@ replication_config = {
 }
 
 
-@sling_assets(replication_config=replication_config)
+@sling_assets(
+    replication_config=replication_config,
+    dagster_sling_translator=DagsterSlingTranslator(),
+)
 def my_assets(context, sling: SlingResource):
     yield from sling.replicate(
         replication_config=replication_config,
-        dagster_sling_translator=DagsterSlingTranslator(),
     )
 
 

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/s3_snowflake.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/s3_snowflake.py
@@ -2,7 +2,6 @@
 # pyright: reportOptionalMemberAccess=none
 
 from dagster_embedded_elt.sling import (
-    DagsterSlingTranslator,
     SlingConnectionResource,
     SlingResource,
     sling_assets,
@@ -45,10 +44,7 @@ replication_config = {
 }
 
 
-@sling_assets(
-    replication_config=replication_config,
-    dagster_sling_translator=DagsterSlingTranslator(),
-)
+@sling_assets(replication_config=replication_config)
 def my_assets(context, sling: SlingResource):
     yield from sling.replicate(context=context)
 

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/sling_dagster_translator.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/sling_dagster_translator.py
@@ -1,4 +1,3 @@
-from dagster_embedded_elt import sling
 from dagster_embedded_elt.sling import (
     DagsterSlingTranslator,
     SlingResource,
@@ -11,11 +10,14 @@ replication_config = file_relative_path(__file__, "../sling_replication.yaml")
 sling_resource = SlingResource(connections=[...])  # Add connections here
 
 
-@sling_assets(replication_config=replication_config)
+@sling_assets(
+    replication_config=replication_config,
+    dagster_sling_translator=DagsterSlingTranslator(),
+)
 def my_assets(context, sling: SlingResource):
     yield from sling.replicate(
+        context=context,
         replication_config=replication_config,
-        dagster_sling_translator=DagsterSlingTranslator(),
     )
     for row in sling.stream_raw_logs():
         context.log.info(row)

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/sling_dagster_translator.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/sling_dagster_translator.py
@@ -1,5 +1,4 @@
 from dagster_embedded_elt.sling import (
-    DagsterSlingTranslator,
     SlingResource,
     sling_assets,
 )
@@ -10,10 +9,7 @@ replication_config = file_relative_path(__file__, "../sling_replication.yaml")
 sling_resource = SlingResource(connections=[...])  # Add connections here
 
 
-@sling_assets(
-    replication_config=replication_config,
-    dagster_sling_translator=DagsterSlingTranslator(),
-)
+@sling_assets(replication_config=replication_config)
 def my_assets(context, sling: SlingResource):
     yield from sling.replicate(context=context)
     for row in sling.stream_raw_logs():

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/sling_dagster_translator.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/sling_dagster_translator.py
@@ -15,10 +15,7 @@ sling_resource = SlingResource(connections=[...])  # Add connections here
     dagster_sling_translator=DagsterSlingTranslator(),
 )
 def my_assets(context, sling: SlingResource):
-    yield from sling.replicate(
-        context=context,
-        replication_config=replication_config,
-    )
+    yield from sling.replicate(context=context)
     for row in sling.stream_raw_logs():
         context.log.info(row)
 

--- a/examples/experimental/sling_decorator/sling_decorator/__init__.py
+++ b/examples/experimental/sling_decorator/sling_decorator/__init__.py
@@ -26,11 +26,14 @@ sling_resource = SlingResource(
 )
 
 
-@sling_assets(replication_config=replication_config)
+@sling_assets(
+    replication_config=replication_config,
+    dagster_sling_translator=DagsterSlingTranslator(),
+)
 def my_assets(context, sling: SlingResource):
     yield from sling.replicate(
+        context=context,
         replication_config=replication_config,
-        dagster_sling_translator=DagsterSlingTranslator(),
     )
     for row in sling.stream_raw_logs():
         context.log.info(row)

--- a/examples/experimental/sling_decorator/sling_decorator/__init__.py
+++ b/examples/experimental/sling_decorator/sling_decorator/__init__.py
@@ -1,6 +1,5 @@
 from dagster import Definitions, file_relative_path
 from dagster_embedded_elt.sling import (
-    DagsterSlingTranslator,
     sling_assets,
 )
 from dagster_embedded_elt.sling.resources import (
@@ -26,10 +25,7 @@ sling_resource = SlingResource(
 )
 
 
-@sling_assets(
-    replication_config=replication_config,
-    dagster_sling_translator=DagsterSlingTranslator(),
-)
+@sling_assets(replication_config=replication_config)
 def my_assets(context, sling: SlingResource):
     yield from sling.replicate(context=context)
     for row in sling.stream_raw_logs():

--- a/examples/experimental/sling_decorator/sling_decorator/__init__.py
+++ b/examples/experimental/sling_decorator/sling_decorator/__init__.py
@@ -31,10 +31,7 @@ sling_resource = SlingResource(
     dagster_sling_translator=DagsterSlingTranslator(),
 )
 def my_assets(context, sling: SlingResource):
-    yield from sling.replicate(
-        context=context,
-        replication_config=replication_config,
-    )
+    yield from sling.replicate(context=context)
     for row in sling.stream_raw_logs():
         context.log.info(row)
 

--- a/js_modules/dagster-ui/packages/ui-core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/metadata/MetadataEntry.tsx
@@ -39,6 +39,8 @@ export const HIDDEN_METADATA_ENTRY_LABELS = new Set([
   'dagster-dbt/exclude',
   'dagster_dbt/manifest',
   'dagster_dbt/dagster_dbt_translator',
+  'dagster_sling/translator',
+  'dagster_sling/replication_config',
 ]);
 
 export const LogRowStructuredContentTable = ({

--- a/js_modules/dagster-ui/packages/ui-core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/metadata/MetadataEntry.tsx
@@ -39,8 +39,8 @@ export const HIDDEN_METADATA_ENTRY_LABELS = new Set([
   'dagster-dbt/exclude',
   'dagster_dbt/manifest',
   'dagster_dbt/dagster_dbt_translator',
-  'dagster_sling/translator',
-  'dagster_sling/replication_config',
+  'dagster_embedded_elt/dagster_sling_translator',
+  'dagster_embedded_elt/sling_replication_config',
 ]);
 
 export const LogRowStructuredContentTable = ({

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
@@ -13,6 +13,7 @@ from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTran
 from dagster_embedded_elt.sling.sling_replication import SlingReplicationParam, validate_replication
 
 METADATA_KEY_TRANSLATOR = "dagster_sling/translator"
+METADATA_KEY_REPLICATION_CONFIG = "dagster_sling/replication_config"
 
 
 def get_streams_from_replication(
@@ -73,10 +74,7 @@ def sling_assets(
             config_path = "/path/to/replication.yaml"
             @sling_assets(replication_config=config_path)
             def my_assets(context, sling: SlingResource):
-                for lines in sling.replicate(
-                    replication_config=config_path,
-                    context=context,
-                ):
+                for lines in sling.replicate(context=context):
                     context.log.info(lines)
     """
     replication_config = validate_replication(replication_config)
@@ -93,6 +91,7 @@ def sling_assets(
                 metadata={  # type: ignore
                     **dagster_sling_translator.get_metadata(stream),
                     METADATA_KEY_TRANSLATOR: dagster_sling_translator,
+                    METADATA_KEY_REPLICATION_CONFIG: replication_config,
                 },
                 group_name=dagster_sling_translator.get_group_name(stream),
                 freshness_policy=dagster_sling_translator.get_freshness_policy(stream),

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
@@ -12,8 +12,8 @@ from dagster._utils.security import non_secure_md5_hash_str
 from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
 from dagster_embedded_elt.sling.sling_replication import SlingReplicationParam, validate_replication
 
-METADATA_KEY_TRANSLATOR = "dagster_sling/translator"
-METADATA_KEY_REPLICATION_CONFIG = "dagster_sling/replication_config"
+METADATA_KEY_TRANSLATOR = "dagster_embedded_elt/dagster_sling_translator"
+METADATA_KEY_REPLICATION_CONFIG = "dagster_embedded_elt/sling_replication_config"
 
 
 def get_streams_from_replication(

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
@@ -74,8 +74,7 @@ def sling_assets(
             config_path = "/path/to/replication.yaml"
             @sling_assets(replication_config=config_path)
             def my_assets(context, sling: SlingResource):
-                for lines in sling.replicate(context=context):
-                    context.log.info(lines)
+                yield from sling.replicate(context=context)
     """
     replication_config = validate_replication(replication_config)
     streams = get_streams_from_replication(replication_config)

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -387,15 +387,9 @@ class SlingResource(ConfigurableResource):
             replication_config = first_asset_metadata.get(METADATA_KEY_REPLICATION_CONFIG)
 
         # if translator has not been defined on metadata _or_ through param, then use the default constructor
-        if not dagster_sling_translator:
-            dagster_sling_translator = DagsterSlingTranslator()
+        dagster_sling_translator = dagster_sling_translator or DagsterSlingTranslator()
 
-        if replication_config is None:
-            raise Exception(
-                f"`ReplicationConfig` must be defined on metadata at {METADATA_KEY_REPLICATION_CONFIG}"
-            )
-
-        replication_config = validate_replication(replication_config)
+        replication_config = validate_replication(replication_config or {})
         stream_definition = get_streams_from_replication(replication_config)
 
         with self._setup_config():

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -13,11 +13,11 @@ from typing import IO, Any, AnyStr, Dict, Generator, Iterator, List, Optional, U
 import sling
 from dagster import (
     AssetExecutionContext,
+    AssetMaterialization,
     ConfigurableResource,
     EnvVar,
     MaterializeResult,
     OpExecutionContext,
-    Output,
     PermissiveConfig,
     get_dagster_logger,
 )
@@ -369,7 +369,7 @@ class SlingResource(ConfigurableResource):
         replication_config: Optional[SlingReplicationParam] = None,
         dagster_sling_translator: Optional[DagsterSlingTranslator] = None,
         debug: bool = False,
-    ) -> Generator[Union[MaterializeResult, Output], None, None]:
+    ) -> Generator[Union[MaterializeResult, AssetMaterialization], None, None]:
         """Runs a Sling replication from the given replication config.
 
         Args:
@@ -379,7 +379,7 @@ class SlingResource(ConfigurableResource):
             debug: Whether to run the replication in debug mode.
 
         Returns:
-            Optional[Generator[MaterializeResult, None, None]]: A generator of MaterializeResult
+            Generator[Union[MaterializeResult, AssetMaterialization], None, None]: A generator of MaterializeResult or AssetMaterialization
         """
         # attempt to retrieve params from asset context if not passed as a parameter
         if not (replication_config or dagster_sling_translator):
@@ -432,6 +432,10 @@ class SlingResource(ConfigurableResource):
             output_name = dagster_sling_translator.get_asset_key(stream)
             if has_asset_def:
                 yield MaterializeResult(
+                    asset_key=output_name, metadata={"elapsed_time": end_time - start_time}
+                )
+            else:
+                yield AssetMaterialization(
                     asset_key=output_name, metadata={"elapsed_time": end_time - start_time}
                 )
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -426,9 +426,11 @@ class SlingResource(ConfigurableResource):
 
         end_time = time.time()
 
+        has_asset_def: bool = bool(context and context.has_assets_def)
+
         for stream in stream_definition:
             output_name = dagster_sling_translator.get_asset_key(stream)
-            if isinstance(context, AssetExecutionContext):
+            if has_asset_def:
                 yield MaterializeResult(
                     asset_key=output_name, metadata={"elapsed_time": end_time - start_time}
                 )

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -432,8 +432,6 @@ class SlingResource(ConfigurableResource):
                 yield MaterializeResult(
                     asset_key=output_name, metadata={"elapsed_time": end_time - start_time}
                 )
-            # elif isinstance(context, OpExecutionContext):
-            #     yield Output(value=None, output_name=str(output_name), metadata={"elapsed_time": end_time - start_time})
 
     def stream_raw_logs(self) -> Generator[str, None, None]:
         """Returns a generator of raw logs from the Sling CLI."""

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_replication.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_replication.py
@@ -1,6 +1,6 @@
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Mapping, Union, cast
+from typing import Any, Mapping, Optional, Union, cast
 
 import dagster._check as check
 import yaml
@@ -18,7 +18,8 @@ def read_replication_path(replication_path: Path) -> Mapping[str, Any]:
     return cast(Mapping[str, Any], yaml.safe_load(replication_path.read_bytes()))
 
 
-def validate_replication(replication: SlingReplicationParam) -> Mapping[str, Any]:
+def validate_replication(replication: Optional[SlingReplicationParam]) -> Mapping[str, Any]:
+    replication = replication or {}
     check.inst_param(replication, "manifest", (Path, str, dict))
 
     if isinstance(replication, str):

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
@@ -66,9 +66,7 @@ def test_runs_base_sling_config(
 ):
     @sling_assets(replication_config=csv_to_sqlite_replication_config)
     def my_sling_assets(context: AssetExecutionContext, sling: SlingResource):
-        for row in sling.replicate(
-            replication_config=csv_to_sqlite_replication_config, context=context
-        ):
+        for row in sling.replicate(context=context):
             logging.info(row)
 
     sling_resource = SlingResource(
@@ -137,6 +135,49 @@ def test_base_with_meta_config_translator():
         AssetKey(["target", "public", "accounts"]): {
             "stream_config": JsonMetadataValue(data=None),
             "dagster_sling/translator": DagsterSlingTranslator(target_prefix="target"),
+            "dagster_sling/replication_config": {
+                "source": "MY_SOURCE",
+                "target": "MY_TARGET",
+                "defaults": {"mode": "full-refresh", "object": "{stream_schema}_{stream_table}"},
+                "streams": {
+                    "public.accounts": None,
+                    "public.users": {
+                        "disabled": True,
+                        "meta": {"dagster": {"asset_key": "public.foo_users"}},
+                    },
+                    "public.finance_departments_old": {
+                        "object": "departments",
+                        "source_options": {"empty_as_null": False},
+                        "meta": {
+                            "dagster": {
+                                "deps": ["foo_one", "foo_two"],
+                                "group": "group_2",
+                                "freshness_policy": {
+                                    "maximum_lag_minutes": 0,
+                                    "cron_schedule": "5 4 * * *",
+                                    "cron_schedule_timezone": "UTC",
+                                },
+                            }
+                        },
+                    },
+                    'public."Transactions"': {
+                        "mode": "incremental",
+                        "primary_key": "id",
+                        "update_key": "last_updated_at",
+                        "meta": {
+                            "dagster": {
+                                "description": "Example Description!",
+                                "auto_materialize_policy": True,
+                            }
+                        },
+                    },
+                    "public.all_users": {
+                        "sql": 'select all_user_id, name \nfrom public."all_Users"\n',
+                        "object": "public.all_users",
+                    },
+                },
+                "env": {"SLING_LOADED_AT_COLUMN": True, "SLING_STREAM_URL_COLUMN": True},
+            },
         },
         AssetKey(["target", "departments"]): {
             "stream_config": JsonMetadataValue(
@@ -157,6 +198,49 @@ def test_base_with_meta_config_translator():
                 }
             ),
             "dagster_sling/translator": DagsterSlingTranslator(target_prefix="target"),
+            "dagster_sling/replication_config": {
+                "source": "MY_SOURCE",
+                "target": "MY_TARGET",
+                "defaults": {"mode": "full-refresh", "object": "{stream_schema}_{stream_table}"},
+                "streams": {
+                    "public.accounts": None,
+                    "public.users": {
+                        "disabled": True,
+                        "meta": {"dagster": {"asset_key": "public.foo_users"}},
+                    },
+                    "public.finance_departments_old": {
+                        "object": "departments",
+                        "source_options": {"empty_as_null": False},
+                        "meta": {
+                            "dagster": {
+                                "deps": ["foo_one", "foo_two"],
+                                "group": "group_2",
+                                "freshness_policy": {
+                                    "maximum_lag_minutes": 0,
+                                    "cron_schedule": "5 4 * * *",
+                                    "cron_schedule_timezone": "UTC",
+                                },
+                            }
+                        },
+                    },
+                    'public."Transactions"': {
+                        "mode": "incremental",
+                        "primary_key": "id",
+                        "update_key": "last_updated_at",
+                        "meta": {
+                            "dagster": {
+                                "description": "Example Description!",
+                                "auto_materialize_policy": True,
+                            }
+                        },
+                    },
+                    "public.all_users": {
+                        "sql": 'select all_user_id, name \nfrom public."all_Users"\n',
+                        "object": "public.all_users",
+                    },
+                },
+                "env": {"SLING_LOADED_AT_COLUMN": True, "SLING_STREAM_URL_COLUMN": True},
+            },
         },
         AssetKey(["target", "public", "transactions"]): {
             "stream_config": JsonMetadataValue(
@@ -173,6 +257,49 @@ def test_base_with_meta_config_translator():
                 }
             ),
             "dagster_sling/translator": DagsterSlingTranslator(target_prefix="target"),
+            "dagster_sling/replication_config": {
+                "source": "MY_SOURCE",
+                "target": "MY_TARGET",
+                "defaults": {"mode": "full-refresh", "object": "{stream_schema}_{stream_table}"},
+                "streams": {
+                    "public.accounts": None,
+                    "public.users": {
+                        "disabled": True,
+                        "meta": {"dagster": {"asset_key": "public.foo_users"}},
+                    },
+                    "public.finance_departments_old": {
+                        "object": "departments",
+                        "source_options": {"empty_as_null": False},
+                        "meta": {
+                            "dagster": {
+                                "deps": ["foo_one", "foo_two"],
+                                "group": "group_2",
+                                "freshness_policy": {
+                                    "maximum_lag_minutes": 0,
+                                    "cron_schedule": "5 4 * * *",
+                                    "cron_schedule_timezone": "UTC",
+                                },
+                            }
+                        },
+                    },
+                    'public."Transactions"': {
+                        "mode": "incremental",
+                        "primary_key": "id",
+                        "update_key": "last_updated_at",
+                        "meta": {
+                            "dagster": {
+                                "description": "Example Description!",
+                                "auto_materialize_policy": True,
+                            }
+                        },
+                    },
+                    "public.all_users": {
+                        "sql": 'select all_user_id, name \nfrom public."all_Users"\n',
+                        "object": "public.all_users",
+                    },
+                },
+                "env": {"SLING_LOADED_AT_COLUMN": True, "SLING_STREAM_URL_COLUMN": True},
+            },
         },
         AssetKey(["target", "public", "all_users"]): {
             "stream_config": JsonMetadataValue(
@@ -182,6 +309,49 @@ def test_base_with_meta_config_translator():
                 }
             ),
             "dagster_sling/translator": DagsterSlingTranslator(target_prefix="target"),
+            "dagster_sling/replication_config": {
+                "source": "MY_SOURCE",
+                "target": "MY_TARGET",
+                "defaults": {"mode": "full-refresh", "object": "{stream_schema}_{stream_table}"},
+                "streams": {
+                    "public.accounts": None,
+                    "public.users": {
+                        "disabled": True,
+                        "meta": {"dagster": {"asset_key": "public.foo_users"}},
+                    },
+                    "public.finance_departments_old": {
+                        "object": "departments",
+                        "source_options": {"empty_as_null": False},
+                        "meta": {
+                            "dagster": {
+                                "deps": ["foo_one", "foo_two"],
+                                "group": "group_2",
+                                "freshness_policy": {
+                                    "maximum_lag_minutes": 0,
+                                    "cron_schedule": "5 4 * * *",
+                                    "cron_schedule_timezone": "UTC",
+                                },
+                            }
+                        },
+                    },
+                    'public."Transactions"': {
+                        "mode": "incremental",
+                        "primary_key": "id",
+                        "update_key": "last_updated_at",
+                        "meta": {
+                            "dagster": {
+                                "description": "Example Description!",
+                                "auto_materialize_policy": True,
+                            }
+                        },
+                    },
+                    "public.all_users": {
+                        "sql": 'select all_user_id, name \nfrom public."all_Users"\n',
+                        "object": "public.all_users",
+                    },
+                },
+                "env": {"SLING_LOADED_AT_COLUMN": True, "SLING_STREAM_URL_COLUMN": True},
+            },
         },
     }
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
@@ -2,6 +2,7 @@ import logging
 import sqlite3
 
 import pytest
+import yaml
 from dagster import (
     AssetExecutionContext,
     AssetKey,
@@ -16,6 +17,7 @@ from dagster_embedded_elt.sling import (
 )
 from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
 from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingResource
+from path import Path
 
 
 @pytest.mark.parametrize(
@@ -102,11 +104,12 @@ def test_with_custom_name(replication_config: SlingReplicationParam):
 
 
 def test_base_with_meta_config_translator():
-    replication_config = file_relative_path(
+    replication_config_path = file_relative_path(
         __file__, "replication_configs/base_with_meta_config/replication.yaml"
     )
+    replication_config = yaml.safe_load(Path(replication_config_path).read_bytes())
 
-    @sling_assets(replication_config=replication_config)
+    @sling_assets(replication_config=replication_config_path)
     def my_sling_assets(): ...
 
     assert my_sling_assets.keys == {
@@ -133,50 +136,10 @@ def test_base_with_meta_config_translator():
     assert my_sling_assets.metadata_by_key == {
         AssetKey(["target", "public", "accounts"]): {
             "stream_config": JsonMetadataValue(data=None),
-            "dagster_sling/translator": DagsterSlingTranslator(target_prefix="target"),
-            "dagster_sling/replication_config": {
-                "source": "MY_SOURCE",
-                "target": "MY_TARGET",
-                "defaults": {"mode": "full-refresh", "object": "{stream_schema}_{stream_table}"},
-                "streams": {
-                    "public.accounts": None,
-                    "public.users": {
-                        "disabled": True,
-                        "meta": {"dagster": {"asset_key": "public.foo_users"}},
-                    },
-                    "public.finance_departments_old": {
-                        "object": "departments",
-                        "source_options": {"empty_as_null": False},
-                        "meta": {
-                            "dagster": {
-                                "deps": ["foo_one", "foo_two"],
-                                "group": "group_2",
-                                "freshness_policy": {
-                                    "maximum_lag_minutes": 0,
-                                    "cron_schedule": "5 4 * * *",
-                                    "cron_schedule_timezone": "UTC",
-                                },
-                            }
-                        },
-                    },
-                    'public."Transactions"': {
-                        "mode": "incremental",
-                        "primary_key": "id",
-                        "update_key": "last_updated_at",
-                        "meta": {
-                            "dagster": {
-                                "description": "Example Description!",
-                                "auto_materialize_policy": True,
-                            }
-                        },
-                    },
-                    "public.all_users": {
-                        "sql": 'select all_user_id, name \nfrom public."all_Users"\n',
-                        "object": "public.all_users",
-                    },
-                },
-                "env": {"SLING_LOADED_AT_COLUMN": True, "SLING_STREAM_URL_COLUMN": True},
-            },
+            "dagster_embedded_elt/dagster_sling_translator": DagsterSlingTranslator(
+                target_prefix="target"
+            ),
+            "dagster_embedded_elt/sling_replication_config": replication_config,
         },
         AssetKey(["target", "departments"]): {
             "stream_config": JsonMetadataValue(
@@ -196,50 +159,10 @@ def test_base_with_meta_config_translator():
                     },
                 }
             ),
-            "dagster_sling/translator": DagsterSlingTranslator(target_prefix="target"),
-            "dagster_sling/replication_config": {
-                "source": "MY_SOURCE",
-                "target": "MY_TARGET",
-                "defaults": {"mode": "full-refresh", "object": "{stream_schema}_{stream_table}"},
-                "streams": {
-                    "public.accounts": None,
-                    "public.users": {
-                        "disabled": True,
-                        "meta": {"dagster": {"asset_key": "public.foo_users"}},
-                    },
-                    "public.finance_departments_old": {
-                        "object": "departments",
-                        "source_options": {"empty_as_null": False},
-                        "meta": {
-                            "dagster": {
-                                "deps": ["foo_one", "foo_two"],
-                                "group": "group_2",
-                                "freshness_policy": {
-                                    "maximum_lag_minutes": 0,
-                                    "cron_schedule": "5 4 * * *",
-                                    "cron_schedule_timezone": "UTC",
-                                },
-                            }
-                        },
-                    },
-                    'public."Transactions"': {
-                        "mode": "incremental",
-                        "primary_key": "id",
-                        "update_key": "last_updated_at",
-                        "meta": {
-                            "dagster": {
-                                "description": "Example Description!",
-                                "auto_materialize_policy": True,
-                            }
-                        },
-                    },
-                    "public.all_users": {
-                        "sql": 'select all_user_id, name \nfrom public."all_Users"\n',
-                        "object": "public.all_users",
-                    },
-                },
-                "env": {"SLING_LOADED_AT_COLUMN": True, "SLING_STREAM_URL_COLUMN": True},
-            },
+            "dagster_embedded_elt/dagster_sling_translator": DagsterSlingTranslator(
+                target_prefix="target"
+            ),
+            "dagster_embedded_elt/sling_replication_config": replication_config,
         },
         AssetKey(["target", "public", "transactions"]): {
             "stream_config": JsonMetadataValue(
@@ -255,50 +178,10 @@ def test_base_with_meta_config_translator():
                     },
                 }
             ),
-            "dagster_sling/translator": DagsterSlingTranslator(target_prefix="target"),
-            "dagster_sling/replication_config": {
-                "source": "MY_SOURCE",
-                "target": "MY_TARGET",
-                "defaults": {"mode": "full-refresh", "object": "{stream_schema}_{stream_table}"},
-                "streams": {
-                    "public.accounts": None,
-                    "public.users": {
-                        "disabled": True,
-                        "meta": {"dagster": {"asset_key": "public.foo_users"}},
-                    },
-                    "public.finance_departments_old": {
-                        "object": "departments",
-                        "source_options": {"empty_as_null": False},
-                        "meta": {
-                            "dagster": {
-                                "deps": ["foo_one", "foo_two"],
-                                "group": "group_2",
-                                "freshness_policy": {
-                                    "maximum_lag_minutes": 0,
-                                    "cron_schedule": "5 4 * * *",
-                                    "cron_schedule_timezone": "UTC",
-                                },
-                            }
-                        },
-                    },
-                    'public."Transactions"': {
-                        "mode": "incremental",
-                        "primary_key": "id",
-                        "update_key": "last_updated_at",
-                        "meta": {
-                            "dagster": {
-                                "description": "Example Description!",
-                                "auto_materialize_policy": True,
-                            }
-                        },
-                    },
-                    "public.all_users": {
-                        "sql": 'select all_user_id, name \nfrom public."all_Users"\n',
-                        "object": "public.all_users",
-                    },
-                },
-                "env": {"SLING_LOADED_AT_COLUMN": True, "SLING_STREAM_URL_COLUMN": True},
-            },
+            "dagster_embedded_elt/dagster_sling_translator": DagsterSlingTranslator(
+                target_prefix="target"
+            ),
+            "dagster_embedded_elt/sling_replication_config": replication_config,
         },
         AssetKey(["target", "public", "all_users"]): {
             "stream_config": JsonMetadataValue(
@@ -307,50 +190,10 @@ def test_base_with_meta_config_translator():
                     "object": "public.all_users",
                 }
             ),
-            "dagster_sling/translator": DagsterSlingTranslator(target_prefix="target"),
-            "dagster_sling/replication_config": {
-                "source": "MY_SOURCE",
-                "target": "MY_TARGET",
-                "defaults": {"mode": "full-refresh", "object": "{stream_schema}_{stream_table}"},
-                "streams": {
-                    "public.accounts": None,
-                    "public.users": {
-                        "disabled": True,
-                        "meta": {"dagster": {"asset_key": "public.foo_users"}},
-                    },
-                    "public.finance_departments_old": {
-                        "object": "departments",
-                        "source_options": {"empty_as_null": False},
-                        "meta": {
-                            "dagster": {
-                                "deps": ["foo_one", "foo_two"],
-                                "group": "group_2",
-                                "freshness_policy": {
-                                    "maximum_lag_minutes": 0,
-                                    "cron_schedule": "5 4 * * *",
-                                    "cron_schedule_timezone": "UTC",
-                                },
-                            }
-                        },
-                    },
-                    'public."Transactions"': {
-                        "mode": "incremental",
-                        "primary_key": "id",
-                        "update_key": "last_updated_at",
-                        "meta": {
-                            "dagster": {
-                                "description": "Example Description!",
-                                "auto_materialize_policy": True,
-                            }
-                        },
-                    },
-                    "public.all_users": {
-                        "sql": 'select all_user_id, name \nfrom public."all_Users"\n',
-                        "object": "public.all_users",
-                    },
-                },
-                "env": {"SLING_LOADED_AT_COLUMN": True, "SLING_STREAM_URL_COLUMN": True},
-            },
+            "dagster_embedded_elt/dagster_sling_translator": DagsterSlingTranslator(
+                target_prefix="target"
+            ),
+            "dagster_embedded_elt/sling_replication_config": replication_config,
         },
     }
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
@@ -60,7 +60,6 @@ def test_disabled_asset():
 
 def test_runs_base_sling_config(
     csv_to_sqlite_replication_config: SlingReplicationParam,
-    path_to_test_csv: str,
     path_to_temp_sqlite_db: str,
     sqlite_connection: sqlite3.Connection,
 ):

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_asset_decorator.py
@@ -81,6 +81,8 @@ def test_runs_base_sling_config(
     res = materialize([my_sling_assets], resources={"sling": sling_resource})
 
     assert res.success
+    assert len(res.get_asset_materialization_events()) == 1
+
     counts = sqlite_connection.execute("SELECT count(1) FROM main.tbl").fetchone()[0]
     assert counts == 3
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_op.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_op.py
@@ -34,5 +34,7 @@ def test_base_sling_config_op(
     res = my_sling_op_yield_events_job.execute_in_process(resources={"sling": sling_resource})
     assert res.success
 
+    assert len(res.get_asset_materialization_events()) == 1
+
     counts = sqlite_connection.execute("SELECT count(1) FROM main.tbl").fetchone()[0]
     assert counts == 3

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_op.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_op.py
@@ -1,5 +1,3 @@
-import logging
-
 from dagster import OpExecutionContext, job, op
 from dagster_embedded_elt.sling import SlingReplicationParam
 from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingResource
@@ -22,10 +20,9 @@ def test_base_sling_config_op(
 
     @op(out={})
     def my_sling_op_yield_events(context: OpExecutionContext, sling: SlingResource):
-        for row in sling.replicate(
+        yield from sling.replicate(
             context=context, replication_config=csv_to_sqlite_replication_config
-        ):
-            logging.info(row)
+        )
 
     @job
     def my_sling_op_yield_events_job():

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_op.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_op.py
@@ -1,0 +1,35 @@
+import logging
+
+from dagster import OpExecutionContext, job, op
+from dagster_embedded_elt.sling import SlingReplicationParam
+from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingResource
+
+
+def test_base_sling_config_op(
+    csv_to_sqlite_replication_config: SlingReplicationParam,
+    path_to_temp_sqlite_db: str,
+):
+    sling_resource = SlingResource(
+        connections=[
+            SlingConnectionResource(type="file", name="SLING_FILE"),
+            SlingConnectionResource(
+                type="sqlite",
+                name="SLING_SQLITE",
+                connection_string=f"sqlite://{path_to_temp_sqlite_db}",
+            ),
+        ]
+    )
+
+    @op(out={})
+    def my_sling_op_yield_events(context: OpExecutionContext, sling: SlingResource):
+        for row in sling.replicate(
+            context=context, replication_config=csv_to_sqlite_replication_config
+        ):
+            logging.info(row)
+
+    @job
+    def my_sling_op_yield_events_job():
+        my_sling_op_yield_events()
+
+    result = my_sling_op_yield_events_job.execute_in_process(resources={"sling": sling_resource})
+    assert result.success

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_op.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_op.py
@@ -28,5 +28,6 @@ def test_base_sling_config_op(
     def my_sling_op_yield_events_job():
         my_sling_op_yield_events()
 
-    result = my_sling_op_yield_events_job.execute_in_process(resources={"sling": sling_resource})
-    assert result.success
+    res = my_sling_op_yield_events_job.execute_in_process(resources={"sling": sling_resource})
+    assert res.success
+    assert len(res.get_job_success_event()) == 1

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_op.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/test_op.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 from dagster import OpExecutionContext, job, op
 from dagster_embedded_elt.sling import SlingReplicationParam
 from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingResource
@@ -6,6 +8,7 @@ from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingR
 def test_base_sling_config_op(
     csv_to_sqlite_replication_config: SlingReplicationParam,
     path_to_temp_sqlite_db: str,
+    sqlite_connection: sqlite3.Connection,
 ):
     sling_resource = SlingResource(
         connections=[
@@ -30,4 +33,6 @@ def test_base_sling_config_op(
 
     res = my_sling_op_yield_events_job.execute_in_process(resources={"sling": sling_resource})
     assert res.success
-    assert len(res.get_job_success_event()) == 1
+
+    counts = sqlite_connection.execute("SELECT count(1) FROM main.tbl").fetchone()[0]
+    assert counts == 3


### PR DESCRIPTION
## Summary & Motivation

The current implementation of the Sling integration requires passing the _DagsterSlingTranslator_ and replication config to both the `@sling_assets` decorator, and the `replicate` method in the function body. 

Following the approach of `dagster-dbt` and the soon-to-be _dlt_ integration. this pull request demonstrates how we can pass the translator to the `replicate` method through the use of metadata. This workaround leads to a more intuitive end-user experience, albeit with more complex implementation.

The negative to this approach is that the _translator_ and _replication-config_ remain on the metadata, see the modified unit test.

## How I Tested These Changes

Ran unit tests.