### PR TITLE
chore(vscode): add default configuration for editor settings and debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,7 +112,6 @@ tags
 
 docs/_build
 python_modules/dagster/docs/_build
-.vscode/
 
 dagit_run_logs
 

--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -1,0 +1,7 @@
+*
+!.gitignore
+!extensions.json
+!README.md
+!settings.json.default
+!launch.json.default
+!tasks.json.default

--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -1,0 +1,27 @@
+# VS Code editor settings
+
+If you use VS Code, we recommend the following configuration:
+
+## Step 1: Install the recommended extensions
+
+The [recommended extensions](.vscode/extensions.json) will automatically show up when browsing
+extensions for your editor. Install them.
+
+See [VS Code's documentation on recommended extensions](https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions)
+to add new extensions to the recommended list.
+
+## Step 2: Enable the default editor settings
+
+The recommended editor settings, [`settings.json.default`](.vscode/settings.json.default), are not enabled by default. To
+enable the default settings, copy the file to `.vscode/settings.json` to enable them for this
+repository. These settings will override any existing user or workspace settings you have already
+configured.
+
+If you already have existing settings, you can instead copy specific configuration from the
+recommended editor settings to your user or workspace settings.
+
+See the [settings precedence](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence) for more details.
+
+Likewise, the recommended debugger entrypoints, [`launch.json.default`](.vscode/launch.json.default)
+and [`tasks.json.default`](.vscode/tasks.json.default), are not enabled by default. To enable the
+default, copy these files to `.vscode/launch.json` and `.vscode/tasks.json`.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,30 @@
+{
+  "recommendations": [
+    /// Python development
+    // https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff
+    "charliermarsh.ruff",
+
+    // https://marketplace.visualstudio.com/items?itemName=ms-python.python
+    "ms-python.python",
+
+    // https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance
+    "ms-python.vscode-pylance",
+
+    /// Typescript development
+    // https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
+    "dbaeumer.vscode-eslint",
+
+    // https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode
+    "esbenp.prettier-vscode",
+
+    // https://marketplace.visualstudio.com/items?itemName=graphql.vscode-graphql
+    "graphql.vscode-graphql",
+
+    /// General development
+    // https://marketplace.visualstudio.com/items?itemName=github.copilot
+    "github.copilot",
+
+    // https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens
+    "eamodio.gitlens"
+  ]
+}

--- a/.vscode/launch.json.default
+++ b/.vscode/launch.json.default
@@ -1,0 +1,56 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Dagster Backend",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "dagster",
+      "args": ["dev"],
+      "env": {},
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}",
+      "justMyCode": false,
+      "preLaunchTask": "Open Dagster",
+      "presentation": {
+        "group": "1_dagster"
+      }
+    },
+    {
+      "name": "Dagster Frontend",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["start"],
+      "cwd": "${workspaceFolder}/js_modules/dagster-ui",
+      "console": "integratedTerminal",
+      "env": {
+        "NEXT_PUBLIC_BACKEND_ORIGIN": "http://127.0.0.1:3000"
+      },
+      "preLaunchTask": "Generate Dagster GraphQL Schema",
+      "presentation": {
+        "group": "1_dagster"
+      }
+    },
+    {
+      "name": "Pytest",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["${file}::${selectedText}"],
+      "presentation": {
+        "group": "0_development_mode"
+      }
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Dagster (Launch All)",
+      "configurations": ["Dagster Frontend", "Dagster Backend"],
+      "stopAll": true,
+      "presentation": {
+        "group": "0_development_mode"
+      }
+    }
+  ]
+}

--- a/.vscode/settings.json.default
+++ b/.vscode/settings.json.default
@@ -1,0 +1,62 @@
+{
+  /// Autofix violations on-save.
+  // https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff
+  // Set this to be the path to your ruff executable, e.g.
+  //
+  // ```bash
+  // which ruff
+  // ```
+  //
+  "ruff.path": [],
+
+  // Set this to be the path to your python interpreter, e.g.
+  //
+  // ```bash
+  // pyenv which python
+  // ```
+  //
+  "ruff.interpreter": [],
+
+  // Format code on-save.
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.ruff": "explicit",
+      "source.organizeImports.ruff": "explicit"
+    }
+  },
+
+  /// Configure linting.
+  // https://code.visualstudio.com/docs/python/linting#_general-linting-settings
+  "python.linting.enabled": true,
+  "python.linting.lintOnSave": true,
+  "python.linting.pylintEnabled": false,
+  "python.linting.mypyEnabled": true,
+
+  /// Configure code analysis.
+  // https://code.visualstudio.com/docs/python/settings-reference#_code-analysis-settings
+  "python.languageServer": "Pylance",
+  "python.analysis.indexing": true,
+  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.autoImportCompletions": true,
+  "python.analysis.completeFunctionParens": true,
+  "python.analysis.inlayHints.variableTypes": true,
+  "python.analysis.inlayHints.functionReturnTypes": false,
+
+  /// Configuration for front-end.
+  // https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
+  "[javascript][typescript][typescriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit",
+      "source.organizeImports.eslint": "explicit",
+      "source.removeUnusedImports": "explicit"
+    }
+  },
+  "[json][jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  }
+}

--- a/.vscode/tasks.json.default
+++ b/.vscode/tasks.json.default
@@ -1,0 +1,24 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Generate Dagster GraphQL Schema",
+      "type": "shell",
+      "command": "yarn workspace @dagster-io/ui-core generate-graphql",
+      "options": {
+        "cwd": "${workspaceFolder}/js_modules/dagster-ui"
+      },
+      "presentation": {
+        "reveal": "silent"
+      }
+    },
+    {
+      "label": "Open Dagster",
+      "type": "shell",
+      "command": "while ! nc -z localhost 3000; do sleep 0.1; done; open http://localhost:3000",
+      "presentation": {
+        "reveal": "silent"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary & Motivation
Been very overdue to have this! Here, we add some recommended settings for folks who are developing on the Dagster framework (backend/frontend) on VS Code.

Also allows two nice workflows for debugging:
- A one stop shop command to setup the Dagster backend/frontend locally with debugging capabilities, and automatically opens the terminal up to localhost:3000.
- You can now highlight a pytest function name that you want to debug and go straight to debugging that test, without needing to manually change the configuration of `launch.json`. `launch.json` will just read your highlighted cursor.

I recommend setting the following keybinding so that you have access to any of these workflows whenever you need:

```json
  {
    "key": "shift+cmd+0",
    "command": "workbench.action.debug.selectandstart"
  },
```

## How I Tested These Changes
local
