### PR TITLE
feat(dbt): do not execute dbt in `--debug` by default

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -350,21 +350,6 @@ def test_dbt_source_freshness_execution(test_dbt_source_freshness_manifest: Dict
     assert result.success
 
 
-def test_dbt_cli_adapter_metadata(
-    test_jaffle_shop_manifest: Dict[str, Any], dbt: DbtCliResource
-) -> None:
-    @dbt_assets(manifest=test_jaffle_shop_manifest)
-    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        # For `dbt-duckdb`, the `rows_affected` metadata is only emitted for seed files.
-        for event in dbt.cli(["seed"], context=context).stream():
-            assert event.metadata.get("rows_affected")
-
-            yield event
-
-    result = materialize([my_dbt_assets], resources={"dbt": dbt})
-    assert result.success
-
-
 def test_dbt_cli_asset_selection(
     test_jaffle_shop_manifest: Dict[str, Any], dbt: DbtCliResource
 ) -> None:


### PR DESCRIPTION
## Summary & Motivation
Reverts https://github.com/dagster-io/dagster/pull/19646 and https://github.com/dagster-io/dagster/pull/19498.

Although we were getting more metadata from dbt, this metadata was:
- Prone to inaccuracy (e.g. see https://github.com/dbt-labs/dbt-bigquery/issues/602)
- Caused pipelines to potentially double in duration, due to the abundancy of logs

This metadata is easy to get if we introduce a wrapper (and then metadata retrieval will be square in the ownership of this integration). With that in mind, we don't need to rely on the metadata from `--debug`. So remove it.

## How I Tested These Changes
pytest
