### PR TITLE
Add timezone param to freshness checks

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/freshness_checks/non_partitioned.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_checks/non_partitioned.py
@@ -17,6 +17,7 @@ from ..assets import AssetsDefinition, SourceAsset
 from ..decorators.asset_check_decorator import asset_check
 from ..events import CoercibleToAssetKey
 from .utils import (
+    DEFAULT_FRESHNESS_CRON_TIMEZONE,
     DEFAULT_FRESHNESS_SEVERITY,
     asset_to_keys_iterable,
     ensure_no_duplicate_assets,
@@ -30,6 +31,7 @@ def build_freshness_checks_for_non_partitioned_assets(
     assets: Sequence[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]],
     maximum_lag_minutes: int,
     freshness_cron: Optional[str] = None,
+    freshness_cron_timezone: str = DEFAULT_FRESHNESS_CRON_TIMEZONE,
     severity: AssetCheckSeverity = DEFAULT_FRESHNESS_SEVERITY,
 ) -> Sequence[AssetChecksDefinition]:
     """For each provided asset, constructs a freshness check definition.
@@ -59,6 +61,8 @@ def build_freshness_checks_for_non_partitioned_assets(
             (cron provided).
         freshness_cron (Optional[str]): The check will pass if the asset was updated within
             maximum_lag_minutes of the most recent tick of this cron.
+        freshness_cron_timezone (Optional[str]): The timezone to use for the cron schedule. If not
+            provided, the timezone will be UTC.
 
     Returns:
         Sequence[AssetChecksDefinition]: A list of `AssetChecksDefinition` objects, each
@@ -71,6 +75,7 @@ def build_freshness_checks_for_non_partitioned_assets(
         "freshness_cron",
         "Expect a valid cron string.",
     )
+    freshness_cron_timezone = check.str_param(freshness_cron_timezone, "freshness_cron_timezone")
     maximum_lag_minutes = check.int_param(maximum_lag_minutes, "maximum_lag_minutes")
     severity = check.inst_param(severity, "severity", AssetCheckSeverity)
 
@@ -82,6 +87,7 @@ def build_freshness_checks_for_non_partitioned_assets(
             freshness_cron=freshness_cron,
             maximum_lag_minutes=maximum_lag_minutes,
             severity=severity,
+            freshness_cron_timezone=freshness_cron_timezone,
         )
     ]
 
@@ -91,6 +97,7 @@ def _build_freshness_check_for_assets(
     freshness_cron: Optional[str],
     maximum_lag_minutes: int,
     severity: AssetCheckSeverity,
+    freshness_cron_timezone: str,
 ) -> Sequence[AssetChecksDefinition]:
     checks = []
     for asset_key in asset_to_keys_iterable(asset):
@@ -108,7 +115,9 @@ def _build_freshness_check_for_assets(
 
             current_time = pendulum.now("UTC")
             current_timestamp = check.float_param(current_time.timestamp(), "current_time")
-            latest_cron_tick = get_latest_completed_cron_tick(freshness_cron, current_time, None)
+            latest_cron_tick = get_latest_completed_cron_tick(
+                freshness_cron, current_time, freshness_cron_timezone
+            )
             lower_search_bound = pendulum.instance(latest_cron_tick or current_time).subtract(
                 minutes=maximum_lag_minutes
             )

--- a/python_modules/dagster/dagster/_core/definitions/freshness_checks/time_window_partitioned.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_checks/time_window_partitioned.py
@@ -15,6 +15,7 @@ from ..assets import AssetsDefinition, SourceAsset
 from ..events import CoercibleToAssetKey
 from ..time_window_partitions import TimeWindowPartitionsDefinition
 from .utils import (
+    DEFAULT_FRESHNESS_CRON_TIMEZONE,
     DEFAULT_FRESHNESS_SEVERITY,
     asset_to_keys_iterable,
     ensure_no_duplicate_assets,
@@ -27,6 +28,7 @@ def build_freshness_checks_for_time_window_partitioned_assets(
     *,
     assets: Sequence[Union[SourceAsset, CoercibleToAssetKey, AssetsDefinition]],
     freshness_cron: str,
+    freshness_cron_timezone: str = DEFAULT_FRESHNESS_CRON_TIMEZONE,
     severity: AssetCheckSeverity = DEFAULT_FRESHNESS_SEVERITY,
 ) -> Sequence[AssetChecksDefinition]:
     """For each provided time-window partitioned asset, constructs a freshness check definition.
