### PR TITLE
[run status sensors] scope run status sensor to code location

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -776,6 +776,12 @@ class RunStatusSensorDefinition(SensorDefinition):
                     # the job has a repository (not manually executed)
                     dagster_run.external_job_origin
                     and
+                    # the job belongs to the current code location
+                    # TODO - need to find a way to get the current code location for the sensor so that we ensure that the jobs
+                    # are in the same code location. Right now comparing repo name doesn't work since most repos have the same name
+                    dagster_run.external_job_origin.external_repository_origin.code_location_origin.location_name
+                    == context
+                    and
                     # the job belongs to the current repository
                     dagster_run.external_job_origin.external_repository_origin.repository_name
                     == context.repository_name

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -769,6 +769,12 @@ class RunStatusSensorDefinition(SensorDefinition):
                 if monitor_all_code_locations:
                     job_match = True
 
+                code_location_name = (
+                    context.code_location_origin.location_name
+                    if context.code_location_origin
+                    else None
+                )
+
                 # check if the run is in the current repository and (if provided) one of jobs specified in monitored_jobs
                 if (
                     not job_match
@@ -777,10 +783,8 @@ class RunStatusSensorDefinition(SensorDefinition):
                     dagster_run.external_job_origin
                     and
                     # the job belongs to the current code location
-                    # TODO - need to find a way to get the current code location for the sensor so that we ensure that the jobs
-                    # are in the same code location. Right now comparing repo name doesn't work since most repos have the same name
                     dagster_run.external_job_origin.external_repository_origin.code_location_origin.location_name
-                    == context
+                    == code_location_name
                     and
                     # the job belongs to the current repository
                     dagster_run.external_job_origin.external_repository_origin.repository_name

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -136,6 +136,7 @@ class SensorEvaluationContext:
         resources (Optional[Dict[str, Any]]): A dict of resource keys to resource
             definitions to be made available during sensor execution.
         last_sensor_start_time (float): The last time that the sensor was started (UTC).
+        code_location_origin (Optional[CodeLocationOrigin]): The code location that the sensor is in.
 
     Example:
         .. code-block:: python

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -81,6 +81,7 @@ if TYPE_CHECKING:
     from dagster import ResourceDefinition
     from dagster._core.definitions.definitions_class import Definitions
     from dagster._core.definitions.repository_definition import RepositoryDefinition
+    from dagster._core.remote_representation.origin import CodeLocationOrigin
 
 
 @whitelist_for_serdes
@@ -161,11 +162,13 @@ class SensorEvaluationContext:
         resources: Optional[Mapping[str, "ResourceDefinition"]] = None,
         definitions: Optional["Definitions"] = None,
         last_sensor_start_time: Optional[float] = None,
+        code_location_origin: Optional["CodeLocationOrigin"] = None,
         # deprecated param
         last_completion_time: Optional[float] = None,
     ):
         from dagster._core.definitions.definitions_class import Definitions
         from dagster._core.definitions.repository_definition import RepositoryDefinition
+        from dagster._core.remote_representation.origin import CodeLocationOrigin
 
         self._exit_stack = ExitStack()
         self._instance_ref = check.opt_inst_param(instance_ref, "instance_ref", InstanceRef)
@@ -185,6 +188,9 @@ class SensorEvaluationContext:
             check.opt_inst_param(definitions, "definitions", Definitions),
             check.opt_inst_param(repository_def, "repository_def", RepositoryDefinition),
             error_on_none=False,
+        )
+        self._code_location_origin = check.opt_inst_param(
+            code_location_origin, "code_location_origin", CodeLocationOrigin
         )
         self._instance = check.opt_inst_param(instance, "instance", DagsterInstance)
         self._sensor_name = sensor_name
@@ -252,6 +258,7 @@ class SensorEvaluationContext:
                 **wrap_resources_for_execution(resources_dict),
             },
             last_sensor_start_time=self._last_sensor_start_time,
+            code_location_origin=self.code_location_origin,
         )
 
     @public
@@ -401,6 +408,11 @@ class SensorEvaluationContext:
     def repository_def(self) -> Optional["RepositoryDefinition"]:
         """Optional[RepositoryDefinition]: The RepositoryDefinition that this sensor resides in."""
         return self._repository_def
