### PR TITLE
Make check.inst() perform type-narrowing

### DIFF
--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -967,6 +967,21 @@ def two_dim_mapping_param(
 
 
 # ########################
+# ##### NARROW
+# ########################
+
+
+def narrow(
+    obj: object,
+    ttype: Union[Type[T], Tuple[Type[T], ...]],
+    additional_message: Optional[str] = None,
+) -> T:
+    if not isinstance(obj, ttype):
+        raise _type_mismatch_error(obj, ttype, additional_message)
+    return obj
+
+
+# ########################
 # ##### NOT NONE
 # ########################
 

--- a/python_modules/dagster/dagster/_config/field.py
+++ b/python_modules/dagster/dagster/_config/field.py
@@ -305,7 +305,7 @@ class Field:
                         "into of a config enum type {name}. You must pass in the underlying "
                         "string represention as the default value. One of {value_set}."
                     ).format(
-                        value_set=[ev.config_value for ev in self.config_type.enum_values],
+                        value_set=[ev.config_value for ev in self.config_type.enum_values],  # type: ignore
                         name=self.config_type.given_name,
                     )
                 )

--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -446,7 +446,7 @@ class AssetGraphView:
 
         @property
         def tw_partition_def(self) -> TimeWindowPartitionsDefinition:
-            return check.narrow(
+            return check.inst(
                 self.tw_dim.partitions_def,
                 TimeWindowPartitionsDefinition,
             )
@@ -456,7 +456,7 @@ class AssetGraphView:
             return self.secondary_dim.partitions_def
 
     def _get_multi_dim_info(self, asset_key: AssetKey) -> "MultiDimInfo":
-        partitions_def = check.narrow(
+        partitions_def = check.inst(
             self._get_partitions_def(asset_key),
             MultiPartitionsDefinition,
         )
@@ -494,4 +494,4 @@ class AssetGraphView:
 def _required_tw_partitions_def(
     partitions_def: Optional["PartitionsDefinition"],
 ) -> TimeWindowPartitionsDefinition:
-    return check.narrow(partitions_def, TimeWindowPartitionsDefinition, "Must be time windowed.")
+    return check.inst(partitions_def, TimeWindowPartitionsDefinition, "Must be time windowed.")

--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -7,7 +7,6 @@ from typing import (
     NewType,
     Optional,
     Sequence,
-    cast,
 )
 
 from dagster import _check as check
@@ -447,9 +446,9 @@ class AssetGraphView:
 
         @property
         def tw_partition_def(self) -> TimeWindowPartitionsDefinition:
-            return cast(
+            return check.narrow(
+                self.tw_dim.partitions_def,
                 TimeWindowPartitionsDefinition,
-                check.inst(self.tw_dim.partitions_def, TimeWindowPartitionsDefinition),
             )
 
         @property
@@ -457,9 +456,9 @@ class AssetGraphView:
             return self.secondary_dim.partitions_def
 
     def _get_multi_dim_info(self, asset_key: AssetKey) -> "MultiDimInfo":
-        partitions_def = cast(
+        partitions_def = check.narrow(
+            self._get_partitions_def(asset_key),
             MultiPartitionsDefinition,
-            check.inst(self._get_partitions_def(asset_key), MultiPartitionsDefinition),
         )
         return self.MultiDimInfo(
             tw_dim=partitions_def.time_window_dimension,
@@ -495,7 +494,4 @@ class AssetGraphView:
 def _required_tw_partitions_def(
     partitions_def: Optional["PartitionsDefinition"],
 ) -> TimeWindowPartitionsDefinition:
-    return cast(
-        TimeWindowPartitionsDefinition,
-        check.inst(partitions_def, TimeWindowPartitionsDefinition, "Must be time windowed."),
-    )
+    return check.narrow(partitions_def, TimeWindowPartitionsDefinition, "Must be time windowed.")


### PR DESCRIPTION
## Summary & Motivation

Make `check.inst` derive the returned type from the passed-in type to runtime-check, thereby performing type-narrowing. This did not used to be possible but improvements to type variable resolution in later versions of pyright support it.

## How I Tested These Changes

Converted a few instances that were both casting and `check.inst`-ing to use `check.narrow`.

Upstack I convert more `cast` instances.