### PR TITLE
Introduce daemon ErrorCapture util

### DIFF
--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -62,7 +62,7 @@ from dagster._core.utils import InheritContextThreadPoolExecutor, make_new_run_i
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._daemon.daemon import DaemonIterator, DagsterDaemon, SpanMarker
 from dagster._daemon.sensor import is_under_min_interval, mark_sensor_state_for_tick
-from dagster._daemon.utils import ErrorCapture
+from dagster._daemon.utils import DaemonErrorCapture
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
 from dagster._utils import (
@@ -269,7 +269,7 @@ class AutoMaterializeLaunchContext:
                         "Unable to reach the code server. Auto-materialization will resume once the code server is available."
                     ) from exception_value
                 except:
-                    error_data = ErrorCapture.on_exception(sys.exc_info())
+                    error_data = DaemonErrorCapture.on_exception(sys.exc_info())
                     self.update_state(
                         TickStatus.FAILURE,
                         error=error_data,
@@ -277,7 +277,7 @@ class AutoMaterializeLaunchContext:
                         failure_count=self._tick.failure_count,
                     )
             else:
-                error_data = ErrorCapture.on_exception(sys.exc_info())
+                error_data = DaemonErrorCapture.on_exception(sys.exc_info())
                 self.update_state(
                     TickStatus.FAILURE, error=error_data, failure_count=self._tick.failure_count + 1
                 )
@@ -822,7 +822,7 @@ class AssetDaemon(DagsterDaemon):
                     is_retry=(retry_tick is not None),
                 )
         except Exception:
-            error_info = ErrorCapture.on_exception(
+            error_info = DaemonErrorCapture.on_exception(
                 exc_info=sys.exc_info(),
                 logger=self._logger,
                 log_message="Auto-materialize daemon caught an error",

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -62,13 +62,13 @@ from dagster._core.utils import InheritContextThreadPoolExecutor, make_new_run_i
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._daemon.daemon import DaemonIterator, DagsterDaemon, SpanMarker
 from dagster._daemon.sensor import is_under_min_interval, mark_sensor_state_for_tick
+from dagster._daemon.utils import ErrorCapture
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
 from dagster._utils import (
     SingleInstigatorDebugCrashFlags,
     check_for_debug_crash,
 )
-from dagster._utils.error import serializable_error_info_from_exc_info
 
 _LEGACY_PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY = "ASSET_DAEMON_CURSOR"
 _PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY = "ASSET_DAEMON_CURSOR_NEW"
@@ -269,7 +269,7 @@ class AutoMaterializeLaunchContext:
                         "Unable to reach the code server. Auto-materialization will resume once the code server is available."
                     ) from exception_value
                 except:
-                    error_data = serializable_error_info_from_exc_info(sys.exc_info())
+                    error_data = ErrorCapture.on_exception(sys.exc_info())
                     self.update_state(
                         TickStatus.FAILURE,
                         error=error_data,
@@ -277,7 +277,7 @@ class AutoMaterializeLaunchContext:
                         failure_count=self._tick.failure_count,
                     )
             else:
-                error_data = serializable_error_info_from_exc_info(sys.exc_info())
+                error_data = ErrorCapture.on_exception(sys.exc_info())
                 self.update_state(
                     TickStatus.FAILURE, error=error_data, failure_count=self._tick.failure_count + 1
                 )
@@ -822,8 +822,11 @@ class AssetDaemon(DagsterDaemon):
                     is_retry=(retry_tick is not None),
                 )
         except Exception:
-            error_info = serializable_error_info_from_exc_info(sys.exc_info())
-            self._logger.exception("Auto-materialize daemon caught an error")
+            error_info = ErrorCapture.on_exception(
+                exc_info=sys.exc_info(),
+                logger=self._logger,
+                log_message="Auto-materialize daemon caught an error",
+            )
 
         yield error_info
 

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -14,7 +14,7 @@ from dagster._core.storage.tags import (
     RUN_FAILURE_REASON_TAG,
 )
 from dagster._core.workspace.context import IWorkspaceProcessContext
-from dagster._utils.error import serializable_error_info_from_exc_info
+from dagster._daemon.utils import ErrorCapture
 
 DEFAULT_REEXECUTION_POLICY = ReexecutionStrategy.FROM_FAILURE
 
