### PR TITLE
docs(university): recommend generating manifest in static path

### DIFF
--- a/docs/dagster-university/pages/dagster-dbt/lesson-4/2-speeding-up-the-development-cycle.md
+++ b/docs/dagster-university/pages/dagster-dbt/lesson-4/2-speeding-up-the-development-cycle.md
@@ -16,25 +16,31 @@ Before we move on, we’ll reduce the number of steps in the feedback loop. We'l
 
 The first detail is that resources don’t need to be part of an asset to be executed. This means that once a `dbt_resource` is defined, you can use it to execute commands when your code location is being built. Rather than manually running `dbt parse`, let’s use the `dbt_resource` to run the command for us.
 
-In `dbt.py`, import the `dbt_resource` with:
+In `dbt.py`, import the `dbt_resource` and the `Path` class from the `pathlib` standard library   with:
 
 ```python
+from pathlib import Path
+
 from ..resources import dbt_resource
 ```
 
 Afterward, above your `dbt_manifest_path` declaration, add this snippet to run `dbt parse`:
 
 ```python
-dbt_resource.cli(["--quiet", "parse"]).wait()
+dbt_resource.cli(["--quiet", "parse"], target_path=Path("target")).wait()
 ```
 
-If you look at the dbt project’s `/target` directory, you’ll see a sub-folder in it that has what looks like a 7-character hash (ex. `821f148`). Every time a `DbtCliResource` executes a command, it stores the artifacts in a unique directory to prevent multiple dbt runs or processes from overwriting each other. This is great in many situations, but in our current one, it would make it a bit annoying to figure out which manifest to read from. Thankfully, the path to this folder can be retrieved by the return value of the `.wait()` call.
+If you look at the dbt project’s `/target` directory, you’ll see it stores the artifacts. To read from the generated manifest, you can retrieve the path to this folder from the return value of the `.wait()` call.
 
 Let’s define a new `dbt_manifest_path` that will always point to the `manifest.json` that was just created from this programmatic `dbt parse` command:
 
 ```python
 dbt_manifest_path = (
-    dbt_resource.cli(["--quiet", "parse"]).wait()
+    dbt_resource.cli(
+        ["--quiet", "parse"],
+        target_path=Path("target"),
+    )
+    .wait()
     .target_path.joinpath("manifest.json")
 )
 ```


### PR DESCRIPTION
## Summary & Motivation
Recommend to generate the dbt `manifest.json` in a static path for local development. This way, the `target/` folder isn't overwhelmed with folders of artifacts during local development -- unique paths should only be created when a Dagster run is invoked.

## How I Tested These Changes
eyes
