### PR TITLE
fix: allow repository name to be changed

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -417,6 +417,7 @@ class Definitions:
 
     def __init__(
         self,
+        name: str = SINGLETON_REPOSITORY_NAME,
         assets: Optional[
             Iterable[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]
         ] = None,
@@ -431,7 +432,7 @@ class Definitions:
         asset_checks: Optional[Iterable[AssetChecksDefinition]] = None,
     ):
         self._created_pending_or_normal_repo = _create_repository_using_definitions_args(
-            name=SINGLETON_REPOSITORY_NAME,
+            name=name,
             assets=assets,
             schedules=schedules,
             sensors=sensors,


### PR DESCRIPTION
## Summary & Motivation
Should resolve this matter since you can now adjust the repo name so sensors don't run on all code locations: https://github.com/dagster-io/dagster/issues/14353#issuecomment-1553335149

## How I Tested These Changes