+
+    @property
+    def code_location_origin(self) -> Optional["CodeLocationOrigin"]:
+        """Optional[CodeLocationOrigin]: The CodeLocation that this sensor resides in."""
+        return self._code_location_origin
 
     @property
     def log(self) -> logging.Logger:

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -541,6 +541,7 @@ class InProcessCodeLocation(CodeLocation):
     ) -> "SensorExecutionData":
         result = get_external_sensor_execution(
             self._get_repo_def(repository_handle.repository_name),
+            self.origin,
             instance.get_ref(),
             name,
             last_tick_completion_time,

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -56,6 +56,7 @@ from dagster._core.remote_representation.external_data import (
     ExternalSensorExecutionErrorData,
     job_name_for_external_partition_set_name,
 )
+from dagster._core.remote_representation.origin import CodeLocationOrigin
 from dagster._core.snap.execution_plan_snapshot import (
     ExecutionPlanSnapshotErrorData,
     snapshot_from_execution_plan,
@@ -350,6 +351,7 @@ def get_external_schedule_execution(
 
 def get_external_sensor_execution(
     repo_def: RepositoryDefinition,
+    code_location_origin: CodeLocationOrigin,
     instance_ref: Optional[InstanceRef],
     sensor_name: str,
     last_tick_completion_timestamp: Optional[float],
@@ -383,6 +385,7 @@ def get_external_sensor_execution(
             sensor_name=sensor_name,
             resources=resources_to_build,
             last_sensor_start_time=last_sensor_start_timestamp,
+            code_location_origin=code_location_origin,
         ) as sensor_context:
             with user_code_error_boundary(
                 SensorExecutionError,

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -890,6 +890,7 @@ class DagsterApiServer(DagsterApiServicer):
             return serialize_value(
                 get_external_sensor_execution(
                     self._get_repo_for_origin(args.repository_origin),
+                    args.repository_origin.code_location_origin,
                     args.instance_ref,
                     args.sensor_name,
                     args.last_tick_completion_time,

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/code_location_scoped_test_workspace.yaml
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/code_location_scoped_test_workspace.yaml
@@ -1,0 +1,3 @@
+load_from:
+  - python_module: dagster_tests.daemon_sensor_tests.locations_for_code_location_scoped_sensor_test.code_location_with_sensor
+  - python_module: dagster_tests.daemon_sensor_tests.locations_for_code_location_scoped_sensor_test.code_location_with_duplicate_job_name

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/locations_for_code_location_scoped_sensor_test/code_location_with_duplicate_job_name.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/locations_for_code_location_scoped_sensor_test/code_location_with_duplicate_job_name.py
@@ -1,0 +1,17 @@
+from dagster import Definitions, job, op
+
+
+# this code location also contains a job named success_job. But it should not trigger the sensor in code_location_with_sensor
+@op
+def an_op():
+    pass
+
+
+@job
+def success_job():
+    an_op()
+
+
+defs = Definitions(
+    jobs=[success_job],
+)

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/locations_for_code_location_scoped_sensor_test/code_location_with_sensor.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/locations_for_code_location_scoped_sensor_test/code_location_with_sensor.py
@@ -1,0 +1,28 @@
+from dagster import DagsterRunStatus, Definitions, RunRequest, job, op, run_status_sensor
+
+
+@op
+def an_op():
+    pass
+
+
+@job
+def success_job():
+    an_op()
+
+
+@job
+def target_job():
+    an_op()
+
+
+@run_status_sensor(
+    run_status=DagsterRunStatus.SUCCESS,
+    monitored_jobs=[success_job],
+    request_job=target_job,
+)
+def success_sensor(_):
+    return RunRequest(job_name="target_job")
+
+
+defs = Definitions(jobs=[success_job, target_job], sensors=[success_sensor])


### PR DESCRIPTION
## Summary & Motivation
This PR fixes a bug in run status sensors where jobs in other code locations were erroneously ticking the run status sensor when it was configured to only tick for jobs in the current code location.

Run status sensors can be set to only monitor specific jobs in the code location/repository where the sensor is located. This functionality was added before `Definitions` was introduced and we used the repository name to ensure that only jobs in the current repository were considered. With code locations/definitions, now all the repositories have the same name, so jobs in other code locations can tick the sensor now. To solve this we pipe the `CodeLocationOrigin` to the sensor evaluation context so that we can compare the code location name for the sensor with the code location name for the job.

## How I Tested These Changes
New unit test, I also run local host cloud and added two code locations with the same named job in each. Confirmed that the job in code location 2 didn't tick the sensor in code location 1


resolves https://github.com/dagster-io/dagster/issues/14353  and https://github.com/dagster-io/dagster/issues/13076