### PR TITLE
Refactor `getNavLinks` and `rightOfSearchBar` into a single DI point for cloud

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/src/App.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/App.tsx
@@ -2,7 +2,7 @@ import {App} from '@dagster-io/ui-core/app/App';
 import {createAppCache} from '@dagster-io/ui-core/app/AppCache';
 import {errorLink, setupErrorToasts} from '@dagster-io/ui-core/app/AppError';
 import {AppProvider} from '@dagster-io/ui-core/app/AppProvider';
-import {AppTopNav} from '@dagster-io/ui-core/app/AppTopNav';
+import {AppTopNav} from '@dagster-io/ui-core/app/AppTopNav/AppTopNav';
 import {ContentRoot} from '@dagster-io/ui-core/app/ContentRoot';
 import {HelpMenu} from '@dagster-io/ui-core/app/HelpMenu';
 import {UserSettingsButton} from '@dagster-io/ui-core/app/UserSettingsButton';

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNav.tsx
@@ -1,156 +1,27 @@
 import {Box, Colors, Icon, IconWrapper, Tooltip} from '@dagster-io/ui-components';
 import * as React from 'react';
-import {Link, NavLink, useHistory} from 'react-router-dom';
+import {Link, NavLink} from 'react-router-dom';
 import styled from 'styled-components';
 
-import {useFeatureFlags} from './Flags';
-import {LayoutContext} from './LayoutProvider';
-import {ShortcutHandler} from './ShortcutHandler';
-import {WebSocketStatus} from './WebSocketProvider';
-import {DeploymentStatusIcon} from '../nav/DeploymentStatusIcon';
-import {VersionNumber} from '../nav/VersionNumber';
+import {AppTopNavRightOfLogo} from './AppTopNavRightOfLogo.oss';
+import {VersionNumber} from '../../nav/VersionNumber';
 import {
   reloadFnForWorkspace,
   useRepositoryLocationReload,
-} from '../nav/useRepositoryLocationReload';
-import {SearchDialog} from '../search/SearchDialog';
+} from '../../nav/useRepositoryLocationReload';
+import {SearchDialog} from '../../search/SearchDialog';
+import {LayoutContext} from '../LayoutProvider';
+import {ShortcutHandler} from '../ShortcutHandler';
+import {WebSocketStatus} from '../WebSocketProvider';
 
-type AppNavLinkType = {
-  title: string;
-  element: React.ReactNode;
-};
 interface Props {
   children?: React.ReactNode;
   searchPlaceholder: string;
-  rightOfSearchBar?: React.ReactNode;
   showStatusWarningIcon?: boolean;
-  getNavLinks?: (navItems: AppNavLinkType[]) => React.ReactNode;
   allowGlobalReload?: boolean;
 }
 
