### PR TITLE
remove key from asset details overview sidebar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -179,10 +179,6 @@ export const AssetNodeOverview = ({
 
   const renderDefinitionSection = () => (
     <Box flex={{direction: 'column', gap: 12}}>
-      <AttributeAndValue label="Key">
-        <MiddleTruncate text={displayNameForAssetKey(assetNode.assetKey)} />
-      </AttributeAndValue>
-
       <AttributeAndValue label="Group">
         <Tag icon="asset_group">
           <Link to={workspacePathFromAddress(repoAddress, `/asset-groups/${assetNode.groupName}`)}>


### PR DESCRIPTION
## Summary & Motivation

It's already shown at the top of the page. When in doubt, less is more!

State before this PR:
![image](https://github.com/dagster-io/dagster/assets/654855/c47e731d-ca50-4bcd-8f00-d056d33bda16)


## How I Tested These Changes
