### PR TITLE
Don't subset node_check_specs_by_output_name

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -175,7 +175,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             value_type=AssetKey,
         )
 
-        check.opt_mapping_param(
+        self._check_specs_by_output_name = check.opt_mapping_param(
             check_specs_by_output_name,
             "check_specs_by_output_name",
             key_type=str,
@@ -255,9 +255,6 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
                 # otherwise, use the selected checks
                 self._selected_asset_check_keys = selected_asset_check_keys
 
-        self._check_specs_by_output_name = {
-            name: spec for name, spec in (check_specs_by_output_name or {}).items()
-        }
         self._check_specs_by_key = {
             spec.key: spec
             for spec in self._check_specs_by_output_name.values()
@@ -1056,7 +1053,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         Returns:
             Iterable[AssetsCheckSpec]:
         """
-        return self._check_specs_by_output_name.values()
+        return self.check_specs_by_output_name.values()
 
     @property
     def check_keys(self) -> AbstractSet[AssetCheckKey]:
@@ -1305,7 +1302,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             is_subset=self.is_subset,
             check_specs_by_output_name=check_specs_by_output_name
             if check_specs_by_output_name
-            else self.check_specs_by_output_name,
+            else self._check_specs_by_output_name,
             selected_asset_check_keys=selected_asset_check_keys
             if selected_asset_check_keys
             else self._selected_asset_check_keys,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -145,14 +145,18 @@ def test_subset_with_checks():
 
     subbed = abc_.subset_for({a, b, c}, selected_asset_check_keys={check1, check2})
     assert subbed.check_specs_by_output_name == abc_.check_specs_by_output_name
+    assert len(subbed.check_specs_by_output_name) == 2
+    assert len(list(subbed.check_specs)) == 2
     assert subbed.node_check_specs_by_output_name == abc_.node_check_specs_by_output_name
 
     subbed = abc_.subset_for({a, b}, selected_asset_check_keys={check1})
     assert len(subbed.check_specs_by_output_name) == 1
+    assert len(list(subbed.check_specs)) == 1
     assert len(subbed.node_check_specs_by_output_name) == 2
 
     subbed_again = subbed.subset_for({a, b}, selected_asset_check_keys=set())
     assert len(subbed_again.check_specs_by_output_name) == 0
+    assert len(list(subbed_again.check_specs)) == 0
     assert len(subbed_again.node_check_specs_by_output_name) == 2
 
 


### PR DESCRIPTION
https://github.com/dagster-io/dagster/pull/20591 separated out `node_check_specs_by_output_name` and `check_specs_by_output_name`, so that we could get the set of original asset keys. But the `with_attributes` fn would replace the former with the latter, so `node_check_specs_by_output_name` would get filtered down in subsets. 

https://github.com/dagster-io/dagster/pull/20568 fixed that, but didn't apply the fix to the `check_specs` property.

For reasons I haven't diagnosed, if `check_specs` doesn't get filtered down properly in subsets then we end up with a circular dependency in purina: https://buildkite.com/dagster/internal/builds/64778#018e779b-8828-4c24-8fb8-bc7eb6cbb1e3/913-965

Easy to get `self.check_specs_by_output_name` vs `self._check_specs_by_output_name` wrong- it's the pattern from `keys_by_output_name`. Maybe we should rename the private var for both.