### PR TITLE
[ui] Bugfixes for asset tags

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -62,9 +62,9 @@ import {ScheduleOrSensorTag} from '../nav/ScheduleOrSensorTag';
 import {useRepositoryLocationForAddress} from '../nav/useRepositoryLocationForAddress';
 import {Description} from '../pipelines/Description';
 import {PipelineTag} from '../pipelines/PipelineReference';
+import {buildTagString} from '../ui/tagAsString';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
-import {buildTagString} from '../ui/tagAsString';
 
 export const AssetNodeOverview = ({
   assetNode,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -64,6 +64,7 @@ import {Description} from '../pipelines/Description';
 import {PipelineTag} from '../pipelines/PipelineReference';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
+import {buildTagString} from '../ui/tagAsString';
 
 export const AssetNodeOverview = ({
   assetNode,
@@ -231,9 +232,7 @@ export const AssetNodeOverview = ({
         {assetNode.tags && assetNode.tags.length > 0 && (
           <Box flex={{gap: 4, alignItems: 'center', wrap: 'wrap'}}>
             {assetNode.tags.map((tag, idx) => (
-              <Tag key={idx}>
-                {tag.key}={tag.value}
-              </Tag>
+              <Tag key={idx}>{buildTagString({key: tag.key, value: tag.value})}</Tag>
             ))}
           </Box>
         )}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useAssetTagFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useAssetTagFilter.tsx
@@ -37,7 +37,7 @@ export const useAssetTagFilter = ({
         />
       );
     },
-    getStringValue: ({value, key}) => `${value}: ${key}`,
+    getStringValue: ({value, key}) => `${key}: ${value}`,
     state: memoizedState ?? emptyArray,
     onStateChanged: (values) => {
       setTags?.(Array.from(values));
@@ -81,6 +81,6 @@ export function doesFilterArrayMatchValueArray<T, V>(
   return !filterArray.some(
     (filterTag) =>
       // If no asset tags match this filter tag return true
-      !valueArray.find((value) => !isMatch(filterTag, value)),
+      !valueArray.find((value) => isMatch(filterTag, value)),
   );
 }


### PR DESCRIPTION
Fixes a few bugs:

- Makes filter value display with `key: value` instead of `value: key`
- Removes an extra `!` operator to fix filtering
- Adjusts asset overview page to hide `__dagster_no_value` tag values

<img width="1278" alt="image" src="https://github.com/dagster-io/dagster/assets/29110579/fc15029a-88eb-4978-be01-e50c52f2422b">
<img width="1280" alt="image" src="https://github.com/dagster-io/dagster/assets/29110579/2aa51cbc-2566-4387-a9f6-2031c4ab7e52">
