### PR TITLE
replace "__dagster_no_value" with the empty string

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/tagAsString.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/tagAsString.ts
@@ -1,7 +1,5 @@
-const TAG_NO_VALUE_SENTINEL = '__dagster_no_value';
-
 export const buildTagString = ({key, value}: {key: string; value: string}) => {
-  if (value === TAG_NO_VALUE_SENTINEL) {
+  if (value === '') {
     return key;
   }
   return `${key}: ${value}`;

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -574,7 +574,6 @@ from dagster._core.storage.partition_status_cache import (
 from dagster._core.storage.tags import (
     MAX_RUNTIME_SECONDS_TAG as MAX_RUNTIME_SECONDS_TAG,
     MEMOIZED_RUN_TAG as MEMOIZED_RUN_TAG,
-    TAG_NO_VALUE as TAG_NO_VALUE,
 )
 from dagster._core.storage.upath_io_manager import UPathIOManager as UPathIOManager
 from dagster._core.types.config_schema import (

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -17,7 +17,6 @@ from dagster._core.selector.subset_selector import (
     fetch_sources,
     parse_clause,
 )
-from dagster._core.storage.tags import TAG_NO_VALUE
 from dagster._model import DagsterModel
 from dagster._serdes.serdes import whitelist_for_serdes
 
@@ -197,9 +196,7 @@ class AssetSelection(ABC, DagsterModel):
         """
         split_by_equals_segments = string.split("=")
         if len(split_by_equals_segments) == 1:
-            return TagAssetSelection(
-                key=string, value=TAG_NO_VALUE, include_sources=include_sources
-            )
+            return TagAssetSelection(key=string, value="", include_sources=include_sources)
         elif len(split_by_equals_segments) == 2:
             key, value = split_by_equals_segments
             return TagAssetSelection(key=key, value=value, include_sources=include_sources)

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -85,9 +85,6 @@ USER_EDITABLE_SYSTEM_TAGS = [
 ]
 
 
-TAG_NO_VALUE = "__dagster_no_value"
-
-
 class TagType(Enum):
     # Custom tag provided by a user
     USER_PROVIDED = "USER_PROVIDED"

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -43,7 +43,6 @@ from dagster._core.definitions.asset_selection import (
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.events import AssetKey
-from dagster._core.storage.tags import TAG_NO_VALUE
 from dagster._serdes import deserialize_value
 from dagster._serdes.serdes import _WHITELIST_MAP
 from pydantic import ValidationError
@@ -712,7 +711,7 @@ def test_deserialize_old_all_asset_selection():
 
 def test_from_string_tag():
     assert AssetSelection.from_string("tag:foo=bar") == AssetSelection.tag("foo", "bar")
-    assert AssetSelection.from_string("tag:foo") == AssetSelection.tag("foo", TAG_NO_VALUE)
+    assert AssetSelection.from_string("tag:foo") == AssetSelection.tag("foo", "")
 
 
 def test_tag():
@@ -738,8 +737,8 @@ def test_tag_string():
             AssetSpec("asset2", tags={"foo": "fooval2"}),
             AssetSpec("asset3", tags={"foo": "fooval", "bar": "barval"}),
             AssetSpec("asset4", tags={"bar": "barval"}),
-            AssetSpec("asset5", tags={"baz": TAG_NO_VALUE}),
-            AssetSpec("asset6", tags={"baz": TAG_NO_VALUE, "bar": "barval"}),
+            AssetSpec("asset5", tags={"baz": ""}),
+            AssetSpec("asset6", tags={"baz": "", "bar": "barval"}),
         ]
     )
     def assets(): ...

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -14,7 +14,6 @@ from dagster._core.definitions.asset_key import (
     check_opt_coercible_to_asset_key_prefix_param,
 )
 from dagster._core.definitions.utils import is_valid_definition_tag_key
-from dagster._core.storage.tags import TAG_NO_VALUE
 
 from .asset_utils import (
     default_asset_key_fn,
@@ -250,7 +249,7 @@ class DagsterDbtTranslator:
                         return {"custom": "tag"}
         """
         tags = dbt_resource_props.get("tags", [])
-        return {tag: TAG_NO_VALUE for tag in tags if is_valid_definition_tag_key(tag)}
+        return {tag: "" for tag in tags if is_valid_definition_tag_key(tag)}
 
     @public
     def get_group_name(self, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -23,7 +23,6 @@ from dagster import (
 )
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster._core.execution.context.compute import AssetExecutionContext
-from dagster._core.storage.tags import TAG_NO_VALUE
 from dagster._core.types.dagster_type import DagsterType
 from dagster_dbt.asset_decorator import DUPLICATE_ASSET_KEY_ERROR_MESSAGE, dbt_assets
 from dagster_dbt.core.resources_v2 import DbtCliResource
@@ -623,10 +622,7 @@ def test_dbt_config_tags(test_meta_config_manifest: Dict[str, Any]) -> None:
     @dbt_assets(manifest=test_meta_config_manifest)
     def my_dbt_assets(): ...
 
-    assert my_dbt_assets.tags_by_key[AssetKey("customers")] == {
-        "foo": TAG_NO_VALUE,
-        "bar-baz": TAG_NO_VALUE,
-    }
+    assert my_dbt_assets.tags_by_key[AssetKey("customers")] == {"foo": "", "bar-baz": ""}
     for asset_key in my_dbt_assets.keys - {AssetKey("customers")}:
         assert my_dbt_assets.tags_by_key[asset_key] == {}
 


### PR DESCRIPTION
## Summary & Motivation

I'm not 100% convinced this is the right direction, but this PR is meant move forward the discussion from this slack thread: https://dagsterlabs.slack.com/archives/C04PD3G2F7H/p1711139737671339.  

It makes the case for replacing "__dagster_no_value" with the empty string.

Why the empty string vs. `None` or `True`? A couple main reasons:
- Avoids backcompat issues from expanding the set of types tags can have
- More straightforward to build UI for inputting
- Docs come out simplest


### Avoids backcompat issues from expanding the set of types tags can have

- Ideally, we'd like to have a single way of handling tags across the system, i.e. run tags and op tags should work the same as asset tags.
- Run tag and op tag values are currently strings (dicts can be supplied to tags arguments, but they're coerced to strings).
- Supporting non-string run & op tag values would be a breaking change, because public methods like OpDefinition.tags would be able to return a different type.

### More straightforward to build UI for inputting

We currently have the ability to run tags in the UI, and we'll probably want to expand this in the future to asset tags at some point.

<img width="732" alt="image" src="https://github.com/dagster-io/dagster/assets/654855/559f30c9-fad5-43c1-ae3b-4b594de4e6d0">

If `True` or `None` have special meaning, then we need to worry about users' expectations when they input those strings directly. I suspect there will be a non-negligible set of users who input tags both in the UI and in code.

### Docs come out the simplest

'Tags are key/value pairs, where the keys are strings and the values are either strings or boolean `True`/`False`. When a tag’s value is True, only the key will be shown in the UI. E.g. `{"PII": True}` will render as just “PII”. When the value is False, the tag will be ignored.'

vs.

'Tags are key/value pairs of strings. If a tag’s value is the empty string, only the key will be shown in the UI. E.g. `{"PII": ""}` will render as just “PII”.'
