### PR TITLE
[ui] Search styles

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/search/AssetSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/AssetSearch.tsx
@@ -1,12 +1,12 @@
-import {Colors, Icon, Spinner} from '@dagster-io/ui-components';
+import {Colors, Icon, IconWrapper, Spinner, UnstyledButton} from '@dagster-io/ui-components';
 import Fuse from 'fuse.js';
 import debounce from 'lodash/debounce';
 import * as React from 'react';
 import {useHistory} from 'react-router-dom';
 import styled from 'styled-components';
 
-import {SearchBox, SearchInput} from './SearchDialog';
-import {SearchResults} from './SearchResults';
+import {SearchInput} from './SearchDialog';
+import {SearchResultItem, SearchResultsList, SearchResultsProps} from './SearchResults';
 import {SearchResult, SearchResultType, isAssetFilterSearchResultType} from './types';
 import {useGlobalSearch} from './useGlobalSearch';
 import {Trace, createTrace} from '../performance';
@@ -162,9 +162,29 @@ export const AssetSearch = () => {
     }
   };
 
+  const rightElement = () => {
+    if (loading) {
+      return <Spinner purpose="body-text" />;
+    }
+    if (queryString.length) {
+      return (
+        <ClearButton
+          onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) => {
+            // Prevent default to avoid stealing focus from the input.
+            e.preventDefault();
+            dispatch({type: 'change-query', queryString: ''});
+          }}
+        >
+          <Icon name="close" size={20} color={Colors.textDisabled()} />
+        </ClearButton>
+      );
+    }
+    return null;
+  };
+
   return (
     <SearchInputWrapper>
-      <SearchBox hasQueryString={!!queryString.length}>
+      <AssetSearchBox $hasQueryString={!!queryString.length}>
         <Icon name="search" color={Colors.accentGray()} size={20} />
         <SearchInput
           data-search-input="1"
@@ -176,10 +196,10 @@ export const AssetSearch = () => {
           type="text"
           value={queryString}
         />
-        {loading ? <Spinner purpose="body-text" /> : null}
-      </SearchBox>
+        {rightElement()}
+      </AssetSearchBox>
       <SearchResultsWrapper>
-        <SearchResults
+        <AssetSearchResults
           highlight={highlight}
           queryString={queryString}
           results={renderedAssetResults}
@@ -191,13 +211,100 @@ export const AssetSearch = () => {
   );
 };
 
+interface Props extends SearchResultsProps {
+  filterResults: Fuse.FuseResult<SearchResult>[];
+}
+
+const AssetSearchResults = (props: Props) => {
+  const {highlight, onClickResult, queryString, results, filterResults} = props;
+
+  if (!results.length && !filterResults.length && queryString) {
+    return <NoAssetResults>No results</NoAssetResults>;
+  }
+
+  return (
+    <SearchResultsList hasResults={!!results.length || !!filterResults.length}>
+      {results.map((result, ii) => (
+        <SearchResultItem
+          key={result.item.href}
+          isHighlight={highlight === ii}
+          result={result}
+          onClickResult={onClickResult}
+        />
+      ))}
+      {filterResults.length > 0 ? (
+        <>
+          <MatchingFiltersHeader>Matching filters</MatchingFiltersHeader>
+          {filterResults.map((result, ii) => (
+            <SearchResultItem
+              key={result.item.href}
+              isHighlight={highlight === ii + results.length}
+              result={result}
+              onClickResult={onClickResult}
+            />
+          ))}
+        </>
+      ) : null}
+    </SearchResultsList>
+  );
+};
+
+interface AssetSearchBoxProps {
+  readonly $hasQueryString: boolean;
+}
+
+const AssetSearchBox = styled.div<AssetSearchBoxProps>`
+  background: ${Colors.backgroundDefault()};
+  border-radius: ${({$hasQueryString}) => ($hasQueryString ? '8px 8px 0 0' : '8px')};
+  border: none;
+  align-items: center;
+  box-shadow: ${({$hasQueryString}) =>
+      $hasQueryString ? Colors.keylineDefault() : Colors.borderDefault()}
+    inset 0px 0px 0px 1px;
+  display: flex;
+  padding: 12px 16px 12px 12px;
+  transition: all 100ms linear;
+
+  :hover {
+    box-shadow: ${({$hasQueryString}) =>
+        $hasQueryString ? Colors.keylineDefault() : Colors.borderHover()}
+      inset 0px 0px 0px 1px;
+  }
+`;
+
+const ClearButton = styled(UnstyledButton)`
+  ${IconWrapper} {
+    transition: background-color 100ms linear;
+    :hover {
+      background-color: ${Colors.textDefault()};
+    }
+  }
+`;
+
 const SearchInputWrapper = styled.div`
   position: relative;
 `;
 
 const SearchResultsWrapper = styled.div`
-  top: 60px;
+  top: 48px;
+  left: 1px;
   position: absolute;
   z-index: 1;
-  width: 100%;
+  width: calc(100% - 2px);
+`;
+
+const NoAssetResults = styled.div`
+  background-color: ${Colors.backgroundDefault()};
+  border-radius: 0 0 8px 8px;
+  color: ${Colors.textLighter()};
+  font-size: 16px;
+  padding: 16px;
+`;
+
+const MatchingFiltersHeader = styled.li`
+  background-color: ${Colors.backgroundDefault()};
+  padding: 8px 12px;
+  border-bottom: 1px solid ${Colors.backgroundGray()};
+  color: ${Colors.textLight()};
+  font-weight: 500;
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -238,7 +238,7 @@ export const SearchDialog = ({searchPlaceholder}: {searchPlaceholder: string}) =
         transitionDuration={100}
       >
         <Container>
-          <SearchBox hasQueryString={!!queryString.length}>
+          <SearchBox $hasQueryString={!!queryString.length}>
             <Icon name="search" color={Colors.accentGray()} size={20} />
             <SearchInput
               data-search-input="1"
@@ -256,7 +256,6 @@ export const SearchDialog = ({searchPlaceholder}: {searchPlaceholder: string}) =
             highlight={highlight}
             queryString={queryString}
             results={renderedResults}
-            filterResults={[]}
             onClickResult={onClickResult}
           />
         </Container>
@@ -290,40 +289,42 @@ const SearchTrigger = styled.button`
 
 const Container = styled.div`
   background-color: ${Colors.backgroundDefault()};
-  border-radius: 4px;
-  box-shadow: 2px 2px 8px ${Colors.shadowDefault()};
+  border-radius: 8px;
+  box-shadow:
+    2px 2px 8px ${Colors.shadowDefault()},
+    ${Colors.keylineDefault()} inset 0px 0px 0px 1px;
   max-height: 60vh;
   left: calc(50% - 300px);
   overflow: hidden;
   width: 600px;
   top: 20vh;
-
-  input {
-    background-color: transparent;
-  }
 `;
 
-interface SearchBoxProps {
-  readonly hasQueryString: boolean;
+export interface SearchBoxProps {
+  readonly $hasQueryString: boolean;
 }
 
 export const SearchBox = styled.div<SearchBoxProps>`
-  border-radius: 8px;
+  background: ${Colors.backgroundDefault()};
+  border-radius: ${({$hasQueryString}) => ($hasQueryString ? '8px 8px 0 0' : '8px')};
+  border: none;
   align-items: center;
-  border: ${({hasQueryString}) =>
-    hasQueryString ? `1px solid ${Colors.borderHover()}` : `1px solid ${Colors.borderDefault()}`};
+  box-shadow: ${({$hasQueryString}) =>
+      $hasQueryString ? Colors.keylineDefault() : Colors.borderDefault()}
+    inset 0px 0px 0px 1px;
   display: flex;
   padding: 12px 20px 12px 12px;
   transition: all 100ms linear;
-  background: ${Colors.backgroundDefaultHover()};
 
   :hover {
-    border: 1px solid ${Colors.borderHover()};
-    background: ${Colors.backgroundDefault()};
+    box-shadow: ${({$hasQueryString}) =>
+        $hasQueryString ? Colors.keylineDefault() : Colors.borderHover()}
+      0 0 0 1px inset;
   }
 `;
 
 export const SearchInput = styled.input`
+  background-color: transparent;
   border: none;
   color: ${Colors.textDefault()};
   font-family: ${FontFamily.default};
@@ -331,10 +332,13 @@ export const SearchInput = styled.input`
   margin-left: 4px;
   outline: none;
   width: 100%;
-  background-color: transparent;
 
   &::placeholder {
     color: ${Colors.textDisabled()};
+  }
+
+  ::focus {
+    outline: none;
   }
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
@@ -120,7 +120,7 @@ function buildSearchLabel(result: Fuse.FuseResult<SearchResult>): JSX.Element[] 
   return labelComponents;
 }
 
-const SearchResultItem = React.memo(({isHighlight, onClickResult, result}: ItemProps) => {
+export const SearchResultItem = React.memo(({isHighlight, onClickResult, result}: ItemProps) => {
   const {item} = result;
   const element = React.useRef<HTMLLIElement>(null);
 
@@ -171,23 +171,22 @@ const SearchResultItem = React.memo(({isHighlight, onClickResult, result}: ItemP
   );
 });
 
-interface Props {
+export interface SearchResultsProps {
   highlight: number;
   onClickResult: (result: Fuse.FuseResult<SearchResult>) => void;
   queryString: string;
   results: Fuse.FuseResult<SearchResult>[];
-  filterResults: Fuse.FuseResult<SearchResult>[];
 }
 
-export const SearchResults = (props: Props) => {
-  const {highlight, onClickResult, queryString, results, filterResults} = props;
+export const SearchResults = (props: SearchResultsProps) => {
+  const {highlight, onClickResult, queryString, results} = props;
 
-  if (!results.length && !filterResults.length && queryString) {
+  if (!results.length && queryString) {
     return <NoResults>No results</NoResults>;
   }
 
   return (
-    <List hasResults={!!results.length || !!filterResults.length}>
+    <SearchResultsList hasResults={!!results.length}>
       {results.map((result, ii) => (
         <SearchResultItem
           key={result.item.href}
@@ -196,36 +195,21 @@ export const SearchResults = (props: Props) => {
           onClickResult={onClickResult}
         />
       ))}
-      {filterResults.length > 0 ? (
-        <>
-          <MatchingFiltersHeader>Matching filters</MatchingFiltersHeader>
-          {filterResults.map((result, ii) => (
-            <SearchResultItem
-              key={result.item.href}
-              isHighlight={highlight === ii + results.length}
-              result={result}
-              onClickResult={onClickResult}
-            />
-          ))}
-        </>
-      ) : (
-        <></>
-      )}
-    </List>
+    </SearchResultsList>
   );
 };
 
-const NoResults = styled.div`
+export const NoResults = styled.div`
   color: ${Colors.textLighter()};
   font-size: 16px;
   padding: 16px;
 `;
 
-interface ListProps {
+interface SearchResultsListProps {
   hasResults: boolean;
 }
 
-const List = styled.ul<ListProps>`
+export const SearchResultsList = styled.ul<SearchResultsListProps>`
   max-height: calc(60vh - 48px);
   margin: 0;
   padding: ${({hasResults}) => (hasResults ? '4px 0' : 'none')};
@@ -233,20 +217,12 @@ const List = styled.ul<ListProps>`
   overflow-y: auto;
   background-color: ${Colors.backgroundDefault()};
   box-shadow: 2px 2px 8px ${Colors.shadowDefault()};
-  border-radius: 4px;
+  border-radius: 0 0 4px 4px;
 `;
 
 interface HighlightableTextProps {
   readonly isHighlight: boolean;
 }
-
-const MatchingFiltersHeader = styled.li`
-  background-color: ${Colors.backgroundDefault()};
-  padding: 8px 12px;
-  border-bottom: 1px solid ${Colors.backgroundGray()};
-  color: ${Colors.textLight()};
-  font-weight: 500;
-`;
 
 const Item = styled.li<HighlightableTextProps>`
   align-items: center;


### PR DESCRIPTION
## Summary & Motivation

Make a handful of changes to asset search and global search. Worked through these in a zoom with @braunjj. Verified all of the changes in light and dark mode.

- Separate some asset search components from global search components. This should hopefully allow faster iteration and experimentation on asset search without also requiring lots of global search testing and changes.
- Remove filter header code from global search, since it's not used there.
- Update box-shadow styles on inputs.
- Modify border-radius values to keep input, results, and containers flush.
- Connect asset search input to its results, apply a background to the empty state.
- Add a "clear" X button to asset search when the input has a value.

## How I Tested These Changes

In light and dark mode, interact with global search and asset search.

- Verify default and hover states on empty and populated inputs.
- Verify correct rendering of results and empty states.
- Verify that clearing the asset search input behaves correctly.