### PR TITLE
[ui] Support active state on side nav button item

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/SideNavItem.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/SideNavItem.tsx
@@ -1,6 +1,6 @@
 import {Box, Colors, IconWrapper, Tooltip, UnstyledButton} from '@dagster-io/ui-components';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
 
 interface SideNavItemInterface {
   key: string;
@@ -57,22 +57,24 @@ export const SideNavItem = (props: Props) => {
 
   return (
     <Tooltip canShow={!!tooltip} content={tooltip} placement="right" display="block">
-      <StyledSideNavButton disabled={disabled} onClick={item.onClick}>
+      <StyledSideNavButton $active={active} disabled={disabled} onClick={item.onClick}>
         {content}
       </StyledSideNavButton>
     </Tooltip>
   );
 };
 
-const StyledSideNavLink = styled(Link)<{$active: boolean}>`
+const sharedSideNavItemStyle = css<{$active: boolean}>`
   background-color: ${({$active}) => ($active ? Colors.backgroundBlue() : 'transparent')};
   border-radius: 8px;
   color: ${({$active}) => ($active ? Colors.textBlue() : Colors.textDefault())};
   display: block;
+  font-size: 14px;
   line-height: 20px;
   text-decoration: none;
   transition: 100ms background-color linear;
   user-select: none;
+  width: 100%;
 
   :focus {
     outline: none;
@@ -95,31 +97,10 @@ const StyledSideNavLink = styled(Link)<{$active: boolean}>`
   }
 `;
 
-const StyledSideNavButton = styled(UnstyledButton)`
-  background-color: transparent;
-  border-radius: 8px;
-  color: ${Colors.textDefault()};
-  display: block;
-  font-size: 14px;
-  line-height: 20px;
-  text-decoration: none;
-  transition: 100ms background-color linear;
-  user-select: none;
-  width: 100%;
+const StyledSideNavLink = styled(Link)<{$active: boolean}>`
+  ${sharedSideNavItemStyle}
+`;
 
-  :focus {
-    outline: none;
-    background-color: ${Colors.backgroundLight()};
-  }
-
-  :hover,
-  :active {
-    background-color: ${Colors.backgroundLightHover()};
-    color: ${Colors.textDefault()};
-    text-decoration: none;
-  }
-
-  ${IconWrapper} {
-    background-color: ${Colors.textDefault()};
-  }
+const StyledSideNavButton = styled(UnstyledButton)<{$active: boolean}>`
+  ${sharedSideNavItemStyle}
 `;


### PR DESCRIPTION
## Summary & Motivation

Consolidate styles for `SideNavItem` links and buttons, allow buttons to have an active state.

Settings:

<img width="292" alt="Screenshot 2024-03-19 at 15 39 21" src="https://github.com/dagster-io/dagster/assets/2823852/02b34461-767f-453e-82b6-c0c731c598d3">

Insights:

<img width="202" alt="Screenshot 2024-03-19 at 15 39 13" src="https://github.com/dagster-io/dagster/assets/2823852/899395a6-f93a-4456-ae74-8c47ff0be97d">

## How I Tested These Changes

View new Settings page and Insights metadata dialog, verify correct rendering of regular, hover, and active states.