### PR TITLE
[ui] Middle-truncate partition names on run matrix

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStepStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStepStatus.tsx
@@ -8,6 +8,7 @@ import {
   Icon,
   Menu,
   MenuItem,
+  MiddleTruncate,
   Popover,
   useViewport,
 } from '@dagster-io/ui-components';
@@ -277,12 +278,12 @@ const PartitionStepStatus = (props: PartitionStepStatusProps) => {
             <Divider />
             {stepRows.map((step) => (
               <LeftLabel
-                style={{paddingLeft: 8 + step.x}}
+                style={{paddingLeft: 8 + step.x, paddingRight: 8}}
                 key={step.name}
                 data-tooltip={step.name}
                 hovered={step.name === hovered?.stepName}
               >
-                {step.name}
+                <MiddleTruncate text={step.name} />
               </LeftLabel>
             ))}
           </GridColumn>


### PR DESCRIPTION
## Summary & Motivation

I think this should resolve https://github.com/dagster-io/dagster/issues/20408.

Use middle truncation (with a hover tooltip) to display step keys on the run Partitions tab run matrix.

<img width="421" alt="Screenshot 2024-03-26 at 12 28 28" src="https://github.com/dagster-io/dagster/assets/2823852/ac5677d2-0529-47da-a7c4-4e89599bafe9">


## How I Tested These Changes

View a toy job with steps that are being truncated. Verify middle truncation.