### PR TITLE
feat: use `difflib` by default to display `AssetKey` mismatch errors

### DIFF
--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection_error_informative.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection_error_informative.py
@@ -1,12 +1,23 @@
 import re
-from importlib.util import find_spec
+import sys
 
+import mock
 import pytest
 from dagster import AssetSelection, Definitions, asset, define_asset_job
 from dagster._core.errors import DagsterInvalidSubsetError
 
 
-@pytest.mark.skipif(not find_spec("rapidfuzz"), reason="Rapidfuzz not installed")
+@pytest.fixture(
+    name="string_similarity_package",
+    params=["difflib", "rapidfuzz"],
+    ids=["no difflib", "no rapidfuzz"],
+    autouse=True,
+)
+def uninstall_string_similarity_package_fixture(request: pytest.FixtureRequest):
+    with mock.patch.dict(sys.modules, {request.param: None}):
+        yield
+
+
 @pytest.mark.parametrize("group_name", [None, "my_group"])
 @pytest.mark.parametrize("asset_key_prefix", [[], ["my_prefix"]])
 def test_typo_asset_selection_one_similar(group_name, asset_key_prefix) -> None:
@@ -37,7 +48,6 @@ def test_typo_asset_selection_no_similar() -> None:
         defs.get_job_def("my_job")
 
 
-@pytest.mark.skipif(not find_spec("rapidfuzz"), reason="Rapidfuzz not installed")
 def test_typo_asset_selection_many_similar() -> None:
     @asset
     def asset1(): ...
@@ -62,7 +72,6 @@ def test_typo_asset_selection_many_similar() -> None:
         defs.get_job_def("my_job")
 
 
-@pytest.mark.skipif(not find_spec("rapidfuzz"), reason="Rapidfuzz not installed")
 def test_typo_asset_selection_wrong_prefix() -> None:
     @asset(key_prefix=["my", "prefix"])
     def asset1(): ...


### PR DESCRIPTION
## Summary & Motivation
I was pursuing `sqlglot` code and saw this: https://github.com/tobymao/sqlglot/blob/a18444dbd7ccfc05b189dcb2005c85a1048cc8de/sqlglot/dialects/dialect.py#L343-L348

And realized there was a string similarity library in the Python stdlib: [`difflib`](https://docs.python.org/3/library/difflib.html). It's inefficient, but does the job. Let's use that if `rapidfuzz` is missing.

Also, once https://github.com/rapidfuzz/rapidfuzz-rs introduces Python bindings, we could probably use that instead and not have to worry about windows dependency shenanigans.

## How I Tested These Changes
pytest: removed skips on existing tests if `rapidfuzz` is uninstalled.
