### PR TITLE
[ui] Fix error dialog width

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/CellTruncationProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/CellTruncationProvider.tsx
@@ -95,6 +95,7 @@ export class CellTruncationProvider extends React.Component<
                 canOutsideClickClose
                 isOpen={this.state.showDialog}
                 onClose={() => this.setState({showDialog: false})}
+                style={{width: 'auto', maxWidth: '80vw'}}
               >
                 <div>{this.dialogContents()}</div>
                 <DialogFooter topBorder>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRow.tsx
@@ -33,7 +33,7 @@ export const Structured = (props: StructuredProps) => {
   const {node, metadata, style, highlighted} = props;
   const [expanded, setExpanded] = useState(false);
 
-  const {title, body, dialogStyle} = useMemo(() => {
+  const {title, body} = useMemo(() => {
     if (node.__typename === 'ExecutionStepFailureEvent') {
       return {
         title: 'Error',
@@ -73,7 +73,6 @@ export const Structured = (props: StructuredProps) => {
           <LogsRowStructuredContent node={node} metadata={metadata} />
         </StructuredContent>
       ),
-      dialogStyle: {width: '80vw', minWidth: '600px', maxWidth: '1000px'},
     };
   }, [metadata, node]);
 
@@ -86,7 +85,7 @@ export const Structured = (props: StructuredProps) => {
         canEscapeKeyClose
         canOutsideClickClose
         onClose={() => setExpanded(false)}
-        style={dialogStyle}
+        style={{width: 'auto', maxWidth: '80vw'}}
       >
         <DialogBody>{body}</DialogBody>
         <DialogFooter topBorder>


### PR DESCRIPTION
## Summary & Motivation

Repair dialog styles for dialogs that were formerly opened via `showCustomAlert`. The default dialog width is too narrow for showing the error box.

## How I Tested These Changes

View a run with a truncated error log, open dialog. Verify that the dialog is once again a sane width.