### PR TITLE
[external-renames] Rename ExternalAssetNode and associates

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
@@ -54,9 +54,9 @@ class AssetChecksLoader:
             repo_sel = RepositorySelector.from_graphql_input(pipeline)
             location = self._context.get_code_location(repo_sel.location_name)
             repo = location.get_repository(repo_sel.repository_name)
-            external_asset_nodes = repo.get_external_asset_checks(job_name=job_name)
-            for external_asset_node in external_asset_nodes:
-                yield (location, repo, external_asset_node)
+            external_asset_checks = repo.get_external_asset_checks(job_name=job_name)
+            for external_asset_check in external_asset_checks:
+                yield (location, repo, external_asset_check)
 
     def _fetch_checks(
         self, limit_per_asset: Optional[int], pipeline: Optional[GraphenePipelineSelector]

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -345,7 +345,7 @@ def wipe_assets(
         if apr.partition_range is None:
             whole_assets_to_wipe.append(apr.asset_key)
         else:
-            node = graphene_info.context.asset_graph.external_asset_nodes_by_key[apr.asset_key]
+            node = graphene_info.context.asset_graph.asset_node_snaps_by_key[apr.asset_key]
             partitions_def = check.not_none(node.partitions_def_data).get_partitions_definition()
             partition_keys = partitions_def.get_partition_keys_in_range(apr.partition_range)
             try:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_condition_evaluations.py
@@ -49,8 +49,8 @@ def _get_graphene_records_from_evaluations(
     for asset_key in asset_keys:
         asset_node = nodes.get(asset_key)
         partitions_defs[asset_key] = (
-            asset_node.external_asset_node.partitions_def_data.get_partitions_definition()
-            if asset_node and asset_node.external_asset_node.partitions_def_data
+            asset_node.asset_node_snap.partitions_def_data.get_partitions_definition()
+            if asset_node and asset_node.asset_node_snap.partitions_def_data
             else None
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -132,16 +132,15 @@ def get_additional_required_keys(
 
     # the set of atomic execution ids that any of the input asset keys are a part of
     required_execution_set_identifiers = {
-        asset_nodes_by_key[asset_key].external_asset_node.execution_set_identifier
+        asset_nodes_by_key[asset_key].asset_node_snap.execution_set_identifier
         for asset_key in asset_keys
     } - {None}
 
     # the set of all asset keys that are part of the required execution sets
     required_asset_keys = {
-        asset_node.external_asset_node.asset_key
+        asset_node.asset_node_snap.asset_key
         for asset_node in asset_nodes_by_key.values()
-        if asset_node.external_asset_node.execution_set_identifier
-        in required_execution_set_identifiers
+        if asset_node.asset_node_snap.execution_set_identifier in required_execution_set_identifiers
     }
 
     return list(required_asset_keys - asset_keys)
@@ -156,18 +155,18 @@ def get_asset_node_definition_collisions(
     repos: Dict[AssetKey, List[GrapheneRepository]] = defaultdict(list)
 
     for remote_asset_node in graphene_info.context.asset_graph.asset_nodes:
-        for repo_handle, external_asset_node in remote_asset_node.repo_node_pairs:
-            if external_asset_node.asset_key in asset_keys:
+        for repo_handle, asset_node_snap in remote_asset_node.repo_node_pairs:
+            if asset_node_snap.asset_key in asset_keys:
                 is_defined = (
-                    external_asset_node.node_definition_name
-                    or external_asset_node.graph_name
-                    or external_asset_node.op_name
+                    asset_node_snap.node_definition_name
+                    or asset_node_snap.graph_name
+                    or asset_node_snap.op_name
                 )
                 if not is_defined:
                     continue
 
                 code_location = graphene_info.context.get_code_location(repo_handle.location_name)
-                repos[external_asset_node.asset_key].append(
+                repos[asset_node_snap.asset_key].append(
                     GrapheneRepository(
                         workspace_context=graphene_info.context,
                         repository=code_location.get_repository(repo_handle.repository_name),
@@ -205,7 +204,7 @@ def _graphene_asset_node(
     return GrapheneAssetNode(
         code_location,
         repo,
-        remote_node.priority_node,
+        remote_node.priority_node_snap,
         asset_checks_loader=asset_checks_loader,
         depended_by_loader=depended_by_loader,
         stale_status_loader=stale_status_loader,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -12,9 +12,9 @@ from dagster._core.definitions.data_version import CachingStaleStatusResolver
 from dagster._core.definitions.events import AssetKey
 from dagster._core.remote_representation import ExternalRepository
 from dagster._core.remote_representation.external_data import (
-    ExternalAssetDependedBy,
-    ExternalAssetDependency,
-    ExternalAssetNode,
+    AssetChildEdgeSnap,
+    AssetNodeSnap,
+    AssetParentEdgeSnap,
 )
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorType
 from dagster._core.workspace.context import WorkspaceRequestContext
@@ -176,8 +176,8 @@ class CrossRepoAssetDependedByLoader:
     def _build_cross_repo_deps(
         self,
     ) -> Tuple[
-        Dict[AssetKey, ExternalAssetNode],
-        Dict[Tuple[str, str], Dict[AssetKey, List[ExternalAssetDependedBy]]],
+        Dict[AssetKey, AssetNodeSnap],
+        Dict[Tuple[str, str], Dict[AssetKey, List[AssetChildEdgeSnap]]],
     ]:
         """For asset X, find all "sink assets" and define them as ExternalAssetNodes. A "sink asset" is
         any asset that depends on X and exists in other repository. This enables displaying cross-repo
@@ -189,7 +189,7 @@ class CrossRepoAssetDependedByLoader:
         source asset location are returned.
         """
         depended_by_assets_by_location_by_source_asset: Dict[
-            AssetKey, Dict[Tuple[str, str], List[ExternalAssetDependedBy]]
+            AssetKey, Dict[Tuple[str, str], List[AssetChildEdgeSnap]]
         ] = defaultdict(lambda: defaultdict(list))
 
         # A mapping containing all derived (non-source) assets and their location
@@ -200,21 +200,19 @@ class CrossRepoAssetDependedByLoader:
         for location in self._context.code_locations:
             repositories = location.get_repositories()
             for repo_name, external_repo in repositories.items():
-                asset_nodes = external_repo.get_external_asset_nodes()
+                asset_nodes = external_repo.get_asset_node_snaps()
                 for asset_node in asset_nodes:
                     location_tuple = (location.name, repo_name)
                     if not asset_node.op_name:  # is source asset
                         depended_by_assets_by_location_by_source_asset[asset_node.asset_key][
                             location_tuple
-                        ].extend(asset_node.depended_by)
+                        ].extend(asset_node.child_edges)
                     else:  # derived asset
                         map_derived_asset_to_location[asset_node.asset_key] = location_tuple
 
-        sink_assets: Dict[AssetKey, ExternalAssetNode] = {}
-        external_asset_deps: Dict[
-            Tuple[str, str], Dict[AssetKey, List[ExternalAssetDependedBy]]
-        ] = defaultdict(
-            lambda: defaultdict(list)
+        sink_assets: Dict[AssetKey, AssetNodeSnap] = {}
+        external_asset_deps: Dict[Tuple[str, str], Dict[AssetKey, List[AssetChildEdgeSnap]]] = (
+            defaultdict(lambda: defaultdict(list))
         )  # nested dict that maps dependedby assets by asset key by location tuple (repo_location.name, repo_name)
 
         for (
@@ -246,28 +244,28 @@ class CrossRepoAssetDependedByLoader:
                 # no output or partition definition data) and no job_names. The Dagster UI displays
                 # all ExternalAssetNodes with no job_names as foreign assets, so sink assets
                 # are defined as ExternalAssetNodes with no definition data.
-                sink_assets[asset.downstream_asset_key] = ExternalAssetNode(
-                    asset_key=asset.downstream_asset_key,
-                    dependencies=[
-                        ExternalAssetDependency(
-                            upstream_asset_key=source_asset,
+                sink_assets[asset.child_asset_key] = AssetNodeSnap(
+                    asset_key=asset.child_asset_key,
+                    parent_edges=[
+                        AssetParentEdgeSnap(
+                            parent_asset_key=source_asset,
                             input_name=asset.input_name,
                             output_name=asset.output_name,
                         )
                     ],
-                    depended_by=[],
+                    child_edges=[],
                     execution_type=AssetExecutionType.UNEXECUTABLE,
                 )
 
         return sink_assets, external_asset_deps
 
-    def get_sink_asset(self, asset_key: AssetKey) -> ExternalAssetNode:
+    def get_sink_asset(self, asset_key: AssetKey) -> AssetNodeSnap:
         sink_assets, _ = self._build_cross_repo_deps()
         return sink_assets[asset_key]
 
     def get_cross_repo_dependent_assets(
         self, repository_location_name: str, repository_name: str, asset_key: AssetKey
-    ) -> Sequence[ExternalAssetDependedBy]:
+    ) -> Sequence[AssetChildEdgeSnap]:
         _, external_asset_deps = self._build_cross_repo_deps()
         return external_asset_deps.get((repository_location_name, repository_name), {}).get(
             asset_key, []

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -24,7 +24,7 @@ from dagster._core.events import DagsterEventType
 from dagster._core.remote_representation import CodeLocation, ExternalRepository
 from dagster._core.remote_representation.external import ExternalJob, ExternalSensor
 from dagster._core.remote_representation.external_data import (
-    ExternalAssetNode,
+    AssetNodeSnap,
     ExternalDynamicPartitionsDefinitionData,
     ExternalMultiPartitionsDefinitionData,
     ExternalPartitionsDefinitionData,
@@ -183,7 +183,7 @@ class GrapheneAssetDependency(graphene.ObjectType):
         super().__init__(inputName=input_name)
 
     def resolve_asset(self, _graphene_info: ResolveInfo):
-        asset_node = self._external_repository.get_external_asset_node(self._asset_key)
+        asset_node = self._external_repository.get_asset_node_snap(self._asset_key)
         if not asset_node and self._depended_by_loader:
             # Only load from dependency loader if asset node cannot be found in current repository
             asset_node = self._depended_by_loader.get_sink_asset(self._asset_key)
@@ -234,7 +234,7 @@ class GrapheneMaterializationUpstreamDataVersion(graphene.ObjectType):
 
 class GrapheneAssetNode(graphene.ObjectType):
     _depended_by_loader: Optional[CrossRepoAssetDependedByLoader]
-    _external_asset_node: ExternalAssetNode
+    _asset_node_snap: AssetNodeSnap
     _node_definition_snap: Optional[Union[GraphDefSnap, OpDefSnap]]
     _external_job: Optional[ExternalJob]
     _external_repository: ExternalRepository
@@ -345,7 +345,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         self,
         repository_location: CodeLocation,
         external_repository: ExternalRepository,
-        external_asset_node: ExternalAssetNode,
+        asset_node_snap: AssetNodeSnap,
         asset_checks_loader: AssetChecksLoader,
         depended_by_loader: Optional[CrossRepoAssetDependedByLoader] = None,
         stale_status_loader: Optional[StaleStatusLoader] = None,
@@ -362,9 +362,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         self._external_repository = check.inst_param(
             external_repository, "external_repository", ExternalRepository
         )
-        self._external_asset_node = check.inst_param(
-            external_asset_node, "external_asset_node", ExternalAssetNode
-        )
+        self._asset_node_snap = check.inst_param(asset_node_snap, "asset_node_snap", AssetNodeSnap)
         self._depended_by_loader = check.opt_inst_param(
             depended_by_loader, "depended_by_loader", CrossRepoAssetDependedByLoader
         )
@@ -387,16 +385,16 @@ class GrapheneAssetNode(graphene.ObjectType):
 
         super().__init__(
             id=get_unique_asset_id(
-                external_asset_node.asset_key, repository_location.name, external_repository.name
+                asset_node_snap.asset_key, repository_location.name, external_repository.name
             ),
-            assetKey=external_asset_node.asset_key,
-            description=external_asset_node.description,
-            opName=external_asset_node.op_name,
-            opVersion=external_asset_node.code_version,
-            groupName=external_asset_node.group_name,
+            assetKey=asset_node_snap.asset_key,
+            description=asset_node_snap.description,
+            opName=asset_node_snap.op_name,
+            opVersion=asset_node_snap.code_version,
+            groupName=asset_node_snap.group_name,
             owners=[
                 self._graphene_asset_owner_from_owner_str(owner)
-                for owner in (external_asset_node.owners or [])
+                for owner in (asset_node_snap.owners or [])
             ],
         )
 
@@ -418,8 +416,8 @@ class GrapheneAssetNode(graphene.ObjectType):
         return self._external_repository
 
     @property
-    def external_asset_node(self) -> ExternalAssetNode:
-        return self._external_asset_node
+    def asset_node_snap(self) -> AssetNodeSnap:
+        return self._asset_node_snap
 
     @property
     def stale_status_loader(self) -> StaleStatusLoader:
@@ -436,23 +434,23 @@ class GrapheneAssetNode(graphene.ObjectType):
     def get_external_job(self) -> ExternalJob:
         if self._external_job is None:
             check.invariant(
-                len(self._external_asset_node.job_names) >= 1,
+                len(self._asset_node_snap.job_names) >= 1,
                 "Asset must be part of at least one job",
             )
             self._external_job = self._external_repository.get_full_external_job(
-                self._external_asset_node.job_names[0]
+                self._asset_node_snap.job_names[0]
             )
         return self._external_job
 
     def get_node_definition_snap(
         self,
     ) -> Union[GraphDefSnap, OpDefSnap]:
-        if self._node_definition_snap is None and len(self._external_asset_node.job_names) > 0:
+        if self._node_definition_snap is None and len(self._asset_node_snap.job_names) > 0:
             node_key = check.not_none(
-                self._external_asset_node.node_definition_name
+                self._asset_node_snap.node_definition_name
                 # nodes serialized using an older Dagster version may not have node_definition_name
-                or self._external_asset_node.graph_name
-                or self._external_asset_node.op_name
+                or self._asset_node_snap.graph_name
+                or self._asset_node_snap.op_name
             )
             self._node_definition_snap = self.get_external_job().get_node_def_snap(node_key)
         # weird mypy bug causes mistyped _node_definition_snap
@@ -477,7 +475,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             check.failed("dynamic_partitions_loader must be provided to get partition keys")
 
         partitions_def_data = (
-            self._external_asset_node.partitions_def_data
+            self._asset_node_snap.partitions_def_data
             if not partitions_def_data
             else partitions_def_data
         )
@@ -513,7 +511,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         return []
 
     def is_multipartitioned(self) -> bool:
-        external_multipartitions_def = self._external_asset_node.partitions_def_data
+        external_multipartitions_def = self._asset_node_snap.partitions_def_data
 
         return external_multipartitions_def is not None and isinstance(
             external_multipartitions_def, ExternalMultiPartitionsDefinitionData
@@ -547,7 +545,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     @property
     def is_executable(self) -> bool:
-        return self._external_asset_node.is_executable
+        return self._asset_node_snap.is_executable
 
     def resolve_hasMaterializePermission(
         self,
@@ -575,7 +573,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
         instance = graphene_info.context.instance
         asset_graph = self._external_repository.asset_graph
-        asset_key = self._external_asset_node.asset_key
+        asset_key = self._asset_node_snap.asset_key
 
         instance_queryer = CachingInstanceQueryer(
             instance=graphene_info.context.instance,
@@ -628,7 +626,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
         if limit == 1 and not partitions and not before_timestamp:
             record = AssetRecord.blocking_get(
-                graphene_info.context, self._external_asset_node.asset_key
+                graphene_info.context, self._asset_node_snap.asset_key
             )
             latest_materialization_event = (
                 record.asset_entry.last_materialization if record else None
@@ -643,7 +641,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             GrapheneMaterializationEvent(event=event)
             for event in get_asset_materializations(
                 graphene_info,
-                self._external_asset_node.asset_key,
+                self._asset_node_snap.asset_key,
                 partitions,
                 before_timestamp=before_timestamp,
                 limit=limit,
@@ -671,7 +669,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             and not before_timestamp
         ):
             record = AssetRecord.blocking_get(
-                graphene_info.context, self._external_asset_node.asset_key
+                graphene_info.context, self._asset_node_snap.asset_key
             )
             latest_observation_event = record.asset_entry.last_observation if record else None
 
@@ -684,7 +682,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             GrapheneObservationEvent(event=event)
             for event in get_asset_observations(
                 graphene_info,
-                self._external_asset_node.asset_key,
+                self._asset_node_snap.asset_key,
                 partitions,
                 before_timestamp=before_timestamp,
                 limit=limit,
@@ -706,7 +704,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         )
 
     def resolve_computeKind(self, _graphene_info: ResolveInfo) -> Optional[str]:
-        return self._external_asset_node.compute_kind
+        return self._asset_node_snap.compute_kind
 
     def resolve_changedReasons(
         self, graphene_info: ResolveInfo
@@ -714,14 +712,14 @@ class GrapheneAssetNode(graphene.ObjectType):
         if self.asset_graph_differ is None:
             # asset_graph_differ is None when not in a branch deployment
             return []
-        return self.asset_graph_differ.get_changes_for_asset(self._external_asset_node.asset_key)
+        return self.asset_graph_differ.get_changes_for_asset(self._asset_node_snap.asset_key)
 
     def resolve_staleStatus(
         self, graphene_info: ResolveInfo, partition: Optional[str] = None
     ) -> Any:  # (GrapheneAssetStaleStatus)
         if partition:
             self._validate_partitions_existence()
-        return self.stale_status_loader.get_status(self._external_asset_node.asset_key, partition)
+        return self.stale_status_loader.get_status(self._asset_node_snap.asset_key, partition)
 
     def resolve_staleStatusByPartition(
         self,
@@ -733,7 +731,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         else:
             self._validate_partitions_existence()
         return [
-            self.stale_status_loader.get_status(self._external_asset_node.asset_key, partition)
+            self.stale_status_loader.get_status(self._asset_node_snap.asset_key, partition)
             for partition in partitions
         ]
 
@@ -759,7 +757,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         self, partition: Optional[str] = None
     ) -> Sequence[GrapheneAssetStaleCause]:
         causes = self.stale_status_loader.get_stale_root_causes(
-            self._external_asset_node.asset_key, partition
+            self._asset_node_snap.asset_key, partition
         )
         return [
             GrapheneAssetStaleCause(
@@ -783,7 +781,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         if partition:
             self._validate_partitions_existence()
         version = self.stale_status_loader.get_current_data_version(
-            self._external_asset_node.asset_key, partition
+            self._asset_node_snap.asset_key, partition
         )
         return None if version == NULL_DATA_VERSION else version.value
 
@@ -796,7 +794,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             self._validate_partitions_existence()
         data_versions = [
             self.stale_status_loader.get_current_data_version(
-                self._external_asset_node.asset_key, partition
+                self._asset_node_snap.asset_key, partition
             )
             for partition in partitions
         ]
@@ -817,9 +815,9 @@ class GrapheneAssetNode(graphene.ObjectType):
             *_depended_by_loader.get_cross_repo_dependent_assets(
                 self._repository_location.name,
                 self._external_repository.name,
-                self._external_asset_node.asset_key,
+                self._asset_node_snap.asset_key,
             ),
-            *self._external_asset_node.depended_by,
+            *self._asset_node_snap.child_edges,
         ]
 
         if not depended_by_asset_nodes:
@@ -827,7 +825,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
         asset_checks_loader = AssetChecksLoader(
             context=graphene_info.context,
-            asset_keys=[dep.downstream_asset_key for dep in depended_by_asset_nodes],
+            asset_keys=[dep.child_asset_key for dep in depended_by_asset_nodes],
         )
 
         return [
@@ -835,7 +833,7 @@ class GrapheneAssetNode(graphene.ObjectType):
                 repository_location=self._repository_location,
                 external_repository=self._external_repository,
                 input_name=dep.input_name,
-                asset_key=dep.downstream_asset_key,
+                asset_key=dep.child_asset_key,
                 asset_checks_loader=asset_checks_loader,
                 depended_by_loader=_depended_by_loader,
             )
@@ -855,48 +853,46 @@ class GrapheneAssetNode(graphene.ObjectType):
             *depended_by_loader.get_cross_repo_dependent_assets(
                 self._repository_location.name,
                 self._external_repository.name,
-                self._external_asset_node.asset_key,
+                self._asset_node_snap.asset_key,
             ),
-            *self._external_asset_node.depended_by,
+            *self._asset_node_snap.child_edges,
         ]
 
-        return [
-            GrapheneAssetKey(path=dep.downstream_asset_key.path) for dep in depended_by_asset_nodes
-        ]
+        return [GrapheneAssetKey(path=dep.child_asset_key.path) for dep in depended_by_asset_nodes]
 
     def resolve_dependencyKeys(self, _graphene_info: ResolveInfo) -> Sequence[GrapheneAssetKey]:
         return [
-            GrapheneAssetKey(path=dep.upstream_asset_key.path)
-            for dep in self._external_asset_node.dependencies
+            GrapheneAssetKey(path=dep.parent_asset_key.path)
+            for dep in self._asset_node_snap.parent_edges
         ]
 
     def resolve_dependencies(self, graphene_info: ResolveInfo) -> Sequence[GrapheneAssetDependency]:
-        if not self._external_asset_node.dependencies:
+        if not self._asset_node_snap.parent_edges:
             return []
 
         asset_checks_loader = AssetChecksLoader(
             context=graphene_info.context,
-            asset_keys=[dep.upstream_asset_key for dep in self._external_asset_node.dependencies],
+            asset_keys=[dep.parent_asset_key for dep in self._asset_node_snap.parent_edges],
         )
         return [
             GrapheneAssetDependency(
                 repository_location=self._repository_location,
                 external_repository=self._external_repository,
                 input_name=dep.input_name,
-                asset_key=dep.upstream_asset_key,
+                asset_key=dep.parent_asset_key,
                 asset_checks_loader=asset_checks_loader,
                 partition_mapping=dep.partition_mapping,
             )
-            for dep in self._external_asset_node.dependencies
+            for dep in self._asset_node_snap.parent_edges
         ]
 
     def resolve_freshnessInfo(
         self, graphene_info: ResolveInfo
     ) -> Optional[GrapheneAssetFreshnessInfo]:
-        if self._external_asset_node.freshness_policy:
+        if self._asset_node_snap.freshness_policy:
             asset_graph = self._external_repository.asset_graph
             return get_freshness_info(
-                asset_key=self._external_asset_node.asset_key,
+                asset_key=self._asset_node_snap.asset_key,
                 # in the future, we can share this same CachingInstanceQueryer across all
                 # GrapheneAssetNodes which share an external repository for improved performance
                 data_time_resolver=CachingDataTimeResolver(
@@ -912,28 +908,28 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_freshnessPolicy(
         self, _graphene_info: ResolveInfo
     ) -> Optional[GrapheneFreshnessPolicy]:
-        if self._external_asset_node.freshness_policy:
-            return GrapheneFreshnessPolicy(self._external_asset_node.freshness_policy)
+        if self._asset_node_snap.freshness_policy:
+            return GrapheneFreshnessPolicy(self._asset_node_snap.freshness_policy)
         return None
 
     def resolve_autoMaterializePolicy(
         self, _graphene_info: ResolveInfo
     ) -> Optional[GrapheneAutoMaterializePolicy]:
-        if self._external_asset_node.auto_materialize_policy:
-            return GrapheneAutoMaterializePolicy(self._external_asset_node.auto_materialize_policy)
+        if self._asset_node_snap.auto_materialize_policy:
+            return GrapheneAutoMaterializePolicy(self._asset_node_snap.auto_materialize_policy)
         return None
 
     def resolve_automationCondition(
         self, _graphene_info: ResolveInfo
     ) -> Optional[GrapheneAutoMaterializePolicy]:
-        if self._external_asset_node.automation_condition:
-            return GrapheneAutomationCondition(self._external_asset_node.automation_condition)
+        if self._asset_node_snap.automation_condition:
+            return GrapheneAutomationCondition(self._asset_node_snap.automation_condition)
         return None
 
     def _sensor_targets_asset(
         self, sensor: ExternalSensor, asset_graph: RemoteAssetGraph, job_names: Set[str]
     ) -> bool:
-        asset_key = self._external_asset_node.asset_key
+        asset_key = self._asset_node_snap.asset_key
 
         if sensor.asset_selection is not None:
             try:
@@ -954,7 +950,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
         job_names = {
             job_name
-            for job_name in self._external_asset_node.job_names
+            for job_name in self._asset_node_snap.job_names
             if not job_name == IMPLICIT_ASSET_JOB_NAME
         }
 
@@ -984,7 +980,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     def _get_auto_materialize_external_sensor(self) -> Optional[ExternalSensor]:
         asset_graph = self._external_repository.asset_graph
 
-        asset_key = self._external_asset_node.asset_key
+        asset_key = self._asset_node_snap.asset_key
         matching_sensors = [
             sensor
             for sensor in self._external_repository.get_external_sensors()
@@ -1018,15 +1014,15 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_backfillPolicy(
         self, _graphene_info: ResolveInfo
     ) -> Optional[GrapheneBackfillPolicy]:
-        if self._external_asset_node.backfill_policy:
-            return GrapheneBackfillPolicy(self._external_asset_node.backfill_policy)
+        if self._asset_node_snap.backfill_policy:
+            return GrapheneBackfillPolicy(self._asset_node_snap.backfill_policy)
         return None
 
     def resolve_jobNames(self, _graphene_info: ResolveInfo) -> Sequence[str]:
-        return self._external_asset_node.job_names
+        return self._asset_node_snap.job_names
 
     def resolve_jobs(self, _graphene_info: ResolveInfo) -> Sequence[GraphenePipeline]:
-        job_names = self._external_asset_node.job_names or []
+        job_names = self._asset_node_snap.job_names or []
         return [
             GraphenePipeline(self._external_repository.get_full_external_job(job_name))
             for job_name in job_names
@@ -1034,16 +1030,16 @@ class GrapheneAssetNode(graphene.ObjectType):
         ]
 
     def resolve_isPartitioned(self, _graphene_info: ResolveInfo) -> bool:
-        return self._external_asset_node.partitions_def_data is not None
+        return self._asset_node_snap.partitions_def_data is not None
 
     def resolve_isMaterializable(self, _graphene_info: ResolveInfo) -> bool:
-        return self._external_asset_node.is_materializable
+        return self._asset_node_snap.is_materializable
 
     def resolve_isObservable(self, _graphene_info: ResolveInfo) -> bool:
-        return self._external_asset_node.is_observable
+        return self._asset_node_snap.is_observable
 
     def resolve_isExecutable(self, _graphene_info: ResolveInfo) -> bool:
-        return self._external_asset_node.is_executable
+        return self._asset_node_snap.is_executable
 
     def resolve_latestMaterializationByPartition(
         self,
@@ -1064,13 +1060,13 @@ class GrapheneAssetNode(graphene.ObjectType):
             latest_storage_ids = sorted(
                 (
                     graphene_info.context.instance.event_log_storage.get_latest_storage_id_by_partition(
-                        self._external_asset_node.asset_key, DagsterEventType.ASSET_MATERIALIZATION
+                        self._asset_node_snap.asset_key, DagsterEventType.ASSET_MATERIALIZATION
                     )
                 ).values()
             )
             events_for_partitions = get_asset_materializations(
                 graphene_info,
-                asset_key=self._external_asset_node.asset_key,
+                asset_key=self._asset_node_snap.asset_key,
                 storage_ids=latest_storage_ids,
             )
             latest_materialization_by_partition = {
@@ -1079,7 +1075,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         else:
             events_for_partitions = get_asset_materializations(
                 graphene_info,
-                self._external_asset_node.asset_key,
+                self._asset_node_snap.asset_key,
                 partitions,
             )
 
@@ -1108,7 +1104,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         partition: str,
     ) -> Optional[GrapheneRun]:
         planned_info = graphene_info.context.instance.get_latest_planned_materialization_info(
-            asset_key=self._external_asset_node.asset_key, partition=partition
+            asset_key=self._asset_node_snap.asset_key, partition=partition
         )
         if not planned_info:
             return None
@@ -1122,14 +1118,14 @@ class GrapheneAssetNode(graphene.ObjectType):
         "GrapheneDefaultPartitionStatuses",
         "GrapheneMultiPartitionStatuses",
     ]:
-        asset_key = self._external_asset_node.asset_key
+        asset_key = self._asset_node_snap.asset_key
 
         if not self._dynamic_partitions_loader:
             check.failed("dynamic_partitions_loader must be provided to get partition keys")
 
         partitions_def = (
-            self._external_asset_node.partitions_def_data.get_partitions_definition()
-            if self._external_asset_node.partitions_def_data
+            self._asset_node_snap.partitions_def_data.get_partitions_definition()
+            if self._asset_node_snap.partitions_def_data
             else None
         )
 
@@ -1156,9 +1152,9 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_partitionStats(
         self, graphene_info: ResolveInfo
     ) -> Optional[GraphenePartitionStats]:
-        partitions_def_data = self._external_asset_node.partitions_def_data
+        partitions_def_data = self._asset_node_snap.partitions_def_data
         if partitions_def_data:
-            asset_key = self._external_asset_node.asset_key
+            asset_key = self._asset_node_snap.asset_key
 
             if not self._dynamic_partitions_loader:
                 check.failed("dynamic_partitions_loader must be provided to get partition keys")
@@ -1173,8 +1169,8 @@ class GrapheneAssetNode(graphene.ObjectType):
                 asset_key,
                 self._dynamic_partitions_loader,
                 (
-                    self._external_asset_node.partitions_def_data.get_partitions_definition()
-                    if self._external_asset_node.partitions_def_data
+                    self._asset_node_snap.partitions_def_data.get_partitions_definition()
+                    if self._asset_node_snap.partitions_def_data
                     else None
                 ),
             )
@@ -1207,21 +1203,21 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_metadata_entries(
         self, _graphene_info: ResolveInfo
     ) -> Sequence[GrapheneMetadataEntry]:
-        return list(iterate_metadata_entries(self._external_asset_node.metadata))
+        return list(iterate_metadata_entries(self._asset_node_snap.metadata))
 
     def resolve_tags(self, _graphene_info: ResolveInfo) -> Sequence[GrapheneDefinitionTag]:
         return [
             GrapheneDefinitionTag(key, value)
-            for key, value in (self._external_asset_node.tags or {}).items()
+            for key, value in (self._asset_node_snap.tags or {}).items()
         ]
 
     def resolve_kinds(self, _graphene_info: ResolveInfo) -> Sequence[str]:
-        if self._external_asset_node.compute_kind:
-            return [self._external_asset_node.compute_kind]
+        if self._asset_node_snap.compute_kind:
+            return [self._asset_node_snap.compute_kind]
 
         return [
             key[len(KIND_PREFIX) :]
-            for key in (self._external_asset_node.tags or {}).keys()
+            for key in (self._asset_node_snap.tags or {}).keys()
             if key.startswith(KIND_PREFIX)
         ]
 
@@ -1241,10 +1237,10 @@ class GrapheneAssetNode(graphene.ObjectType):
         check.failed(f"Unknown solid definition type {type(node_def_snap)}")
 
     def resolve_opNames(self, _graphene_info: ResolveInfo) -> Sequence[str]:
-        return self._external_asset_node.op_names or []
+        return self._asset_node_snap.op_names or []
 
     def resolve_graphName(self, _graphene_info: ResolveInfo) -> Optional[str]:
-        return self._external_asset_node.graph_name
+        return self._asset_node_snap.graph_name
 
     def resolve_partitionKeysByDimension(
         self,
@@ -1256,7 +1252,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         # time partitions. StartIdx is inclusive, endIdx is exclusive.
         # For non time partition definitions, these arguments will be ignored
         # and the full list of partition keys will be returned.
-        if not self._external_asset_node.partitions_def_data:
+        if not self._asset_node_snap.partitions_def_data:
             return []
 
         if self.is_multipartitioned():
@@ -1274,7 +1270,7 @@ class GrapheneAssetNode(graphene.ObjectType):
                 )
                 for dimension in cast(
                     ExternalMultiPartitionsDefinitionData,
-                    self._external_asset_node.partitions_def_data,
+                    self._asset_node_snap.partitions_def_data,
                 ).external_partition_dimension_definitions
             ]
 
@@ -1282,7 +1278,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             GrapheneDimensionPartitionKeys(
                 name="default",
                 type=GraphenePartitionDefinitionType.from_partition_def_data(
-                    self._external_asset_node.partitions_def_data
+                    self._asset_node_snap.partitions_def_data
                 ),
                 partition_keys=self.get_partition_keys(start_idx=startIdx, end_idx=endIdx),
             )
@@ -1294,7 +1290,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_partitionDefinition(
         self, _graphene_info: ResolveInfo
     ) -> Optional[GraphenePartitionDefinition]:
-        partitions_def_data = self._external_asset_node.partitions_def_data
+        partitions_def_data = self._asset_node_snap.partitions_def_data
         if partitions_def_data:
             return GraphenePartitionDefinition(partitions_def_data)
         return None
@@ -1320,10 +1316,10 @@ class GrapheneAssetNode(graphene.ObjectType):
             "GrapheneListDagsterType", "GrapheneNullableDagsterType", "GrapheneRegularDagsterType"
         ]
     ]:
-        if not self._external_asset_node.is_materializable:
+        if not self._asset_node_snap.is_materializable:
             return None
         external_pipeline = self.get_external_job()
-        output_name = self.external_asset_node.output_name
+        output_name = self._asset_node_snap.output_name
         if output_name:
             for output_def in self.get_node_definition_snap().output_def_snaps:
                 if output_def.name == output_name:
@@ -1334,16 +1330,16 @@ class GrapheneAssetNode(graphene.ObjectType):
         return None
 
     def _get_partitions_def(self) -> PartitionsDefinition:
-        if not self._external_asset_node.partitions_def_data:
+        if not self._asset_node_snap.partitions_def_data:
             check.failed("Asset node has no partitions definition")
-        return self._external_asset_node.partitions_def_data.get_partitions_definition()
+        return self._asset_node_snap.partitions_def_data.get_partitions_definition()
 
     def _validate_partitions_existence(self) -> None:
-        if not self._external_asset_node.partitions_def_data:
+        if not self._asset_node_snap.partitions_def_data:
             check.failed("Asset node has no partitions definition")
 
     def resolve_hasAssetChecks(self, graphene_info: ResolveInfo) -> bool:
-        return has_asset_checks(graphene_info, self._external_asset_node.asset_key)
+        return has_asset_checks(graphene_info, self._asset_node_snap.asset_key)
 
     def resolve_assetChecksOrError(
         self,
@@ -1352,7 +1348,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         pipeline: Optional[GraphenePipelineSelector] = None,
     ) -> AssetChecksOrErrorUnion:
         return self._asset_checks_loader.get_checks_for_asset(
-            self._external_asset_node.asset_key, limit, pipeline
+            self._asset_node_snap.asset_key, limit, pipeline
         )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -43,7 +43,7 @@ from dagster_graphql.schema.used_solid import GrapheneUsedSolid
 from dagster_graphql.schema.util import ResolveInfo, non_null_list
 
 if TYPE_CHECKING:
-    from dagster._core.remote_representation.external_data import ExternalAssetNode
+    from dagster._core.remote_representation.external_data import AssetNodeSnap
 
 GrapheneLocationStateChangeEventType = graphene.Enum.from_enum(LocationStateChangeEventType)
 
@@ -384,31 +384,31 @@ class GrapheneRepository(graphene.ObjectType):
         ]
 
     def resolve_assetNodes(self, graphene_info: ResolveInfo):
-        external_asset_nodes = self._repository.get_external_asset_nodes()
+        asset_node_snaps = self._repository.get_asset_node_snaps()
         asset_checks_loader = AssetChecksLoader(
             context=graphene_info.context,
-            asset_keys=[node.asset_key for node in external_asset_nodes],
+            asset_keys=[node.asset_key for node in asset_node_snaps],
         )
         return [
             GrapheneAssetNode(
                 self._repository_location,
                 self._repository,
-                external_asset_node,
+                asset_node_snap,
                 asset_checks_loader=asset_checks_loader,
                 stale_status_loader=self._stale_status_loader,
                 dynamic_partitions_loader=self._dynamic_partitions_loader,
                 asset_graph_differ=self._asset_graph_differ,
             )
-            for external_asset_node in self._repository.get_external_asset_nodes()
+            for asset_node_snap in self._repository.get_asset_node_snaps()
         ]
 
     def resolve_assetGroups(self, _graphene_info: ResolveInfo):
-        groups: Dict[str, List[ExternalAssetNode]] = {}
-        for external_asset_node in self._repository.get_external_asset_nodes():
-            if not external_asset_node.group_name:
+        groups: Dict[str, List[AssetNodeSnap]] = {}
+        for asset_node_snap in self._repository.get_asset_node_snaps():
+            if not asset_node_snap.group_name:
                 continue
-            external_assets = groups.setdefault(external_asset_node.group_name, [])
-            external_assets.append(external_asset_node)
+            external_assets = groups.setdefault(asset_node_snap.group_name, [])
+            external_assets.append(asset_node_snap)
 
         return [
             GrapheneAssetGroup(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -941,7 +941,7 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
         handle = self._external_job.repository_handle
         location = graphene_info.context.get_code_location(handle.location_name)
         repository = location.get_repository(handle.repository_name)
-        return bool(repository.get_external_asset_nodes(self._external_job.name))
+        return bool(repository.get_asset_node_snaps(self._external_job.name))
 
     def resolve_repository(self, graphene_info: ResolveInfo):
         from dagster_graphql.schema.external import GrapheneRepository

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -965,14 +965,14 @@ class GrapheneQuery(graphene.ObjectType):
                 return []
 
             repo = repo_loc.get_repository(repo_sel.repository_name)
-            external_asset_nodes = repo.get_external_asset_nodes()
+            asset_node_snaps = repo.get_asset_node_snaps()
             results = (
                 [
                     (repo_loc, repo, asset_node)
-                    for asset_node in external_asset_nodes
+                    for asset_node in asset_node_snaps
                     if asset_node.group_name == group_name
                 ]
-                if external_asset_nodes
+                if asset_node_snaps
                 else []
             )
         elif pipeline is not None:
@@ -985,10 +985,10 @@ class GrapheneQuery(graphene.ObjectType):
 
             repo = repo_loc.get_repository(repo_sel.repository_name)
 
-            external_asset_nodes = repo.get_external_asset_nodes(job_name)
+            asset_node_snaps = repo.get_asset_node_snaps(job_name)
             results = (
-                [(repo_loc, repo, asset_node) for asset_node in external_asset_nodes]
-                if external_asset_nodes
+                [(repo_loc, repo, asset_node) for asset_node in asset_node_snaps]
+                if asset_node_snaps
                 else []
             )
         else:
@@ -1008,7 +1008,7 @@ class GrapheneQuery(graphene.ObjectType):
                     repo_handle = remote_node.priority_repository_handle
                     code_loc = graphene_info.context.get_code_location(repo_handle.location_name)
                     repo = code_loc.get_repository(repo_handle.repository_name)
-                    results.append((code_loc, repo, remote_node.priority_node))
+                    results.append((code_loc, repo, remote_node.priority_node_snap))
 
         # Filter down to requested asset keys
         results = [
@@ -1049,7 +1049,7 @@ class GrapheneQuery(graphene.ObjectType):
             GrapheneAssetNode(
                 code_loc,
                 repo,
-                external_asset_node,
+                asset_node_snap,
                 asset_checks_loader=asset_checks_loader,
                 depended_by_loader=depended_by_loader,
                 stale_status_loader=stale_status_loader,
@@ -1064,7 +1064,7 @@ class GrapheneQuery(graphene.ObjectType):
                 if base_deployment_context is not None
                 else None,
             )
-            for (code_loc, repo, external_asset_node) in results
+            for (code_loc, repo, asset_node_snap) in results
         ]
         return sorted(nodes, key=lambda node: node.id)
 
@@ -1154,7 +1154,7 @@ class GrapheneQuery(graphene.ObjectType):
 
         # Build mapping of asset key to the step keys required to generate the asset
         step_keys_by_asset: Dict[AssetKey, Sequence[str]] = {
-            remote_node.key: remote_node.priority_node.op_names
+            remote_node.key: remote_node.priority_node_snap.op_names
             for remote_node in remote_nodes
             if remote_node
         }

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -441,7 +441,7 @@ class ISolidDefinitionMixin:
             ext_repo = location.get_repository(repo_handle.repository_name)
             nodes = [
                 node
-                for node in ext_repo.get_external_asset_nodes()
+                for node in ext_repo.get_asset_node_snaps()
                 if (
                     (node.node_definition_name == self.solid_def_name)
                     or (node.graph_name and node.graph_name == self.solid_def_name)

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -146,7 +146,7 @@ class AssetGraphDiffer:
 
         We cannot make RemoteAssetGraphs directly from the workspaces because if multiple code locations
         use the same asset key, those asset keys will override each other in the dictionaries the RemoteAssetGraph
-        creates (see from_repository_handles_and_external_asset_nodes in RemoteAssetGraph). We need to ensure
+        creates (see from_repository_handles_and_asset_node_snaps in RemoteAssetGraph). We need to ensure
         that we are comparing assets in the same code location and repository, so we need to make the
         RemoteAssetGraph from an ExternalRepository to ensure that there are no duplicate asset keys
         that could override each other.

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -41,10 +41,7 @@ from dagster._core.remote_representation.external import ExternalRepository
 from dagster._core.remote_representation.handle import RepositoryHandle
 
 if TYPE_CHECKING:
-    from dagster._core.remote_representation.external_data import (
-        ExternalAssetCheck,
-        ExternalAssetNode,
-    )
+    from dagster._core.remote_representation.external_data import AssetNodeSnap, ExternalAssetCheck
     from dagster._core.selector.subset_selector import DependencyGraph
 
 
@@ -55,14 +52,14 @@ class RemoteAssetNode(BaseAssetNode):
         parent_keys: AbstractSet[AssetKey],
         child_keys: AbstractSet[AssetKey],
         execution_set_keys: AbstractSet[EntityKey],
-        repo_node_pairs: Sequence[Tuple[RepositoryHandle, "ExternalAssetNode"]],
+        repo_node_pairs: Sequence[Tuple[RepositoryHandle, "AssetNodeSnap"]],
         check_keys: AbstractSet[AssetCheckKey],
     ):
         self.key = key
         self.parent_keys = parent_keys
         self.child_keys = child_keys
         self._repo_node_pairs = repo_node_pairs
-        self._external_asset_nodes = [node for _, node in repo_node_pairs]
+        self._asset_node_snaps = [node for _, node in repo_node_pairs]
         self._check_keys = check_keys
         self._execution_set_keys = execution_set_keys
 
@@ -70,55 +67,55 @@ class RemoteAssetNode(BaseAssetNode):
 
     @property
     def description(self) -> Optional[str]:
-        return self.priority_node.description
+        return self.priority_node_snap.description
 
     @property
     def group_name(self) -> str:
-        return self.priority_node.group_name or DEFAULT_GROUP_NAME
+        return self.priority_node_snap.group_name or DEFAULT_GROUP_NAME
 
     @cached_property
     def is_materializable(self) -> bool:
-        return any(node.is_materializable for node in self._external_asset_nodes)
+        return any(node.is_materializable for node in self._asset_node_snaps)
 
     @cached_property
     def is_observable(self) -> bool:
-        return any(node.is_observable for node in self._external_asset_nodes)
+        return any(node.is_observable for node in self._asset_node_snaps)
 
     @cached_property
     def is_external(self) -> bool:
-        return all(node.is_external for node in self._external_asset_nodes)
+        return all(node.is_external for node in self._asset_node_snaps)
 
     @cached_property
     def is_executable(self) -> bool:
-        return any(node.is_executable for node in self._external_asset_nodes)
+        return any(node.is_executable for node in self._asset_node_snaps)
 
     @property
     def metadata(self) -> ArbitraryMetadataMapping:
-        return self.priority_node.metadata
+        return self.priority_node_snap.metadata
 
     @property
     def tags(self) -> Mapping[str, str]:
-        return self.priority_node.tags or {}
+        return self.priority_node_snap.tags or {}
 
     @property
     def owners(self) -> Sequence[str]:
-        return self.priority_node.owners or []
+        return self.priority_node_snap.owners or []
 
     @property
     def is_partitioned(self) -> bool:
-        return self.priority_node.partitions_def_data is not None
+        return self.priority_node_snap.partitions_def_data is not None
 
     @cached_property
     def partitions_def(self) -> Optional[PartitionsDefinition]:
-        external_def = self.priority_node.partitions_def_data
+        external_def = self.priority_node_snap.partitions_def_data
         return external_def.get_partitions_definition() if external_def else None
 
     @property
     def partition_mappings(self) -> Mapping[AssetKey, PartitionMapping]:
         if self.is_materializable:
             return {
-                dep.upstream_asset_key: dep.partition_mapping
-                for dep in self._materializable_node.dependencies
+                dep.parent_asset_key: dep.partition_mapping
+                for dep in self._materializable_node_snap.parent_edges
                 if dep.partition_mapping is not None
             }
         else:
@@ -128,34 +125,40 @@ class RemoteAssetNode(BaseAssetNode):
     def freshness_policy(self) -> Optional[FreshnessPolicy]:
         # It is currently not possible to access the freshness policy for an observation definition
         # if a materialization definition also exists. This needs to be fixed.
-        return self.priority_node.freshness_policy
+        return self.priority_node_snap.freshness_policy
 
     @property
     def auto_materialize_policy(self) -> Optional[AutoMaterializePolicy]:
-        return self._materializable_node.auto_materialize_policy if self.is_materializable else None
+        return (
+            self._materializable_node_snap.auto_materialize_policy
+            if self.is_materializable
+            else None
+        )
 
     @property
     def automation_condition(self) -> Optional[AutomationCondition]:
         if self.is_materializable:
-            return self._materializable_node.automation_condition
+            return self._materializable_node_snap.automation_condition
         elif self.is_observable:
-            return self._observable_node.automation_condition
+            return self._observable_node_snap.automation_condition
         else:
             return None
 
     @property
     def auto_observe_interval_minutes(self) -> Optional[float]:
-        return self._observable_node.auto_observe_interval_minutes if self.is_observable else None
+        return (
+            self._observable_node_snap.auto_observe_interval_minutes if self.is_observable else None
+        )
 
     @property
     def backfill_policy(self) -> Optional[BackfillPolicy]:
-        return self._materializable_node.backfill_policy if self.is_materializable else None
+        return self._materializable_node_snap.backfill_policy if self.is_materializable else None
 
     @property
     def code_version(self) -> Optional[str]:
         # It is currently not possible to access the code version for an observation definition if a
         # materialization definition also exists. This needs to be fixed.
-        return self.priority_node.code_version
+        return self.priority_node_snap.code_version
 
     @property
     def check_keys(self) -> AbstractSet[AssetCheckKey]:
@@ -175,7 +178,7 @@ class RemoteAssetNode(BaseAssetNode):
     def job_names(self) -> Sequence[str]:
         # It is currently not possible to access the job names for an observation definition if a
         # materialization definition also exists. This needs to be fixed.
-        return self.priority_node.job_names if self.is_executable else []
+        return self.priority_node_snap.job_names if self.is_executable else []
 
     @property
     def priority_repository_handle(self) -> RepositoryHandle:
@@ -194,11 +197,11 @@ class RemoteAssetNode(BaseAssetNode):
         return [repo_handle for repo_handle, _ in self._repo_node_pairs]
 
     @property
-    def repo_node_pairs(self) -> Sequence[Tuple[RepositoryHandle, "ExternalAssetNode"]]:
+    def repo_node_pairs(self) -> Sequence[Tuple[RepositoryHandle, "AssetNodeSnap"]]:
         return self._repo_node_pairs
 
     @cached_property
-    def priority_node(self) -> "ExternalAssetNode":
+    def priority_node_snap(self) -> "AssetNodeSnap":
         # Return a materialization node if it exists, otherwise return an observable node if it
         # exists, otherwise return any node. This exists to preserve implicit behavior, where the
         # materialization node was previously preferred over the observable node. This is a
@@ -206,25 +209,25 @@ class RemoteAssetNode(BaseAssetNode):
         # either a materialization or observation node.
         return next(
             itertools.chain(
-                (node for node in self._external_asset_nodes if node.is_materializable),
-                (node for node in self._external_asset_nodes if node.is_observable),
-                (node for node in self._external_asset_nodes),
+                (node for node in self._asset_node_snaps if node.is_materializable),
+                (node for node in self._asset_node_snaps if node.is_observable),
+                (node for node in self._asset_node_snaps),
             )
         )
 
     ##### HELPERS
 
     @cached_property
-    def _materializable_node(self) -> "ExternalAssetNode":
+    def _materializable_node_snap(self) -> "AssetNodeSnap":
         try:
-            return next(node for node in self._external_asset_nodes if node.is_materializable)
+            return next(node for node in self._asset_node_snaps if node.is_materializable)
         except StopIteration:
             check.failed("No materializable node found")
 
     @cached_property
-    def _observable_node(self) -> "ExternalAssetNode":
+    def _observable_node_snap(self) -> "AssetNodeSnap":
         try:
-            return next((node for node in self._external_asset_nodes if node.is_observable))
+            return next((node for node in self._asset_node_snaps if node.is_observable))
         except StopIteration:
             check.failed("No observable node found")
 
@@ -247,27 +250,27 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
         self._repository_handles_by_asset_check_key = repository_handles_by_asset_check_key
 
     @classmethod
-    def from_repository_handles_and_external_asset_nodes(
+    def from_repository_handles_and_asset_node_snaps(
         cls,
-        repo_handle_assets: Sequence[Tuple[RepositoryHandle, "ExternalAssetNode"]],
+        repo_handle_assets: Sequence[Tuple[RepositoryHandle, "AssetNodeSnap"]],
         repo_handle_asset_checks: Sequence[Tuple[RepositoryHandle, "ExternalAssetCheck"]],
     ) -> "RemoteAssetGraph":
         _warn_on_duplicate_nodes(repo_handle_assets)
 
         # Build an index of execution sets by key. An execution set is a set of assets and checks
-        # that must be executed together. ExternalAssetNodes and ExternalAssetChecks already have an
+        # that must be executed together. AssetNodeSnaps and ExternalAssetChecks already have an
         # optional execution_set_identifier set. A null execution_set_identifier indicates that the
         # node or check can be executed independently.
         assets = [asset for _, asset in repo_handle_assets]
         asset_checks = [asset_check for _, asset_check in repo_handle_asset_checks]
         execution_sets_by_key = _build_execution_set_index(assets, asset_checks)
 
-        # Index all (RepositoryHandle, ExternalAssetNode) pairs by their asset key, then use this to
+        # Index all (RepositoryHandle, AssetNodeSnap) pairs by their asset key, then use this to
         # build the set of RemoteAssetNodes (indexed by key). Each RemoteAssetNode wraps the set of
         # pairs for an asset key.
-        repo_node_pairs_by_key: Dict[
-            AssetKey, List[Tuple[RepositoryHandle, "ExternalAssetNode"]]
-        ] = defaultdict(list)
+        repo_node_pairs_by_key: Dict[AssetKey, List[Tuple[RepositoryHandle, "AssetNodeSnap"]]] = (
+            defaultdict(list)
+        )
 
         # Build the dependency graph of asset keys.
         all_keys = {asset.asset_key for asset in assets}
@@ -276,9 +279,9 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
 
         for repo_handle, node in repo_handle_assets:
             repo_node_pairs_by_key[node.asset_key].append((repo_handle, node))
-            for dep in node.dependencies:
-                upstream[node.asset_key].add(dep.upstream_asset_key)
-                downstream[dep.upstream_asset_key].add(node.asset_key)
+            for dep in node.parent_edges:
+                upstream[node.asset_key].add(dep.parent_asset_key)
+                downstream[dep.parent_asset_key].add(node.asset_key)
 
         dep_graph: DependencyGraph[AssetKey] = {"upstream": upstream, "downstream": downstream}
 
@@ -329,11 +332,11 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
     ##### REMOTE-SPECIFIC METHODS
 
     @property
-    def external_asset_nodes_by_key(self) -> Mapping[AssetKey, "ExternalAssetNode"]:
+    def asset_node_snaps_by_key(self) -> Mapping[AssetKey, "AssetNodeSnap"]:
         # This exists to support existing callsites but it should be removed ASAP, since it exposes
-        # `ExternalAssetNode` instances directly. All sites using this should use RemoteAssetNode
+        # `AssetNodeSnap` instances directly. All sites using this should use RemoteAssetNode
         # instead.
-        return {k: node.priority_node for k, node in self._asset_nodes_by_key.items()}
+        return {k: node.priority_node_snap for k, node in self._asset_nodes_by_key.items()}
 
     @property
     def asset_checks(self) -> Sequence["ExternalAssetCheck"]:
@@ -397,16 +400,16 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
 
 
 def _warn_on_duplicate_nodes(
-    repo_handle_external_asset_nodes: Sequence[Tuple[RepositoryHandle, "ExternalAssetNode"]],
+    repo_handle_asset_node_snaps: Sequence[Tuple[RepositoryHandle, "AssetNodeSnap"]],
 ) -> None:
     # Split the nodes into materializable, observable, and unexecutable nodes. Observable and
-    # unexecutable `ExternalAssetNode` represent both source and external assets-- the
-    # "External" in "ExternalAssetNode" is unrelated to the "external" in "external asset", this
-    # is just an unfortunate naming collision. `ExternalAssetNode` will be renamed eventually.
-    materializable_node_pairs: List[Tuple[RepositoryHandle, "ExternalAssetNode"]] = []
-    observable_node_pairs: List[Tuple[RepositoryHandle, "ExternalAssetNode"]] = []
-    unexecutable_node_pairs: List[Tuple[RepositoryHandle, "ExternalAssetNode"]] = []
-    for repo_handle, node in repo_handle_external_asset_nodes:
+    # unexecutable `AssetNodeSnap` represent both source and external assets-- the
+    # "External" in "AssetNodeSnap" is unrelated to the "external" in "external asset", this
+    # is just an unfortunate naming collision. `AssetNodeSnap` will be renamed eventually.
+    materializable_node_pairs: List[Tuple[RepositoryHandle, "AssetNodeSnap"]] = []
+    observable_node_pairs: List[Tuple[RepositoryHandle, "AssetNodeSnap"]] = []
+    unexecutable_node_pairs: List[Tuple[RepositoryHandle, "AssetNodeSnap"]] = []
+    for repo_handle, node in repo_handle_asset_node_snaps:
         if node.is_source and node.is_observable:
             observable_node_pairs.append((repo_handle, node))
         elif node.is_source:
@@ -423,7 +426,7 @@ def _warn_on_duplicate_nodes(
 
 
 def _warn_on_duplicates_within_subset(
-    node_pairs: Sequence[Tuple[RepositoryHandle, "ExternalAssetNode"]],
+    node_pairs: Sequence[Tuple[RepositoryHandle, "AssetNodeSnap"]],
     execution_type: AssetExecutionType,
 ) -> None:
     repo_handles_by_asset_key: DefaultDict[AssetKey, List[RepositoryHandle]] = defaultdict(list)
@@ -444,24 +447,24 @@ def _warn_on_duplicates_within_subset(
 
 
 def _build_execution_set_index(
-    external_asset_nodes: Iterable["ExternalAssetNode"],
+    asset_node_snaps: Iterable["AssetNodeSnap"],
     external_asset_checks: Iterable["ExternalAssetCheck"],
 ) -> Mapping[EntityKey, AbstractSet[EntityKey]]:
-    from dagster._core.remote_representation.external_data import ExternalAssetNode
+    from dagster._core.remote_representation.external_data import AssetNodeSnap
 
-    all_items = [*external_asset_nodes, *external_asset_checks]
+    all_items = [*asset_node_snaps, *external_asset_checks]
 
     execution_sets_by_id: Dict[str, Set[EntityKey]] = defaultdict(set)
     for item in all_items:
         id = item.execution_set_identifier
-        key = item.asset_key if isinstance(item, ExternalAssetNode) else item.key
+        key = item.asset_key if isinstance(item, AssetNodeSnap) else item.key
         if id is not None:
             execution_sets_by_id[id].add(key)
 
     execution_sets_by_key: Dict[EntityKey, Set[EntityKey]] = {}
     for item in all_items:
         id = item.execution_set_identifier
-        key = item.asset_key if isinstance(item, ExternalAssetNode) else item.key
+        key = item.asset_key if isinstance(item, AssetNodeSnap) else item.key
         execution_sets_by_key[key] = execution_sets_by_id[id] if id is not None else {key}
 
     return execution_sets_by_key

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -467,8 +467,8 @@ def get_stats_from_external_repo(external_repo: "ExternalRepository") -> Mapping
     num_pipelines_in_repo = len(external_repo.get_all_external_jobs())
     num_schedules_in_repo = len(external_repo.get_external_schedules())
     num_sensors_in_repo = len(external_repo.get_external_sensors())
-    external_asset_nodes = external_repo.get_external_asset_nodes()
-    num_assets_in_repo = len(external_asset_nodes)
+    asset_node_snaps = external_repo.get_asset_node_snaps()
+    num_assets_in_repo = len(asset_node_snaps)
     external_resources = external_repo.get_external_resources()
 
     num_checks = len(external_repo.external_repository_data.external_asset_checks or [])
@@ -489,7 +489,7 @@ def get_stats_from_external_repo(external_repo: "ExternalRepository") -> Mapping
     num_dbt_assets_in_repo = 0
     num_assets_with_code_versions_in_repo = 0
 
-    for asset in external_asset_nodes:
+    for asset in asset_node_snaps:
         if asset.partitions_def_data:
             num_partitioned_assets_in_repo += 1
 

--- a/python_modules/dagster/dagster/_core/workspace/workspace.py
+++ b/python_modules/dagster/dagster/_core/workspace/workspace.py
@@ -10,10 +10,7 @@ from dagster._utils.error import SerializableErrorInfo
 if TYPE_CHECKING:
     from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
     from dagster._core.remote_representation import CodeLocation, CodeLocationOrigin
-    from dagster._core.remote_representation.external_data import (
-        ExternalAssetCheck,
-        ExternalAssetNode,
-    )
+    from dagster._core.remote_representation.external_data import AssetNodeSnap, ExternalAssetCheck
     from dagster._core.remote_representation.handle import RepositoryHandle
 
 
@@ -66,16 +63,16 @@ class WorkspaceSnapshot:
             for code_location in code_locations
             for repo in code_location.get_repositories().values()
         )
-        repo_handle_assets: Sequence[Tuple["RepositoryHandle", "ExternalAssetNode"]] = []
+        repo_handle_assets: Sequence[Tuple["RepositoryHandle", "AssetNodeSnap"]] = []
         repo_handle_asset_checks: Sequence[Tuple["RepositoryHandle", "ExternalAssetCheck"]] = []
 
         for repo in repos:
-            for external_asset_node in repo.get_external_asset_nodes():
-                repo_handle_assets.append((repo.handle, external_asset_node))
+            for asset_node_snap in repo.get_asset_node_snaps():
+                repo_handle_assets.append((repo.handle, asset_node_snap))
             for external_asset_check in repo.get_external_asset_checks():
                 repo_handle_asset_checks.append((repo.handle, external_asset_check))
 
-        return RemoteAssetGraph.from_repository_handles_and_external_asset_nodes(
+        return RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
             repo_handle_assets=repo_handle_assets,
             repo_handle_asset_checks=repo_handle_asset_checks,
         )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -38,21 +38,21 @@ from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterDefinitionChangedDeserializationError
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.remote_representation.external_data import (
+    asset_node_snaps_from_repo,
     external_asset_checks_from_defs,
-    external_asset_nodes_from_defs,
 )
 from dagster._core.test_utils import freeze_time, instance_for_test
 from dagster._time import create_datetime, get_current_datetime
 
 
-def to_external_asset_graph(assets, asset_checks=None) -> BaseAssetGraph:
+def to_remote_asset_graph(assets, asset_checks=None) -> RemoteAssetGraph:
     @repository
     def repo():
         return assets + (asset_checks or [])
 
-    external_asset_nodes = external_asset_nodes_from_defs(repo.get_all_jobs(), repo.asset_graph)
-    return RemoteAssetGraph.from_repository_handles_and_external_asset_nodes(
-        [(MagicMock(), asset_node) for asset_node in external_asset_nodes],
+    asset_node_snaps = asset_node_snaps_from_repo(repo)
+    return RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
+        [(MagicMock(), asset_node) for asset_node in asset_node_snaps],
         [
             (MagicMock(), asset_check)
             for asset_check in external_asset_checks_from_defs(
@@ -63,7 +63,7 @@ def to_external_asset_graph(assets, asset_checks=None) -> BaseAssetGraph:
 
 
 @pytest.fixture(
-    name="asset_graph_from_assets", params=[AssetGraph.from_assets, to_external_asset_graph]
+    name="asset_graph_from_assets", params=[AssetGraph.from_assets, to_remote_asset_graph]
 )
 def asset_graph_from_assets_fixture(request) -> Callable[[List[AssetsDefinition]], BaseAssetGraph]:
     return request.param
@@ -277,7 +277,7 @@ def test_custom_unsupported_partition_mapping():
         def child(parent): ...
 
     internal_asset_graph = AssetGraph.from_assets([parent, child])
-    external_asset_graph = to_external_asset_graph([parent, child])
+    external_asset_graph = to_remote_asset_graph([parent, child])
 
     with instance_for_test() as instance:
         current_time = get_current_datetime()
@@ -881,13 +881,21 @@ def test_cross_code_location_partition_mapping() -> None:
     @asset(partitions_def=HourlyPartitionsDefinition(start_date="2022-01-01-00:00"))
     def a(): ...
 
+    @repository
+    def repo_a():
+        return [a]
+
     @asset(partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"), deps=["a"])
     def b(): ...
 
-    a_nodes = external_asset_nodes_from_defs([], AssetGraph.from_assets([a]))
-    b_nodes = external_asset_nodes_from_defs([], AssetGraph.from_assets([b]))
+    @repository
+    def repo_b():
+        return [b]
 
-    asset_graph = RemoteAssetGraph.from_repository_handles_and_external_asset_nodes(
+    a_nodes = asset_node_snaps_from_repo(repo_a)
+    b_nodes = asset_node_snaps_from_repo(repo_b)
+
+    asset_graph = RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
         [(MagicMock(), asset_node) for asset_node in [*a_nodes, *b_nodes]], []
     )
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_repository_load.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_repository_load.py
@@ -305,7 +305,7 @@ def test_dagster_definitions():
 
     def the_assert(external_repo: ExternalRepository):
         assert external_repo.name == "__repository__"
-        assert len(external_repo.get_external_asset_nodes()) == 1
+        assert len(external_repo.get_asset_node_snaps()) == 1
         executed["yes"] = True
 
     assert successfully_load_repository_via_cli(cli_args, the_assert)

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -56,7 +56,7 @@ from dagster._core.execution.asset_backfill import (
     execute_asset_backfill_iteration_inner,
     get_canceling_asset_backfill_iteration_data,
 )
-from dagster._core.remote_representation.external_data import external_asset_nodes_from_defs
+from dagster._core.remote_representation.external_data import asset_node_snaps_from_repo
 from dagster._core.storage.dagster_run import RunsFilter
 from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
@@ -554,7 +554,7 @@ def get_asset_graph(
             for assets_def in assets
             for dep_key in assets_def.dependency_keys
         )
-        return external_asset_graph_from_assets_by_repo_name(assets_by_repo_name)
+        return remote_asset_graph_from_assets_by_repo_name(assets_by_repo_name)
 
 
 def execute_asset_backfill_iteration_consume_generator(
@@ -733,22 +733,22 @@ def _requested_asset_partitions_in_run_request(
     return requested_asset_partitions
 
 
-def external_asset_graph_from_assets_by_repo_name(
+def remote_asset_graph_from_assets_by_repo_name(
     assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
 ) -> RemoteAssetGraph:
-    from_repository_handles_and_external_asset_nodes = []
+    from_repository_handles_and_asset_node_snaps = []
 
     for repo_name, assets in assets_by_repo_name.items():
         repo = Definitions(assets=assets).get_repository_def()
 
-        external_asset_nodes = external_asset_nodes_from_defs(repo.get_all_jobs(), repo.asset_graph)
+        asset_node_snaps = asset_node_snaps_from_repo(repo)
         repo_handle = MagicMock(repository_name=repo_name)
-        from_repository_handles_and_external_asset_nodes.extend(
-            [(repo_handle, asset_node) for asset_node in external_asset_nodes]
+        from_repository_handles_and_asset_node_snaps.extend(
+            [(repo_handle, asset_node) for asset_node in asset_node_snaps]
         )
 
-    return RemoteAssetGraph.from_repository_handles_and_external_asset_nodes(
-        from_repository_handles_and_external_asset_nodes, []
+    return RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
+        from_repository_handles_and_asset_node_snaps, []
     )
 
 
@@ -835,7 +835,7 @@ def test_serialization(static_serialization, time_window_serialization):
         @asset(partitions_def=static_partitions)
         def static_asset(): ...
 
-        return external_asset_graph_from_assets_by_repo_name({"repo": [daily_asset, static_asset]})
+        return remote_asset_graph_from_assets_by_repo_name({"repo": [daily_asset, static_asset]})
 
     asset_graph1 = make_asset_graph1()
     assert AssetBackfillData.is_valid_serialization(time_window_serialization, asset_graph1) is True
@@ -848,7 +848,7 @@ def test_serialization(static_serialization, time_window_serialization):
         @asset(partitions_def=time_window_partitions)
         def static_asset(): ...
 
-        return external_asset_graph_from_assets_by_repo_name({"repo": [daily_asset, static_asset]})
+        return remote_asset_graph_from_assets_by_repo_name({"repo": [daily_asset, static_asset]})
 
     asset_graph2 = make_asset_graph2()
     assert (
@@ -863,7 +863,7 @@ def test_serialization(static_serialization, time_window_serialization):
         @asset(partitions_def=static_partitions)
         def static_asset(): ...
 
-        return external_asset_graph_from_assets_by_repo_name({"repo": [daily_asset, static_asset]})
+        return remote_asset_graph_from_assets_by_repo_name({"repo": [daily_asset, static_asset]})
 
     asset_graph3 = make_asset_graph3()
 
@@ -877,7 +877,7 @@ def test_serialization(static_serialization, time_window_serialization):
         @asset(partitions_def=time_window_partitions)
         def static_asset(): ...
 
-        return external_asset_graph_from_assets_by_repo_name(
+        return remote_asset_graph_from_assets_by_repo_name(
             {"repo": [daily_asset_renamed, static_asset]}
         )
 

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
@@ -108,8 +108,10 @@ def test_repository_data_can_reload_without_restarting(
     request_context = workspace_process_context.create_request_context()
     code_location = request_context.get_code_location("test")
     repo = code_location.get_repository("bar_repo")
-    assert repo.has_external_job("foo_4")
+
+    assert repo.has_external_job("foo_5")
+    assert not repo.has_external_job("foo_4")
     assert not repo.has_external_job("foo_3")
 
-    external_job = repo.get_full_external_job("foo_4")
-    assert external_job.has_node_invocation("do_something_4")
+    external_job = repo.get_full_external_job("foo_5")
+    assert external_job.has_node_invocation("do_something_5")

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -31,13 +31,13 @@ from dagster._core.definitions.time_window_partitions import TimeWindowPartition
 from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.remote_representation.external_data import (
-    ExternalAssetDependedBy,
-    ExternalAssetDependency,
-    ExternalAssetNode,
+    AssetChildEdgeSnap,
+    AssetNodeSnap,
+    AssetParentEdgeSnap,
     ExternalTimeWindowPartitionsDefinitionData,
     SensorSnap,
     TargetSnap,
-    external_asset_nodes_from_defs,
+    asset_node_snaps_from_repo,
     external_multi_partitions_definition_from_def,
     external_time_window_partitions_definition_from_def,
 )
@@ -46,14 +46,9 @@ from dagster._time import create_datetime, get_timezone
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
 
 
-def _get_external_asset_nodes_from_definitions(
-    defs: Definitions,
-) -> Sequence[ExternalAssetNode]:
+def _get_asset_node_snaps_from_definitions(defs: Definitions) -> Sequence[AssetNodeSnap]:
     repo = defs.get_repository_def()
-    return sorted(
-        external_asset_nodes_from_defs(repo.get_all_jobs(), repo.asset_graph),
-        key=lambda n: n.asset_key,
-    )
+    return sorted(asset_node_snaps_from_repo(repo), key=lambda n: n.asset_key)
 
 
 def test_single_asset_job():
@@ -61,18 +56,18 @@ def test_single_asset_job():
     def asset1():
         return 1
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(
             assets=[asset1],
             jobs=[define_asset_job("assets_job", [asset1])],
         )
     )
 
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey("asset1"),
-            dependencies=[],
-            depended_by=[],
+            parent_edges=[],
+            child_edges=[],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="asset1",
             graph_name=None,
@@ -91,18 +86,18 @@ def test_asset_with_default_backfill_policy():
     def asset1():
         return 1
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(
             assets=[asset1],
             jobs=[define_asset_job("assets_job", [asset1])],
         )
     )
 
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey("asset1"),
-            dependencies=[],
-            depended_by=[],
+            parent_edges=[],
+            child_edges=[],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="asset1",
             graph_name=None,
@@ -122,18 +117,18 @@ def test_asset_with_single_run_backfill_policy():
     def asset1():
         return 1
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(
             assets=[asset1],
             jobs=[define_asset_job("assets_job", [asset1])],
         )
     )
 
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey("asset1"),
-            dependencies=[],
-            depended_by=[],
+            parent_edges=[],
+            child_edges=[],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="asset1",
             graph_name=None,
@@ -148,8 +143,8 @@ def test_asset_with_single_run_backfill_policy():
     ]
 
     assert (
-        deserialize_value(serialize_value(external_asset_nodes[0]), ExternalAssetNode)
-        == external_asset_nodes[0]
+        deserialize_value(serialize_value(asset_node_snaps[0]), AssetNodeSnap)
+        == asset_node_snaps[0]
     )
 
 
@@ -171,18 +166,18 @@ def test_asset_with_multi_run_backfill_policy():
     def asset1():
         return 1
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(
             assets=[asset1],
             jobs=[define_asset_job("assets_job", [asset1])],
         )
     )
 
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey("asset1"),
-            dependencies=[],
-            depended_by=[],
+            parent_edges=[],
+            child_edges=[],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="asset1",
             graph_name=None,
@@ -213,9 +208,9 @@ def test_asset_with_group_name():
     def asset1():
         return 1
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(Definitions(assets=[asset1]))
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(Definitions(assets=[asset1]))
 
-    assert external_asset_nodes[0].group_name == "group1"
+    assert asset_node_snaps[0].group_name == "group1"
 
 
 def test_asset_missing_group_name():
@@ -223,9 +218,9 @@ def test_asset_missing_group_name():
     def asset1():
         return 1
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(Definitions(assets=[asset1]))
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(Definitions(assets=[asset1]))
 
-    assert external_asset_nodes[0].group_name == DEFAULT_GROUP_NAME
+    assert asset_node_snaps[0].group_name == DEFAULT_GROUP_NAME
 
 
 def test_asset_invalid_group_name():
@@ -251,18 +246,18 @@ def test_two_asset_job():
     def asset2(asset1):
         assert asset1 == 1
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(
             assets=[asset1, asset2],
             jobs=[define_asset_job("assets_job", [asset1, asset2])],
         ),
     )
 
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey("asset1"),
-            dependencies=[],
-            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey("asset2"))],
+            parent_edges=[],
+            child_edges=[AssetChildEdgeSnap(child_asset_key=AssetKey("asset2"))],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="asset1",
             node_definition_name="asset1",
@@ -273,10 +268,10 @@ def test_two_asset_job():
             output_name="result",
             group_name=DEFAULT_GROUP_NAME,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey("asset2"),
-            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey("asset1"))],
-            depended_by=[],
+            parent_edges=[AssetParentEdgeSnap(parent_asset_key=AssetKey("asset1"))],
+            child_edges=[],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="asset2",
             node_definition_name="asset2",
@@ -297,26 +292,26 @@ def test_input_name_matches_output_name():
     def something(result):
         pass
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(
             assets=[not_result, something],
             jobs=[define_asset_job("assets_job", [something])],
         )
     )
 
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey("not_result"),
-            dependencies=[],
-            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey("something"))],
+            parent_edges=[],
+            child_edges=[AssetChildEdgeSnap(child_asset_key=AssetKey("something"))],
             execution_type=AssetExecutionType.UNEXECUTABLE,
             job_names=[],
             group_name=DEFAULT_GROUP_NAME,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey("something"),
-            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey("not_result"))],
-            depended_by=[],
+            parent_edges=[AssetParentEdgeSnap(parent_asset_key=AssetKey("not_result"))],
+            child_edges=[],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="something",
             node_definition_name="something",
@@ -355,15 +350,15 @@ def test_assets_excluded_from_subset_not_in_job():
         asset_graph=AssetGraph.from_assets(all_assets)
     )
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(assets=[abc, a2, c2], jobs=[as_job, cs_job])
     )
 
     assert (
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey("a"),
-            dependencies=[],
-            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey("a2"))],
+            parent_edges=[],
+            child_edges=[AssetChildEdgeSnap(child_asset_key=AssetKey("a2"))],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="abc",
             node_definition_name="abc",
@@ -374,14 +369,14 @@ def test_assets_excluded_from_subset_not_in_job():
             group_name=DEFAULT_GROUP_NAME,
             metadata=normalize_metadata(out_metadata, allow_invalid=True),
         )
-        in external_asset_nodes
+        in asset_node_snaps
     )
 
     assert (
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey("c"),
-            dependencies=[],
-            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey("c2"))],
+            parent_edges=[],
+            child_edges=[AssetChildEdgeSnap(child_asset_key=AssetKey("c2"))],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="abc",
             node_definition_name="abc",
@@ -391,7 +386,7 @@ def test_assets_excluded_from_subset_not_in_job():
             output_name="c",
             group_name=DEFAULT_GROUP_NAME,
         )
-        in external_asset_nodes
+        in asset_node_snaps
     )
 
 
@@ -408,20 +403,20 @@ def test_two_downstream_assets_job():
     def asset2_b(asset1):
         assert asset1 == 1
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(
             assets=[asset1, asset2_a, asset2_b],
             jobs=[define_asset_job("assets_job", [asset1, asset2_a, asset2_b])],
         )
     )
 
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey("asset1"),
-            dependencies=[],
-            depended_by=[
-                ExternalAssetDependedBy(downstream_asset_key=AssetKey("asset2_a")),
-                ExternalAssetDependedBy(downstream_asset_key=AssetKey("asset2_b")),
+            parent_edges=[],
+            child_edges=[
+                AssetChildEdgeSnap(child_asset_key=AssetKey("asset2_a")),
+                AssetChildEdgeSnap(child_asset_key=AssetKey("asset2_b")),
             ],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="asset1",
@@ -433,10 +428,10 @@ def test_two_downstream_assets_job():
             output_name="result",
             group_name=DEFAULT_GROUP_NAME,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey("asset2_a"),
-            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey("asset1"))],
-            depended_by=[],
+            parent_edges=[AssetParentEdgeSnap(parent_asset_key=AssetKey("asset1"))],
+            child_edges=[],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="asset2_a",
             node_definition_name="asset2_a",
@@ -447,10 +442,10 @@ def test_two_downstream_assets_job():
             output_name="result",
             group_name=DEFAULT_GROUP_NAME,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey("asset2_b"),
-            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey("asset1"))],
-            depended_by=[],
+            parent_edges=[AssetParentEdgeSnap(parent_asset_key=AssetKey("asset1"))],
+            child_edges=[],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="asset2_b",
             node_definition_name="asset2_b",
@@ -475,15 +470,15 @@ def test_cross_job_asset_dependency():
 
     assets_job1 = define_asset_job("assets_job1", [asset1])
     assets_job2 = define_asset_job("assets_job2", [asset2])
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(assets=[asset1, asset2], jobs=[assets_job1, assets_job2])
     )
 
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey("asset1"),
-            dependencies=[],
-            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey("asset2"))],
+            parent_edges=[],
+            child_edges=[AssetChildEdgeSnap(child_asset_key=AssetKey("asset2"))],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="asset1",
             node_definition_name="asset1",
@@ -494,10 +489,10 @@ def test_cross_job_asset_dependency():
             output_name="result",
             group_name=DEFAULT_GROUP_NAME,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey("asset2"),
-            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey("asset1"))],
-            depended_by=[],
+            parent_edges=[AssetParentEdgeSnap(parent_asset_key=AssetKey("asset1"))],
+            child_edges=[],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="asset2",
             node_definition_name="asset2",
@@ -519,18 +514,18 @@ def test_same_asset_in_multiple_jobs():
     job1 = define_asset_job("job1", [asset1])
     job2 = define_asset_job("job2", [asset1])
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(
             assets=[asset1],
             jobs=[job1, job2],
         )
     )
 
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey("asset1"),
-            dependencies=[],
-            depended_by=[],
+            parent_edges=[],
+            child_edges=[],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="asset1",
             node_definition_name="asset1",
@@ -557,17 +552,17 @@ def test_basic_multi_asset():
 
     assets_job = define_asset_job("assets_job", [assets])
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(assets=[assets], jobs=[assets_job])
     )
 
     execution_set_identifier = assets.unique_id
 
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey(f"asset{i}"),
-            dependencies=[],
-            depended_by=[],
+            parent_edges=[],
+            child_edges=[],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="assets",
             node_definition_name="assets",
@@ -613,7 +608,7 @@ def test_inter_op_dependency():
     )
     all_assets_job = define_asset_job("assets_job", [in1, in2, assets, downstream])
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(
             assets=[in1, in2, assets, downstream],
             jobs=[subset_job, all_assets_job],
@@ -622,15 +617,15 @@ def test_inter_op_dependency():
     )
     # sort so that test is deterministic
 
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey(["downstream"]),
-            dependencies=[
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["mixed"])),
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["only_in"])),
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["only_out"])),
+            parent_edges=[
+                AssetParentEdgeSnap(parent_asset_key=AssetKey(["mixed"])),
+                AssetParentEdgeSnap(parent_asset_key=AssetKey(["only_in"])),
+                AssetParentEdgeSnap(parent_asset_key=AssetKey(["only_out"])),
             ],
