### PR TITLE
[ui] Fix link to tags on asset catalog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -232,7 +232,7 @@ export const AssetNodeOverview = ({
         {assetNode.tags && assetNode.tags.length > 0 && (
           <Box flex={{gap: 4, alignItems: 'center', wrap: 'wrap'}}>
             {assetNode.tags.map((tag, idx) => (
-              <Tag key={idx}>{buildTagString({key: tag.key, value: tag.value})}</Tag>
+              <Tag key={idx}>{buildTagString(tag)}</Tag>
             ))}
           </Box>
         )}

--- a/js_modules/dagster-ui/packages/ui-core/src/search/BuildAssetSearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/BuildAssetSearchResults.tsx
@@ -1,6 +1,7 @@
 import {COMMON_COLLATOR} from '../app/Util';
 import {AssetTableDefinitionFragment} from '../assets/types/AssetTableFragment.types';
-import {Tag, buildTagString} from '../ui/tagAsString';
+import {DefinitionTag} from '../graphql/types';
+import {buildTagString} from '../ui/tagAsString';
 import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {repoAddressFromPath} from '../workspace/repoAddressFromPath';
@@ -17,7 +18,7 @@ type CountByComputeKind = {
 };
 
 type CountPerTag = {
-  tag: Tag;
+  tag: DefinitionTag;
   assetCount: number;
 };
 
@@ -74,7 +75,7 @@ export function buildAssetCountBySection(assets: AssetDefinitionMetadata[]): Ass
       }
 
       assetDefinition.tags.forEach((tag) => {
-        const stringifiedTag = JSON.stringify({key: tag.key, value: tag.value});
+        const stringifiedTag = JSON.stringify(tag);
         assetCountByTag[stringifiedTag] = (assetCountByTag[stringifiedTag] || 0) + 1;
       });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -15,11 +15,12 @@ import {useIndexedDBCachedQuery} from './useIndexedDBCachedQuery';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
-import {Tag, buildTagString} from '../ui/tagAsString';
+import {buildTagString} from '../ui/tagAsString';
 import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 import {repoAddressAsURLString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePath} from '../workspace/workspacePath';
+import {DefinitionTag} from '../graphql/types';
 
 export const linkToAssetTableWithGroupFilter = (groupMetadata: GroupMetadata) => {
   return `/assets?${qs.stringify({groups: JSON.stringify([groupMetadata])})}`;
@@ -31,7 +32,7 @@ export const linkToAssetTableWithComputeKindFilter = (computeKind: string) => {
   })}`;
 };
 
-export const linkToAssetTableWithTagFilter = (tag: Tag) => {
+export const linkToAssetTableWithTagFilter = (tag: DefinitionTag) => {
   return `/assets?${qs.stringify({
     tags: JSON.stringify([tag]),
   })}`;

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -15,12 +15,12 @@ import {useIndexedDBCachedQuery} from './useIndexedDBCachedQuery';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
+import {DefinitionTag} from '../graphql/types';
 import {buildTagString} from '../ui/tagAsString';
 import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 import {repoAddressAsURLString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePath} from '../workspace/workspacePath';
-import {DefinitionTag} from '../graphql/types';
 
 export const linkToAssetTableWithGroupFilter = (groupMetadata: GroupMetadata) => {
   return `/assets?${qs.stringify({groups: JSON.stringify([groupMetadata])})}`;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useAssetTagFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useAssetTagFilter.tsx
@@ -72,8 +72,15 @@ export function useAssetTagsForAssets(
 export function doesFilterArrayMatchValueArray<T, V>(
   filterArray: T[],
   valueArray: V[],
-  isMatch: (value1: T, value2: V) => boolean = (val1, val2) =>
-    JSON.stringify(val1) === JSON.stringify(val2),
+  isMatch: (value1: T, value2: V) => boolean = (val1, val2) => {
+    if (typeof val1 === 'object' && typeof val2 !== 'object') {
+      return (
+        JSON.stringify(val1, Object.keys(val1).sort()) ===
+        JSON.stringify(val2, Object.keys(val2).sort())
+      );
+    }
+    return JSON.stringify(val1) === JSON.stringify(val2);
+  },
 ) {
   if (filterArray.length && !valueArray.length) {
     return false;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useAssetTagFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useAssetTagFilter.tsx
@@ -1,3 +1,4 @@
+import isEqual from 'lodash/isEqual';
 import memoize from 'lodash/memoize';
 import {useMemo} from 'react';
 
@@ -73,13 +74,7 @@ export function doesFilterArrayMatchValueArray<T, V>(
   filterArray: T[],
   valueArray: V[],
   isMatch: (value1: T, value2: V) => boolean = (val1, val2) => {
-    if (typeof val1 === 'object' && typeof val2 !== 'object') {
-      return (
-        JSON.stringify(val1, Object.keys(val1).sort()) ===
-        JSON.stringify(val2, Object.keys(val2).sort())
-      );
-    }
-    return JSON.stringify(val1) === JSON.stringify(val2);
+    return isEqual(val1, val2);
   },
 ) {
   if (filterArray.length && !valueArray.length) {

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/tagAsString.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/tagAsString.ts
@@ -1,10 +1,5 @@
 const TAG_NO_VALUE_SENTINEL = '__dagster_no_value';
 
-export type Tag = {
-  key: string;
-  value: string;
-};
-
 export const buildTagString = ({key, value}: {key: string; value: string}) => {
   if (value === TAG_NO_VALUE_SENTINEL) {
     return key;


### PR DESCRIPTION
The asset table filters by matching `DefinitionTag` objects, this PR adjusts the asset catalog to use `DefinitionTag` instead of a custom type. This fixes the asset tags links.