### PR TITLE
Allow custom job namespace for user code deployments

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -130,7 +130,7 @@ DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP: "{{ template "dagster.fullname" . }}-pip
     {{- if .schedulerName }}
     scheduler_name: {{ .schedulerName }}
     {{- end }}
-    namespace: {{ .values.jobNamespace | default $.Release.Namespace }}
+    namespace: {{ .Values.jobNamespace | default $.Release.Namespace }}
     service_account_name: {{ include "dagsterUserDeployments.serviceAccountName" $ }}
     {{- if and (.env) (kindIs "slice" .env) }}
     env: {{- .env | toYaml | nindent 6 }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -130,7 +130,7 @@ DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP: "{{ template "dagster.fullname" . }}-pip
     {{- if .schedulerName }}
     scheduler_name: {{ .schedulerName }}
     {{- end }}
-    namespace: {{ $.Release.Namespace }}
+    namespace: {{ .values.jobNamespace | default $.Release.Namespace }}
     service_account_name: {{ include "dagsterUserDeployments.serviceAccountName" $ }}
     {{- if and (.env) (kindIs "slice" .env) }}
     env: {{- .env | toYaml | nindent 6 }}


### PR DESCRIPTION
## Summary & Motivation

I needed the ability to set job namespace differently from the deployed namespace for deployments with argoCD. The namespace argoCD generally works with is the argocd namespace. I'd like to keep the argocd namespace, but give the jobs runs a namespace
that is in line with the deployment namespace

## How I Tested These Changes

I deployed with these changes to kubernetes with and without Values.jobNamespace set. When Values.jobNamespace is set the value for jobs is set to that value, instead of Release.Namespace value. But set to Release.Namespace if Values.jobNamespace is not set, like in any previous deployments. Making these changes backwards compatible.