### PR TITLE
remove ability to specify runId in graphql launch run mutations

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2197,7 +2197,6 @@ input AssetKeyInput {
 }
 
 input ExecutionMetadata {
-  runId: String
   tags: [ExecutionTag!]
   rootRunId: String
   parentRunId: String

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -1354,7 +1354,6 @@ export type EventTag = {
 export type ExecutionMetadata = {
   parentRunId?: InputMaybe<Scalars['String']['input']>;
   rootRunId?: InputMaybe<Scalars['String']['input']>;
-  runId?: InputMaybe<Scalars['String']['input']>;
   tags?: InputMaybe<Array<ExecutionTag>>;
 };
 
@@ -7719,7 +7718,6 @@ export const buildExecutionMetadata = (
     parentRunId:
       overrides && overrides.hasOwnProperty('parentRunId') ? overrides.parentRunId! : 'autem',
     rootRunId: overrides && overrides.hasOwnProperty('rootRunId') ? overrides.rootRunId! : 'ut',
-    runId: overrides && overrides.hasOwnProperty('runId') ? overrides.runId! : 'dolor',
     tags: overrides && overrides.hasOwnProperty('tags') ? overrides.tags! : [],
   };
 };

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -259,7 +259,6 @@ class GrapheneResourceSelector(graphene.InputObjectType):
 
 
 class GrapheneExecutionMetadata(graphene.InputObjectType):
-    runId = graphene.String()
     tags = graphene.List(graphene.NonNull(GrapheneExecutionTag))
     rootRunId = graphene.String(
         description="""The ID of the run at the root of the run group. All partial /

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reexecution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reexecution.py
@@ -1,5 +1,4 @@
 from dagster._core.test_utils import wait_for_runs_to_finish
-from dagster._core.utils import make_new_run_id
 from dagster_graphql.client.query import (
     LAUNCH_PIPELINE_EXECUTION_MUTATION,
     LAUNCH_PIPELINE_REEXECUTION_MUTATION,
@@ -24,7 +23,6 @@ query RunQuery($runId: ID!) {
 class TestReexecution(ExecutingGraphQLContextTestMatrix):
     def test_full_pipeline_reexecution_fs_storage(self, graphql_context, snapshot):
         selector = infer_job_selector(graphql_context, "csv_hello_world")
-        run_id = make_new_run_id()
         result_one = execute_dagster_graphql(
             graphql_context,
             LAUNCH_PIPELINE_EXECUTION_MUTATION,
@@ -32,7 +30,6 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
                 "executionParams": {
                     "selector": selector,
                     "runConfigData": csv_hello_world_ops_config(),
-                    "executionMetadata": {"runId": run_id},
                     "mode": "default",
                 }
             },
@@ -40,6 +37,9 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
 
         assert result_one.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
 
+        run_id = result_one.data["launchPipelineExecution"]["run"]["runId"]
+
+        # overwrite run_id for the snapshot
         result_one.data["launchPipelineExecution"]["run"]["runId"] = "<runId dummy value>"
         result_one.data["launchPipelineExecution"]["run"]["runConfigYaml"] = (
             "<runConfigYaml dummy value>"
@@ -48,8 +48,6 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
         snapshot.assert_match(result_one.data)
 
         # reexecution
-        new_run_id = make_new_run_id()
-
         result_two = execute_dagster_graphql(
             graphql_context,
             LAUNCH_PIPELINE_REEXECUTION_MUTATION,
@@ -58,7 +56,6 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
                     "selector": selector,
                     "runConfigData": csv_hello_world_ops_config(),
                     "executionMetadata": {
-                        "runId": new_run_id,
                         "rootRunId": run_id,
                         "parentRunId": run_id,
                     },
@@ -73,7 +70,6 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
         assert query_result["run"]["parentRunId"] == run_id
 
     def test_full_pipeline_reexecution_in_memory_storage(self, graphql_context, snapshot):
-        run_id = make_new_run_id()
         selector = infer_job_selector(graphql_context, "csv_hello_world")
         result_one = execute_dagster_graphql(
             graphql_context,
@@ -82,7 +78,6 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
                 "executionParams": {
                     "selector": selector,
                     "runConfigData": csv_hello_world_ops_config(),
-                    "executionMetadata": {"runId": run_id},
                     "mode": "default",
                 }
             },
@@ -90,6 +85,9 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
 
         assert result_one.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
 
+        run_id = result_one.data["launchPipelineExecution"]["run"]["runId"]
+
+        # overwrite run_id for the snapshot
         result_one.data["launchPipelineExecution"]["run"]["runId"] = "<runId dummy value>"
         result_one.data["launchPipelineExecution"]["run"]["runConfigYaml"] = (
             "<runConfigYaml dummy value>"
@@ -98,8 +96,6 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
         snapshot.assert_match(result_one.data)
 
         # reexecution
-        new_run_id = make_new_run_id()
-
         result_two = execute_dagster_graphql(
             graphql_context,
             LAUNCH_PIPELINE_REEXECUTION_MUTATION,
@@ -108,7 +104,6 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
                     "selector": selector,
                     "runConfigData": csv_hello_world_ops_config(),
                     "executionMetadata": {
-                        "runId": new_run_id,
                         "rootRunId": run_id,
                         "parentRunId": run_id,
                     },
@@ -124,14 +119,12 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
 
     def test_pipeline_reexecution_successful_launch(self, graphql_context):
         selector = infer_job_selector(graphql_context, "no_config_job")
-        run_id = make_new_run_id()
         result = execute_dagster_graphql(
             context=graphql_context,
             query=LAUNCH_PIPELINE_EXECUTION_MUTATION,
             variables={
                 "executionParams": {
                     "selector": selector,
-                    "executionMetadata": {"runId": run_id},
                     "mode": "default",
                 }
             },
@@ -142,6 +135,7 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
 
         wait_for_runs_to_finish(graphql_context.instance)
 
+        run_id = result.data["launchPipelineExecution"]["run"]["runId"]
         result = execute_dagster_graphql(
             context=graphql_context, query=RUN_QUERY, variables={"runId": run_id}
         )
@@ -149,7 +143,6 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
         assert result.data["pipelineRunOrError"]["status"] == "SUCCESS"
 
         # reexecution
-        new_run_id = make_new_run_id()
         result = execute_dagster_graphql(
             context=graphql_context,
             query=LAUNCH_PIPELINE_REEXECUTION_MUTATION,
@@ -157,7 +150,6 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
                 "executionParams": {
                     "selector": selector,
                     "executionMetadata": {
-                        "runId": new_run_id,
                         "rootRunId": run_id,
                         "parentRunId": run_id,
                     },
@@ -169,6 +161,7 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
 
         wait_for_runs_to_finish(graphql_context.instance)
 
+        new_run_id = result.data["launchPipelineReexecution"]["run"]["runId"]
         result = execute_dagster_graphql(
             context=graphql_context, query=RUN_QUERY, variables={"runId": new_run_id}
         )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
@@ -9,7 +9,6 @@ from dagster._core.storage.tags import (
     RUN_FAILURE_REASON_TAG,
 )
 from dagster._core.test_utils import create_run_for_test, poll_for_finished_run
-from dagster._core.utils import make_new_run_id
 from dagster._core.workspace.context import WorkspaceRequestContext
 from dagster._seven.temp_dir import get_system_temp_directory
 from dagster_graphql.client.query import (
@@ -39,7 +38,6 @@ from .utils import (
     step_did_succeed,
     step_did_succeed_in_records,
     step_started,
-    sync_execute_get_events,
 )
 
 
@@ -315,7 +313,6 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
 
     def test_successful_pipeline_reexecution(self, graphql_context: WorkspaceRequestContext):
         selector = infer_job_selector(graphql_context, "csv_hello_world")
-        run_id = make_new_run_id()
         result_one = execute_dagster_graphql_and_finish_runs(
             graphql_context,
             LAUNCH_PIPELINE_EXECUTION_MUTATION,
@@ -323,10 +320,10 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
                 "executionParams": {
                     "selector": selector,
                     "runConfigData": csv_hello_world_ops_config(),
-                    "executionMetadata": {"runId": run_id},
                 }
             },
         )
+        run_id = result_one.data["launchPipelineExecution"]["run"]["runId"]
 
         assert result_one.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
 
@@ -336,8 +333,6 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
         assert get_step_output_event(logs, "sum_sq_op")
 
         # retry
-        new_run_id = make_new_run_id()
-
         result_two = execute_dagster_graphql_and_finish_runs(
             graphql_context,
             LAUNCH_PIPELINE_REEXECUTION_MUTATION,
@@ -347,7 +342,6 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
                     "runConfigData": csv_hello_world_ops_config(),
                     "stepKeys": ["sum_sq_op"],
                     "executionMetadata": {
-                        "runId": new_run_id,
                         "rootRunId": run_id,
                         "parentRunId": run_id,
                         "tags": [{"key": RESUME_RETRY_TAG, "value": "true"}],
@@ -359,6 +353,7 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
         query_result = result_two.data["launchPipelineReexecution"]
         assert query_result["__typename"] == "LaunchRunSuccess"
 
+        new_run_id = query_result["run"]["runId"]
         result = get_all_logs_for_finished_run_via_subscription(graphql_context, new_run_id)
         logs = result["pipelineRunLogs"]["messages"]
 
@@ -376,22 +371,20 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
         context = graphql_context
         selector = infer_job_selector(graphql_context, "csv_hello_world")
 
-        run_id = make_new_run_id()
-        execute_dagster_graphql_and_finish_runs(
+        result = execute_dagster_graphql_and_finish_runs(
             context,
             LAUNCH_PIPELINE_EXECUTION_MUTATION,
             variables={
                 "executionParams": {
                     "selector": selector,
                     "runConfigData": csv_hello_world_ops_config(),
-                    "executionMetadata": {"runId": run_id},
                 }
             },
         )
+        run_id = result.data["launchPipelineExecution"]["run"]["runId"]
 
         # retry
-        new_run_id = make_new_run_id()
-        execute_dagster_graphql_and_finish_runs(
+        retry_result = execute_dagster_graphql_and_finish_runs(
             context,
             LAUNCH_PIPELINE_REEXECUTION_MUTATION,
             variables={
@@ -400,7 +393,6 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
                     "runConfigData": csv_hello_world_ops_config(),
                     "stepKeys": ["sum_sq_op"],
                     "executionMetadata": {
-                        "runId": new_run_id,
                         "rootRunId": run_id,
                         "parentRunId": run_id,
                         "tags": [{"key": RESUME_RETRY_TAG, "value": "true"}],
@@ -408,18 +400,19 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
                 }
             },
         )
+        new_run_id = retry_result.data["launchPipelineReexecution"]["run"]["runId"]
 
-        result_one = execute_dagster_graphql_and_finish_runs(
+        info_result_one = execute_dagster_graphql_and_finish_runs(
             context, PIPELINE_REEXECUTION_INFO_QUERY, variables={"runId": run_id}
         )
-        query_result_one = result_one.data["pipelineRunOrError"]
+        query_result_one = info_result_one.data["pipelineRunOrError"]
         assert query_result_one["__typename"] == "Run"
         assert query_result_one["stepKeysToExecute"] is None
 
-        result_two = execute_dagster_graphql_and_finish_runs(
+        info_result_two = execute_dagster_graphql_and_finish_runs(
             context, PIPELINE_REEXECUTION_INFO_QUERY, variables={"runId": new_run_id}
         )
-        query_result_two = result_two.data["pipelineRunOrError"]
+        query_result_two = info_result_two.data["pipelineRunOrError"]
         assert query_result_two["__typename"] == "Run"
         stepKeysToExecute = query_result_two["stepKeysToExecute"]
         assert stepKeysToExecute is not None
@@ -428,7 +421,6 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
     def test_pipeline_reexecution_invalid_step_in_subset(
         self, graphql_context: WorkspaceRequestContext
     ):
-        run_id = make_new_run_id()
         selector = infer_job_selector(graphql_context, "csv_hello_world")
         result_one = execute_dagster_graphql_and_finish_runs(
             graphql_context,
@@ -437,15 +429,13 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
                 "executionParams": {
                     "selector": selector,
                     "runConfigData": csv_hello_world_ops_config(),
-                    "executionMetadata": {"runId": run_id},
                 }
             },
         )
         assert result_one.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
+        run_id = result_one.data["launchPipelineExecution"]["run"]["runId"]
 
         # retry
-        new_run_id = make_new_run_id()
-
         result_two = execute_dagster_graphql_and_finish_runs(
             graphql_context,
             LAUNCH_PIPELINE_REEXECUTION_MUTATION,
@@ -455,7 +445,6 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
                     "runConfigData": csv_hello_world_ops_config(),
                     "stepKeys": ["nope"],
                     "executionMetadata": {
-                        "runId": new_run_id,
                         "rootRunId": run_id,
                         "parentRunId": run_id,
                         "tags": [{"key": RESUME_RETRY_TAG, "value": "true"}],
@@ -693,17 +682,22 @@ def test_graphene_reexecution_strategy():
         assert ReexecutionStrategy[strategy.value]
 
 
-def _do_retry_intermediates_test(graphql_context, run_id, reexecution_run_id):
+def _do_retry_intermediates_test(graphql_context):
     selector = infer_job_selector(graphql_context, "eventually_successful")
-    logs = sync_execute_get_events(
-        context=graphql_context,
+    result = execute_dagster_graphql_and_finish_runs(
+        graphql_context,
+        LAUNCH_PIPELINE_EXECUTION_MUTATION,
         variables={
             "executionParams": {
                 "selector": selector,
-                "executionMetadata": {"runId": run_id},
             }
         },
     )
+    assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
+    run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+    logs = get_all_logs_for_finished_run_via_subscription(graphql_context, run_id)[
+        "pipelineRunLogs"
+    ]["messages"]
 
     assert step_did_succeed(logs, "spawn")
     assert step_did_fail(logs, "fail")
@@ -718,7 +712,6 @@ def _do_retry_intermediates_test(graphql_context, run_id, reexecution_run_id):
             "executionParams": {
                 "selector": selector,
                 "executionMetadata": {
-                    "runId": reexecution_run_id,
                     "rootRunId": run_id,
                     "parentRunId": run_id,
                     "tags": [{"key": RESUME_RETRY_TAG, "value": "true"}],
@@ -727,17 +720,18 @@ def _do_retry_intermediates_test(graphql_context, run_id, reexecution_run_id):
         },
     )
 
-    return retry_one
+    retry_run_id = retry_one.data["launchPipelineReexecution"]["run"]["runId"]
+    return retry_run_id
 
 
 class TestRetryExecutionAsyncOnlyBehavior(ExecutingGraphQLContextTestMatrix):
     def test_retry_requires_intermediates_async_only(
         self, graphql_context: WorkspaceRequestContext
     ):
-        run_id = make_new_run_id()
-        reexecution_run_id = make_new_run_id()
+        # run_id = make_new_run_id()
+        # reexecution_run_id = make_new_run_id()
 
-        _do_retry_intermediates_test(graphql_context, run_id, reexecution_run_id)
+        reexecution_run_id = _do_retry_intermediates_test(graphql_context)
         reexecution_run = graphql_context.instance.get_run_by_id(reexecution_run_id)
         assert reexecution_run
         assert reexecution_run.is_failure_or_canceled
@@ -745,8 +739,7 @@ class TestRetryExecutionAsyncOnlyBehavior(ExecutingGraphQLContextTestMatrix):
     def test_retry_early_terminate(self, graphql_context: WorkspaceRequestContext):
         instance = graphql_context.instance
         selector = infer_job_selector(graphql_context, "retry_multi_input_early_terminate_job")
-        run_id = make_new_run_id()
-        execute_dagster_graphql(
+        result = execute_dagster_graphql(
             graphql_context,
             LAUNCH_PIPELINE_EXECUTION_MUTATION,
             variables={
@@ -758,10 +751,11 @@ class TestRetryExecutionAsyncOnlyBehavior(ExecutingGraphQLContextTestMatrix):
                             "get_input_two": {"config": {"wait_to_terminate": True}},
                         },
                     },
-                    "executionMetadata": {"runId": run_id},
                 }
             },
         )
+
+        run_id = result.data["launchPipelineExecution"]["run"]["runId"]
         # Wait until the first step succeeded
         while instance.get_run_stats(run_id).steps_succeeded < 1:
             sleep(0.1)
@@ -789,9 +783,7 @@ class TestRetryExecutionAsyncOnlyBehavior(ExecutingGraphQLContextTestMatrix):
         assert run and run.status == DagsterRunStatus.CANCELED
 
         # Start retry
-        new_run_id = make_new_run_id()
-
-        execute_dagster_graphql_and_finish_runs(
+        retry_result = execute_dagster_graphql_and_finish_runs(
             graphql_context,
             LAUNCH_PIPELINE_REEXECUTION_MUTATION,
             variables={
@@ -804,7 +796,6 @@ class TestRetryExecutionAsyncOnlyBehavior(ExecutingGraphQLContextTestMatrix):
                         },
                     },
                     "executionMetadata": {
-                        "runId": new_run_id,
                         "rootRunId": run_id,
                         "parentRunId": run_id,
                         "tags": [{"key": RESUME_RETRY_TAG, "value": "true"}],
@@ -813,6 +804,7 @@ class TestRetryExecutionAsyncOnlyBehavior(ExecutingGraphQLContextTestMatrix):
             },
         )
 
+        new_run_id = retry_result.data["launchPipelineReexecution"]["run"]["runId"]
         retry_records = instance.all_logs(new_run_id)
         # The first step should not run and the other three steps should succeed in retry
         assert step_did_not_run_in_records(retry_records, "return_one")


### PR DESCRIPTION
## Summary & Motivation
We want to remove custom-non-UUID run ids.

There are currently two sources of generation: an optional graphql metadata param and the non-public `DagsterInstance.create_run` instance method.   

This PR wholesale removes this parameter, which is only used in tests.

## How I Tested These Changes
BK