### PR TITLE
RFC: Add the step's set of asset keys set to the STEP_START, STEP_SKIPPED and STEP_FAILURE events

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -213,6 +213,18 @@ class IStepContext(IPlanContext):
     def node_handle(self) -> "NodeHandle":
         raise NotImplementedError()
 
+    @property
+    def asset_keys(self) -> Set[AssetKey]:
+        result = set()
+        for output in self.step.step_output_dict.values():
+            if not output.properties:
+                continue
+            asset_key = output.properties.asset_key
+            if asset_key:
+                result.add(asset_key)
+
+        return result
+
 
 class PlanOrchestrationContext(IPlanContext):
     """Context for the orchestration of a run.


### PR DESCRIPTION
Summary:
The idea is that this would allow us to react, either synchronously or asynchronously, to inbound step failure and skip events, and update our understanding of the status of the asset keys that were intended to be materialized by this step. If a materialization event already came in, great. If not, mark the relevant assets as skipped or failed in the relevant table for that asset.

Planning to add tests and stuff and I wouldn't land this before we have something ready to actually use the data, but curious if this approach seems high-level reasonable

