### PR TITLE
Catalog mode feedback...

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/RoundedButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/RoundedButton.tsx
@@ -13,11 +13,15 @@ export const RoundedButton = styled.button`
   height: 32px;
   text-align: left;
   display: block;
-  padding: 0 8px 0 4px;
+  padding: 0 8px;
   user-select: none;
 
   &:focus,
   &:active {
     outline: none;
+  }
+
+  &:hover {
+    background-color: ${Colors.navButtonHover()};
   }
 `;


### PR DESCRIPTION
## Summary & Motivation

- Catalog mode pill needs 4px of padding on the left
- Can we add the same hover effect on the Catalog mode pill as the deployment dropdown pill?

Both of the above come from RoundedButton

## How I Tested These Changes

Locally with shadow dagit