### PR TITLE
Freshness renames

### DIFF
--- a/docs/sphinx/sections/api/apidocs/asset-checks.rst
+++ b/docs/sphinx/sections/api/apidocs/asset-checks.rst
@@ -27,6 +27,6 @@ Dagster allows you to define and execute checks on your software-defined assets.
 
 .. autoclass:: AssetChecksDefinition
 
-.. autofunction:: build_freshness_checks_for_non_partitioned_assets
+.. autofunction:: build_last_update_freshness_checks
 
-.. autofunction:: build_freshness_checks_for_time_window_partitioned_assets
+.. autofunction:: build_last_time_partitioned_checks

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -210,11 +210,11 @@ from dagster._core.definitions.external_asset import (
     external_asset_from_spec as external_asset_from_spec,
     external_assets_from_specs as external_assets_from_specs,
 )
-from dagster._core.definitions.freshness_checks.non_partitioned import (
-    build_freshness_checks_for_non_partitioned_assets as build_freshness_checks_for_non_partitioned_assets,
+from dagster._core.definitions.freshness_checks.last_update import (
+    build_last_update_freshness_checks as build_last_update_freshness_checks,
 )
-from dagster._core.definitions.freshness_checks.time_window_partitioned import (
-    build_freshness_checks_for_time_window_partitioned_assets as build_freshness_checks_for_time_window_partitioned_assets,
+from dagster._core.definitions.freshness_checks.time_partitioned import (
+    build_last_time_partitioned_checks as build_last_time_partitioned_checks,
 )
 from dagster._core.definitions.freshness_policy import FreshnessPolicy as FreshnessPolicy
 from dagster._core.definitions.freshness_policy_sensor_definition import (

--- a/python_modules/dagster/dagster/_core/definitions/freshness_checks/time_partitioned.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_checks/time_partitioned.py
@@ -26,7 +26,7 @@ from .utils import (
 
 
 @experimental
-def build_freshness_checks_for_time_window_partitioned_assets(
+def build_last_time_partitioned_checks(
     *,
     assets: Sequence[Union[SourceAsset, CoercibleToAssetKey, AssetsDefinition]],
     freshness_cron: str,

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_time_partitioned.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_time_partitioned.py
@@ -10,8 +10,8 @@ from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.definitions.asset_out import AssetOut
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.freshness_checks.time_window_partitioned import (
-    build_freshness_checks_for_time_window_partitioned_assets,
+from dagster._core.definitions.freshness_checks.time_partitioned import (
+    build_last_time_partitioned_checks,
 )
 from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.definitions.source_asset import SourceAsset
@@ -35,26 +35,26 @@ def test_params() -> None:
     def my_partitioned_asset():
         pass
 
-    result = build_freshness_checks_for_time_window_partitioned_assets(
+    result = build_last_time_partitioned_checks(
         assets=[my_partitioned_asset], freshness_cron="0 0 * * *"
     )
     assert len(result) == 1
     assert next(iter(result[0].check_keys)).asset_key == my_partitioned_asset.key
 
-    result = build_freshness_checks_for_time_window_partitioned_assets(
+    result = build_last_time_partitioned_checks(
         assets=[my_partitioned_asset.key], freshness_cron="0 0 * * *", freshness_cron_timezone="UTC"
     )
     assert len(result) == 1
     assert next(iter(result[0].check_keys)).asset_key == my_partitioned_asset.key
 
     src_asset = SourceAsset("source_asset")
-    result = build_freshness_checks_for_time_window_partitioned_assets(
+    result = build_last_time_partitioned_checks(
         assets=[src_asset], freshness_cron="0 0 * * *", freshness_cron_timezone="UTC"
     )
     assert len(result) == 1
     assert next(iter(result[0].check_keys)).asset_key == src_asset.key
 
-    result = build_freshness_checks_for_time_window_partitioned_assets(
+    result = build_last_time_partitioned_checks(
         assets=[my_partitioned_asset, src_asset],
         freshness_cron="0 0 * * *",
         freshness_cron_timezone="UTC",
@@ -66,7 +66,7 @@ def test_params() -> None:
     }
 
     with pytest.raises(Exception, match="Found duplicate assets"):
-        build_freshness_checks_for_time_window_partitioned_assets(
+        build_last_time_partitioned_checks(
             assets=[my_partitioned_asset, my_partitioned_asset],
             freshness_cron="0 0 * * *",
             freshness_cron_timezone="UTC",
@@ -85,7 +85,7 @@ def test_params() -> None:
     def my_multi_asset(context):
         pass
 
-    result = build_freshness_checks_for_time_window_partitioned_assets(
+    result = build_last_time_partitioned_checks(
         assets=[my_multi_asset], freshness_cron="0 0 * * *", freshness_cron_timezone="UTC"
     )
     assert len(result) == 2
@@ -94,47 +94,47 @@ def test_params() -> None:
     )
 
     with pytest.raises(Exception, match="freshness_cron must be a valid cron string."):
-        build_freshness_checks_for_time_window_partitioned_assets(
+        build_last_time_partitioned_checks(
             assets=[my_multi_asset], freshness_cron="0 0 * * * *", freshness_cron_timezone="UTC"
         )
 
     with pytest.raises(Exception, match="Found duplicate assets"):
-        build_freshness_checks_for_time_window_partitioned_assets(
+        build_last_time_partitioned_checks(
             assets=[my_multi_asset, my_multi_asset],
             freshness_cron="0 0 * * *",
             freshness_cron_timezone="UTC",
         )
 
     with pytest.raises(Exception, match="Found duplicate assets"):
-        build_freshness_checks_for_time_window_partitioned_assets(
+        build_last_time_partitioned_checks(
             assets=[my_multi_asset, my_partitioned_asset],
             freshness_cron="0 0 * * *",
             freshness_cron_timezone="UTC",
         )
 
     coercible_key = "blah"
-    result = build_freshness_checks_for_time_window_partitioned_assets(
+    result = build_last_time_partitioned_checks(
         assets=[coercible_key], freshness_cron="0 0 * * *", freshness_cron_timezone="UTC"
     )
     assert len(result) == 1
     assert next(iter(result[0].check_keys)).asset_key == AssetKey.from_coercible(coercible_key)
 
     with pytest.raises(Exception, match="Found duplicate assets"):
-        build_freshness_checks_for_time_window_partitioned_assets(
+        build_last_time_partitioned_checks(
             assets=[coercible_key, coercible_key],
             freshness_cron="0 0 * * *",
             freshness_cron_timezone="UTC",
         )
 
     regular_asset_key = AssetKey("regular_asset_key")
-    result = build_freshness_checks_for_time_window_partitioned_assets(
+    result = build_last_time_partitioned_checks(
         assets=[regular_asset_key], freshness_cron="0 0 * * *", freshness_cron_timezone="UTC"
     )
     assert len(result) == 1
     assert next(iter(result[0].check_keys)).asset_key == regular_asset_key
 
     with pytest.raises(Exception, match="Found duplicate assets"):
-        build_freshness_checks_for_time_window_partitioned_assets(
+        build_last_time_partitioned_checks(
             assets=[regular_asset_key, regular_asset_key],
             freshness_cron="0 0 * * *",
             freshness_cron_timezone="UTC",
@@ -156,7 +156,7 @@ def test_result_cron_param(
 
     start_time = pendulum.datetime(2021, 1, 3, 1, 0, 0, tz="UTC")  # 2021-01-03 at 01:00:00
 
-    freshness_checks = build_freshness_checks_for_time_window_partitioned_assets(
+    freshness_checks = build_last_time_partitioned_checks(
         assets=[my_asset],
         freshness_cron="0 9 * * *",  # 09:00 UTC
         freshness_cron_timezone="UTC",
@@ -245,7 +245,7 @@ def test_invalid_runtime_assets(
     def non_partitioned_asset():
         pass
 
-    asset_checks = build_freshness_checks_for_time_window_partitioned_assets(
+    asset_checks = build_last_time_partitioned_checks(
         assets=[non_partitioned_asset], freshness_cron="0 9 * * *", freshness_cron_timezone="UTC"
     )
 
@@ -263,7 +263,7 @@ def test_invalid_runtime_assets(
     def static_partitioned_asset():
         pass
 
-    asset_checks = build_freshness_checks_for_time_window_partitioned_assets(
+    asset_checks = build_last_time_partitioned_checks(
         assets=[static_partitioned_asset], freshness_cron="0 9 * * *", freshness_cron_timezone="UTC"
     )
 
@@ -290,7 +290,7 @@ def test_observations(
     def my_asset():
         pass
 
-    freshness_checks = build_freshness_checks_for_time_window_partitioned_assets(
+    freshness_checks = build_last_time_partitioned_checks(
         assets=[my_asset],
         freshness_cron="0 9 * * *",
         freshness_cron_timezone="UTC",  # 09:00 UTC


### PR DESCRIPTION
Rename freshness check APIs to be less about the assets which are using them, and more about the particular definition of freshness that they espouse. We realized that it's possible for time window partitioned assets to want to make use of "last update time freshness", and so felt that an API rename was necessary.
New names are `build_last_update_freshness_checks` and `build_time_partitioned_freshness_checks`

While we discussed more radical api changes to try to unify these, ultimately landed here (not too far from where we originally were). @schrockn @bosmat-elementl happy to discuss further / schedule a meeting if you all want to talk about that further.

How I tested this
existing test suite.
