### PR TITLE
[pyright] 1.1.349 -> 1.1.356

### DIFF
--- a/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/docstring_flags.py
+++ b/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/docstring_flags.py
@@ -95,7 +95,7 @@ def visit_inline_flag(self, node: inline_flag):
 
 
 class flag(nodes.Element):
-    local_attributes = [*nodes.Element.local_attributes, *FLAG_ATTRS]  # type: ignore
+    local_attributes = [*nodes.Element.local_attributes, *FLAG_ATTRS]
 
 
 def visit_flag(self, node: flag):

--- a/pyright/alt-1/requirements-pinned.txt
+++ b/pyright/alt-1/requirements-pinned.txt
@@ -17,7 +17,6 @@ asn1crypto==1.5.1
 astroid==3.1.0
 asttokens==2.4.1
 async-lru==2.0.4
-async-timeout==4.0.3
 attrs==23.2.0
 babel==2.14.0
 backoff==2.2.1
@@ -71,17 +70,16 @@ decopatch==1.4.10
 decorator==5.1.1
 deepdiff==6.7.1
 defusedxml==0.7.1
-deltalake==0.16.2
+deltalake==0.16.3
 dill==0.3.8
 distlib==0.3.8
 docker==7.0.0
 docstring-parser==0.16
 duckdb==0.10.1
-exceptiongroup==1.2.0
 execnet==2.0.2
 executing==2.0.1
 fastjsonschema==2.19.1
-filelock==3.13.2
+filelock==3.13.3
 fonttools==4.50.0
 fqdn==1.5.1
 frozenlist==1.4.1
@@ -205,8 +203,8 @@ py==1.11.0
 py4j==0.10.9.7
 pyarrow==15.0.2
 pyarrow-hotfix==0.6
-pyasn1==0.5.1
-pyasn1-modules==0.3.0
+pyasn1==0.6.0
+pyasn1-modules==0.4.0
 pycparser==2.21
 pydantic==2.6.4
 pydantic-core==2.16.3
@@ -215,7 +213,7 @@ pyjwt==2.8.0
 pylint==3.1.0
 pyopenssl==24.1.0
 pyparsing==3.1.2
-pyright==1.1.349
+pyright==1.1.356
 pyspark==3.5.1
 pytest==7.4.4
 pytest-cases==3.8.4
@@ -259,8 +257,8 @@ snowflake-sqlalchemy==1.5.1
 sortedcontainers==2.4.0
 soupsieve==2.5
 sqlalchemy==1.4.52
-sqlglot==23.0.5
-sqlglotrs==0.1.2
+sqlglot==23.2.0
+sqlglotrs==0.1.3
 sqlparse==0.4.4
 stack-data==0.6.3
 starlette==0.37.2
@@ -281,7 +279,7 @@ tox==3.25.0
 tqdm==4.66.2
 traitlets==5.14.2
 typeguard==4.2.1
-typer==0.10.0
+typer==0.11.0
 types-backports==0.1.3
 types-certifi==2021.10.8.3
 types-chardet==5.0.4.6

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -35,7 +35,6 @@ asn1crypto==1.5.1
 -e examples/assets_pandas_pyspark
 asttokens==2.4.1
 async-lru==2.0.4
-async-timeout==4.0.3
 attrs==23.2.0
 autodocsumm==0.2.12
 autoflake==2.3.1
@@ -57,8 +56,8 @@ bitmath==1.3.3.1
 bleach==6.1.0
 blinker==1.7.0
 bokeh==3.4.0
-boto3==1.34.69
-botocore==1.34.69
+boto3==1.34.71
+botocore==1.34.71
 buildkite-test-collector==0.1.7
 cachecontrol==0.14.0
 cached-property==1.5.2
@@ -177,7 +176,7 @@ decopatch==1.4.10
 decorator==5.1.1
 deepdiff==6.7.1
 defusedxml==0.7.1
-deltalake==0.16.2
+deltalake==0.16.3
 deprecated==1.2.14
 -e examples/development_to_production
 dict2css==0.3.0.post1