-            depended_by=[],
+            child_edges=[],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="downstream",
             node_definition_name="downstream",
@@ -642,12 +637,12 @@ def test_inter_op_dependency():
             metadata={},
             group_name=DEFAULT_GROUP_NAME,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey(["in1"]),
-            dependencies=[],
-            depended_by=[
-                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["mixed"])),
-                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["only_in"])),
+            parent_edges=[],
+            child_edges=[
+                AssetChildEdgeSnap(child_asset_key=AssetKey(["mixed"])),
+                AssetChildEdgeSnap(child_asset_key=AssetKey(["only_in"])),
             ],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="in1",
@@ -660,10 +655,10 @@ def test_inter_op_dependency():
             metadata={},
             group_name=DEFAULT_GROUP_NAME,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey(["in2"]),
-            dependencies=[],
-            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey(["only_in"]))],
+            parent_edges=[],
+            child_edges=[AssetChildEdgeSnap(child_asset_key=AssetKey(["only_in"]))],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="in2",
             node_definition_name="in2",
@@ -675,15 +670,15 @@ def test_inter_op_dependency():
             metadata={},
             group_name=DEFAULT_GROUP_NAME,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey(["mixed"]),
-            dependencies=[
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["in1"])),
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["only_in"])),
+            parent_edges=[
+                AssetParentEdgeSnap(parent_asset_key=AssetKey(["in1"])),
+                AssetParentEdgeSnap(parent_asset_key=AssetKey(["only_in"])),
             ],
