### PR TITLE
test(dbt): do not invoke `dbt deps` multiple times

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
@@ -57,7 +57,9 @@ def disable_openblas_threading_affinity_fixture() -> None:
 def _create_dbt_invocation(project_dir: Path, build_project: bool = False) -> DbtCliInvocation:
     dbt = DbtCliResource(project_dir=os.fspath(project_dir), global_config_flags=["--quiet"])
 
-    dbt.cli(["deps"]).wait()
+    if not project_dir.joinpath("dbt_packages").exists():
+        dbt.cli(["deps"], raise_on_error=False).wait()
+
     dbt_invocation = dbt.cli(["compile"]).wait()
 
     if build_project:


### PR DESCRIPTION
## Summary & Motivation
Resolves these sorts of errors: https://buildkite.com/dagster/dagster-dagster/builds/79537#018e812c-5e29-445b-b896-0ef7b63a0ee0

> FileExistsError: [Errno 17] File exists: 'dbt_packages/dagster'

Meaning the dbt packages have already been installed by a separate `pytest-xdist` process. So don't try and install them again.

## How I Tested These Changes
bk