@@ -46,6 +48,8 @@ def build_freshness_checks_for_time_window_partitioned_assets(
             constructed `AssetChecksDefinition`.
         freshness_cron (str): The check will pass if the partition time window most recently
             completed by the time of the last cron tick has been observed/materialized.
+        freshness_cron_timezone (Optional[str]): The timezone to use for the cron schedule. If not
+            provided, defaults to "UTC".
 
     Returns:
         Sequence[AssetChecksDefinition]: A list of `AssetChecksDefinition` objects, each
@@ -53,16 +57,20 @@ def build_freshness_checks_for_time_window_partitioned_assets(
     """
     ensure_no_duplicate_assets(assets)
     freshness_cron = check.str_param(freshness_cron, "freshness_cron")
+
     check.invariant(
         is_valid_cron_string(freshness_cron),
         "freshness_cron must be a valid cron string.",
     )
     severity = check.inst_param(severity, "severity", AssetCheckSeverity)
+    freshness_cron_timezone = check.str_param(freshness_cron_timezone, "freshness_cron_timezone")
 
     return [
         check
         for asset in assets
-        for check in _build_freshness_checks_for_asset(asset, freshness_cron, severity)
+        for check in _build_freshness_checks_for_asset(
+            asset, freshness_cron, severity, freshness_cron_timezone
+        )
     ]
 
 
@@ -70,6 +78,7 @@ def _build_freshness_checks_for_asset(
     asset: Union[SourceAsset, CoercibleToAssetKey, AssetsDefinition],
     freshness_cron: str,
     severity: AssetCheckSeverity,
+    freshness_cron_timezone: str,
 ) -> Sequence[AssetChecksDefinition]:
     checks = []
     for asset_key in asset_to_keys_iterable(asset):
@@ -92,7 +101,7 @@ def _build_freshness_checks_for_asset(
             )
             latest_cron_tick_time = check.not_none(
                 get_latest_completed_cron_tick(
-                    freshness_cron, current_time, partitions_def.timezone
+                    freshness_cron, current_time, freshness_cron_timezone
                 ),
                 "expected there to be a previous tick of the provided cron",
             )

--- a/python_modules/dagster/dagster/_core/definitions/freshness_checks/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_checks/utils.py
@@ -11,6 +11,7 @@ from ..assets import AssetsDefinition, SourceAsset
 from ..events import AssetKey, CoercibleToAssetKey
 
 DEFAULT_FRESHNESS_SEVERITY = AssetCheckSeverity.WARN
+DEFAULT_FRESHNESS_CRON_TIMEZONE = "UTC"
 
 
 def ensure_no_duplicate_assets(

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_non_partitioned.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_non_partitioned.py
@@ -45,6 +45,7 @@ def test_params() -> None:
     result = build_freshness_checks_for_non_partitioned_assets(
         assets=[my_asset, src_asset], maximum_lag_minutes=10
     )
+
     assert len(result) == 2
     assert next(iter(result[0].check_keys)).asset_key == my_asset.key
 
@@ -52,6 +53,15 @@ def test_params() -> None:
         build_freshness_checks_for_non_partitioned_assets(
             assets=[my_asset, my_asset], maximum_lag_minutes=10
         )
+
+    result = build_freshness_checks_for_non_partitioned_assets(
+        assets=[my_asset],
+        maximum_lag_minutes=10,
+        freshness_cron="0 0 * * *",
+        freshness_cron_timezone="UTC",
+    )
+    assert len(result) == 1
+    assert next(iter(result[0].check_keys)).asset_key == my_asset.key
 
 
 @pytest.mark.parametrize(
@@ -93,12 +103,14 @@ def test_check_result_cron_non_partitioned(
 
     start_time = pendulum.datetime(2021, 1, 1, 1, 0, 0, tz="UTC")
     freshness_cron = "0 0 * * *"  # Every day at midnight.
+    freshness_cron_timezone = "UTC"
     maximum_lag_minutes = 10
 
     freshness_checks = build_freshness_checks_for_non_partitioned_assets(
         assets=[my_asset],
         freshness_cron=freshness_cron,
         maximum_lag_minutes=maximum_lag_minutes,
+        freshness_cron_timezone=freshness_cron_timezone,
     )
 
     freeze_datetime = start_time

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_time_window_partitioned.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_time_window_partitioned.py
@@ -42,20 +42,22 @@ def test_params() -> None:
     assert next(iter(result[0].check_keys)).asset_key == my_partitioned_asset.key
 
     result = build_freshness_checks_for_time_window_partitioned_assets(
-        assets=[my_partitioned_asset.key], freshness_cron="0 0 * * *"
+        assets=[my_partitioned_asset.key], freshness_cron="0 0 * * *", freshness_cron_timezone="UTC"
     )
     assert len(result) == 1
     assert next(iter(result[0].check_keys)).asset_key == my_partitioned_asset.key
 
     src_asset = SourceAsset("source_asset")
     result = build_freshness_checks_for_time_window_partitioned_assets(
-        assets=[src_asset], freshness_cron="0 0 * * *"
+        assets=[src_asset], freshness_cron="0 0 * * *", freshness_cron_timezone="UTC"
     )
     assert len(result) == 1
     assert next(iter(result[0].check_keys)).asset_key == src_asset.key
 
     result = build_freshness_checks_for_time_window_partitioned_assets(
-        assets=[my_partitioned_asset, src_asset], freshness_cron="0 0 * * *"
+        assets=[my_partitioned_asset, src_asset],
+        freshness_cron="0 0 * * *",
+        freshness_cron_timezone="UTC",
     )
     assert len(result) == 2
     assert {next(iter(checks_def.check_keys)).asset_key for checks_def in result} == {
@@ -65,7 +67,9 @@ def test_params() -> None:
 
     with pytest.raises(Exception, match="Found duplicate assets"):
         build_freshness_checks_for_time_window_partitioned_assets(
-            assets=[my_partitioned_asset, my_partitioned_asset], freshness_cron="0 0 * * *"
+            assets=[my_partitioned_asset, my_partitioned_asset],
+            freshness_cron="0 0 * * *",
+            freshness_cron_timezone="UTC",
         )
 
     @multi_asset(
@@ -82,7 +86,7 @@ def test_params() -> None:
         pass
 
     result = build_freshness_checks_for_time_window_partitioned_assets(
-        assets=[my_multi_asset], freshness_cron="0 0 * * *"
+        assets=[my_multi_asset], freshness_cron="0 0 * * *", freshness_cron_timezone="UTC"
     )
     assert len(result) == 2
     assert {next(iter(checks_def.check_keys)).asset_key for checks_def in result} == set(
@@ -91,41 +95,49 @@ def test_params() -> None:
 
     with pytest.raises(Exception, match="freshness_cron must be a valid cron string."):
         build_freshness_checks_for_time_window_partitioned_assets(
-            assets=[my_multi_asset], freshness_cron="0 0 * * * *"
+            assets=[my_multi_asset], freshness_cron="0 0 * * * *", freshness_cron_timezone="UTC"
         )
 
     with pytest.raises(Exception, match="Found duplicate assets"):
         build_freshness_checks_for_time_window_partitioned_assets(
-            assets=[my_multi_asset, my_multi_asset], freshness_cron="0 0 * * *"
+            assets=[my_multi_asset, my_multi_asset],
+            freshness_cron="0 0 * * *",
+            freshness_cron_timezone="UTC",
         )
 
     with pytest.raises(Exception, match="Found duplicate assets"):
         build_freshness_checks_for_time_window_partitioned_assets(
-            assets=[my_multi_asset, my_partitioned_asset], freshness_cron="0 0 * * *"
+            assets=[my_multi_asset, my_partitioned_asset],
+            freshness_cron="0 0 * * *",
+            freshness_cron_timezone="UTC",
         )
 
     coercible_key = "blah"
     result = build_freshness_checks_for_time_window_partitioned_assets(
-        assets=[coercible_key], freshness_cron="0 0 * * *"
+        assets=[coercible_key], freshness_cron="0 0 * * *", freshness_cron_timezone="UTC"
     )
     assert len(result) == 1
     assert next(iter(result[0].check_keys)).asset_key == AssetKey.from_coercible(coercible_key)
 
     with pytest.raises(Exception, match="Found duplicate assets"):
         build_freshness_checks_for_time_window_partitioned_assets(
-            assets=[coercible_key, coercible_key], freshness_cron="0 0 * * *"
+            assets=[coercible_key, coercible_key],
+            freshness_cron="0 0 * * *",
+            freshness_cron_timezone="UTC",
         )
 
     regular_asset_key = AssetKey("regular_asset_key")
     result = build_freshness_checks_for_time_window_partitioned_assets(
-        assets=[regular_asset_key], freshness_cron="0 0 * * *"
+        assets=[regular_asset_key], freshness_cron="0 0 * * *", freshness_cron_timezone="UTC"
     )
     assert len(result) == 1
     assert next(iter(result[0].check_keys)).asset_key == regular_asset_key
 
     with pytest.raises(Exception, match="Found duplicate assets"):
         build_freshness_checks_for_time_window_partitioned_assets(
-            assets=[regular_asset_key, regular_asset_key], freshness_cron="0 0 * * *"
+            assets=[regular_asset_key, regular_asset_key],
+            freshness_cron="0 0 * * *",
+            freshness_cron_timezone="UTC",
         )
 
 
@@ -147,6 +159,7 @@ def test_result_cron_param(
     freshness_checks = build_freshness_checks_for_time_window_partitioned_assets(
         assets=[my_asset],
         freshness_cron="0 9 * * *",  # 09:00 UTC
+        freshness_cron_timezone="UTC",
     )
 
     freeze_datetime = start_time
@@ -233,7 +246,7 @@ def test_invalid_runtime_assets(
         pass
 
     asset_checks = build_freshness_checks_for_time_window_partitioned_assets(
-        assets=[non_partitioned_asset], freshness_cron="0 9 * * *"
+        assets=[non_partitioned_asset], freshness_cron="0 9 * * *", freshness_cron_timezone="UTC"
     )
 
     with pytest.raises(CheckError, match="not a TimeWindowPartitionsDefinition."):
@@ -251,7 +264,7 @@ def test_invalid_runtime_assets(
         pass
 
     asset_checks = build_freshness_checks_for_time_window_partitioned_assets(
-        assets=[static_partitioned_asset], freshness_cron="0 9 * * *"
+        assets=[static_partitioned_asset], freshness_cron="0 9 * * *", freshness_cron_timezone="UTC"
     )
 
     with pytest.raises(CheckError, match="not a TimeWindowPartitionsDefinition."):
@@ -279,7 +292,8 @@ def test_observations(
 
     freshness_checks = build_freshness_checks_for_time_window_partitioned_assets(
         assets=[my_asset],
-        freshness_cron="0 9 * * *",  # 09:00 UTC
+        freshness_cron="0 9 * * *",
+        freshness_cron_timezone="UTC",  # 09:00 UTC
     )
 
     with pendulum_freeze_time(pendulum.datetime(2021, 1, 3, 1, 0, 0, tz="UTC")):


### PR DESCRIPTION
Timezone param necessary for non partitioned freshness checks. Even in the case of partitioned freshness checks, the more flexible and consistent thing to do is expose this parameter.

How I tested this
Added to existing tests timezone param