-            depended_by=[
-                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["downstream"])),
-                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["only_out"])),
+            child_edges=[
+                AssetChildEdgeSnap(child_asset_key=AssetKey(["downstream"])),
+                AssetChildEdgeSnap(child_asset_key=AssetKey(["only_out"])),
             ],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="assets",
@@ -695,16 +690,16 @@ def test_inter_op_dependency():
             output_name="mixed",
             group_name=DEFAULT_GROUP_NAME,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey(["only_in"]),
-            dependencies=[
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["in1"])),
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["in2"])),
+            parent_edges=[
+                AssetParentEdgeSnap(parent_asset_key=AssetKey(["in1"])),
+                AssetParentEdgeSnap(parent_asset_key=AssetKey(["in2"])),
             ],
-            depended_by=[
-                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["downstream"])),
-                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["mixed"])),
-                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["only_out"])),
+            child_edges=[
+                AssetChildEdgeSnap(child_asset_key=AssetKey(["downstream"])),
+                AssetChildEdgeSnap(child_asset_key=AssetKey(["mixed"])),
+                AssetChildEdgeSnap(child_asset_key=AssetKey(["only_out"])),
             ],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="assets",
@@ -717,14 +712,14 @@ def test_inter_op_dependency():
             metadata={},
             group_name=DEFAULT_GROUP_NAME,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey(["only_out"]),
