### PR TITLE
make target materialization None for check evaluations with asset observations

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
@@ -137,7 +137,12 @@ class AssetCheckResult(
             resolved_check_name = next(iter(check_names_with_specs))
 
         input_asset_info = step_context.get_input_asset_version_info(resolved_asset_key)
-        if input_asset_info is not None:
+        from dagster._core.events import DagsterEventType
+
+        if (
+            input_asset_info is not None
+            and input_asset_info.event_type == DagsterEventType.ASSET_MATERIALIZATION
+        ):
             target_materialization_data = AssetCheckEvaluationTargetMaterializationData(
                 run_id=input_asset_info.run_id,
                 storage_id=input_asset_info.storage_id,

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
@@ -17,12 +17,14 @@ from dagster import (
     ExecuteInProcessResult,
     IOManager,
     MetadataValue,
+    ObserveResult,
     ResourceParam,
     SourceAsset,
     asset,
     asset_check,
     define_asset_job,
     multi_asset_check,
+    observable_source_asset,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.errors import (
@@ -775,3 +777,24 @@ def test_multi_asset_check_subset():
         )
         == 1
     )
+
+
+def test_target_materialization_observable_source_asset():
+    @observable_source_asset
+    def asset1():
+        return ObserveResult()
+
+    @asset_check(asset=asset1)
+    def check1():
+        return AssetCheckResult(passed=True)
+
+    result = execute_assets_and_checks(assets=[asset1], asset_checks=[check1])
+    assert result.success
+
+    check_evals = result.get_asset_check_evaluations()
+    assert len(check_evals) == 1
+    check_eval = check_evals[0]
+    assert check_eval.asset_key == AssetKey("asset1")
+    assert check_eval.check_name == "check1"
+
+    assert check_eval.target_materialization_data is None


### PR DESCRIPTION
## Summary & Motivation

Prior to this PR, if an asset check executed on an observable source asset, the check evaluation's "Target materialization" would point to the latest observation event for the asset. This was confusing/misleading in the UI.  This change causes it to be `None` instead.

It could make sense for asset check evaluations to track observations they correspond to, but this PR leaves that for future work, because I think there's some difficult nuance there.

## How I Tested These Changes

Added a test. Verified that "Target materialization" doesn't show up in the check evaluation UI for this example, and that it did prior to this PR:

```python
from dagster import (
    AssetCheckResult,
    Definitions,
    ObserveResult,
    asset_check,
    observable_source_asset,
)


@observable_source_asset
def asset1():
    return ObserveResult()


@asset_check(asset=asset1)
def check1():
    return AssetCheckResult(passed=True)


defs = Definitions(assets=[asset1], asset_checks=[check1])
```