@@ -198,14 +197,13 @@ duckdb==0.10.1
 ecdsa==0.18.0
 email-validator==1.3.1
 entrypoints==0.4
-exceptiongroup==1.2.0
 execnet==2.0.2
 executing==2.0.1
 expandvars==0.12.0
 fastavro==1.9.4
 fastjsonschema==2.19.1
 -e examples/feature_graph_backed_assets
-filelock==3.13.2
+filelock==3.13.3
 flask==2.2.5
 flask-appbuilder==4.3.6
 flask-babel==2.0.0
@@ -217,7 +215,7 @@ flask-login==0.6.3
 flask-session==0.5.0
 flask-sqlalchemy==2.5.1
 flask-wtf==1.2.1
-flatbuffers==24.3.7
+flatbuffers==24.3.25
 fonttools==4.50.0
 fqdn==1.5.1
 frozenlist==1.4.1
@@ -299,15 +297,15 @@ jupyterlab-server==2.25.4
 jupyterlab-widgets==3.0.10
 jwt==1.3.1
 kiwisolver==1.4.5
-kombu==5.3.5
+kombu==5.3.6
 kopf==1.37.1
 kubernetes==29.0.0
 kubernetes-asyncio==29.0.0
 langchain==0.1.11
 langchain-community==0.0.29
-langchain-core==0.1.33
+langchain-core==0.1.34
 langchain-text-splitters==0.0.1
-langsmith==0.1.31
+langsmith==0.1.33
 lazy-object-proxy==1.10.0
 leather==0.4.0
 limits==3.10.1
@@ -352,7 +350,7 @@ nbconvert==7.16.3
 nbformat==5.10.3
 nest-asyncio==1.6.0
 networkx==2.8.8
-nh3==0.2.15
+nh3==0.2.17
 nodeenv==1.8.0
 noteable-origami==0.0.35
 notebook==7.1.2
@@ -364,7 +362,7 @@ objgraph==3.6.1
 onnx==1.16.0
 onnxconverter-common==1.13.0
 onnxruntime==1.17.1
-openai==1.14.2
+openai==1.14.3
 openapi-schema-validator==0.6.2
 openapi-spec-validator==0.7.1
 opentelemetry-api==1.23.0
@@ -421,8 +419,8 @@ py-partiql-parser==0.5.0
 py4j==0.10.9.7
 pyarrow==15.0.2
 pyarrow-hotfix==0.6
-pyasn1==0.5.1
-pyasn1-modules==0.3.0
+pyasn1==0.6.0
+pyasn1-modules==0.4.0
 pycparser==2.21
 pydantic==1.10.14
 pydata-google-auth==1.8.2
@@ -433,7 +431,7 @@ pynacl==1.5.0
 pyopenssl==24.1.0
 pyparsing==3.1.2
 pypd==1.1.0
-pyright==1.1.349
+pyright==1.1.356
 pysocks==1.7.1
 pyspark==3.5.1
 pytablereader==0.31.4
@@ -517,8 +515,8 @@ sphinxcontrib-serializinghtml==1.1.10
 sqlalchemy==1.4.52
 sqlalchemy-jsonfield==1.0.2
 sqlalchemy-utils==0.41.2
-sqlglot==23.0.5
-sqlglotrs==0.1.2
+sqlglot==23.2.0
+sqlglotrs==0.1.3
 sqlparse==0.4.4
 sshpubkeys==3.3.1
 sshtunnel==0.4.0
@@ -554,7 +552,7 @@ twilio==9.0.2
 twine==1.15.0
 typeguard==4.2.1
 typepy==1.3.2
-typer==0.10.0
+typer==0.11.0
 types-backports==0.1.3
 types-certifi==2021.10.8.3
 types-chardet==5.0.4.6
@@ -590,7 +588,7 @@ uvicorn==0.29.0
 uvloop==0.19.0
 vine==5.1.0
 virtualenv==20.25.0
-wandb==0.16.4
+wandb==0.16.5
 watchdog==4.0.0
 watchfiles==0.21.0
 wcwidth==0.2.13

