### PR TITLE
Fix asset check base jobs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -83,10 +83,11 @@ def get_base_asset_jobs(
                 *asset_graph.asset_keys_for_partitions_def(partitions_def=partitions_def),
                 *asset_graph.unpartitioned_asset_keys,
             }
-            # For now, to preserve behavior keep all asset checks in all base jobs. When checks
-            # support partitions, they should only go in the corresponding partitioned job.
-            selection = (
-                AssetSelection.keys(*executable_asset_keys) | AssetSelection.all_asset_checks()
+            # For now, to preserve behavior keep all orphaned asset checks (where the target check
+            # has no corresponding executable definition) in all base jobs. When checks support
+            # partitions, they should only go in the corresponding partitioned job.
+            selection = AssetSelection.keys(*executable_asset_keys) | AssetSelection.checks(
+                *asset_graph.orphan_asset_check_keys
             )
             jobs.append(
                 build_assets_job(

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -268,6 +268,11 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
     def asset_check_keys(self) -> AbstractSet[AssetCheckKey]: ...
 
     @cached_property
+    def orphan_asset_check_keys(self) -> AbstractSet[AssetCheckKey]:
+        """Asset check keys that target an asset with no corresponding executable definition in the graph."""
+        return {k for k in self.asset_check_keys if k.asset_key not in self.executable_asset_keys}
+
+    @cached_property
     def all_partitions_defs(self) -> Sequence[PartitionsDefinition]:
         return sorted(
             set(node.partitions_def for node in self.asset_nodes if node.partitions_def), key=repr

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -3,12 +3,16 @@ import os
 
 import pytest
 from dagster import (
+    AssetCheckKey,
+    AssetCheckSpec,
     AssetKey,
     AssetOut,
     AssetsDefinition,
+    AssetSpec,
     DagsterEventType,
     DagsterInvalidDefinitionError,
     DailyPartitionsDefinition,
+    DataVersionsByPartition,
     Definitions,
     DependencyDefinition,
     Field,
@@ -18,6 +22,7 @@ from dagster import (
     In,
     IOManager,
     Nothing,
+    ObserveResult,
     Out,
     Output,
     ResourceDefinition,
@@ -28,6 +33,7 @@ from dagster import (
     io_manager,
     materialize_to_memory,
     multi_asset,
+    multi_observable_source_asset,
     observable_source_asset,
     op,
     resource,
@@ -35,10 +41,12 @@ from dagster import (
 )
 from dagster._config import StringSource
 from dagster._core.definitions import AssetIn, SourceAsset, asset
+from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_selection import AssetSelection, CoercibleToAssetSelection
 from dagster._core.definitions.assets_job import get_base_asset_jobs
 from dagster._core.definitions.data_version import DataVersion
+from dagster._core.definitions.decorators.asset_check_decorator import asset_check
 from dagster._core.definitions.dependency import NodeHandle, NodeInvocation
 from dagster._core.definitions.executor_definition import in_process_executor
 from dagster._core.definitions.external_asset import create_external_asset_from_source_asset
@@ -2010,6 +2018,93 @@ def test_get_base_asset_jobs_multiple_partitions_defs_and_observable_assets():
     assert {job_def.name for job_def in jobs} == {
         "__ASSET_JOB_0",
         "__ASSET_JOB_1",
+    }
+
+
+def test_get_base_asset_jobs_multiple_partitions_defs_and_asset_checks_and_observables():
+    with disable_dagster_warnings():
+        partitions_1 = StaticPartitionsDefinition(["2020-01-01", "2020-01-02"])
+
+        @asset(
+            partitions_def=partitions_1,
+            check_specs=[AssetCheckSpec(name="p1_check1", asset="p1_asset")],
+        )
+        def p1_asset():
+            return 1
+
+        @asset_check(asset="p1_asset")
+        def p1_check2():
+            return AssetCheckResult(passed=True)
+
+        @observable_source_asset(partitions_def=partitions_1)
+        def p1_observable():
+            return DataVersionsByPartition({"2020-01-01": "alpha"})
+
+        @asset_check(asset=p1_observable.key)
+        def p1_observable_check():
+            return AssetCheckResult(passed=True)
+
+        partitions_2 = StaticPartitionsDefinition(["2020-01-01", "2020-01-03"])
+
+        @asset(
+            partitions_def=partitions_2,
+            check_specs=[AssetCheckSpec(name="p2_check1", asset="p2_asset")],
+        )
+        def p2_asset():
+            return 1
+
+        @asset_check(asset="p2_asset")
+        def p2_check2():
+            return AssetCheckResult(passed=True)
+
+        @multi_observable_source_asset(
+            partitions_def=partitions_2,
+            specs=[AssetSpec("p2_observable")],
+            check_specs=[AssetCheckSpec(name="p2_observable_check1", asset="p2_observable")],
+        )
+        def p2_observable():
+            yield ObserveResult(asset_key="p2_observable")
+            yield AssetCheckResult(passed=True)
+
+        @asset_check(asset="p2_observable")
+        def p2_observable_check2():
+            return AssetCheckResult(passed=True)
+
+        @asset_check(asset="external_asset")
+        def orphan_check():
+            return AssetCheckResult(passed=True)
+
+    defs = Definitions(
+        assets=[p1_asset, p2_asset, p1_observable, p2_observable],
+        asset_checks=[
+            p1_check2,
+            p2_check2,
+            orphan_check,
+            p1_observable_check,
+            p2_observable_check2,
+        ],
+    )
+    p1_key = AssetKey("p1_asset")
+    p1_observable_key = AssetKey("p1_observable")
+    p2_key = AssetKey("p2_asset")
+    p2_observable_key = AssetKey("p2_observable")
+    external_key = AssetKey("external_asset")
+
+    p1_job_def = defs.get_implicit_job_def_for_assets([p1_key])
+    assert p1_job_def.asset_layer.asset_graph.asset_check_keys == {
+        AssetCheckKey(p1_key, "p1_check1"),
+        AssetCheckKey(p1_key, "p1_check2"),
+        AssetCheckKey(p1_observable_key, "p1_observable_check"),
+        AssetCheckKey(external_key, "orphan_check"),
+    }
+
+    p2_job_def = defs.get_implicit_job_def_for_assets([p2_key])
+    assert p2_job_def.asset_layer.asset_graph.asset_check_keys == {
+        AssetCheckKey(p2_key, "p2_check1"),
+        AssetCheckKey(p2_key, "p2_check2"),
+        AssetCheckKey(p2_observable_key, "p2_observable_check1"),
+        AssetCheckKey(p2_observable_key, "p2_observable_check2"),
+        AssetCheckKey(external_key, "orphan_check"),
     }
 
 


### PR DESCRIPTION
## Summary & Motivation

#20446 converted `AssetChecksDefinition` to a subclass of `AssetsDefinition`. The existing behavior of `get_base_asset_jobs` was to assign all `AssetChecksDefinition` to all base jobs. This was treating them the way we treat unpartitioned assets (also assigned to all base jobs), presumably because asset checks don’t support partitions yet.

#20446 attempted to preserve this behavior, but the previous state led to only the checks defined as standalone `AssetChecksDefinition` being assigned to every base job. After the PR, this became every asset check being assigned to every base job. When we have at least two partitions definitions A and B in a repo, and at least one A-partitioned asset has an “included” check (i.e. in same op as materialization), this triggers the error, because the subsetting logic will attempt to extract the included check from the A-partitioned asset for inclusion in the B-partitioned base job. This will fail if the A-partitioned assets def isn’t subsettable.

The solution in this PR is to explicitly include only “orphaned” asset checks in every base job, meaning asset checks without a corresponding materializable in-repo asset, in every job. This works because: (a) an orphaned asset check will never trigger the error since it will never be in a part of an AssetsDefinition that requires subsetting; (b) all other asset checks should be included automatically in the base job that includes their corresponding materializable asset.

## How I Tested These Changes

New unit test against asset check base jobs.
