### PR TITLE
Revert "Revert "Use dbt indirect selection with asset checks (#20568)" (#20720)"

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -175,7 +175,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             value_type=AssetKey,
         )
 
-        check.opt_mapping_param(
+        self._check_specs_by_output_name = check.opt_mapping_param(
             check_specs_by_output_name,
             "check_specs_by_output_name",
             key_type=str,
@@ -255,9 +255,6 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
                 # otherwise, use the selected checks
                 self._selected_asset_check_keys = selected_asset_check_keys
 
-        self._check_specs_by_output_name = {
-            name: spec for name, spec in (check_specs_by_output_name or {}).items()
-        }
         self._check_specs_by_key = {
             spec.key: spec
             for spec in self._check_specs_by_output_name.values()
@@ -1056,7 +1053,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         Returns:
             Iterable[AssetsCheckSpec]:
         """
-        return self._check_specs_by_output_name.values()
+        return self.check_specs_by_output_name.values()
 
     @property
     def check_keys(self) -> AbstractSet[AssetCheckKey]:
@@ -1305,7 +1302,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             is_subset=self.is_subset,
             check_specs_by_output_name=check_specs_by_output_name
             if check_specs_by_output_name
-            else self.check_specs_by_output_name,
+            else self._check_specs_by_output_name,
             selected_asset_check_keys=selected_asset_check_keys
             if selected_asset_check_keys
             else self._selected_asset_check_keys,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -145,14 +145,18 @@ def test_subset_with_checks():
 
     subbed = abc_.subset_for({a, b, c}, selected_asset_check_keys={check1, check2})
     assert subbed.check_specs_by_output_name == abc_.check_specs_by_output_name
+    assert len(subbed.check_specs_by_output_name) == 2
+    assert len(list(subbed.check_specs)) == 2
     assert subbed.node_check_specs_by_output_name == abc_.node_check_specs_by_output_name
 
     subbed = abc_.subset_for({a, b}, selected_asset_check_keys={check1})
     assert len(subbed.check_specs_by_output_name) == 1
+    assert len(list(subbed.check_specs)) == 1
     assert len(subbed.node_check_specs_by_output_name) == 2
 
     subbed_again = subbed.subset_for({a, b}, selected_asset_check_keys=set())
     assert len(subbed_again.check_specs_by_output_name) == 0
+    assert len(list(subbed_again.check_specs)) == 0
     assert len(subbed_again.node_check_specs_by_output_name) == 2
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -12,11 +12,12 @@ from dagster import (
     AssetsDefinition,
     AssetSelection,
     ExecuteInProcessResult,
+    build_asset_context,
     materialize,
 )
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.asset_defs import load_assets_from_dbt_manifest
-from dagster_dbt.core.resources_v2 import DbtCliResource
+from dagster_dbt.core.resources_v2 import DbtCliResource, get_subset_selection_for_context
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, DagsterDbtTranslatorSettings
 
 from ..dbt_projects import test_asset_checks_path
@@ -214,7 +215,7 @@ def test_with_asset_checks(
         raise_on_error=False,
     )
 
-    assert not result.get_asset_observation_events()
+    assert result.get_asset_observation_events()
     assert result.get_asset_check_evaluations()
 
 
@@ -286,6 +287,8 @@ def test_materialize_no_selection(
     assert not result.success  # fail_tests_model fails
     assert len(result.get_asset_materialization_events()) == 10
     assert len(result.get_asset_check_evaluations()) == 24
+    # one singular test
+    assert len(result.get_asset_observation_events()) == 1
 
 
 def test_materialize_asset_and_checks(
@@ -299,6 +302,33 @@ def test_materialize_asset_and_checks(
     assert result.success
     assert len(result.get_asset_materialization_events()) == 1
     assert len(result.get_asset_check_evaluations()) == 2
+    assert len(result.get_asset_observation_events()) == 5
+    # no tests were excluded, so we include singular and relationship tests
+    assert {
+        (e.asset_key, e.asset_observation_data.asset_observation.metadata.get("unique_id").value)  # type: ignore[attr-defined]
+        for e in result.get_asset_observation_events()
+    } == {
+        (
+            AssetKey(["customers"]),
+            "test.test_dagster_asset_checks.assert_singular_test_is_not_asset_check",
+        ),
+        (
+            AssetKey(["customers"]),
+            "test.test_dagster_asset_checks.relationships_with_duplicate_orders_ref_customers___customer_id__customer_id__ref_customers_.d9e47ca78e",
+        ),
+        (
+            AssetKey(["customers"]),
+            "test.test_dagster_asset_checks.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
+        ),
+        (
+            AssetKey(["orders"]),
+            "test.test_dagster_asset_checks.relationships_with_duplicate_orders_ref_customers___customer_id__customer_id__ref_customers_.d9e47ca78e",
+        ),
+        (
+            AssetKey(["orders"]),
+            "test.test_dagster_asset_checks.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
+        ),
+    }
 
 
 def test_materialize_asset_no_checks(
@@ -312,6 +342,8 @@ def test_materialize_asset_no_checks(
     assert result.success
     assert len(result.get_asset_materialization_events()) == 1
     assert len(result.get_asset_check_evaluations()) == 0
+    # since checks are exclued, we don't run the singular or relationship tests
+    assert len(result.get_asset_observation_events()) == 0
 
 
 def test_materialize_checks_no_asset(
@@ -328,6 +360,9 @@ def test_materialize_checks_no_asset(
     assert result.success
     assert len(result.get_asset_materialization_events()) == 0
     assert len(result.get_asset_check_evaluations()) == 2
+    # since we're not materializing the asset, we can't use indirect selection and therefore
+    # don't run the singular or relationship tests
+    assert len(result.get_asset_observation_events()) == 0
 
 
 def test_asset_checks_results(
@@ -442,3 +477,43 @@ def test_select_model_with_tests(
     assert result.success
     assert len(result.get_asset_materialization_events()) == 1
     assert len(result.get_asset_check_evaluations()) == 2
+    # no tests were excluded, so we include singular and relationship tests
+    assert len(result.get_asset_observation_events()) == 5
+    assert {
+        (e.asset_key, e.asset_observation_data.asset_observation.metadata.get("unique_id").value)  # type: ignore[attr-defined]
+        for e in result.get_asset_observation_events()
+    } == {
+        (
+            AssetKey(["customers"]),
+            "test.test_dagster_asset_checks.assert_singular_test_is_not_asset_check",
+        ),
+        (
+            AssetKey(["customers"]),
+            "test.test_dagster_asset_checks.relationships_with_duplicate_orders_ref_customers___customer_id__customer_id__ref_customers_.d9e47ca78e",
+        ),
+        (
+            AssetKey(["customers"]),
+            "test.test_dagster_asset_checks.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
+        ),
+        (
+            AssetKey(["orders"]),
+            "test.test_dagster_asset_checks.relationships_with_duplicate_orders_ref_customers___customer_id__customer_id__ref_customers_.d9e47ca78e",
+        ),
+        (
+            AssetKey(["orders"]),
+            "test.test_dagster_asset_checks.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
+        ),
+    }
+
+
+def _get_subset_selection(assets_def: AssetsDefinition, manifest: Dict[str, Any]):
+    context = build_asset_context().bind(
+        assets_def.op, None, assets_def, None, {"dbt": DbtCliResource}
+    )
+    return get_subset_selection_for_context(
+        context,
+        manifest,
+        "my_select_str",
+        "my_exclude_str",
+        dagster_dbt_translator_with_checks,
+    )


### PR DESCRIPTION
Try again with https://github.com/dagster-io/dagster/pull/20727 fixed

NO_SKIP

^ we'd catch the error this time