--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -831,7 +831,7 @@ class ResourceDependency(Generic[V]):
     def __set_name__(self, _owner, name):
         self._name = name
 
-    def __get__(self, obj: "ConfigurableResourceFactory", __owner: Any) -> V:
+    def __get__(self, obj: "ConfigurableResourceFactory", owner: Any) -> V:
         return getattr(obj, self._name)
 
     def __set__(self, obj: Optional[object], value: ResourceOrPartialOrValue[V]) -> None:

--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -174,7 +174,7 @@ class TypecheckAllowPartialResourceInitParams:
     def __set_name__(self, _owner, name):
         self._assigned_name = name
 
-    def __get__(self: Self, obj: Any, __owner: Any) -> Self:
+    def __get__(self: Self, obj: Any, owner: Any) -> Self:
         # no-op implementation (only used to affect type signature)
         return cast(Self, getattr(obj, self._assigned_name))
 

--- a/python_modules/dagster/dagster/_config/validate.py
+++ b/python_modules/dagster/dagster/_config/validate.py
@@ -220,9 +220,7 @@ def validate_selector_config(
     )
 
     if child_evaluate_value_result.success:
-        return EvaluateValueResult.for_value(  # type: ignore
-            {field_name: child_evaluate_value_result.value}
-        )
+        return EvaluateValueResult.for_value({field_name: child_evaluate_value_result.value})
     else:
         return child_evaluate_value_result
 
@@ -300,7 +298,7 @@ def _validate_shape_config(
     if errors:
         return EvaluateValueResult.for_errors(errors)
     else:
-        return EvaluateValueResult.for_value(config_value)  # type: ignore
+        return EvaluateValueResult.for_value(config_value)
 
 
 def validate_permissive_shape_config(

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -309,7 +309,7 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
         """
         check.inst_param(context, "context", OutputContext)
         metadata = context.definition_metadata
-        path = check.str_param(metadata.get("path"), "metadata.path")  # type: ignore  # (possible none)
+        path = check.str_param(metadata.get("path"), "metadata.path")
 
         filepath = self._get_path(path)
 
@@ -329,7 +329,7 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
         """Unpickle the file from a given file path and Load it to a data object."""
         check.inst_param(context, "context", InputContext)
         metadata = context.upstream_output.definition_metadata  # type: ignore  # (possible none)
-        path = check.str_param(metadata.get("path"), "metadata.path")  # type: ignore  # (possible none)
+        path = check.str_param(metadata.get("path"), "metadata.path")
         filepath = self._get_path(path)
         context.log.debug(f"Loading file from: {filepath}")
 

--- a/python_modules/dagster/dagster/_seven/compat/pendulum.py
+++ b/python_modules/dagster/dagster/_seven/compat/pendulum.py
@@ -30,7 +30,7 @@ def pendulum_create_timezone(tz_name: str):
 
         return Timezone(tz_name)
     else:
-        return pendulum.tz.timezone(tz_name)  # type: ignore
+        return pendulum.tz.timezone(tz_name)
 
 
 @contextmanager

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/conftest.py
@@ -65,7 +65,7 @@ def execute_check_for_asset(
 ) -> ExecuteInProcessResult:
     the_job = define_asset_job(
         name="test_asset_job",
-        selection=AssetSelection.checks(*asset_checks),
+        selection=AssetSelection.checks(*(asset_checks or [])),
     )
 
     defs = Definitions(assets=assets, asset_checks=asset_checks, jobs=[the_job])

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -141,7 +141,7 @@ setup(
         ],
         "mypy": ["mypy==1.8.0"],
         "pyright": [
-            "pyright==1.1.349",
+            "pyright==1.1.356",
             ### Stub packages
             "pandas-stubs",  # version will be resolved against pandas
             "types-backports",  # version will be resolved against backports


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/8962

Bump pyright from 1.1.349 -> 1.1.356.

Fix a few surfaced type errors and remove no-longer needed type-ignores.

## How I Tested These Changes

Existing test suite.