-            dependencies=[
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["mixed"])),
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["only_in"])),
+            parent_edges=[
+                AssetParentEdgeSnap(parent_asset_key=AssetKey(["mixed"])),
+                AssetParentEdgeSnap(parent_asset_key=AssetKey(["only_in"])),
             ],
-            depended_by=[
-                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["downstream"])),
+            child_edges=[
+                AssetChildEdgeSnap(child_asset_key=AssetKey(["downstream"])),
             ],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="assets",
@@ -748,11 +743,11 @@ def test_source_asset_with_op() -> None:
 
     assets_job = define_asset_job("assets_job", [bar])
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(assets=[foo, bar], jobs=[assets_job])
     )
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey("bar"),
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="bar",
@@ -760,18 +755,18 @@ def test_source_asset_with_op() -> None:
             graph_name=None,
             op_names=["bar"],
             description=None,
-            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey("foo"))],
-            depended_by=[],
+            parent_edges=[AssetParentEdgeSnap(parent_asset_key=AssetKey("foo"))],
+            child_edges=[],
             job_names=["__ASSET_JOB", "assets_job"],
             output_name="result",
             group_name=DEFAULT_GROUP_NAME,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey("foo"),
             execution_type=AssetExecutionType.UNEXECUTABLE,
             description=None,
