### PR TITLE
Prefer observables over regular source assets when rendering in UI.

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -222,7 +222,11 @@ def get_asset_nodes_by_asset_key(
         _, _, preexisting_asset_node = asset_nodes_by_asset_key.get(
             external_asset_node.asset_key, (None, None, None)
         )
-        if preexisting_asset_node is None or preexisting_asset_node.is_source:
+        # If an asset node is already in the dict, we only overwrite it if that preexisting node is
+        # not executable in some manner (i.e. it is a source asset that is not an observable)
+        if preexisting_asset_node is None or (
+            preexisting_asset_node.is_source and not preexisting_asset_node.is_observable
+        ):
             if asset_keys is None or external_asset_node.asset_key in asset_keys:
                 asset_nodes_by_asset_key[external_asset_node.asset_key] = (
                     repo_loc,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/cross_repo_asset_deps.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/cross_repo_asset_deps.py
@@ -1,4 +1,5 @@
 from dagster import AssetKey, SourceAsset, asset, repository
+from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
 
 
 @asset
@@ -10,6 +11,13 @@ def derived_asset():
 def upstream_assets_repository():
     return [derived_asset]
 
+
+@observable_source_asset
+def sometimes_observable_source_asset():
+    return 5
+
+
+unexecutable_src = SourceAsset("sometimes_observable_source_asset")
 
 source_assets = [SourceAsset(AssetKey("derived_asset")), SourceAsset("always_source_asset")]
 
@@ -26,9 +34,9 @@ def downstream_asset2(derived_asset, always_source_asset):
 
 @repository
 def downstream_assets_repository1():
-    return [downstream_asset1, *source_assets]
+    return [downstream_asset1, *source_assets, unexecutable_src]
 
 
 @repository
 def downstream_assets_repository2():
-    return [downstream_asset2, *source_assets]
+    return [downstream_asset2, *source_assets, sometimes_observable_source_asset]


### PR DESCRIPTION
Solves an issue we ran into in purina where we treat observable source assets the same as any other source asset when rendering in the UI, and so you end up with an unexecutable asset which should actually be executable.

How I tested this:
Added a test that ensures when there's multiple repos containing an observable, that we pick the observable.