### PR TITLE
DagsterModel.model_copy

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -592,8 +592,8 @@ class AndAssetSelection(AssetSelection):
         )
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self.copy(
-            updates=dict(
+        return self.model_copy(
+            update=dict(
                 operands=[
                     operand.to_serializable_asset_selection(asset_graph)
                     for operand in self.operands
@@ -635,8 +635,8 @@ class OrAssetSelection(AssetSelection):
         )
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self.copy(
-            updates=dict(
+        return self.model_copy(
+            update=dict(
                 operands=[
                     operand.to_serializable_asset_selection(asset_graph)
                     for operand in self.operands
@@ -671,8 +671,8 @@ class SubtractAssetSelection(AssetSelection):
         ) - self.right.resolve_checks_inner(asset_graph, allow_missing=allow_missing)
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self.copy(
-            updates=dict(
+        return self.model_copy(
+            update=dict(
                 left=self.left.to_serializable_asset_selection(asset_graph),
                 right=self.right.to_serializable_asset_selection(asset_graph),
             )
@@ -696,8 +696,8 @@ class SinksAssetSelection(AssetSelection):
         return fetch_sinks(asset_graph.asset_dep_graph, selection)
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self.copy(
-            updates=dict(child=self.child.to_serializable_asset_selection(asset_graph))
+        return self.model_copy(
+            update=dict(child=self.child.to_serializable_asset_selection(asset_graph))
         )
 
 
@@ -715,8 +715,8 @@ class RequiredNeighborsAssetSelection(AssetSelection):
         return output
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self.copy(
-            updates=dict(child=self.child.to_serializable_asset_selection(asset_graph))
+        return self.model_copy(
+            update=dict(child=self.child.to_serializable_asset_selection(asset_graph))
         )
 
 
@@ -731,8 +731,8 @@ class RootsAssetSelection(AssetSelection):
         return fetch_sources(asset_graph.asset_dep_graph, selection)
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self.copy(
-            updates=dict(child=self.child.to_serializable_asset_selection(asset_graph))
+        return self.model_copy(
+            update=dict(child=self.child.to_serializable_asset_selection(asset_graph))
         )
 
 
@@ -764,8 +764,8 @@ class DownstreamAssetSelection(AssetSelection):
         )
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self.copy(
-            updates=dict(child=self.child.to_serializable_asset_selection(asset_graph))
+        return self.model_copy(
+            update=dict(child=self.child.to_serializable_asset_selection(asset_graph))
         )
 
 
@@ -941,8 +941,8 @@ class UpstreamAssetSelection(AssetSelection):
         return {key for key in all_upstream if key in asset_graph.materializable_asset_keys}
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self.copy(
-            updates=dict(child=self.child.to_serializable_asset_selection(asset_graph))
+        return self.model_copy(
+            update=dict(child=self.child.to_serializable_asset_selection(asset_graph))
         )
 
     def __str__(self) -> str:
@@ -973,6 +973,6 @@ class ParentSourcesAssetSelection(AssetSelection):
         return {key for key in all_upstream if key in asset_graph.external_asset_keys}
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self.copy(
-            updates=dict(child=self.child.to_serializable_asset_selection(asset_graph))
+        return self.model_copy(
+            update=dict(child=self.child.to_serializable_asset_selection(asset_graph))
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -592,10 +592,13 @@ class AndAssetSelection(AssetSelection):
         )
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self._replace(
-            operands=[
-                operand.to_serializable_asset_selection(asset_graph) for operand in self.operands
-            ]
+        return self.copy(
+            updates=dict(
+                operands=[
+                    operand.to_serializable_asset_selection(asset_graph)
+                    for operand in self.operands
+                ]
+            )
         )
 
     def needs_parentheses_when_operand(self) -> bool:
@@ -632,10 +635,13 @@ class OrAssetSelection(AssetSelection):
         )
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self._replace(
-            operands=[
-                operand.to_serializable_asset_selection(asset_graph) for operand in self.operands
-            ]
+        return self.copy(
+            updates=dict(
+                operands=[
+                    operand.to_serializable_asset_selection(asset_graph)
+                    for operand in self.operands
+                ]
+            )
         )
 
     def needs_parentheses_when_operand(self) -> bool:
@@ -665,9 +671,11 @@ class SubtractAssetSelection(AssetSelection):
         ) - self.right.resolve_checks_inner(asset_graph, allow_missing=allow_missing)
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self._replace(
-            left=self.left.to_serializable_asset_selection(asset_graph),
-            right=self.right.to_serializable_asset_selection(asset_graph),
+        return self.copy(
+            updates=dict(
+                left=self.left.to_serializable_asset_selection(asset_graph),
+                right=self.right.to_serializable_asset_selection(asset_graph),
+            )
         )
 
     def needs_parentheses_when_operand(self) -> bool:
@@ -688,7 +696,9 @@ class SinksAssetSelection(AssetSelection):
         return fetch_sinks(asset_graph.asset_dep_graph, selection)
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self._replace(child=self.child.to_serializable_asset_selection(asset_graph))
+        return self.copy(
+            updates=dict(child=self.child.to_serializable_asset_selection(asset_graph))
+        )
 
 
 @whitelist_for_serdes
@@ -705,7 +715,9 @@ class RequiredNeighborsAssetSelection(AssetSelection):
         return output
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self._replace(child=self.child.to_serializable_asset_selection(asset_graph))
+        return self.copy(
+            updates=dict(child=self.child.to_serializable_asset_selection(asset_graph))
+        )
 
 
 @whitelist_for_serdes
@@ -719,7 +731,9 @@ class RootsAssetSelection(AssetSelection):
         return fetch_sources(asset_graph.asset_dep_graph, selection)
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self._replace(child=self.child.to_serializable_asset_selection(asset_graph))
+        return self.copy(
+            updates=dict(child=self.child.to_serializable_asset_selection(asset_graph))
+        )
 
 
 @whitelist_for_serdes
@@ -750,7 +764,9 @@ class DownstreamAssetSelection(AssetSelection):
         )
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self._replace(child=self.child.to_serializable_asset_selection(asset_graph))
+        return self.copy(
+            updates=dict(child=self.child.to_serializable_asset_selection(asset_graph))
+        )
 
 
 @whitelist_for_serdes
@@ -925,7 +941,9 @@ class UpstreamAssetSelection(AssetSelection):
         return {key for key in all_upstream if key in asset_graph.materializable_asset_keys}
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self._replace(child=self.child.to_serializable_asset_selection(asset_graph))
+        return self.copy(
+            updates=dict(child=self.child.to_serializable_asset_selection(asset_graph))
+        )
 
     def __str__(self) -> str:
         if self.depth is None:
@@ -955,4 +973,6 @@ class ParentSourcesAssetSelection(AssetSelection):
         return {key for key in all_upstream if key in asset_graph.external_asset_keys}
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self._replace(child=self.child.to_serializable_asset_selection(asset_graph))
+        return self.copy(
+            updates=dict(child=self.child.to_serializable_asset_selection(asset_graph))
+        )

--- a/python_modules/dagster/dagster/_model/__init__.py
+++ b/python_modules/dagster/dagster/_model/__init__.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import pydantic
 from pydantic import BaseModel
 
 
@@ -15,3 +16,10 @@ class DagsterModel(BaseModel):
     class Config:
         extra = "forbid"
         frozen = True
+
+    def _replace(self, **kwargs: Any):
+        if pydantic.__version__ >= "2":
+            func = getattr(BaseModel, "model_copy")
+        else:
+            func = getattr(BaseModel, "copy")
+        return func(self, update=kwargs)

--- a/python_modules/dagster/dagster/_model/__init__.py
+++ b/python_modules/dagster/dagster/_model/__init__.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-import pydantic
 from pydantic import BaseModel
 
 
@@ -16,10 +15,3 @@ class DagsterModel(BaseModel):
     class Config:
         extra = "forbid"
         frozen = True
-
-    def _replace(self, **kwargs: Any):
-        if pydantic.__version__ >= "2":
-            func = getattr(BaseModel, "model_copy")
-        else:
-            func = getattr(BaseModel, "copy")
-        return func(self, update=kwargs)

--- a/python_modules/dagster/dagster/_model/__init__.py
+++ b/python_modules/dagster/dagster/_model/__init__.py
@@ -1,6 +1,8 @@
-from typing import Any
+from typing import Any, Dict, Optional
 
+import pydantic
 from pydantic import BaseModel
+from typing_extensions import Self
 
 
 class DagsterModel(BaseModel):
@@ -15,3 +17,9 @@ class DagsterModel(BaseModel):
     class Config:
         extra = "forbid"
         frozen = True
+
+    def model_copy(self, *, update: Optional[Dict[str, Any]] = None, deep: bool = False) -> Self:
+        if pydantic.__version__ >= "2":
+            return super().model_copy(update=update, deep=deep)  # type: ignore
+        else:
+            return super().copy(update=update, deep=deep)

--- a/python_modules/dagster/dagster_tests/model_tests/test_dagster_model.py
+++ b/python_modules/dagster/dagster_tests/model_tests/test_dagster_model.py
@@ -35,3 +35,14 @@ def test_override_constructor_in_subclass_wrong_type():
 
     with pytest.raises(ValidationError):
         MyClass(foo="fdsjk", bar="fdslk")
+
+
+def test_replace():
+    class MyClass(DagsterModel):
+        foo: str
+        bar: int
+
+    obj = MyClass(foo="abc", bar=5)
+    assert obj._replace(foo="xyz") == MyClass(foo="xyz", bar=5)
+    assert obj._replace(bar=6) == MyClass(foo="abc", bar=6)
+    assert obj._replace(foo="xyz", bar=6) == MyClass(foo="xyz", bar=6)

--- a/python_modules/dagster/dagster_tests/model_tests/test_dagster_model.py
+++ b/python_modules/dagster/dagster_tests/model_tests/test_dagster_model.py
@@ -37,12 +37,12 @@ def test_override_constructor_in_subclass_wrong_type():
         MyClass(foo="fdsjk", bar="fdslk")
 
 
-def test_replace():
+def test_model_copy():
     class MyClass(DagsterModel):
         foo: str
         bar: int
 
     obj = MyClass(foo="abc", bar=5)
-    assert obj._replace(foo="xyz") == MyClass(foo="xyz", bar=5)
-    assert obj._replace(bar=6) == MyClass(foo="abc", bar=6)
-    assert obj._replace(foo="xyz", bar=6) == MyClass(foo="xyz", bar=6)
+    assert obj.model_copy(update=dict(foo="xyz")) == MyClass(foo="xyz", bar=5)
+    assert obj.model_copy(update=dict(bar=6)) == MyClass(foo="abc", bar=6)
+    assert obj.model_copy(update=dict(foo="xyz", bar=6)) == MyClass(foo="xyz", bar=6)


### PR DESCRIPTION
## Summary & Motivation

It's often useful to create a copy of an object with a few fields replaced.  We do this fairly often with `NamedTuple._replace`. When we switch to `DagsterModel`, what should we use instead?

Pydantic 1 has `copy`. `copy` is deprecated in Pydantic 2. Pydantic 2 has `model_copy`. We support both versions.

Options:
- Define `_replace` on `DagsterModel`. This would make refactoring from `NamedTuple` to `DagsterModel` the easiest. But it's the least pydantic-y.
- Standardize on `copy`. This would require some way of suppressing deprecation warnings for Pydantic 2.
- Standardize on `model_copy`. This requires overriding `model_copy` to delegate to `copy` when using Pydantic 1.

The third option is what's implemented this PR (cribbed from @maximearmstrong's earlier implementation of `AssetSelection.replace`).  I like it because it's the most forward-looking.

## How I Tested These Changes