-            dependencies=[],
-            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey("bar"))],
+            parent_edges=[],
+            child_edges=[AssetChildEdgeSnap(child_asset_key=AssetKey("bar"))],
             job_names=[],
             group_name=DEFAULT_GROUP_NAME,
         ),
@@ -782,25 +777,23 @@ def test_unused_source_asset():
     foo = SourceAsset(key=AssetKey("foo"), description="abc")
     bar = SourceAsset(key=AssetKey("bar"), description="def")
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
-        Definitions(assets=[foo, bar])
-    )
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(Definitions(assets=[foo, bar]))
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey("bar"),
             description="def",
-            dependencies=[],
-            depended_by=[],
+            parent_edges=[],
+            child_edges=[],
             execution_type=AssetExecutionType.UNEXECUTABLE,
             job_names=[],
             group_name=DEFAULT_GROUP_NAME,
             is_source=True,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey("foo"),
             description="abc",
-            dependencies=[],
-            depended_by=[],
+            parent_edges=[],
+            child_edges=[],
             execution_type=AssetExecutionType.UNEXECUTABLE,
             job_names=[],
             group_name=DEFAULT_GROUP_NAME,
@@ -818,33 +811,33 @@ def test_used_source_asset():
 
     job1 = define_asset_job("job1", [foo])
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(
             assets=[bar, foo],
             jobs=[job1],
         )
     )
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey("bar"),
             description="def",
