### PR TITLE
Use dbt indirect selection with asset checks

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/multi_asset.py
+++ b/python_modules/dagster-test/dagster_test/toys/multi_asset.py
@@ -1,0 +1,32 @@
+from dagster import (
+    AssetSpec,
+    Definitions,
+    ObserveResult,
+    asset,
+    define_asset_job,
+    multi_asset,
+)
+
+
+@multi_asset(specs=[AssetSpec("one"), AssetSpec("two")])
+def johann():
+    return [
+        ObserveResult(
+            asset_key="one",
+            metadata={"one": 1},
+        ),
+        ObserveResult(
+            asset_key="two",
+            metadata={"two": 2},
+        ),
+    ]
+
+
+@asset
+def my_asset(one):
+    return one
+
+
+my_job = define_asset_job("my_job", [my_asset])
+
+defs = Definitions(jobs=[my_job], assets=[johann, my_asset])

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -175,7 +175,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             value_type=AssetKey,
         )
 
-        check.opt_mapping_param(
+        self._check_specs_by_output_name = check.opt_mapping_param(
             check_specs_by_output_name,
             "check_specs_by_output_name",
             key_type=str,
@@ -255,9 +255,6 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
                 # otherwise, use the selected checks
                 self._selected_asset_check_keys = selected_asset_check_keys
 
-        self._check_specs_by_output_name = {
-            name: spec for name, spec in (check_specs_by_output_name or {}).items()
-        }
         self._check_specs_by_key = {
             spec.key: spec
             for spec in self._check_specs_by_output_name.values()
@@ -1305,7 +1302,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             is_subset=self.is_subset,
             check_specs_by_output_name=check_specs_by_output_name
             if check_specs_by_output_name
-            else self.check_specs_by_output_name,
+            else self._check_specs_by_output_name,
             selected_asset_check_keys=selected_asset_check_keys
             if selected_asset_check_keys
             else self._selected_asset_check_keys,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -10,6 +10,7 @@ from contextlib import suppress
 from dataclasses import InitVar, dataclass, field
 from pathlib import Path
 from typing import (
+    AbstractSet,
     Any,
     Dict,
     Iterator,
@@ -133,7 +134,7 @@ class DbtCliEventMessage:
         self,
         dagster_dbt_translator: DagsterDbtTranslator,
         validated_manifest: Mapping[str, Any],
-        upstream_unique_ids: List[str],
+        upstream_unique_ids: AbstractSet[str],
         metadata: Mapping[str, Any],
         description: Optional[str] = None,
     ) -> Iterator[AssetObservation]:
@@ -254,7 +255,8 @@ class DbtCliEventMessage:
                     },
                 )
         elif manifest and node_resource_type == NodeType.Test and is_node_finished:
-            upstream_unique_ids: List[str] = manifest["parent_map"][unique_id]
+            # dbt 1.5 may have duplicate upstreams, filter with a set
+            upstream_unique_ids: AbstractSet[str] = set(manifest["parent_map"][unique_id])
             test_resource_props = manifest["nodes"][unique_id]
             metadata = {
                 **default_metadata,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -17,6 +17,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    Tuple,
     Union,
     cast,
 )
@@ -1164,14 +1165,9 @@ def get_subset_selection_for_context(
 
             If the current execution context is not performing a subsetted execution,
             return CLI arguments composed of the inputed selection and exclusion arguments.
-        Optional[str]: A value for the DBT_INDIRECT_SELECTION environment variable
-
-                    if dagster_dbt_translator.settings.enable_asset_checks:
-                if (
-                    assets_def.node_check_specs_by_output_name
-                    != assets_def.check_specs_by_output_name
-                ):
-                    env["DBT_INDIRECT_SELECTION"] = "empty"
+        Optional[str]: A value for the DBT_INDIRECT_SELECTION environment variable. If None, then
+            the environment variable is not set and will either use dbt's default (eager) or the
+            user's setting.
     """
     default_dbt_selection = []
     if select:
@@ -1188,16 +1184,18 @@ def get_subset_selection_for_context(
         assets_def.check_specs_by_output_name != assets_def.node_check_specs_by_output_name
     )
 
-    # It's nice to use the default dbt selection arguments when not subsetting for readability.
-    # However with asset checks, we make a tradeoff between readability and functionality for the user.
-    # This is because we use an explicit selection of each individual dbt resource we execute to ensure
-    # we control which models *and tests* run. By using explicit selection, we allow the user to
-    # also subset the execution of dbt tests.
+    # It's nice to use the default dbt selection arguments when not subsetting for readability. We
+    # also use dbt indirect selection to avoid hitting cli arg length limits.
+    # https://github.com/dagster-io/dagster/issues/16997#issuecomment-1832443279
+    # A biproduct is that we'll run singular dbt tests (not currently modeled as asset checks) in
+    # cases when we can use indirection selection, an not when we need to turn it off.
     if not (is_asset_subset or is_checks_subset):
         logger.info(
             "A dbt subsetted execution is not being performed. Using the default dbt selection"
             f" arguments `{default_dbt_selection}`."
         )
+        # default eager indirect selection. This means we'll also run any singular tests (which
+        # aren't modeled as asset checks currently).
         return default_dbt_selection, None
 
     selected_dbt_non_test_resources = []
@@ -1220,15 +1218,34 @@ def get_subset_selection_for_context(
 
         selected_dbt_tests.append(fqn_selector)
 
-    if is_asset_subset:
+    # if all asset checks for the subsetted assets are selected, then we can just select the
+    # assets and use indirect selection for the tests. We verify that
+    # 1. all the selected checks are for selected assets
+    # 2. no checks for selected assets are excluded
+    # This also means we'll run any singular tests.
+    selected_checks_target_selected_assets = all(
+        check_key.asset_key in context.selected_asset_keys
+        for check_key in context.selected_asset_check_keys
+    )
+    all_check_keys = {
+        check_spec.key for check_spec in assets_def.node_check_specs_by_output_name.values()
+    }
+    all_checks_included_for_selected_assets = all(
+        check_key.asset_key not in context.selected_asset_check_keys
+        for check_key in (all_check_keys - context.selected_asset_check_keys)
+    )
+
+    if selected_checks_target_selected_assets and all_checks_included_for_selected_assets:
         selected_dbt_resources = selected_dbt_non_test_resources + selected_dbt_tests
-        indirect_selection = "empty"
+        indirect_selection = None
         logger.info(
             "A dbt subsetted execution is being performed. Overriding default dbt selection"
             f" arguments `{default_dbt_selection}` with arguments: `{selected_dbt_resources}`. "
-            "Because asset checks are subsetted, setting DBT_INDIRECT_SELECTION=empty"
         )
-
+    # otherwise we select all assets and tests explicitly, and turn off indirect selection. This risks
+    # hitting the CLI argument length limit, but in the common scenarios that can be launched from the UI
+    # (all checks disabled, only one check and no assets) it's not a concern.
+    # Since we're setting DBT_INDIRECT_SELECTION=empty, we won't run any singular tests.
     else:
         check.invariant(is_checks_subset)
         selected_dbt_resources = selected_dbt_non_test_resources + selected_dbt_tests

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -21,6 +21,7 @@ from typing import (
     cast,
 )
 
+import dagster._check as check
 import dateutil.parser
 import orjson
 from dagster import (
@@ -1094,23 +1095,16 @@ class DbtCliResource(ConfigurableResource):
                 [assets_def]
             )
 
-            # When dbt is enabled with asset checks, we turn off any indirection with dbt selection.
-            # This way, the Dagster context completely determines what is executed in a dbt
-            # invocation.
-            if dagster_dbt_translator.settings.enable_asset_checks:
-                logger.info(
-                    "Setting environment variable `DBT_INDIRECT_SELECTION` to 'empty'. When dbt "
-                    "tests are modeled as asset checks, they are executed through explicit selection."
-                )
-                env["DBT_INDIRECT_SELECTION"] = "empty"
-
-            selection_args = get_subset_selection_for_context(
+            selection_args, indirect_selection = get_subset_selection_for_context(
                 context=context,
                 manifest=manifest,
                 select=context.op.tags.get(DAGSTER_DBT_SELECT_METADATA_KEY),
                 exclude=context.op.tags.get(DAGSTER_DBT_EXCLUDE_METADATA_KEY),
                 dagster_dbt_translator=dagster_dbt_translator,
             )
+
+            if indirect_selection:
+                env["DBT_INDIRECT_SELECTION"] = indirect_selection
         else:
             manifest = validate_manifest(manifest) if manifest else {}
 
@@ -1153,8 +1147,9 @@ def get_subset_selection_for_context(
     select: Optional[str],
     exclude: Optional[str],
     dagster_dbt_translator: DagsterDbtTranslator,
-) -> List[str]:
-    """Generate a dbt selection string to materialize the selected resources in a subsetted execution context.
+) -> Tuple[List[str], Optional[str]]:
+    """Generate a dbt selection string and DBT_INDIRECT_SELECTION setting to execute the selected
+    resources in a subsetted execution context.
 
     See https://docs.getdbt.com/reference/node-selection/syntax#how-does-selection-work.
 
@@ -1169,6 +1164,14 @@ def get_subset_selection_for_context(
 
             If the current execution context is not performing a subsetted execution,
             return CLI arguments composed of the inputed selection and exclusion arguments.
+        Optional[str]: A value for the DBT_INDIRECT_SELECTION environment variable
+
+                    if dagster_dbt_translator.settings.enable_asset_checks:
+                if (
+                    assets_def.node_check_specs_by_output_name
+                    != assets_def.check_specs_by_output_name
+                ):
+                    env["DBT_INDIRECT_SELECTION"] = "empty"
     """
     default_dbt_selection = []
     if select:
@@ -1179,19 +1182,25 @@ def get_subset_selection_for_context(
     dbt_resource_props_by_output_name = get_dbt_resource_props_by_output_name(manifest)
     dbt_resource_props_by_test_name = get_dbt_resource_props_by_test_name(manifest)
 
+    assets_def = context.assets_def
+    is_asset_subset = assets_def.keys_by_output_name != assets_def.node_keys_by_output_name
+    is_checks_subset = (
+        assets_def.check_specs_by_output_name != assets_def.node_check_specs_by_output_name
+    )
+
     # It's nice to use the default dbt selection arguments when not subsetting for readability.
     # However with asset checks, we make a tradeoff between readability and functionality for the user.
     # This is because we use an explicit selection of each individual dbt resource we execute to ensure
     # we control which models *and tests* run. By using explicit selection, we allow the user to
     # also subset the execution of dbt tests.
-    if not context.is_subset and not dagster_dbt_translator.settings.enable_asset_checks:
+    if not (is_asset_subset or is_checks_subset):
         logger.info(
             "A dbt subsetted execution is not being performed. Using the default dbt selection"
             f" arguments `{default_dbt_selection}`."
         )
-        return default_dbt_selection
+        return default_dbt_selection, None
 
-    selected_dbt_resources = []
+    selected_dbt_non_test_resources = []
     for output_name in context.selected_output_names:
         dbt_resource_props = dbt_resource_props_by_output_name[output_name]
 
@@ -1199,8 +1208,9 @@ def get_subset_selection_for_context(
         # https://docs.getdbt.com/reference/node-selection/methods#the-file-or-fqn-method
         fqn_selector = f"fqn:{'.'.join(dbt_resource_props['fqn'])}"
 
-        selected_dbt_resources.append(fqn_selector)
+        selected_dbt_non_test_resources.append(fqn_selector)
 
+    selected_dbt_tests = []
     for _, check_name in context.selected_asset_check_keys:
         test_resource_props = dbt_resource_props_by_test_name[check_name]
 
@@ -1208,25 +1218,32 @@ def get_subset_selection_for_context(
         # https://docs.getdbt.com/reference/node-selection/methods#the-file-or-fqn-method
         fqn_selector = f"fqn:{'.'.join(test_resource_props['fqn'])}"
 
-        selected_dbt_resources.append(fqn_selector)
+        selected_dbt_tests.append(fqn_selector)
+
+    if is_asset_subset:
+        selected_dbt_resources = selected_dbt_non_test_resources + selected_dbt_tests
+        indirect_selection = "empty"
+        logger.info(
+            "A dbt subsetted execution is being performed. Overriding default dbt selection"
+            f" arguments `{default_dbt_selection}` with arguments: `{selected_dbt_resources}`. "
+            "Because asset checks are subsetted, setting DBT_INDIRECT_SELECTION=empty"
+        )
+
+    else:
+        check.invariant(is_checks_subset)
+        selected_dbt_resources = selected_dbt_non_test_resources + selected_dbt_tests
+        indirect_selection = "empty"
+        logger.info(
+            "A dbt subsetted execution is being performed. Overriding default dbt selection"
+            f" arguments `{default_dbt_selection}` with arguments: `{selected_dbt_resources}`. "
+            "Because asset checks are subsetted, setting DBT_INDIRECT_SELECTION=empty"
+        )
 
     # Take the union of all the selected resources.
     # https://docs.getdbt.com/reference/node-selection/set-operators#unions
     union_selected_dbt_resources = ["--select"] + [" ".join(selected_dbt_resources)]
 
-    if context.is_subset:
-        logger.info(
-            "A dbt subsetted execution is being performed. Overriding default dbt selection"
-            f" arguments `{default_dbt_selection}` with arguments: `{union_selected_dbt_resources}`"
-        )
-    else:
-        logger.info(
-            "A dbt subsetted execution is not being performed. Because asset checks are enabled,"
-            f" converting the default dbt selection arguments `{default_dbt_selection}` with the "
-            f"explicit set of models and tests: `{union_selected_dbt_resources}`"
-        )
-
-    return union_selected_dbt_resources
+    return union_selected_dbt_resources, indirect_selection
 
 
 def get_dbt_resource_props_by_output_name(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -286,7 +286,7 @@ def test_materialize_no_selection(
     assert not result.success  # fail_tests_model fails
     assert len(result.get_asset_materialization_events()) == 10
     assert len(result.get_asset_check_evaluations()) == 24
-    assert len(result.get_asset_observation_events()) == 0
+    assert len(result.get_asset_observation_events()) == 1
 
 
 def test_materialize_asset_and_checks(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -286,6 +286,7 @@ def test_materialize_no_selection(
     assert not result.success  # fail_tests_model fails
     assert len(result.get_asset_materialization_events()) == 10
     assert len(result.get_asset_check_evaluations()) == 24
+    assert len(result.get_asset_observation_events()) == 0
 
 
 def test_materialize_asset_and_checks(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -305,7 +305,7 @@ def test_materialize_asset_and_checks(
     assert len(result.get_asset_observation_events()) == 5
     # no tests were excluded, so we include singular and relationship tests
     assert {
-        (e.asset_key, e.asset_observation_data.asset_observation.metadata.get("unique_id").value)
+        (e.asset_key, e.asset_observation_data.asset_observation.metadata.get("unique_id").value)  # type: ignore[attr-defined]
         for e in result.get_asset_observation_events()
     } == {
         (
@@ -480,7 +480,7 @@ def test_select_model_with_tests(
     # no tests were excluded, so we include singular and relationship tests
     assert len(result.get_asset_observation_events()) == 5
     assert {
-        (e.asset_key, e.asset_observation_data.asset_observation.metadata.get("unique_id").value)
+        (e.asset_key, e.asset_observation_data.asset_observation.metadata.get("unique_id").value)  # type: ignore[attr-defined]
         for e in result.get_asset_observation_events()
     } == {
         (
@@ -516,17 +516,4 @@ def _get_subset_selection(assets_def: AssetsDefinition, manifest: Dict[str, Any]
         "my_select_str",
         "my_exclude_str",
         dagster_dbt_translator_with_checks,
-    )
-
-
-def test_get_subset_selection_for_context(test_asset_checks_manifest: Dict[str, Any]):
-    @dbt_assets(
-        manifest=test_asset_checks_manifest,
-        dagster_dbt_translator=dagster_dbt_translator_with_checks,
-    )
-    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource): ...
-
-    assert _get_subset_selection(my_dbt_assets, test_asset_checks_manifest) == (
-        ["--select", "my_select_str", "--exclude", "my_exclude_str"],
-        None,
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -12,8 +12,8 @@ from dagster import (
     AssetsDefinition,
     AssetSelection,
     ExecuteInProcessResult,
-    materialize,
     build_asset_context,
+    materialize,
 )
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.asset_defs import load_assets_from_dbt_manifest


### PR DESCRIPTION
Two birds with one stone: reduce hitting cli arg limits https://github.com/dagster-io/dagster/issues/16997#issuecomment-1832443279 and stop ignoring singular tests when asset checks are enabled

internal discussion: https://www.notion.so/dagster/dbt-asset-checks-GA-962f362f86c24ff6aa053a6d5d0213c8?pvs=4#90d90384bce543fab01dc5044b9cb8ea

My expecation is that with this change, dbt users will be running the same set of dbt tests before and after turning on dbt asset checks. We aren't overriding DBT_INDIRECT_SELECTION to empty anymore, unless you filter out asset checks from the dbt side (which non-checks users wouldn't be doing). As a result:
- we'll respect whatever indirection selection mode users set
- we'll execute singular tests and log observations for them. Previously they were filtered out
- we'll execute relationship tests (if selection is eager) when the primary asset is filtered out. See https://github.com/dagster-io/dagster/pull/20568#discussion_r1535844659