### PR TITLE
Push back ExpectationResult breaking version

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -417,8 +417,8 @@ class AssetMaterialization(
 
 
 @deprecated(
-    breaking_version="1.7",
-    additional_warn_text="Please use AssetCheckResult and @asset_check instead.",
+    breaking_version="2.0",
+    additional_warn_text="If using assets, use AssetCheckResult and @asset_check instead.",
 )
 @whitelist_for_serdes(
     storage_field_names={"metadata": "metadata_entries"},

--- a/python_modules/dagster/dagster_tests/execution_tests/test_expectations.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_expectations.py
@@ -92,5 +92,5 @@ def test_expectation_result_deprecated() -> None:
     assert is_deprecated(ExpectationResult)
     assert (
         get_deprecated_info(ExpectationResult).additional_warn_text
-        == "Please use AssetCheckResult and @asset_check instead."
+        == "If using assets, use AssetCheckResult and @asset_check instead."
     )


### PR DESCRIPTION
We still have active users of this on Op jobs. We're not planning to break them in 1.7.