### PR TITLE
feat(asset-overview): add experimental flag to enable asset overview

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -19,7 +19,11 @@ export const FeatureFlag = {
 export type FeatureFlagType = keyof typeof FeatureFlag;
 
 export const getFeatureFlags: () => FeatureFlagType[] = memoize(
-  () => getJSONForKey(DAGSTER_FLAGS_KEY) || [],
+  () =>
+    getJSONForKey(DAGSTER_FLAGS_KEY) || [
+      // Enable the new asset details page by default.
+      FeatureFlag.flagUseNewOverviewPage,
+    ],
 );
 
 export const featureEnabled = memoize((flag: FeatureFlagType) => getFeatureFlags().includes(flag));

--- a/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
@@ -25,6 +25,10 @@ export const getVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagUseNewAutomationPage,
   },
   {
+    key: 'Use new asset overview page',
+    flagType: FeatureFlag.flagUseNewOverviewPage,
+  },
+  {
     key: 'Use new settings page',
     flagType: FeatureFlag.flagSettingsPage,
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetViewDefinition.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetViewDefinition.fixtures.ts
@@ -6,7 +6,14 @@ import {
   buildRepository,
   buildRepositoryLocation,
   buildResourceRequirement,
+  buildWorkspace,
+  buildWorkspaceLocationEntry,
 } from '../../graphql/types';
+import {ROOT_WORKSPACE_QUERY} from '../../workspace/WorkspaceContext';
+import {
+  RootWorkspaceQuery,
+  RootWorkspaceQueryVariables,
+} from '../../workspace/types/WorkspaceContext.types';
 import {ASSET_VIEW_DEFINITION_QUERY} from '../AssetView';
 import {buildQueryMock} from '../AutoMaterializePolicyPage/__fixtures__/AutoMaterializePolicyPage.fixtures';
 import {
@@ -142,6 +149,34 @@ export const AssetViewDefinitionSDA = buildQueryMock<
         targetingInstigators: [],
         owners: [],
       }),
+    }),
+  },
+});
+
+export const RootWorkspaceWithOneLocation = buildQueryMock<
+  RootWorkspaceQuery,
+  RootWorkspaceQueryVariables
+>({
+  query: ROOT_WORKSPACE_QUERY,
+  variables: {},
+  data: {
+    workspaceOrError: buildWorkspace({
+      locationEntries: [
+        buildWorkspaceLocationEntry({
+          locationOrLoadError: buildRepositoryLocation({
+            repositories: [
+              buildRepository({
+                id: '4d0b1967471d9a4682ccc97d12c1c508d0d9c2e1',
+                name: 'repo',
+                location: buildRepositoryLocation({
+                  id: 'test.py',
+                  name: 'test.py',
+                }),
+              }),
+            ],
+          }),
+        }),
+      ],
     }),
   },
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetView.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetView.test.tsx
@@ -22,12 +22,14 @@ import {
   buildAssetNode,
 } from '../../graphql/types';
 import {buildQueryMock} from '../../testing/mocking';
+import {WorkspaceProvider} from '../../workspace/WorkspaceContext';
 import {AssetView} from '../AssetView';
 import {
   AssetViewDefinitionNonSDA,
   AssetViewDefinitionSDA,
   AssetViewDefinitionSourceAsset,
   LatestMaterializationTimestamp,
+  RootWorkspaceWithOneLocation,
 } from '../__fixtures__/AssetViewDefinition.fixtures';
 
 // This file must be mocked because Jest can't handle `import.meta.url`.
@@ -57,6 +59,7 @@ describe('AssetView', () => {
     return (
       <MockedProvider
         mocks={[
+          RootWorkspaceWithOneLocation,
           AssetViewDefinitionSDA,
           AssetViewDefinitionNonSDA,
           AssetViewDefinitionSourceAsset,
@@ -72,11 +75,13 @@ describe('AssetView', () => {
           }),
         ]}
       >
-        <AssetLiveDataProvider>
-          <MemoryRouter initialEntries={[path]}>
-            <AssetView assetKey={assetKey} headerBreadcrumbs={[]} />
-          </MemoryRouter>
-        </AssetLiveDataProvider>
+        <WorkspaceProvider>
+          <AssetLiveDataProvider>
+            <MemoryRouter initialEntries={[path]}>
+              <AssetView assetKey={assetKey} headerBreadcrumbs={[]} />
+            </MemoryRouter>
+          </AssetLiveDataProvider>
+        </WorkspaceProvider>
       </MockedProvider>
     );
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/useAssetTabs.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/useAssetTabs.test.tsx
@@ -240,11 +240,11 @@ describe('buildAssetTabs', () => {
     );
     const tabKeys = hookResult.result.current.map(({id}) => id);
     expect(tabKeys).toEqual([
+      'overview',
       'partitions',
       'events',
       'checks',
       'plots',
-      'definition',
       'lineage',
       'automation',
     ]);
@@ -258,7 +258,7 @@ describe('buildAssetTabs', () => {
       }),
     );
     const tabKeys = hookResult.result.current.map(({id}) => id);
-    expect(tabKeys).toEqual(['partitions', 'events', 'checks', 'plots', 'definition', 'lineage']);
+    expect(tabKeys).toEqual(['overview', 'partitions', 'events', 'checks', 'plots', 'lineage']);
   });
 
   it('hides partitions tab if no partitions', () => {
@@ -269,7 +269,7 @@ describe('buildAssetTabs', () => {
       }),
     );
     const tabKeys = hookResult.result.current.map(({id}) => id);
-    expect(tabKeys).toEqual(['events', 'checks', 'plots', 'definition', 'lineage', 'automation']);
+    expect(tabKeys).toEqual(['overview', 'events', 'checks', 'plots', 'lineage', 'automation']);
   });
 
   it('hides partitions and auto-materialize tabs if no partitions or auto-materializing', () => {
@@ -280,6 +280,6 @@ describe('buildAssetTabs', () => {
       }),
     );
     const tabKeys = hookResult.result.current.map(({id}) => id);
-    expect(tabKeys).toEqual(['events', 'checks', 'plots', 'definition', 'lineage']);
+    expect(tabKeys).toEqual(['overview', 'events', 'checks', 'plots', 'lineage']);
   });
 });


### PR DESCRIPTION
## Summary & Motivation
We are enabling the asset details page for everyone in OSS, but keeping the flag in case folks want to turn it off.

This will respect whether the user has previously toggled the feature on/off. The default introduced in this PR will only be populated if the flags key in local storage is not present.

## How I Tested These Changes
local
