### PR TITLE
fix owner tag display in catalog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverview.tsx
@@ -352,7 +352,7 @@ export const AssetsOverview = ({viewerName}: {viewerName?: string}) => {
                     link={linkToAssetGraphOwner(owner)}
                   >
                     <span style={TextOverflowStyle}>
-                      <UserDisplay email={owner} />
+                      <UserDisplay email={owner} isFilter />
                     </span>
                   </CountForAssetType>
                 ))}


### PR DESCRIPTION
## Summary & Motivation
as titled. Gets rid of the tag and extra padding on the user profile in the Owners section
<img width="598" alt="image" src="https://github.com/dagster-io/dagster/assets/2798333/0f15d7b6-7fb4-4230-a369-e7fdd02f2158">


## How I Tested These Changes
Loade the UI