### PR TITLE
[ui] Assets overview: Add plots section

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
@@ -129,7 +129,7 @@ export const AssetEventDetail = ({
 
       <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
         <Subheading>Metadata</Subheading>
-        <AssetEventMetadataEntriesTable event={event} showDescriptions />
+        <AssetEventMetadataEntriesTable assetKey={assetKey} event={event} showDescriptions />
       </Box>
 
       {event.__typename === 'MaterializationEvent' && (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventMetadataEntriesTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventMetadataEntriesTable.tsx
@@ -1,10 +1,22 @@
-import {Box, Button, Caption, Colors, Icon, Mono, Tag, TextInput} from '@dagster-io/ui-components';
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Caption,
+  Colors,
+  Icon,
+  Mono,
+  Tag,
+  TextInput,
+} from '@dagster-io/ui-components';
 import dayjs from 'dayjs';
 import uniqBy from 'lodash/uniqBy';
 import {useMemo, useState} from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
+import {AssetEventMetadataPlots} from './AssetEventMetadataPlots';
+import {AssetKey} from './types';
 import {
   AssetMaterializationFragment,
   AssetObservationFragment,
@@ -23,27 +35,13 @@ type TableEvent = Pick<
   runId?: string;
 };
 
-/**
- * This component shows the metadata entries attached to an Asset Materialization or Observation event.
- * AssetNodes also have definition-time metadata, which is unrelated to this event metadata.
- */
-export const AssetEventMetadataEntriesTable = ({
-  event,
-  observations,
-  definitionMetadata,
-  definitionLoadTimestamp,
-  showDescriptions,
-  showTimestamps,
-  showHeader,
-  showFilter,
-  hideTableSchema,
-  displayedByDefault = 100,
-  emptyState,
-}: {
+interface Props {
+  assetKey?: AssetKey;
   event: TableEvent | null;
   observations?: TableEvent[] | null;
   definitionMetadata?: MetadataEntryFragment[];
   definitionLoadTimestamp?: number;
+  assetHasDefinedPartitions?: boolean;
   showDescriptions?: boolean;
   showTimestamps?: boolean;
   showHeader?: boolean;
@@ -51,9 +49,33 @@ export const AssetEventMetadataEntriesTable = ({
   hideTableSchema?: boolean;
   displayedByDefault?: number;
   emptyState?: React.ReactNode;
-}) => {
+}
+
+/**
+ * This component shows the metadata entries attached to an Asset Materialization or Observation event.
+ * AssetNodes also have definition-time metadata, which is unrelated to this event metadata.
+ */
+export const AssetEventMetadataEntriesTable = ({
+  assetKey,
+  event,
+  observations,
+  definitionMetadata,
+  definitionLoadTimestamp,
+  assetHasDefinedPartitions,
+  showDescriptions,
+  showTimestamps,
+  showHeader,
+  showFilter,
+  hideTableSchema,
+  displayedByDefault = 100,
+  emptyState,
+}: Props) => {
   const [filter, setFilter] = useState('');
   const [displayedCount, setDisplayedCount] = useState(displayedByDefault);
+  const [view, setView] = useState<'table' | 'plots'>('table');
+  const [plotView, setPlotView] = useState<'partition' | 'time'>(
+    assetHasDefinedPartitions ? 'partition' : 'time',
+  );
 
   // If there are multiple observation events that contain entries with the same label,
   // or if a metadata key is present on the definition and then emitted in an event,
@@ -107,86 +129,121 @@ export const AssetEventMetadataEntriesTable = ({
   return (
     <>
       {showFilter && (
-        <Box padding={{bottom: 12}}>
-          <TextInput
-            value={filter}
-            style={{minWidth: 250}}
-            icon="search"
-            onChange={(e) => setFilter(e.target.value)}
-            placeholder="Filter metadata keys"
+        <Box
+          padding={{bottom: 12}}
+          flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
+        >
+          {view === 'table' ? (
+            <TextInput
+              value={filter}
+              style={{minWidth: 250}}
+              icon="search"
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Filter metadata keys"
+            />
+          ) : (
+            <ButtonGroup
+              activeItems={new Set([plotView])}
+              onClick={(id: 'partition' | 'time') => {
+                setPlotView(id);
+              }}
+              buttons={[
+                {id: 'partition', label: 'Partitions', icon: 'partition'},
+                {id: 'time', label: 'Events', icon: 'materialization'},
+              ]}
+            />
+          )}
+          <ButtonGroup
+            activeItems={new Set([view])}
+            onClick={(id: 'table' | 'plots') => {
+              setView(id);
+            }}
+            buttons={[
+              {id: 'table', icon: 'table_view', label: 'Table'},
+              {id: 'plots', icon: 'asset_plot', label: 'Plots'},
+            ]}
           />
         </Box>
       )}
-      <AssetEventMetadataScrollContainer>
-        <StyledTableWithHeader>
-          {showHeader && (
-            <thead>
-              <tr>
-                <td>Key</td>
-                {showTimestamps && <td style={{width: 200}}>Timestamp</td>}
-                <td>Value</td>
-                {showDescriptions && <td>Description</td>}
-              </tr>
-            </thead>
-          )}
-          <tbody>
-            {filteredRows.length === 0 && (
-              <tr>
-                <td colSpan={4}>
-                  <Caption color={Colors.textLight()}>No metadata entries</Caption>
-                </td>
-              </tr>
+      {view === 'table' ? (
+        <AssetEventMetadataScrollContainer>
+          <StyledTableWithHeader>
+            {showHeader && (
+              <thead>
+                <tr>
+                  <td>Key</td>
+                  {showTimestamps && <td style={{width: 200}}>Timestamp</td>}
+                  <td>Value</td>
+                  {showDescriptions && <td>Description</td>}
+                </tr>
+              </thead>
             )}
-            {filteredRows.slice(0, displayedCount).map(({entry, timestamp, runId, icon}) => (
-              <tr key={`metadata-${timestamp}-${entry.label}`}>
-                <td>
-                  <Mono>{entry.label}</Mono>
-                </td>
-                {showTimestamps && (
+            <tbody>
+              {filteredRows.length === 0 && (
+                <tr>
+                  <td colSpan={4}>
+                    <Caption color={Colors.textLight()}>No metadata entries</Caption>
+                  </td>
+                </tr>
+              )}
+              {filteredRows.slice(0, displayedCount).map(({entry, timestamp, runId, icon}) => (
+                <tr key={`metadata-${timestamp}-${entry.label}`}>
                   <td>
-                    <Tag>
-                      <Box flex={{gap: 4, alignItems: 'center'}}>
-                        <Icon name={icon} />
-                        <Timestamp timestamp={{ms: Number(timestamp)}} />
-                      </Box>
-                    </Tag>
+                    <Mono>{entry.label}</Mono>
                   </td>
-                )}
-                <td>
-                  <Mono>
-                    <MetadataEntry entry={entry} expandSmallValues={true} />
-                  </Mono>
-                </td>
-                {showDescriptions && (
-                  <td style={{opacity: 0.7}}>
-                    {runId && (
-                      <ObservedInRun
-                        runId={runId}
-                        timestamp={timestamp}
-                        relativeTo={event?.timestamp}
-                      />
-                    )}
-                    {entry.description}
+                  {showTimestamps && (
+                    <td>
+                      <Tag>
+                        <Box flex={{gap: 4, alignItems: 'center'}}>
+                          <Icon name={icon} />
+                          <Timestamp timestamp={{ms: Number(timestamp)}} />
+                        </Box>
+                      </Tag>
+                    </td>
+                  )}
+                  <td>
+                    <Mono>
+                      <MetadataEntry entry={entry} expandSmallValues={true} />
+                    </Mono>
                   </td>
-                )}
-              </tr>
-            ))}
-          </tbody>
-        </StyledTableWithHeader>
-        {displayedCount < filteredRows.length ? (
-          <Box padding={{vertical: 8}}>
-            <Button small onClick={() => setDisplayedCount(Number.MAX_SAFE_INTEGER)}>
-              Show {filteredRows.length - displayedCount} more
-            </Button>
-          </Box>
-        ) : displayedCount > displayedByDefault ? (
-          <Box padding={{vertical: 8}}>
-            <Button small onClick={() => setDisplayedCount(displayedByDefault)}>
-              Show less
-            </Button>
-          </Box>
-        ) : undefined}
-      </AssetEventMetadataScrollContainer>
+                  {showDescriptions && (
+                    <td style={{opacity: 0.7}}>
+                      {runId && (
+                        <ObservedInRun
+                          runId={runId}
+                          timestamp={timestamp}
+                          relativeTo={event?.timestamp}
+                        />
+                      )}
+                      {entry.description}
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </StyledTableWithHeader>
+          {displayedCount < filteredRows.length ? (
+            <Box padding={{vertical: 8}}>
+              <Button small onClick={() => setDisplayedCount(Number.MAX_SAFE_INTEGER)}>
+                Show {filteredRows.length - displayedCount} more
+              </Button>
+            </Box>
+          ) : displayedCount > displayedByDefault ? (
+            <Box padding={{vertical: 8}}>
+              <Button small onClick={() => setDisplayedCount(displayedByDefault)}>
+                Show less
+              </Button>
+            </Box>
+          ) : undefined}
+        </AssetEventMetadataScrollContainer>
+      ) : null}
+      {view === 'plots' ? (
+        <AssetEventMetadataPlots
+          assetKey={assetKey}
+          params={plotView === 'partition' ? {partition: ''} : {time: ''}}
+          assetHasDefinedPartitions={!!assetHasDefinedPartitions}
+        />
+      ) : null}
     </>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventMetadataPlots.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventMetadataPlots.tsx
@@ -1,0 +1,33 @@
+import {Box, SpinnerWithText} from '@dagster-io/ui-components';
+import {useMemo} from 'react';
+
+import {AssetMaterializationGraphs} from './AssetMaterializationGraphs';
+import {useGroupedEvents} from './groupByPartition';
+import {AssetKey, AssetViewParams} from './types';
+import {useRecentAssetEvents} from './useRecentAssetEvents';
+
+interface Props {
+  assetKey?: AssetKey;
+  params: AssetViewParams;
+  assetHasDefinedPartitions: boolean;
+}
+
+export const AssetEventMetadataPlots = (props: Props) => {
+  const {assetKey, params, assetHasDefinedPartitions} = props;
+  const {materializations, observations, loadedPartitionKeys, loading, xAxis} =
+    useRecentAssetEvents(assetKey, params, {assetHasDefinedPartitions});
+
+  const grouped = useGroupedEvents(xAxis, materializations, observations, loadedPartitionKeys);
+  const activeItems = useMemo(() => new Set([xAxis]), [xAxis]);
+  console.log(activeItems);
+
+  if (loading) {
+    return (
+      <Box padding={{vertical: 24}} flex={{direction: 'row', justifyContent: 'center'}}>
+        <SpinnerWithText label="Loading plots…" />
+      </Box>
+    );
+  }
+
+  return <AssetMaterializationGraphs xAxis={xAxis} groups={grouped} />;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMaterializationGraphs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMaterializationGraphs.tsx
@@ -32,18 +32,24 @@ export const AssetMaterializationGraphs = (props: {
     return <span />; // chartjs and our useViewport hook don't play nicely with jest
   }
 
+  const columns = props.columnCount || 2;
+
   return (
     <>
       <div
         style={{
           display: 'grid',
-          gridTemplateColumns: `1fr `.repeat(props.columnCount || 2),
+          gridTemplateColumns: `1fr `.repeat(columns),
           justifyContent: 'stretch',
         }}
       >
-        {graphLabels.map((label) => (
-          <Box key={label} style={{width: '100%'}} border="bottom">
-            <Box style={{width: '100%'}} border="right">
+        {graphLabels.map((label, ii) => (
+          <Box
+            key={label}
+            style={{width: '100%'}}
+            border={ii < columns ? 'top-and-bottom' : 'bottom'}
+          >
+            <Box style={{width: '100%'}} border={ii % columns ? 'right' : 'left-and-right'}>
               {props.asSidebarSection ? (
                 <Box padding={{horizontal: 24, top: 8}} flex={{justifyContent: 'space-between'}}>
                   <Caption style={{fontWeight: 700}}>{label}</Caption>
@@ -79,7 +85,7 @@ export const AssetMaterializationGraphs = (props: {
             No numeric metadata entries available to be graphed.
           </Box>
         ) : (
-          <Box padding={{horizontal: 24, top: 64}}>
+          <Box padding={{horizontal: 24, vertical: 64}}>
             <NonIdealState
               shrinkable
               icon="asset_plot"

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -398,6 +398,7 @@ export const AssetNodeOverview = ({
           )}
           <LargeCollapsibleSection header="Metadata" icon="view_list">
             <AssetEventMetadataEntriesTable
+              assetKey={assetNode.assetKey}
               showHeader
               showTimestamps
               showFilter
@@ -405,6 +406,7 @@ export const AssetNodeOverview = ({
               observations={[]}
               definitionMetadata={assetMetadata}
               definitionLoadTimestamp={assetNodeLoadTimestamp}
+              assetHasDefinedPartitions={!!assetNode.partitionDefinition}
               event={materialization || observation || null}
               emptyState={
                 <SectionEmptyState

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPlots.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPlots.tsx
@@ -1,11 +1,10 @@
-import {Box, ButtonGroup, Spinner, Subheading} from '@dagster-io/ui-components';
-import {useEffect, useMemo} from 'react';
+import {Box, ButtonGroup, SpinnerWithText} from '@dagster-io/ui-components';
+import {useMemo} from 'react';
 
 import {AssetMaterializationGraphs} from './AssetMaterializationGraphs';
 import {useGroupedEvents} from './groupByPartition';
 import {AssetKey, AssetViewParams} from './types';
 import {useRecentAssetEvents} from './useRecentAssetEvents';
-import {useTrackEvent} from '../app/analytics';
 
 interface Props {
   assetKey: AssetKey;
@@ -15,46 +14,21 @@ interface Props {
 }
 
 export const AssetPlots = ({assetKey, assetHasDefinedPartitions, params, setParams}: Props) => {
-  // Track the event explicitly because the tab is based on a querystring, so the typical
-  // pageview event would not be matched to the Plots tab.
-  const trackEvent = useTrackEvent();
-  useEffect(() => trackEvent('viewAssetPlots'), [trackEvent]);
-
   const {materializations, observations, loadedPartitionKeys, loading, xAxis} =
     useRecentAssetEvents(assetKey, params, {assetHasDefinedPartitions});
 
   const grouped = useGroupedEvents(xAxis, materializations, observations, loadedPartitionKeys);
   const activeItems = useMemo(() => new Set([xAxis]), [xAxis]);
 
-  if (loading) {
-    return (
-      <Box>
+  return (
+    <>
+      {assetHasDefinedPartitions ? (
         <Box
           flex={{justifyContent: 'space-between', alignItems: 'center'}}
           border="bottom"
           padding={{vertical: 16, left: 24, right: 12}}
           style={{marginBottom: -1}}
         >
-          <Subheading>Asset plots</Subheading>
-        </Box>
-        <Box padding={{vertical: 48}}>
-          <Spinner purpose="page" />
-        </Box>
-      </Box>
-    );
-  }
-
-  return (
-    <Box>
-      <Box
-        flex={{justifyContent: 'space-between', alignItems: 'center'}}
-        border="bottom"
-        padding={{vertical: 16, left: 24, right: 12}}
-        style={{marginBottom: -1}}
-      >
-        <Subheading>Asset plots</Subheading>
-
-        {assetHasDefinedPartitions ? (
           <div style={{margin: '-6px 0 '}}>
             <ButtonGroup
               activeItems={activeItems}
@@ -71,9 +45,15 @@ export const AssetPlots = ({assetKey, assetHasDefinedPartitions, params, setPara
               }
             />
           </div>
-        ) : null}
-      </Box>
-      <AssetMaterializationGraphs xAxis={xAxis} groups={grouped} />
-    </Box>
+        </Box>
+      ) : null}
+      {loading ? (
+        <Box padding={{vertical: 48}} flex={{direction: 'row', justifyContent: 'center'}}>
+          <SpinnerWithText label="Loading plots…" />
+        </Box>
+      ) : (
+        <AssetMaterializationGraphs xAxis={xAxis} groups={grouped} />
+      )}
+    </>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPlotsPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPlotsPage.tsx
@@ -1,0 +1,26 @@
+import {Box, Subheading} from '@dagster-io/ui-components';
+import {useEffect} from 'react';
+
+import {AssetPlots} from './AssetPlots';
+import {useTrackEvent} from '../app/analytics';
+
+export const AssetPlotsPage = (props: React.ComponentProps<typeof AssetPlots>) => {
+  // Track the event explicitly because the tab is based on a querystring, so the typical
+  // pageview event would not be matched to the Plots tab.
+  const trackEvent = useTrackEvent();
+  useEffect(() => trackEvent('viewAssetPlots'), [trackEvent]);
+
+  return (
+    <div>
+      <Box
+        flex={{justifyContent: 'space-between', alignItems: 'center'}}
+        border="bottom"
+        padding={{vertical: 16, left: 24, right: 12}}
+        style={{marginBottom: -1}}
+      >
+        <Subheading>Asset plots</Subheading>
+      </Box>
+      <AssetPlots {...props} />
+    </div>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
@@ -86,6 +86,7 @@ export const buildAssetTabMap = (input: AssetTabConfigInput) => {
       id: 'plots',
       title: 'Plots',
       to: buildAssetViewParams({...params, view: 'plots'}),
+      hidden: flagUseNewOverviewPage,
     } as AssetTabConfig,
     definition: {
       id: 'definition',

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -17,7 +17,7 @@ import {
 } from './AssetNodeOverview';
 import {AssetPageHeader} from './AssetPageHeader';
 import {AssetPartitions} from './AssetPartitions';
-import {AssetPlots} from './AssetPlots';
+import {AssetPlotsPage} from './AssetPlotsPage';
 import {AssetTabs} from './AssetTabs';
 import {AssetAutomaterializePolicyPage} from './AutoMaterializePolicyPage/AssetAutomaterializePolicyPage';
 import {AssetAutomaterializePolicyPageOld} from './AutoMaterializePolicyPageOld/AssetAutomaterializePolicyPage';
@@ -209,7 +209,7 @@ export const AssetView = ({assetKey, trace, headerBreadcrumbs}: Props) => {
       return <AssetLoadingDefinitionState />;
     }
     return (
-      <AssetPlots
+      <AssetPlotsPage
         assetKey={assetKey}
         assetHasDefinedPartitions={!!definition?.partitionDefinition}
         params={params}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
@@ -56,7 +56,7 @@ export function useRecentAssetEvents(
     },
   );
 
-  return useMemo(() => {
+  const value = useMemo(() => {
     const asset = data?.assetOrError.__typename === 'Asset' ? data?.assetOrError : null;
     const materializations = asset?.assetMaterializations || [];
     const observations = asset?.assetObservations || [];
@@ -79,6 +79,8 @@ export function useRecentAssetEvents(
       xAxis,
     };
   }, [data, loading, refetch, loadUsingPartitionKeys, xAxis]);
+
+  return value;
 }
 
 export type RecentAssetEvents = ReturnType<typeof useRecentAssetEvents>;


### PR DESCRIPTION
## Summary & Motivation

Move Plots into the Metadata section of the new Asset overview page, and remove the Plots tab.

The graphs themselves are largely unchanged, apart from adding a top/left keyline.

Example video on https://linear.app/dagster-labs/issue/FE-225/add-metadata-plots-to-asset-details-overview-and-remove-plots-tab.

## How I Tested These Changes

With Asset Overview flag enabled, view assets with and without partitions. Verify that Plots load and render correctly. Switch to partitions view, verify same.