### PR TITLE
[RFC] DagsterModel arbitrary_types_allowed

### DIFF
--- a/python_modules/dagster/dagster/_model/__init__.py
+++ b/python_modules/dagster/dagster/_model/__init__.py
@@ -9,6 +9,7 @@ class DagsterModel(BaseModel):
     """Standardizes on Pydantic settings that are stricter than the default.
     - Frozen, to avoid complexity caused by mutation.
     - extra=forbid, to avoid bugs caused by accidentally constructing with the wrong arguments.
+    - arbitrary_types_allowed, to allow non-model class params to be validated with isinstance.
     """
 
     def __init__(self, **data: Any) -> None:
@@ -17,6 +18,7 @@ class DagsterModel(BaseModel):
     class Config:
         extra = "forbid"
         frozen = True
+        arbitrary_types_allowed = True
 
     def model_copy(self, *, update: Optional[Dict[str, Any]] = None) -> Self:
         if pydantic.__version__ >= "2":

--- a/python_modules/dagster/dagster_tests/model_tests/test_dagster_model.py
+++ b/python_modules/dagster/dagster_tests/model_tests/test_dagster_model.py
@@ -46,3 +46,20 @@ def test_model_copy():
     assert obj.model_copy(update=dict(foo="xyz")) == MyClass(foo="xyz", bar=5)
     assert obj.model_copy(update=dict(bar=6)) == MyClass(foo="abc", bar=6)
     assert obj.model_copy(update=dict(foo="xyz", bar=6)) == MyClass(foo="xyz", bar=6)
+
+
+def test_non_model_param():
+    class SomeClass: ...
+
+    class OtherClass: ...
+
+    class MyModel(DagsterModel):
+        some_class: SomeClass
+
+    MyModel(some_class=SomeClass())
+
+    with pytest.raises(ValidationError):
+        MyModel(some_class=OtherClass())  # wrong class
+
+    with pytest.raises(ValidationError):
+        MyModel(some_class=SomeClass)  # forgot ()


### PR DESCRIPTION
Allow `DagsterModel` to take arbtirary class instances as params, validating them with `isinstance`. 

https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.arbitrary_types_allowed

I had a class that was heading in the immutable value object direction so I decided to try out `DagsterModel` and ended up hitting this snag. It had a little overridable class for customizing some behavior as a param.

## How I Tested These Changes

added test