@@ -194,7 +194,7 @@ def consume_new_runs_for_automatic_reexecution(
         try:
             retry_run(run, retry_number, workspace_process_context)
         except Exception:
-            error_info = serializable_error_info_from_exc_info(sys.exc_info())
+            error_info = ErrorCapture.on_exception(exc_info=sys.exc_info())
             workspace_process_context.instance.report_engine_event(
                 "Failed to retry run",
                 run,

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -14,7 +14,7 @@ from dagster._core.storage.tags import (
     RUN_FAILURE_REASON_TAG,
 )
 from dagster._core.workspace.context import IWorkspaceProcessContext
-from dagster._daemon.utils import ErrorCapture
+from dagster._daemon.utils import DaemonErrorCapture
 
 DEFAULT_REEXECUTION_POLICY = ReexecutionStrategy.FROM_FAILURE
 
@@ -194,7 +194,7 @@ def consume_new_runs_for_automatic_reexecution(
         try:
             retry_run(run, retry_number, workspace_process_context)
         except Exception:
-            error_info = ErrorCapture.on_exception(exc_info=sys.exc_info())
+            error_info = DaemonErrorCapture.on_exception(exc_info=sys.exc_info())
             workspace_process_context.instance.report_engine_event(
                 "Failed to retry run",
                 run,

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -59,7 +59,6 @@ def execute_backfill_jobs(
                 sys.exc_info(),
                 logger=logger,
                 log_message=f"Backfill failed for {backfill.backfill_id}",
-                append_error_info_to_log_message=True,
             )
             instance.update_backfill(
                 backfill.with_status(BulkActionStatus.FAILED).with_error(error_info)

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -6,7 +6,7 @@ from dagster._core.execution.asset_backfill import execute_asset_backfill_iterat
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.execution.job_backfill import execute_job_backfill_iteration
 from dagster._core.workspace.context import IWorkspaceProcessContext
-from dagster._daemon.utils import ErrorCapture
+from dagster._daemon.utils import DaemonErrorCapture
 from dagster._utils.error import SerializableErrorInfo
 
 
@@ -55,7 +55,7 @@ def execute_backfill_jobs(
                     backfill, logger, workspace_process_context, debug_crash_flags, instance
                 )
         except Exception:
-            error_info = ErrorCapture.on_exception(
+            error_info = DaemonErrorCapture.on_exception(
                 sys.exc_info(),
                 logger=logger,
                 log_message=f"Backfill failed for {backfill.backfill_id}",

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -6,7 +6,8 @@ from dagster._core.execution.asset_backfill import execute_asset_backfill_iterat
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.execution.job_backfill import execute_job_backfill_iteration
 from dagster._core.workspace.context import IWorkspaceProcessContext
-from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
+from dagster._daemon.utils import ErrorCapture
+from dagster._utils.error import SerializableErrorInfo
 
 
 def execute_backfill_iteration(
@@ -54,9 +55,13 @@ def execute_backfill_jobs(
                     backfill, logger, workspace_process_context, debug_crash_flags, instance
                 )
         except Exception:
-            error_info = serializable_error_info_from_exc_info(sys.exc_info())
+            error_info = ErrorCapture.on_exception(
+                sys.exc_info(),
+                logger=logger,
+                log_message=f"Backfill failed for {backfill.backfill_id}",
+                append_error_info_to_log_message=True,
+            )
             instance.update_backfill(
                 backfill.with_status(BulkActionStatus.FAILED).with_error(error_info)
             )
-            logger.error(f"Backfill failed for {backfill.backfill_id}: {error_info.to_string()}")
             yield error_info

--- a/python_modules/dagster/dagster/_daemon/daemon.py
+++ b/python_modules/dagster/dagster/_daemon/daemon.py
@@ -28,7 +28,10 @@ from dagster._daemon.monitoring import (
 from dagster._daemon.sensor import execute_sensor_iteration_loop
 from dagster._daemon.types import DaemonHeartbeat
 from dagster._scheduler.scheduler import execute_scheduler_iteration_loop
-from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
+from dagster._utils.error import (
+    SerializableErrorInfo,
+    serializable_error_info_from_exc_info,
+)
 
 if TYPE_CHECKING:
     from pendulum.datetime import DateTime

--- a/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
+++ b/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
@@ -19,6 +19,7 @@ from dagster._core.storage.dagster_run import (
 )
 from dagster._core.storage.tags import MAX_RUNTIME_SECONDS_TAG
 from dagster._core.workspace.context import IWorkspace, IWorkspaceProcessContext
+from dagster._daemon.utils import ErrorCapture
 from dagster._utils import DebugCrashFlags
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
@@ -193,11 +194,12 @@ def execute_run_monitoring_iteration(
             else:
                 check.invariant(False, f"Unexpected run status: {run_record.dagster_run.status}")
         except Exception:
-            error_info = serializable_error_info_from_exc_info(sys.exc_info())
-            logger.error(
-                f"Hit error while monitoring run {run_record.dagster_run.run_id}: {error_info}"
+            yield ErrorCapture.on_exception(
+                exc_info=sys.exc_info(),
+                logger=logger,
+                log_message=f"Hit error while monitoring run {run_record.dagster_run.run_id}",
+                append_error_info_to_log_message=True,
             )
-            yield error_info
         else:
             yield
 

--- a/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
+++ b/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
@@ -19,7 +19,7 @@ from dagster._core.storage.dagster_run import (
 )
 from dagster._core.storage.tags import MAX_RUNTIME_SECONDS_TAG
 from dagster._core.workspace.context import IWorkspace, IWorkspaceProcessContext
-from dagster._daemon.utils import ErrorCapture
+from dagster._daemon.utils import DaemonErrorCapture
 from dagster._utils import DebugCrashFlags
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
@@ -194,7 +194,7 @@ def execute_run_monitoring_iteration(
             else:
                 check.invariant(False, f"Unexpected run status: {run_record.dagster_run.status}")
         except Exception:
-            yield ErrorCapture.on_exception(
+            yield DaemonErrorCapture.on_exception(
                 exc_info=sys.exc_info(),
                 logger=logger,
                 log_message=f"Hit error while monitoring run {run_record.dagster_run.run_id}",

--- a/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
+++ b/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
@@ -198,7 +198,6 @@ def execute_run_monitoring_iteration(
                 exc_info=sys.exc_info(),
                 logger=logger,
                 log_message=f"Hit error while monitoring run {run_record.dagster_run.run_id}",
-                append_error_info_to_log_message=True,
             )
         else:
             yield

--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -34,7 +34,7 @@ from dagster._core.utils import InheritContextThreadPoolExecutor
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._core.workspace.workspace import IWorkspace
 from dagster._daemon.daemon import DaemonIterator, IntervalDaemon
-from dagster._utils.error import serializable_error_info_from_exc_info
+from dagster._daemon.utils import ErrorCapture
 from dagster._utils.tags import TagConcurrencyLimitsCounter
 
 PAGE_SIZE = 100
@@ -378,7 +378,7 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
         try:
             instance.run_launcher.launch_run(LaunchRunContext(dagster_run=run, workspace=workspace))
         except Exception as e:
-            error = serializable_error_info_from_exc_info(sys.exc_info())
+            error = ErrorCapture.on_exception(exc_info=sys.exc_info())
 
             run = check.not_none(instance.get_run_by_id(run.run_id))
             # Make sure we don't re-enqueue a run if it has already finished or moved into STARTED:

--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -34,7 +34,7 @@ from dagster._core.utils import InheritContextThreadPoolExecutor
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._core.workspace.workspace import IWorkspace
 from dagster._daemon.daemon import DaemonIterator, IntervalDaemon
-from dagster._daemon.utils import ErrorCapture
+from dagster._daemon.utils import DaemonErrorCapture
 from dagster._utils.tags import TagConcurrencyLimitsCounter
 
 PAGE_SIZE = 100
@@ -378,7 +378,7 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
         try:
             instance.run_launcher.launch_run(LaunchRunContext(dagster_run=run, workspace=workspace))
         except Exception as e:
-            error = ErrorCapture.on_exception(exc_info=sys.exc_info())
+            error = DaemonErrorCapture.on_exception(exc_info=sys.exc_info())
 
             run = check.not_none(instance.get_run_by_id(run.run_id))
             # Make sure we don't re-enqueue a run if it has already finished or moved into STARTED:

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -54,7 +54,7 @@ from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, Runs
 from dagster._core.storage.tags import RUN_KEY_TAG, SENSOR_NAME_TAG
 from dagster._core.telemetry import SENSOR_RUN_CREATED, hash_name, log_action
 from dagster._core.workspace.context import IWorkspaceProcessContext
-from dagster._daemon.utils import ErrorCapture
+from dagster._daemon.utils import DaemonErrorCapture
 from dagster._scheduler.stale import resolve_stale_or_missing_assets
 from dagster._utils import DebugCrashFlags, SingleInstigatorDebugCrashFlags, check_for_debug_crash
 from dagster._utils.error import SerializableErrorInfo
@@ -226,7 +226,7 @@ class SensorLaunchContext(AbstractContextManager):
 
         # Log the error if the failure wasn't an interrupt or the daemon generator stopping
         if exception_value and not isinstance(exception_value, GeneratorExit):
-            error_info = ErrorCapture.on_exception(exc_info=sys.exc_info())
+            error_info = DaemonErrorCapture.on_exception(exc_info=sys.exc_info())
             self.update_state(TickStatus.FAILURE, error=error_info)
 
         self._write()
@@ -471,7 +471,7 @@ def _process_tick_generator(
             )
 
     except Exception:
-        error_info = ErrorCapture.on_exception(
+        error_info = DaemonErrorCapture.on_exception(
             exc_info=sys.exc_info(),
             logger=logger,
             log_message=f"Sensor daemon caught an error for sensor {external_sensor.name}",
@@ -570,7 +570,7 @@ def _submit_run_request(
         instance.submit_run(run.run_id, workspace_process_context.create_request_context())
         logger.info(f"Completed launch of run {run.run_id} for {external_sensor.name}")
     except Exception:
-        error_info = ErrorCapture.on_exception(
+        error_info = DaemonErrorCapture.on_exception(
             exc_info=sys.exc_info(),
             logger=logger,
             log_message=f"Run {run.run_id} created successfully but failed to launch",

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -54,9 +54,10 @@ from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, Runs
 from dagster._core.storage.tags import RUN_KEY_TAG, SENSOR_NAME_TAG
 from dagster._core.telemetry import SENSOR_RUN_CREATED, hash_name, log_action
 from dagster._core.workspace.context import IWorkspaceProcessContext
+from dagster._daemon.utils import ErrorCapture
 from dagster._scheduler.stale import resolve_stale_or_missing_assets
 from dagster._utils import DebugCrashFlags, SingleInstigatorDebugCrashFlags, check_for_debug_crash
-from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
+from dagster._utils.error import SerializableErrorInfo
 from dagster._utils.merger import merge_dicts
 
 if TYPE_CHECKING:
@@ -225,8 +226,8 @@ class SensorLaunchContext(AbstractContextManager):
 
         # Log the error if the failure wasn't an interrupt or the daemon generator stopping
         if exception_value and not isinstance(exception_value, GeneratorExit):
-            error_data = serializable_error_info_from_exc_info(sys.exc_info())
-            self.update_state(TickStatus.FAILURE, error=error_data)
+            error_info = ErrorCapture.on_exception(exc_info=sys.exc_info())
+            self.update_state(TickStatus.FAILURE, error=error_info)
 
         self._write()
 
@@ -470,8 +471,11 @@ def _process_tick_generator(
             )
 
     except Exception:
-        error_info = serializable_error_info_from_exc_info(sys.exc_info())
-        logger.exception(f"Sensor daemon caught an error for sensor {external_sensor.name}")
+        error_info = ErrorCapture.on_exception(
+            exc_info=sys.exc_info(),
+            logger=logger,
+            log_message=f"Sensor daemon caught an error for sensor {external_sensor.name}",
+        )
 
     yield error_info
 
@@ -566,8 +570,12 @@ def _submit_run_request(
         instance.submit_run(run.run_id, workspace_process_context.create_request_context())
         logger.info(f"Completed launch of run {run.run_id} for {external_sensor.name}")
     except Exception:
-        error_info = serializable_error_info_from_exc_info(sys.exc_info())
-        logger.error(f"Run {run.run_id} created successfully but failed to launch: {error_info}")
+        error_info = ErrorCapture.on_exception(
+            exc_info=sys.exc_info(),
+            logger=logger,
+            log_message=f"Run {run.run_id} created successfully but failed to launch",
+            append_error_info_to_log_message=True,
+        )
 
     check_for_debug_crash(sensor_debug_crash_flags, "RUN_LAUNCHED")
     return SubmitRunRequestResult(run_key=run_request.run_key, error_info=error_info, run=run)

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -574,7 +574,6 @@ def _submit_run_request(
             exc_info=sys.exc_info(),
             logger=logger,
             log_message=f"Run {run.run_id} created successfully but failed to launch",
-            append_error_info_to_log_message=True,
         )
 
     check_for_debug_crash(sensor_debug_crash_flags, "RUN_LAUNCHED")

--- a/python_modules/dagster/dagster/_daemon/utils.py
+++ b/python_modules/dagster/dagster/_daemon/utils.py
@@ -15,7 +15,7 @@ class ErrorCapture:
         logger: Optional[logging.Logger] = None,
         log_message: Optional[str] = None,
         append_error_info_to_log_message: bool = False,
-    ) -> SerializableErrorInfo:
+    ) -> Optional[SerializableErrorInfo]:
         error_info = serializable_error_info_from_exc_info(exc_info)
         if logger and log_message:
             if append_error_info_to_log_message:

--- a/python_modules/dagster/dagster/_daemon/utils.py
+++ b/python_modules/dagster/dagster/_daemon/utils.py
@@ -14,12 +14,9 @@ class ErrorCapture:
         exc_info: ExceptionInfo,
         logger: Optional[logging.Logger] = None,
         log_message: Optional[str] = None,
-        append_error_info_to_log_message: bool = False,
     ) -> SerializableErrorInfo:
         error_info = serializable_error_info_from_exc_info(exc_info)
         if logger and log_message:
-            if append_error_info_to_log_message:
-                log_message += f": {error_info}"
             logger.exception(log_message)
         return error_info
 

--- a/python_modules/dagster/dagster/_daemon/utils.py
+++ b/python_modules/dagster/dagster/_daemon/utils.py
@@ -1,0 +1,27 @@
+import logging
+from typing import Optional
+
+from dagster._utils.error import (
+    ExceptionInfo,
+    SerializableErrorInfo,
+    serializable_error_info_from_exc_info,
+)
+
+
+class ErrorCapture:
+    @staticmethod
+    def default_on_exception(
+        exc_info: ExceptionInfo,
+        logger: Optional[logging.Logger] = None,
+        log_message: Optional[str] = None,
+        append_error_info_to_log_message: bool = False,
+    ) -> SerializableErrorInfo:
+        error_info = serializable_error_info_from_exc_info(exc_info)
+        if logger and log_message:
+            if append_error_info_to_log_message:
+                log_message += f": {error_info}"
+            logger.exception(log_message)
+        return error_info
+
+    # global behavior for how to handle unexpected exceptions
+    on_exception = default_on_exception

--- a/python_modules/dagster/dagster/_daemon/utils.py
+++ b/python_modules/dagster/dagster/_daemon/utils.py
@@ -8,7 +8,7 @@ from dagster._utils.error import (
 )
 
 
-class ErrorCapture:
+class DaemonErrorCapture:
     @staticmethod
     def default_on_exception(
         exc_info: ExceptionInfo,

--- a/python_modules/dagster/dagster/_daemon/utils.py
+++ b/python_modules/dagster/dagster/_daemon/utils.py
@@ -15,7 +15,7 @@ class ErrorCapture:
         logger: Optional[logging.Logger] = None,
         log_message: Optional[str] = None,
         append_error_info_to_log_message: bool = False,
-    ) -> Optional[SerializableErrorInfo]:
+    ) -> SerializableErrorInfo:
         error_info = serializable_error_info_from_exc_info(exc_info)
         if logger and log_message:
             if append_error_info_to_log_message:

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -1433,7 +1433,7 @@ def test_launch_failure(caplog, executor, workspace_context, external_repo):
                 [run.run_id],
             )
 
-            assert f"Run {run.run_id} created successfully but failed to launch:" in caplog.text
+            assert f"Run {run.run_id} created successfully but failed to launch" in caplog.text
 
             assert "The entire purpose of this is to throw on launch" in caplog.text
 


### PR DESCRIPTION
Similar to https://github.com/dagster-io/dagster/pull/6527

But for daemons. This introduces an `ErrorCapture` util that provides a
way to override default error handling in our daemons.

Unlike the graphql implementation that inspired this, our daemons tend
to include their own custom exception logging on error. The `on_capture`
method can optionally be provided arguments to preserve the existing
logging behavior.