### PR TITLE
[docs] - Asset owner alerts (DOC-156)

### DIFF
--- a/docs/content/dagster-cloud/managing-deployments/alerts.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/alerts.mdx
@@ -109,7 +109,7 @@ Alert policies are configured on a **per-deployment basis**. This means, for exa
 
 Dagster Cloud can send notifications via:
 
-- [Email](/dagster-cloud/managing-deployments/alerts/email)
+- [Email](/dagster-cloud/managing-deployments/alerts/email), either to a list of recipients or asset owners
 - [Microsoft Teams](/dagster-cloud/managing-deployments/alerts/microsoft-teams)
 - [Slack](/dagster-cloud/managing-deployments/alerts/slack)
 


### PR DESCRIPTION
## Summary & Motivation

This PR adds a note about emailing asset owners to the Dagster Cloud alerting docs. What was added in #20019 was moved to a dedicated page about email notifications - this PR just adds info to the main alerting page.

Admittedly, this feels a bit light at the moment without dedicated asset owner docs. We can link to those when they're ready.

## How I Tested These Changes

👀 
