### PR TITLE
[external-renames] ExternalTargetData -> TargetSnap

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -168,7 +168,7 @@ def get_sensors_for_pipeline(
     results = []
     for external_sensor in external_sensors:
         if pipeline_selector.job_name not in [
-            target.job_name for target in external_sensor.get_external_targets()
+            target.job_name for target in external_sensor.get_targets()
         ]:
             continue
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -944,7 +944,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             if asset_key in asset_selection:
                 return True
 
-        return any(target.job_name in job_names for target in sensor.get_external_targets())
+        return any(target.job_name in job_names for target in sensor.get_targets())
 
     def resolve_targetingInstigators(self, graphene_info) -> Sequence[GrapheneSensor]:
         external_sensors = self._external_repository.get_external_sensors()

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -6,7 +6,7 @@ from dagster import DefaultSensorStatus
 from dagster._core.definitions.selector import SensorSelector
 from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster._core.remote_representation import ExternalSensor, ExternalTargetData
+from dagster._core.remote_representation import ExternalSensor, TargetSnap
 from dagster._core.remote_representation.external import CompoundID, ExternalRepository
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus
 from dagster._core.workspace.permissions import Permissions
@@ -50,10 +50,8 @@ class GrapheneTarget(graphene.ObjectType):
     class Meta:
         name = "Target"
 
-    def __init__(self, external_target: ExternalTargetData):
-        self._external_target = check.inst_param(
-            external_target, "external_target", ExternalTargetData
-        )
+    def __init__(self, external_target: TargetSnap):
+        self._external_target = check.inst_param(external_target, "external_target", TargetSnap)
         super().__init__(
             pipelineName=external_target.job_name,
             mode=external_target.mode,
@@ -114,7 +112,7 @@ class GrapheneSensor(graphene.ObjectType):
             jobOriginId=external_sensor.get_external_origin_id(),
             minIntervalSeconds=external_sensor.min_interval_seconds,
             description=external_sensor.description,
-            targets=[GrapheneTarget(target) for target in external_sensor.get_external_targets()],
+            targets=[GrapheneTarget(target) for target in external_sensor.get_targets()],
             metadata=GrapheneSensorMetadata(
                 assetKeys=external_sensor.metadata.asset_keys if external_sensor.metadata else None
             ),

--- a/python_modules/dagster/dagster/_core/remote_representation/__init__.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/__init__.py
@@ -30,10 +30,10 @@ from dagster._core.remote_representation.external_data import (
     ExternalRepositoryErrorData as ExternalRepositoryErrorData,
     ExternalScheduleExecutionErrorData as ExternalScheduleExecutionErrorData,
     ExternalSensorExecutionErrorData as ExternalSensorExecutionErrorData,
-    ExternalTargetData as ExternalTargetData,
     PartitionSetSnap as PartitionSetSnap,
     ScheduleSnap as ScheduleSnap,
     SensorSnap as SensorSnap,
+    TargetSnap as TargetSnap,
     external_job_data_from_def as external_job_data_from_def,
     external_repository_data_from_def as external_repository_data_from_def,
 )

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -53,12 +53,12 @@ from dagster._core.remote_representation.external_data import (
     ExternalResourceData,
     ExternalResourceValue,
     ExternalSensorMetadata,
-    ExternalTargetData,
     NestedResource,
     PartitionSetSnap,
     ResourceJobUsageEntry,
     ScheduleSnap,
     SensorSnap,
+    TargetSnap,
 )
 from dagster._core.remote_representation.handle import (
     InstigatorHandle,
@@ -985,19 +985,19 @@ class ExternalSensor:
         target = self._get_single_target()
         return target.op_selection if target else None
 
-    def _get_single_target(self) -> Optional[ExternalTargetData]:
+    def _get_single_target(self) -> Optional[TargetSnap]:
         if self._external_sensor_data.target_dict:
             return next(iter(self._external_sensor_data.target_dict.values()))
         else:
             return None
 
-    def get_target_data(self, job_name: Optional[str] = None) -> Optional[ExternalTargetData]:
+    def get_target(self, job_name: Optional[str] = None) -> Optional[TargetSnap]:
         if job_name:
             return self._external_sensor_data.target_dict[job_name]
         else:
             return self._get_single_target()
 
-    def get_external_targets(self) -> Sequence[ExternalTargetData]:
+    def get_targets(self) -> Sequence[TargetSnap]:
         return list(self._external_sensor_data.target_dict.values())
 
     @property

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -421,10 +421,11 @@ class ExternalScheduleExecutionErrorData:
 
 
 @whitelist_for_serdes(
-    storage_field_names={"job_name": "pipeline_name", "op_selection": "solid_selection"}
+    storage_name="ExternalTargetData",
+    storage_field_names={"job_name": "pipeline_name", "op_selection": "solid_selection"},
 )
 @record
-class ExternalTargetData:
+class TargetSnap:
     job_name: str
     mode: str
     op_selection: Optional[Sequence[str]]
@@ -451,7 +452,7 @@ class SensorSnap(IHaveNew):
     mode: Optional[str]
     min_interval: Optional[int]
     description: Optional[str]
-    target_dict: Mapping[str, ExternalTargetData]
+    target_dict: Mapping[str, TargetSnap]
     metadata: Optional[ExternalSensorMetadata]
     default_status: Optional[DefaultSensorStatus]
     sensor_type: Optional[SensorType]
@@ -467,7 +468,7 @@ class SensorSnap(IHaveNew):
         mode: Optional[str] = None,
         min_interval: Optional[int] = None,
         description: Optional[str] = None,
-        target_dict: Optional[Mapping[str, ExternalTargetData]] = None,
+        target_dict: Optional[Mapping[str, TargetSnap]] = None,
         metadata: Optional[ExternalSensorMetadata] = None,
         default_status: Optional[DefaultSensorStatus] = None,
         sensor_type: Optional[SensorType] = None,
@@ -479,7 +480,7 @@ class SensorSnap(IHaveNew):
             # handle the legacy case where the ExternalSensorData was constructed from an earlier
             # version of dagster
             target_dict = {
-                job_name: ExternalTargetData(
+                job_name: TargetSnap(
                     job_name=check.str_param(job_name, "job_name"),
                     mode=check.opt_str_param(mode, "mode", DEFAULT_MODE_NAME),
                     op_selection=check.opt_nullable_sequence_param(
@@ -526,7 +527,7 @@ class SensorSnap(IHaveNew):
 
         if sensor_def.asset_selection is not None:
             target_dict = {
-                base_asset_job_name: ExternalTargetData(
+                base_asset_job_name: TargetSnap(
                     job_name=base_asset_job_name, mode=DEFAULT_MODE_NAME, op_selection=None
                 )
                 for base_asset_job_name in repository_def.get_implicit_asset_job_names()
@@ -539,7 +540,7 @@ class SensorSnap(IHaveNew):
             )
         else:
             target_dict = {
-                target.job_name: ExternalTargetData(
+                target.job_name: TargetSnap(
                     job_name=target.job_name,
                     mode=DEFAULT_MODE_NAME,
                     op_selection=target.op_selection,

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -48,7 +48,7 @@ from dagster._core.execution.backfill import PartitionBackfill
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.code_location import CodeLocation
 from dagster._core.remote_representation.external import ExternalJob, ExternalSensor
-from dagster._core.remote_representation.external_data import ExternalTargetData
+from dagster._core.remote_representation.external_data import TargetSnap
 from dagster._core.scheduler.instigation import (
     DynamicPartitionsRequestResult,
     InstigatorState,
@@ -689,9 +689,7 @@ def _submit_run_request(
 
     sensor_origin = external_sensor.get_external_origin()
 
-    target_data: ExternalTargetData = check.not_none(
-        external_sensor.get_target_data(run_request.job_name)
-    )
+    target_data: TargetSnap = check.not_none(external_sensor.get_target(run_request.job_name))
 
     # reload the code_location on each submission, request_context derived data can become out date
     # * non-threaded: if number of serial submissions is too many
@@ -1266,7 +1264,7 @@ def _get_or_create_sensor_run(
     external_job: ExternalJob,
     run_id: str,
     run_request: RunRequest,
-    target_data: ExternalTargetData,
+    target_data: TargetSnap,
     existing_runs_by_key: Mapping[Optional[str], DagsterRun],
 ) -> Union[DagsterRun, SkippedSensorRun]:
     run = existing_runs_by_key.get(run_request.run_key) or instance.get_run_by_id(run_id)
@@ -1297,7 +1295,7 @@ def _create_sensor_run(
     external_job: ExternalJob,
     run_id: str,
     run_request: RunRequest,
-    target_data: ExternalTargetData,
+    target_data: TargetSnap,
 ) -> DagsterRun:
     from dagster._daemon.daemon import get_telemetry_daemon_session_id
 

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -34,9 +34,9 @@ from dagster._core.remote_representation.external_data import (
     ExternalAssetDependedBy,
     ExternalAssetDependency,
     ExternalAssetNode,
-    ExternalTargetData,
     ExternalTimeWindowPartitionsDefinitionData,
     SensorSnap,
+    TargetSnap,
     external_asset_nodes_from_defs,
     external_multi_partitions_definition_from_def,
     external_time_window_partitions_definition_from_def,
@@ -1115,7 +1115,7 @@ def test_back_compat_external_sensor():
     assert len(external_sensor_data.target_dict) == 1
     assert "my_pipeline" in external_sensor_data.target_dict
     target = external_sensor_data.target_dict["my_pipeline"]
-    assert isinstance(target, ExternalTargetData)
+    assert isinstance(target, TargetSnap)
     assert target.job_name == "my_pipeline"
 
 


### PR DESCRIPTION
## Summary & Motivation

Renames:

- `ExternalTargetData` -> `TargetSnap`
- rename associated methods that reference "external targets"

## How I Tested These Changes

Existing test suite.
