### PR TITLE
fix(dbt): retrieve schema from sources to compute column lineage

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -172,13 +172,17 @@ def test_column_lineage(
         AssetKey(["stg_customers"]): TableColumnLineage(
             deps_by_column={
                 "customer_id": [
-                    TableColumnDep(asset_key=AssetKey(["raw_customers"]), column_name="id")
+                    TableColumnDep(asset_key=AssetKey(["raw_source_customers"]), column_name="id")
                 ],
                 "first_name": [
-                    TableColumnDep(asset_key=AssetKey(["raw_customers"]), column_name="first_name")
+                    TableColumnDep(
+                        asset_key=AssetKey(["raw_source_customers"]), column_name="first_name"
+                    )
                 ],
                 "last_name": [
-                    TableColumnDep(asset_key=AssetKey(["raw_customers"]), column_name="last_name")
+                    TableColumnDep(
+                        asset_key=AssetKey(["raw_source_customers"]), column_name="last_name"
+                    )
                 ],
             }
         ),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/sources.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/sources.yml
@@ -1,0 +1,10 @@
+version: 2
+
+sources:
+  - name: jaffle_shop
+    schema: main
+    tables:
+      - name: raw_customers
+        meta:
+          dagster:
+            asset_key: ["raw_source_customers"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/staging/stg_customers.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/staging/stg_customers.sql
@@ -4,7 +4,7 @@ with source as (
     Normally we would select from the table here, but we are using seeds to load
     our data in this project
     #}
-    select * from {{ ref('raw_customers') }}
+    select * from {{ source('jaffle_shop', 'raw_customers') }}
 
 ),
 

--- a/python_modules/libraries/dagster-dbt/dbt_packages/dagster/macros/log_column_level_metadata.sql
+++ b/python_modules/libraries/dagster-dbt/dbt_packages/dagster/macros/log_column_level_metadata.sql
@@ -17,13 +17,14 @@
         {%- set parent_relations = [] -%}
 
         {%- for ref_args in model.refs -%}
-            {%- set ref_relation = ref(ref_args['name'], package=ref_args.get('package'), version=ref_args.get('version'))-%}
+            {%- set ref_relation = ref(ref_args['name'], package=ref_args.get('package'), version=ref_args.get('version')) -%}
             {%- set _ = parent_relations.append(ref_relation) -%}
         {%- endfor -%}
 
         {%- for source_args in model.sources -%}
-            {%- set source_relation = source(source_args[0], sources_args[1])-%}
-            {%- set _ = parent_relations.append(ref_relation) -%}
+            {%- set source_name, table_name = source_args -%}
+            {%- set source_relation = source(source_name, table_name) -%}
+            {%- set _ = parent_relations.append(source_relation) -%}
         {%- endfor -%}
 
         -- Return a structured log of


### PR DESCRIPTION
## Summary & Motivation
Retrieving the schema for dbt sources to input into `sqlglot` for column lineage was untested. As a result, a syntax error in the `log_column_level_metadata` macro went through.

Fix that, and add an explicit test where we compute lineage properly, when a dbt source is present and is an upstream reference to a model.

## How I Tested These Changes
pytest
