### PR TITLE
[dagster-snowflake-pandas] fix column names not being quoted

### DIFF
--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -121,11 +121,11 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
             # forced the table name to be uppercase, so we mimic that behavior here for feature parity
             # in the future we could allow non-uppercase table names
             table_name=table_slice.table.upper(),
-            schema=table_slice.schema,
-            database=table_slice.database,
+            schema=table_slice.schema.upper(),
+            database=table_slice.database.upper(),
             auto_create_table=True,
             use_logical_type=True,
-            quote_identifiers=False,  # In the future we can set this to True to allow lowercase identifiers
+            quote_identifiers=True,
         )
 
         return {

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -122,7 +122,7 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
             # in the future we could allow non-uppercase table names
             table_name=table_slice.table.upper(),
             schema=table_slice.schema.upper(),
-            database=table_slice.database.upper(),
+            database=table_slice.database.upper() if table_slice.database else None,
             auto_create_table=True,
             use_logical_type=True,
             quote_identifiers=True,

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -118,8 +118,8 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
             conn=connection,
             df=with_uppercase_cols,
             # originally we used pd.to_sql with pd_writer method to write the df to snowflake. pd_writer
-            # forced the table name to be uppercase, so we mimic that behavior here for feature parity
-            # in the future we could allow non-uppercase table names
+            # forced the database, schema, and table name to be uppercase, so we mimic that behavior here for feature parity
+            # in the future we could allow non-uppercase names
             table_name=table_slice.table.upper(),
             schema=table_slice.schema.upper(),
             database=table_slice.database.upper() if table_slice.database else None,

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -768,50 +768,17 @@ def test_quoted_identifiers_asset(io_manager):
         def illegal_column_name(context: AssetExecutionContext) -> DataFrame:
             return DataFrame(
                 {
-                    "5foo": [1, 2, 3],
-                    "A": [4, 5, 6],
+                    "5foo": [1, 2, 3],  # columns that start with numbers need to be quoted
+                    "column with a space": [1, 2, 3],
+                    "column_with_punctuation!": [1, 2, 3],
+                    "by": [1, 2, 3],  # reserved
                 }
             )
 
-        # asset_full_name = f"{SCHEMA}__{table_name}"
-        # snowflake_table_path = f"{SCHEMA}.{table_name}"
-
-        # snowflake_conn = SnowflakeResource(database=DATABASE, **SHARED_BUILDKITE_SNOWFLAKE_CONF)
-
-        resource_defs = {"io_manager": io_manager, "fs_io": fs_io_manager}
-        materialize(
+        resource_defs = {"io_manager": io_manager}
+        res = materialize(
             [illegal_column_name],
             resources=resource_defs,
         )
 
-        # with snowflake_conn.get_connection() as conn:
-        #     out_df = (
-        #         conn.cursor().execute(f"SELECT * FROM {snowflake_table_path}").fetch_pandas_all()
-        #     )
-        #     assert out_df["A"].tolist() == ["1", "1", "1"]
-
-        # materialize(
-        #     [daily_partitioned, downstream_partitioned],
-        #     partition_key="2022-01-02",
-        #     resources=resource_defs,
-        #     run_config={"ops": {asset_full_name: {"config": {"value": "2"}}}},
-        # )
-
-        # with snowflake_conn.get_connection() as conn:
-        #     out_df = (
-        #         conn.cursor().execute(f"SELECT * FROM {snowflake_table_path}").fetch_pandas_all()
-        #     )
-        #     assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]
-
-        # materialize(
-        #     [daily_partitioned, downstream_partitioned],
-        #     partition_key="2022-01-01",
-        #     resources=resource_defs,
-        #     run_config={"ops": {asset_full_name: {"config": {"value": "3"}}}},
-        # )
-
-        # with snowflake_conn.get_connection() as conn:
-        #     out_df = (
-        #         conn.cursor().execute(f"SELECT * FROM {snowflake_table_path}").fetch_pandas_all()
-        #     )
-        #     assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3"]
+        assert res.success


### PR DESCRIPTION
## Summary & Motivation
https://github.com/dagster-io/dagster/issues/20552 raised a bug with the snowflake i/o manager where column names were no longer being quoted. This is because we were previously using `pd.to_sql` with the `pd_writer` function and then switched to `write_pandas` in https://github.com/dagster-io/dagster/pull/18410. 

It seems as though `to_sql/pd_writer` would use quote identifiers for column names, but not for database/schema/table names whereas `write_pandas` will either use quote identifiers for everything, or not use quote identifiers for everything. I erroneously set `write_pandas` to not use quote identifiers so that database/schema/table names were consistent across versions, but that meant that column names went from being quoted to not quoted. 

To fix this, we can set `write_pandas` to use quote identifiers and manually make database/schema/table names all uppercase, which is what happens when quote identifiers are not used

## How I Tested These Changes
Wrote a new unit test that has a column name that requires quote identifiers. The test failed, then i made the changes in this PR and the test succeeds 