-            dependencies=[],
-            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey(["foo"]))],
+            parent_edges=[],
+            child_edges=[AssetChildEdgeSnap(child_asset_key=AssetKey(["foo"]))],
             execution_type=AssetExecutionType.UNEXECUTABLE,
             job_names=[],
             group_name=DEFAULT_GROUP_NAME,
             is_source=True,
             tags={"biz": "baz"},
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey("foo"),
             op_name="foo",
             node_definition_name="foo",
             graph_name=None,
             op_names=["foo"],
             description=None,
-            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey(["bar"]))],
-            depended_by=[],
+            parent_edges=[AssetParentEdgeSnap(parent_asset_key=AssetKey(["bar"]))],
+            child_edges=[],
             execution_type=AssetExecutionType.MATERIALIZATION,
             job_names=["__ASSET_JOB", "job1"],
             output_name="result",
@@ -887,15 +880,15 @@ def test_graph_output_metadata_and_description() -> None:
 
     assets_job = define_asset_job("assets_job", [zero, three_asset])
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(assets=[zero, three_asset], jobs=[assets_job])
     )
 
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey(["three"]),
-            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey(["zero"]))],
-            depended_by=[],
+            parent_edges=[AssetParentEdgeSnap(parent_asset_key=AssetKey(["zero"]))],
+            child_edges=[],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="three",
             node_definition_name="add_one",
