### PR TITLE
[ui] Display repo path in group search result

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
@@ -159,6 +159,7 @@ export const SearchResultItem = React.memo(({isHighlight, onClickResult, result}
               <Caption>{assetFilterPrefixString(item.type)}:&nbsp;</Caption>
             )}
             {labelComponents.map((component) => component)}
+            {item.repoPath && <Caption>&nbsp;in {item.repoPath}</Caption>}
           </StyledTag>
           <div style={{marginLeft: '8px'}}>
             <Description isHighlight={isHighlight}>

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
@@ -151,15 +151,17 @@ export const SearchResultItem = React.memo(({isHighlight, onClickResult, result}
             $interactive={false}
             $textColor={Colors.textDefault()}
           >
-            <Icon
-              name={iconForType(item.type)}
-              color={isHighlight ? Colors.textDefault() : Colors.textLight()}
-            />
-            {isAssetFilterSearchResultType(item.type) && (
-              <Caption>{assetFilterPrefixString(item.type)}:&nbsp;</Caption>
-            )}
-            {labelComponents.map((component) => component)}
-            {item.repoPath && <Caption>&nbsp;in {item.repoPath}</Caption>}
+            <Box flex={{gap: 4}}>
+              <Icon
+                name={iconForType(item.type)}
+                color={isHighlight ? Colors.textDefault() : Colors.textLight()}
+              />
+              {isAssetFilterSearchResultType(item.type) && (
+                <Caption>{assetFilterPrefixString(item.type)}:</Caption>
+              )}
+              <div>{labelComponents.map((component) => component)}</div>
+              {item.repoPath && <Caption>in {item.repoPath}</Caption>}
+            </Box>
           </StyledTag>
           <div style={{marginLeft: '8px'}}>
             <Description isHighlight={isHighlight}>

--- a/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
@@ -41,6 +41,7 @@ export type SearchResult = {
   type: SearchResultType | AssetFilterSearchResultType;
   tags?: string;
   numResults?: number;
+  repoPath?: string;
 };
 
 export type ReadyResponse = {type: 'ready'};

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -225,6 +225,10 @@ const secondaryDataToSearchResults = (
         type: AssetFilterSearchResultType.AssetGroup,
         href: linkToAssetTableWithGroupFilter(groupAssetCount.groupMetadata),
         numResults: groupAssetCount.assetCount,
+        repoPath: buildRepoPathForHuman(
+          groupAssetCount.groupMetadata.repositoryName,
+          groupAssetCount.groupMetadata.repositoryLocationName,
+        ),
       }),
     );
 


### PR DESCRIPTION
Per discussion with @braunjj:

Instead of
<img width="1001" alt="image" src="https://github.com/dagster-io/dagster/assets/29110579/6e854d33-d9e7-4b96-a478-38508e3c36b8">

We now see:
<img width="691" alt="image" src="https://github.com/dagster-io/dagster/assets/29110579/2961c868-ddde-491e-a64b-cb1bb4804b26">
