### PR TITLE
AssetCheckExecutionContext

### DIFF
--- a/docs/content/guides/dagster-pipes/subprocess/reference.mdx
+++ b/docs/content/guides/dagster-pipes/subprocess/reference.mdx
@@ -132,8 +132,8 @@ On Dagster's side, the `PipesClientCompletedInvocation` object returned from `Pi
 import shutil
 
 from dagster import (
+    AssetCheckExecutionContext,
     AssetCheckResult,
-    AssetExecutionContext,
     Definitions,
     MaterializeResult,
     PipesSubprocessClient,
@@ -149,14 +149,14 @@ def my_asset(): ...
 
 @asset_check(asset="my_asset")
 def no_empty_order_check(
-    context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient
+    context: AssetCheckExecutionContext, pipes_subprocess_client: PipesSubprocessClient
 ) -> AssetCheckResult:
     cmd = [
         shutil.which("python"),
         file_relative_path(__file__, "external_code.py"),
     ]
     return pipes_subprocess_client.run(
-        command=cmd, context=context
+        command=cmd, context=context.op_execution_context
     ).get_asset_check_result()
 
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/with_asset_check/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/subprocess/with_asset_check/dagster_code.py
@@ -1,8 +1,8 @@
 import shutil
 
 from dagster import (
+    AssetCheckExecutionContext,
     AssetCheckResult,
-    AssetExecutionContext,
     Definitions,
     MaterializeResult,
     PipesSubprocessClient,
@@ -18,14 +18,14 @@ def my_asset(): ...
 
 @asset_check(asset="my_asset")
 def no_empty_order_check(
-    context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient
+    context: AssetCheckExecutionContext, pipes_subprocess_client: PipesSubprocessClient
 ) -> AssetCheckResult:
     cmd = [
         shutil.which("python"),
         file_relative_path(__file__, "external_code.py"),
     ]
     return pipes_subprocess_client.run(
-        command=cmd, context=context
+        command=cmd, context=context.op_execution_context
     ).get_asset_check_result()
 
 

--- a/examples/experimental/external_assets/external_assets/pipes/__init__.py
+++ b/examples/experimental/external_assets/external_assets/pipes/__init__.py
@@ -1,4 +1,5 @@
 from dagster import (
+    AssetCheckExecutionContext,
     AssetExecutionContext,
     AssetKey,
     DailyPartitionsDefinition,
@@ -42,9 +43,11 @@ def telem_post_processing(context: AssetExecutionContext, k8s_pipes_client: Pipe
 
 
 @asset_check(asset="telem_post_processing")
-def telem_post_processing_check(context: AssetExecutionContext, k8s_pipes_client: PipesK8sClient):
+def telem_post_processing_check(
+    context: AssetCheckExecutionContext, k8s_pipes_client: PipesK8sClient
+):
     return k8s_pipes_client.run(
-        context=context,
+        context=context.op_execution_context,
         namespace="default",
         image="pipes-check:latest",
         env={"DAGSTER_PIPES_IS_DAGSTER_PIPED_PROCESS": encode_env_var(True)},

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -451,6 +451,7 @@ from dagster._core.execution.api import (
 )
 from dagster._core.execution.build_resources import build_resources as build_resources
 from dagster._core.execution.context.compute import (
+    AssetCheckExecutionContext as AssetCheckExecutionContext,
     AssetExecutionContext as AssetExecutionContext,
     OpExecutionContext as OpExecutionContext,
 )

--- a/python_modules/dagster/dagster/_core/definitions/freshness_checks/non_partitioned.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_checks/non_partitioned.py
@@ -8,7 +8,9 @@ from dagster._core.definitions.metadata import (
     MetadataValue,
     TimestampMetadataValue,
 )
-from dagster._core.execution.context.compute import AssetExecutionContext
+from dagster._core.execution.context.compute import (
+    AssetCheckExecutionContext,
+)
 from dagster._utils.schedules import get_latest_completed_cron_tick, is_valid_cron_string
 
 from ..asset_check_result import AssetCheckResult
@@ -107,7 +109,7 @@ def _build_freshness_check_for_assets(
             description=f"Evaluates freshness for targeted asset. Cron: {freshness_cron}, Maximum lag minutes: {maximum_lag_minutes}.",
             name="freshness_check",
         )
-        def the_check(context: AssetExecutionContext) -> AssetCheckResult:
+        def the_check(context: AssetCheckExecutionContext) -> AssetCheckResult:
             check.invariant(
                 context.job_def.asset_layer.asset_graph.get(asset_key).partitions_def is None,
                 "Expected non-partitioned asset",

--- a/python_modules/dagster/dagster/_core/definitions/freshness_checks/time_window_partitioned.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_checks/time_window_partitioned.py
@@ -6,7 +6,9 @@ from dagster import _check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.definitions.decorators.asset_check_decorator import asset_check
 from dagster._core.definitions.metadata import TimestampMetadataValue
-from dagster._core.execution.context.compute import AssetExecutionContext
+from dagster._core.execution.context.compute import (
+    AssetCheckExecutionContext,
+)
 from dagster._utils.schedules import get_latest_completed_cron_tick, is_valid_cron_string
 
 from ..asset_check_result import AssetCheckResult
@@ -88,7 +90,7 @@ def _build_freshness_checks_for_asset(
             description="Evaluates freshness for targeted asset.",
             name="freshness_check",
         )
-        def the_check(context: AssetExecutionContext) -> AssetCheckResult:
+        def the_check(context: AssetCheckExecutionContext) -> AssetCheckResult:
             current_time = pendulum.now()
             current_timestamp = check.float_param(current_time.timestamp(), "current_time")
             partitions_def: TimeWindowPartitionsDefinition = cast(

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -562,18 +562,23 @@ def _validate_context_type_hint(fn):
 
     from dagster._core.decorator_utils import get_function_params
     from dagster._core.definitions.decorators.op_decorator import is_context_provided
-    from dagster._core.execution.context.compute import AssetExecutionContext, OpExecutionContext
+    from dagster._core.execution.context.compute import (
+        AssetCheckExecutionContext,
+        AssetExecutionContext,
+        OpExecutionContext,
+    )
 
     params = get_function_params(fn)
     if is_context_provided(params):
-        if (
-            params[0].annotation is not AssetExecutionContext
-            and params[0].annotation is not OpExecutionContext
-            and params[0].annotation is not EmptyAnnotation
-        ):
+        if params[0].annotation not in [
+            AssetExecutionContext,
+            OpExecutionContext,
+            EmptyAnnotation,
+            AssetCheckExecutionContext,
+        ]:
             raise DagsterInvalidDefinitionError(
                 f"Cannot annotate `context` parameter with type {params[0].annotation}. `context`"
-                " must be annotated with AssetExecutionContext, OpExecutionContext, or left blank."
+                " must be annotated with AssetExecutionContext, AssetCheckExecutionContext, OpExecutionContext, or left blank."
             )
 
 

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1,4 +1,4 @@
-from abc import ABC, ABCMeta, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod, abstractproperty
 from contextlib import contextmanager
 from contextvars import ContextVar
 from inspect import (
@@ -24,7 +24,7 @@ from dagster._annotations import (
     experimental,
     public,
 )
-from dagster._core.definitions.asset_check_spec import AssetCheckKey
+from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSpec
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import (
     DataProvenance,
@@ -66,6 +66,11 @@ from .system import StepExecutionContext
 # This metaclass has to exist for OpExecutionContext to have a metaclass
 class AbstractComputeMetaclass(ABCMeta):
     pass
+
+
+class _HasOpExecutionContext(ABC):
+    @abstractproperty
+    def op_execution_context(self) -> "OpExecutionContext": ...
 
 
 class AbstractComputeExecutionContext(ABC, metaclass=AbstractComputeMetaclass):
@@ -133,7 +138,9 @@ class OpExecutionContextMetaClass(AbstractComputeMetaclass):
         return super().__instancecheck__(instance)
 
 
-class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionContextMetaClass):
+class OpExecutionContext(
+    AbstractComputeExecutionContext, _HasOpExecutionContext, metaclass=OpExecutionContextMetaClass
+):
     """The ``context`` object that can be made available as the first argument to the function
     used for computing an op or asset.
 
@@ -162,6 +169,10 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
         self._pdb: Optional[ForkedPdb] = None
         self._events: List[DagsterEvent] = []
         self._output_metadata: Dict[str, Any] = {}
+
+    @property
+    def op_execution_context(self) -> "OpExecutionContext":
+        return self
 
     @public
     @property
@@ -1295,7 +1306,7 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
 
     @staticmethod
     def get() -> "OpExecutionContext":
-        ctx = _current_asset_execution_context.get()
+        ctx = _current_execution_context.get()
         if ctx is None:
             raise DagsterInvariantViolationError("No current OpExecutionContext in scope.")
         return ctx.op_execution_context
@@ -1371,9 +1382,14 @@ class AssetExecutionContext(OpExecutionContext):
 
     @staticmethod
     def get() -> "AssetExecutionContext":
-        ctx = _current_asset_execution_context.get()
+        ctx = _current_execution_context.get()
         if ctx is None:
             raise DagsterInvariantViolationError("No current AssetExecutionContext in scope.")
+        if isinstance(ctx, AssetCheckExecutionContext):
+            raise DagsterInvariantViolationError(
+                "Can't use AssetExecutionContext.get() in the context of an "
+                "AssetCheckExecutionContext. Use AssetCheckExecutionContext.get() instead."
+            )
         return ctx
 
     @property
@@ -1781,29 +1797,149 @@ class AssetExecutionContext(OpExecutionContext):
         self.op_execution_context.set_requires_typed_event_stream(error_message=error_message)
 
 
+class AssetCheckExecutionContext(_HasOpExecutionContext):
+    def __init__(self, op_execution_context: OpExecutionContext) -> None:
+        self._op_execution_context = check.inst_param(
+            op_execution_context, "op_execution_context", OpExecutionContext
+        )
+        self._step_execution_context = self._op_execution_context._step_execution_context  # noqa: SLF001
+
+    @staticmethod
+    def get() -> "AssetExecutionContext":
+        ctx = _current_execution_context.get()
+        if ctx is None:
+            raise DagsterInvariantViolationError("No current AssetExecutionContext in scope.")
+        if isinstance(ctx, AssetCheckExecutionContext):
+            raise DagsterInvariantViolationError(
+                "Can't use AssetExecutionContext.get() in the context of an "
+                "AssetCheckExecutionContext. Use AssetCheckExecutionContext.get() instead."
+            )
+        return ctx
+
+    @property
+    def op_execution_context(self) -> OpExecutionContext:
+        return self._op_execution_context
+
+    @public
+    @property
+    def log(self) -> DagsterLogManager:
+        """The log manager available in the execution context. Logs will be viewable in the Dagster UI.
+        Returns: DagsterLogManager.
+        """
+        return self.op_execution_context.log
+
+    @public
+    @property
+    def pdb(self) -> ForkedPdb:
+        """Gives access to pdb debugging from within the asset. Materializing the asset via the
+        Dagster UI or CLI will enter the pdb debugging context in the process used to launch the UI or
+        run the CLI.
+
+        Returns: dagster.utils.forked_pdb.ForkedPdb
+        """
+        return self.op_execution_context.pdb
+
+    @property
+    def run(self) -> DagsterRun:
+        """The DagsterRun object corresponding to the execution. Information like run_id,
+        run configuration, and the assets selected for materialization can be found on the DagsterRun.
+        """
+        return self.op_execution_context.run
+
+    @public
+    @property
+    def job_def(self) -> JobDefinition:
+        """The definition for the currently executing job. Information like the job name, and job tags
+        can be found on the JobDefinition.
+        Returns: JobDefinition.
+        """
+        return self.op_execution_context.job_def
+
+    #### check related
+    @public
+    @property
+    @_copy_docs_from_op_execution_context
+    def selected_asset_check_keys(self) -> AbstractSet[AssetCheckKey]:
+        return self.op_execution_context.selected_asset_check_keys
+
+    @public
+    @property
+    def check_specs(self) -> Sequence[AssetCheckSpec]:
+        """The asset check specs for the currently executing asset check."""
+        return list(self.op_execution_context.assets_def.check_specs)
+
+    #### op related
+
+    @property
+    @_copy_docs_from_op_execution_context
+    def retry_number(self):
+        return self.op_execution_context.retry_number
+
+    @_copy_docs_from_op_execution_context
+    def describe_op(self) -> str:
+        return self.op_execution_context.describe_op()
+
+    @public
+    @property
+    @_copy_docs_from_op_execution_context
+    def op_def(self) -> OpDefinition:
+        return self.op_execution_context.op_def
+
+    #### execution related
+
+    @public
+    @property
+    @_copy_docs_from_op_execution_context
+    def instance(self) -> DagsterInstance:
+        return self.op_execution_context.instance
+
+    @property
+    @_copy_docs_from_op_execution_context
+    def step_launcher(self) -> Optional[StepLauncher]:
+        return self.op_execution_context.step_launcher
+
+    @_copy_docs_from_op_execution_context
+    def get_step_execution_context(self) -> StepExecutionContext:
+        return self.op_execution_context.get_step_execution_context()
+
+    # misc
+
+    @public
+    @property
+    @_copy_docs_from_op_execution_context
+    def resources(self) -> Any:
+        return self.op_execution_context.resources
+
+    @property
+    @_copy_docs_from_op_execution_context
+    def is_subset(self):
+        return self.op_execution_context.is_subset
+
+
+ExecutionContextTypes = Union[OpExecutionContext, AssetExecutionContext, AssetCheckExecutionContext]
+
+
 @contextmanager
 def enter_execution_context(
     step_context: StepExecutionContext,
-) -> Iterator[Union[OpExecutionContext, AssetExecutionContext]]:
+) -> Iterator[ExecutionContextTypes]:
     """Get the correct context based on the type of step (op or asset) and the user provided context
     type annotation. Follows these rules.
 
-    step type     annotation                result
-    asset         AssetExecutionContext     AssetExecutionContext
-    asset         OpExecutionContext        OpExecutionContext
-    asset         None                      AssetExecutionContext
-    op            AssetExecutionContext     Error - we cannot init an AssetExecutionContext w/o an AssetsDefinition
-    op            OpExecutionContext        OpExecutionContext
-    op            None                      OpExecutionContext
-    asset_check   AssetExecutionContext     AssetExecutionContext
-    asset_check   OpExecutionContext        OpExecutionContext
-    asset_check   None                      AssetExecutionContext
+    step type     annotation                   result
+    asset         AssetExecutionContext        AssetExecutionContext
+    asset         AssetCheckExecutionContext   Error - not an asset check
+    asset         OpExecutionContext           OpExecutionContext
+    asset         None                         AssetExecutionContext
+    op            AssetExecutionContext        Error - we cannot init an AssetExecutioext w/o an AssetsDefinition
+    op            AssetCheckExecutionContext   Error - not an asset check
+    op            OpExecutionContext           OpExecutionContext
+    op            None                         OpExecutionContext
+    asset_check   AssetCheckExecutionContext   AssetCheckExecutionContext
+    asset_check   AssetExecutionContext        Error - not an asset
+    asset_check   OpExecutionContext           OpExecutionContext
+    asset_check   None                         AssetCheckExecutionContext
 
-    For ops in graph-backed assets
-    step type     annotation                result
-    op            AssetExecutionContext     AssetExecutionContext
-    op            OpExecutionContext        OpExecutionContext
-    op            None                      OpExecutionContext
     """
     is_sda_step = step_context.is_sda_step
     is_op_in_graph_asset = step_context.is_in_graph_asset
@@ -1819,25 +1955,45 @@ def enter_execution_context(
         context_param = compute_fn.get_context_arg()
         context_annotation = context_param.annotation
 
+    if context_annotation is AssetCheckExecutionContext and not is_asset_check:
+        if is_sda_step:
+            raise DagsterInvalidDefinitionError(
+                "Cannot annotate @asset `context` parameter with type AssetCheckExecutionContext. "
+                "`context` must be annotated with AssetExecutionContext, OpExecutionContext, or left blank."
+            )
+        else:
+            raise DagsterInvalidDefinitionError(
+                "Cannot annotate @op `context` parameter with type AssetCheckExecutionContext. "
+                "`context` must be annotated with OpExecutionContext, AssetExecutionContext (if part of "
+                "a graph-backed-asset) or left blank."
+            )
+
     # It would be nice to do this check at definition time, rather than at run time, but we don't
     # know if the op is part of an op job or a graph-backed asset until we have the step execution context
-    if (
-        context_annotation is AssetExecutionContext
-        and not is_sda_step
-        and not is_asset_check
-        and not is_op_in_graph_asset
-    ):
-        # AssetExecutionContext requires an AssetsDefinition during init, so an op in an op job
-        # cannot be annotated with AssetExecutionContext
-        raise DagsterInvalidDefinitionError(
-            "Cannot annotate @op `context` parameter with type AssetExecutionContext unless the"
-            " op is part of a graph-backed asset. `context` must be annotated with"
-            " OpExecutionContext, or left blank."
-        )
+    if context_annotation is AssetExecutionContext and not is_sda_step and not is_op_in_graph_asset:
+        if is_asset_check:
+            raise DagsterInvalidDefinitionError(
+                "Cannot annotate @asset_check `context` parameter with type AssetExecutionContext. "
+                "`context` must be annotated with AssetCheckExecutionContext, OpExecutionContext, or left blank."
+            )
+        else:
+            # AssetExecutionContext requires an AssetsDefinition during init, so an op in an op job
+            # cannot be annotated with AssetExecutionContext
+            raise DagsterInvalidDefinitionError(
+                "Cannot annotate @op `context` parameter with type AssetExecutionContext unless the"
+                " op is part of a graph-backed asset. `context` must be annotated with"
+                " OpExecutionContext, or left blank."
+            )
 
-    # Structured assuming upcoming changes to make AssetExecutionContext contain an OpExecutionContext
-    asset_ctx = AssetExecutionContext(op_execution_context=OpExecutionContext(step_context))
-    asset_token = _current_asset_execution_context.set(asset_ctx)
+    # default to AssetCheckExecutionContext in @asset_checks
+    if is_asset_check and not is_op_in_graph_asset and context_annotation is not OpExecutionContext:
+        asset_ctx = AssetCheckExecutionContext(
+            op_execution_context=OpExecutionContext(step_context)
+        )
+    else:
+        asset_ctx = AssetExecutionContext(op_execution_context=OpExecutionContext(step_context))
+
+    asset_token = _current_execution_context.set(asset_ctx)
 
     try:
         if context_annotation is EmptyAnnotation:
@@ -1856,9 +2012,9 @@ def enter_execution_context(
         else:
             yield asset_ctx.op_execution_context
     finally:
-        _current_asset_execution_context.reset(asset_token)
+        _current_execution_context.reset(asset_token)
 
 
-_current_asset_execution_context: ContextVar[Optional[AssetExecutionContext]] = ContextVar(
-    "_current_asset_execution_context", default=None
-)
+_current_execution_context: ContextVar[
+    Optional[Union[AssetExecutionContext, AssetCheckExecutionContext]]
+] = ContextVar("_current_execution_context", default=None)

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -36,12 +36,12 @@ from dagster._core.types.dagster_type import DagsterTypeKind, is_generic_output_
 from dagster._utils import is_named_tuple_instance
 from dagster._utils.warnings import disable_dagster_warnings
 
-from ..context.compute import OpExecutionContext
+from ..context.compute import ExecutionContextTypes
 
 
 def create_op_compute_wrapper(
     op_def: OpDefinition,
-) -> Callable[[OpExecutionContext, Mapping[str, InputDefinition]], Any]:
+) -> Callable[[ExecutionContextTypes, Mapping[str, InputDefinition]], Any]:
     compute_fn = cast(DecoratedOpFunction, op_def.compute_fn)
     fn = compute_fn.decorated_fn
     input_defs = op_def.input_defs
@@ -58,7 +58,7 @@ def create_op_compute_wrapper(
 
     @wraps(fn)
     def compute(
-        context: OpExecutionContext,
+        context: ExecutionContextTypes,
         input_defs: Mapping[str, InputDefinition],
     ) -> Union[Iterator[Output], AsyncIterator[Output]]:
         kwargs = {}
@@ -95,7 +95,9 @@ def create_op_compute_wrapper(
 
 
 async def _coerce_async_op_to_async_gen(
-    awaitable: Awaitable[Any], context: OpExecutionContext, output_defs: Sequence[OutputDefinition]
+    awaitable: Awaitable[Any],
+    context: ExecutionContextTypes,
+    output_defs: Sequence[OutputDefinition],
 ) -> AsyncIterator[Any]:
     result = await awaitable
     for event in validate_and_coerce_op_result_to_iterator(result, context, output_defs):
@@ -104,7 +106,7 @@ async def _coerce_async_op_to_async_gen(
 
 def invoke_compute_fn(
     fn: Callable[..., Any],
-    context: OpExecutionContext,
+    context: ExecutionContextTypes,
     kwargs: Mapping[str, Any],
     context_arg_provided: bool,
     config_arg_cls: Optional[Type[Config]],
@@ -114,10 +116,12 @@ def invoke_compute_fn(
     if config_arg_cls:
         # config_arg_cls is either a Config class or a primitive type
         if issubclass(config_arg_cls, Config):
-            to_pass = config_arg_cls._get_non_default_public_field_values_cls(context.op_config)  # noqa: SLF001
+            to_pass = config_arg_cls._get_non_default_public_field_values_cls(  # noqa: SLF001
+                context.op_execution_context.op_config
+            )
             args_to_pass["config"] = config_arg_cls(**to_pass)
         else:
-            args_to_pass["config"] = context.op_config
+            args_to_pass["config"] = context.op_execution_context.op_config
     if resource_args:
         for resource_name, arg_name in resource_args.items():
             args_to_pass[arg_name] = context.resources.original_resource_dict[resource_name]
@@ -126,7 +130,13 @@ def invoke_compute_fn(
 
 
 def _coerce_op_compute_fn_to_iterator(
-    fn, output_defs, context, context_arg_provided, kwargs, config_arg_class, resource_arg_mapping
+    fn,
+    output_defs,
+    context: ExecutionContextTypes,
+    context_arg_provided,
+    kwargs,
+    config_arg_class,
+    resource_arg_mapping,
 ):
     result = invoke_compute_fn(
         fn, context, kwargs, context_arg_provided, config_arg_class, resource_arg_mapping
@@ -136,7 +146,7 @@ def _coerce_op_compute_fn_to_iterator(
 
 
 def _zip_and_iterate_op_result(
-    result: Any, context: OpExecutionContext, output_defs: Sequence[OutputDefinition]
+    result: Any, context: ExecutionContextTypes, output_defs: Sequence[OutputDefinition]
 ) -> Iterator[Tuple[int, Any, OutputDefinition]]:
     # Filtering the expected output defs here is an unfortunate temporary solution to deal with the
     # change in expected outputs that occurs as a result of putting `AssetCheckResults` onto
@@ -163,14 +173,16 @@ def _zip_and_iterate_op_result(
 # Filter out output_defs corresponding to asset check results that already exist on a
 # MaterializeResult.
 def _filter_expected_output_defs(
-    result: Any, context: OpExecutionContext, output_defs: Sequence[OutputDefinition]
+    result: Any, context: ExecutionContextTypes, output_defs: Sequence[OutputDefinition]
 ) -> Sequence[OutputDefinition]:
     result_tuple = (
         (result,) if not isinstance(result, tuple) or is_named_tuple_instance(result) else result
     )
     asset_results = [x for x in result_tuple if isinstance(x, AssetResult)]
     remove_outputs = [
-        r.get_spec_python_identifier(asset_key=x.asset_key or context.asset_key)
+        r.get_spec_python_identifier(
+            asset_key=x.asset_key or context.op_execution_context.asset_key
+        )
         for x in asset_results
         for r in x.check_results or []
     ]
@@ -178,7 +190,7 @@ def _filter_expected_output_defs(
 
 
 def _validate_multi_return(
-    context: OpExecutionContext,
+    context: ExecutionContextTypes,
     result: Any,
     output_defs: Sequence[OutputDefinition],
 ) -> Any:
@@ -240,7 +252,9 @@ def _check_output_object_name(
 
 
 def validate_and_coerce_op_result_to_iterator(
-    result: Any, context: OpExecutionContext, output_defs: Sequence[OutputDefinition]
+    result: Any,
+    context: ExecutionContextTypes,
+    output_defs: Sequence[OutputDefinition],
 ) -> Iterator[Any]:
     if inspect.isgenerator(result):
         # this happens when a user explicitly returns a generator in the op
@@ -252,7 +266,7 @@ def validate_and_coerce_op_result_to_iterator(
             "returning an AssetMaterialization "
             "or an ExpectationResult from "
             f"{context.op_def.node_type_str} you must yield them "
-            "directly, or log them using the OpExecutionContext.log_event method to avoid "
+            "directly, or log them using the ExecutionContexts.log_event method to avoid "
             "ambiguity with an implied result from returning a "
             "value. Check out the docs on logging events here: "
             "https://docs.dagster.io/concepts/ops-jobs-graphs/op-events#op-events-and-exceptions"
@@ -270,7 +284,7 @@ def validate_and_coerce_op_result_to_iterator(
     # results that will be registered in the instance, without additional fancy inference (like
     # wrapping `None` in an `Output`). We therefore skip any return-specific validation for this
     # mode and treat returned values as if they were yielded.
-    elif output_defs and context.requires_typed_event_stream:
+    elif output_defs and context.op_execution_context.requires_typed_event_stream:
         # If nothing was returned, treat it as an empty tuple instead of a `(None,)`.
         # This is important for delivering the correct error message when an output is missing.
         if result is None:

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -266,7 +266,7 @@ def validate_and_coerce_op_result_to_iterator(
             "returning an AssetMaterialization "
             "or an ExpectationResult from "
             f"{context.op_def.node_type_str} you must yield them "
-            "directly, or log them using the ExecutionContexts.log_event method to avoid "
+            "directly, or log them using the context.log_event method to avoid "
             "ambiguity with an implied result from returning a "
             "value. Check out the docs on logging events here: "
             "https://docs.dagster.io/concepts/ops-jobs-graphs/op-events#op-events-and-exceptions"

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_execution_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_execution_context.py
@@ -89,6 +89,7 @@ def test_deprecation_warnings():
         "is_subset",
         "partition_keys",
         "retry_number",
+        "op_execution_context",
     ]
 
     other_ignores = [

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
@@ -350,6 +350,12 @@ def test_context_provided_to_asset_check():
 
     execute_assets_and_checks(assets=[to_check], asset_checks=[op_annotation])
 
+    @asset_check(asset=to_check)
+    def check_annotation(context: AssetCheckExecutionContext):
+        assert not isinstance(context, AssetCheckExecutionContext)
+
+    execute_assets_and_checks(assets=[to_check], asset_checks=[op_annotation])
+
 
 def test_context_provided_to_blocking_asset_check():
     instance = DagsterInstance.ephemeral()
@@ -399,7 +405,7 @@ def test_context_provided_to_blocking_asset_check():
 def test_error_on_invalid_context_annotation():
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="must be annotated with AssetExecutionContext, OpExecutionContext, or left blank",
+        match="must be annotated with AssetExecutionContext, AssetCheckExecutionContext, OpExecutionContext, or left blank",
     ):
 
         @op
@@ -408,7 +414,7 @@ def test_error_on_invalid_context_annotation():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="must be annotated with AssetExecutionContext, OpExecutionContext, or left blank",
+        match="must be annotated with AssetExecutionContext, AssetCheckExecutionContext, OpExecutionContext, or left blank",
     ):
 
         @asset

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_blocking_asset_checks.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_blocking_asset_checks.py
@@ -9,6 +9,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_checks import build_asset_with_blocking_check
 from dagster._core.definitions.asset_in import AssetIn
+from dagster._core.execution.context.compute import OpExecutionContext
 
 
 def execute_assets_and_checks(
@@ -40,7 +41,7 @@ def pass_check():
 
 
 @asset_check(asset="my_asset")
-def fail_check_if_tagged(context: AssetCheckExecutionContext):
+def fail_check_if_tagged(context: OpExecutionContext):
     return AssetCheckResult(
         passed="fail_check" not in context.run.tags.keys(), check_name="fail_check_if_tagged"
     )
@@ -109,7 +110,7 @@ def my_asset_with_managed_input(upstream_asset):
 
 
 @asset_check(asset="my_asset_with_managed_input")
-def fail_check_if_tagged_2(context: AssetCheckExecutionContext, my_asset_with_managed_input):
+def fail_check_if_tagged_2(context: OpExecutionContext, my_asset_with_managed_input):
     assert my_asset_with_managed_input == "bar"
     return AssetCheckResult(
         passed="fail_check" not in context.run.tags.keys(), check_name="fail_check_if_tagged_2"

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_blocking_asset_checks.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_blocking_asset_checks.py
@@ -1,6 +1,6 @@
 from dagster import (
+    AssetCheckExecutionContext,
     AssetCheckResult,
-    AssetExecutionContext,
     AssetKey,
     Definitions,
     ExecuteInProcessResult,
@@ -40,7 +40,7 @@ def pass_check():
 
 
 @asset_check(asset="my_asset")
-def fail_check_if_tagged(context: AssetExecutionContext):
+def fail_check_if_tagged(context: AssetCheckExecutionContext):
     return AssetCheckResult(
         passed="fail_check" not in context.run.tags.keys(), check_name="fail_check_if_tagged"
     )
@@ -109,7 +109,7 @@ def my_asset_with_managed_input(upstream_asset):
 
 
 @asset_check(asset="my_asset_with_managed_input")
-def fail_check_if_tagged_2(context: AssetExecutionContext, my_asset_with_managed_input):
+def fail_check_if_tagged_2(context: AssetCheckExecutionContext, my_asset_with_managed_input):
     assert my_asset_with_managed_input == "bar"
     return AssetCheckResult(
         passed="fail_check" not in context.run.tags.keys(), check_name="fail_check_if_tagged_2"

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
@@ -13,6 +13,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.errors import DagsterInvariantViolationError
+from dagster._core.execution.context.compute import AssetCheckExecutionContext
 from dagster_pipes import (
     DagsterPipesError,
     PipesContext,
@@ -228,9 +229,11 @@ def test_get_asset_check_result() -> None:
 
     @asset_check(asset="an_asset")
     def an_asset_check(
-        context: AssetExecutionContext, inprocess_client: InProcessPipesClient
+        context: AssetCheckExecutionContext, inprocess_client: InProcessPipesClient
     ) -> AssetCheckResult:
-        return inprocess_client.run(context=context, fn=_impl).get_asset_check_result()
+        return inprocess_client.run(
+            context=context.op_execution_context, fn=_impl
+        ).get_asset_check_result()
 
     result = (
         Definitions(

--- a/python_modules/libraries/dagster-openai/dagster_openai/resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai/resources.py
@@ -216,9 +216,7 @@ class OpenAIResource(ConfigurableResource):
 
     @public
     @contextmanager
-    def get_client(
-        self, context: Union[AssetExecutionContext, OpExecutionContext]
-    ) -> Generator[Client, None, None]:
+    def get_client(self, context: AssetExecutionContext) -> Generator[Client, None, None]:
         """Yields an ``openai.Client`` for interacting with the OpenAI API.
 
         By default, in an asset context, the client comes with wrapped endpoints

--- a/python_modules/libraries/dagster-openai/dagster_openai/resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai/resources.py
@@ -51,7 +51,9 @@ def _add_to_asset_metadata(
 
 @public
 @experimental
-def with_usage_metadata(context: AssetExecutionContext, output_name: Optional[str], func):
+def with_usage_metadata(
+    context: Union[AssetExecutionContext, OpExecutionContext], output_name: Optional[str], func
+):
     """This wrapper can be used on any endpoint of the
     `openai library <https://github.com/openai/openai-python>`
     to log the OpenAI API usage metadata in the asset metadata.
@@ -216,7 +218,9 @@ class OpenAIResource(ConfigurableResource):
 
     @public
     @contextmanager
-    def get_client(self, context: AssetExecutionContext) -> Generator[Client, None, None]:
+    def get_client(
+        self, context: Union[AssetExecutionContext, OpExecutionContext]
+    ) -> Generator[Client, None, None]:
         """Yields an ``openai.Client`` for interacting with the OpenAI API.
 
         By default, in an asset context, the client comes with wrapped endpoints


### PR DESCRIPTION
Internal convo: https://dagsterlabs.slack.com/archives/C06FFA6CQ5N/p1710987449207629

A barebones `AssetCheckExecutionContext`. The only new field for now is `check_specs`. Deprecated methods on `AssetExecutionContext` are left out (e.g. dagster_run, has_tag). Asset specific methods (e.g. selected_asset_keys) are also left out. In order to leave these out, `AssetExecutionContext` is not a subclass of `OpExecutionContext` (but it does store one). This necessitates some changes to the execution path to call `context.op_execution_context`, since `AssetCheckExecutionContext` won't have some methods like `requires_typed_event_stream` at the top level.

New type annotation rules:
```
    step type     annotation                   result
    asset         AssetCheckExecutionContext   Error - not an asset check
    op            AssetCheckExecutionContext   Error - not an asset check
    asset_check   AssetCheckExecutionContext   AssetCheckExecutionContext
    asset_check   AssetExecutionContext        Error - not an asset
    asset_check   OpExecutionContext           OpExecutionContext
    asset_check   None                         AssetCheckExecutionContext
```

