### PR TITLE
feat(dbt): add `schedule_name` to `build_schedule_from_dbt_selection`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -240,6 +240,7 @@ def build_schedule_from_dbt_selection(
     cron_schedule: str,
     dbt_select: str = "fqn:*",
     dbt_exclude: Optional[str] = None,
+    schedule_name: Optional[str] = None,
     tags: Optional[Mapping[str, str]] = None,
     config: Optional[RunConfig] = None,
     execution_timezone: Optional[str] = None,
@@ -255,6 +256,7 @@ def build_schedule_from_dbt_selection(
         cron_schedule (str): The cron schedule to define the schedule.
         dbt_select (str): A dbt selection string to specify a set of dbt resources.
         dbt_exclude (Optional[str]): A dbt selection string to exclude a set of dbt resources.
+        schedule_name (Optional[str]): The name of the dbt schedule to create.
         tags (Optional[Mapping[str, str]]): A dictionary of tags (string key-value pairs) to attach
             to the scheduled runs.
         config (Optional[RunConfig]): The config that parameterizes the execution of this schedule.
@@ -282,6 +284,7 @@ def build_schedule_from_dbt_selection(
             )
     """
     return ScheduleDefinition(
+        name=schedule_name,
         cron_schedule=cron_schedule,
         job=define_asset_job(
             name=job_name,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_schedules.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_schedules.py
@@ -12,6 +12,7 @@ from dagster_dbt import DbtManifestAssetSelection, build_schedule_from_dbt_selec
         "cron_schedule",
         "dbt_select",
         "dbt_exclude",
+        "schedule_name",
         "tags",
         "config",
         "execution_timezone",
@@ -26,6 +27,7 @@ from dagster_dbt import DbtManifestAssetSelection, build_schedule_from_dbt_selec
             None,
             None,
             None,
+            None,
             DefaultScheduleStatus.STOPPED,
         ),
         (
@@ -33,6 +35,7 @@ from dagster_dbt import DbtManifestAssetSelection, build_schedule_from_dbt_selec
             "0 * * * *",
             "fqn:*",
             "fqn:staging.*",
+            "my_custom_schedule",
             {"my": "tag"},
             RunConfig(ops={"my_op": {"config": "value"}}),
             "America/Vancouver",
@@ -46,6 +49,7 @@ def test_dbt_build_schedule(
     cron_schedule: str,
     dbt_select: str,
     dbt_exclude: Optional[str],
+    schedule_name: Optional[str],
     tags: Optional[Mapping[str, str]],
     config: Optional[RunConfig],
     execution_timezone: Optional[str],
@@ -59,6 +63,7 @@ def test_dbt_build_schedule(
         job_name=job_name,
         cron_schedule=cron_schedule,
         dbt_select=dbt_select,
+        schedule_name=schedule_name,
         dbt_exclude=dbt_exclude,
         tags=tags,
         config=config,
@@ -66,7 +71,7 @@ def test_dbt_build_schedule(
         default_status=default_status,
     )
 
-    assert test_daily_schedule.name == f"{job_name}_schedule"
+    assert test_daily_schedule.name == schedule_name or f"{job_name}_schedule"
     assert test_daily_schedule.job.name == job_name
     assert test_daily_schedule.execution_timezone == execution_timezone
     assert test_daily_schedule.default_status == default_status


### PR DESCRIPTION
## Summary & Motivation
Users cannot apply the function [`dagster_dbt.build_schedule_from_dbt_selection()`](https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py#L237) if they want to name the resulted schedule anything other than the name of the job plus “_schedule” (i.e. the default of [ScheduleDefinition](https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/_core/definitions/schedule_definition.py#L484)).

## How I Tested These Changes
First, I used the argument `schedule_name` to create an original name for a dbt asset schedule using the adjusted function [`dagster_dbt.build_schedule_from_dbt_selection()`](https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py#L237). Secondly, I tried the function without the argument `schedule_name` to test whether the dbt asset schedule is created using the default job name plus “_schedule”. 