@@ -907,10 +900,10 @@ def test_graph_output_metadata_and_description() -> None:
             metadata=(normalize_metadata({**asset_metadata, **out_metadata}, allow_invalid=True)),
             group_name=DEFAULT_GROUP_NAME,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey(["zero"]),
-            dependencies=[],
-            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey(["three"]))],
+            parent_edges=[],
+            child_edges=[AssetChildEdgeSnap(child_asset_key=AssetKey(["three"]))],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="zero",
             node_definition_name="zero",
@@ -989,19 +982,19 @@ def test_nasty_nested_graph_asset() -> None:
 
     assets_job = define_asset_job("assets_job", [zero, eight_and_five, thirteen_and_six, twenty])
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(assets=[zero, eight_and_five, thirteen_and_six, twenty], jobs=[assets_job])
     )
 
-    assert external_asset_nodes[-3:] == [
-        ExternalAssetNode(
+    assert asset_node_snaps[-3:] == [
+        AssetNodeSnap(
             asset_key=AssetKey(["thirteen"]),
-            dependencies=[
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["eight"])),
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["five"])),
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["zero"])),
+            parent_edges=[
+                AssetParentEdgeSnap(parent_asset_key=AssetKey(["eight"])),
+                AssetParentEdgeSnap(parent_asset_key=AssetKey(["five"])),
+                AssetParentEdgeSnap(parent_asset_key=AssetKey(["zero"])),
             ],
