### PR TITLE
[Manual performance instrumentation] use timestamp of last page transition for start timestamp of page load trace

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -40,11 +40,11 @@ import {AssetLiveDataProvider} from '../asset-data/AssetLiveDataProvider';
 import {AssetRunLogObserver} from '../asset-graph/AssetRunLogObserver';
 import {DeploymentStatusProvider, DeploymentStatusType} from '../instance/DeploymentStatusProvider';
 import {InstancePageContext} from '../instance/InstancePageContext';
+import {PerformancePageNavigationListener} from '../performance';
 import {JobFeatureProvider} from '../pipelines/JobFeatureContext';
 import {WorkspaceProvider} from '../workspace/WorkspaceContext';
 
 import './blueprint.css';
-import {PerformancePageNavigationListener} from '../performance';
 
 // The solid sidebar and other UI elements insert zero-width spaces so solid names
 // break on underscores rather than arbitrary characters, but we need to remove these

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -44,6 +44,7 @@ import {JobFeatureProvider} from '../pipelines/JobFeatureContext';
 import {WorkspaceProvider} from '../workspace/WorkspaceContext';
 
 import './blueprint.css';
+import {PerformancePageNavigationListener} from '../performance';
 
 // The solid sidebar and other UI elements insert zero-width spaces so solid names
 // break on underscores rather than arbitrary characters, but we need to remove these
@@ -218,6 +219,7 @@ export const AppProvider = (props: AppProviderProps) => {
             <PermissionsProvider>
               <BrowserRouter basename={basePath || ''}>
                 <CompatRouter>
+                  <PerformancePageNavigationListener />
                   <TimeProvider>
                     <WorkspaceProvider>
                       <DeploymentStatusProvider include={statusPolling}>


### PR DESCRIPTION
## Summary & Motivation

Use timestamp of last page transition for start timestamp of page load trace

## How I Tested These Changes

tested it with local host cloud
