### PR TITLE
[ui] Rename asset catalog / overview files

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/src/InjectedComponents.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/InjectedComponents.tsx
@@ -1,7 +1,7 @@
 import {AppTopNavRightOfLogo} from '@dagster-io/ui-core/app/AppTopNav/AppTopNavRightOfLogo.oss';
 import {InjectedComponentContext} from '@dagster-io/ui-core/app/InjectedComponentContext';
 import {UserPreferences} from '@dagster-io/ui-core/app/UserSettingsDialog/UserPreferences.oss';
-import AssetsCatalogRoot from '@dagster-io/ui-core/assets/AssetsCatalogRoot';
+import AssetsOverviewRoot from '@dagster-io/ui-core/assets/AssetsOverviewRoot';
 
 export const InjectedComponents = ({children}: {children: React.ReactNode}) => {
   return (
@@ -9,7 +9,7 @@ export const InjectedComponents = ({children}: {children: React.ReactNode}) => {
       value={{
         AppTopNavRightOfLogo,
         UserPreferences,
-        AssetsOverview: AssetsCatalogRoot,
+        AssetsOverview: AssetsOverviewRoot,
       }}
     >
       {children}

--- a/js_modules/dagster-ui/packages/ui-core/src/app/InjectedComponentContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/InjectedComponentContext.tsx
@@ -3,7 +3,7 @@ import React, {useContext} from 'react';
 // import using type so that the actual file doesn't get bundled into Cloud if it's not imported directly by cloud.
 import type {AppTopNavRightOfLogo} from './AppTopNav/AppTopNavRightOfLogo.oss';
 import type {UserPreferences} from './UserSettingsDialog/UserPreferences.oss';
-import AssetsCatalogRoot from '../assets/AssetsCatalogRoot';
+import AssetsOverviewRoot from '../assets/AssetsOverviewRoot';
 
 type ComponentType = keyof React.JSX.IntrinsicElements | React.JSXElementConstructor<any>;
 type AComponentFromComponent<TComponent extends ComponentType> = AComponentWithProps<
@@ -18,7 +18,7 @@ type InjectedComponentContextType = {
   AppTopNavRightOfLogo: AComponentFromComponent<typeof AppTopNavRightOfLogo> | null;
   OverviewPageAlerts?: AComponentWithProps | null;
   UserPreferences?: AComponentFromComponent<typeof UserPreferences> | null;
-  AssetsOverview: AComponentFromComponent<typeof AssetsCatalogRoot> | null;
+  AssetsOverview: AComponentFromComponent<typeof AssetsOverviewRoot> | null;
 };
 export const InjectedComponentContext = React.createContext<InjectedComponentContextType>({
   AppTopNavRightOfLogo: null,

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/AppTopNav.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/AppTopNav.test.tsx
@@ -2,7 +2,7 @@ import {MockedProvider} from '@apollo/client/testing';
 import {render, screen} from '@testing-library/react';
 import {MemoryRouter} from 'react-router-dom';
 
-import AssetsCatalogRoot from '../../assets/AssetsCatalogRoot';
+import AssetsOverviewRoot from '../../assets/AssetsOverviewRoot';
 import {AppTopNav} from '../AppTopNav/AppTopNav';
 import {AppTopNavRightOfLogo} from '../AppTopNav/AppTopNavRightOfLogo.oss';
 import {InjectedComponentContext} from '../InjectedComponentContext';
@@ -16,7 +16,7 @@ describe('AppTopNav', () => {
   it('renders links and controls', async () => {
     render(
       <InjectedComponentContext.Provider
-        value={{AppTopNavRightOfLogo, AssetsOverview: AssetsCatalogRoot}}
+        value={{AppTopNavRightOfLogo, AssetsOverview: AssetsOverviewRoot}}
       >
         <MockedProvider>
           <MemoryRouter>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverviewRoot.tsx
@@ -11,16 +11,16 @@ import {AssetsCatalogTable} from './AssetsCatalogTable';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {AssetKey} from './types';
 import {
-  AssetsCatalogRootQuery,
-  AssetsCatalogRootQueryVariables,
-} from './types/AssetsCatalogRoot.types';
+  AssetsOverviewRootQuery,
+  AssetsOverviewRootQueryVariables,
+} from './types/AssetsOverviewRoot.types';
 import {useTrackPageView} from '../app/analytics';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {usePageLoadTrace} from '../performance';
 import {ReloadAllButton} from '../workspace/ReloadAllButton';
 
-export const AssetsCatalogRoot = ({
+export const AssetsOverviewRoot = ({
   writeAssetVisit,
   headerBreadcrumbs,
 }: {
@@ -36,8 +36,8 @@ export const AssetsCatalogRoot = ({
     .filter((x: string) => x)
     .map(decodeURIComponent);
 
-  const queryResult = useQuery<AssetsCatalogRootQuery, AssetsCatalogRootQueryVariables>(
-    ASSETS_CATALOG_ROOT_QUERY,
+  const queryResult = useQuery<AssetsOverviewRootQuery, AssetsOverviewRootQueryVariables>(
+    ASSETS_OVERVIEW_ROOT_QUERY,
     {
       skip: currentPath.length === 0,
       variables: {assetKey: {path: currentPath}},
@@ -51,7 +51,7 @@ export const AssetsCatalogRoot = ({
   );
 
   const trace = usePageLoadTrace(
-    currentPath && currentPath.length === 0 ? 'AssetsCatalogRoot' : 'AssetCatalogAssetView',
+    currentPath && currentPath.length === 0 ? 'AssetsOverviewRoot' : 'AssetCatalogAssetView',
   );
 
   React.useEffect(() => {
@@ -113,10 +113,10 @@ export const AssetsCatalogRoot = ({
 
 // Imported via React.lazy, which requires a default export.
 // eslint-disable-next-line import/no-default-export
-export default AssetsCatalogRoot;
+export default AssetsOverviewRoot;
 
-export const ASSETS_CATALOG_ROOT_QUERY = gql`
-  query AssetsCatalogRootQuery($assetKey: AssetKeyInput!) {
+export const ASSETS_OVERVIEW_ROOT_QUERY = gql`
+  query AssetsOverviewRootQuery($assetKey: AssetKeyInput!) {
     assetOrError(assetKey: $assetKey) {
       ... on Asset {
         id

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetsOverviewRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetsOverviewRoot.types.ts
@@ -2,11 +2,11 @@
 
 import * as Types from '../../graphql/types';
 
-export type AssetsCatalogRootQueryVariables = Types.Exact<{
+export type AssetsOverviewRootQueryVariables = Types.Exact<{
   assetKey: Types.AssetKeyInput;
 }>;
 
-export type AssetsCatalogRootQuery = {
+export type AssetsOverviewRootQuery = {
   __typename: 'Query';
   assetOrError:
     | {__typename: 'Asset'; id: string; key: {__typename: 'AssetKey'; path: Array<string>}}


### PR DESCRIPTION
Previously the new asset details page component was titled `AssetsCatalogRoot`, this PR renames it to `AssetsOverview` for clarity.