### PR TITLE
DbtProject state artifacts handling

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
@@ -74,6 +74,7 @@ class DbtProject(DagsterModel):
     project_dir: Path
     target_dir: Path
     manifest_path: Path
+    state_dir: Optional[Path]
     packaged_project_dir: Optional[Path]
     manifest_preparer: Optional[DbtManifestPreparer]
 
@@ -82,6 +83,7 @@ class DbtProject(DagsterModel):
         project_dir: Union[Path, str],
         *,
         target_dir: Union[Path, str] = "target",
+        state_dir: Optional[Union[Path, str]] = None,
         packaged_project_dir: Optional[Union[Path, str]] = None,
         manifest_preparer: Optional[DbtManifestPreparer] = DagsterDbtManifestPreparer(),
     ):
@@ -93,6 +95,8 @@ class DbtProject(DagsterModel):
             target_dir (Union[str, Path]):
                 The folder in the project directory to output artifacts.
                 Default: "target"
+            state_dir (Optional[Union[str, Path]]):
+                The folder in the project directory to reference artifacts from another run.
             manifest_preparer (Optional[DbtManifestPreparer]):
                 A object for ensuring that manifest.json is in the right state at
                 the right times.
@@ -120,6 +124,7 @@ class DbtProject(DagsterModel):
             project_dir=project_dir,
             target_dir=target_dir,
             manifest_path=manifest_path,
+            state_dir=current_project_dir.joinpath(state_dir) if state_dir else None,
             packaged_project_dir=packaged_project_dir,
             manifest_preparer=manifest_preparer,
         )
@@ -128,6 +133,12 @@ class DbtProject(DagsterModel):
 
     def prepare_for_deployment(self) -> None:
         prepare_for_deployment(self)
+
+    def get_state_dir_if_populated(self) -> Optional[Path]:
+        if self.state_dir and self.state_dir.joinpath("manifest.json").exists():
+            return self.state_dir
+
+        return None
 
 
 def prepare_for_deployment(project: DbtProject) -> None:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
@@ -1,5 +1,9 @@
+import os
+import shutil
+from pathlib import Path
+
 import pytest
-from dagster import AssetExecutionContext, Definitions
+from dagster import AssetExecutionContext, Definitions, materialize_to_memory
 from dagster._core.test_utils import environ
 from dagster._utils.test import copy_directory
 from dagster_dbt import dbt_assets
@@ -44,3 +48,77 @@ def test_opt_in_env_var() -> None:
     ) as project_dir:
         my_project = DbtProject(project_dir)
         assert my_project.manifest_path.exists()
+
+
+def test_state_defer(tmp_path) -> None:
+    def my_deployment_prep(project: DbtProject):
+        prepare_for_deployment(project)
+
+        shuffle_path = Path(tmp_path).joinpath("prod_manifest.json")
+        state_dir = project.state_dir
+        assert state_dir
+        env = os.environ["DAGSTER_DBT_JAFFLE_SCHEMA"]
+        if env == "staging":
+            os.makedirs(state_dir, exist_ok=True)
+            shutil.copyfile(
+                shuffle_path,
+                state_dir.joinpath("manifest.json"),
+            )
+        elif env == "prod":
+            shutil.copyfile(
+                project.manifest_path,
+                shuffle_path,
+            )
+        else:
+            assert False, env  # should not reach
+
+    with copy_directory(test_jaffle_shop_path) as project_dir:
+        # simulate deploying and running prod
+        with environ({"DAGSTER_DBT_JAFFLE_SCHEMA": "prod"}):
+            my_project = DbtProject(
+                project_dir,
+                state_dir="prod_artifacts",
+            )
+            dbt_resource = DbtCliResource(my_project)
+
+            dbt_resource.cli(["seed"]).wait()  # test set-up
+
+            my_deployment_prep(my_project)
+
+            @dbt_assets(manifest=my_project.manifest_path)
+            def my_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+                defer_args = dbt.get_defer_args()
+                if os.getenv("DAGSTER_DBT_JAFFLE_SCHEMA") == "staging":
+                    assert defer_args, defer_args
+                yield from dbt.cli(
+                    ["run", *defer_args],
+                    context=context,
+                ).stream()
+
+            # produce all prod assets
+            result = materialize_to_memory(
+                [my_assets],
+                resources={"dbt": dbt_resource},
+            )
+            assert result.success
+
+        # and then deploying and running in staging
+        with environ({"DAGSTER_DBT_JAFFLE_SCHEMA": "staging"}):
+            # subselect but no defer fails
+            result = materialize_to_memory(
+                [my_assets],
+                resources={"dbt": DbtCliResource(my_project)},
+                selection="orders",
+                raise_on_error=False,
+            )
+            assert not result.success
+
+            my_deployment_prep(my_project)
+
+            # subselect with defer works
+            result = materialize_to_memory(
+                [my_assets],
+                resources={"dbt": DbtCliResource(my_project)},
+                selection="orders",
+            )
+            assert result.success

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/profiles.yml
@@ -3,5 +3,6 @@ jaffle_shop:
   outputs:
     dev:
       type: duckdb
-      path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH') }}"
+      path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH', 'target/local.duckdb') }}"
+      schema: "{{ env_var('DAGSTER_DBT_JAFFLE_SCHEMA', 'dev') }}"
       threads: 24


### PR DESCRIPTION
Introduce capabilities to `DbtProject` to allow it to make adding `--defer --state $PATH` as easy as possible. 

* `DbtProject` gets a `state_dir` property
* `DbtCliResource` gets `state_dir` and `get_defer_args()`. `get_defer_args` is setup to work such that it can be always used in a @dbt_assets cli invocation but will only add the args when the `state_dir` is populated with a `manifest.json`
* `DagsterDbtProjectManager` gets a `manage_state_artifacts` that is invoked when `state_dir` is set on the project. 


## How I Tested These Changes

added test