-            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey(["twenty"]))],
+            child_edges=[AssetChildEdgeSnap(child_asset_key=AssetKey(["twenty"]))],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="create_thirteen_and_six",
             node_definition_name="add_one",
@@ -1019,13 +1012,13 @@ def test_nasty_nested_graph_asset() -> None:
             metadata={},
             group_name=DEFAULT_GROUP_NAME,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey(["twenty"]),
-            dependencies=[
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["six"])),
-                ExternalAssetDependency(upstream_asset_key=AssetKey(["thirteen"])),
+            parent_edges=[
+                AssetParentEdgeSnap(parent_asset_key=AssetKey(["six"])),
+                AssetParentEdgeSnap(parent_asset_key=AssetKey(["thirteen"])),
             ],
-            depended_by=[],
+            child_edges=[],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="create_twenty",
             node_definition_name="add_one",
@@ -1037,14 +1030,14 @@ def test_nasty_nested_graph_asset() -> None:
             metadata={},
             group_name=DEFAULT_GROUP_NAME,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey(["zero"]),
-            dependencies=[],
-            depended_by=[
-                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["eight"])),
-                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["five"])),
-                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["six"])),
-                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["thirteen"])),
+            parent_edges=[],
+            child_edges=[
+                AssetChildEdgeSnap(child_asset_key=AssetKey(["eight"])),
+                AssetChildEdgeSnap(child_asset_key=AssetKey(["five"])),
+                AssetChildEdgeSnap(child_asset_key=AssetKey(["six"])),
+                AssetChildEdgeSnap(child_asset_key=AssetKey(["thirteen"])),
             ],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="zero",
@@ -1069,15 +1062,15 @@ def test_deps_resolve_group():
         del asset1
 
     assets_job = define_asset_job("assets_job", [asset1, asset2])
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(assets=[asset1, asset2], jobs=[assets_job])
     )
 
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey(["abc", "asset1"]),
-            dependencies=[],
-            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey("asset2"))],
+            parent_edges=[],
+            child_edges=[AssetChildEdgeSnap(child_asset_key=AssetKey("asset2"))],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="abc__asset1",
             node_definition_name="abc__asset1",
@@ -1088,10 +1081,10 @@ def test_deps_resolve_group():
             output_name="result",
             group_name=DEFAULT_GROUP_NAME,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey("asset2"),
-            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey(["abc", "asset1"]))],
-            depended_by=[],
+            parent_edges=[AssetParentEdgeSnap(parent_asset_key=AssetKey(["abc", "asset1"]))],
+            child_edges=[],
             execution_type=AssetExecutionType.MATERIALIZATION,
             op_name="asset2",
             node_definition_name="asset2",
@@ -1199,10 +1192,10 @@ def test_graph_asset_description():
 
     assets_job = define_asset_job("assets_job", [foo])
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
         Definitions(assets=[foo], jobs=[assets_job])
     )
-    assert external_asset_nodes[0].description == "bar"
+    assert asset_node_snaps[0].description == "bar"
 
 
 def test_graph_multi_asset_description():
@@ -1223,14 +1216,14 @@ def test_graph_multi_asset_description():
 
     assets_job = define_asset_job("assets_job", [foo])
 
-    external_asset_nodes = {
+    asset_node_snaps = {
         asset_node.asset_key: asset_node
-        for asset_node in _get_external_asset_nodes_from_definitions(
+        for asset_node in _get_asset_node_snaps_from_definitions(
             Definitions(assets=[foo], jobs=[assets_job])
         )
     }
-    assert external_asset_nodes[AssetKey("asset1")].description == "bar"
-    assert external_asset_nodes[AssetKey("asset2")].description == "baz"
+    assert asset_node_snaps[AssetKey("asset1")].description == "bar"
+    assert asset_node_snaps[AssetKey("asset2")].description == "baz"
 
 
 def test_external_time_window_valid_partition_key():
@@ -1252,24 +1245,22 @@ def test_external_assets_def_to_external_asset_graph():
         [AssetSpec("asset1"), AssetSpec("asset2", deps=["asset1"])]
     )
 
-    external_asset_nodes = _get_external_asset_nodes_from_definitions(
-        Definitions(assets=[asset1, asset2])
-    )
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(Definitions(assets=[asset1, asset2]))
 
-    assert len(external_asset_nodes) == 2
+    assert len(asset_node_snaps) == 2
 
-    assert external_asset_nodes == [
-        ExternalAssetNode(
+    assert asset_node_snaps == [
+        AssetNodeSnap(
             asset_key=AssetKey(["asset1"]),
-            dependencies=[],
-            depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey("asset2"))],
+            parent_edges=[],
+            child_edges=[AssetChildEdgeSnap(child_asset_key=AssetKey("asset2"))],
             execution_type=AssetExecutionType.UNEXECUTABLE,
             group_name=DEFAULT_GROUP_NAME,
         ),
-        ExternalAssetNode(
+        AssetNodeSnap(
             asset_key=AssetKey("asset2"),
-            dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey(["asset1"]))],
-            depended_by=[],
+            parent_edges=[AssetParentEdgeSnap(parent_asset_key=AssetKey(["asset1"]))],
+            child_edges=[],
             execution_type=AssetExecutionType.UNEXECUTABLE,
             group_name=DEFAULT_GROUP_NAME,
         ),
@@ -1277,18 +1268,18 @@ def test_external_assets_def_to_external_asset_graph():
 
 
 def test_historical_external_asset_node_that_models_underlying_external_assets_def() -> None:
-    assert not ExternalAssetNode(
+    assert not AssetNodeSnap(
         asset_key=AssetKey("asset_one"),
-        dependencies=[],
-        depended_by=[],
+        parent_edges=[],
+        child_edges=[],
         # purposefully not using constants here so we know when we are breaking ourselves
         metadata={"dagster/asset_execution_type": TextMetadataValue("UNEXECUTABLE")},
     ).is_executable
 
-    assert ExternalAssetNode(
+    assert AssetNodeSnap(
         asset_key=AssetKey("asset_one"),
-        dependencies=[],
-        depended_by=[],
+        parent_edges=[],
+        child_edges=[],
     ).is_executable
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/base_scenario.py
@@ -153,7 +153,7 @@ class AssetReconciliationScenario(
             ),
             ("expected_evaluations", Optional[Sequence[AssetEvaluationSpec]]),
             ("requires_respect_materialization_data_versions", bool),
-            ("supports_with_external_asset_graph", bool),
+            ("supports_with_remote_asset_graph", bool),
             ("expected_error_message", Optional[str]),
         ],
     )
@@ -179,7 +179,7 @@ class AssetReconciliationScenario(
         ] = None,
         expected_evaluations: Optional[Sequence[AssetEvaluationSpec]] = None,
         requires_respect_materialization_data_versions: bool = False,
-        supports_with_external_asset_graph: bool = True,
+        supports_with_remote_asset_graph: bool = True,
         expected_error_message: Optional[str] = None,
     ) -> "AssetReconciliationScenario":
         # For scenarios with no auto-materialize policies, we infer auto-materialize policies
@@ -220,7 +220,7 @@ class AssetReconciliationScenario(
             code_locations=code_locations,
             expected_evaluations=expected_evaluations,
             requires_respect_materialization_data_versions=requires_respect_materialization_data_versions,
-            supports_with_external_asset_graph=supports_with_external_asset_graph,
+            supports_with_remote_asset_graph=supports_with_remote_asset_graph,
             expected_error_message=expected_error_message,
         )
 
@@ -246,7 +246,7 @@ class AssetReconciliationScenario(
         self,
         instance,
         scenario_name=None,
-        with_external_asset_graph=False,
+        with_remote_asset_graph=False,
         respect_materialization_data_versions=False,
     ):
         if (
@@ -332,7 +332,7 @@ class AssetReconciliationScenario(
                 ) = self.cursor_from.do_sensor_scenario(
                     instance,
                     scenario_name=scenario_name,
-                    with_external_asset_graph=with_external_asset_graph,
+                    with_remote_asset_graph=with_remote_asset_graph,
                 )
                 for run_request in run_requests:
                     instance.create_run_for_job(
@@ -376,7 +376,7 @@ class AssetReconciliationScenario(
             test_time += self.evaluation_delta
         with freeze_time(test_time):
             # get asset_graph
-            if not with_external_asset_graph:
+            if not with_remote_asset_graph:
                 asset_graph = repo.asset_graph
             else:
                 assert scenario_name is not None, "scenario_name must be provided for daemon runs"


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/8998

Renames:

- `ExternalAssetNode` -> `AssetNodeSnap`
- `ExternalAssetDependency` -> `AssetParentEdgeSnap`
- `ExternalAssetDependedBy` -> `AssetChildEdgeSnap`
- a bunch of private methods and local variables that were inflections of "external asset node"

Note that "parent"/"child" terminology was used for renames because it is consistent with the terminology used in `AssetGraph`.

Also:

- `external_asset_nodes_from_defs` renamed to `asset_node_snaps_from_repo`, now just takes a `RepositoryDefinition`

## How I Tested These Changes

Existing test suite.