### PR TITLE
Update check.inst callsites to account for narrowing

### DIFF
--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -97,9 +97,8 @@ def _execute_run_command_body(
         f"Run with id '{run_id}' not found for run execution.",
     )
 
-    check.inst(
+    check.not_none(
         dagster_run.job_code_origin,
-        JobPythonOrigin,
         f"Run with id '{run_id}' does not include an origin.",
     )
 
@@ -193,9 +192,8 @@ def _resume_run_command_body(
         instance.get_run_by_id(run_id),  # type: ignore
         f"Run with id '{run_id}' not found for run execution.",
     )
-    check.inst(
+    check.not_none(
         dagster_run.job_code_origin,
-        JobPythonOrigin,
         f"Run with id '{run_id}' does not include an origin.",
     )
 
@@ -328,7 +326,10 @@ def execute_step_command(input_json, compressed_input_json):
         args = deserialize_value(input_json, ExecuteStepArgs)
 
         with get_instance_for_cli(instance_ref=args.instance_ref) as instance:
-            dagster_run = instance.get_run_by_id(args.run_id)
+            dagster_run = check.not_none(
+                instance.get_run_by_id(args.run_id),
+                f"Run with id '{args.run_id}' not found for step execution",
+            )
 
             buff = []
 
@@ -353,14 +354,8 @@ def _execute_step_command_body(
         else None
     )
     try:
-        check.inst(
-            dagster_run,
-            DagsterRun,
-            f"Run with id '{args.run_id}' not found for step execution",
-        )
-        check.inst(
+        check.not_none(
             dagster_run.job_code_origin,
-            JobPythonOrigin,
             f"Run with id '{args.run_id}' does not include an origin.",
         )
 

--- a/python_modules/dagster/dagster/_config/config_type.py
+++ b/python_modules/dagster/dagster/_config/config_type.py
@@ -431,9 +431,7 @@ class ScalarUnion(ConfigType):
     ):
         from .field import resolve_to_config_type
 
-        self.scalar_type = check.inst(
-            cast(ConfigType, resolve_to_config_type(scalar_type)), ConfigType
-        )
+        self.scalar_type = check.inst(resolve_to_config_type(scalar_type), ConfigType)
         self.non_scalar_type = resolve_to_config_type(non_scalar_schema)
 
         check.param_invariant(self.scalar_type.kind == ConfigTypeKind.SCALAR, "scalar_type")

--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -478,15 +478,12 @@ class ConfigurableResourceFactory(
 
         partial_resources_to_update: Dict[str, Any] = {}
         if self._nested_partial_resources:
-            context_with_mapping = cast(
+            context_with_mapping = check.inst(
+                context,
                 InitResourceContextWithKeyMapping,
-                check.inst(
-                    context,
-                    InitResourceContextWithKeyMapping,
-                    "This ConfiguredResource contains unresolved partially-specified nested"
-                    " resources, and so can only be initialized using a"
-                    " InitResourceContextWithKeyMapping",
-                ),
+                "This ConfiguredResource contains unresolved partially-specified nested"
+                " resources, and so can only be initialized using a"
+                " InitResourceContextWithKeyMapping",
             )
             partial_resources_to_update = {
                 attr_name: context_with_mapping.resources_by_id[id(resource)]

--- a/python_modules/dagster/dagster/_config/validate.py
+++ b/python_modules/dagster/dagster/_config/validate.py
@@ -55,8 +55,7 @@ def is_config_scalar_valid(config_type_snap: ConfigTypeSnap, config_value: objec
 
 
 def validate_config(config_schema: object, config_value: T) -> EvaluateValueResult[T]:
-    config_type = resolve_to_config_type(config_schema)
-    config_type = check.inst(cast(ConfigType, config_type), ConfigType)
+    config_type = check.inst(resolve_to_config_type(config_schema), ConfigType)
 
     return validate_config_from_snap(
         config_schema_snapshot=config_type.get_schema_snapshot(),

--- a/python_modules/dagster/dagster/_core/definitions/input.py
+++ b/python_modules/dagster/dagster/_core/definitions/input.py
@@ -114,7 +114,7 @@ class InputDefinition:
         self._name = check_valid_name(name, allow_list=["config"])
 
         self._type_not_set = dagster_type is None
-        self._dagster_type = check.inst(resolve_dagster_type(dagster_type), DagsterType)
+        self._dagster_type = resolve_dagster_type(dagster_type)
 
         self._description = check.opt_str_param(description, "description")
 

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -109,11 +109,15 @@ class ScheduleType(Enum):
         return {"HOURLY": 1, "DAILY": 2, "WEEKLY": 3, "MONTHLY": 4}[self.value]
 
     def __gt__(self, other: "ScheduleType") -> bool:
-        check.inst(other, ScheduleType, "Cannot compare ScheduleType with non-ScheduleType")
+        check.inst_param(
+            other, "other", ScheduleType, "Cannot compare ScheduleType with non-ScheduleType"
+        )
         return self.ordinal > other.ordinal
 
     def __lt__(self, other: "ScheduleType") -> bool:
-        check.inst(other, ScheduleType, "Cannot compare ScheduleType with non-ScheduleType")
+        check.inst_param(
+            other, "other", ScheduleType, "Cannot compare ScheduleType with non-ScheduleType"
+        )
         return self.ordinal < other.ordinal
 
 

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -888,10 +888,11 @@ class StaticPartitionMapping(
                 self._inverse_mapping[downstream_key].add(upstream_key)
 
     @cached_method
-    def _check_upstream(self, *, upstream_partitions_def: PartitionsDefinition):
+    def _check_upstream(self, *, upstream_partitions_def: StaticPartitionsDefinition):
         """Validate that the mapping from upstream to downstream is only defined on upstream keys."""
-        check.inst(
+        check.inst_param(
             upstream_partitions_def,
+            "upstream_partitions_def",
             StaticPartitionsDefinition,
             "StaticPartitionMapping can only be defined between two StaticPartitionsDefinitions",
         )
@@ -903,10 +904,11 @@ class StaticPartitionMapping(
             )
 
     @cached_method
-    def _check_downstream(self, *, downstream_partitions_def: PartitionsDefinition):
+    def _check_downstream(self, *, downstream_partitions_def: StaticPartitionsDefinition):
         """Validate that the mapping from upstream to downstream only maps to downstream keys."""
-        check.inst(
+        check.inst_param(
             downstream_partitions_def,
+            "downstream_partitions_def",
             StaticPartitionsDefinition,
             "StaticPartitionMapping can only be defined between two StaticPartitionsDefinitions",
         )
@@ -921,8 +923,8 @@ class StaticPartitionMapping(
     def get_downstream_partitions_for_partitions(
         self,
         upstream_partitions_subset: PartitionsSubset,
-        upstream_partitions_def: PartitionsDefinition,
-        downstream_partitions_def: PartitionsDefinition,
+        upstream_partitions_def: StaticPartitionsDefinition,
+        downstream_partitions_def: StaticPartitionsDefinition,
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> PartitionsSubset:
@@ -938,7 +940,7 @@ class StaticPartitionMapping(
         self,
         downstream_partitions_subset: Optional[PartitionsSubset],
         downstream_partitions_def: Optional[PartitionsDefinition],
-        upstream_partitions_def: PartitionsDefinition,
+        upstream_partitions_def: StaticPartitionsDefinition,
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> UpstreamPartitionsResult:

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -806,8 +806,7 @@ class SensorDefinition(IHasInternalInit):
         if not result or result == [None]:
             skip_message = "Sensor function returned an empty result"
         elif len(result) == 1:
-            item = result[0]
-            check.inst(item, (SkipReason, RunRequest, DagsterRunReaction, SensorResult))
+            item = check.inst(result[0], (SkipReason, RunRequest, DagsterRunReaction, SensorResult))
 
             if isinstance(item, SensorResult):
                 run_requests = list(item.run_requests) if item.run_requests else []

--- a/python_modules/dagster/dagster/_core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/active.py
@@ -305,7 +305,7 @@ class ActiveExecution:
 
     def get_step_by_key(self, step_key: str) -> ExecutionStep:
         step = self._plan.get_step_by_key(step_key)
-        return cast(ExecutionStep, check.inst(step, ExecutionStep))
+        return check.inst(step, ExecutionStep)
 
     def get_steps_to_execute(
         self,

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
@@ -102,10 +102,10 @@ def inner_plan_execution_iterator(
                         for step_event in check.generator(
                             dagster_event_sequence_for_step(step_context)
                         ):
-                            check.inst(step_event, DagsterEvent)
-                            step_event_list.append(step_event)
-                            yield step_event
-                            active_execution.handle_event(step_event)
+                            dagster_event = check.inst(step_event, DagsterEvent)
+                            step_event_list.append(dagster_event)
+                            yield dagster_event
+                            active_execution.handle_event(dagster_event)
 
                         active_execution.verify_complete(job_context, step.key)
 
@@ -121,10 +121,10 @@ def inner_plan_execution_iterator(
                         for step_event in check.generator(
                             dagster_event_sequence_for_step(step_context)
                         ):
-                            check.inst(step_event, DagsterEvent)
-                            step_event_list.append(step_event)
-                            yield step_event
-                            active_execution.handle_event(step_event)
+                            dagster_event = check.inst(step_event, DagsterEvent)
+                            step_event_list.append(dagster_event)
+                            yield dagster_event
+                            active_execution.handle_event(dagster_event)
 
                         active_execution.verify_complete(job_context, step.key)
 

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -749,7 +749,7 @@ class ExecutionPlan(
 
     def get_executable_step_by_key(self, key: str) -> ExecutionStep:
         step = self.get_step_by_key(key)
-        return cast(ExecutionStep, check.inst(step, ExecutionStep))
+        return check.inst(step, ExecutionStep)
 
     def get_all_steps_in_topo_order(self) -> Sequence[IExecutionStep]:
         return [step for step_level in self.get_all_steps_by_level() for step in step_level]
@@ -1126,11 +1126,8 @@ class ExecutionPlan(
             if step_snap.kind == StepKind.COMPUTE:
                 step: IExecutionStep = ExecutionStep(
                     check.inst(
-                        cast(
-                            Union[StepHandle, ResolvedFromDynamicStepHandle],
-                            step_snap.step_handle,
-                        ),
-                        ttype=(StepHandle, ResolvedFromDynamicStepHandle),
+                        step_snap.step_handle,
+                        (StepHandle, ResolvedFromDynamicStepHandle),
                     ),
                     job_name,
                     step_inputs,  # type: ignore  # (plain StepInput only)
@@ -1140,8 +1137,8 @@ class ExecutionPlan(
             elif step_snap.kind == StepKind.UNRESOLVED_MAPPED:
                 step = UnresolvedMappedExecutionStep(
                     check.inst(
-                        cast(UnresolvedStepHandle, step_snap.step_handle),
-                        ttype=UnresolvedStepHandle,
+                        step_snap.step_handle,
+                        UnresolvedStepHandle,
                     ),
                     job_name,
                     step_inputs,  # type: ignore  # (StepInput or UnresolvedMappedStepInput only)
@@ -1150,7 +1147,7 @@ class ExecutionPlan(
                 )
             elif step_snap.kind == StepKind.UNRESOLVED_COLLECT:
                 step = UnresolvedCollectExecutionStep(
-                    check.inst(cast(StepHandle, step_snap.step_handle), ttype=StepHandle),
+                    check.inst(step_snap.step_handle, StepHandle),
                     job_name,
                     step_inputs,  # type: ignore  # (StepInput or UnresolvedCollectStepInput only)
                     step_outputs,

--- a/python_modules/dagster/dagster/_core/execution/run_cancellation_thread.py
+++ b/python_modules/dagster/dagster/_core/execution/run_cancellation_thread.py
@@ -1,5 +1,5 @@
 import threading
-from typing import Tuple, cast
+from typing import Tuple
 
 import dagster._check as check
 from dagster._core.instance import DagsterInstance, InstanceRef
@@ -14,13 +14,10 @@ def _kill_on_cancel(instance_ref: InstanceRef, run_id, shutdown_event):
     with DagsterInstance.from_ref(instance_ref) as instance:
         while not shutdown_event.is_set():
             shutdown_event.wait(instance.cancellation_thread_poll_interval_seconds)
-            run = cast(
+            run = check.inst(
+                instance.get_run_by_id(run_id),
                 DagsterRun,
-                check.inst(
-                    instance.get_run_by_id(run_id),
-                    DagsterRun,
-                    "Run not found for cancellation thread",
-                ),
+                "Run not found for cancellation thread",
             )
             if run.status in [
                 DagsterRunStatus.CANCELING,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2592,7 +2592,6 @@ class DagsterInstance(DynamicPartitionsStore):
         Args:
             run_id (str): The id of the run.
         """
-        from dagster._core.remote_representation import ExternalJobOrigin
         from dagster._core.run_coordinator import SubmitRunContext
 
         run = self.get_run_by_id(run_id)
@@ -2601,14 +2600,12 @@ class DagsterInstance(DynamicPartitionsStore):
                 f"Could not load run {run_id} that was passed to submit_run"
             )
 
-        check.inst(
+        check.not_none(
             run.external_job_origin,
-            ExternalJobOrigin,
             "External pipeline origin must be set for submitted runs",
         )
-        check.inst(
+        check.not_none(
             run.job_code_origin,
-            JobPythonOrigin,
             "Python origin must be set for submitted runs",
         )
 

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -385,11 +385,9 @@ class DagsterRun(
         if status == DagsterRunStatus.QUEUED:
             # Placing this with the other imports causes a cyclic import
             # https://github.com/dagster-io/dagster/issues/3181
-            from dagster._core.remote_representation.origin import ExternalJobOrigin
 
-            check.inst(
+            check.not_none(
                 self.external_job_origin,
-                ExternalJobOrigin,
                 "external_pipeline_origin is required for queued runs",
             )
 

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -53,7 +53,6 @@ from dagster._core.events import DagsterEvent
 from dagster._core.instance import DagsterInstance
 from dagster._core.launcher import RunLauncher
 from dagster._core.remote_representation.origin import (
-    ExternalJobOrigin,
     InProcessCodeLocationOrigin,
 )
 from dagster._core.run_coordinator import RunCoordinator, SubmitRunContext
@@ -426,7 +425,7 @@ class MockedRunCoordinator(RunCoordinator, ConfigurableClass):
 
     def submit_run(self, context: SubmitRunContext):
         dagster_run = context.dagster_run
-        check.inst(dagster_run.external_job_origin, ExternalJobOrigin)
+        check.not_none(dagster_run.external_job_origin)
         self._queue.append(dagster_run)
         return dagster_run
 

--- a/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/executor.py
+++ b/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/executor.py
@@ -15,7 +15,6 @@ from dagster._cli.api import ExecuteStepArgs
 from dagster._core.events import EngineEventData
 from dagster._core.events.utils import filter_dagster_events_from_cli_logs
 from dagster._core.execution.retries import RetryMode
-from dagster._core.storage.dagster_run import DagsterRun
 from dagster._serdes import pack_value, serialize_value, unpack_value
 from dagster._utils.merger import merge_dicts
 from dagster_celery.config import DEFAULT_CONFIG, dict_wrapper
@@ -231,10 +230,8 @@ def create_docker_task(celery_app, **task_kwargs):
         check.dict_param(docker_config, "docker_config")
 
         instance = DagsterInstance.from_ref(execute_step_args.instance_ref)
-        dagster_run = instance.get_run_by_id(execute_step_args.run_id)
-        check.inst(
-            dagster_run,
-            DagsterRun,
+        dagster_run = check.not_none(
+            instance.get_run_by_id(execute_step_args.run_id),
             f"Could not load run {execute_step_args.run_id}",
         )
         step_keys_str = ", ".join(execute_step_args.step_keys_to_execute)

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -20,7 +20,7 @@ from dagster._core.events.log import EventLogEntry
 from dagster._core.events.utils import filter_dagster_events_from_cli_logs
 from dagster._core.execution.plan.objects import StepFailureData, UserFailureData
 from dagster._core.execution.retries import RetryMode
-from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
+from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._serdes import pack_value, serialize_value, unpack_value
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster_celery.config import DEFAULT_CONFIG, dict_wrapper
@@ -308,13 +308,11 @@ def create_k8s_job_task(celery_app, **task_kwargs):
 
         api_client = DagsterKubernetesClient.production_client()
         instance = DagsterInstance.from_ref(execute_step_args.instance_ref)
-        dagster_run = instance.get_run_by_id(execute_step_args.run_id)
-
-        check.inst(
-            dagster_run,
-            DagsterRun,
+        dagster_run = check.not_none(
+            instance.get_run_by_id(execute_step_args.run_id),
             f"Could not load run {execute_step_args.run_id}",
         )
+
         step_key = execute_step_args.step_keys_to_execute[0]
 
         celery_worker_name = self.request.hostname

--- a/python_modules/libraries/dagster-dask/dagster_dask/executor.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/executor.py
@@ -277,8 +277,7 @@ class DaskExecutor(Executor):
             # Allow interrupts while waiting for the results from Dask
             for future, result in iterate_with_context(raise_execution_interrupts, futures):
                 for step_event in result:
-                    check.inst(step_event, DagsterEvent)
-                    yield step_event
+                    yield check.inst(step_event, DagsterEvent)
 
     def build_dict(self, job_name):
         """Returns a dict we can use for kwargs passed to dask client instantiation.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -315,11 +315,8 @@ def _get_dbt_op(
         required_resource_keys={dbt_resource_key},
     )
     def _dbt_op(context: OpExecutionContext, config: DbtOpConfig):
-        dbt_resource: Union[DbtCliResource, DbtCliClient] = getattr(
-            context.resources, dbt_resource_key
-        )
-        check.inst(
-            dbt_resource,
+        dbt_resource = check.inst(
+            dbt_resource := getattr(context.resources, dbt_resource_key),
             (DbtCliResource, DbtCliClient),
             "Resource with key 'dbt_resource_key' must be a DbtCliResource or DbtCliClient"
             f" object, but is a {type(dbt_resource)}",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -8,7 +8,6 @@ from typing import (
     Optional,
     Sequence,
     Union,
-    cast,
 )
 
 import dateutil
@@ -183,7 +182,7 @@ def generate_events(
             manifest_json=manifest_json,
         ):
             yield check.inst(
-                cast(Union[AssetMaterialization, AssetObservation], event),
+                event,
                 (AssetMaterialization, AssetObservation),
             )
 
@@ -224,7 +223,7 @@ def generate_materializations(
             asset_key_prefix + info["unique_id"].split(".")
         ),
     ):
-        yield check.inst(cast(AssetMaterialization, event), AssetMaterialization)
+        yield check.inst(event, AssetMaterialization)
 
 
 def select_unique_ids_from_manifest(

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
@@ -125,7 +125,9 @@ def create_table_schema_metadata_from_dataframe(
     Returns:
         TableSchemaMetadataValue: returns an object with the TableSchema for the DataFrame.
     """
-    check.inst(pandas_df, pd.DataFrame, "Input must be a pandas DataFrame object")
+    check.inst_param(
+        pandas_df, "pandas_df", pd.DataFrame, "Input must be a pandas DataFrame object"
+    )
     return MetadataValue.table_schema(
         TableSchema(
             columns=[


### PR DESCRIPTION
## Summary & Motivation

Audit all `check.inst()` callsites in OSS and adjust them in light of the new narrowing behavior of `check.inst`.

- In some cases I was able to delete a now rendundant `cast()`
- In some cases `inst()` was used where `inst_param()` should've been. I replaced the call.
- In some cases `check.inst` was being used to do a non-null check, so I just changed it to `check.not_none`.
- In some cases, the `check.inst` call was unnecessary/rendundant so I deleted it.

## How I Tested These Changes

Existing test suite.