-export const AppTopNav = ({
-  children,
-  rightOfSearchBar,
-  searchPlaceholder,
-  getNavLinks,
-  allowGlobalReload = false,
-}: Props) => {
-  const history = useHistory();
-  const {flagSettingsPage, flagUseNewOverviewPage} = useFeatureFlags();
-
-  const navLinks = () => {
-    return [
-      {
-        title: 'overview',
-        element: (
-          <ShortcutHandler
-            key="overview"
-            onShortcut={() => history.push('/overview')}
-            shortcutLabel="⌥1"
-            shortcutFilter={(e) => e.altKey && e.code === 'Digit1'}
-          >
-            <TopNavLink to="/overview" data-cy="AppTopNav_StatusLink">
-              Overview
-            </TopNavLink>
-          </ShortcutHandler>
-        ),
-      },
-      {
-        title: 'runs',
-        element: (
-          <ShortcutHandler
-            key="runs"
-            onShortcut={() => history.push('/runs')}
-            shortcutLabel="⌥2"
-            shortcutFilter={(e) => e.altKey && e.code === 'Digit2'}
-          >
-            <TopNavLink to="/runs" data-cy="AppTopNav_RunsLink">
-              Runs
-            </TopNavLink>
-          </ShortcutHandler>
-        ),
-      },
-      {
-        title: 'assets',
-        element: (
-          <ShortcutHandler
-            key="assets"
-            onShortcut={() => history.push('/assets')}
-            shortcutLabel="⌥3"
-            shortcutFilter={(e) => e.altKey && e.code === 'Digit3'}
-          >
-            <TopNavLink
-              to={flagUseNewOverviewPage ? '/assets-overview' : '/assets'}
-              data-cy="AppTopNav_AssetsLink"
-              isActive={(_, location) => {
-                const {pathname} = location;
-                return pathname.startsWith('/assets') || pathname.startsWith('/asset-groups');
-              }}
-              exact={false}
-            >
-              Assets
-            </TopNavLink>
-          </ShortcutHandler>
-        ),
-      },
-      flagSettingsPage
-        ? {
-            title: 'settings',
-            element: (
-              <ShortcutHandler
-                key="settings"
-                onShortcut={() => history.push('/settings')}
-                shortcutLabel="⌥4"
-                shortcutFilter={(e) => e.altKey && e.code === 'Digit4'}
-              >
-                <TopNavLink
-                  to="/settings"
-                  data-cy="AppTopNav_SettingsLink"
-                  isActive={(_, location) => {
-                    const {pathname} = location;
-                    return pathname.startsWith('/settings') || pathname.startsWith('/locations');
-                  }}
-                >
-                  <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
-                    Settings
-                    <DeploymentStatusIcon />
-                  </Box>
-                </TopNavLink>
-              </ShortcutHandler>
-            ),
-          }
-        : {
-            title: 'deployment',
-            element: (
-              <ShortcutHandler
-                key="deployment"
-                onShortcut={() => history.push('/locations')}
-                shortcutLabel="⌥4"
-                shortcutFilter={(e) => e.altKey && e.code === 'Digit4'}
-              >
-                <TopNavLink
-                  to="/locations"
-                  data-cy="AppTopNav_StatusLink"
-                  isActive={(_, location) => {
-                    const {pathname} = location;
-                    return (
-                      pathname.startsWith('/locations') ||
-                      pathname.startsWith('/health') ||
-                      pathname.startsWith('/config')
-                    );
-                  }}
-                >
-                  <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
-                    Deployment
-                    <DeploymentStatusIcon />
-                  </Box>
-                </TopNavLink>
-              </ShortcutHandler>
-            ),
-          },
-    ];
-  };
-
+export const AppTopNav = ({children, searchPlaceholder, allowGlobalReload = false}: Props) => {
   const {reloading, tryReload} = useRepositoryLocationReload({
     scope: 'workspace',
     reloadFn: reloadFnForWorkspace,
@@ -160,10 +31,7 @@ export const AppTopNav = ({
     <AppTopNavContainer>
       <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
         <AppTopNavLogo />
-        <Box margin={{left: 8}} flex={{direction: 'row', alignItems: 'center', gap: 16}}>
-          {getNavLinks ? getNavLinks(navLinks()) : navLinks().map((link) => link.element)}
-        </Box>
-        {rightOfSearchBar}
+        <AppTopNavRightOfLogo />
       </Box>
       <Box flex={{direction: 'row', alignItems: 'center'}}>
         {allowGlobalReload ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavLinks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavLinks.tsx
@@ -1,0 +1,133 @@
+import {Box} from '@dagster-io/ui-components';
+import {useHistory} from 'react-router-dom';
+
+import {TopNavLink} from './AppTopNav';
+import {DeploymentStatusIcon} from '../../nav/DeploymentStatusIcon';
+import {FeatureFlag, featureEnabled} from '../Flags';
+import {ShortcutHandler} from '../ShortcutHandler';
+
+export type AppNavLinkType = {
+  title: string;
+  element: React.ReactNode;
+};
+
+export const AppTopNavLinks = ({links}: {links: AppNavLinkType[]}) => {
+  return (
+    <Box margin={{left: 8}} flex={{direction: 'row', alignItems: 'center', gap: 16}}>
+      {links.map((link) => link.element)}
+    </Box>
+  );
+};
+
+export const navLinks = (history: ReturnType<typeof useHistory>) => {
+  return [
+    {
+      title: 'overview',
+      element: (
+        <ShortcutHandler
+          key="overview"
+          onShortcut={() => history.push('/overview')}
+          shortcutLabel="⌥1"
+          shortcutFilter={(e) => e.altKey && e.code === 'Digit1'}
+        >
+          <TopNavLink to="/overview" data-cy="AppTopNav_StatusLink">
+            Overview
+          </TopNavLink>
+        </ShortcutHandler>
+      ),
+    },
+    {
+      title: 'runs',
+      element: (
+        <ShortcutHandler
+          key="runs"
+          onShortcut={() => history.push('/runs')}
+          shortcutLabel="⌥2"
+          shortcutFilter={(e) => e.altKey && e.code === 'Digit2'}
+        >
+          <TopNavLink to="/runs" data-cy="AppTopNav_RunsLink">
+            Runs
+          </TopNavLink>
+        </ShortcutHandler>
+      ),
+    },
+    {
+      title: 'assets',
+      element: (
+        <ShortcutHandler
+          key="assets"
+          onShortcut={() => history.push('/assets')}
+          shortcutLabel="⌥3"
+          shortcutFilter={(e) => e.altKey && e.code === 'Digit3'}
+        >
+          <TopNavLink
+            to={featureEnabled(FeatureFlag.flagUseNewOverviewPage) ? '/assets-overview' : '/assets'}
+            data-cy="AppTopNav_AssetsLink"
+            isActive={(_, location) => {
+              const {pathname} = location;
+              return pathname.startsWith('/assets') || pathname.startsWith('/asset-groups');
+            }}
+            exact={false}
+          >
+            Assets
+          </TopNavLink>
+        </ShortcutHandler>
+      ),
+    },
+    featureEnabled(FeatureFlag.flagSettingsPage)
+      ? {
+          title: 'settings',
+          element: (
+            <ShortcutHandler
+              key="settings"
+              onShortcut={() => history.push('/settings')}
+              shortcutLabel="⌥4"
+              shortcutFilter={(e) => e.altKey && e.code === 'Digit4'}
+            >
+              <TopNavLink
+                to="/settings"
+                data-cy="AppTopNav_SettingsLink"
+                isActive={(_, location) => {
+                  const {pathname} = location;
+                  return pathname.startsWith('/settings') || pathname.startsWith('/locations');
+                }}
+              >
+                <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
+                  Settings
+                  <DeploymentStatusIcon />
+                </Box>
+              </TopNavLink>
+            </ShortcutHandler>
+          ),
+        }
+      : {
+          title: 'deployment',
+          element: (
+            <ShortcutHandler
+              key="deployment"
+              onShortcut={() => history.push('/locations')}
+              shortcutLabel="⌥4"
+              shortcutFilter={(e) => e.altKey && e.code === 'Digit4'}
+            >
+              <TopNavLink
+                to="/locations"
+                data-cy="AppTopNav_StatusLink"
+                isActive={(_, location) => {
+                  const {pathname} = location;
+                  return (
+                    pathname.startsWith('/locations') ||
+                    pathname.startsWith('/health') ||
+                    pathname.startsWith('/config')
+                  );
+                }}
+              >
+                <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
+                  Deployment
+                  <DeploymentStatusIcon />
+                </Box>
+              </TopNavLink>
+            </ShortcutHandler>
+          ),
+        },
+  ];
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavRightOfLogo.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavRightOfLogo.oss.tsx
@@ -1,0 +1,9 @@
+import {memo} from 'react';
+import {useHistory} from 'react-router-dom';
+
+import {AppTopNavLinks, navLinks} from './AppTopNavLinks';
+
+export const AppTopNavRightOfLogo = memo(() => {
+  const history = useHistory();
+  return <AppTopNavLinks links={navLinks(history)} />;
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavRightOfLogo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavRightOfLogo.tsx
@@ -1,0 +1,3 @@
+import {componentStub} from '../CloudComponentContext';
+
+export const AppTopNavRightOfLogo = componentStub('AppTopNavRightOfLogo');

--- a/js_modules/dagster-ui/packages/ui-core/src/app/CloudComponentContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/CloudComponentContext.tsx
@@ -1,0 +1,16 @@
+import React, {useContext} from 'react';
+
+import {AppTopNavRightOfLogo} from './AppTopNav/AppTopNavRightOfLogo.oss';
+
+export const CloudComponentContext = React.createContext<{
+  AppTopNavRightOfLogo: (() => React.ReactNode) | React.MemoExoticComponent<() => React.ReactNode>;
+}>({
+  AppTopNavRightOfLogo,
+});
+
+export const componentStub = (component: keyof React.ContextType<typeof CloudComponentContext>) => {
+  return () => {
+    const {[component]: Component} = useContext(CloudComponentContext);
+    return <Component />;
+  };
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/AppTopNav.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/AppTopNav.test.tsx
@@ -2,7 +2,7 @@ import {MockedProvider} from '@apollo/client/testing';
 import {render, screen} from '@testing-library/react';
 import {MemoryRouter} from 'react-router-dom';
 
-import {AppTopNav} from '../AppTopNav';
+import {AppTopNav} from '../AppTopNav/AppTopNav';
 
 // We don't need to render the search input here.
 jest.mock('../../search/SearchDialog', () => ({
@@ -14,7 +14,7 @@ describe('AppTopNav', () => {
     render(
       <MockedProvider>
         <MemoryRouter>
-          <AppTopNav searchPlaceholder="Test..." rightOfSearchBar={<div>RightOfSearchBar</div>} />
+          <AppTopNav searchPlaceholder="Test..." />
         </MemoryRouter>
       </MockedProvider>,
     );
@@ -25,6 +25,5 @@ describe('AppTopNav', () => {
     expect(screen.getByText('Runs').closest('a')).toHaveAttribute('href', '/runs');
     expect(screen.getByText('Assets').closest('a')).toHaveAttribute('href', '/assets');
     expect(screen.getByText('Deployment').closest('a')).toHaveAttribute('href', '/locations');
-    expect(screen.getByText('RightOfSearchBar')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary & Motivation
For cloud we want to optionally render only a single nav link and also render a custom catalog mode button. This can be achieved using the existing `getNavLinks` and `rightOfSearchbar` props but instead I think we can combine these into a single concept "AppTopNavRightOfOfLogo" (really rolls off the tongue)

To allow cloud to override this new DI point easily I added `CloudComponentContext`, The context helps reduce some boilerplate with the `componentStub` method. I'm proposing we adopt a pattern of creating stub files wherever cloud has an injection point and using`.oss.tsx` for the actual oss implementation. This will help us identify where our DI points which will somewhat help us figure out if changes need to be tested in cloud,  but I don't feel strongly and am open to dropping this convention or using a different one.

## How I Tested These Changes

local host cloud

