### PR TITLE
chore: remove `yamllint`

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,7 +1,0 @@
----
-extends: default
-
-rules:
-  comments-indentation: disable
-  line-length:
-    max: 130


### PR DESCRIPTION
## Summary & Motivation
As the title. We use prettier for this now.

## How I Tested These Changes
see bk pass
