### PR TITLE
[ui] Jobs root

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
@@ -20,6 +20,7 @@ const ScheduledRunListRoot = lazy(() => import('../runs/ScheduledRunListRoot'));
 const SnapshotRoot = lazy(() => import('../snapshots/SnapshotRoot'));
 const GuessJobLocationRoot = lazy(() => import('../workspace/GuessJobLocationRoot'));
 const SettingsRoot = lazy(() => import('../settings/SettingsRoot'));
+const JobsRoot = lazy(() => import('../jobs/JobsRoot'));
 
 export const ContentRoot = memo(() => {
   const {pathname} = useLocation();
@@ -98,6 +99,11 @@ export const ContentRoot = memo(() => {
           <Route path="/overview">
             <Suspense fallback={<div />}>
               <OverviewRoot />
+            </Suspense>
+          </Route>
+          <Route path="/jobs">
+            <Suspense fallback={<div />}>
+              <JobsRoot />
             </Suspense>
           </Route>
           <Route path="/automation">

--- a/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
@@ -2,24 +2,24 @@ import {gql, useQuery} from '@apollo/client';
 import {
   Box,
   Colors,
-  Heading,
   NonIdealState,
-  PageHeader,
   Spinner,
+  SpinnerWithText,
   TextInput,
 } from '@dagster-io/ui-components';
 import {useContext, useMemo} from 'react';
 
 import {OverviewJobsQuery, OverviewJobsQueryVariables} from './types/JobsPageContent.types';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
-import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
-import {useTrackPageView} from '../app/analytics';
+import {
+  FIFTEEN_SECONDS,
+  QueryRefreshCountdown,
+  useQueryRefreshAtInterval,
+} from '../app/QueryRefresh';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
-import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {RepoFilterButton} from '../instance/RepoFilterButton';
 import {OverviewJobsTable} from '../overview/OverviewJobsTable';
-import {OverviewTabs} from '../overview/OverviewTabs';
 import {sortRepoBuckets} from '../overview/sortRepoBuckets';
 import {visibleRepoKeys} from '../overview/visibleRepoKeys';
 import {SearchInputSpinner} from '../ui/SearchInputSpinner';
@@ -28,10 +28,7 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
-export const OverviewJobsRoot = () => {
-  useTrackPageView();
-  useDocumentTitle('Overview | Jobs');
-
+export const JobsPageContent = () => {
   const {allRepos, visibleRepos, loading: workspaceLoading} = useContext(WorkspaceContext);
   const [searchValue, setSearchValue] = useQueryPersistedState<string>({
     queryKey: 'search',
@@ -131,35 +128,34 @@ export const OverviewJobsRoot = () => {
   const showSearchSpinner = (workspaceLoading && !repoCount) || (loading && !data);
 
   return (
-    <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
-      <PageHeader
-        title={<Heading>Overview</Heading>}
-        tabs={<OverviewTabs tab="jobs" refreshState={refreshState} />}
-      />
+    <>
       <Box
         padding={{horizontal: 24, vertical: 16}}
-        flex={{direction: 'row', alignItems: 'center', gap: 12, grow: 0}}
+        flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between', grow: 0}}
       >
-        {repoCount > 1 ? <RepoFilterButton /> : null}
-        <TextInput
-          icon="search"
-          value={searchValue}
-          rightElement={
-            showSearchSpinner ? <SearchInputSpinner tooltipContent="Loading jobs…" /> : undefined
-          }
-          onChange={(e) => setSearchValue(e.target.value)}
-          placeholder="Filter by job name…"
-          style={{width: '340px'}}
-        />
+        <Box flex={{direction: 'row', gap: 12, alignItems: 'center'}}>
+          {repoCount > 1 ? <RepoFilterButton /> : null}
+          <TextInput
+            icon="search"
+            value={searchValue}
+            rightElement={
+              showSearchSpinner ? <SearchInputSpinner tooltipContent="Loading jobs…" /> : undefined
+            }
+            onChange={(e) => setSearchValue(e.target.value)}
+            placeholder="Filter by job name…"
+            style={{width: '340px'}}
+          />
+        </Box>
+        <QueryRefreshCountdown refreshState={refreshState} />
       </Box>
       {loading && !repoCount ? (
         <Box padding={64}>
-          <Spinner purpose="page" />
+          <SpinnerWithText label="Loading jobs…" />
         </Box>
       ) : (
         content()
       )}
-    </Box>
+    </>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsRoot.tsx
@@ -1,0 +1,21 @@
+import {Box, Heading, PageHeader} from '@dagster-io/ui-components';
+
+import {JobsPageContent} from './JobsPageContent';
+import {useTrackPageView} from '../app/analytics';
+import {useDocumentTitle} from '../hooks/useDocumentTitle';
+
+export const JobsRoot = () => {
+  useTrackPageView();
+  useDocumentTitle('Jobs');
+
+  return (
+    <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
+      <PageHeader title={<Heading>Jobs</Heading>} />
+      <JobsPageContent />
+    </Box>
+  );
+};
+
+// Imported via React.lazy, which requires a default export.
+// eslint-disable-next-line import/no-default-export
+export default JobsRoot;

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewJobsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewJobsRoot.tsx
@@ -1,0 +1,18 @@
+import {Box, Heading, PageHeader} from '@dagster-io/ui-components';
+
+import {OverviewTabs} from './OverviewTabs';
+import {useTrackPageView} from '../app/analytics';
+import {useDocumentTitle} from '../hooks/useDocumentTitle';
+import {JobsPageContent} from '../jobs/JobsPageContent';
+
+export const OverviewJobsRoot = () => {
+  useTrackPageView();
+  useDocumentTitle('Overview | Jobs');
+
+  return (
+    <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
+      <PageHeader title={<Heading>Overview</Heading>} tabs={<OverviewTabs tab="jobs" />} />
+      <JobsPageContent />
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
@@ -1,13 +1,13 @@
 import {Redirect, Route, Switch} from 'react-router-dom';
 
 import {OverviewActivityRoot} from './OverviewActivityRoot';
+import {OverviewJobsRoot} from './OverviewJobsRoot';
 import {OverviewResourcesRoot} from './OverviewResourcesRoot';
 import {OverviewSchedulesRoot} from './OverviewSchedulesRoot';
 import {OverviewSensorsRoot} from './OverviewSensorsRoot';
 import {AutomaterializationRoot} from '../assets/auto-materialization/AutomaterializationRoot';
 import {InstanceBackfillsRoot} from '../instance/InstanceBackfillsRoot';
 import {BackfillPage} from '../instance/backfill/BackfillPage';
-import {OverviewJobsRoot} from '../jobs/JobsPageContent';
 
 export const OverviewRoot = () => {
   return (


### PR DESCRIPTION
## Summary & Motivation

Create a new `JobsRoot` page that lives outside of Overview. The content is reused from the existing page, and I tried to preserve the git history by using a separate commit.

## How I Tested These Changes

View `/jobs`, verify rendering and scroll behavior. View Overview, then Jobs tab. Verify same.