### PR TITLE
[external-renames] Rename External*Origin classes -> Remote*Origin

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -88,8 +88,8 @@ def launch_reexecution_from_parent_run(
     )
     origin = check.not_none(parent_run.external_job_origin)
     selector = JobSubsetSelector(
-        location_name=origin.external_repository_origin.code_location_origin.location_name,
-        repository_name=origin.external_repository_origin.repository_name,
+        location_name=origin.repository_origin.code_location_origin.location_name,
+        repository_name=origin.repository_origin.repository_name,
         job_name=parent_run.job_name,
         asset_selection=parent_run.asset_selection,
         asset_check_selection=parent_run.asset_check_selection,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -209,7 +209,7 @@ def get_schedule_next_tick(
     if not schedule_state.is_running:
         return None
 
-    repository_origin = schedule_state.origin.external_repository_origin
+    repository_origin = schedule_state.origin.repository_origin
     if not graphene_info.context.has_code_location(
         repository_origin.code_location_origin.location_name
     ):

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -186,7 +186,7 @@ def get_sensor_next_tick(
 
     check.inst_param(sensor_state, "sensor_state", InstigatorState)
 
-    repository_origin = sensor_state.origin.external_repository_origin
+    repository_origin = sensor_state.origin.repository_origin
     if not graphene_info.context.has_code_location(
         repository_origin.code_location_origin.location_name
     ):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -301,8 +301,8 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             return None
 
         origin = self._backfill_job.partition_set_origin
-        location_name = origin.external_repository_origin.code_location_origin.location_name
-        repository_name = origin.external_repository_origin.repository_name
+        location_name = origin.repository_origin.code_location_origin.location_name
+        repository_name = origin.repository_origin.repository_name
         if not graphene_info.context.has_code_location(location_name):
             return None
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -588,7 +588,7 @@ class GrapheneInstigationState(graphene.ObjectType):
         )
 
     def resolve_repositoryOrigin(self, _graphene_info: ResolveInfo):
-        origin = self._instigator_state.origin.external_repository_origin
+        origin = self._instigator_state.origin.repository_origin
         return GrapheneRepositoryOrigin(origin)
 
     def resolve_repositoryName(self, _graphene_info: ResolveInfo):
@@ -635,7 +635,7 @@ class GrapheneInstigationState(graphene.ObjectType):
     def resolve_runs(self, graphene_info: ResolveInfo, limit: Optional[int] = None):
         from .pipelines.pipeline import GrapheneRun
 
-        repository_label = self._instigator_state.origin.external_repository_origin.get_label()
+        repository_label = self._instigator_state.origin.repository_origin.get_label()
         if self._instigator_state.instigator_type == InstigatorType.SENSOR:
             filters = RunsFilter(
                 tags={

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -342,7 +342,7 @@ class GraphenePartitionSet(graphene.ObjectType):
         )
 
     def resolve_repositoryOrigin(self, _):
-        origin = self._external_partition_set.get_external_origin().external_repository_origin
+        origin = self._external_partition_set.get_external_origin().repository_origin
         return GrapheneRepositoryOrigin(origin)
 
     def resolve_backfills(
@@ -356,7 +356,7 @@ class GraphenePartitionSet(graphene.ObjectType):
             if backfill.partition_set_origin
             and backfill.partition_set_origin.partition_set_name
             == self._external_partition_set.name
-            and backfill.partition_set_origin.external_repository_origin.repository_name
+            and backfill.partition_set_origin.repository_origin.repository_name
             == self._external_repository_handle.repository_name
         ]
         return [GraphenePartitionBackfill(backfill) for backfill in matching[:limit]]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -425,9 +425,7 @@ class GrapheneRun(graphene.ObjectType):
 
     def resolve_repositoryOrigin(self, _graphene_info: ResolveInfo):
         return (
-            GrapheneRepositoryOrigin(
-                self.dagster_run.external_job_origin.external_repository_origin
-            )
+            GrapheneRepositoryOrigin(self.dagster_run.external_job_origin.repository_origin)
             if self.dagster_run.external_job_origin
             else None
         )
@@ -770,7 +768,7 @@ class GrapheneIPipelineSnapshotMixin:
                 job_name=pipeline.name,
                 tags={
                     REPOSITORY_LABEL_TAG: (
-                        pipeline.get_external_origin().external_repository_origin.get_label()
+                        pipeline.get_external_origin().repository_origin.get_label()
                     )
                 },
             )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/repository_origin.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/repository_origin.py
@@ -2,7 +2,7 @@ from typing import Sequence
 
 import dagster._check as check
 import graphene
-from dagster._core.remote_representation import ExternalRepositoryOrigin
+from dagster._core.remote_representation import RemoteRepositoryOrigin
 
 from .util import ResolveInfo, non_null_list
 
@@ -24,9 +24,9 @@ class GrapheneRepositoryOrigin(graphene.ObjectType):
     class Meta:
         name = "RepositoryOrigin"
 
-    def __init__(self, origin: ExternalRepositoryOrigin):
+    def __init__(self, origin: RemoteRepositoryOrigin):
         super().__init__()
-        self._origin = check.inst_param(origin, "origin", ExternalRepositoryOrigin)
+        self._origin = check.inst_param(origin, "origin", RemoteRepositoryOrigin)
 
     def resolve_id(self, _graphene_info: ResolveInfo) -> str:
         return self._origin.get_id()

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -19,7 +19,7 @@ from dagster._core.definitions.auto_materialize_rule_evaluation import (
 from dagster._core.definitions.partition import PartitionsDefinition, StaticPartitionsDefinition
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.sensor_definition import SensorType
-from dagster._core.remote_representation.origin import ExternalInstigatorOrigin
+from dagster._core.remote_representation.origin import RemoteInstigatorOrigin
 from dagster._core.scheduler.instigation import (
     InstigatorState,
     InstigatorStatus,
@@ -328,8 +328,8 @@ query GetEvaluationsForEvaluationIdQuery($evaluationId: Int!) {
 
 class TestAssetConditionEvaluations(ExecutingGraphQLContextTestMatrix):
     def test_auto_materialize_sensor(self, graphql_context: WorkspaceRequestContext):
-        sensor_origin = ExternalInstigatorOrigin(
-            external_repository_origin=infer_repository(graphql_context).get_external_origin(),
+        sensor_origin = RemoteInstigatorOrigin(
+            repository_origin=infer_repository(graphql_context).get_external_origin(),
             instigator_name="my_auto_materialize_sensor",
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -21,7 +21,7 @@ from dagster._core.execution.backfill import (
     BulkActionStatus,
     PartitionBackfill,
 )
-from dagster._core.remote_representation.origin import ExternalPartitionSetOrigin
+from dagster._core.remote_representation.origin import RemotePartitionSetOrigin
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import BACKFILL_ID_TAG, PARTITION_NAME_TAG
 from dagster._core.test_utils import create_run_for_test, environ
@@ -285,8 +285,8 @@ class TestPartitionBackillReadonlyFailure(ReadonlyGraphQLContextTestMatrix):
 
         backfill = PartitionBackfill(
             backfill_id=make_new_backfill_id(),
-            partition_set_origin=ExternalPartitionSetOrigin(
-                external_repository_origin=repository.get_external_origin(),
+            partition_set_origin=RemotePartitionSetOrigin(
+                repository_origin=repository.get_external_origin(),
                 partition_set_name="integer_partition",
             ),
             status=BulkActionStatus.REQUESTED,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -4,8 +4,8 @@ import sys
 import pendulum
 import pytest
 from dagster._core.remote_representation import (
-    ExternalRepositoryOrigin,
     InProcessCodeLocationOrigin,
+    RemoteRepositoryOrigin,
 )
 from dagster._core.scheduler.instigation import (
     InstigatorState,
@@ -327,7 +327,7 @@ def _get_unloadable_schedule_origin(name):
         python_file=__file__,
         working_directory=working_directory,
     )
-    return ExternalRepositoryOrigin(
+    return RemoteRepositoryOrigin(
         InProcessCodeLocationOrigin(loadable_target_origin), "fake_repository"
     ).get_instigator_origin(name)
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -8,8 +8,8 @@ from dagster._core.definitions.sensor_definition import (
     SensorType,
 )
 from dagster._core.remote_representation import (
-    ExternalRepositoryOrigin,
     InProcessCodeLocationOrigin,
+    RemoteRepositoryOrigin,
 )
 from dagster._core.scheduler.instigation import (
     InstigatorState,
@@ -1311,7 +1311,7 @@ def _get_unloadable_sensor_origin(name):
         python_file=__file__,
         working_directory=working_directory,
     )
-    return ExternalRepositoryOrigin(
+    return RemoteRepositoryOrigin(
         InProcessCodeLocationOrigin(loadable_target_origin), "fake_repository"
     ).get_instigator_origin(name)
 

--- a/python_modules/dagster-test/dagster_test/test_project/__init__.py
+++ b/python_modules/dagster-test/dagster_test/test_project/__init__.py
@@ -26,9 +26,9 @@ from dagster._core.remote_representation import (
     InProcessCodeLocationOrigin,
 )
 from dagster._core.remote_representation.origin import (
-    ExternalInstigatorOrigin,
-    ExternalJobOrigin,
-    ExternalRepositoryOrigin,
+    RemoteInstigatorOrigin,
+    RemoteJobOrigin,
+    RemoteRepositoryOrigin,
 )
 from dagster._core.test_utils import in_process_test_workspace
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
@@ -200,14 +200,14 @@ class ReOriginatedExternalJobForTest(ExternalJob):
             ),
         )
 
-    def get_external_origin(self) -> ExternalJobOrigin:
+    def get_external_origin(self) -> RemoteJobOrigin:
         """Hack! Inject origin that the k8s images will use. The BK image uses a different directory
         structure (/workdir/python_modules/dagster-test/dagster_test/test_project) than the images
         inside the kind cluster (/dagster_test/test_project). As a result the normal origin won't
         work, we need to inject this one.
         """
-        return ExternalJobOrigin(
-            external_repository_origin=ExternalRepositoryOrigin(
+        return RemoteJobOrigin(
+            repository_origin=RemoteRepositoryOrigin(
                 code_location_origin=InProcessCodeLocationOrigin(
                     loadable_target_origin=LoadableTargetOrigin(
                         executable_path="python",
@@ -240,8 +240,8 @@ class ReOriginatedExternalScheduleForTest(ExternalSchedule):
         gRPC server repo location origin. As a result the normal origin won't work, we need to
         inject this one.
         """
-        return ExternalInstigatorOrigin(
-            external_repository_origin=ExternalRepositoryOrigin(
+        return RemoteInstigatorOrigin(
+            repository_origin=RemoteRepositoryOrigin(
                 code_location_origin=GrpcServerCodeLocationOrigin(
                     host="user-code-deployment-1",
                     port=3030,

--- a/python_modules/dagster/dagster/_api/snapshot_execution_plan.py
+++ b/python_modules/dagster/dagster/_api/snapshot_execution_plan.py
@@ -7,7 +7,7 @@ from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.external_data import DEFAULT_MODE_NAME
-from dagster._core.remote_representation.origin import ExternalJobOrigin
+from dagster._core.remote_representation.origin import RemoteJobOrigin
 from dagster._core.snap.execution_plan_snapshot import (
     ExecutionPlanSnapshot,
     ExecutionPlanSnapshotErrorData,
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 def sync_get_external_execution_plan_grpc(
     api_client: "DagsterGrpcClient",
-    job_origin: ExternalJobOrigin,
+    job_origin: RemoteJobOrigin,
     run_config: Mapping[str, Any],
     job_snapshot_id: str,
     asset_selection: Optional[AbstractSet[AssetKey]] = None,
@@ -34,7 +34,7 @@ def sync_get_external_execution_plan_grpc(
     from dagster._grpc.client import DagsterGrpcClient
 
     check.inst_param(api_client, "api_client", DagsterGrpcClient)
-    check.inst_param(job_origin, "job_origin", ExternalJobOrigin)
+    check.inst_param(job_origin, "job_origin", RemoteJobOrigin)
     op_selection = check.opt_sequence_param(op_selection, "op_selection", of_type=str)
     asset_selection = check.opt_nullable_set_param(
         asset_selection, "asset_selection", of_type=AssetKey

--- a/python_modules/dagster/dagster/_api/snapshot_job.py
+++ b/python_modules/dagster/dagster/_api/snapshot_job.py
@@ -5,7 +5,7 @@ from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.remote_representation.external_data import ExternalJobSubsetResult
-from dagster._core.remote_representation.origin import ExternalJobOrigin
+from dagster._core.remote_representation.origin import RemoteJobOrigin
 from dagster._grpc.types import JobSubsetSnapshotArgs
 from dagster._serdes import deserialize_value
 
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 def sync_get_external_job_subset_grpc(
     api_client: "DagsterGrpcClient",
-    job_origin: ExternalJobOrigin,
+    job_origin: RemoteJobOrigin,
     include_parent_snapshot: bool,
     op_selection: Optional[Sequence[str]] = None,
     asset_selection: Optional[AbstractSet[AssetKey]] = None,
@@ -24,7 +24,7 @@ def sync_get_external_job_subset_grpc(
     from dagster._grpc.client import DagsterGrpcClient
 
     check.inst_param(api_client, "api_client", DagsterGrpcClient)
-    job_origin = check.inst_param(job_origin, "job_origin", ExternalJobOrigin)
+    job_origin = check.inst_param(job_origin, "job_origin", RemoteJobOrigin)
     op_selection = check.opt_nullable_sequence_param(op_selection, "op_selection", of_type=str)
     asset_selection = check.opt_nullable_set_param(
         asset_selection, "asset_selection", of_type=AssetKey

--- a/python_modules/dagster/dagster/_api/snapshot_repository.py
+++ b/python_modules/dagster/dagster/_api/snapshot_repository.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 def sync_get_streaming_external_repositories_data_grpc(
     api_client: "DagsterGrpcClient", code_location: "CodeLocation"
 ) -> Mapping[str, ExternalRepositoryData]:
-    from dagster._core.remote_representation import CodeLocation, ExternalRepositoryOrigin
+    from dagster._core.remote_representation import CodeLocation, RemoteRepositoryOrigin
 
     check.inst_param(code_location, "code_location", CodeLocation)
 
@@ -24,7 +24,7 @@ def sync_get_streaming_external_repositories_data_grpc(
     for repository_name in code_location.repository_names:  # type: ignore
         external_repository_chunks = list(
             api_client.streaming_external_repository(
-                external_repository_origin=ExternalRepositoryOrigin(
+                external_repository_origin=RemoteRepositoryOrigin(
                     code_location.origin,
                     repository_name,
                 )

--- a/python_modules/dagster/dagster/_cli/run.py
+++ b/python_modules/dagster/dagster/_cli/run.py
@@ -104,7 +104,7 @@ def run_migrate_command(from_label, **kwargs):
         ) as external_job:
             new_job_origin = external_job.get_external_origin()
             job_name = external_job.name
-            to_label = new_job_origin.external_repository_origin.get_label()
+            to_label = new_job_origin.repository_origin.get_label()
 
         if not to_label:
             raise click.UsageError("Must specify valid job targets to migrate history to.")

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -783,11 +783,11 @@ class RunStatusSensorDefinition(SensorDefinition):
                     dagster_run.external_job_origin
                     and
                     # the job belongs to the current code location
-                    dagster_run.external_job_origin.external_repository_origin.code_location_origin.location_name
+                    dagster_run.external_job_origin.repository_origin.code_location_origin.location_name
                     == code_location_name
                     and
                     # the job belongs to the current repository
-                    dagster_run.external_job_origin.external_repository_origin.repository_name
+                    dagster_run.external_job_origin.repository_origin.repository_name
                     == context.repository_name
                 ):
                     if monitored_jobs:
@@ -801,7 +801,7 @@ class RunStatusSensorDefinition(SensorDefinition):
                     # make a JobSelector for the run in question
                     external_repository_origin = check.not_none(
                         dagster_run.external_job_origin
-                    ).external_repository_origin
+                    ).repository_origin
                     run_job_selector = JobSelector(
                         location_name=external_repository_origin.code_location_origin.location_name,
                         repository_name=external_repository_origin.repository_name,

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -10,7 +10,7 @@ from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.errors import DagsterDefinitionChangedDeserializationError
 from dagster._core.execution.bulk_actions import BulkActionType
 from dagster._core.instance import DynamicPartitionsStore
-from dagster._core.remote_representation.origin import ExternalPartitionSetOrigin
+from dagster._core.remote_representation.origin import RemotePartitionSetOrigin
 from dagster._core.storage.tags import USER_TAG
 from dagster._core.workspace.workspace import IWorkspace
 from dagster._serdes import whitelist_for_serdes
@@ -50,7 +50,7 @@ class PartitionBackfill(
             ("error", Optional[SerializableErrorInfo]),
             ("asset_selection", Optional[Sequence[AssetKey]]),
             # fields that are only used by job backfills
-            ("partition_set_origin", Optional[ExternalPartitionSetOrigin]),
+            ("partition_set_origin", Optional[RemotePartitionSetOrigin]),
             ("partition_names", Optional[Sequence[str]]),
             ("last_submitted_partition_name", Optional[str]),
             ("reexecution_steps", Optional[Sequence[str]]),
@@ -69,7 +69,7 @@ class PartitionBackfill(
         backfill_timestamp: float,
         error: Optional[SerializableErrorInfo] = None,
         asset_selection: Optional[Sequence[AssetKey]] = None,
-        partition_set_origin: Optional[ExternalPartitionSetOrigin] = None,
+        partition_set_origin: Optional[RemotePartitionSetOrigin] = None,
         partition_names: Optional[Sequence[str]] = None,
         last_submitted_partition_name: Optional[str] = None,
         reexecution_steps: Optional[Sequence[str]] = None,
@@ -97,7 +97,7 @@ class PartitionBackfill(
             check.opt_inst_param(error, "error", SerializableErrorInfo),
             check.opt_nullable_sequence_param(asset_selection, "asset_selection", of_type=AssetKey),
             check.opt_inst_param(
-                partition_set_origin, "partition_set_origin", ExternalPartitionSetOrigin
+                partition_set_origin, "partition_set_origin", RemotePartitionSetOrigin
             ),
             check.opt_nullable_sequence_param(partition_names, "partition_names", of_type=str),
             check.opt_str_param(last_submitted_partition_name, "last_submitted_partition_name"),

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -17,7 +17,7 @@ from dagster._core.remote_representation.external_data import (
     ExternalPartitionExecutionParamData,
     ExternalPartitionSetExecutionParamData,
 )
-from dagster._core.remote_representation.origin import ExternalPartitionSetOrigin
+from dagster._core.remote_representation.origin import RemotePartitionSetOrigin
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import (
     PARENT_RUN_ID_TAG,
@@ -104,14 +104,14 @@ def execute_job_backfill_iteration(
 def _check_repo_has_partition_set(
     workspace_process_context: IWorkspaceProcessContext, backfill_job: PartitionBackfill
 ) -> None:
-    origin = cast(ExternalPartitionSetOrigin, backfill_job.partition_set_origin)
+    origin = cast(RemotePartitionSetOrigin, backfill_job.partition_set_origin)
 
-    location_name = origin.external_repository_origin.code_location_origin.location_name
+    location_name = origin.repository_origin.code_location_origin.location_name
 
     workspace = workspace_process_context.create_request_context()
     code_location = workspace.get_code_location(location_name)
 
-    repo_name = origin.external_repository_origin.repository_name
+    repo_name = origin.repository_origin.repository_name
     if not code_location.has_repository(repo_name):
         raise DagsterBackfillFailedError(
             f"Could not find repository {repo_name} in location {code_location.name} to "
@@ -175,9 +175,9 @@ def submit_backfill_runs(
     partition_names: Optional[Sequence[str]] = None,
 ) -> Iterable[Optional[str]]:
     """Returns the run IDs of the submitted runs."""
-    origin = cast(ExternalPartitionSetOrigin, backfill_job.partition_set_origin)
+    origin = cast(RemotePartitionSetOrigin, backfill_job.partition_set_origin)
 
-    repository_origin = origin.external_repository_origin
+    repository_origin = origin.repository_origin
     repo_name = repository_origin.repository_name
     location_name = repository_origin.code_location_origin.location_name
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -143,9 +143,9 @@ if TYPE_CHECKING:
     from dagster._core.remote_representation import (
         CodeLocation,
         ExternalJob,
-        ExternalJobOrigin,
         ExternalSensor,
         HistoricalJob,
+        RemoteJobOrigin,
     )
     from dagster._core.remote_representation.external import ExternalSchedule
     from dagster._core.run_coordinator import RunCoordinator
@@ -1137,7 +1137,7 @@ class DagsterInstance(DynamicPartitionsStore):
         parent_run_id: Optional[str] = None,
         op_selection: Optional[Sequence[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
-        external_job_origin: Optional["ExternalJobOrigin"] = None,
+        external_job_origin: Optional["RemoteJobOrigin"] = None,
         job_code_origin: Optional[JobPythonOrigin] = None,
         repository_load_data: Optional["RepositoryLoadData"] = None,
     ) -> DagsterRun:
@@ -1220,7 +1220,7 @@ class DagsterInstance(DynamicPartitionsStore):
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
         asset_check_selection: Optional[AbstractSet["AssetCheckKey"]] = None,
         op_selection: Optional[Sequence[str]] = None,
-        external_job_origin: Optional["ExternalJobOrigin"] = None,
+        external_job_origin: Optional["RemoteJobOrigin"] = None,
         job_code_origin: Optional[JobPythonOrigin] = None,
     ) -> DagsterRun:
         # https://github.com/dagster-io/dagster/issues/2403
@@ -1481,13 +1481,13 @@ class DagsterInstance(DynamicPartitionsStore):
         asset_check_selection: Optional[AbstractSet["AssetCheckKey"]],
         resolved_op_selection: Optional[AbstractSet[str]],
         op_selection: Optional[Sequence[str]],
-        external_job_origin: Optional["ExternalJobOrigin"],
+        external_job_origin: Optional["RemoteJobOrigin"],
         job_code_origin: Optional[JobPythonOrigin],
         asset_job_partitions_def: Optional["PartitionsDefinition"] = None,
     ) -> DagsterRun:
         from dagster._core.definitions.asset_check_spec import AssetCheckKey
         from dagster._core.definitions.utils import normalize_tags
-        from dagster._core.remote_representation.origin import ExternalJobOrigin
+        from dagster._core.remote_representation.origin import RemoteJobOrigin
         from dagster._core.snap import ExecutionPlanSnapshot, JobSnapshot
 
         check.str_param(job_name, "job_name")
@@ -1588,7 +1588,7 @@ class DagsterInstance(DynamicPartitionsStore):
         # If these are not set the created run will never be able to be relaunched from
         # the information just in the run or in another process.
 
-        check.opt_inst_param(external_job_origin, "external_job_origin", ExternalJobOrigin)
+        check.opt_inst_param(external_job_origin, "external_job_origin", RemoteJobOrigin)
         check.opt_inst_param(job_code_origin, "job_code_origin", JobPythonOrigin)
 
         dagster_run = self._construct_run_with_snapshots(

--- a/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
+++ b/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
@@ -115,7 +115,7 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
 
         external_job_origin = check.not_none(run.external_job_origin)
         code_location = context.workspace.get_code_location(
-            external_job_origin.external_repository_origin.code_location_origin.location_name
+            external_job_origin.repository_origin.code_location_origin.location_name
         )
 
         check.inst(

--- a/python_modules/dagster/dagster/_core/remote_representation/__init__.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/__init__.py
@@ -44,12 +44,12 @@ from .historical import HistoricalJob as HistoricalJob
 from .origin import (
     IN_PROCESS_NAME as IN_PROCESS_NAME,
     CodeLocationOrigin as CodeLocationOrigin,
-    ExternalInstigatorOrigin as ExternalInstigatorOrigin,
-    ExternalJobOrigin as ExternalJobOrigin,
-    ExternalRepositoryOrigin as ExternalRepositoryOrigin,
     GrpcServerCodeLocationOrigin as GrpcServerCodeLocationOrigin,
     InProcessCodeLocationOrigin as InProcessCodeLocationOrigin,
     ManagedGrpcPythonEnvCodeLocationOrigin as ManagedGrpcPythonEnvCodeLocationOrigin,
+    RemoteInstigatorOrigin as RemoteInstigatorOrigin,
+    RemoteJobOrigin as RemoteJobOrigin,
+    RemoteRepositoryOrigin as RemoteRepositoryOrigin,
 )
 
 # ruff: isort: split

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -40,10 +40,10 @@ from dagster._core.execution.plan.handle import ResolvedFromDynamicStepHandle, S
 from dagster._core.instance import DagsterInstance
 from dagster._core.origin import JobPythonOrigin, RepositoryPythonOrigin
 from dagster._core.remote_representation.origin import (
-    ExternalInstigatorOrigin,
-    ExternalJobOrigin,
-    ExternalPartitionSetOrigin,
-    ExternalRepositoryOrigin,
+    RemoteInstigatorOrigin,
+    RemoteJobOrigin,
+    RemotePartitionSetOrigin,
+    RemoteRepositoryOrigin,
 )
 from dagster._core.snap import ExecutionPlanSnapshot
 from dagster._core.snap.job_snapshot import JobSnapshot
@@ -333,7 +333,7 @@ class ExternalRepository:
             RepositorySelector(self._handle.location_name, self._handle.repository_name)
         )
 
-    def get_external_origin(self) -> ExternalRepositoryOrigin:
+    def get_external_origin(self) -> RemoteRepositoryOrigin:
         return self.handle.get_external_origin()
 
     def get_python_origin(self) -> RepositoryPythonOrigin:
@@ -547,7 +547,7 @@ class ExternalJob(RepresentedJob):
         repository_python_origin = self.repository_handle.get_python_origin()
         return JobPythonOrigin(self.name, repository_python_origin)
 
-    def get_external_origin(self) -> ExternalJobOrigin:
+    def get_external_origin(self) -> RemoteJobOrigin:
         return self.handle.get_external_origin()
 
     def get_external_origin_id(self) -> str:
@@ -758,7 +758,7 @@ class ExternalSchedule:
     def handle(self) -> InstigatorHandle:
         return self._handle
 
-    def get_external_origin(self) -> ExternalInstigatorOrigin:
+    def get_external_origin(self) -> RemoteInstigatorOrigin:
         return self.handle.get_external_origin()
 
     def get_external_origin_id(self) -> str:
@@ -902,7 +902,7 @@ class ExternalSensor:
     def run_tags(self) -> Mapping[str, str]:
         return self._external_sensor_data.run_tags
 
-    def get_external_origin(self) -> ExternalInstigatorOrigin:
+    def get_external_origin(self) -> RemoteInstigatorOrigin:
         return self._handle.get_external_origin()
 
     def get_external_origin_id(self) -> str:
@@ -1016,7 +1016,7 @@ class ExternalPartitionSet:
     def repository_handle(self) -> RepositoryHandle:
         return self._handle.repository_handle
 
-    def get_external_origin(self) -> ExternalPartitionSetOrigin:
+    def get_external_origin(self) -> RemotePartitionSetOrigin:
         return self._handle.get_external_origin()
 
     def get_external_origin_id(self) -> str:

--- a/python_modules/dagster/dagster/_core/remote_representation/handle.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/handle.py
@@ -5,7 +5,7 @@ from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.origin import RepositoryPythonOrigin
 from dagster._core.remote_representation.origin import (
     CodeLocationOrigin,
-    ExternalRepositoryOrigin,
+    RemoteRepositoryOrigin,
 )
 
 if TYPE_CHECKING:
@@ -40,7 +40,7 @@ class RepositoryHandle(
         return self.code_location_origin.location_name
 
     def get_external_origin(self):
-        return ExternalRepositoryOrigin(
+        return RemoteRepositoryOrigin(
             self.code_location_origin,
             self.repository_name,
         )

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -22,7 +22,7 @@ from dagster._core.definitions.run_request import (
 )
 from dagster._core.definitions.selector import InstigatorSelector, RepositorySelector
 from dagster._core.definitions.sensor_definition import SensorType
-from dagster._core.remote_representation.origin import ExternalInstigatorOrigin
+from dagster._core.remote_representation.origin import RemoteInstigatorOrigin
 from dagster._serdes import create_snapshot_id
 from dagster._serdes.errors import DeserializationError
 from dagster._serdes.serdes import (
@@ -212,7 +212,7 @@ class InstigatorState(
     NamedTuple(
         "_InstigationState",
         [
-            ("origin", ExternalInstigatorOrigin),
+            ("origin", RemoteInstigatorOrigin),
             ("instigator_type", InstigatorType),
             ("status", InstigatorStatus),
             ("instigator_data", Optional[InstigatorData]),
@@ -221,14 +221,14 @@ class InstigatorState(
 ):
     def __new__(
         cls,
-        origin: ExternalInstigatorOrigin,
+        origin: RemoteInstigatorOrigin,
         instigator_type: InstigatorType,
         status: InstigatorStatus,
         instigator_data: Optional[InstigatorData] = None,
     ):
         return super(InstigatorState, cls).__new__(
             cls,
-            check.inst_param(origin, "origin", ExternalInstigatorOrigin),
+            check.inst_param(origin, "origin", RemoteInstigatorOrigin),
             check.inst_param(instigator_type, "instigator_type", InstigatorType),
             check.inst_param(status, "status", InstigatorStatus),
             check_instigator_data(instigator_type, instigator_data),
@@ -248,13 +248,13 @@ class InstigatorState(
 
     @property
     def repository_origin_id(self) -> str:
-        return self.origin.external_repository_origin.get_id()
+        return self.origin.repository_origin.get_id()
 
     @property
     def repository_selector(self) -> RepositorySelector:
         return RepositorySelector(
-            self.origin.external_repository_origin.code_location_origin.location_name,
-            self.origin.external_repository_origin.repository_name,
+            self.origin.repository_origin.code_location_origin.location_name,
+            self.origin.repository_origin.repository_name,
         )
 
     @property
@@ -269,8 +269,8 @@ class InstigatorState(
     def selector_id(self) -> str:
         return create_snapshot_id(
             InstigatorSelector(
-                self.origin.external_repository_origin.code_location_origin.location_name,
-                self.origin.external_repository_origin.repository_name,
+                self.origin.repository_origin.code_location_origin.location_name,
+                self.origin.repository_origin.repository_name,
                 self.origin.instigator_name,
             )
         )

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
     from dagster._core.execution.stats import RunStepKeyStatsSnapshot
     from dagster._core.instance import DagsterInstance
-    from dagster._core.remote_representation.origin import ExternalJobOrigin
+    from dagster._core.remote_representation.origin import RemoteJobOrigin
     from dagster._core.scheduler.instigation import (
         AutoMaterializeAssetEvaluationRecord,
         InstigatorState,
@@ -344,7 +344,7 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     def set_cursor_values(self, pairs: Mapping[str, str]) -> None:
         return self._storage.run_storage.set_cursor_values(pairs)
 
-    def replace_job_origin(self, run: "DagsterRun", job_origin: "ExternalJobOrigin") -> None:
+    def replace_job_origin(self, run: "DagsterRun", job_origin: "RemoteJobOrigin") -> None:
         return self._storage.run_storage.replace_job_origin(run, job_origin)
 
 

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -22,7 +22,7 @@ from dagster._utils import PrintFn
 from ..daemon_cursor import DaemonCursorStorage
 
 if TYPE_CHECKING:
-    from dagster._core.remote_representation.origin import ExternalJobOrigin
+    from dagster._core.remote_representation.origin import RemoteJobOrigin
 
 
 class RunGroupInfo(TypedDict):
@@ -383,4 +383,4 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         return None
 
     @abstractmethod
-    def replace_job_origin(self, run: "DagsterRun", job_origin: "ExternalJobOrigin") -> None: ...
+    def replace_job_origin(self, run: "DagsterRun", job_origin: "RemoteJobOrigin") -> None: ...

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -204,7 +204,7 @@ def write_repo_tag(conn: Connection, run: DagsterRun) -> None:
         # nothing to do
         return
 
-    repository_label = run.external_job_origin.external_repository_origin.get_label()
+    repository_label = run.external_job_origin.repository_origin.get_label()
     try:
         conn.execute(
             RunTagsTable.insert().values(

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -40,7 +40,7 @@ from dagster._core.events import (
     RunFailureReason,
 )
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
-from dagster._core.remote_representation.origin import ExternalJobOrigin
+from dagster._core.remote_representation.origin import RemoteJobOrigin
 from dagster._core.snap import (
     ExecutionPlanSnapshot,
     JobSnapshot,
@@ -923,8 +923,8 @@ class SqlRunStorage(RunStorage):
                 )
 
     # Migrating run history
-    def replace_job_origin(self, run: DagsterRun, job_origin: ExternalJobOrigin) -> None:
-        new_label = job_origin.external_repository_origin.get_label()
+    def replace_job_origin(self, run: DagsterRun, job_origin: RemoteJobOrigin) -> None:
+        new_label = job_origin.repository_origin.get_label()
         with self.connect() as conn:
             conn.execute(
                 RunsTable.update()

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -42,7 +42,7 @@ from dagster._core.remote_representation import (
     ExternalSensor,
 )
 from dagster._core.remote_representation.external import ExternalRepository
-from dagster._core.remote_representation.origin import ExternalInstigatorOrigin
+from dagster._core.remote_representation.origin import RemoteInstigatorOrigin
 from dagster._core.scheduler.instigation import (
     InstigatorState,
     InstigatorStatus,
@@ -145,7 +145,7 @@ def _get_pre_sensor_auto_materialize_cursor(
 
 
 def get_current_evaluation_id(
-    instance: DagsterInstance, sensor_origin: Optional[ExternalInstigatorOrigin]
+    instance: DagsterInstance, sensor_origin: Optional[RemoteInstigatorOrigin]
 ) -> Optional[int]:
     if not sensor_origin:
         cursor = _get_pre_sensor_auto_materialize_cursor(instance, None)
@@ -335,7 +335,7 @@ class AssetDaemon(DagsterDaemon):
     def _get_print_sensor_name(self, sensor: Optional[ExternalSensor]) -> str:
         if not sensor:
             return ""
-        repo_origin = sensor.get_external_origin().external_repository_origin
+        repo_origin = sensor.get_external_origin().repository_origin
         repo_name = repo_origin.repository_name
         location_name = repo_origin.code_location_origin.location_name
         repo_name = (

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -113,7 +113,7 @@ def retry_run(
         )
         return
 
-    origin = failed_run.external_job_origin.external_repository_origin
+    origin = failed_run.external_job_origin.repository_origin
     code_location = workspace.get_code_location(origin.code_location_origin.location_name)
     repo_name = origin.repository_name
 

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -537,7 +537,7 @@ def _submit_run_request(
     code_location = _get_code_location_for_sensor(workspace_process_context, external_sensor)
     job_subset_selector = JobSubsetSelector(
         location_name=code_location.name,
-        repository_name=sensor_origin.external_repository_origin.repository_name,
+        repository_name=sensor_origin.repository_origin.repository_name,
         job_name=target_data.job_name,
         op_selection=target_data.op_selection,
         asset_selection=run_request.asset_selection,
@@ -579,7 +579,7 @@ def _get_code_location_for_sensor(
 ) -> CodeLocation:
     sensor_origin = external_sensor.get_external_origin()
     return workspace_process_context.create_request_context().get_code_location(
-        sensor_origin.external_repository_origin.code_location_origin.location_name
+        sensor_origin.repository_origin.code_location_origin.location_name
     )
 
 
@@ -912,8 +912,8 @@ def _fetch_existing_runs(
         # otherwise prevent the same named sensor across repos from effecting each other
         elif (
             run.external_job_origin is not None
-            and run.external_job_origin.external_repository_origin.get_selector_id()
-            == external_sensor.get_external_origin().external_repository_origin.get_selector_id()
+            and run.external_job_origin.repository_origin.get_selector_id()
+            == external_sensor.get_external_origin().repository_origin.get_selector_id()
             and run.tags.get(SENSOR_NAME_TAG) == external_sensor.name
         ):
             valid_runs.append(run)

--- a/python_modules/dagster/dagster/_grpc/client.py
+++ b/python_modules/dagster/dagster/_grpc/client.py
@@ -14,7 +14,7 @@ import dagster._seven as seven
 from dagster._core.errors import DagsterUserCodeUnreachableError
 from dagster._core.events import EngineEventData
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.origin import ExternalRepositoryOrigin
+from dagster._core.remote_representation.origin import RemoteRepositoryOrigin
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._serdes import serialize_value
 from dagster._utils.error import serializable_error_info_from_exc_info
@@ -324,13 +324,13 @@ class DagsterGrpcClient:
 
     def external_repository(
         self,
-        external_repository_origin: ExternalRepositoryOrigin,
+        external_repository_origin: RemoteRepositoryOrigin,
         defer_snapshots: bool = False,
     ) -> str:
         check.inst_param(
             external_repository_origin,
             "external_repository_origin",
-            ExternalRepositoryOrigin,
+            RemoteRepositoryOrigin,
         )
 
         res = self._query(
@@ -345,13 +345,13 @@ class DagsterGrpcClient:
 
     def external_job(
         self,
-        external_repository_origin: ExternalRepositoryOrigin,
+        external_repository_origin: RemoteRepositoryOrigin,
         job_name: str,
     ) -> api_pb2.ExternalJobReply:
         check.inst_param(
             external_repository_origin,
             "external_repository_origin",
-            ExternalRepositoryOrigin,
+            RemoteRepositoryOrigin,
         )
 
         return self._query(
@@ -363,7 +363,7 @@ class DagsterGrpcClient:
 
     def streaming_external_repository(
         self,
-        external_repository_origin: ExternalRepositoryOrigin,
+        external_repository_origin: RemoteRepositoryOrigin,
         defer_snapshots: bool = False,
         timeout=DEFAULT_REPOSITORY_GRPC_TIMEOUT,
     ) -> Iterator[dict]:

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -54,7 +54,7 @@ from dagster._core.remote_representation.external_data import (
     external_job_data_from_def,
     external_repository_data_from_def,
 )
-from dagster._core.remote_representation.origin import ExternalRepositoryOrigin
+from dagster._core.remote_representation.origin import RemoteRepositoryOrigin
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.utils import FuturesAwareThreadPoolExecutor, RequestUtilizationMetrics
 from dagster._core.workspace.autodiscovery import LoadableTarget
@@ -502,7 +502,7 @@ class DagsterApiServer(DagsterApiServicer):
 
     def _get_repo_for_origin(
         self,
-        external_repo_origin: ExternalRepositoryOrigin,
+        external_repo_origin: RemoteRepositoryOrigin,
     ) -> RepositoryDefinition:
         loaded_repos = check.not_none(self._loaded_repositories)
         if external_repo_origin.repository_name not in loaded_repos.definitions_by_name:
@@ -562,7 +562,7 @@ class DagsterApiServer(DagsterApiServicer):
         )
 
         execution_plan_snapshot_or_error = get_external_execution_plan_snapshot(
-            self._get_repo_for_origin(execution_plan_args.job_origin.external_repository_origin),
+            self._get_repo_for_origin(execution_plan_args.job_origin.repository_origin),
             execution_plan_args.job_origin.job_name,
             execution_plan_args,
         )
@@ -734,7 +734,7 @@ class DagsterApiServer(DagsterApiServicer):
             serialized_external_pipeline_subset_result = serialize_value(
                 get_external_pipeline_subset_result(
                     self._get_repo_for_origin(
-                        job_subset_snapshot_args.job_origin.external_repository_origin
+                        job_subset_snapshot_args.job_origin.repository_origin
                     ),
                     job_subset_snapshot_args.job_origin.job_name,
                     job_subset_snapshot_args.op_selection,
@@ -760,7 +760,7 @@ class DagsterApiServer(DagsterApiServicer):
         try:
             repository_origin = deserialize_value(
                 request.serialized_repository_python_origin,
-                ExternalRepositoryOrigin,
+                RemoteRepositoryOrigin,
             )
 
             return serialize_value(
@@ -789,7 +789,7 @@ class DagsterApiServer(DagsterApiServicer):
         try:
             repository_origin = deserialize_value(
                 request.serialized_repository_origin,
-                ExternalRepositoryOrigin,
+                RemoteRepositoryOrigin,
             )
 
             job_def = self._get_repo_for_origin(repository_origin).get_job(request.job_name)
@@ -1018,7 +1018,7 @@ class DagsterApiServer(DagsterApiServicer):
 
             # reconstructable required for handing execution off to subprocess
             recon_repo = check.not_none(self._loaded_repositories).reconstructables_by_name[
-                execute_external_job_args.job_origin.external_repository_origin.repository_name
+                execute_external_job_args.job_origin.repository_origin.repository_name
             ]
             recon_job = recon_repo.get_reconstructable_job(
                 execute_external_job_args.job_origin.job_name

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -13,8 +13,8 @@ from dagster._core.origin import JobPythonOrigin, get_python_environment_entry_p
 from dagster._core.remote_representation.external_data import DEFAULT_MODE_NAME
 from dagster._core.remote_representation.origin import (
     CodeLocationOrigin,
-    ExternalJobOrigin,
-    ExternalRepositoryOrigin,
+    RemoteJobOrigin,
+    RemoteRepositoryOrigin,
 )
 from dagster._serdes import serialize_value, whitelist_for_serdes
 from dagster._serdes.serdes import SetToSequenceFieldSerializer
@@ -32,7 +32,7 @@ class ExecutionPlanSnapshotArgs(
     NamedTuple(
         "_ExecutionPlanSnapshotArgs",
         [
-            ("job_origin", ExternalJobOrigin),
+            ("job_origin", RemoteJobOrigin),
             ("op_selection", Sequence[str]),
             ("run_config", Mapping[str, object]),
             ("step_keys_to_execute", Optional[Sequence[str]]),
@@ -47,7 +47,7 @@ class ExecutionPlanSnapshotArgs(
 ):
     def __new__(
         cls,
-        job_origin: ExternalJobOrigin,
+        job_origin: RemoteJobOrigin,
         op_selection: Sequence[str],
         run_config: Mapping[str, object],
         step_keys_to_execute: Optional[Sequence[str]],
@@ -60,7 +60,7 @@ class ExecutionPlanSnapshotArgs(
     ):
         return super(ExecutionPlanSnapshotArgs, cls).__new__(
             cls,
-            job_origin=check.inst_param(job_origin, "job_origin", ExternalJobOrigin),
+            job_origin=check.inst_param(job_origin, "job_origin", RemoteJobOrigin),
             op_selection=check.opt_sequence_param(op_selection, "op_selection", of_type=str),
             run_config=check.mapping_param(run_config, "run_config", key_type=str),
             mode=check.str_param(mode, "mode"),
@@ -200,7 +200,7 @@ class ExecuteExternalJobArgs(
     NamedTuple(
         "_ExecuteExternalJobArgs",
         [
-            ("job_origin", ExternalJobOrigin),
+            ("job_origin", RemoteJobOrigin),
             ("run_id", str),
             ("instance_ref", Optional[InstanceRef]),
         ],
@@ -208,7 +208,7 @@ class ExecuteExternalJobArgs(
 ):
     def __new__(
         cls,
-        job_origin: ExternalJobOrigin,
+        job_origin: RemoteJobOrigin,
         run_id: str,
         instance_ref: Optional[InstanceRef],
     ):
@@ -217,7 +217,7 @@ class ExecuteExternalJobArgs(
             job_origin=check.inst_param(
                 job_origin,
                 "job_origin",
-                ExternalJobOrigin,
+                RemoteJobOrigin,
             ),
             run_id=check.str_param(run_id, "run_id"),
             instance_ref=check.opt_inst_param(instance_ref, "instance_ref", InstanceRef),
@@ -404,7 +404,7 @@ class PartitionArgs(
     NamedTuple(
         "_PartitionArgs",
         [
-            ("repository_origin", ExternalRepositoryOrigin),
+            ("repository_origin", RemoteRepositoryOrigin),
             ("partition_set_name", str),
             ("partition_name", str),
             ("instance_ref", Optional[InstanceRef]),
@@ -413,7 +413,7 @@ class PartitionArgs(
 ):
     def __new__(
         cls,
-        repository_origin: ExternalRepositoryOrigin,
+        repository_origin: RemoteRepositoryOrigin,
         partition_set_name: str,
         partition_name: str,
         instance_ref: Optional[InstanceRef] = None,
@@ -423,7 +423,7 @@ class PartitionArgs(
             repository_origin=check.inst_param(
                 repository_origin,
                 "repository_origin",
-                ExternalRepositoryOrigin,
+                RemoteRepositoryOrigin,
             ),
             partition_set_name=check.str_param(partition_set_name, "partition_set_name"),
             partition_name=check.str_param(partition_name, "partition_name"),
@@ -435,14 +435,14 @@ class PartitionArgs(
 class PartitionNamesArgs(
     NamedTuple(
         "_PartitionNamesArgs",
-        [("repository_origin", ExternalRepositoryOrigin), ("partition_set_name", str)],
+        [("repository_origin", RemoteRepositoryOrigin), ("partition_set_name", str)],
     )
 ):
-    def __new__(cls, repository_origin: ExternalRepositoryOrigin, partition_set_name: str):
+    def __new__(cls, repository_origin: RemoteRepositoryOrigin, partition_set_name: str):
         return super(PartitionNamesArgs, cls).__new__(
             cls,
             repository_origin=check.inst_param(
-                repository_origin, "repository_origin", ExternalRepositoryOrigin
+                repository_origin, "repository_origin", RemoteRepositoryOrigin
             ),
             partition_set_name=check.str_param(partition_set_name, "partition_set_name"),
         )
@@ -453,7 +453,7 @@ class PartitionSetExecutionParamArgs(
     NamedTuple(
         "_PartitionSetExecutionParamArgs",
         [
-            ("repository_origin", ExternalRepositoryOrigin),
+            ("repository_origin", RemoteRepositoryOrigin),
             ("partition_set_name", str),
             ("partition_names", Sequence[str]),
             ("instance_ref", Optional[InstanceRef]),
@@ -462,7 +462,7 @@ class PartitionSetExecutionParamArgs(
 ):
     def __new__(
         cls,
-        repository_origin: ExternalRepositoryOrigin,
+        repository_origin: RemoteRepositoryOrigin,
         partition_set_name: str,
         partition_names: Sequence[str],
         instance_ref: Optional[InstanceRef] = None,
@@ -470,7 +470,7 @@ class PartitionSetExecutionParamArgs(
         return super(PartitionSetExecutionParamArgs, cls).__new__(
             cls,
             repository_origin=check.inst_param(
-                repository_origin, "repository_origin", ExternalRepositoryOrigin
+                repository_origin, "repository_origin", RemoteRepositoryOrigin
             ),
             partition_set_name=check.str_param(partition_set_name, "partition_set_name"),
             partition_names=check.sequence_param(partition_names, "partition_names", of_type=str),
@@ -491,7 +491,7 @@ class JobSubsetSnapshotArgs(
     NamedTuple(
         "_JobSubsetSnapshotArgs",
         [
-            ("job_origin", ExternalJobOrigin),
+            ("job_origin", RemoteJobOrigin),
             ("op_selection", Optional[Sequence[str]]),
             ("asset_selection", Optional[AbstractSet[AssetKey]]),
             ("asset_check_selection", Optional[AbstractSet[AssetCheckKey]]),
@@ -501,7 +501,7 @@ class JobSubsetSnapshotArgs(
 ):
     def __new__(
         cls,
-        job_origin: ExternalJobOrigin,
+        job_origin: RemoteJobOrigin,
         op_selection: Optional[Sequence[str]],
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
         asset_check_selection: Optional[AbstractSet[AssetCheckKey]] = None,
@@ -509,7 +509,7 @@ class JobSubsetSnapshotArgs(
     ):
         return super(JobSubsetSnapshotArgs, cls).__new__(
             cls,
-            job_origin=check.inst_param(job_origin, "job_origin", ExternalJobOrigin),
+            job_origin=check.inst_param(job_origin, "job_origin", RemoteJobOrigin),
             op_selection=check.opt_nullable_sequence_param(
                 op_selection, "op_selection", of_type=str
             ),
@@ -546,7 +546,7 @@ class ExternalScheduleExecutionArgs(
     NamedTuple(
         "_ExternalScheduleExecutionArgs",
         [
-            ("repository_origin", ExternalRepositoryOrigin),
+            ("repository_origin", RemoteRepositoryOrigin),
             ("instance_ref", Optional[InstanceRef]),
             ("schedule_name", str),
             ("scheduled_execution_timestamp", Optional[float]),
@@ -558,7 +558,7 @@ class ExternalScheduleExecutionArgs(
 ):
     def __new__(
         cls,
-        repository_origin: ExternalRepositoryOrigin,
+        repository_origin: RemoteRepositoryOrigin,
         instance_ref: Optional[InstanceRef],
         schedule_name: str,
         scheduled_execution_timestamp: Optional[float] = None,
@@ -569,7 +569,7 @@ class ExternalScheduleExecutionArgs(
         return super(ExternalScheduleExecutionArgs, cls).__new__(
             cls,
             repository_origin=check.inst_param(
-                repository_origin, "repository_origin", ExternalRepositoryOrigin
+                repository_origin, "repository_origin", RemoteRepositoryOrigin
             ),
             instance_ref=check.opt_inst_param(instance_ref, "instance_ref", InstanceRef),
             schedule_name=check.str_param(schedule_name, "schedule_name"),
@@ -590,7 +590,7 @@ class SensorExecutionArgs(
     NamedTuple(
         "_SensorExecutionArgs",
         [
-            ("repository_origin", ExternalRepositoryOrigin),
+            ("repository_origin", RemoteRepositoryOrigin),
             ("instance_ref", Optional[InstanceRef]),
             ("sensor_name", str),
             ("last_tick_completion_time", Optional[float]),
@@ -606,7 +606,7 @@ class SensorExecutionArgs(
 ):
     def __new__(
         cls,
-        repository_origin: ExternalRepositoryOrigin,
+        repository_origin: RemoteRepositoryOrigin,
         instance_ref: Optional[InstanceRef],
         sensor_name: str,
         last_tick_completion_time: Optional[float] = None,
@@ -628,7 +628,7 @@ class SensorExecutionArgs(
         return super(SensorExecutionArgs, cls).__new__(
             cls,
             repository_origin=check.inst_param(
-                repository_origin, "repository_origin", ExternalRepositoryOrigin
+                repository_origin, "repository_origin", RemoteRepositoryOrigin
             ),
             instance_ref=check.opt_inst_param(instance_ref, "instance_ref", InstanceRef),
             sensor_name=check.str_param(sensor_name, "sensor_name"),
@@ -649,19 +649,19 @@ class ExternalJobArgs(
     NamedTuple(
         "_ExternalJobArgs",
         [
-            ("repository_origin", ExternalRepositoryOrigin),
+            ("repository_origin", RemoteRepositoryOrigin),
             ("instance_ref", InstanceRef),
             ("name", str),
         ],
     )
 ):
     def __new__(
-        cls, repository_origin: ExternalRepositoryOrigin, instance_ref: InstanceRef, name: str
+        cls, repository_origin: RemoteRepositoryOrigin, instance_ref: InstanceRef, name: str
     ):
         return super(ExternalJobArgs, cls).__new__(
             cls,
             repository_origin=check.inst_param(
-                repository_origin, "repository_origin", ExternalRepositoryOrigin
+                repository_origin, "repository_origin", RemoteRepositoryOrigin
             ),
             instance_ref=check.inst_param(instance_ref, "instance_ref", InstanceRef),
             name=check.str_param(name, "name"),

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -298,7 +298,7 @@ def launch_scheduled_runs(
         and schedule_state.status == InstigatorStatus.DECLARED_IN_CODE
     ]
     for state in states_to_delete:
-        location_name = state.origin.external_repository_origin.code_location_origin.location_name
+        location_name = state.origin.repository_origin.code_location_origin.location_name
         # don't clean up auto running state if its location is an error state
         if location_name not in error_locations:
             logger.info(
@@ -709,8 +709,8 @@ def _submit_run_request(
             )
     else:
         job_subset_selector = JobSubsetSelector(
-            location_name=schedule_origin.external_repository_origin.code_location_origin.location_name,
-            repository_name=schedule_origin.external_repository_origin.repository_name,
+            location_name=schedule_origin.repository_origin.code_location_origin.location_name,
+            repository_name=schedule_origin.repository_origin.repository_name,
             job_name=external_schedule.job_name,
             op_selection=external_schedule.op_selection,
             asset_selection=run_request.asset_selection,
@@ -762,7 +762,7 @@ def _get_code_location_for_schedule(
 ) -> CodeLocation:
     schedule_origin = external_schedule.get_external_origin()
     return workspace_process_context.create_request_context().get_code_location(
-        schedule_origin.external_repository_origin.code_location_origin.location_name
+        schedule_origin.repository_origin.code_location_origin.location_name
     )
 
 
@@ -893,8 +893,8 @@ def _get_existing_run_for_request(
             matching_runs.append(run)
         # otherwise prevent the same named schedule (with the same execution time) across repos from effecting each other
         elif (
-            external_schedule.get_external_origin().external_repository_origin.get_selector_id()
-            == run.external_job_origin.external_repository_origin.get_selector_id()
+            external_schedule.get_external_origin().repository_origin.get_selector_id()
+            == run.external_job_origin.repository_origin.get_selector_id()
         ):
             matching_runs.append(run)
 

--- a/python_modules/dagster/dagster/_utils/external.py
+++ b/python_modules/dagster/dagster/_utils/external.py
@@ -4,18 +4,18 @@ import dagster._check as check
 from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.remote_representation import CodeLocation
 from dagster._core.remote_representation.external import ExternalJob
-from dagster._core.remote_representation.origin import ExternalJobOrigin
+from dagster._core.remote_representation.origin import RemoteJobOrigin
 
 
 def external_job_from_location(
     code_location: CodeLocation,
-    external_job_origin: ExternalJobOrigin,
+    external_job_origin: RemoteJobOrigin,
     op_selection: Optional[Sequence[str]],
 ) -> ExternalJob:
     check.inst_param(code_location, "code_location", CodeLocation)
-    check.inst_param(external_job_origin, "external_pipeline_origin", ExternalJobOrigin)
+    check.inst_param(external_job_origin, "external_pipeline_origin", RemoteJobOrigin)
 
-    repo_name = external_job_origin.external_repository_origin.repository_name
+    repo_name = external_job_origin.repository_origin.repository_name
     job_name = external_job_origin.job_name
 
     check.invariant(

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -14,8 +14,8 @@ from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.remote_representation import (
-    ExternalRepositoryOrigin,
     ManagedGrpcPythonEnvCodeLocationOrigin,
+    RemoteRepositoryOrigin,
 )
 from dagster._core.scheduler.instigation import (
     InstigatorState,
@@ -70,7 +70,7 @@ class TestScheduleStorage:
 
     @staticmethod
     def fake_repo_target():
-        return ExternalRepositoryOrigin(
+        return RemoteRepositoryOrigin(
             ManagedGrpcPythonEnvCodeLocationOrigin(
                 LoadableTargetOrigin(
                     executable_path=sys.executable, module_name="fake", attribute="fake"

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -15,7 +15,7 @@ from dagster._core.remote_representation import (
 from dagster._core.remote_representation.external import ExternalRepository
 from dagster._core.remote_representation.external_data import ExternalJobData
 from dagster._core.remote_representation.handle import RepositoryHandle
-from dagster._core.remote_representation.origin import ExternalRepositoryOrigin
+from dagster._core.remote_representation.origin import RemoteRepositoryOrigin
 from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._serdes.serdes import deserialize_value
@@ -107,7 +107,7 @@ def test_giant_external_repository_streaming_grpc():
 
 def test_defer_snapshots(instance: DagsterInstance):
     with get_bar_repo_code_location(instance) as code_location:
-        repo_origin = ExternalRepositoryOrigin(
+        repo_origin = RemoteRepositoryOrigin(
             code_location.origin,
             "bar_repo",
         )

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -63,9 +63,9 @@ from dagster._core.definitions.sensor_definition import (
 from dagster._core.events import DagsterEventType
 from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR
 from dagster._core.remote_representation import (
-    ExternalInstigatorOrigin,
-    ExternalRepositoryOrigin,
     ExternalSensor,
+    RemoteInstigatorOrigin,
+    RemoteRepositoryOrigin,
 )
 from dagster._core.remote_representation.external import ExternalRepository
 from dagster._core.remote_representation.origin import (
@@ -1156,7 +1156,7 @@ def test_sensors_keyed_on_selector_not_origin(
 
         existing_origin = external_sensor.get_external_origin()
 
-        code_location_origin = existing_origin.external_repository_origin.code_location_origin
+        code_location_origin = existing_origin.repository_origin.code_location_origin
         assert isinstance(code_location_origin, ManagedGrpcPythonEnvCodeLocationOrigin)
         modified_loadable_target_origin = code_location_origin.loadable_target_origin._replace(
             executable_path="/different/executable_path"
@@ -1164,7 +1164,7 @@ def test_sensors_keyed_on_selector_not_origin(
 
         # Change metadata on the origin that shouldn't matter for execution
         modified_origin = existing_origin._replace(
-            external_repository_origin=existing_origin.external_repository_origin._replace(
+            repository_origin=existing_origin.repository_origin._replace(
                 code_location_origin=code_location_origin._replace(
                     loadable_target_origin=modified_loadable_target_origin
                 )
@@ -1205,9 +1205,9 @@ def test_bad_load_sensor_repository(
         valid_origin = external_sensor.get_external_origin()
 
         # Swap out a new repository name
-        invalid_repo_origin = ExternalInstigatorOrigin(
-            ExternalRepositoryOrigin(
-                valid_origin.external_repository_origin.code_location_origin,
+        invalid_repo_origin = RemoteInstigatorOrigin(
+            RemoteRepositoryOrigin(
+                valid_origin.repository_origin.code_location_origin,
                 "invalid_repo_name",
             ),
             valid_origin.instigator_name,
@@ -1240,8 +1240,8 @@ def test_bad_load_sensor(executor, instance, workspace_context, external_repo):
         valid_origin = external_sensor.get_external_origin()
 
         # Swap out a new repository name
-        invalid_repo_origin = ExternalInstigatorOrigin(
-            valid_origin.external_repository_origin,
+        invalid_repo_origin = RemoteInstigatorOrigin(
+            valid_origin.repository_origin,
             "invalid_sensor",
         )
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -51,8 +51,8 @@ from dagster._core.execution.asset_backfill import RUN_CHUNK_SIZE
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.remote_representation import (
     ExternalRepository,
-    ExternalRepositoryOrigin,
     InProcessCodeLocationOrigin,
+    RemoteRepositoryOrigin,
 )
 from dagster._core.storage.dagster_run import IN_PROGRESS_RUN_STATUSES, DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import (
@@ -183,7 +183,7 @@ def config_job():
 
 def _unloadable_partition_set_origin():
     working_directory = os.path.dirname(__file__)
-    return ExternalRepositoryOrigin(
+    return RemoteRepositoryOrigin(
         InProcessCodeLocationOrigin(
             LoadableTargetOrigin(
                 executable_path=sys.executable,

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -21,8 +21,8 @@ from dagster._core.remote_representation.external import ExternalRepository
 from dagster._core.remote_representation.external_data import external_repository_data_from_def
 from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.remote_representation.origin import (
-    ExternalRepositoryOrigin,
     RegisteredCodeLocationOrigin,
+    RemoteRepositoryOrigin,
 )
 from dagster._core.test_utils import instance_for_test
 
@@ -99,7 +99,7 @@ def test_default_auto_materialize_sensors(instance_with_auto_materialize_sensors
     instance = instance_with_auto_materialize_sensors
 
     repo_handle = MagicMock(spec=RepositoryHandle)
-    repo_handle.get_external_origin.return_value = ExternalRepositoryOrigin(
+    repo_handle.get_external_origin.return_value = RemoteRepositoryOrigin(
         code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
         repository_name="bar_repo",
     )
@@ -137,7 +137,7 @@ def test_default_auto_materialize_sensors_without_observable(
     instance = instance_with_auto_materialize_sensors
 
     repo_handle = MagicMock(spec=RepositoryHandle)
-    repo_handle.get_external_origin.return_value = ExternalRepositoryOrigin(
+    repo_handle.get_external_origin.return_value = RemoteRepositoryOrigin(
         code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
         repository_name="bar_repo",
     )
@@ -164,7 +164,7 @@ def test_default_auto_materialize_sensors_without_observable(
 
 def test_no_default_auto_materialize_sensors(instance_without_auto_materialize_sensors):
     repo_handle = MagicMock(spec=RepositoryHandle)
-    repo_handle.get_external_origin.return_value = ExternalRepositoryOrigin(
+    repo_handle.get_external_origin.return_value = RemoteRepositoryOrigin(
         code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
         repository_name="bar_repo",
     )
@@ -201,7 +201,7 @@ def test_combine_default_sensors_with_non_default_sensors(instance_with_auto_mat
     )
 
     repo_handle = MagicMock(spec=RepositoryHandle)
-    repo_handle.get_external_origin.return_value = ExternalRepositoryOrigin(
+    repo_handle.get_external_origin.return_value = RemoteRepositoryOrigin(
         code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
         repository_name="bar_repo",
     )
@@ -272,7 +272,7 @@ def test_custom_sensors_cover_all(instance_with_auto_materialize_sensors):
     )
 
     repo_handle = MagicMock(spec=RepositoryHandle)
-    repo_handle.get_external_origin.return_value = ExternalRepositoryOrigin(
+    repo_handle.get_external_origin.return_value = RemoteRepositoryOrigin(
         code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
         repository_name="bar_repo",
     )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario.py
@@ -42,8 +42,8 @@ from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
 )
 from dagster._core.remote_representation.origin import (
-    ExternalInstigatorOrigin,
-    ExternalRepositoryOrigin,
+    RemoteInstigatorOrigin,
+    RemoteRepositoryOrigin,
 )
 from dagster._core.scheduler.instigation import SensorInstigatorData, TickStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
@@ -294,8 +294,8 @@ class AssetDaemonScenarioState(ScenarioState):
         if not self.sensor_name:
             return None
         code_location_origin = get_code_location_origin(self.scenario_spec)
-        return ExternalInstigatorOrigin(
-            external_repository_origin=ExternalRepositoryOrigin(
+        return RemoteInstigatorOrigin(
+            repository_origin=RemoteRepositoryOrigin(
                 code_location_origin=code_location_origin,
                 repository_name=SINGLETON_REPOSITORY_NAME,
             ),

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -668,14 +668,14 @@ def test_external_job_origin_instigator_origin():
     legacy_env, klass, repo_klass, location_klass = build_legacy_whitelist_map()
 
     from dagster._core.remote_representation.origin import (
-        ExternalInstigatorOrigin,
-        ExternalRepositoryOrigin,
         GrpcServerCodeLocationOrigin,
+        RemoteInstigatorOrigin,
+        RemoteRepositoryOrigin,
     )
 
     # serialize from current code, compare against old code
-    instigator_origin = ExternalInstigatorOrigin(
-        external_repository_origin=ExternalRepositoryOrigin(
+    instigator_origin = RemoteInstigatorOrigin(
+        repository_origin=RemoteRepositoryOrigin(
             code_location_origin=GrpcServerCodeLocationOrigin(
                 host="localhost", port=1234, location_name="test_location"
             ),
@@ -701,7 +701,7 @@ def test_external_job_origin_instigator_origin():
     )
     job_origin_str = serialize_value(job_origin, legacy_env)
 
-    job_to_instigator = deserialize_value(job_origin_str, ExternalInstigatorOrigin)
+    job_to_instigator = deserialize_value(job_origin_str, RemoteInstigatorOrigin)
     # ensure that the origin id is stable
     assert job_to_instigator.get_id() == job_origin.get_id()
 
@@ -913,9 +913,9 @@ def test_repo_label_tag_migration():
 
 def test_add_bulk_actions_columns():
     from dagster._core.remote_representation.origin import (
-        ExternalPartitionSetOrigin,
-        ExternalRepositoryOrigin,
         GrpcServerCodeLocationOrigin,
+        RemotePartitionSetOrigin,
+        RemoteRepositoryOrigin,
     )
     from dagster._core.storage.runs.schema import BulkActionsTable
 
@@ -955,8 +955,8 @@ def test_add_bulk_actions_columns():
             assert backfill_count == migrated_row_count
 
             # check that we are writing to selector id, action types
-            external_origin = ExternalPartitionSetOrigin(
-                external_repository_origin=ExternalRepositoryOrigin(
+            external_origin = RemotePartitionSetOrigin(
+                repository_origin=RemoteRepositoryOrigin(
                     code_location_origin=GrpcServerCodeLocationOrigin(port=1234, host="localhost"),
                     repository_name="fake_repository",
                 ),

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_metrics.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_metrics.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation import ExternalRepositoryOrigin
+from dagster._core.remote_representation import RemoteRepositoryOrigin
 from dagster._core.remote_representation.origin import (
     GrpcServerCodeLocationOrigin,
 )
@@ -49,7 +49,7 @@ def test_metrics_retrieval_annotations():
 
 
 def _launch_sensor_execution(
-    repo_origin: ExternalRepositoryOrigin, client: DagsterGrpcClient, instance: DagsterInstance
+    repo_origin: RemoteRepositoryOrigin, client: DagsterGrpcClient, instance: DagsterInstance
 ):
     client.external_sensor_execution(
         sensor_execution_args=SensorExecutionArgs(
@@ -91,7 +91,7 @@ def test_ping_metrics_retrieval(provide_flag: bool):
         client = DagsterGrpcClient(port=port)
 
         with instance_for_test() as instance:
-            repo_origin = ExternalRepositoryOrigin(
+            repo_origin = RemoteRepositoryOrigin(
                 code_location_origin=GrpcServerCodeLocationOrigin(port=port, host="localhost"),
                 repository_name="the_repo",
             )

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -9,10 +9,10 @@ from dagster import _seven
 from dagster._api.list_repositories import sync_list_repositories_grpc
 from dagster._core.errors import DagsterUserCodeUnreachableError
 from dagster._core.remote_representation.origin import (
-    ExternalJobOrigin,
-    ExternalRepositoryOrigin,
     GrpcServerCodeLocationOrigin,
     RegisteredCodeLocationOrigin,
+    RemoteJobOrigin,
+    RemoteRepositoryOrigin,
 )
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.test_utils import (
@@ -711,9 +711,9 @@ def test_load_with_secrets_loader_instance_ref(entrypoint):
                     run = create_run_for_test(instance, job_name="needs_env_var_job")
                     run_id = run.run_id
 
-                    job_origin = ExternalJobOrigin(
+                    job_origin = RemoteJobOrigin(
                         job_name="needs_env_var_job",
-                        external_repository_origin=ExternalRepositoryOrigin(
+                        repository_origin=RemoteRepositoryOrigin(
                             repository_name="needs_env_var_repo",
                             code_location_origin=RegisteredCodeLocationOrigin("not_used"),
                         ),
@@ -828,7 +828,7 @@ def test_sensor_timeout(entrypoint):
         client = DagsterGrpcClient(port=port)
 
         with instance_for_test() as instance:
-            repo_origin = ExternalRepositoryOrigin(
+            repo_origin = RemoteRepositoryOrigin(
                 code_location_origin=GrpcServerCodeLocationOrigin(port=port, host="localhost"),
                 repository_name="bar_repo",
             )

--- a/python_modules/dagster/dagster_tests/storage_tests/test_dagster_run.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_dagster_run.py
@@ -10,9 +10,9 @@ from dagster._core.origin import (
     RepositoryPythonOrigin,
 )
 from dagster._core.remote_representation.origin import (
-    ExternalJobOrigin,
-    ExternalRepositoryOrigin,
     InProcessCodeLocationOrigin,
+    RemoteJobOrigin,
+    RemoteRepositoryOrigin,
 )
 from dagster._core.storage.dagster_run import (
     IN_PROGRESS_RUN_STATUSES,
@@ -26,8 +26,8 @@ from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 
 def test_queued_job_origin_check():
     code_pointer = ModuleCodePointer("fake", "fake", working_directory=None)
-    fake_job_origin = ExternalJobOrigin(
-        ExternalRepositoryOrigin(
+    fake_job_origin = RemoteJobOrigin(
+        RemoteRepositoryOrigin(
             InProcessCodeLocationOrigin(
                 LoadableTargetOrigin(
                     executable_path=sys.executable,

--- a/python_modules/dagster/dagster_tests/storage_tests/test_job_run.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_job_run.py
@@ -10,9 +10,9 @@ from dagster._core.origin import (
     RepositoryPythonOrigin,
 )
 from dagster._core.remote_representation.origin import (
-    ExternalJobOrigin,
-    ExternalRepositoryOrigin,
     InProcessCodeLocationOrigin,
+    RemoteJobOrigin,
+    RemoteRepositoryOrigin,
 )
 from dagster._core.storage.dagster_run import (
     IN_PROGRESS_RUN_STATUSES,
@@ -26,8 +26,8 @@ from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 
 def test_queued_job_origin_check():
     code_pointer = ModuleCodePointer("fake", "fake", working_directory=None)
-    fake_job_origin = ExternalJobOrigin(
-        ExternalRepositoryOrigin(
+    fake_job_origin = RemoteJobOrigin(
+        RemoteRepositoryOrigin(
             InProcessCodeLocationOrigin(
                 LoadableTargetOrigin(
                     executable_path=sys.executable,

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -77,9 +77,9 @@ from dagster._core.remote_representation.external_data import (
     external_partitions_definition_from_def,
 )
 from dagster._core.remote_representation.origin import (
-    ExternalJobOrigin,
-    ExternalRepositoryOrigin,
     InProcessCodeLocationOrigin,
+    RemoteJobOrigin,
+    RemoteRepositoryOrigin,
 )
 from dagster._core.storage.asset_check_execution_record import (
     AssetCheckExecutionRecordStatus,
@@ -121,8 +121,8 @@ def create_and_delete_test_runs(instance: DagsterInstance, run_ids: Sequence[str
             create_run_for_test(
                 instance,
                 run_id=run_id,
-                external_job_origin=ExternalJobOrigin(
-                    ExternalRepositoryOrigin(
+                external_job_origin=RemoteJobOrigin(
+                    RemoteRepositoryOrigin(
                         InProcessCodeLocationOrigin(
                             LoadableTargetOrigin(
                                 executable_path=sys.executable,

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -19,8 +19,8 @@ from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.instance import DagsterInstance, InstanceType
 from dagster._core.launcher.sync_in_memory_run_launcher import SyncInMemoryRunLauncher
 from dagster._core.remote_representation import (
-    ExternalRepositoryOrigin,
     ManagedGrpcPythonEnvCodeLocationOrigin,
+    RemoteRepositoryOrigin,
 )
 from dagster._core.run_coordinator import DefaultRunCoordinator
 from dagster._core.snap import create_job_snapshot_id
@@ -91,7 +91,7 @@ class TestRunStorage:
     @staticmethod
     def fake_repo_target(repo_name=None):
         name = repo_name or "fake_repo_name"
-        return ExternalRepositoryOrigin(
+        return RemoteRepositoryOrigin(
             ManagedGrpcPythonEnvCodeLocationOrigin(
                 LoadableTargetOrigin(
                     executable_path=sys.executable, module_name="fake", attribute="fake"

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/utils.py
@@ -2,7 +2,7 @@ import hashlib
 import re
 from typing import Any, Mapping
 
-from dagster._core.remote_representation.origin import ExternalJobOrigin
+from dagster._core.remote_representation.origin import RemoteJobOrigin
 
 from .tasks import DagsterEcsTaskDefinitionConfig
 
@@ -21,11 +21,11 @@ def _get_family_hash(name):
 
 def get_task_definition_family(
     prefix: str,
-    job_origin: ExternalJobOrigin,
+    job_origin: RemoteJobOrigin,
 ) -> str:
     job_name = job_origin.job_name
-    repo_name = job_origin.external_repository_origin.repository_name
-    location_name = job_origin.external_repository_origin.code_location_origin.location_name
+    repo_name = job_origin.repository_origin.repository_name
+    location_name = job_origin.repository_origin.code_location_origin.location_name
 
     assert len(prefix) < 32
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_utils.py
@@ -1,7 +1,7 @@
 from dagster._core.remote_representation.origin import (
-    ExternalJobOrigin,
-    ExternalRepositoryOrigin,
     RegisteredCodeLocationOrigin,
+    RemoteJobOrigin,
+    RemoteRepositoryOrigin,
 )
 from dagster_aws.ecs.utils import get_task_definition_family, sanitize_family
 
@@ -16,8 +16,8 @@ def test_sanitize_family():
 
 
 def test_get_task_definition_family():
-    external_job_origin = ExternalJobOrigin(
-        external_repository_origin=ExternalRepositoryOrigin(
+    external_job_origin = RemoteJobOrigin(
+        repository_origin=RemoteRepositoryOrigin(
             repository_name="the_repo",
             code_location_origin=RegisteredCodeLocationOrigin(location_name="the_location"),
         ),
@@ -35,8 +35,8 @@ def test_long_names():
     long_repo_name = "b" * 512
     long_location_name = "c" * 512
 
-    external_job_origin = ExternalJobOrigin(
-        external_repository_origin=ExternalRepositoryOrigin(
+    external_job_origin = RemoteJobOrigin(
+        repository_origin=RemoteRepositoryOrigin(
             repository_name=long_repo_name,
             code_location_origin=RegisteredCodeLocationOrigin(location_name=long_location_name),
         ),

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -366,7 +366,7 @@ def create_k8s_job_task(celery_app, **task_kwargs):
         }
         if dagster_run.external_job_origin:
             labels["dagster/code-location"] = (
-                dagster_run.external_job_origin.external_repository_origin.code_location_origin.location_name
+                dagster_run.external_job_origin.repository_origin.code_location_origin.location_name
             )
         job = construct_dagster_k8s_job(
             job_config,

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -213,7 +213,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
         }
         if run.external_job_origin:
             labels["dagster/code-location"] = (
-                run.external_job_origin.external_repository_origin.code_location_origin.location_name
+                run.external_job_origin.repository_origin.code_location_origin.location_name
             )
 
         job = construct_dagster_k8s_job(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -275,7 +275,7 @@ class K8sStepHandler(StepHandler):
         }
         if run.external_job_origin:
             labels["dagster/code-location"] = (
-                run.external_job_origin.external_repository_origin.code_location_origin.location_name
+                run.external_job_origin.repository_origin.code_location_origin.location_name
             )
         job = construct_dagster_k8s_job(
             job_config=job_config,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -240,7 +240,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         }
         if run.external_job_origin:
             labels["dagster/code-location"] = (
-                run.external_job_origin.external_repository_origin.code_location_origin.location_name
+                run.external_job_origin.repository_origin.code_location_origin.location_name
             )
 
         job = construct_dagster_k8s_job(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -315,7 +315,7 @@ def execute_k8s_job(
     }
     if context.dagster_run.external_job_origin:
         labels["dagster/code-location"] = (
-            context.dagster_run.external_job_origin.external_repository_origin.code_location_origin.location_name
+            context.dagster_run.external_job_origin.repository_origin.code_location_origin.location_name
         )
 
     job = construct_dagster_k8s_job(


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/8960

Rename the following classes:

- `ExternalJobOrigin` -> `RemoteJobOrigin`
- `ExternalRepositoryOrigin` -> `RemoteRepositoryOrigin`
- `ExternalInstigatorOrigin` -> `RemoteInstigatorOrigin`
- `ExternalPartitionSetOrigin` -> `RemotePartitionSetOrigin`

Also rename the `external_repository_origin` field on these classes to just `repository_origin` (elsewhere we do not use the `external_` qualifier.

## How I Tested These Changes

Existing test suite.