### PR TITLE
[external-renames] remote origin

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
+++ b/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
@@ -31,7 +31,7 @@ def create_run(instance, **kwargs):
         )
         return create_run_for_test(
             instance,
-            external_job_origin=handle.get_external_origin(),
+            external_job_origin=handle.get_remote_origin(),
             job_code_origin=handle.get_python_origin(),
             job_name=handle.job_name,
             job_snapshot=foo.get_job_snapshot(),

--- a/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/test_monitoring.py
+++ b/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/test_monitoring.py
@@ -132,7 +132,7 @@ def test_docker_monitoring(aws_env):
                 run = instance.create_run_for_job(
                     job_def=recon_job.get_definition(),
                     run_config=run_config,
-                    external_job_origin=external_job.get_external_origin(),
+                    external_job_origin=external_job.get_remote_origin(),
                     job_code_origin=external_job.get_python_origin(),
                 )
 
@@ -225,7 +225,7 @@ def test_docker_monitoring_run_out_of_attempts(aws_env):
                 run = instance.create_run_for_job(
                     job_def=recon_job.get_definition(),
                     run_config=run_config,
-                    external_job_origin=external_job.get_external_origin(),
+                    external_job_origin=external_job.get_remote_origin(),
                     job_code_origin=external_job.get_python_origin(),
                 )
 

--- a/integration_tests/test_suites/daemon-test-suite/test_queued.py
+++ b/integration_tests/test_suites/daemon-test-suite/test_queued.py
@@ -13,7 +13,7 @@ def create_run(instance: DagsterInstance, external_job: ExternalJob, **kwargs: A
     job_args = merge_dicts(
         {
             "job_name": "foo_job",
-            "external_job_origin": external_job.get_external_origin(),
+            "external_job_origin": external_job.get_remote_origin(),
             "job_code_origin": external_job.get_python_origin(),
         },
         kwargs,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -161,7 +161,7 @@ def create_and_launch_partition_backfill(
 
         backfill = PartitionBackfill(
             backfill_id=backfill_id,
-            partition_set_origin=external_partition_set.get_external_origin(),
+            partition_set_origin=external_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=partition_names,
             from_failure=bool(backfill_params.get("fromFailure")),

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -111,7 +111,7 @@ def create_valid_pipeline_run(
         root_run_id=execution_params.execution_metadata.root_run_id,
         parent_run_id=execution_params.execution_metadata.parent_run_id,
         status=DagsterRunStatus.NOT_STARTED,
-        external_job_origin=external_pipeline.get_external_origin(),
+        external_job_origin=external_pipeline.get_remote_origin(),
         job_code_origin=external_pipeline.get_python_origin(),
         asset_graph=code_location.get_repository(
             external_pipeline.repository_handle.repository_name

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
@@ -30,7 +30,7 @@ def get_instigator_state_by_selector(
 
     if instigator_id:
         state = graphene_info.context.instance.get_instigator_state(
-            origin_id=instigator_id.external_origin_id,
+            origin_id=instigator_id.remote_origin_id,
             selector_id=instigator_id.selector_id,
         )
         # if the state tells us the status on its own short cut and return it
@@ -44,14 +44,14 @@ def get_instigator_state_by_selector(
     if repository.has_external_sensor(selector.name):
         external_sensor = repository.get_external_sensor(selector.name)
         stored_state = graphene_info.context.instance.get_instigator_state(
-            external_sensor.get_external_origin_id(),
+            external_sensor.get_remote_origin_id(),
             external_sensor.selector_id,
         )
         current_state = external_sensor.get_current_instigator_state(stored_state)
     elif repository.has_external_schedule(selector.name):
         external_schedule = repository.get_external_schedule(selector.name)
         stored_state = graphene_info.context.instance.get_instigator_state(
-            external_schedule.get_external_origin_id(),
+            external_schedule.get_remote_origin_id(),
             external_schedule.selector_id,
         )
         current_state = external_schedule.get_current_instigator_state(stored_state)
@@ -71,7 +71,7 @@ def get_instigation_states_by_repository_id(
     )
 
     states = graphene_info.context.instance.all_instigator_state(
-        repository_origin_id=repository_id.external_origin_id,
+        repository_origin_id=repository_id.remote_origin_id,
         repository_selector_id=repository_id.selector_id,
     )
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -208,7 +208,7 @@ def get_partition_set_partition_statuses(
             statuses=[status for status in DagsterRunStatus if status != DagsterRunStatus.CANCELED],
             tags={
                 PARTITION_SET_TAG: partition_set_name,
-                REPOSITORY_LABEL_TAG: repository_handle.get_external_origin().get_label(),
+                REPOSITORY_LABEL_TAG: repository_handle.get_remote_origin().get_label(),
             },
         )
     )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -55,7 +55,7 @@ def stop_schedule(
     instance = graphene_info.context.instance
 
     external_schedules = {
-        schedule.get_external_origin_id(): schedule
+        schedule.get_remote_origin_id(): schedule
         for repository_location in graphene_info.context.code_locations
         for repository in repository_location.get_repositories().values()
         for schedule in repository.get_external_schedules()
@@ -125,7 +125,7 @@ def get_schedules_or_error(
     batch_loader = RepositoryScopedBatchLoader(graphene_info.context.instance, repository)
     external_schedules = repository.get_external_schedules()
     schedule_states = graphene_info.context.instance.all_instigator_state(
-        repository_origin_id=repository.get_external_origin_id(),
+        repository_origin_id=repository.get_remote_origin_id(),
         repository_selector_id=repository_selector.selector_id,
         instigator_type=InstigatorType.SCHEDULE,
         instigator_statuses=instigator_statuses,
@@ -171,7 +171,7 @@ def get_schedules_for_pipeline(
             continue
 
         schedule_state = graphene_info.context.instance.get_instigator_state(
-            external_schedule.get_external_origin_id(),
+            external_schedule.get_remote_origin_id(),
             external_schedule.selector_id,
         )
         results.append(GrapheneSchedule(external_schedule, repository, schedule_state))
@@ -197,7 +197,7 @@ def get_schedule_or_error(
     external_schedule = repository.get_external_schedule(schedule_selector.schedule_name)
 
     schedule_state = graphene_info.context.instance.get_instigator_state(
-        external_schedule.get_external_origin_id(), external_schedule.selector_id
+        external_schedule.get_remote_origin_id(), external_schedule.selector_id
     )
     return GrapheneSchedule(external_schedule, repository, schedule_state)
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -42,7 +42,7 @@ def get_sensors_or_error(
     batch_loader = RepositoryScopedBatchLoader(graphene_info.context.instance, repository)
     sensors = repository.get_external_sensors()
     sensor_states = graphene_info.context.instance.all_instigator_state(
-        repository_origin_id=repository.get_external_origin_id(),
+        repository_origin_id=repository.get_remote_origin_id(),
         repository_selector_id=repository_selector.selector_id,
         instigator_type=InstigatorType.SENSOR,
         instigator_statuses=instigator_statuses,
@@ -79,7 +79,7 @@ def get_sensor_or_error(graphene_info: ResolveInfo, selector: SensorSelector) ->
         raise UserFacingGraphQLError(GrapheneSensorNotFoundError(selector.sensor_name))
     external_sensor = repository.get_external_sensor(selector.sensor_name)
     sensor_state = graphene_info.context.instance.get_instigator_state(
-        external_sensor.get_external_origin_id(),
+        external_sensor.get_remote_origin_id(),
         external_sensor.selector_id,
     )
 
@@ -110,7 +110,7 @@ def stop_sensor(
     instance = graphene_info.context.instance
 
     external_sensors = {
-        sensor.get_external_origin_id(): sensor
+        sensor.get_remote_origin_id(): sensor
         for code_location in graphene_info.context.code_locations
         for repository in code_location.get_repositories().values()
         for sensor in repository.get_external_sensors()
@@ -173,7 +173,7 @@ def get_sensors_for_pipeline(
             continue
 
         sensor_state = graphene_info.context.instance.get_instigator_state(
-            external_sensor.get_external_origin_id(),
+            external_sensor.get_remote_origin_id(),
             external_sensor.selector_id,
         )
         results.append(GrapheneSensor(external_sensor, repository, sensor_state))
@@ -240,7 +240,7 @@ def set_sensor_cursor(
     instance = graphene_info.context.instance
     external_sensor = repository.get_external_sensor(selector.sensor_name)
     stored_state = instance.get_instigator_state(
-        external_sensor.get_external_origin_id(),
+        external_sensor.get_remote_origin_id(),
         external_sensor.selector_id,
     )
     sensor_state = external_sensor.get_current_instigator_state(stored_state)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -67,7 +67,7 @@ class RepositoryScopedBatchLoader:
 
         if data_type == RepositoryDataType.SCHEDULE_STATES:
             schedule_states = self._instance.all_instigator_state(
-                repository_origin_id=self._repository.get_external_origin_id(),
+                repository_origin_id=self._repository.get_remote_origin_id(),
                 repository_selector_id=self._repository.selector_id,
                 instigator_type=InstigatorType.SCHEDULE,
             )
@@ -76,7 +76,7 @@ class RepositoryScopedBatchLoader:
 
         elif data_type == RepositoryDataType.SENSOR_STATES:
             sensor_states = self._instance.all_instigator_state(
-                repository_origin_id=self._repository.get_external_origin_id(),
+                repository_origin_id=self._repository.get_remote_origin_id(),
                 repository_selector_id=self._repository.selector_id,
                 instigator_type=InstigatorType.SENSOR,
             )
@@ -90,12 +90,12 @@ class RepositoryScopedBatchLoader:
                 ]
                 ticks_by_selector = self._instance.get_batch_ticks(selector_ids, limit=limit)
                 for schedule in self._repository.get_external_schedules():
-                    fetched[schedule.get_external_origin_id()] = list(
+                    fetched[schedule.get_remote_origin_id()] = list(
                         ticks_by_selector.get(schedule.selector_id, [])
                     )
             else:
                 for schedule in self._repository.get_external_schedules():
-                    origin_id = schedule.get_external_origin_id()
+                    origin_id = schedule.get_remote_origin_id()
                     fetched[origin_id] = list(
                         self._instance.get_ticks(origin_id, schedule.selector_id, limit=limit)
                     )
@@ -107,12 +107,12 @@ class RepositoryScopedBatchLoader:
                 ]
                 ticks_by_selector = self._instance.get_batch_ticks(selector_ids, limit=limit)
                 for sensor in self._repository.get_external_sensors():
-                    fetched[sensor.get_external_origin_id()] = list(
+                    fetched[sensor.get_remote_origin_id()] = list(
                         ticks_by_selector.get(sensor.selector_id, [])
                     )
             else:
                 for sensor in self._repository.get_external_sensors():
-                    origin_id = sensor.get_external_origin_id()
+                    origin_id = sensor.get_remote_origin_id()
                     fetched[origin_id] = list(
                         self._instance.get_ticks(origin_id, sensor.selector_id, limit=limit)
                     )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -964,7 +964,7 @@ class GrapheneAssetNode(graphene.ObjectType):
                 continue
 
             sensor_state = graphene_info.context.instance.get_instigator_state(
-                external_sensor.get_external_origin_id(),
+                external_sensor.get_remote_origin_id(),
                 external_sensor.selector_id,
             )
             results.append(GrapheneSensor(external_sensor, self._external_repository, sensor_state))
@@ -972,7 +972,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         for external_schedule in external_schedules:
             if external_schedule.job_name in job_names:
                 schedule_state = graphene_info.context.instance.get_instigator_state(
-                    external_schedule.get_external_origin_id(),
+                    external_schedule.get_remote_origin_id(),
                     external_schedule.selector_id,
                 )
                 results.append(
@@ -1010,7 +1010,7 @@ class GrapheneAssetNode(graphene.ObjectType):
                 return None
 
             return get_current_evaluation_id(
-                graphene_info.context.instance, external_sensor.get_external_origin()
+                graphene_info.context.instance, external_sensor.get_remote_origin()
             )
         else:
             return get_current_evaluation_id(graphene_info.context.instance, None)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -311,7 +311,7 @@ class GrapheneRepository(graphene.ObjectType):
         return self._repository.get_compound_id().to_string()
 
     def resolve_origin(self, _graphene_info: ResolveInfo):
-        origin = self._repository.get_external_origin()
+        origin = self._repository.get_remote_origin()
         return GrapheneRepositoryOrigin(origin)
 
     def resolve_location(self, _graphene_info: ResolveInfo):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -577,7 +577,7 @@ class GrapheneInstigationState(graphene.ObjectType):
             batch_loader, "batch_loader", RepositoryScopedBatchLoader
         )
         cid = CompoundID(
-            external_origin_id=instigator_state.instigator_origin_id,
+            remote_origin_id=instigator_state.instigator_origin_id,
             selector_id=instigator_state.selector_id,
         )
         super().__init__(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -384,7 +384,7 @@ class GraphenePartitionSet(graphene.ObjectType):
         return self._partition_names
 
     def resolve_id(self, _graphene_info: ResolveInfo):
-        return self._external_partition_set.get_external_origin_id()
+        return self._external_partition_set.get_remote_origin_id()
 
     @capture_error
     def resolve_partitionsOrError(
@@ -427,7 +427,7 @@ class GraphenePartitionSet(graphene.ObjectType):
         )
 
     def resolve_repositoryOrigin(self, _):
-        origin = self._external_partition_set.get_external_origin().repository_origin
+        origin = self._external_partition_set.get_remote_origin().repository_origin
         return GrapheneRepositoryOrigin(origin)
 
     def resolve_backfills(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -779,7 +779,7 @@ class GrapheneIPipelineSnapshotMixin:
                 job_name=pipeline.name,
                 tags={
                     REPOSITORY_LABEL_TAG: (
-                        pipeline.get_external_origin().repository_origin.get_label()
+                        pipeline.get_remote_origin().repository_origin.get_label()
                     )
                 },
             )
@@ -923,7 +923,7 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
         self._external_job = check.inst_param(external_job, "external_job", ExternalJob)
 
     def resolve_id(self, _graphene_info: ResolveInfo):
-        return self._external_job.get_external_origin_id()
+        return self._external_job.get_remote_origin_id()
 
     def get_represented_job(self) -> RepresentedJob:
         return self._external_job
@@ -1024,35 +1024,31 @@ class GrapheneGraph(graphene.ObjectType):
     )
     modes = non_null_list(GrapheneMode)
 
-    def __init__(self, external_pipeline, solid_handle_id=None):
-        self._external_pipeline = check.inst_param(
-            external_pipeline, "external_pipeline", ExternalJob
-        )
+    def __init__(self, external_job: ExternalJob, solid_handle_id=None):
+        self._external_job = check.inst_param(external_job, "external_job", ExternalJob)
         self._solid_handle_id = check.opt_str_param(solid_handle_id, "solid_handle_id")
         super().__init__()
 
     def resolve_id(self, _graphene_info: ResolveInfo):
         if self._solid_handle_id:
-            return (
-                f"{self._external_pipeline.get_external_origin_id()}:solid:{self._solid_handle_id}"
-            )
-        return f"graph:{self._external_pipeline.get_external_origin_id()}"
+            return f"{self._external_job.get_remote_origin_id()}:solid:{self._solid_handle_id}"
+        return f"graph:{self._external_job.get_remote_origin_id()}"
 
     def resolve_name(self, _graphene_info: ResolveInfo):
-        return self._external_pipeline.get_graph_name()
+        return self._external_job.get_graph_name()
 
     def resolve_description(self, _graphene_info: ResolveInfo):
-        return self._external_pipeline.description
+        return self._external_job.description
 
     def resolve_solid_handle(
         self, _graphene_info: ResolveInfo, handleID: str
     ) -> Optional[GrapheneSolidHandle]:
-        return build_solid_handles(self._external_pipeline).get(handleID)
+        return build_solid_handles(self._external_job).get(handleID)
 
     def resolve_solid_handles(
         self, _graphene_info: ResolveInfo, parentHandleID: Optional[str] = None
     ) -> Sequence[GrapheneSolidHandle]:
-        handles = build_solid_handles(self._external_pipeline)
+        handles = build_solid_handles(self._external_job)
 
         if parentHandleID == "":
             handles = {key: handle for key, handle in handles.items() if not handle.parent}

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/__init__.py
@@ -113,12 +113,12 @@ class GrapheneStopRunningScheduleMutation(graphene.Mutation):
     ):
         if id:
             cid = CompoundID.from_string(id)
-            schedule_origin_id = cid.external_origin_id
+            schedule_origin_id = cid.remote_origin_id
             schedule_selector_id = cid.selector_id
         elif schedule_origin_id and CompoundID.is_valid_string(schedule_origin_id):
             # cross-push handle if InstigationState.id being passed through as origin id
             cid = CompoundID.from_string(schedule_origin_id)
-            schedule_origin_id = cid.external_origin_id
+            schedule_origin_id = cid.remote_origin_id
             schedule_selector_id = cid.selector_id
         elif schedule_origin_id is None or schedule_selector_id is None:
             raise DagsterInvariantViolationError(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -109,7 +109,7 @@ class GrapheneSensor(graphene.ObjectType):
 
         super().__init__(
             name=external_sensor.name,
-            jobOriginId=external_sensor.get_external_origin_id(),
+            jobOriginId=external_sensor.get_remote_origin_id(),
             minIntervalSeconds=external_sensor.min_interval_seconds,
             description=external_sensor.description,
             targets=[GrapheneTarget(target) for target in external_sensor.get_targets()],
@@ -248,12 +248,12 @@ class GrapheneStopSensorMutation(graphene.Mutation):
     ):
         if id:
             cid = CompoundID.from_string(id)
-            sensor_origin_id = cid.external_origin_id
+            sensor_origin_id = cid.remote_origin_id
             sensor_selector_id = cid.selector_id
         elif job_origin_id and CompoundID.is_valid_string(job_origin_id):
             # cross-push handle if InstigationState.id being passed through as origin id
             cid = CompoundID.from_string(job_origin_id)
-            sensor_origin_id = cid.external_origin_id
+            sensor_origin_id = cid.remote_origin_id
             sensor_selector_id = cid.selector_id
         elif job_origin_id is None or job_selector_id is None:
             raise DagsterInvariantViolationError("Must specify id or jobOriginId and jobSelectorId")

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -353,7 +353,7 @@ query GetTruePartitions($assetKey: AssetKeyInput!, $evaluationId: Int!, $nodeUni
 class TestAssetConditionEvaluations(ExecutingGraphQLContextTestMatrix):
     def test_auto_materialize_sensor(self, graphql_context: WorkspaceRequestContext):
         sensor_origin = RemoteInstigatorOrigin(
-            repository_origin=infer_repository(graphql_context).get_external_origin(),
+            repository_origin=infer_repository(graphql_context).get_remote_origin(),
             instigator_name="my_auto_materialize_sensor",
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -312,7 +312,7 @@ class TestPartitionBackillReadonlyFailure(ReadonlyGraphQLContextTestMatrix):
         backfill = PartitionBackfill(
             backfill_id=make_new_backfill_id(),
             partition_set_origin=RemotePartitionSetOrigin(
-                repository_origin=repository.get_external_origin(),
+                repository_origin=repository.get_remote_origin(),
                 partition_set_name="integer_partition",
             ),
             status=BulkActionStatus.REQUESTED,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
@@ -73,7 +73,7 @@ class TestRetryExecutionReadonly(ReadonlyGraphQLContextTestMatrix):
         repository = code_location.get_repository("test_repo")
         external_job_origin = repository.get_full_external_job(
             "eventually_successful"
-        ).get_external_origin()
+        ).get_remote_origin()
 
         run_id = create_run_for_test(
             graphql_context.instance,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
@@ -878,7 +878,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
         repository = code_location.get_repository("test_repo")
 
         partition_set_origin = RemotePartitionSetOrigin(
-            repository_origin=repository.get_external_origin(),
+            repository_origin=repository.get_remote_origin(),
             partition_set_name="foo_partition",
         )
         for _ in range(3):
@@ -890,7 +890,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
             _create_run_for_backfill(graphql_context, backfill_id, job_name="foo")
 
         partition_set_origin = RemotePartitionSetOrigin(
-            repository_origin=repository.get_external_origin(),
+            repository_origin=repository.get_remote_origin(),
             partition_set_name="bar_partition",
         )
         for _ in range(3):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -934,7 +934,7 @@ class TestScheduleMutations(ExecutingGraphQLContextTestMatrix):
         schedule_id = start_result.data["startSchedule"]["scheduleState"]["id"]
         cid = CompoundID.from_string(schedule_id)
         instigator_state = graphql_context.instance.get_instigator_state(
-            cid.external_origin_id, cid.selector_id
+            cid.remote_origin_id, cid.selector_id
         )
 
         assert instigator_state
@@ -959,7 +959,7 @@ class TestScheduleMutations(ExecutingGraphQLContextTestMatrix):
             variables={"scheduleSelector": schedule_selector},
         )
         reset_instigator_state = graphql_context.instance.get_instigator_state(
-            cid.external_origin_id, cid.selector_id
+            cid.remote_origin_id, cid.selector_id
         )
 
         assert reset_instigator_state
@@ -1048,7 +1048,7 @@ class TestScheduleMutations(ExecutingGraphQLContextTestMatrix):
         )
         cid = CompoundID.from_string(schedule_id)
         reset_instigator_state = graphql_context.instance.get_instigator_state(
-            cid.external_origin_id, cid.selector_id
+            cid.remote_origin_id, cid.selector_id
         )
 
         assert reset_instigator_state

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -962,7 +962,7 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
 
         cid = CompoundID.from_string(sensor_id)
         instigator_state = graphql_context.instance.get_instigator_state(
-            cid.external_origin_id, cid.selector_id
+            cid.remote_origin_id, cid.selector_id
         )
 
         assert instigator_state
@@ -1002,7 +1002,7 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
         )
         cid = CompoundID.from_string(sensor_id)
         instigator_state = graphql_context.instance.get_instigator_state(
-            cid.external_origin_id, cid.selector_id
+            cid.remote_origin_id, cid.selector_id
         )
 
         assert instigator_state
@@ -1018,7 +1018,7 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
         )
 
         instigator_state = graphql_context.instance.get_instigator_state(
-            cid.external_origin_id, cid.selector_id
+            cid.remote_origin_id, cid.selector_id
         )
 
         assert instigator_state
@@ -1067,7 +1067,7 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
 
         cid = CompoundID.from_string(sensor_id)
         instigator_state = graphql_context.instance.get_instigator_state(
-            cid.external_origin_id, cid.selector_id
+            cid.remote_origin_id, cid.selector_id
         )
 
         assert instigator_state
@@ -1142,7 +1142,7 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
 
         cid = CompoundID.from_string(sensor_id)
         instigator_state = graphql_context.instance.get_instigator_state(
-            cid.external_origin_id, cid.selector_id
+            cid.remote_origin_id, cid.selector_id
         )
 
         assert instigator_state
@@ -1188,12 +1188,12 @@ def test_sensor_next_ticks(graphql_context: WorkspaceRequestContext):
     # test default sensor with no tick
     graphql_context.instance.add_instigator_state(
         InstigatorState(
-            external_sensor.get_external_origin(), InstigatorType.SENSOR, InstigatorStatus.RUNNING
+            external_sensor.get_remote_origin(), InstigatorType.SENSOR, InstigatorStatus.RUNNING
         )
     )
     graphql_context.instance.add_instigator_state(
         InstigatorState(
-            external_error_sensor.get_external_origin(),
+            external_error_sensor.get_remote_origin(),
             InstigatorType.SENSOR,
             InstigatorStatus.RUNNING,
         )
@@ -1267,7 +1267,7 @@ def test_sensor_tick_range(graphql_context: WorkspaceRequestContext):
     # turn the sensor on
     graphql_context.instance.add_instigator_state(
         InstigatorState(
-            external_sensor.get_external_origin(), InstigatorType.SENSOR, InstigatorStatus.RUNNING
+            external_sensor.get_remote_origin(), InstigatorType.SENSOR, InstigatorStatus.RUNNING
         )
     )
 
@@ -1399,7 +1399,7 @@ def test_sensor_ticks_filtered(graphql_context: WorkspaceRequestContext):
     # turn the sensor on
     graphql_context.instance.add_instigator_state(
         InstigatorState(
-            external_sensor.get_external_origin(), InstigatorType.SENSOR, InstigatorStatus.RUNNING
+            external_sensor.get_remote_origin(), InstigatorType.SENSOR, InstigatorStatus.RUNNING
         )
     )
 
@@ -1410,7 +1410,7 @@ def test_sensor_ticks_filtered(graphql_context: WorkspaceRequestContext):
     # create a started tick
     started_tick_id, _ = graphql_context.instance.create_tick(
         TickData(
-            instigator_origin_id=external_sensor.get_external_origin().get_id(),
+            instigator_origin_id=external_sensor.get_remote_origin().get_id(),
             instigator_name=sensor_name,
             instigator_type=InstigatorType.SENSOR,
             status=TickStatus.STARTED,
@@ -1422,7 +1422,7 @@ def test_sensor_ticks_filtered(graphql_context: WorkspaceRequestContext):
     # create a skipped tick
     skipped_tick_id, _ = graphql_context.instance.create_tick(
         TickData(
-            instigator_origin_id=external_sensor.get_external_origin().get_id(),
+            instigator_origin_id=external_sensor.get_remote_origin().get_id(),
             instigator_name=sensor_name,
             instigator_type=InstigatorType.SENSOR,
             status=TickStatus.SKIPPED,
@@ -1434,7 +1434,7 @@ def test_sensor_ticks_filtered(graphql_context: WorkspaceRequestContext):
     # create a failed tick
     failed_tick_id, _ = graphql_context.instance.create_tick(
         TickData(
-            instigator_origin_id=external_sensor.get_external_origin().get_id(),
+            instigator_origin_id=external_sensor.get_remote_origin().get_id(),
             instigator_name=sensor_name,
             instigator_type=InstigatorType.SENSOR,
             status=TickStatus.FAILURE,
@@ -1582,7 +1582,7 @@ def test_sensor_tick_logs(graphql_context: WorkspaceRequestContext):
     # turn the sensor on
     instance.add_instigator_state(
         InstigatorState(
-            external_sensor.get_external_origin(), InstigatorType.SENSOR, InstigatorStatus.RUNNING
+            external_sensor.get_remote_origin(), InstigatorType.SENSOR, InstigatorStatus.RUNNING
         )
     )
 
@@ -1618,7 +1618,7 @@ def test_sensor_dynamic_partitions_request_results(graphql_context: WorkspaceReq
     # turn the sensor on
     instance.add_instigator_state(
         InstigatorState(
-            external_sensor.get_external_origin(), InstigatorType.SENSOR, InstigatorStatus.RUNNING
+            external_sensor.get_remote_origin(), InstigatorType.SENSOR, InstigatorStatus.RUNNING
         )
     )
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sync_run_launcher.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sync_run_launcher.py
@@ -37,7 +37,7 @@ def test_sync_run_launcher_run():
             run = create_run_for_test(
                 instance=instance,
                 job_name=external_pipeline.name,
-                external_job_origin=external_pipeline.get_external_origin(),
+                external_job_origin=external_pipeline.get_remote_origin(),
                 job_code_origin=external_pipeline.get_python_origin(),
             )
 

--- a/python_modules/dagster-test/dagster_test/test_project/__init__.py
+++ b/python_modules/dagster-test/dagster_test/test_project/__init__.py
@@ -167,7 +167,7 @@ class ReOriginatedExternalJobForTest(ExternalJob):
             ),
         )
 
-    def get_external_origin(self) -> RemoteJobOrigin:
+    def get_remote_origin(self) -> RemoteJobOrigin:
         """Hack! Inject origin that the k8s images will use. The BK image uses a different directory
         structure (/workdir/python_modules/dagster-test/dagster_test/test_project) than the images
         inside the kind cluster (/dagster_test/test_project). As a result the normal origin won't
@@ -202,7 +202,7 @@ class ReOriginatedExternalScheduleForTest(ExternalSchedule):
             external_schedule.handle.repository_handle,
         )
 
-    def get_external_origin(self):
+    def get_remote_origin(self):
         """Hack! Inject origin that the k8s images will use. The k8s helm chart workspace uses a
         gRPC server repo location origin. As a result the normal origin won't work, we need to
         inject this one.

--- a/python_modules/dagster-test/dagster_test_tests/test_test_project.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_test_project.py
@@ -14,4 +14,4 @@ def test_reoriginated_external_job():
             reoriginated_pipeline = ReOriginatedExternalJobForTest(external_pipeline)
 
             assert reoriginated_pipeline.get_python_origin()
-            assert reoriginated_pipeline.get_external_origin()
+            assert reoriginated_pipeline.get_remote_origin()

--- a/python_modules/dagster/dagster/_api/snapshot_partition.py
+++ b/python_modules/dagster/dagster/_api/snapshot_partition.py
@@ -29,7 +29,7 @@ def sync_get_external_partition_names_grpc(
     check.inst_param(api_client, "api_client", DagsterGrpcClient)
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
     check.str_param(job_name, "job_name")
-    repository_origin = repository_handle.get_external_origin()
+    repository_origin = repository_handle.get_remote_origin()
     result = deserialize_value(
         api_client.external_partition_names(
             partition_names_args=PartitionNamesArgs(
@@ -59,7 +59,7 @@ def sync_get_external_partition_config_grpc(
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
     check.str_param(job_name, "job_name")
     check.str_param(partition_name, "partition_name")
-    repository_origin = repository_handle.get_external_origin()
+    repository_origin = repository_handle.get_remote_origin()
     result = deserialize_value(
         api_client.external_partition_config(
             partition_args=PartitionArgs(
@@ -92,7 +92,7 @@ def sync_get_external_partition_tags_grpc(
     check.str_param(job_name, "job_name")
     check.str_param(partition_name, "partition_name")
 
-    repository_origin = repository_handle.get_external_origin()
+    repository_origin = repository_handle.get_remote_origin()
     result = deserialize_value(
         api_client.external_partition_tags(
             partition_args=PartitionArgs(
@@ -125,7 +125,7 @@ def sync_get_external_partition_set_execution_param_data_grpc(
     check.str_param(partition_set_name, "partition_set_name")
     check.sequence_param(partition_names, "partition_names", of_type=str)
 
-    repository_origin = repository_handle.get_external_origin()
+    repository_origin = repository_handle.get_remote_origin()
 
     result = deserialize_value(
         api_client.external_partition_set_execution_params(

--- a/python_modules/dagster/dagster/_api/snapshot_schedule.py
+++ b/python_modules/dagster/dagster/_api/snapshot_schedule.py
@@ -24,7 +24,7 @@ def sync_get_external_schedule_execution_data_ephemeral_grpc(
 ) -> ScheduleExecutionData:
     from dagster._grpc.client import ephemeral_grpc_api_client
 
-    origin = repository_handle.get_external_origin()
+    origin = repository_handle.get_remote_origin()
     with ephemeral_grpc_api_client(
         origin.code_location_origin.loadable_target_origin
     ) as api_client:
@@ -54,7 +54,7 @@ def sync_get_external_schedule_execution_data_grpc(
         scheduled_execution_time, "scheduled_execution_time", TimestampWithTimezone
     )
 
-    origin = repository_handle.get_external_origin()
+    origin = repository_handle.get_remote_origin()
     result = deserialize_value(
         api_client.external_schedule_execution(
             external_schedule_execution_args=ExternalScheduleExecutionArgs(

--- a/python_modules/dagster/dagster/_api/snapshot_sensor.py
+++ b/python_modules/dagster/dagster/_api/snapshot_sensor.py
@@ -27,7 +27,7 @@ def sync_get_external_sensor_execution_data_ephemeral_grpc(
 ) -> SensorExecutionData:
     from dagster._grpc.client import ephemeral_grpc_api_client
 
-    origin = repository_handle.get_external_origin()
+    origin = repository_handle.get_remote_origin()
     with ephemeral_grpc_api_client(
         origin.code_location_origin.loadable_target_origin
     ) as api_client:
@@ -64,7 +64,7 @@ def sync_get_external_sensor_execution_data_grpc(
     check.opt_str_param(last_run_key, "last_run_key")
     check.opt_str_param(cursor, "cursor")
 
-    origin = repository_handle.get_external_origin()
+    origin = repository_handle.get_remote_origin()
 
     result = deserialize_value(
         api_client.external_sensor_execution(

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -492,7 +492,7 @@ def _create_external_run(
         job_snapshot=external_job.job_snapshot,
         execution_plan_snapshot=execution_plan_snapshot,
         parent_job_snapshot=external_job.parent_job_snapshot,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
         asset_selection=None,
         asset_check_selection=None,
@@ -682,7 +682,7 @@ def _execute_backfill_command_at_location(
         backfill_id = make_new_backfill_id()
         backfill_job = PartitionBackfill(
             backfill_id=backfill_id,
-            partition_set_origin=job_partition_set.get_external_origin(),
+            partition_set_origin=job_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=partition_names,
             from_failure=False,

--- a/python_modules/dagster/dagster/_cli/run.py
+++ b/python_modules/dagster/dagster/_cli/run.py
@@ -101,7 +101,7 @@ def run_migrate_command(from_label, **kwargs):
         with get_external_job_from_kwargs(
             instance, version=dagster_version, kwargs=kwargs
         ) as external_job:
-            new_job_origin = external_job.get_external_origin()
+            new_job_origin = external_job.get_remote_origin()
             job_name = external_job.name
             to_label = new_job_origin.repository_origin.get_label()
 

--- a/python_modules/dagster/dagster/_cli/schedule.py
+++ b/python_modules/dagster/dagster/_cli/schedule.py
@@ -31,11 +31,11 @@ def print_changes(external_repository, instance, print_fn=print, preview=False):
     errors = debug_info.errors
     external_schedules = external_repository.get_external_schedules()
     schedule_states = instance.all_instigator_state(
-        external_repository.get_external_origin_id(),
+        external_repository.get_remote_origin_id(),
         external_repository.selector_id,
         InstigatorType.SCHEDULE,
     )
-    external_schedules_dict = {s.get_external_origin_id(): s for s in external_schedules}
+    external_schedules_dict = {s.get_remote_origin_id(): s for s in external_schedules}
     schedule_states_dict = {s.instigator_origin_id: s for s in schedule_states}
 
     external_schedule_origin_ids = set(external_schedules_dict.keys())
@@ -179,7 +179,7 @@ def execute_list_command(running_filter, stopped_filter, name_filter, cli_args, 
             stored_schedules_by_origin_id = {
                 stored_schedule_state.instigator_origin_id: stored_schedule_state
                 for stored_schedule_state in instance.all_instigator_state(
-                    external_repo.get_external_origin_id(),
+                    external_repo.get_remote_origin_id(),
                     external_repo.selector_id,
                     instigator_type=InstigatorType.SCHEDULE,
                 )
@@ -189,7 +189,7 @@ def execute_list_command(running_filter, stopped_filter, name_filter, cli_args, 
 
             for external_schedule in repo_schedules:
                 schedule_state = external_schedule.get_current_instigator_state(
-                    stored_schedules_by_origin_id.get(external_schedule.get_external_origin_id())
+                    stored_schedules_by_origin_id.get(external_schedule.get_remote_origin_id())
                 )
 
                 if running_filter and not schedule_state.is_running:
@@ -280,7 +280,7 @@ def execute_stop_command(schedule_name, cli_args, print_fn, instance=None):
             try:
                 external_schedule = external_repo.get_external_schedule(schedule_name)
                 instance.stop_schedule(
-                    external_schedule.get_external_origin_id(),
+                    external_schedule.get_remote_origin_id(),
                     external_schedule.selector_id,
                     external_schedule,
                 )
@@ -321,7 +321,7 @@ def execute_logs_command(schedule_name, cli_args, print_fn, instance=None):
 
             logs_path = os.path.join(
                 instance.logs_path_for_schedule(
-                    external_repo.get_external_schedule(schedule_name).get_external_origin_id()
+                    external_repo.get_external_schedule(schedule_name).get_remote_origin_id()
                 )
             )
 
@@ -381,7 +381,7 @@ def execute_restart_command(schedule_name, all_running_flag, cli_args, print_fn)
 
             if all_running_flag:
                 for schedule_state in instance.all_instigator_state(
-                    external_repo.get_external_origin_id(),
+                    external_repo.get_remote_origin_id(),
                     external_repo.selector_id,
                     InstigatorType.SCHEDULE,
                 ):
@@ -403,7 +403,7 @@ def execute_restart_command(schedule_name, all_running_flag, cli_args, print_fn)
             else:
                 external_schedule = external_repo.get_external_schedule(schedule_name)
                 schedule_state = instance.get_instigator_state(
-                    external_schedule.get_external_origin_id(),
+                    external_schedule.get_remote_origin_id(),
                     external_schedule.selector_id,
                 )
                 if schedule_state is not None and schedule_state.status != InstigatorStatus.RUNNING:

--- a/python_modules/dagster/dagster/_cli/sensor.py
+++ b/python_modules/dagster/dagster/_cli/sensor.py
@@ -37,7 +37,7 @@ def print_changes(external_repository, instance, print_fn=print, preview=False):
         external_repository.get_origin_id(), external_repository.selector_id, InstigatorType.SENSOR
     )
     external_sensors = external_repository.get_external_sensors()
-    external_sensors_dict = {s.get_external_origin_id(): s for s in external_sensors}
+    external_sensors_dict = {s.get_remote_origin_id(): s for s in external_sensors}
     sensor_states_dict = {s.instigator_origin_id: s for s in sensor_states}
 
     external_sensor_origin_ids = set(external_sensors_dict.keys())
@@ -140,7 +140,7 @@ def execute_list_command(running_filter, stopped_filter, name_filter, cli_args, 
             stored_sensors_by_origin_id = {
                 stored_sensor_state.instigator_origin_id: stored_sensor_state
                 for stored_sensor_state in instance.all_instigator_state(
-                    external_repo.get_external_origin_id(),
+                    external_repo.get_remote_origin_id(),
                     external_repo.selector_id,
                     instigator_type=InstigatorType.SENSOR,
                 )
@@ -150,7 +150,7 @@ def execute_list_command(running_filter, stopped_filter, name_filter, cli_args, 
 
             for external_sensor in repo_sensors:
                 sensor_state = external_sensor.get_current_instigator_state(
-                    stored_sensors_by_origin_id.get(external_sensor.get_external_origin_id())
+                    stored_sensors_by_origin_id.get(external_sensor.get_remote_origin_id())
                 )
 
                 if running_filter and not sensor_state.is_running:
@@ -224,7 +224,7 @@ def execute_stop_command(sensor_name, cli_args, print_fn):
             try:
                 external_sensor = external_repo.get_external_sensor(sensor_name)
                 instance.stop_sensor(
-                    external_sensor.get_external_origin_id(),
+                    external_sensor.get_remote_origin_id(),
                     external_sensor.selector_id,
                     external_sensor,
                 )
@@ -347,12 +347,12 @@ def execute_cursor_command(sensor_name, cli_args, print_fn):
             check_repo_and_scheduler(external_repo, instance)
             external_sensor = external_repo.get_external_sensor(sensor_name)
             job_state = instance.get_instigator_state(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
+                external_sensor.get_remote_origin_id(), external_sensor.selector_id
             )
             if not job_state:
                 instance.add_instigator_state(
                     InstigatorState(
-                        external_sensor.get_external_origin(),
+                        external_sensor.get_remote_origin(),
                         InstigatorType.SENSOR,
                         InstigatorStatus.STOPPED,
                         SensorInstigatorData(

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -484,7 +484,7 @@ def create_backfill_run(
         root_run_id=root_run_id,
         parent_run_id=parent_run_id,
         status=DagsterRunStatus.NOT_STARTED,
-        external_job_origin=external_pipeline.get_external_origin(),
+        external_job_origin=external_pipeline.get_remote_origin(),
         job_code_origin=external_pipeline.get_python_origin(),
         op_selection=op_selection,
         asset_selection=(

--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -208,7 +208,7 @@ def _create_asset_run(
                 root_run_id=None,
                 parent_run_id=None,
                 status=DagsterRunStatus.NOT_STARTED,
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=external_job.get_python_origin(),
                 asset_selection=frozenset(run_request.asset_selection)
                 if run_request.asset_selection

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1698,7 +1698,7 @@ class DagsterInstance(DynamicPartitionsStore):
             op_selection=parent_run.op_selection,
             asset_selection=parent_run.asset_selection,
             asset_check_selection=parent_run.asset_check_selection,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
             asset_graph=code_location.get_repository(
                 external_job.repository_handle.repository_name
@@ -2806,7 +2806,7 @@ class DagsterInstance(DynamicPartitionsStore):
         )
 
         stored_state = self.get_instigator_state(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
 
         computed_state = external_sensor.get_current_instigator_state(stored_state)
@@ -2816,7 +2816,7 @@ class DagsterInstance(DynamicPartitionsStore):
         if not stored_state:
             return self.add_instigator_state(
                 InstigatorState(
-                    external_sensor.get_external_origin(),
+                    external_sensor.get_remote_origin(),
                     InstigatorType.SENSOR,
                     InstigatorStatus.RUNNING,
                     SensorInstigatorData(
@@ -2861,7 +2861,7 @@ class DagsterInstance(DynamicPartitionsStore):
             assert external_sensor
             return self.add_instigator_state(
                 InstigatorState(
-                    external_sensor.get_external_origin(),
+                    external_sensor.get_remote_origin(),
                     InstigatorType.SENSOR,
                     InstigatorStatus.STOPPED,
                     SensorInstigatorData(
@@ -2889,7 +2889,7 @@ class DagsterInstance(DynamicPartitionsStore):
         )
 
         stored_state = self.get_instigator_state(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         new_status = InstigatorStatus.DECLARED_IN_CODE
 
@@ -2901,7 +2901,7 @@ class DagsterInstance(DynamicPartitionsStore):
 
             reset_state = self.add_instigator_state(
                 state=InstigatorState(
-                    external_sensor.get_external_origin(),
+                    external_sensor.get_remote_origin(),
                     InstigatorType.SENSOR,
                     new_status,
                     new_instigator_data,

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -854,7 +854,7 @@ class GrpcServerCodeLocation(CodeLocation):
 
         execution_plan_snapshot_or_error = sync_get_external_execution_plan_grpc(
             api_client=self.client,
-            job_origin=external_job.get_external_origin(),
+            job_origin=external_job.get_remote_origin(),
             run_config=run_config,
             job_snapshot_id=external_job.identifying_job_snapshot_id,
             asset_selection=asset_selection,
@@ -881,7 +881,7 @@ class GrpcServerCodeLocation(CodeLocation):
         job_handle = JobHandle(selector.job_name, external_repository.handle)
         subset = sync_get_external_job_subset_grpc(
             self.client,
-            job_handle.get_external_origin(),
+            job_handle.get_remote_origin(),
             include_parent_snapshot=False,
             op_selection=selector.op_selection,
             asset_selection=selector.asset_selection,

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -95,11 +95,11 @@ _DELIMITER = "::"
 class CompoundID:
     """Compound ID object for the two id schemes that state is recorded in the database against."""
 
-    external_origin_id: str
+    remote_origin_id: str
     selector_id: str
 
     def to_string(self) -> str:
-        return f"{self.external_origin_id}{_DELIMITER}{self.selector_id}"
+        return f"{self.remote_origin_id}{_DELIMITER}{self.selector_id}"
 
     @staticmethod
     def from_string(serialized: str):
@@ -108,7 +108,7 @@ class CompoundID:
             raise DagsterInvariantViolationError(f"Invalid serialized InstigatorID: {serialized}")
 
         return CompoundID(
-            external_origin_id=parts[0],
+            remote_origin_id=parts[0],
             selector_id=parts[1],
         )
 
@@ -382,21 +382,21 @@ class ExternalRepository:
 
     def get_compound_id(self) -> CompoundID:
         return CompoundID(
-            external_origin_id=self.get_external_origin_id(),
+            remote_origin_id=self.get_remote_origin_id(),
             selector_id=self.selector_id,
         )
 
-    def get_external_origin(self) -> RemoteRepositoryOrigin:
-        return self.handle.get_external_origin()
+    def get_remote_origin(self) -> RemoteRepositoryOrigin:
+        return self.handle.get_remote_origin()
 
     def get_python_origin(self) -> RepositoryPythonOrigin:
         return self.handle.get_python_origin()
 
-    def get_external_origin_id(self) -> str:
+    def get_remote_origin_id(self) -> str:
         """A means of identifying the repository this ExternalRepository represents based on
         where it came from.
         """
-        return self.get_external_origin().get_id()
+        return self.get_remote_origin().get_id()
 
     def get_external_asset_nodes(
         self, job_name: Optional[str] = None
@@ -656,11 +656,11 @@ class ExternalJob(RepresentedJob):
         repository_python_origin = self.repository_handle.get_python_origin()
         return JobPythonOrigin(self.name, repository_python_origin)
 
-    def get_external_origin(self) -> RemoteJobOrigin:
-        return self.handle.get_external_origin()
+    def get_remote_origin(self) -> RemoteJobOrigin:
+        return self.handle.get_remote_origin()
 
-    def get_external_origin_id(self) -> str:
-        return self.get_external_origin().get_id()
+    def get_remote_origin_id(self) -> str:
+        return self.get_remote_origin().get_id()
 
 
 class ExternalExecutionPlan:
@@ -875,11 +875,11 @@ class ExternalSchedule:
     def tags(self) -> Mapping[str, str]:
         return self._external_schedule_data.tags
 
-    def get_external_origin(self) -> RemoteInstigatorOrigin:
-        return self.handle.get_external_origin()
+    def get_remote_origin(self) -> RemoteInstigatorOrigin:
+        return self.handle.get_remote_origin()
 
-    def get_external_origin_id(self) -> str:
-        return self.get_external_origin().get_id()
+    def get_remote_origin_id(self) -> str:
+        return self.get_remote_origin().get_id()
 
     @property
     def selector(self) -> InstigatorSelector:
@@ -903,7 +903,7 @@ class ExternalSchedule:
 
     def get_compound_id(self) -> CompoundID:
         return CompoundID(
-            external_origin_id=self.get_external_origin_id(),
+            remote_origin_id=self.get_remote_origin_id(),
             selector_id=self.selector_id,
         )
 
@@ -925,7 +925,7 @@ class ExternalSchedule:
                 return stored_state
 
             return InstigatorState(
-                self.get_external_origin(),
+                self.get_remote_origin(),
                 InstigatorType.SCHEDULE,
                 InstigatorStatus.DECLARED_IN_CODE,
                 ScheduleInstigatorData(self.cron_schedule, start_timestamp=None),
@@ -943,7 +943,7 @@ class ExternalSchedule:
                 )
 
             return InstigatorState(
-                self.get_external_origin(),
+                self.get_remote_origin(),
                 InstigatorType.SCHEDULE,
                 InstigatorStatus.STOPPED,
                 ScheduleInstigatorData(self.cron_schedule, start_timestamp=None),
@@ -1025,11 +1025,11 @@ class ExternalSensor:
     def run_tags(self) -> Mapping[str, str]:
         return self._external_sensor_data.run_tags
 
-    def get_external_origin(self) -> RemoteInstigatorOrigin:
-        return self._handle.get_external_origin()
+    def get_remote_origin(self) -> RemoteInstigatorOrigin:
+        return self._handle.get_remote_origin()
 
-    def get_external_origin_id(self) -> str:
-        return self.get_external_origin().get_id()
+    def get_remote_origin_id(self) -> str:
+        return self.get_remote_origin().get_id()
 
     @property
     def selector(self) -> InstigatorSelector:
@@ -1053,7 +1053,7 @@ class ExternalSensor:
 
     def get_compound_id(self) -> CompoundID:
         return CompoundID(
-            external_origin_id=self.get_external_origin_id(),
+            remote_origin_id=self.get_remote_origin_id(),
             selector_id=self.selector_id,
         )
 
@@ -1075,7 +1075,7 @@ class ExternalSensor:
                 stored_state
                 if stored_state
                 else InstigatorState(
-                    self.get_external_origin(),
+                    self.get_remote_origin(),
                     InstigatorType.SENSOR,
                     InstigatorStatus.DECLARED_IN_CODE,
                     SensorInstigatorData(
@@ -1096,7 +1096,7 @@ class ExternalSensor:
                 )
 
             return InstigatorState(
-                self.get_external_origin(),
+                self.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.STOPPED,
                 SensorInstigatorData(
@@ -1151,11 +1151,11 @@ class ExternalPartitionSet:
     def repository_handle(self) -> RepositoryHandle:
         return self._handle.repository_handle
 
-    def get_external_origin(self) -> RemotePartitionSetOrigin:
-        return self._handle.get_external_origin()
+    def get_remote_origin(self) -> RemotePartitionSetOrigin:
+        return self._handle.get_remote_origin()
 
-    def get_external_origin_id(self) -> str:
-        return self.get_external_origin().get_id()
+    def get_remote_origin_id(self) -> str:
+        return self.get_remote_origin().get_id()
 
     def has_partition_name_data(self) -> bool:
         # Partition sets from older versions of Dagster as well as partition sets using

--- a/python_modules/dagster/dagster/_core/remote_representation/handle.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/handle.py
@@ -36,7 +36,7 @@ class RepositoryHandle(
     def location_name(self) -> str:
         return self.code_location_origin.location_name
 
-    def get_external_origin(self):
+    def get_remote_origin(self):
         return RemoteRepositoryOrigin(
             self.code_location_origin,
             self.repository_name,
@@ -67,8 +67,8 @@ class JobHandle(
     def location_name(self):
         return self.repository_handle.location_name
 
-    def get_external_origin(self):
-        return self.repository_handle.get_external_origin().get_job_origin(self.job_name)
+    def get_remote_origin(self):
+        return self.repository_handle.get_remote_origin().get_job_origin(self.job_name)
 
     def get_python_origin(self):
         return self.repository_handle.get_python_origin().get_job_origin(self.job_name)
@@ -97,8 +97,8 @@ class InstigatorHandle(
     def location_name(self):
         return self.repository_handle.location_name
 
-    def get_external_origin(self):
-        return self.repository_handle.get_external_origin().get_instigator_origin(
+    def get_remote_origin(self):
+        return self.repository_handle.get_remote_origin().get_instigator_origin(
             self.instigator_name
         )
 
@@ -124,7 +124,7 @@ class PartitionSetHandle(
     def location_name(self):
         return self.repository_handle.location_name
 
-    def get_external_origin(self):
-        return self.repository_handle.get_external_origin().get_partition_set_origin(
+    def get_remote_origin(self):
+        return self.repository_handle.get_remote_origin().get_partition_set_origin(
             self.partition_set_name
         )

--- a/python_modules/dagster/dagster/_core/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_core/scheduler/scheduler.py
@@ -79,7 +79,7 @@ class Scheduler(abc.ABC):
         check.inst_param(external_schedule, "external_schedule", ExternalSchedule)
 
         stored_state = instance.get_instigator_state(
-            external_schedule.get_external_origin_id(), external_schedule.selector_id
+            external_schedule.get_remote_origin_id(), external_schedule.selector_id
         )
         computed_state = external_schedule.get_current_instigator_state(stored_state)
         if computed_state.is_running:
@@ -92,7 +92,7 @@ class Scheduler(abc.ABC):
 
         if not stored_state:
             started_state = InstigatorState(
-                external_schedule.get_external_origin(),
+                external_schedule.get_remote_origin(),
                 InstigatorType.SCHEDULE,
                 InstigatorStatus.RUNNING,
                 new_instigator_data,
@@ -135,7 +135,7 @@ class Scheduler(abc.ABC):
         if not stored_state:
             assert external_schedule
             stopped_state = InstigatorState(
-                external_schedule.get_external_origin(),
+                external_schedule.get_remote_origin(),
                 InstigatorType.SCHEDULE,
                 InstigatorStatus.STOPPED,
                 ScheduleInstigatorData(
@@ -169,7 +169,7 @@ class Scheduler(abc.ABC):
         check.inst_param(external_schedule, "external_schedule", ExternalSchedule)
 
         stored_state = instance.get_instigator_state(
-            external_schedule.get_external_origin_id(), external_schedule.selector_id
+            external_schedule.get_remote_origin_id(), external_schedule.selector_id
         )
 
         new_status = InstigatorStatus.DECLARED_IN_CODE
@@ -181,7 +181,7 @@ class Scheduler(abc.ABC):
             )
             reset_state = instance.add_instigator_state(
                 state=InstigatorState(
-                    external_schedule.get_external_origin(),
+                    external_schedule.get_remote_origin(),
                     InstigatorType.SCHEDULE,
                     new_status,
                     new_instigator_data,

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -308,7 +308,7 @@ class AutoMaterializeLaunchContext:
                 continue
             self._instance.purge_ticks(
                 (
-                    self._external_sensor.get_external_origin().get_id()
+                    self._external_sensor.get_remote_origin().get_id()
                     if self._external_sensor
                     else _PRE_SENSOR_AUTO_MATERIALIZE_ORIGIN_ID
                 ),
@@ -347,7 +347,7 @@ class AssetDaemon(DagsterDaemon):
     def _get_print_sensor_name(self, sensor: Optional[ExternalSensor]) -> str:
         if not sensor:
             return ""
-        repo_origin = sensor.get_external_origin().repository_origin
+        repo_origin = sensor.get_remote_origin().repository_origin
         repo_name = repo_origin.repository_name
         location_name = repo_origin.code_location_origin.location_name
         repo_name = (
@@ -576,7 +576,7 @@ class AssetDaemon(DagsterDaemon):
             elif not auto_materialize_state:
                 assert sensor.default_status == DefaultSensorStatus.RUNNING
                 auto_materialize_state = InstigatorState(
-                    sensor.get_external_origin(),
+                    sensor.get_remote_origin(),
                     InstigatorType.SENSOR,
                     InstigatorStatus.DECLARED_IN_CODE,
                     SensorInstigatorData(
@@ -629,7 +629,7 @@ class AssetDaemon(DagsterDaemon):
 
         for sensor, repo in sensors_and_repos:
             new_auto_materialize_state = InstigatorState(
-                sensor.get_external_origin(),
+                sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 (
                     InstigatorStatus.DECLARED_IN_CODE
@@ -719,7 +719,7 @@ class AssetDaemon(DagsterDaemon):
 
         if sensor:
             auto_materialize_instigator_state = check.not_none(
-                instance.get_instigator_state(sensor.get_external_origin_id(), sensor.selector_id)
+                instance.get_instigator_state(sensor.get_remote_origin_id(), sensor.selector_id)
             )
             if is_under_min_interval(auto_materialize_instigator_state, sensor):
                 # check the since we might have been queued before processing
@@ -780,8 +780,8 @@ class AssetDaemon(DagsterDaemon):
                     asset_graph,
                 )
 
-                instigator_origin_id = sensor.get_external_origin().get_id()
-                instigator_selector_id = sensor.get_external_origin().get_selector().get_id()
+                instigator_origin_id = sensor.get_remote_origin().get_id()
+                instigator_selector_id = sensor.get_remote_origin().get_selector().get_id()
                 instigator_name = sensor.name
             else:
                 stored_cursor = _get_pre_sensor_auto_materialize_cursor(instance, asset_graph)
@@ -995,7 +995,7 @@ class AssetDaemon(DagsterDaemon):
             # they determine that nothing needs to be retried
             if sensor:
                 state = instance.get_instigator_state(
-                    sensor.get_external_origin_id(), sensor.selector_id
+                    sensor.get_remote_origin_id(), sensor.selector_id
                 )
                 instance.update_instigator_state(
                     check.not_none(state).with_data(

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -136,7 +136,7 @@ class _ScheduleLaunchContext(AbstractContextManager):
             if day_offset <= 0:
                 continue
             self._instance.purge_ticks(
-                self._external_schedule.get_external_origin_id(),
+                self._external_schedule.get_remote_origin_id(),
                 selector_id=self._external_schedule.selector_id,
                 before=(get_current_datetime() - datetime.timedelta(days=day_offset)).timestamp(),
                 tick_statuses=list(statuses),
@@ -328,7 +328,7 @@ def launch_scheduled_runs(
             if not schedule_state:
                 assert external_schedule.default_status == DefaultScheduleStatus.RUNNING
                 schedule_state = InstigatorState(
-                    external_schedule.get_external_origin(),
+                    external_schedule.get_remote_origin(),
                     InstigatorType.SCHEDULE,
                     InstigatorStatus.DECLARED_IN_CODE,
                     ScheduleInstigatorData(
@@ -496,7 +496,7 @@ def launch_scheduled_runs_for_schedule_iterator(
     end_datetime_utc = check.inst_param(end_datetime_utc, "end_datetime_utc", datetime.datetime)
     instance = workspace_process_context.instance
 
-    instigator_origin_id = external_schedule.get_external_origin_id()
+    instigator_origin_id = external_schedule.get_remote_origin_id()
     ticks = instance.get_ticks(instigator_origin_id, external_schedule.selector_id, limit=1)
     latest_tick: Optional[InstigatorTick] = ticks[0] if ticks else None
 
@@ -700,7 +700,7 @@ def _submit_run_request(
     debug_crash_flags,
 ) -> SubmitRunRequestResult:
     instance = workspace_process_context.instance
-    schedule_origin = external_schedule.get_external_origin()
+    schedule_origin = external_schedule.get_remote_origin()
 
     run = _get_existing_run_for_request(instance, external_schedule, schedule_time, run_request)
     if run:
@@ -771,7 +771,7 @@ def _get_code_location_for_schedule(
     workspace_process_context: IWorkspaceProcessContext,
     external_schedule: ExternalSchedule,
 ) -> CodeLocation:
-    schedule_origin = external_schedule.get_external_origin()
+    schedule_origin = external_schedule.get_remote_origin()
     return workspace_process_context.create_request_context().get_code_location(
         schedule_origin.repository_origin.code_location_origin.location_name
     )
@@ -910,7 +910,7 @@ def _get_existing_run_for_request(
             matching_runs.append(run)
         # otherwise prevent the same named schedule (with the same execution time) across repos from effecting each other
         elif (
-            external_schedule.get_external_origin().repository_origin.get_selector_id()
+            external_schedule.get_remote_origin().repository_origin.get_selector_id()
             == run.external_job_origin.repository_origin.get_selector_id()
         ):
             matching_runs.append(run)
@@ -979,7 +979,7 @@ def _create_scheduler_run(
         job_snapshot=external_job.job_snapshot,
         execution_plan_snapshot=execution_plan_snapshot,
         parent_job_snapshot=external_job.parent_job_snapshot,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
         asset_selection=(
             frozenset(run_request.asset_selection) if run_request.asset_selection else None

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_get_current_runs.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_get_current_runs.py
@@ -23,7 +23,7 @@ def test_launch_run_grpc():
             res = deserialize_value(
                 api_client.start_run(
                     ExecuteExternalJobArgs(
-                        job_origin=job_handle.get_external_origin(),
+                        job_origin=job_handle.get_remote_origin(),
                         run_id=run_id,
                         instance_ref=instance.get_ref(),
                     )

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_launch_run.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_launch_run.py
@@ -33,7 +33,7 @@ def test_launch_run_with_unloadable_job_grpc():
             run = create_run_for_test(instance, "foo")
             run_id = run.run_id
 
-            original_origin = job_handle.get_external_origin()
+            original_origin = job_handle.get_remote_origin()
 
             # point the api to a pipeline that cannot be loaded
             res = deserialize_value(
@@ -84,7 +84,7 @@ def test_launch_run_grpc():
             res = deserialize_value(
                 api_client.start_run(
                     ExecuteExternalJobArgs(
-                        job_origin=job_handle.get_external_origin(),
+                        job_origin=job_handle.get_remote_origin(),
                         run_id=run_id,
                         instance_ref=instance.get_ref(),
                     )
@@ -130,7 +130,7 @@ def test_launch_unloadable_run_grpc():
                 res = deserialize_value(
                     api_client.start_run(
                         ExecuteExternalJobArgs(
-                            job_origin=job_handle.get_external_origin(),
+                            job_origin=job_handle.get_remote_origin(),
                             run_id=run_id,
                             instance_ref=other_instance.get_ref(),
                         )

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_execution_plan.py
@@ -24,7 +24,7 @@ def test_execution_plan_error_grpc(instance: DagsterInstance):
         ):
             sync_get_external_execution_plan_grpc(
                 api_client,
-                job_handle.get_external_origin(),
+                job_handle.get_remote_origin(),
                 run_config={},
                 asset_selection={AssetKey("fake")},
                 job_snapshot_id="12345",
@@ -38,7 +38,7 @@ def test_execution_plan_snapshot_api_grpc(instance: DagsterInstance):
 
         execution_plan_snapshot = sync_get_external_execution_plan_grpc(
             api_client,
-            job_handle.get_external_origin(),
+            job_handle.get_remote_origin(),
             run_config={},
             job_snapshot_id="12345",
         )
@@ -58,7 +58,7 @@ def test_execution_plan_with_step_keys_to_execute_snapshot_api_grpc(instance: Da
 
         execution_plan_snapshot = sync_get_external_execution_plan_grpc(
             api_client,
-            job_handle.get_external_origin(),
+            job_handle.get_remote_origin(),
             run_config={},
             job_snapshot_id="12345",
             step_keys_to_execute=["do_something"],
@@ -78,7 +78,7 @@ def test_execution_plan_with_subset_snapshot_api_grpc(instance: DagsterInstance)
 
         execution_plan_snapshot = sync_get_external_execution_plan_grpc(
             api_client,
-            job_handle.get_external_origin(),
+            job_handle.get_remote_origin(),
             run_config={"ops": {"do_input": {"inputs": {"x": {"value": "test"}}}}},
             job_snapshot_id="12345",
             op_selection=["do_input"],

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_job.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_job.py
@@ -15,7 +15,7 @@ from dagster_tests.api_tests.utils import get_bar_repo_code_location
 def _test_job_subset_grpc(job_handle, api_client, op_selection=None, include_parent_snapshot=True):
     return sync_get_external_job_subset_grpc(
         api_client,
-        job_handle.get_external_origin(),
+        job_handle.get_remote_origin(),
         op_selection=op_selection,
         include_parent_snapshot=include_parent_snapshot,
     )
@@ -40,7 +40,7 @@ def test_job_snapshot_deserialize_error(instance):
         external_pipeline_subset_result = deserialize_value(
             api_client.external_pipeline_subset(
                 pipeline_subset_snapshot_args=JobSubsetSnapshotArgs(
-                    job_origin=job_handle.get_external_origin(),
+                    job_origin=job_handle.get_remote_origin(),
                     op_selection=None,
                     asset_selection=None,
                     include_parent_snapshot=True,

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
@@ -92,7 +92,7 @@ def test_external_partition_names_deserialize_error_grpc(instance: DagsterInstan
         api_client = code_location.client
 
         repository_handle = code_location.get_repository("bar_repo").handle
-        repository_origin = repository_handle.get_external_origin()
+        repository_origin = repository_handle.get_remote_origin()
 
         result = deserialize_value(
             api_client.external_partition_names(
@@ -166,7 +166,7 @@ def test_external_partition_config_deserialize_error_grpc(instance: DagsterInsta
         result = deserialize_value(
             api_client.external_partition_config(
                 partition_args=PartitionArgs(
-                    repository_origin=repository_handle.get_external_origin(),
+                    repository_origin=repository_handle.get_remote_origin(),
                     partition_set_name="foo_partition_set",
                     partition_name="bar",
                     instance_ref=instance.get_ref(),
@@ -230,7 +230,7 @@ def test_external_partition_tags_different_partitions_defs(instance: DagsterInst
 def test_external_partitions_tags_deserialize_error_grpc(instance: DagsterInstance):
     with get_bar_repo_code_location(instance) as code_location:
         repository_handle = code_location.get_repository("bar_repo").handle
-        repository_origin = repository_handle.get_external_origin()
+        repository_origin = repository_handle.get_remote_origin()
 
         api_client = code_location.client
 
@@ -276,7 +276,7 @@ def test_external_partition_set_execution_params_deserialize_error_grpc(instance
     with get_bar_repo_code_location(instance) as code_location:
         repository_handle = code_location.get_repository("bar_repo").handle
 
-        repository_origin = repository_handle.get_external_origin()
+        repository_origin = repository_handle.get_remote_origin()
 
         api_client = code_location.client
 
@@ -343,7 +343,7 @@ def test_external_partition_tags_grpc_backcompat_no_job_name(instance: DagsterIn
         result = deserialize_value(
             api_client.external_partition_tags(
                 partition_args=PartitionArgs(
-                    repository_origin=repository_handle.get_external_origin(),
+                    repository_origin=repository_handle.get_remote_origin(),
                     partition_set_name="baz_partition_set",
                     partition_name="c",
                     instance_ref=instance.get_ref(),
@@ -365,7 +365,7 @@ def test_external_partition_names_grpc_backcompat_no_job_name(instance: DagsterI
         result = deserialize_value(
             api_client.external_partition_names(
                 partition_names_args=PartitionNamesArgs(
-                    repository_origin=repository_handle.get_external_origin(),
+                    repository_origin=repository_handle.get_remote_origin(),
                     partition_set_name="baz_partition_set",
                 )
             )

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_schedule_execution_data.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_schedule_execution_data.py
@@ -55,7 +55,7 @@ def test_external_schedule_client_timeout(instance, env_var_default_val: Optiona
 def test_external_schedule_execution_data_api_grpc_fallback_to_streaming():
     with instance_for_test() as instance:
         with get_bar_repo_handle(instance) as repository_handle:
-            origin = repository_handle.get_external_origin()
+            origin = repository_handle.get_remote_origin()
             with ephemeral_grpc_api_client(
                 origin.code_location_origin.loadable_target_origin
             ) as api_client:
@@ -99,7 +99,7 @@ def test_external_schedule_execution_data_api_never_execute_grpc():
 def test_external_schedule_execution_deserialize_error():
     with instance_for_test() as instance:
         with get_bar_repo_handle(instance) as repository_handle:
-            origin = repository_handle.get_external_origin()
+            origin = repository_handle.get_remote_origin()
             with ephemeral_grpc_api_client(
                 origin.code_location_origin.loadable_target_origin
             ) as api_client:

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_sensor.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_sensor.py
@@ -31,7 +31,7 @@ def test_external_sensor_grpc(instance):
 
 def test_external_sensor_grpc_fallback_to_streaming(instance):
     with get_bar_repo_handle(instance) as repository_handle:
-        origin = repository_handle.get_external_origin()
+        origin = repository_handle.get_remote_origin()
         with ephemeral_grpc_api_client(
             origin.code_location_origin.loadable_target_origin
         ) as api_client:
@@ -95,7 +95,7 @@ def test_external_sensor_client_timeout(instance, timeout: int, env_var_default_
 
 def test_external_sensor_deserialize_error(instance):
     with get_bar_repo_handle(instance) as repository_handle:
-        origin = repository_handle.get_external_origin()
+        origin = repository_handle.get_remote_origin()
         with ephemeral_grpc_api_client(
             origin.code_location_origin.loadable_target_origin
         ) as api_client:

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -914,7 +914,7 @@ def create_repo_run(instance):
         run = create_run_for_test(
             instance,
             job_name="my_job",
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
         instance.launch_run(run.run_id, context)

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -304,7 +304,7 @@ def test_submit_run():
             run = create_run_for_test(
                 instance=instance,
                 job_name=external_job.name,
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=external_job.get_python_origin(),
             )
 

--- a/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_default_run_coordinator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_default_run_coordinator.py
@@ -35,7 +35,7 @@ def _create_run(
     job_args = merge_dicts(
         {
             "job_name": "foo",
-            "external_job_origin": external_pipeline.get_external_origin(),
+            "external_job_origin": external_pipeline.get_remote_origin(),
             "job_code_origin": external_pipeline.get_python_origin(),
         },
         kwargs,

--- a/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_queued_run_coordinator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_queued_run_coordinator.py
@@ -62,7 +62,7 @@ class TestQueuedRunCoordinator:
         job_args = merge_dicts(
             {
                 "job_name": "foo",
-                "external_job_origin": external_pipeline.get_external_origin(),
+                "external_job_origin": external_pipeline.get_remote_origin(),
                 "job_code_origin": external_pipeline.get_python_origin(),
             },
             kwargs,

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_asset_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_asset_sensor_run.py
@@ -31,7 +31,7 @@ def test_monitor_source_asset_sensor(executor):
 
             evaluate_sensors(workspace_ctx, executor)
 
-            ticks = instance.get_ticks(the_sensor.get_external_origin_id(), the_sensor.selector_id)
+            ticks = instance.get_ticks(the_sensor.get_remote_origin_id(), the_sensor.selector_id)
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -46,7 +46,7 @@ def test_monitor_source_asset_sensor(executor):
 
             evaluate_sensors(workspace_ctx, executor)
 
-            ticks = instance.get_ticks(the_sensor.get_external_origin_id(), the_sensor.selector_id)
+            ticks = instance.get_ticks(the_sensor.get_remote_origin_id(), the_sensor.selector_id)
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
@@ -437,14 +437,14 @@ def test_resources(
         external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         assert instance.get_runs_count() == base_run_count
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 0
 
@@ -454,7 +454,7 @@ def test_resources(
         assert instance.get_runs_count() == base_run_count + 1
         run = instance.get_runs()[0]
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
         assert ticks[0].run_keys == ["foo"]
@@ -497,13 +497,13 @@ def test_resources_freshness_policy_sensor(
         external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 0
 
@@ -519,7 +519,7 @@ def test_resources_freshness_policy_sensor(
 
     with freeze_time(freeze_datetime):
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 2
         validate_tick(
@@ -569,13 +569,13 @@ def test_resources_run_status_sensor(
         external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 0
 
@@ -592,7 +592,7 @@ def test_resources_run_status_sensor(
 
     with freeze_time(freeze_datetime):
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 2
 
@@ -647,13 +647,13 @@ def test_resources_run_failure_sensor(
         external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 0
 
@@ -670,7 +670,7 @@ def test_resources_run_failure_sensor(
 
     with freeze_time(freeze_datetime):
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 2
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -142,7 +142,7 @@ def test_run_status_sensor(
         instance.start_sensor(started_sensor)
 
         state = instance.get_instigator_state(
-            started_sensor.get_external_origin_id(), started_sensor.selector_id
+            started_sensor.get_remote_origin_id(), started_sensor.selector_id
         )
         assert (
             cast(SensorInstigatorData, check.not_none(state).instigator_data).sensor_type
@@ -152,7 +152,7 @@ def test_run_status_sensor(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            success_sensor.get_external_origin_id(), success_sensor.selector_id
+            success_sensor.get_remote_origin_id(), success_sensor.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -169,7 +169,7 @@ def test_run_status_sensor(
         external_job = external_repo.get_full_external_job("failure_job")
         run = instance.create_run_for_job(
             failure_job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
         instance.submit_run(run.run_id, workspace_context.create_request_context())
@@ -183,7 +183,7 @@ def test_run_status_sensor(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            success_sensor.get_external_origin_id(), success_sensor.selector_id
+            success_sensor.get_remote_origin_id(), success_sensor.selector_id
         )
         assert len(ticks) == 2
         validate_tick(
@@ -194,7 +194,7 @@ def test_run_status_sensor(
         )
 
         ticks = instance.get_ticks(
-            started_sensor.get_external_origin_id(), started_sensor.selector_id
+            started_sensor.get_remote_origin_id(), started_sensor.selector_id
         )
         assert len(ticks) == 2
         validate_tick(
@@ -208,7 +208,7 @@ def test_run_status_sensor(
         external_job = external_repo.get_full_external_job("foo_job")
         run = instance.create_run_for_job(
             foo_job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
         instance.submit_run(run.run_id, workspace_context.create_request_context())
@@ -224,7 +224,7 @@ def test_run_status_sensor(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            success_sensor.get_external_origin_id(), success_sensor.selector_id
+            success_sensor.get_remote_origin_id(), success_sensor.selector_id
         )
         assert len(ticks) == 3
         validate_tick(
@@ -235,7 +235,7 @@ def test_run_status_sensor(
         )
 
         ticks = instance.get_ticks(
-            started_sensor.get_external_origin_id(), started_sensor.selector_id
+            started_sensor.get_remote_origin_id(), started_sensor.selector_id
         )
         assert len(ticks) == 3
         validate_tick(
@@ -263,7 +263,7 @@ def test_run_failure_sensor(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+            failure_sensor.get_remote_origin_id(), failure_sensor.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -280,7 +280,7 @@ def test_run_failure_sensor(
         external_job = external_repo.get_full_external_job("failure_job")
         run = instance.create_run_for_job(
             failure_job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
         instance.submit_run(run.run_id, workspace_context.create_request_context())
@@ -294,7 +294,7 @@ def test_run_failure_sensor(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+            failure_sensor.get_remote_origin_id(), failure_sensor.selector_id
         )
         assert len(ticks) == 2
         validate_tick(
@@ -321,7 +321,7 @@ def test_run_failure_sensor_that_fails(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+            failure_sensor.get_remote_origin_id(), failure_sensor.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -338,7 +338,7 @@ def test_run_failure_sensor_that_fails(
         external_job = external_repo.get_full_external_job("failure_job")
         run = instance.create_run_for_job(
             failure_job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
         instance.submit_run(run.run_id, workspace_context.create_request_context())
@@ -352,7 +352,7 @@ def test_run_failure_sensor_that_fails(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+            failure_sensor.get_remote_origin_id(), failure_sensor.selector_id
         )
         assert len(ticks) == 2
         validate_tick(
@@ -370,7 +370,7 @@ def test_run_failure_sensor_that_fails(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+            failure_sensor.get_remote_origin_id(), failure_sensor.selector_id
         )
         assert len(ticks) == 3
         validate_tick(
@@ -395,7 +395,7 @@ def test_run_failure_sensor_filtered(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+            failure_sensor.get_remote_origin_id(), failure_sensor.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -412,7 +412,7 @@ def test_run_failure_sensor_filtered(
         external_job = external_repo.get_full_external_job("failure_job_2")
         run = instance.create_run_for_job(
             failure_job_2,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
         instance.submit_run(run.run_id, workspace_context.create_request_context())
@@ -426,7 +426,7 @@ def test_run_failure_sensor_filtered(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+            failure_sensor.get_remote_origin_id(), failure_sensor.selector_id
         )
         assert len(ticks) == 2
         validate_tick(
@@ -443,7 +443,7 @@ def test_run_failure_sensor_filtered(
         external_job = external_repo.get_full_external_job("failure_job")
         run = instance.create_run_for_job(
             failure_job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
         instance.submit_run(run.run_id, workspace_context.create_request_context())
@@ -458,7 +458,7 @@ def test_run_failure_sensor_filtered(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+            failure_sensor.get_remote_origin_id(), failure_sensor.selector_id
         )
         assert len(ticks) == 3
         validate_tick(
@@ -491,7 +491,7 @@ def test_run_failure_sensor_overfetch(
                 evaluate_sensors(workspace_context, executor)
 
                 ticks = instance.get_ticks(
-                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                    failure_sensor.get_remote_origin_id(), failure_sensor.selector_id
                 )
                 assert len(ticks) == 1
                 validate_tick(
@@ -515,7 +515,7 @@ def test_run_failure_sensor_overfetch(
 
                     run = instance.create_run_for_job(
                         failure_job_2,
-                        external_job_origin=external_job_2.get_external_origin(),
+                        external_job_origin=external_job_2.get_remote_origin(),
                         job_code_origin=external_job_2.get_python_origin(),
                     )
                     instance.report_run_failed(run)
@@ -524,7 +524,7 @@ def test_run_failure_sensor_overfetch(
 
                     run = instance.create_run_for_job(
                         failure_job,
-                        external_job_origin=external_job.get_external_origin(),
+                        external_job_origin=external_job.get_remote_origin(),
                         job_code_origin=external_job.get_python_origin(),
                     )
                     instance.report_run_failed(run)
@@ -538,7 +538,7 @@ def test_run_failure_sensor_overfetch(
                 evaluate_sensors(workspace_context, executor)
 
                 ticks = instance.get_ticks(
-                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                    failure_sensor.get_remote_origin_id(), failure_sensor.selector_id
                 )
                 assert len(ticks) == 2
                 validate_tick(
@@ -579,7 +579,7 @@ def test_run_failure_sensor_overfetch(
                 evaluate_sensors(workspace_context, executor)
 
                 ticks = instance.get_ticks(
-                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                    failure_sensor.get_remote_origin_id(), failure_sensor.selector_id
                 )
                 assert len(ticks) == 3
                 validate_tick(
@@ -660,7 +660,7 @@ def test_run_status_sensor_interleave(storage_config_fn, executor: Optional[Thre
                 evaluate_sensors(workspace_context, executor)
 
                 ticks = instance.get_ticks(
-                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                    failure_sensor.get_remote_origin_id(), failure_sensor.selector_id
                 )
                 assert len(ticks) == 1
                 validate_tick(
@@ -678,7 +678,7 @@ def test_run_status_sensor_interleave(storage_config_fn, executor: Optional[Thre
                 # start run 1
                 run1 = instance.create_run_for_job(
                     hanging_job,
-                    external_job_origin=external_job.get_external_origin(),
+                    external_job_origin=external_job.get_remote_origin(),
                     job_code_origin=external_job.get_python_origin(),
                 )
                 instance.submit_run(run1.run_id, workspace_context.create_request_context())
@@ -686,7 +686,7 @@ def test_run_status_sensor_interleave(storage_config_fn, executor: Optional[Thre
                 # start run 2
                 run2 = instance.create_run_for_job(
                     hanging_job,
-                    external_job_origin=external_job.get_external_origin(),
+                    external_job_origin=external_job.get_remote_origin(),
                     job_code_origin=external_job.get_python_origin(),
                 )
                 instance.submit_run(run2.run_id, workspace_context.create_request_context())
@@ -704,7 +704,7 @@ def test_run_status_sensor_interleave(storage_config_fn, executor: Optional[Thre
                 evaluate_sensors(workspace_context, executor)
 
                 ticks = instance.get_ticks(
-                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                    failure_sensor.get_remote_origin_id(), failure_sensor.selector_id
                 )
                 assert len(ticks) == 2
                 validate_tick(
@@ -729,7 +729,7 @@ def test_run_status_sensor_interleave(storage_config_fn, executor: Optional[Thre
                 evaluate_sensors(workspace_context, executor)
 
                 ticks = instance.get_ticks(
-                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                    failure_sensor.get_remote_origin_id(), failure_sensor.selector_id
                 )
                 assert len(ticks) == 3
                 validate_tick(
@@ -760,7 +760,7 @@ def test_run_failure_sensor_empty_run_records(
                 evaluate_sensors(workspace_context, executor)
 
                 ticks = instance.get_ticks(
-                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                    failure_sensor.get_remote_origin_id(), failure_sensor.selector_id
                 )
                 assert len(ticks) == 1
                 validate_tick(
@@ -801,7 +801,7 @@ def test_run_failure_sensor_empty_run_records(
                 evaluate_sensors(workspace_context, executor)
 
                 ticks = instance.get_ticks(
-                    failure_sensor.get_external_origin_id(), failure_sensor.selector_id
+                    failure_sensor.get_remote_origin_id(), failure_sensor.selector_id
                 )
                 assert len(ticks) == 2
                 validate_tick(
@@ -852,7 +852,7 @@ def test_all_code_locations_run_status_sensor(executor: Optional[ThreadPoolExecu
 
             evaluate_sensors(workspace_context, executor)
 
-            ticks = [*instance.get_ticks(my_sensor.get_external_origin_id(), my_sensor.selector_id)]
+            ticks = [*instance.get_ticks(my_sensor.get_remote_origin_id(), my_sensor.selector_id)]
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -876,7 +876,7 @@ def test_all_code_locations_run_status_sensor(executor: Optional[ThreadPoolExecu
 
             dagster_run = instance.create_run_for_job(
                 another_success_job,
-                external_job_origin=external_another_job.get_external_origin(),
+                external_job_origin=external_another_job.get_remote_origin(),
                 job_code_origin=external_another_job.get_python_origin(),
             )
 
@@ -889,7 +889,7 @@ def test_all_code_locations_run_status_sensor(executor: Optional[ThreadPoolExecu
         with freeze_time(freeze_datetime):
             evaluate_sensors(workspace_context, executor)
 
-            ticks = [*instance.get_ticks(my_sensor.get_external_origin_id(), my_sensor.selector_id)]
+            ticks = [*instance.get_ticks(my_sensor.get_remote_origin_id(), my_sensor.selector_id)]
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -939,7 +939,7 @@ def test_all_code_location_run_failure_sensor(executor: Optional[ThreadPoolExecu
 
             evaluate_sensors(workspace_context, executor)
 
-            ticks = [*instance.get_ticks(my_sensor.get_external_origin_id(), my_sensor.selector_id)]
+            ticks = [*instance.get_ticks(my_sensor.get_remote_origin_id(), my_sensor.selector_id)]
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -963,7 +963,7 @@ def test_all_code_location_run_failure_sensor(executor: Optional[ThreadPoolExecu
 
             dagster_run = instance.create_run_for_job(
                 another_failure_job,
-                external_job_origin=external_another_job.get_external_origin(),
+                external_job_origin=external_another_job.get_remote_origin(),
                 job_code_origin=external_another_job.get_python_origin(),
             )
 
@@ -976,7 +976,7 @@ def test_all_code_location_run_failure_sensor(executor: Optional[ThreadPoolExecu
         with freeze_time(freeze_datetime):
             evaluate_sensors(workspace_context, executor)
 
-            ticks = [*instance.get_ticks(my_sensor.get_external_origin_id(), my_sensor.selector_id)]
+            ticks = [*instance.get_ticks(my_sensor.get_remote_origin_id(), my_sensor.selector_id)]
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1030,7 +1030,7 @@ def test_cross_code_location_run_status_sensor(executor: Optional[ThreadPoolExec
 
             ticks = [
                 *instance.get_ticks(
-                    success_sensor.get_external_origin_id(), success_sensor.selector_id
+                    success_sensor.get_remote_origin_id(), success_sensor.selector_id
                 )
             ]
             assert len(ticks) == 1
@@ -1056,7 +1056,7 @@ def test_cross_code_location_run_status_sensor(executor: Optional[ThreadPoolExec
 
             dagster_run = instance.create_run_for_job(
                 success_job,
-                external_job_origin=external_success_job.get_external_origin(),
+                external_job_origin=external_success_job.get_remote_origin(),
                 job_code_origin=external_success_job.get_python_origin(),
             )
 
@@ -1071,7 +1071,7 @@ def test_cross_code_location_run_status_sensor(executor: Optional[ThreadPoolExec
 
             ticks = [
                 *instance.get_ticks(
-                    success_sensor.get_external_origin_id(), success_sensor.selector_id
+                    success_sensor.get_remote_origin_id(), success_sensor.selector_id
                 )
             ]
             assert len(ticks) == 2
@@ -1129,7 +1129,7 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
 
             ticks = [
                 *instance.get_ticks(
-                    success_sensor.get_external_origin_id(), success_sensor.selector_id
+                    success_sensor.get_remote_origin_id(), success_sensor.selector_id
                 )
             ]
             assert len(ticks) == 1
@@ -1155,7 +1155,7 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
 
             dagster_run = instance.create_run_for_job(
                 success_job,
-                external_job_origin=external_success_job.get_external_origin(),
+                external_job_origin=external_success_job.get_remote_origin(),
                 job_code_origin=external_success_job.get_python_origin(),
             )
 
@@ -1170,7 +1170,7 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
 
             ticks = [
                 *instance.get_ticks(
-                    success_sensor.get_external_origin_id(), success_sensor.selector_id
+                    success_sensor.get_remote_origin_id(), success_sensor.selector_id
                 )
             ]
 
@@ -1204,7 +1204,7 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
 
             dagster_run = instance.create_run_for_job(
                 another_success_job,
-                external_job_origin=external_another_success_job.get_external_origin(),
+                external_job_origin=external_another_success_job.get_remote_origin(),
                 job_code_origin=external_another_success_job.get_python_origin(),
             )
 
@@ -1219,7 +1219,7 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
 
             ticks = [
                 *instance.get_ticks(
-                    success_sensor.get_external_origin_id(), success_sensor.selector_id
+                    success_sensor.get_remote_origin_id(), success_sensor.selector_id
                 )
             ]
 
@@ -1276,7 +1276,7 @@ def test_code_location_scoped_run_status_sensor(executor: Optional[ThreadPoolExe
 
             ticks = [
                 *instance.get_ticks(
-                    success_sensor.get_external_origin_id(), success_sensor.selector_id
+                    success_sensor.get_remote_origin_id(), success_sensor.selector_id
                 )
             ]
             assert len(ticks) == 1
@@ -1302,7 +1302,7 @@ def test_code_location_scoped_run_status_sensor(executor: Optional[ThreadPoolExe
 
             dagster_run = instance.create_run_for_job(
                 success_job,
-                external_job_origin=external_success_job.get_external_origin(),
+                external_job_origin=external_success_job.get_remote_origin(),
                 job_code_origin=external_success_job.get_python_origin(),
             )
 
@@ -1317,7 +1317,7 @@ def test_code_location_scoped_run_status_sensor(executor: Optional[ThreadPoolExe
 
             ticks = [
                 *instance.get_ticks(
-                    success_sensor.get_external_origin_id(), success_sensor.selector_id
+                    success_sensor.get_remote_origin_id(), success_sensor.selector_id
                 )
             ]
             assert len(ticks) == 2
@@ -1340,7 +1340,7 @@ def test_code_location_scoped_run_status_sensor(executor: Optional[ThreadPoolExe
 
             dagster_run = instance.create_run_for_job(
                 success_job,
-                external_job_origin=external_success_job.get_external_origin(),
+                external_job_origin=external_success_job.get_remote_origin(),
                 job_code_origin=external_success_job.get_python_origin(),
             )
 
@@ -1355,7 +1355,7 @@ def test_code_location_scoped_run_status_sensor(executor: Optional[ThreadPoolExe
 
             ticks = [
                 *instance.get_ticks(
-                    success_sensor.get_external_origin_id(), success_sensor.selector_id
+                    success_sensor.get_remote_origin_id(), success_sensor.selector_id
                 )
             ]
             assert len(ticks) == 3
@@ -1384,7 +1384,7 @@ def test_cross_repo_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
             evaluate_sensors(workspace_context, executor)
 
             ticks = instance.get_ticks(
-                cross_repo_sensor.get_external_origin_id(), cross_repo_sensor.selector_id
+                cross_repo_sensor.get_remote_origin_id(), cross_repo_sensor.selector_id
             )
             assert len(ticks) == 1
             validate_tick(
@@ -1401,7 +1401,7 @@ def test_cross_repo_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
             external_job = the_other_repo.get_full_external_job("the_job")
             run = instance.create_run_for_job(
                 the_job,
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=external_job.get_python_origin(),
             )
             instance.submit_run(run.run_id, workspace_context.create_request_context())
@@ -1414,7 +1414,7 @@ def test_cross_repo_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
             evaluate_sensors(workspace_context, executor)
 
             ticks = instance.get_ticks(
-                cross_repo_sensor.get_external_origin_id(), cross_repo_sensor.selector_id
+                cross_repo_sensor.get_remote_origin_id(), cross_repo_sensor.selector_id
             )
             assert len(ticks) == 2
             validate_tick(
@@ -1446,7 +1446,7 @@ def test_cross_repo_job_run_status_sensor(executor: Optional[ThreadPoolExecutor]
             assert instance.get_runs_count() == 0
 
             ticks = instance.get_ticks(
-                cross_repo_sensor.get_external_origin_id(), cross_repo_sensor.selector_id
+                cross_repo_sensor.get_remote_origin_id(), cross_repo_sensor.selector_id
             )
             assert len(ticks) == 1
             validate_tick(
@@ -1463,7 +1463,7 @@ def test_cross_repo_job_run_status_sensor(executor: Optional[ThreadPoolExecutor]
             external_job = the_other_repo.get_full_external_job("the_job")
             run = instance.create_run_for_job(
                 the_job,
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=external_job.get_python_origin(),
             )
             instance.submit_run(run.run_id, workspace_context.create_request_context())
@@ -1478,7 +1478,7 @@ def test_cross_repo_job_run_status_sensor(executor: Optional[ThreadPoolExecutor]
             wait_for_all_runs_to_finish(instance)
 
             ticks = instance.get_ticks(
-                cross_repo_sensor.get_external_origin_id(), cross_repo_sensor.selector_id
+                cross_repo_sensor.get_remote_origin_id(), cross_repo_sensor.selector_id
             )
             assert len(ticks) == 2
             validate_tick(
@@ -1501,7 +1501,7 @@ def test_cross_repo_job_run_status_sensor(executor: Optional[ThreadPoolExecutor]
             assert len(run_request_runs) == 1
 
             ticks = instance.get_ticks(
-                cross_repo_sensor.get_external_origin_id(), cross_repo_sensor.selector_id
+                cross_repo_sensor.get_remote_origin_id(), cross_repo_sensor.selector_id
             )
             assert len(ticks) == 3
             validate_tick(
@@ -1529,7 +1529,7 @@ def test_partitioned_job_run_status_sensor(
         assert instance.get_runs_count() == 0
 
         ticks = instance.get_ticks(
-            success_sensor.get_external_origin_id(), success_sensor.selector_id
+            success_sensor.get_remote_origin_id(), success_sensor.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -1546,7 +1546,7 @@ def test_partitioned_job_run_status_sensor(
         external_job = external_repo.get_full_external_job("daily_partitioned_job")
         run = instance.create_run_for_job(
             daily_partitioned_job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
             tags={"dagster/partition": "2022-08-01"},
         )
@@ -1564,7 +1564,7 @@ def test_partitioned_job_run_status_sensor(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            success_sensor.get_external_origin_id(), success_sensor.selector_id
+            success_sensor.get_remote_origin_id(), success_sensor.selector_id
         )
         assert len(ticks) == 2
         validate_tick(
@@ -1598,7 +1598,7 @@ def test_different_instance_run_status_sensor(executor: Optional[ThreadPoolExecu
                 evaluate_sensors(workspace_context, executor)
 
                 ticks = instance.get_ticks(
-                    cross_repo_sensor.get_external_origin_id(), cross_repo_sensor.selector_id
+                    cross_repo_sensor.get_remote_origin_id(), cross_repo_sensor.selector_id
                 )
                 assert len(ticks) == 1
                 validate_tick(
@@ -1615,7 +1615,7 @@ def test_different_instance_run_status_sensor(executor: Optional[ThreadPoolExecu
                 external_job = the_other_repo.get_full_external_job("the_job")
                 run = the_other_instance.create_run_for_job(
                     the_job,
-                    external_job_origin=external_job.get_external_origin(),
+                    external_job_origin=external_job.get_remote_origin(),
                     job_code_origin=external_job.get_python_origin(),
                 )
                 the_other_instance.submit_run(
@@ -1630,7 +1630,7 @@ def test_different_instance_run_status_sensor(executor: Optional[ThreadPoolExecu
                 evaluate_sensors(workspace_context, executor)
 
                 ticks = instance.get_ticks(
-                    cross_repo_sensor.get_external_origin_id(), cross_repo_sensor.selector_id
+                    cross_repo_sensor.get_remote_origin_id(), cross_repo_sensor.selector_id
                 )
                 assert len(ticks) == 2
                 # the_pipeline was run in another instance, so the cross_repo_sensor should not trigger
@@ -1659,7 +1659,7 @@ def test_instance_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
             evaluate_sensors(workspace_context, executor)
 
             ticks = instance.get_ticks(
-                instance_sensor.get_external_origin_id(), instance_sensor.selector_id
+                instance_sensor.get_remote_origin_id(), instance_sensor.selector_id
             )
             assert len(ticks) == 1
             validate_tick(
@@ -1676,7 +1676,7 @@ def test_instance_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
             external_job = the_other_repo.get_full_external_job("the_job")
             run = instance.create_run_for_job(
                 the_job,
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=external_job.get_python_origin(),
             )
             instance.submit_run(run.run_id, workspace_context.create_request_context())
@@ -1689,7 +1689,7 @@ def test_instance_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
             evaluate_sensors(workspace_context, executor)
 
             ticks = instance.get_ticks(
-                instance_sensor.get_external_origin_id(), instance_sensor.selector_id
+                instance_sensor.get_remote_origin_id(), instance_sensor.selector_id
             )
             assert len(ticks) == 2
             validate_tick(
@@ -1714,7 +1714,7 @@ def test_logging_run_status_sensor(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            success_sensor.get_external_origin_id(), success_sensor.selector_id
+            success_sensor.get_remote_origin_id(), success_sensor.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -1730,7 +1730,7 @@ def test_logging_run_status_sensor(
         external_job = external_repo.get_full_external_job("foo_job")
         run = instance.create_run_for_job(
             foo_job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
         instance.submit_run(run.run_id, workspace_context.create_request_context())
@@ -1744,7 +1744,7 @@ def test_logging_run_status_sensor(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            success_sensor.get_external_origin_id(), success_sensor.selector_id
+            success_sensor.get_remote_origin_id(), success_sensor.selector_id
         )
         assert len(ticks) == 2
         validate_tick(

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_failure_recovery.py
@@ -21,10 +21,8 @@ from dagster._time import create_datetime, get_timezone
 from dagster._vendored.dateutil.relativedelta import relativedelta
 from mock import patch
 
-from dagster_tests.daemon_sensor_tests.test_sensor_run import (
-    create_workspace_load_target,
-    wait_for_all_runs_to_start,
-)
+from dagster_tests.daemon_sensor_tests.conftest import create_workspace_load_target
+from dagster_tests.daemon_sensor_tests.test_sensor_run import wait_for_all_runs_to_start
 
 spawn_ctx = multiprocessing.get_context("spawn")
 
@@ -67,7 +65,7 @@ def test_failure_before_run_created(crash_location, crash_signal, instance, exte
         external_sensor = external_repo.get_external_sensor("simple_sensor")
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
@@ -81,7 +79,7 @@ def test_failure_before_run_created(crash_location, crash_signal, instance, exte
         launch_process.start()
         launch_process.join(timeout=60)
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SKIPPED
@@ -102,7 +100,7 @@ def test_failure_before_run_created(crash_location, crash_signal, instance, exte
         assert launch_process.exitcode != 0
 
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 2
         assert ticks[0].status == TickStatus.STARTED
@@ -124,7 +122,7 @@ def test_failure_before_run_created(crash_location, crash_signal, instance, exte
         assert instance.get_runs_count() == 1
 
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 3
         assert ticks[0].status == TickStatus.SUCCESS
@@ -145,7 +143,7 @@ def test_failure_after_run_created_before_run_launched(
         external_sensor = external_repo.get_external_sensor("run_key_sensor")
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
@@ -163,7 +161,7 @@ def test_failure_after_run_created_before_run_launched(
         assert launch_process.exitcode != 0
 
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
 
         assert len(ticks) == 1
@@ -190,7 +188,7 @@ def test_failure_after_run_created_before_run_launched(
         run = instance.get_runs()[0]
 
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1  # we resumed the original tick, so still a single tick
         assert ticks[0].status == TickStatus.SUCCESS
@@ -204,7 +202,7 @@ def test_failure_after_run_created_before_run_launched(
 
         assert launch_process.exitcode == 0
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 2  # did another tick, no new runs launched
         assert ticks[0].status == TickStatus.SKIPPED
@@ -228,7 +226,7 @@ def test_failure_after_run_launched(crash_location, crash_signal, instance, exte
         external_sensor = external_repo.get_external_sensor("run_key_sensor")
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
@@ -246,7 +244,7 @@ def test_failure_after_run_launched(crash_location, crash_signal, instance, exte
         assert launch_process.exitcode != 0
 
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
 
         assert len(ticks) == 1
@@ -272,7 +270,7 @@ def test_failure_after_run_launched(crash_location, crash_signal, instance, exte
         run = instance.get_runs()[0]
 
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1  # we resumed the original tick, so still a single tick
         assert ticks[0].status == TickStatus.SUCCESS
@@ -286,7 +284,7 @@ def test_failure_after_run_launched(crash_location, crash_signal, instance, exte
 
         assert launch_process.exitcode == 0
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 2  # did another tick, no new runs launched
         assert ticks[0].status == TickStatus.SKIPPED
@@ -314,7 +312,7 @@ def test_failure_after_run_ids_reserved(
         external_sensor = external_repo.get_external_sensor("only_once_cursor_sensor")
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
@@ -332,7 +330,7 @@ def test_failure_after_run_ids_reserved(
         assert launch_process.exitcode != 0
 
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
 
         assert len(ticks) == 1
@@ -349,7 +347,7 @@ def test_failure_after_run_ids_reserved(
         assert launch_process.exitcode == 0
 
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
 
         assert len(ticks) == 1  # we resumed the original tick, so still a single tick
@@ -369,7 +367,7 @@ def test_failure_after_run_ids_reserved(
         assert mock_get_ticks.call_count == 0
 
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 2  # new tick, nothing happened
         assert ticks[0].status == TickStatus.SKIPPED

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -1071,7 +1071,7 @@ def validate_tick(
     expected_error=None,
 ):
     tick_data = tick.tick_data
-    assert tick_data.instigator_origin_id == external_sensor.get_external_origin_id()
+    assert tick_data.instigator_origin_id == external_sensor.get_remote_origin_id()
     assert tick_data.instigator_name == external_sensor.name
     assert tick_data.instigator_type == InstigatorType.SENSOR
     assert tick_data.status == expected_status, tick_data.error
@@ -1147,7 +1147,7 @@ def test_ignore_auto_materialize_sensor(instance, workspace_context, external_re
         assert external_sensor
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
                 instigator_data=SensorInstigatorData(
@@ -1158,7 +1158,7 @@ def test_ignore_auto_materialize_sensor(instance, workspace_context, external_re
         evaluate_sensors(workspace_context, executor)
         # No ticks because of the sensor type
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 0
 
@@ -1170,14 +1170,14 @@ def test_simple_sensor(instance, workspace_context, external_repo, executor):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 0
 
@@ -1185,7 +1185,7 @@ def test_simple_sensor(instance, workspace_context, external_repo, executor):
 
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -1204,7 +1204,7 @@ def test_simple_sensor(instance, workspace_context, external_repo, executor):
         run = instance.get_runs()[0]
         validate_run_started(run)
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 2
 
@@ -1229,7 +1229,7 @@ def test_sensors_keyed_on_selector_not_origin(
     with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
 
-        existing_origin = external_sensor.get_external_origin()
+        existing_origin = external_sensor.get_remote_origin()
 
         code_location_origin = existing_origin.repository_origin.code_location_origin
         assert isinstance(code_location_origin, ManagedGrpcPythonEnvCodeLocationOrigin)
@@ -1258,7 +1258,7 @@ def test_sensors_keyed_on_selector_not_origin(
 
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
 
@@ -1274,7 +1274,7 @@ def test_bad_load_sensor_repository(
     with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
 
-        valid_origin = external_sensor.get_external_origin()
+        valid_origin = external_sensor.get_remote_origin()
 
         # Swap out a new repository name
         invalid_repo_origin = RemoteInstigatorOrigin(
@@ -1306,7 +1306,7 @@ def test_bad_load_sensor(executor, instance, workspace_context, external_repo):
     with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
 
-        valid_origin = external_sensor.get_external_origin()
+        valid_origin = external_sensor.get_remote_origin()
 
         # Swap out a new repository name
         invalid_repo_origin = RemoteInstigatorOrigin(
@@ -1335,20 +1335,20 @@ def test_error_sensor(caplog, executor, instance, workspace_context, external_re
         external_sensor = external_repo.get_external_sensor("error_sensor")
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
 
         state = instance.get_instigator_state(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert state.instigator_data is None
 
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 0
 
@@ -1356,7 +1356,7 @@ def test_error_sensor(caplog, executor, instance, workspace_context, external_re
 
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -1375,7 +1375,7 @@ def test_error_sensor(caplog, executor, instance, workspace_context, external_re
 
         # Tick updated the sensor's last tick time, but not its cursor (due to the failure)
         state = instance.get_instigator_state(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert state.instigator_data.sensor_type == SensorType.STANDARD
         assert state.instigator_data.cursor is None
@@ -1395,21 +1395,21 @@ def test_wrong_config_sensor(caplog, executor, instance, workspace_context, exte
         external_sensor = external_repo.get_external_sensor("wrong_config_sensor")
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 0
 
         evaluate_sensors(workspace_context, executor)
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
 
@@ -1432,7 +1432,7 @@ def test_wrong_config_sensor(caplog, executor, instance, workspace_context, exte
         evaluate_sensors(workspace_context, executor)
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 2
 
@@ -1463,14 +1463,14 @@ def test_launch_failure(caplog, executor, workspace_context, external_repo):
             external_sensor = external_repo.get_external_sensor("always_on_sensor")
             instance.add_instigator_state(
                 InstigatorState(
-                    external_sensor.get_external_origin(),
+                    external_sensor.get_remote_origin(),
                     InstigatorType.SENSOR,
                     InstigatorStatus.RUNNING,
                 )
             )
             assert instance.get_runs_count() == 0
             ticks = instance.get_ticks(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
+                external_sensor.get_remote_origin_id(), external_sensor.selector_id
             )
             assert len(ticks) == 0
 
@@ -1479,7 +1479,7 @@ def test_launch_failure(caplog, executor, workspace_context, external_repo):
             assert instance.get_runs_count() == 1
             run = instance.get_runs()[0]
             ticks = instance.get_ticks(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
+                external_sensor.get_remote_origin_id(), external_sensor.selector_id
             )
             assert len(ticks) == 1
             validate_tick(
@@ -1511,7 +1511,7 @@ def test_launch_once(caplog, executor, instance, workspace_context, external_rep
         external_sensor = external_repo.get_external_sensor("run_key_sensor")
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
@@ -1520,7 +1520,7 @@ def test_launch_once(caplog, executor, instance, workspace_context, external_rep
 
         assert mock_get_ticks.call_count == 0
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert mock_get_ticks.call_count == 1
         assert len(ticks) == 0
@@ -1535,7 +1535,7 @@ def test_launch_once(caplog, executor, instance, workspace_context, external_rep
         assert instance.get_runs_count() == 1
         run = instance.get_runs()[0]
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert mock_get_ticks.call_count == 3
 
@@ -1559,7 +1559,7 @@ def test_launch_once(caplog, executor, instance, workspace_context, external_rep
 
         assert instance.get_runs_count() == 1
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
 
         assert len(ticks) == 2
@@ -1597,7 +1597,7 @@ def test_launch_once(caplog, executor, instance, workspace_context, external_rep
         assert mock_get_ticks.call_count == 0
 
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
 
         assert len(ticks) == 3
@@ -1615,19 +1615,19 @@ def test_custom_interval_sensor(executor, instance, workspace_context, external_
         external_sensor = external_repo.get_external_sensor("custom_interval_sensor")
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 0
 
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
         validate_tick(ticks[0], external_sensor, freeze_datetime, TickStatus.SKIPPED)
@@ -1637,7 +1637,7 @@ def test_custom_interval_sensor(executor, instance, workspace_context, external_
     with freeze_time(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         # no additional tick created after 30 seconds
         assert len(ticks) == 1
@@ -1647,7 +1647,7 @@ def test_custom_interval_sensor(executor, instance, workspace_context, external_
     with freeze_time(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 2
 
@@ -1698,7 +1698,7 @@ def test_custom_interval_sensor_with_offset(
 
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
@@ -1707,7 +1707,7 @@ def test_custom_interval_sensor_with_offset(
         # create a tick
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
 
@@ -1715,7 +1715,7 @@ def test_custom_interval_sensor_with_offset(
         # advanced
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
 
@@ -1732,7 +1732,7 @@ def test_custom_interval_sensor_with_offset(
 
         assert get_current_datetime() == freeze_datetime + relativedelta(seconds=65)
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 2
         assert sum(sleeps) == 65
@@ -1742,18 +1742,18 @@ def test_sensor_start_stop(executor, instance, workspace_context, external_repo)
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("always_on_sensor")
-        external_origin_id = external_sensor.get_external_origin_id()
+        remote_origin_id = external_sensor.get_remote_origin_id()
         instance.start_sensor(external_sensor)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        ticks = instance.get_ticks(remote_origin_id, external_sensor.selector_id)
         assert len(ticks) == 0
 
         evaluate_sensors(workspace_context, executor)
 
         assert instance.get_runs_count() == 1
         run = instance.get_runs()[0]
-        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        ticks = instance.get_ticks(remote_origin_id, external_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -1769,17 +1769,17 @@ def test_sensor_start_stop(executor, instance, workspace_context, external_repo)
         evaluate_sensors(workspace_context, executor)
         # no new ticks, no new runs, we are below the 30 second min interval
         assert instance.get_runs_count() == 1
-        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        ticks = instance.get_ticks(remote_origin_id, external_sensor.selector_id)
         assert len(ticks) == 1
 
         # stop / start
-        instance.stop_sensor(external_origin_id, external_sensor.selector_id, external_sensor)
+        instance.stop_sensor(remote_origin_id, external_sensor.selector_id, external_sensor)
         instance.start_sensor(external_sensor)
 
         evaluate_sensors(workspace_context, executor)
         # no new ticks, no new runs, we are below the 30 second min interval
         assert instance.get_runs_count() == 1
-        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        ticks = instance.get_ticks(remote_origin_id, external_sensor.selector_id)
         assert len(ticks) == 1
 
         freeze_datetime = freeze_datetime + relativedelta(seconds=16)
@@ -1788,7 +1788,7 @@ def test_sensor_start_stop(executor, instance, workspace_context, external_repo)
         evaluate_sensors(workspace_context, executor)
         # should have new tick, new run, we are after the 30 second min interval
         assert instance.get_runs_count() == 2
-        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        ticks = instance.get_ticks(remote_origin_id, external_sensor.selector_id)
         assert len(ticks) == 2
 
 
@@ -1799,7 +1799,7 @@ def test_large_sensor(executor, instance, workspace_context, external_repo):
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor, timeout=300)
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -1817,7 +1817,7 @@ def test_many_request_sensor(executor, submit_executor, instance, workspace_cont
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor, submit_executor=submit_executor)
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -1837,9 +1837,7 @@ def test_cursor_sensor(executor, instance, workspace_context, external_repo):
         instance.start_sensor(run_sensor)
         evaluate_sensors(workspace_context, executor)
 
-        skip_ticks = instance.get_ticks(
-            skip_sensor.get_external_origin_id(), skip_sensor.selector_id
-        )
+        skip_ticks = instance.get_ticks(skip_sensor.get_remote_origin_id(), skip_sensor.selector_id)
         assert len(skip_ticks) == 1
         validate_tick(
             skip_ticks[0],
@@ -1849,7 +1847,7 @@ def test_cursor_sensor(executor, instance, workspace_context, external_repo):
         )
         assert skip_ticks[0].cursor == "1"
 
-        run_ticks = instance.get_ticks(run_sensor.get_external_origin_id(), run_sensor.selector_id)
+        run_ticks = instance.get_ticks(run_sensor.get_remote_origin_id(), run_sensor.selector_id)
         assert len(run_ticks) == 1
         validate_tick(
             run_ticks[0],
@@ -1863,9 +1861,7 @@ def test_cursor_sensor(executor, instance, workspace_context, external_repo):
     with freeze_time(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
 
-        skip_ticks = instance.get_ticks(
-            skip_sensor.get_external_origin_id(), skip_sensor.selector_id
-        )
+        skip_ticks = instance.get_ticks(skip_sensor.get_remote_origin_id(), skip_sensor.selector_id)
         assert len(skip_ticks) == 2
         validate_tick(
             skip_ticks[0],
@@ -1875,7 +1871,7 @@ def test_cursor_sensor(executor, instance, workspace_context, external_repo):
         )
         assert skip_ticks[0].cursor == "2"
 
-        run_ticks = instance.get_ticks(run_sensor.get_external_origin_id(), run_sensor.selector_id)
+        run_ticks = instance.get_ticks(run_sensor.get_remote_origin_id(), run_sensor.selector_id)
         assert len(run_ticks) == 2
         validate_tick(
             run_ticks[0],
@@ -1890,11 +1886,11 @@ def test_run_request_asset_selection_sensor(executor, instance, workspace_contex
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("run_request_asset_selection_sensor")
-        external_origin_id = external_sensor.get_external_origin_id()
+        remote_origin_id = external_sensor.get_remote_origin_id()
         instance.start_sensor(external_sensor)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        ticks = instance.get_ticks(remote_origin_id, external_sensor.selector_id)
         assert len(ticks) == 0
 
         evaluate_sensors(workspace_context, executor)
@@ -1902,7 +1898,7 @@ def test_run_request_asset_selection_sensor(executor, instance, workspace_contex
         assert instance.get_runs_count() == 1
         run = instance.get_runs()[0]
         assert run.asset_selection == {AssetKey("a"), AssetKey("b")}
-        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        ticks = instance.get_ticks(remote_origin_id, external_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -1923,11 +1919,11 @@ def test_run_request_check_selection_only_sensor(
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("run_request_check_only_sensor")
-        external_origin_id = external_sensor.get_external_origin_id()
+        remote_origin_id = external_sensor.get_remote_origin_id()
         instance.start_sensor(external_sensor)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        ticks = instance.get_ticks(remote_origin_id, external_sensor.selector_id)
         assert len(ticks) == 0
 
         evaluate_sensors(workspace_context, executor)
@@ -1936,7 +1932,7 @@ def test_run_request_check_selection_only_sensor(
         run = instance.get_runs()[0]
         assert run.asset_check_selection == {AssetCheckKey(AssetKey("a"), "check_a")}
         assert run.asset_selection is None
-        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        ticks = instance.get_ticks(remote_origin_id, external_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -2005,11 +2001,11 @@ def test_targets_asset_selection_sensor(executor, instance, workspace_context, e
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("targets_asset_selection_sensor")
-        external_origin_id = external_sensor.get_external_origin_id()
+        remote_origin_id = external_sensor.get_remote_origin_id()
         instance.start_sensor(external_sensor)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        ticks = instance.get_ticks(remote_origin_id, external_sensor.selector_id)
         assert len(ticks) == 0
 
         evaluate_sensors(workspace_context, executor)
@@ -2027,7 +2023,7 @@ def test_targets_asset_selection_sensor(executor, instance, workspace_context, e
             == 1
         )
         assert len([run for run in runs if run.asset_selection == {AssetKey("asset_b")}]) == 1
-        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        ticks = instance.get_ticks(remote_origin_id, external_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -2048,11 +2044,11 @@ def test_partitioned_asset_selection_sensor(executor, instance, workspace_contex
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("partitioned_asset_selection_sensor")
-        external_origin_id = external_sensor.get_external_origin_id()
+        remote_origin_id = external_sensor.get_remote_origin_id()
         instance.start_sensor(external_sensor)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        ticks = instance.get_ticks(remote_origin_id, external_sensor.selector_id)
         assert len(ticks) == 0
 
         evaluate_sensors(workspace_context, executor)
@@ -2061,7 +2057,7 @@ def test_partitioned_asset_selection_sensor(executor, instance, workspace_contex
         run = instance.get_runs()[0]
         assert run.asset_selection == {AssetKey("hourly_asset_3")}
         assert run.tags["dagster/partition"] == "2022-08-01-00:00"
-        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        ticks = instance.get_ticks(remote_origin_id, external_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -2082,7 +2078,7 @@ def test_asset_sensor(executor, instance, workspace_context, external_repo):
 
         evaluate_sensors(workspace_context, executor)
 
-        ticks = instance.get_ticks(foo_sensor.get_external_origin_id(), foo_sensor.selector_id)
+        ticks = instance.get_ticks(foo_sensor.get_remote_origin_id(), foo_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -2098,7 +2094,7 @@ def test_asset_sensor(executor, instance, workspace_context, external_repo):
 
         # should fire the asset sensor
         evaluate_sensors(workspace_context, executor)
-        ticks = instance.get_ticks(foo_sensor.get_external_origin_id(), foo_sensor.selector_id)
+        ticks = instance.get_ticks(foo_sensor.get_remote_origin_id(), foo_sensor.selector_id)
         assert len(ticks) == 2
         validate_tick(
             ticks[0],
@@ -2120,7 +2116,7 @@ def test_asset_job_sensor(executor, instance, workspace_context, external_repo):
 
         evaluate_sensors(workspace_context, executor)
 
-        ticks = instance.get_ticks(job_sensor.get_external_origin_id(), job_sensor.selector_id)
+        ticks = instance.get_ticks(job_sensor.get_remote_origin_id(), job_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -2137,7 +2133,7 @@ def test_asset_job_sensor(executor, instance, workspace_context, external_repo):
 
         # should fire the asset sensor
         evaluate_sensors(workspace_context, executor)
-        ticks = instance.get_ticks(job_sensor.get_external_origin_id(), job_sensor.selector_id)
+        ticks = instance.get_ticks(job_sensor.get_remote_origin_id(), job_sensor.selector_id)
         assert len(ticks) == 2
         validate_tick(
             ticks[0],
@@ -2165,7 +2161,7 @@ def test_asset_sensor_not_triggered_on_observation(
         # observation should not fire the asset sensor
         evaluate_sensors(workspace_context, executor)
 
-        ticks = instance.get_ticks(foo_sensor.get_external_origin_id(), foo_sensor.selector_id)
+        ticks = instance.get_ticks(foo_sensor.get_remote_origin_id(), foo_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -2181,7 +2177,7 @@ def test_asset_sensor_not_triggered_on_observation(
 
         # materialization should fire the asset sensor
         evaluate_sensors(workspace_context, executor)
-        ticks = instance.get_ticks(foo_sensor.get_external_origin_id(), foo_sensor.selector_id)
+        ticks = instance.get_ticks(foo_sensor.get_remote_origin_id(), foo_sensor.selector_id)
         assert len(ticks) == 2
         validate_tick(
             ticks[0],
@@ -2204,7 +2200,7 @@ def test_multi_asset_sensor(executor, instance, workspace_context, external_repo
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            a_and_b_sensor.get_external_origin_id(), a_and_b_sensor.selector_id
+            a_and_b_sensor.get_remote_origin_id(), a_and_b_sensor.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -2223,7 +2219,7 @@ def test_multi_asset_sensor(executor, instance, workspace_context, external_repo
 
         # sensor should not fire
         ticks = instance.get_ticks(
-            a_and_b_sensor.get_external_origin_id(), a_and_b_sensor.selector_id
+            a_and_b_sensor.get_remote_origin_id(), a_and_b_sensor.selector_id
         )
         assert len(ticks) == 2
         validate_tick(
@@ -2242,7 +2238,7 @@ def test_multi_asset_sensor(executor, instance, workspace_context, external_repo
         # should fire the asset sensor
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
-            a_and_b_sensor.get_external_origin_id(), a_and_b_sensor.selector_id
+            a_and_b_sensor.get_remote_origin_id(), a_and_b_sensor.selector_id
         )
         assert len(ticks) == 3
         validate_tick(
@@ -2266,7 +2262,7 @@ def test_asset_selection_sensor(executor, instance, workspace_context, external_
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            asset_selection_sensor.get_external_origin_id(), asset_selection_sensor.selector_id
+            asset_selection_sensor.get_remote_origin_id(), asset_selection_sensor.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -2290,7 +2286,7 @@ def test_multi_asset_sensor_targets_asset_selection(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            multi_asset_sensor_targets_asset_selection.get_external_origin_id(),
+            multi_asset_sensor_targets_asset_selection.get_remote_origin_id(),
             multi_asset_sensor_targets_asset_selection.selector_id,
         )
         assert len(ticks) == 1
@@ -2310,7 +2306,7 @@ def test_multi_asset_sensor_targets_asset_selection(
 
         # sensor should not fire
         ticks = instance.get_ticks(
-            multi_asset_sensor_targets_asset_selection.get_external_origin_id(),
+            multi_asset_sensor_targets_asset_selection.get_remote_origin_id(),
             multi_asset_sensor_targets_asset_selection.selector_id,
         )
         assert len(ticks) == 2
@@ -2330,7 +2326,7 @@ def test_multi_asset_sensor_targets_asset_selection(
         # should fire the asset sensor
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
-            multi_asset_sensor_targets_asset_selection.get_external_origin_id(),
+            multi_asset_sensor_targets_asset_selection.get_remote_origin_id(),
             multi_asset_sensor_targets_asset_selection.selector_id,
         )
         assert len(ticks) == 3
@@ -2356,7 +2352,7 @@ def test_multi_asset_sensor_w_many_events(executor, instance, workspace_context,
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            backlog_sensor.get_external_origin_id(), backlog_sensor.selector_id
+            backlog_sensor.get_remote_origin_id(), backlog_sensor.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -2374,7 +2370,7 @@ def test_multi_asset_sensor_w_many_events(executor, instance, workspace_context,
         # sensor should not fire
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
-            backlog_sensor.get_external_origin_id(), backlog_sensor.selector_id
+            backlog_sensor.get_remote_origin_id(), backlog_sensor.selector_id
         )
         assert len(ticks) == 2
         validate_tick(
@@ -2393,7 +2389,7 @@ def test_multi_asset_sensor_w_many_events(executor, instance, workspace_context,
         # should fire the asset sensor
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
-            backlog_sensor.get_external_origin_id(), backlog_sensor.selector_id
+            backlog_sensor.get_remote_origin_id(), backlog_sensor.selector_id
         )
         assert len(ticks) == 3
         validate_tick(
@@ -2418,9 +2414,7 @@ def test_multi_asset_sensor_w_no_cursor_update(
 
         evaluate_sensors(workspace_context, executor)
 
-        ticks = instance.get_ticks(
-            cursor_sensor.get_external_origin_id(), cursor_sensor.selector_id
-        )
+        ticks = instance.get_ticks(cursor_sensor.get_remote_origin_id(), cursor_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -2435,9 +2429,7 @@ def test_multi_asset_sensor_w_no_cursor_update(
         materialize([asset_a], instance=instance)
 
         evaluate_sensors(workspace_context, executor)
-        ticks = instance.get_ticks(
-            cursor_sensor.get_external_origin_id(), cursor_sensor.selector_id
-        )
+        ticks = instance.get_ticks(cursor_sensor.get_remote_origin_id(), cursor_sensor.selector_id)
         assert len(ticks) == 2
         validate_tick(
             ticks[0],
@@ -2456,9 +2448,7 @@ def test_multi_asset_sensor_hourly_to_weekly(executor, instance, workspace_conte
 
         evaluate_sensors(workspace_context, executor)
 
-        ticks = instance.get_ticks(
-            cursor_sensor.get_external_origin_id(), cursor_sensor.selector_id
-        )
+        ticks = instance.get_ticks(cursor_sensor.get_remote_origin_id(), cursor_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -2482,9 +2472,7 @@ def test_multi_asset_sensor_hourly_to_hourly(executor, instance, workspace_conte
 
         evaluate_sensors(workspace_context, executor)
 
-        ticks = instance.get_ticks(
-            cursor_sensor.get_external_origin_id(), cursor_sensor.selector_id
-        )
+        ticks = instance.get_ticks(cursor_sensor.get_remote_origin_id(), cursor_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -2507,9 +2495,7 @@ def test_multi_asset_sensor_hourly_to_hourly(executor, instance, workspace_conte
 
         evaluate_sensors(workspace_context, executor)
 
-        ticks = instance.get_ticks(
-            cursor_sensor.get_external_origin_id(), cursor_sensor.selector_id
-        )
+        ticks = instance.get_ticks(cursor_sensor.get_remote_origin_id(), cursor_sensor.selector_id)
         assert len(ticks) == 2
         validate_tick(ticks[0], cursor_sensor, freeze_datetime, TickStatus.SKIPPED)
 
@@ -2522,9 +2508,7 @@ def test_sensor_result_multi_asset_sensor(executor, instance, workspace_context,
 
         evaluate_sensors(workspace_context, executor)
 
-        ticks = instance.get_ticks(
-            cursor_sensor.get_external_origin_id(), cursor_sensor.selector_id
-        )
+        ticks = instance.get_ticks(cursor_sensor.get_remote_origin_id(), cursor_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -2544,9 +2528,7 @@ def test_cursor_update_sensor_result_multi_asset_sensor(
 
         evaluate_sensors(workspace_context, executor)
 
-        ticks = instance.get_ticks(
-            cursor_sensor.get_external_origin_id(), cursor_sensor.selector_id
-        )
+        ticks = instance.get_ticks(cursor_sensor.get_remote_origin_id(), cursor_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -2565,7 +2547,7 @@ def test_multi_job_sensor(executor, instance, workspace_context, external_repo):
 
         evaluate_sensors(workspace_context, executor)
 
-        ticks = instance.get_ticks(job_sensor.get_external_origin_id(), job_sensor.selector_id)
+        ticks = instance.get_ticks(job_sensor.get_remote_origin_id(), job_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -2583,7 +2565,7 @@ def test_multi_job_sensor(executor, instance, workspace_context, external_repo):
     with freeze_time(freeze_datetime):
         # should fire the asset sensor
         evaluate_sensors(workspace_context, executor)
-        ticks = instance.get_ticks(job_sensor.get_external_origin_id(), job_sensor.selector_id)
+        ticks = instance.get_ticks(job_sensor.get_remote_origin_id(), job_sensor.selector_id)
         assert len(ticks) == 2
         validate_tick(
             ticks[0],
@@ -2606,7 +2588,7 @@ def test_bad_run_request_untargeted(executor, instance, workspace_context, exter
 
         evaluate_sensors(workspace_context, executor)
 
-        ticks = instance.get_ticks(job_sensor.get_external_origin_id(), job_sensor.selector_id)
+        ticks = instance.get_ticks(job_sensor.get_remote_origin_id(), job_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -2628,7 +2610,7 @@ def test_bad_run_request_mismatch(executor, instance, workspace_context, externa
 
         evaluate_sensors(workspace_context, executor)
 
-        ticks = instance.get_ticks(job_sensor.get_external_origin_id(), job_sensor.selector_id)
+        ticks = instance.get_ticks(job_sensor.get_remote_origin_id(), job_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -2649,7 +2631,7 @@ def test_bad_run_request_unspecified(executor, instance, workspace_context, exte
 
         evaluate_sensors(workspace_context, executor)
 
-        ticks = instance.get_ticks(job_sensor.get_external_origin_id(), job_sensor.selector_id)
+        ticks = instance.get_ticks(job_sensor.get_remote_origin_id(), job_sensor.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -2677,8 +2659,8 @@ def test_status_in_code_sensor(executor, instance):
             running_sensor = external_repo.get_external_sensor("always_running_sensor")
             not_running_sensor = external_repo.get_external_sensor("never_running_sensor")
 
-            always_running_origin = running_sensor.get_external_origin()
-            never_running_origin = not_running_sensor.get_external_origin()
+            always_running_origin = running_sensor.get_remote_origin()
+            never_running_origin = not_running_sensor.get_remote_origin()
 
             assert instance.get_runs_count() == 0
             assert (
@@ -2708,7 +2690,7 @@ def test_status_in_code_sensor(executor, instance):
             assert instigator_state.status == InstigatorStatus.DECLARED_IN_CODE
 
             ticks = instance.get_ticks(
-                running_sensor.get_external_origin_id(), running_sensor.selector_id
+                running_sensor.get_remote_origin_id(), running_sensor.selector_id
             )
             assert len(ticks) == 1
             validate_tick(
@@ -2765,7 +2747,7 @@ def test_status_in_code_sensor(executor, instance):
 
             # time hasn't advanced, so tick count shouldn't change either
             ticks = instance.get_ticks(
-                running_sensor.get_external_origin_id(), running_sensor.selector_id
+                running_sensor.get_remote_origin_id(), running_sensor.selector_id
             )
             assert len(ticks) == 1
 
@@ -2777,7 +2759,7 @@ def test_status_in_code_sensor(executor, instance):
             run = instance.get_runs()[0]
             validate_run_started(run)
             ticks = instance.get_ticks(
-                running_sensor.get_external_origin_id(), running_sensor.selector_id
+                running_sensor.get_remote_origin_id(), running_sensor.selector_id
             )
 
             assert len(ticks) == 2
@@ -2810,14 +2792,14 @@ def test_run_request_list_sensor(executor, instance, workspace_context, external
         external_sensor = external_repo.get_external_sensor("request_list_sensor")
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 0
 
@@ -2825,7 +2807,7 @@ def test_run_request_list_sensor(executor, instance, workspace_context, external
 
         assert instance.get_runs_count() == 2
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
 
@@ -2836,13 +2818,13 @@ def test_sensor_purge(executor, instance, workspace_context, external_repo):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 0
 
@@ -2850,7 +2832,7 @@ def test_sensor_purge(executor, instance, workspace_context, external_repo):
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
         freeze_datetime = freeze_datetime + relativedelta(days=6)
@@ -2859,7 +2841,7 @@ def test_sensor_purge(executor, instance, workspace_context, external_repo):
         # create another tick
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 2
 
@@ -2869,7 +2851,7 @@ def test_sensor_purge(executor, instance, workspace_context, external_repo):
         # create another tick, but the first tick should be purged
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 2
 
@@ -2887,13 +2869,13 @@ def test_sensor_custom_purge(executor, workspace_context, external_repo):
             external_sensor = external_repo.get_external_sensor("simple_sensor")
             instance.add_instigator_state(
                 InstigatorState(
-                    external_sensor.get_external_origin(),
+                    external_sensor.get_remote_origin(),
                     InstigatorType.SENSOR,
                     InstigatorStatus.RUNNING,
                 )
             )
             ticks = instance.get_ticks(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
+                external_sensor.get_remote_origin_id(), external_sensor.selector_id
             )
             assert len(ticks) == 0
 
@@ -2901,7 +2883,7 @@ def test_sensor_custom_purge(executor, workspace_context, external_repo):
             evaluate_sensors(purge_ws_ctx, executor)
 
             ticks = instance.get_ticks(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
+                external_sensor.get_remote_origin_id(), external_sensor.selector_id
             )
             assert len(ticks) == 1
             freeze_datetime = freeze_datetime + relativedelta(days=8)
@@ -2911,7 +2893,7 @@ def test_sensor_custom_purge(executor, workspace_context, external_repo):
             # default purge day offset is 7
             evaluate_sensors(purge_ws_ctx, executor)
             ticks = instance.get_ticks(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
+                external_sensor.get_remote_origin_id(), external_sensor.selector_id
             )
             assert len(ticks) == 2
 
@@ -2921,7 +2903,7 @@ def test_sensor_custom_purge(executor, workspace_context, external_repo):
             # create another tick, but the first tick should be purged
             evaluate_sensors(purge_ws_ctx, executor)
             ticks = instance.get_ticks(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
+                external_sensor.get_remote_origin_id(), external_sensor.selector_id
             )
             assert len(ticks) == 2
 
@@ -2956,7 +2938,7 @@ def test_repository_namespacing(executor):
         status_in_code_repo = full_location.get_repository("the_status_in_code_repo")
         running_sensor = status_in_code_repo.get_external_sensor("always_running_sensor")
         instance.stop_sensor(
-            running_sensor.get_external_origin_id(), running_sensor.selector_id, running_sensor
+            running_sensor.get_remote_origin_id(), running_sensor.selector_id, running_sensor
         )
 
         external_sensor = external_repo.get_external_sensor("run_key_sensor")
@@ -2966,14 +2948,14 @@ def test_repository_namespacing(executor):
             instance.start_sensor(external_sensor)
             assert instance.get_runs_count() == 0
             ticks = instance.get_ticks(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
+                external_sensor.get_remote_origin_id(), external_sensor.selector_id
             )
             assert len(ticks) == 0
 
             instance.start_sensor(other_sensor)
             assert instance.get_runs_count() == 0
             ticks = instance.get_ticks(
-                other_sensor.get_external_origin_id(), other_sensor.selector_id
+                other_sensor.get_remote_origin_id(), other_sensor.selector_id
             )
             assert len(ticks) == 0
 
@@ -2984,13 +2966,13 @@ def test_repository_namespacing(executor):
             assert instance.get_runs_count() == 2  # both copies of the sensor
 
             ticks = instance.get_ticks(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
+                external_sensor.get_remote_origin_id(), external_sensor.selector_id
             )
             assert len(ticks) == 1
             assert ticks[0].status == TickStatus.SUCCESS
 
             ticks = instance.get_ticks(
-                other_sensor.get_external_origin_id(), other_sensor.selector_id
+                other_sensor.get_remote_origin_id(), other_sensor.selector_id
             )
             assert len(ticks) == 1
 
@@ -3000,7 +2982,7 @@ def test_repository_namespacing(executor):
             evaluate_sensors(full_workspace_context, executor)
             assert instance.get_runs_count() == 2  # still 2
             ticks = instance.get_ticks(
-                external_sensor.get_external_origin_id(), external_sensor.selector_id
+                external_sensor.get_remote_origin_id(), external_sensor.selector_id
             )
             assert len(ticks) == 2
 
@@ -3016,22 +2998,18 @@ def test_sensor_logging(executor, instance, workspace_context, external_repo, se
     external_sensor = external_repo.get_external_sensor(sensor_name)
     instance.add_instigator_state(
         InstigatorState(
-            external_sensor.get_external_origin(),
+            external_sensor.get_remote_origin(),
             InstigatorType.SENSOR,
             InstigatorStatus.RUNNING,
         )
     )
     assert instance.get_runs_count() == 0
-    ticks = instance.get_ticks(
-        external_sensor.get_external_origin_id(), external_sensor.selector_id
-    )
+    ticks = instance.get_ticks(external_sensor.get_remote_origin_id(), external_sensor.selector_id)
     assert len(ticks) == 0
 
     evaluate_sensors(workspace_context, executor)
 
-    ticks = instance.get_ticks(
-        external_sensor.get_external_origin_id(), external_sensor.selector_id
-    )
+    ticks = instance.get_ticks(external_sensor.get_remote_origin_id(), external_sensor.selector_id)
     assert len(ticks) == 1
     tick = ticks[0]
     assert tick.log_key == [
@@ -3059,23 +3037,19 @@ def test_sensor_logging_on_tick_failure(
     external_sensor = external_repo.get_external_sensor("logging_fail_tick_sensor")
     instance.add_instigator_state(
         InstigatorState(
-            external_sensor.get_external_origin(),
+            external_sensor.get_remote_origin(),
             InstigatorType.SENSOR,
             InstigatorStatus.RUNNING,
         )
     )
-    ticks = instance.get_ticks(
-        external_sensor.get_external_origin_id(), external_sensor.selector_id
-    )
+    ticks = instance.get_ticks(external_sensor.get_remote_origin_id(), external_sensor.selector_id)
 
     assert instance.get_runs_count() == 0
     assert len(ticks) == 0
 
     evaluate_sensors(workspace_context, executor)
 
-    ticks = instance.get_ticks(
-        external_sensor.get_external_origin_id(), external_sensor.selector_id
-    )
+    ticks = instance.get_ticks(external_sensor.get_remote_origin_id(), external_sensor.selector_id)
 
     assert len(ticks) == 1
 
@@ -3107,22 +3081,18 @@ def test_add_dynamic_partitions_sensor(
     external_sensor = external_repo.get_external_sensor("add_dynamic_partitions_sensor")
     instance.add_instigator_state(
         InstigatorState(
-            external_sensor.get_external_origin(),
+            external_sensor.get_remote_origin(),
             InstigatorType.SENSOR,
             InstigatorStatus.RUNNING,
         )
     )
-    ticks = instance.get_ticks(
-        external_sensor.get_external_origin_id(), external_sensor.selector_id
-    )
+    ticks = instance.get_ticks(external_sensor.get_remote_origin_id(), external_sensor.selector_id)
     assert len(ticks) == 0
 
     evaluate_sensors(workspace_context, executor)
 
     assert set(instance.get_dynamic_partitions("quux")) == set(["baz", "foo"])
-    ticks = instance.get_ticks(
-        external_sensor.get_external_origin_id(), external_sensor.selector_id
-    )
+    ticks = instance.get_ticks(external_sensor.get_remote_origin_id(), external_sensor.selector_id)
 
     assert "Added partition keys to dynamic partitions definition 'quux': ['baz']" in caplog.text
     assert (
@@ -3147,14 +3117,12 @@ def test_add_delete_skip_dynamic_partitions(
     )
     instance.add_instigator_state(
         InstigatorState(
-            external_sensor.get_external_origin(),
+            external_sensor.get_remote_origin(),
             InstigatorType.SENSOR,
             InstigatorStatus.RUNNING,
         )
     )
-    ticks = instance.get_ticks(
-        external_sensor.get_external_origin_id(), external_sensor.selector_id
-    )
+    ticks = instance.get_ticks(external_sensor.get_remote_origin_id(), external_sensor.selector_id)
     assert len(ticks) == 0
 
     freeze_datetime = create_datetime(
@@ -3170,7 +3138,7 @@ def test_add_delete_skip_dynamic_partitions(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
         assert set(instance.get_dynamic_partitions("quux")) == set(["1"])
@@ -3204,7 +3172,7 @@ def test_add_delete_skip_dynamic_partitions(
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 2
 
@@ -3238,21 +3206,17 @@ def test_error_on_deleted_dynamic_partitions_run_request(
     )
     instance.add_instigator_state(
         InstigatorState(
-            external_sensor.get_external_origin(),
+            external_sensor.get_remote_origin(),
             InstigatorType.SENSOR,
             InstigatorStatus.RUNNING,
         )
     )
-    ticks = instance.get_ticks(
-        external_sensor.get_external_origin_id(), external_sensor.selector_id
-    )
+    ticks = instance.get_ticks(external_sensor.get_remote_origin_id(), external_sensor.selector_id)
     assert len(ticks) == 0
 
     evaluate_sensors(workspace_context, executor)
 
-    ticks = instance.get_ticks(
-        external_sensor.get_external_origin_id(), external_sensor.selector_id
-    )
+    ticks = instance.get_ticks(external_sensor.get_remote_origin_id(), external_sensor.selector_id)
     assert len(ticks) == 1
     validate_tick(
         ticks[0],
@@ -3278,21 +3242,17 @@ def test_multipartitions_with_dynamic_dims_run_request_sensor(
     external_sensor = external_repo.get_external_sensor(sensor_name)
     instance.add_instigator_state(
         InstigatorState(
-            external_sensor.get_external_origin(),
+            external_sensor.get_remote_origin(),
             InstigatorType.SENSOR,
             InstigatorStatus.RUNNING,
         )
     )
-    ticks = instance.get_ticks(
-        external_sensor.get_external_origin_id(), external_sensor.selector_id
-    )
+    ticks = instance.get_ticks(external_sensor.get_remote_origin_id(), external_sensor.selector_id)
     assert len(ticks) == 0
 
     evaluate_sensors(workspace_context, executor)
 
-    ticks = instance.get_ticks(
-        external_sensor.get_external_origin_id(), external_sensor.selector_id
-    )
+    ticks = instance.get_ticks(external_sensor.get_remote_origin_id(), external_sensor.selector_id)
     assert len(ticks) == 1
 
     if is_expected_success:
@@ -3322,21 +3282,17 @@ def test_multipartition_asset_with_static_time_dimensions_run_requests_sensor(
     )
     instance.add_instigator_state(
         InstigatorState(
-            external_sensor.get_external_origin(),
+            external_sensor.get_remote_origin(),
             InstigatorType.SENSOR,
             InstigatorStatus.RUNNING,
         )
     )
-    ticks = instance.get_ticks(
-        external_sensor.get_external_origin_id(), external_sensor.selector_id
-    )
+    ticks = instance.get_ticks(external_sensor.get_remote_origin_id(), external_sensor.selector_id)
     assert len(ticks) == 0
 
     evaluate_sensors(workspace_context, executor)
 
-    ticks = instance.get_ticks(
-        external_sensor.get_external_origin_id(), external_sensor.selector_id
-    )
+    ticks = instance.get_ticks(external_sensor.get_remote_origin_id(), external_sensor.selector_id)
     assert len(ticks) == 1
 
     validate_tick(
@@ -3374,14 +3330,14 @@ def test_stale_request_context(instance, workspace_context, external_repo):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 0
 
@@ -3400,7 +3356,7 @@ def test_stale_request_context(instance, workspace_context, external_repo):
 
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -3436,7 +3392,7 @@ def test_stale_request_context(instance, workspace_context, external_repo):
         wait_for_futures(futures, timeout=FUTURES_TIMEOUT)
 
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 2
 
@@ -3476,7 +3432,7 @@ def test_start_tick_sensor(executor, instance, workspace_context, external_repo)
     freeze_datetime = freeze_datetime + relativedelta(seconds=60)
     with freeze_time(freeze_datetime):
         instance.stop_sensor(
-            start_skip_sensor.get_external_origin_id(),
+            start_skip_sensor.get_remote_origin_id(),
             start_skip_sensor.selector_id,
             start_skip_sensor,
         )
@@ -3497,7 +3453,7 @@ def test_start_tick_sensor(executor, instance, workspace_context, external_repo)
 
 
 def _get_last_tick(instance, sensor):
-    ticks = instance.get_ticks(sensor.get_external_origin_id(), sensor.selector_id)
+    ticks = instance.get_ticks(sensor.get_remote_origin_id(), sensor.selector_id)
     return ticks[0]
 
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_asset_checks.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_asset_checks.py
@@ -61,7 +61,7 @@ def test_asset_check_run_request_sensor(instance: DagsterInstance, executor):
 
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
@@ -70,7 +70,7 @@ def test_asset_check_run_request_sensor(instance: DagsterInstance, executor):
 
         assert instance.get_runs_count() == 1
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_daemon.py
@@ -164,7 +164,7 @@ def test_backfill_request_sensor(instance: DagsterInstance, executor, sensor_nam
 
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
@@ -173,7 +173,7 @@ def test_backfill_request_sensor(instance: DagsterInstance, executor, sensor_nam
 
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
 
@@ -210,14 +210,14 @@ def test_asset_selection_outside_of_range(instance, executor):
 
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
 
         validate_tick(
@@ -241,14 +241,14 @@ def test_invalid_partition(instance, executor):
 
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
 
         # allow creating a backfill with an invalid partition. it will get caught in the daemon
@@ -271,14 +271,14 @@ def test_single_partition(instance, executor):
 
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
 
         backfills = instance.get_backfills()
@@ -303,14 +303,14 @@ def test_backfill_and_run_request(instance, executor):
 
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_external_origin(),
+                external_sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
-            external_sensor.get_external_origin_id(), external_sensor.selector_id
+            external_sensor.get_remote_origin_id(), external_sensor.selector_id
         )
 
         backfills = instance.get_backfills()

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -511,7 +511,7 @@ def test_simple_backfill(
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
-            partition_set_origin=external_partition_set.get_external_origin(),
+            partition_set_origin=external_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -544,7 +544,7 @@ def test_canceled_backfill(
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
-            partition_set_origin=external_partition_set.get_external_origin(),
+            partition_set_origin=external_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -582,7 +582,7 @@ def test_failure_backfill(
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="shouldfail",
-            partition_set_origin=external_partition_set.get_external_origin(),
+            partition_set_origin=external_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -631,7 +631,7 @@ def test_failure_backfill(
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="fromfailure",
-            partition_set_origin=external_partition_set.get_external_origin(),
+            partition_set_origin=external_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=True,
@@ -683,7 +683,7 @@ def test_job_backfill_status(
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
-            partition_set_origin=external_partition_set.get_external_origin(),
+            partition_set_origin=external_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -743,7 +743,7 @@ def test_partial_backfill(
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="full",
-            partition_set_origin=external_partition_set.get_external_origin(),
+            partition_set_origin=external_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -790,7 +790,7 @@ def test_partial_backfill(
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="partial",
-            partition_set_origin=external_partition_set.get_external_origin(),
+            partition_set_origin=external_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -833,7 +833,7 @@ def test_large_backfill(
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
-            partition_set_origin=external_partition_set.get_external_origin(),
+            partition_set_origin=external_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -1072,7 +1072,7 @@ def test_backfill_from_partitioned_job(
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="partition_schedule_from_job",
-            partition_set_origin=external_partition_set.get_external_origin(),
+            partition_set_origin=external_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=partition_keys[:3],
             from_failure=False,
@@ -1107,7 +1107,7 @@ def test_backfill_with_asset_selection(
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="backfill_with_asset_selection",
-            partition_set_origin=external_partition_set.get_external_origin(),
+            partition_set_origin=external_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=partition_keys,
             from_failure=False,
@@ -1277,7 +1277,7 @@ def test_backfill_from_failure_for_subselection(
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="fromfailure",
-            partition_set_origin=external_partition_set.get_external_origin(),
+            partition_set_origin=external_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one"],
             from_failure=True,
@@ -1958,7 +1958,7 @@ def _get_abcd_job_backfill(external_repo: ExternalRepository, job_name: str) -> 
     external_partition_set = external_repo.get_external_partition_set(f"{job_name}_partition_set")
     return PartitionBackfill(
         backfill_id="simple",
-        partition_set_origin=external_partition_set.get_external_origin(),
+        partition_set_origin=external_partition_set.get_remote_origin(),
         status=BulkActionStatus.REQUESTED,
         partition_names=["a", "b", "c", "d"],
         from_failure=False,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
@@ -52,7 +52,7 @@ def test_simple(instance: DagsterInstance, external_repo: ExternalRepository):
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
-            partition_set_origin=external_partition_set.get_external_origin(),
+            partition_set_origin=external_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -83,7 +83,7 @@ def test_before_submit(
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
-            partition_set_origin=external_partition_set.get_external_origin(),
+            partition_set_origin=external_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -130,7 +130,7 @@ def test_crash_after_submit(
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
-            partition_set_origin=external_partition_set.get_external_origin(),
+            partition_set_origin=external_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -92,7 +92,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     def create_run(self, instance, job_handle, **kwargs):
         create_run_for_test(
             instance,
-            external_job_origin=job_handle.get_external_origin(),
+            external_job_origin=job_handle.get_remote_origin(),
             job_code_origin=job_handle.get_python_origin(),
             job_name="foo",
             **kwargs,
@@ -101,7 +101,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     def create_queued_run(self, instance, job_handle, **kwargs):
         run = create_run_for_test(
             instance,
-            external_job_origin=job_handle.get_external_origin(),
+            external_job_origin=job_handle.get_remote_origin(),
             job_code_origin=job_handle.get_python_origin(),
             job_name="foo",
             status=DagsterRunStatus.NOT_STARTED,
@@ -135,7 +135,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         )
         run = create_run_for_test(
             instance,
-            external_job_origin=subset_job.get_external_origin(),
+            external_job_origin=subset_job.get_remote_origin(),
             job_code_origin=subset_job.get_python_origin(),
             job_name=subset_job.name,
             execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -97,7 +97,7 @@ def test_default_auto_materialize_sensors(instance_with_auto_materialize_sensors
     instance = instance_with_auto_materialize_sensors
 
     repo_handle = MagicMock(spec=RepositoryHandle)
-    repo_handle.get_external_origin.return_value = RemoteRepositoryOrigin(
+    repo_handle.get_remote_origin.return_value = RemoteRepositoryOrigin(
         code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
         repository_name="bar_repo",
     )
@@ -135,7 +135,7 @@ def test_default_auto_materialize_sensors_without_observable(
     instance = instance_with_auto_materialize_sensors
 
     repo_handle = MagicMock(spec=RepositoryHandle)
-    repo_handle.get_external_origin.return_value = RemoteRepositoryOrigin(
+    repo_handle.get_remote_origin.return_value = RemoteRepositoryOrigin(
         code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
         repository_name="bar_repo",
     )
@@ -162,7 +162,7 @@ def test_default_auto_materialize_sensors_without_observable(
 
 def test_no_default_auto_materialize_sensors(instance_without_auto_materialize_sensors):
     repo_handle = MagicMock(spec=RepositoryHandle)
-    repo_handle.get_external_origin.return_value = RemoteRepositoryOrigin(
+    repo_handle.get_remote_origin.return_value = RemoteRepositoryOrigin(
         code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
         repository_name="bar_repo",
     )
@@ -199,7 +199,7 @@ def test_combine_default_sensors_with_non_default_sensors(instance_with_auto_mat
     )
 
     repo_handle = MagicMock(spec=RepositoryHandle)
-    repo_handle.get_external_origin.return_value = RemoteRepositoryOrigin(
+    repo_handle.get_remote_origin.return_value = RemoteRepositoryOrigin(
         code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
         repository_name="bar_repo",
     )
@@ -270,7 +270,7 @@ def test_custom_sensors_cover_all(instance_with_auto_materialize_sensors):
     )
 
     repo_handle = MagicMock(spec=RepositoryHandle)
-    repo_handle.get_external_origin.return_value = RemoteRepositoryOrigin(
+    repo_handle.get_remote_origin.return_value = RemoteRepositoryOrigin(
         code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
         repository_name="bar_repo",
     )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -134,11 +134,9 @@ def _get_current_state(context: WorkspaceRequestContext) -> Mapping[str, Instiga
     state_by_name = {}
     for sensor in _get_automation_sensors(context):
         state = check.not_none(
-            context.instance.get_instigator_state(
-                sensor.get_external_origin_id(), sensor.selector_id
-            )
+            context.instance.get_instigator_state(sensor.get_remote_origin_id(), sensor.selector_id)
         )
-        state_by_name[f"{sensor.name}_{sensor.get_external_origin_id()}"] = state
+        state_by_name[f"{sensor.name}_{sensor.get_remote_origin_id()}"] = state
     return state_by_name
 
 
@@ -163,8 +161,8 @@ def _get_runs_for_latest_ticks(context: WorkspaceProcessContext) -> Sequence[Dag
     request_context = context.create_request_context()
     for sensor in _get_automation_sensors(request_context):
         ticks = request_context.instance.get_ticks(
-            sensor.get_external_origin_id(),
-            sensor.get_external_origin().get_selector().get_id(),
+            sensor.get_remote_origin_id(),
+            sensor.get_remote_origin().get_selector().get_id(),
             limit=1,
         )
         latest_tick = next(iter(ticks), None)

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
@@ -219,7 +219,7 @@ class AssetDaemonScenarioState(ScenarioState):
             if sensor:
                 auto_materialize_instigator_state = check.not_none(
                     self.instance.get_instigator_state(
-                        sensor.get_external_origin_id(), sensor.selector_id
+                        sensor.get_remote_origin_id(), sensor.selector_id
                     )
                 )
                 new_cursor = asset_daemon_cursor_from_instigator_serialized_cursor(

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/scenario_state.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/scenario_state.py
@@ -424,7 +424,7 @@ class ScenarioState:
 
     def stop_sensor(self, sensor_name: str) -> Self:
         with self._get_external_sensor(sensor_name) as sensor:
-            self.instance.stop_sensor(sensor.get_external_origin_id(), sensor.selector_id, sensor)
+            self.instance.stop_sensor(sensor.get_remote_origin_id(), sensor.selector_id, sensor)
         return self
 
     @contextmanager

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
@@ -212,7 +212,7 @@ def _create_run(
     )
     run = instance.create_run_for_job(
         job_def=job_def,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
     run = instance.get_run_by_id(run.run_id)

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -964,7 +964,7 @@ def test_add_bulk_actions_columns():
             assert backfill_count == migrated_row_count
 
             # check that we are writing to selector id, action types
-            external_origin = RemotePartitionSetOrigin(
+            remote_origin = RemotePartitionSetOrigin(
                 repository_origin=RemoteRepositoryOrigin(
                     code_location_origin=GrpcServerCodeLocationOrigin(port=1234, host="localhost"),
                     repository_name="fake_repository",
@@ -974,7 +974,7 @@ def test_add_bulk_actions_columns():
             instance.add_backfill(
                 PartitionBackfill(
                     backfill_id="simple",
-                    partition_set_origin=external_origin,
+                    partition_set_origin=remote_origin,
                     status=BulkActionStatus.REQUESTED,
                     partition_names=["one", "two", "three"],
                     from_failure=False,

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
@@ -210,7 +210,7 @@ def test_successful_run(
     dagster_run = instance.create_run_for_job(
         job_def=noop_job,
         run_config=run_config,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
     run_id = dagster_run.run_id
@@ -270,7 +270,7 @@ def test_successful_run_from_pending(
         job_snapshot=external_job.job_snapshot,
         execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,
         parent_job_snapshot=external_job.parent_job_snapshot,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
         asset_selection=None,
         op_selection=None,
@@ -348,7 +348,7 @@ def test_invalid_instance_run():
 
                         run = instance.create_run_for_job(
                             job_def=noop_job,
-                            external_job_origin=external_job.get_external_origin(),
+                            external_job_origin=external_job.get_remote_origin(),
                             job_code_origin=external_job.get_python_origin(),
                         )
                         with pytest.raises(
@@ -385,7 +385,7 @@ def test_crashy_run(
     run = instance.create_run_for_job(
         job_def=crashy_job,
         run_config=run_config,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
 
@@ -467,7 +467,7 @@ def test_exity_run(
     run = instance.create_run_for_job(
         job_def=exity_job,
         run_config=run_config,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
 
@@ -527,7 +527,7 @@ def test_terminated_run(
     run = instance.create_run_for_job(
         job_def=sleepy_job,
         run_config=run_config,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
 
@@ -630,7 +630,7 @@ def test_cleanup_after_force_terminate(
     run = instance.create_run_for_job(
         job_def=sleepy_job,
         run_config=run_config,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
 
@@ -731,7 +731,7 @@ def test_single_op_selection_execution(
         job_def=math_diamond,
         run_config=run_config,
         op_selection=["return_one"],
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
     run_id = run.run_id
@@ -770,7 +770,7 @@ def test_multi_op_selection_execution(
         job_def=math_diamond,
         run_config=run_config,
         op_selection=["return_one", "multiply_by_2"],
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
     run_id = run.run_id
@@ -809,7 +809,7 @@ def test_job_that_fails_run_worker(
     run = instance.create_run_for_job(
         job_def=job_that_fails_run_worker,
         run_config={},
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
     run_id = run.run_id
@@ -858,7 +858,7 @@ def test_engine_events(
     run = instance.create_run_for_job(
         job_def=math_diamond,
         run_config=run_config,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
     run_id = run.run_id

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
@@ -55,7 +55,7 @@ def test_run_always_finishes():
                 dagster_run = instance.create_run_for_job(
                     job_def=slow_job,
                     run_config=None,
-                    external_job_origin=external_job.get_external_origin(),
+                    external_job_origin=external_job.get_remote_origin(),
                     job_code_origin=external_job.get_python_origin(),
                 )
                 run_id = dagster_run.run_id
@@ -146,7 +146,7 @@ def test_run_from_pending_repository():
                     job_snapshot=external_job.job_snapshot,
                     execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,
                     parent_job_snapshot=external_job.parent_job_snapshot,
-                    external_job_origin=external_job.get_external_origin(),
+                    external_job_origin=external_job.get_remote_origin(),
                     job_code_origin=external_job.get_python_origin(),
                     asset_selection=None,
                     op_selection=None,
@@ -218,7 +218,7 @@ def test_terminate_after_shutdown():
             dagster_run = instance.create_run_for_job(
                 job_def=sleepy_job,
                 run_config=None,
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=external_job.get_python_origin(),
             )
 
@@ -241,7 +241,7 @@ def test_terminate_after_shutdown():
             doomed_to_fail_dagster_run = instance.create_run_for_job(
                 job_def=math_diamond,
                 run_config=None,
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=external_job.get_python_origin(),
             )
 
@@ -290,7 +290,7 @@ def test_server_down():
                 dagster_run = instance.create_run_for_job(
                     job_def=sleepy_job,
                     run_config=None,
-                    external_job_origin=external_job.get_external_origin(),
+                    external_job_origin=external_job.get_remote_origin(),
                     job_code_origin=external_job.get_python_origin(),
                 )
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_pythonic_resources.py
@@ -191,7 +191,7 @@ def test_resources(
 
         assert instance.get_runs_count() == 0
         ticks = instance.get_ticks(
-            external_schedule.get_external_origin_id(), external_schedule.selector_id
+            external_schedule.get_remote_origin_id(), external_schedule.selector_id
         )
         assert len(ticks) == 0
     freeze_datetime = freeze_datetime + relativedelta(seconds=30)
@@ -201,7 +201,7 @@ def test_resources(
         wait_for_all_runs_to_start(instance)
 
         ticks: Sequence[InstigatorTick] = instance.get_ticks(
-            external_schedule.get_external_origin_id(), external_schedule.selector_id
+            external_schedule.get_remote_origin_id(), external_schedule.selector_id
         )
 
         assert len(ticks) == 1

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
@@ -105,7 +105,7 @@ def test_failure_recovery_before_run_created(
         assert scheduler_process.exitcode != 0
 
         ticks = instance.get_ticks(
-            external_schedule.get_external_origin_id(), external_schedule.selector_id
+            external_schedule.get_remote_origin_id(), external_schedule.selector_id
         )
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.STARTED
@@ -131,7 +131,7 @@ def test_failure_recovery_before_run_created(
         )
 
         ticks = instance.get_ticks(
-            external_schedule.get_external_origin_id(), external_schedule.selector_id
+            external_schedule.get_remote_origin_id(), external_schedule.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -176,7 +176,7 @@ def test_failure_recovery_after_run_created(
         assert scheduler_process.exitcode != 0
 
         ticks = instance.get_ticks(
-            external_schedule.get_external_origin_id(), external_schedule.selector_id
+            external_schedule.get_remote_origin_id(), external_schedule.selector_id
         )
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.STARTED
@@ -220,7 +220,7 @@ def test_failure_recovery_after_run_created(
         validate_run_exists(instance.get_runs()[0], initial_datetime)
 
         ticks = instance.get_ticks(
-            external_schedule.get_external_origin_id(), external_schedule.selector_id
+            external_schedule.get_remote_origin_id(), external_schedule.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -271,7 +271,7 @@ def test_failure_recovery_after_tick_success(
         validate_run_exists(instance.get_runs()[0], initial_datetime)
 
         ticks = instance.get_ticks(
-            external_schedule.get_external_origin_id(), external_schedule.selector_id
+            external_schedule.get_remote_origin_id(), external_schedule.selector_id
         )
         assert len(ticks) == 1
 
@@ -303,7 +303,7 @@ def test_failure_recovery_after_tick_success(
         validate_run_exists(instance.get_runs()[0], initial_datetime)
 
         ticks = instance.get_ticks(
-            external_schedule.get_external_origin_id(), external_schedule.selector_id
+            external_schedule.get_remote_origin_id(), external_schedule.selector_id
         )
         assert len(ticks) == 1
         validate_tick(
@@ -350,7 +350,7 @@ def test_failure_recovery_between_multi_runs(
         validate_run_exists(instance.get_runs()[0], initial_datetime)
 
         ticks = instance.get_ticks(
-            external_schedule.get_external_origin_id(), external_schedule.selector_id
+            external_schedule.get_remote_origin_id(), external_schedule.selector_id
         )
         assert len(ticks) == 1
 
@@ -366,7 +366,7 @@ def test_failure_recovery_between_multi_runs(
         assert instance.get_runs_count() == 2
         validate_run_exists(instance.get_runs()[0], initial_datetime)
         ticks = instance.get_ticks(
-            external_schedule.get_external_origin_id(), external_schedule.selector_id
+            external_schedule.get_remote_origin_id(), external_schedule.selector_id
         )
         assert len(ticks) == 1
         validate_tick(

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -650,7 +650,7 @@ def validate_tick(
     expected_skip_reason: Optional[str] = None,
 ) -> None:
     tick_data = tick.tick_data
-    assert tick_data.instigator_origin_id == external_schedule.get_external_origin_id()
+    assert tick_data.instigator_origin_id == external_schedule.get_remote_origin_id()
     assert tick_data.instigator_name == external_schedule.name
     assert tick_data.timestamp == expected_datetime.timestamp()
     assert tick_data.status == expected_status
@@ -820,8 +820,8 @@ def test_status_in_code_schedule(instance: DagsterInstance, executor: ThreadPool
             running_schedule = external_repo.get_external_schedule("always_running_schedule")
             not_running_schedule = external_repo.get_external_schedule("never_running_schedule")
 
-            always_running_origin = running_schedule.get_external_origin()
-            never_running_origin = not_running_schedule.get_external_origin()
+            always_running_origin = running_schedule.get_remote_origin()
+            never_running_origin = not_running_schedule.get_remote_origin()
 
             assert instance.get_runs_count() == 0
             assert (
@@ -1002,11 +1002,11 @@ def test_change_default_status(instance: DagsterInstance, executor: ThreadPoolEx
 
         not_running_schedule = external_repo.get_external_schedule("never_running_schedule")
 
-        never_running_origin = not_running_schedule.get_external_origin()
+        never_running_origin = not_running_schedule.get_remote_origin()
 
         # never_running_schedule used to have default status RUNNING
         schedule_state = InstigatorState(
-            not_running_schedule.get_external_origin(),
+            not_running_schedule.get_remote_origin(),
             InstigatorType.SCHEDULE,
             InstigatorStatus.DECLARED_IN_CODE,
             ScheduleInstigatorData(
@@ -1035,7 +1035,7 @@ def test_change_default_status(instance: DagsterInstance, executor: ThreadPoolEx
             # schedule can still be manually started
 
             schedule_state = InstigatorState(
-                not_running_schedule.get_external_origin(),
+                not_running_schedule.get_remote_origin(),
                 InstigatorType.SCHEDULE,
                 InstigatorStatus.RUNNING,
                 ScheduleInstigatorData(
@@ -1083,17 +1083,17 @@ def test_repository_namespacing(instance: DagsterInstance, executor):
             status_in_code_repo = full_location.get_repository("the_status_in_code_repo")
             running_sched = status_in_code_repo.get_external_schedule("always_running_schedule")
             instance.stop_schedule(
-                running_sched.get_external_origin_id(),
+                running_sched.get_remote_origin_id(),
                 running_sched.selector_id,
                 running_sched,
             )
 
             external_schedule = external_repo.get_external_schedule("multi_run_list_schedule")
-            schedule_origin = external_schedule.get_external_origin()
+            schedule_origin = external_schedule.get_remote_origin()
             instance.start_schedule(external_schedule)
 
             other_schedule = other_repo.get_external_schedule("multi_run_list_schedule")
-            other_origin = external_schedule.get_external_origin()
+            other_origin = external_schedule.get_remote_origin()
             instance.start_schedule(other_schedule)
 
             assert instance.get_runs_count() == 0
@@ -1161,7 +1161,7 @@ def test_stale_request_context(
     with freeze_time(freeze_datetime):
         external_schedule = external_repo.get_external_schedule("many_requests_schedule")
 
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
 
         instance.start_schedule(external_schedule)
         executor = ThreadPoolExecutor()
@@ -1220,7 +1220,7 @@ def test_launch_failure(
     ) as scheduler_instance:
         external_schedule = external_repo.get_external_schedule("simple_schedule")
 
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
         freeze_datetime = feb_27_2019_start_of_day()
         with freeze_time(freeze_datetime):
             exploding_ctx = workspace_context.copy_for_test_instance(scheduler_instance)
@@ -1270,10 +1270,10 @@ def test_schedule_mutation(
         "the_repo"
     )
     schedule_one = repo_one.get_external_schedule("simple_schedule")
-    origin_one = schedule_one.get_external_origin()
+    origin_one = schedule_one.get_remote_origin()
     assert schedule_one.cron_schedule == "0 2 * * *"
     schedule_two = repo_two.get_external_schedule("simple_schedule")
-    origin_two = schedule_two.get_external_origin()
+    origin_two = schedule_two.get_remote_origin()
     assert schedule_two.cron_schedule == "0 1 * * *"
 
     assert schedule_one.selector_id == schedule_two.selector_id
@@ -1330,7 +1330,7 @@ class TestSchedulerRun:
         with freeze_time(freeze_datetime):
             external_schedule = external_repo.get_external_schedule("simple_schedule")
 
-            schedule_origin = external_schedule.get_external_origin()
+            schedule_origin = external_schedule.get_remote_origin()
 
             scheduler_instance.start_schedule(external_schedule)
 
@@ -1495,7 +1495,7 @@ class TestSchedulerRun:
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("simple_schedule")
-        existing_origin = external_schedule.get_external_origin()
+        existing_origin = external_schedule.get_remote_origin()
 
         code_location_origin = existing_origin.repository_origin.code_location_origin
         assert isinstance(code_location_origin, ManagedGrpcPythonEnvCodeLocationOrigin)
@@ -1548,7 +1548,7 @@ class TestSchedulerRun:
             # Create an old tick from several days ago
             scheduler_instance.create_tick(
                 TickData(
-                    instigator_origin_id=external_schedule.get_external_origin_id(),
+                    instigator_origin_id=external_schedule.get_remote_origin_id(),
                     instigator_name="simple_schedule",
                     instigator_type=InstigatorType.SCHEDULE,
                     status=TickStatus.STARTED,
@@ -1557,7 +1557,7 @@ class TestSchedulerRun:
                 )
             )
 
-            schedule_origin = external_schedule.get_external_origin()
+            schedule_origin = external_schedule.get_remote_origin()
             scheduler_instance.start_schedule(external_schedule)
 
         freeze_datetime = freeze_datetime + relativedelta(seconds=2)
@@ -1579,7 +1579,7 @@ class TestSchedulerRun:
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("simple_schedule")
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
 
         evaluate_schedules(workspace_context, executor, get_current_datetime())
         assert scheduler_instance.get_runs_count() == 0
@@ -1602,7 +1602,7 @@ class TestSchedulerRun:
         assert code_location is not None
         external_repo = code_location.get_repository("the_repo")
         external_schedule = external_repo.get_external_schedule("simple_schedule_no_timezone")
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
         initial_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
 
         with freeze_time(initial_datetime):
@@ -1652,7 +1652,7 @@ class TestSchedulerRun:
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("wrong_config_schedule")
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
         freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
         with freeze_time(freeze_datetime):
             scheduler_instance.start_schedule(external_schedule)
@@ -1723,7 +1723,7 @@ class TestSchedulerRun:
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("wrong_config_schedule")
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
         freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
         with freeze_time(freeze_datetime):
             scheduler_instance.start_schedule(external_schedule)
@@ -1824,7 +1824,7 @@ class TestSchedulerRun:
         else:
             schedule_name = "passes_on_retry_schedule_async"
         external_schedule = external_repo.get_external_schedule(schedule_name)
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
         freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
         with freeze_time(freeze_datetime):
             scheduler_instance.start_schedule(external_schedule)
@@ -1927,7 +1927,7 @@ class TestSchedulerRun:
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("bad_should_execute_schedule")
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
         initial_datetime = create_datetime(
             year=2019,
             month=2,
@@ -1967,7 +1967,7 @@ class TestSchedulerRun:
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("skip_schedule")
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
         freeze_datetime = feb_27_2019_start_of_day()
         with freeze_time(freeze_datetime):
             scheduler_instance.start_schedule(external_schedule)
@@ -1997,7 +1997,7 @@ class TestSchedulerRun:
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("wrong_config_schedule")
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
         freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
         with freeze_time(freeze_datetime):
             scheduler_instance.start_schedule(external_schedule)
@@ -2029,7 +2029,7 @@ class TestSchedulerRun:
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("default_config_schedule")
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
         initial_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
         with freeze_time(initial_datetime):
             scheduler_instance.start_schedule(external_schedule)
@@ -2103,8 +2103,8 @@ class TestSchedulerRun:
             "bad_should_execute_on_odd_days_schedule"
         )
 
-        good_origin = good_schedule.get_external_origin()
-        bad_origin = bad_schedule.get_external_origin()
+        good_origin = good_schedule.get_remote_origin()
+        bad_origin = bad_schedule.get_remote_origin()
         unloadable_origin = _get_unloadable_schedule_origin()
         freeze_datetime = feb_27_2019_start_of_day()
         with freeze_time(freeze_datetime):
@@ -2221,7 +2221,7 @@ class TestSchedulerRun:
     ):
         external_schedule = external_repo.get_external_schedule("simple_schedule")
 
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
         freeze_datetime = feb_27_2019_start_of_day()  # 00:00:00
         with freeze_time(freeze_datetime):
             # Start schedule exactly at midnight
@@ -2247,7 +2247,7 @@ class TestSchedulerRun:
         freeze_datetime = feb_27_2019_one_second_to_midnight()
         with freeze_time(freeze_datetime):
             external_schedule = external_repo.get_external_schedule("simple_schedule")
-            valid_schedule_origin = external_schedule.get_external_origin()
+            valid_schedule_origin = external_schedule.get_remote_origin()
 
             # Swap out a new repository name
             invalid_repo_origin = RemoteInstigatorOrigin(
@@ -2289,7 +2289,7 @@ class TestSchedulerRun:
         freeze_datetime = feb_27_2019_one_second_to_midnight()
         with freeze_time(freeze_datetime):
             external_schedule = external_repo.get_external_schedule("simple_schedule")
-            valid_schedule_origin = external_schedule.get_external_origin()
+            valid_schedule_origin = external_schedule.get_remote_origin()
 
             # Swap out a new schedule name
             invalid_repo_origin = RemoteInstigatorOrigin(
@@ -2331,7 +2331,7 @@ class TestSchedulerRun:
 
         with freeze_time(freeze_datetime):
             external_schedule = external_repo.get_external_schedule("simple_schedule")
-            valid_schedule_origin = external_schedule.get_external_origin()
+            valid_schedule_origin = external_schedule.get_remote_origin()
 
             code_location_origin = valid_schedule_origin.repository_origin.code_location_origin
             assert isinstance(code_location_origin, ManagedGrpcPythonEnvCodeLocationOrigin)
@@ -2386,13 +2386,13 @@ class TestSchedulerRun:
 
             assert scheduler_instance.get_runs_count() == 2
             ticks = scheduler_instance.get_ticks(
-                external_schedule.get_external_origin_id(), external_schedule.selector_id
+                external_schedule.get_remote_origin_id(), external_schedule.selector_id
             )
             assert len(ticks) == 1
             assert ticks[0].status == TickStatus.SUCCESS
 
             hourly_ticks = scheduler_instance.get_ticks(
-                external_hourly_schedule.get_external_origin_id(),
+                external_hourly_schedule.get_remote_origin_id(),
                 external_hourly_schedule.selector_id,
             )
             assert len(hourly_ticks) == 1
@@ -2405,13 +2405,13 @@ class TestSchedulerRun:
             assert scheduler_instance.get_runs_count() == 3
 
             ticks = scheduler_instance.get_ticks(
-                external_schedule.get_external_origin_id(), external_schedule.selector_id
+                external_schedule.get_remote_origin_id(), external_schedule.selector_id
             )
             assert len(ticks) == 1
             assert ticks[0].status == TickStatus.SUCCESS
 
             hourly_ticks = scheduler_instance.get_ticks(
-                external_hourly_schedule.get_external_origin_id(),
+                external_hourly_schedule.get_remote_origin_id(),
                 external_hourly_schedule.selector_id,
             )
             assert len(hourly_ticks) == 2
@@ -2429,7 +2429,7 @@ class TestSchedulerRun:
         freeze_datetime = feb_27_2019_start_of_day()
         with freeze_time(freeze_datetime):
             external_schedule = external_repo.get_external_schedule("union_schedule")
-            schedule_origin = external_schedule.get_external_origin()
+            schedule_origin = external_schedule.get_remote_origin()
             scheduler_instance.start_schedule(external_schedule)
 
         # No new runs should be launched
@@ -2544,7 +2544,7 @@ class TestSchedulerRun:
         freeze_datetime = feb_27_2019_one_second_to_midnight()
         with freeze_time(freeze_datetime):
             external_schedule = external_repo.get_external_schedule("multi_run_schedule")
-            schedule_origin = external_schedule.get_external_origin()
+            schedule_origin = external_schedule.get_remote_origin()
             scheduler_instance.start_schedule(external_schedule)
 
             assert scheduler_instance.get_runs_count() == 0
@@ -2622,7 +2622,7 @@ class TestSchedulerRun:
         freeze_datetime = feb_27_2019_one_second_to_midnight()
         with freeze_time(freeze_datetime):
             external_schedule = external_repo.get_external_schedule("multi_run_list_schedule")
-            schedule_origin = external_schedule.get_external_origin()
+            schedule_origin = external_schedule.get_remote_origin()
             scheduler_instance.start_schedule(external_schedule)
 
             assert scheduler_instance.get_runs_count() == 0
@@ -2702,7 +2702,7 @@ class TestSchedulerRun:
             external_schedule = external_repo.get_external_schedule(
                 "multi_run_schedule_with_missing_run_key"
             )
-            schedule_origin = external_schedule.get_external_origin()
+            schedule_origin = external_schedule.get_remote_origin()
             scheduler_instance.start_schedule(external_schedule)
 
             evaluate_schedules(workspace_context, executor, get_current_datetime())
@@ -2734,7 +2734,7 @@ class TestSchedulerRun:
         freeze_datetime = feb_27_2019_one_second_to_midnight()
         with freeze_time(freeze_datetime):
             external_schedule = external_repo.get_external_schedule("large_schedule")
-            schedule_origin = external_schedule.get_external_origin()
+            schedule_origin = external_schedule.get_remote_origin()
             scheduler_instance.start_schedule(external_schedule)
 
             freeze_datetime = freeze_datetime + relativedelta(seconds=2)
@@ -2760,7 +2760,7 @@ class TestSchedulerRun:
         with freeze_time(freeze_datetime):
             external_schedule = external_repo.get_external_schedule("empty_schedule")
 
-            schedule_origin = external_schedule.get_external_origin()
+            schedule_origin = external_schedule.get_remote_origin()
 
             scheduler_instance.start_schedule(external_schedule)
 
@@ -2794,7 +2794,7 @@ class TestSchedulerRun:
         with freeze_time(freeze_datetime):
             external_schedule = external_repo.get_external_schedule("many_requests_schedule")
 
-            schedule_origin = external_schedule.get_external_origin()
+            schedule_origin = external_schedule.get_remote_origin()
 
             scheduler_instance.start_schedule(external_schedule)
 
@@ -2830,7 +2830,7 @@ class TestSchedulerRun:
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
         external_schedule = external_repo.get_external_schedule("asset_selection_schedule")
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
 
         with freeze_time(freeze_datetime):
             scheduler_instance.start_schedule(external_schedule)
@@ -2961,7 +2961,7 @@ class TestSchedulerRun:
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
         external_schedule = external_repo.get_external_schedule("source_asset_observation_schedule")
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
 
         with freeze_time(freeze_datetime):
             scheduler_instance.start_schedule(external_schedule)

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
@@ -34,7 +34,7 @@ def test_non_utc_timezone_run(
     with freeze_time(freeze_datetime):
         external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
 
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
 
         instance.start_schedule(external_schedule)
 
@@ -100,8 +100,8 @@ def test_differing_timezones(
             "daily_eastern_time_schedule"
         )
 
-        schedule_origin = external_schedule.get_external_origin()
-        eastern_origin = external_eastern_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
+        eastern_origin = external_eastern_schedule.get_remote_origin()
 
         instance.start_schedule(external_schedule)
         instance.start_schedule(external_eastern_schedule)
@@ -210,7 +210,7 @@ def test_different_days_in_different_timezones(
     with freeze_time(freeze_datetime):
         # Runs every day at 11PM (CST)
         external_schedule = external_repo.get_external_schedule("daily_late_schedule")
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
@@ -271,7 +271,7 @@ def test_hourly_dst_spring_forward(
     ).astimezone(get_timezone("US/Pacific"))
 
     external_schedule = external_repo.get_external_schedule("hourly_central_time_schedule")
-    schedule_origin = external_schedule.get_external_origin()
+    schedule_origin = external_schedule.get_remote_origin()
     with freeze_time(freeze_datetime):
         instance.start_schedule(external_schedule)
         evaluate_schedules(workspace_context, executor, get_current_datetime())
@@ -344,7 +344,7 @@ def test_hourly_dst_fall_back(
     ).astimezone(get_timezone("US/Pacific"))
 
     external_schedule = external_repo.get_external_schedule("hourly_central_time_schedule")
-    schedule_origin = external_schedule.get_external_origin()
+    schedule_origin = external_schedule.get_remote_origin()
     with freeze_time(freeze_datetime):
         instance.start_schedule(external_schedule)
         evaluate_schedules(workspace_context, executor, get_current_datetime())
@@ -426,7 +426,7 @@ def test_daily_dst_spring_forward(
     ).astimezone(get_timezone("US/Pacific"))
 
     external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
-    schedule_origin = external_schedule.get_external_origin()
+    schedule_origin = external_schedule.get_remote_origin()
     with freeze_time(freeze_datetime):
         instance.start_schedule(external_schedule)
         evaluate_schedules(workspace_context, executor, get_current_datetime())
@@ -494,7 +494,7 @@ def test_daily_dst_fall_back(
 
     with freeze_time(freeze_datetime):
         external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
         instance.start_schedule(external_schedule)
         evaluate_schedules(workspace_context, executor, get_current_datetime())
 
@@ -564,7 +564,7 @@ def test_execute_during_dst_transition_spring_forward(
         external_schedule = external_repo.get_external_schedule(
             "daily_dst_transition_schedule_skipped_time"
         )
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
         instance.start_schedule(external_schedule)
         evaluate_schedules(workspace_context, executor, get_current_datetime())
 
@@ -644,7 +644,7 @@ def test_execute_during_dst_transition_fall_back(
         external_schedule = external_repo.get_external_schedule(
             "daily_dst_transition_schedule_doubled_time"
         )
-        schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_remote_origin()
         instance.start_schedule(external_schedule)
         evaluate_schedules(workspace_context, executor, get_current_datetime())
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -282,7 +282,7 @@ def other_external_job(other_workspace: WorkspaceRequestContext) -> ExternalJob:
 def run(instance: DagsterInstance, job: JobDefinition, external_job: ExternalJob) -> DagsterRun:
     return instance.create_run_for_job(
         job,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
 
@@ -293,7 +293,7 @@ def other_run(
 ) -> DagsterRun:
     return instance.create_run_for_job(
         job,
-        external_job_origin=other_external_job.get_external_origin(),
+        external_job_origin=other_external_job.get_remote_origin(),
         job_code_origin=other_external_job.get_python_origin(),
     )
 
@@ -305,7 +305,7 @@ def launch_run(
     def _launch_run(instance: DagsterInstance) -> None:
         run = instance.create_run_for_job(
             job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
         instance.launch_run(run.run_id, workspace)
@@ -359,7 +359,7 @@ def custom_run(
 ) -> DagsterRun:
     return custom_instance.create_run_for_job(
         job,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
 
@@ -572,7 +572,7 @@ def launch_run_with_container_context(
 
         run = instance.create_run_for_job(
             job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=python_origin,
         )
         instance.launch_run(run.run_id, workspace)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -129,7 +129,7 @@ def test_launcher_fargate_spot(
     instance = instance_fargate_spot
     run = instance.create_run_for_job(
         job,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
     initial_task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
@@ -156,7 +156,7 @@ def test_launcher_fargate_spot(
     # Override capacity provider strategy with tags
     run = instance.create_run_for_job(
         job,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
     instance.add_run_tags(
@@ -205,7 +205,7 @@ def test_launcher_dont_use_current_task(
     instance = instance_dont_use_current_task
     run = instance.create_run_for_job(
         job,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
 
@@ -597,7 +597,7 @@ def test_default_task_definition_resources(ecs, instance_cm, run, workspace, job
     ) as instance:
         run = instance.create_run_for_job(
             job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
         initial_tasks = ecs.list_tasks()["taskArns"]
@@ -631,7 +631,7 @@ def test_default_task_definition_resources(ecs, instance_cm, run, workspace, job
     ) as instance:
         run = instance.create_run_for_job(
             job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
         initial_tasks = ecs.list_tasks()["taskArns"]
@@ -665,7 +665,7 @@ def test_default_task_definition_resources(ecs, instance_cm, run, workspace, job
     ) as instance:
         run = instance.create_run_for_job(
             job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
         initial_tasks = ecs.list_tasks()["taskArns"]
@@ -746,7 +746,7 @@ def test_launching_with_task_definition_dict(ecs, instance_cm, run, workspace, j
     ) as instance:
         run = instance.create_run_for_job(
             job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
 
@@ -803,7 +803,7 @@ def test_launching_with_task_definition_dict(ecs, instance_cm, run, workspace, j
 
         second_run = run = instance.create_run_for_job(
             job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
 
@@ -846,7 +846,7 @@ def test_launching_custom_task_definition(ecs, instance_cm, run, workspace, job,
     ) as instance:
         run = instance.create_run_for_job(
             job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
 
@@ -940,7 +940,7 @@ def test_launcher_run_resources(
     instance = instance_with_resources
     run = instance.create_run_for_job(
         job,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
 
@@ -964,7 +964,7 @@ def test_launch_cannot_use_system_tags(instance_cm, workspace, job, external_job
     ) as instance:
         run = instance.create_run_for_job(
             job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
         with pytest.raises(Exception, match="Cannot override system ECS tag: dagster/run_id"):
@@ -1105,7 +1105,7 @@ def test_status(
 
     run = instance.create_run_for_job(
         job,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
         tags={RUN_WORKER_ID_TAG: "abcdef"},
     )
@@ -1206,7 +1206,7 @@ def test_status(
     # STARTING runs with these errors are considered a transient failure that can be retried
     starting_run = instance.create_run_for_job(
         job,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
         status=DagsterRunStatus.STARTING,
         tags={RUN_WORKER_ID_TAG: "efghi"},
@@ -1246,7 +1246,7 @@ def test_overrides_too_long(
 
     run = instance.create_run_for_job(
         job,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=mock_job_code_origin,
     )
 
@@ -1316,7 +1316,7 @@ def test_external_launch_type(
     ) as instance:
         run = instance.create_run_for_job(
             job,
-            external_job_origin=external_job.get_external_origin(),
+            external_job_origin=external_job.get_remote_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
 

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
@@ -362,7 +362,7 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
                 job_name=job_name,
                 run_config=run_config,
                 tags=tags,
-                external_job_origin=fake_external_job.get_external_origin(),
+                external_job_origin=fake_external_job.get_remote_origin(),
                 job_code_origin=fake_external_job.get_python_origin(),
             )
             celery_k8s_run_launcher.launch_run(LaunchRunContext(run, workspace))
@@ -440,7 +440,7 @@ def test_raise_on_error(kubeconfig_file):
                 instance,
                 job_name=job_name,
                 run_config=run_config,
-                external_job_origin=fake_external_job.get_external_origin(),
+                external_job_origin=fake_external_job.get_remote_origin(),
                 job_code_origin=fake_external_job.get_python_origin(),
             )
             celery_k8s_run_launcher.launch_run(LaunchRunContext(run, workspace))
@@ -492,7 +492,7 @@ def test_k8s_executor_config_override(kubeconfig_file):
                 instance,
                 job_name=job_name,
                 run_config={"execution": {"celery-k8s": {}}},
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=external_job.get_python_origin(),
             )
             celery_k8s_run_launcher.launch_run(LaunchRunContext(run, workspace))
@@ -507,7 +507,7 @@ def test_k8s_executor_config_override(kubeconfig_file):
                 run_config={
                     "execution": {"celery-k8s": {"config": {"job_image": "fake-image-name"}}}
                 },
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=external_job.get_python_origin(),
             )
             celery_k8s_run_launcher.launch_run(LaunchRunContext(run, workspace))

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_launcher.py
@@ -91,7 +91,7 @@ def test_successful_run(
     dagster_run = instance.create_run_for_job(
         job_def=noop_job,
         run_config=run_config,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
     run_id = dagster_run.run_id
@@ -136,7 +136,7 @@ def test_crashy_run(
     run = instance.create_run_for_job(
         job_def=crashy_job,
         run_config=run_config,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
 
@@ -182,7 +182,7 @@ def test_exity_run(
     run = instance.create_run_for_job(
         job_def=exity_job,
         run_config=run_config,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
 
@@ -232,7 +232,7 @@ def test_terminated_run(
     run = instance.create_run_for_job(
         job_def=sleepy_job,
         run_config=run_config,
-        external_job_origin=external_job.get_external_origin(),
+        external_job_origin=external_job.get_remote_origin(),
         job_code_origin=external_job.get_python_origin(),
     )
 

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
@@ -69,7 +69,7 @@ def test_launch_docker_no_network(aws_env):
             run = instance.create_run_for_job(
                 job_def=recon_job.get_definition(),
                 run_config=run_config,
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=external_job.get_python_origin(),
             )
             instance.launch_run(run.run_id, workspace)
@@ -154,7 +154,7 @@ def test_launch_docker_image_on_job_config(aws_env):
                 run = instance.create_run_for_job(
                     job_def=recon_job.get_definition(),
                     run_config=run_config,
-                    external_job_origin=external_job.get_external_origin(),
+                    external_job_origin=external_job.get_remote_origin(),
                     job_code_origin=external_job.get_python_origin(),
                 )
                 instance.launch_run(run.run_id, workspace)
@@ -226,7 +226,7 @@ def test_terminate_launched_docker_run(aws_env):
             run = instance.create_run_for_job(
                 job_def=recon_job.get_definition(),
                 run_config=run_config,
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=external_job.get_python_origin(),
             )
 
@@ -293,7 +293,7 @@ def test_launch_docker_invalid_image(aws_env):
             run = instance.create_run_for_job(
                 job_def=recon_job.get_definition(),
                 run_config=run_config,
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=external_job.get_python_origin(),
             )
 
@@ -486,7 +486,7 @@ def _test_launch(
             run = instance.create_run_for_job(
                 job_def=recon_job.get_definition(),
                 run_config=run_config,
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=recon_job.get_python_origin(),
             )
 

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
@@ -94,7 +94,7 @@ def test_image_on_job(monkeypatch, aws_env, from_pending_repository, asset_selec
             run = instance.create_run_for_job(
                 job_def=recon_job.get_definition(),
                 run_config=run_config,
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=external_job.get_python_origin(),
                 repository_load_data=repository_load_data,
                 asset_selection=frozenset(asset_selection) if asset_selection else None,
@@ -169,7 +169,7 @@ def test_container_context_on_job(aws_env):
             run = instance.create_run_for_job(
                 job_def=recon_job.get_definition(),
                 run_config=run_config,
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=recon_job.get_python_origin(),
             )
 
@@ -236,7 +236,7 @@ def test_recovery(aws_env):
             run = instance.create_run_for_job(
                 job_def=recon_job.get_definition(),
                 run_config=run_config,
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=external_job.get_python_origin(),
             )
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
@@ -459,7 +459,7 @@ def test_step_handler(kubeconfig_file, k8s_instance):
             run = create_run_for_test(
                 k8s_instance,
                 job_name="bar",
-                external_job_origin=fake_external_job.get_external_origin(),
+                external_job_origin=fake_external_job.get_remote_origin(),
                 job_code_origin=recon_job.get_python_origin(),
             )
             list(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
@@ -192,7 +192,7 @@ def test_launcher_with_container_context(kubeconfig_file):
             run = create_run_for_test(
                 instance,
                 job_name=job_name,
-                external_job_origin=fake_external_job.get_external_origin(),
+                external_job_origin=fake_external_job.get_remote_origin(),
                 job_code_origin=python_origin,
             )
             k8s_run_launcher.register_instance(instance)
@@ -256,7 +256,7 @@ def test_launcher_with_container_context(kubeconfig_file):
             run = create_run_for_test(
                 instance,
                 job_name=job_name,
-                external_job_origin=fake_external_job.get_external_origin(),
+                external_job_origin=fake_external_job.get_remote_origin(),
                 job_code_origin=python_origin,
             )
             k8s_run_launcher.launch_run(LaunchRunContext(run, workspace))
@@ -275,7 +275,7 @@ def test_launcher_with_container_context(kubeconfig_file):
             run = create_run_for_test(
                 instance,
                 job_name=job_name,
-                external_job_origin=fake_external_job.get_external_origin(),
+                external_job_origin=fake_external_job.get_remote_origin(),
                 job_code_origin=python_origin,
             )
             k8s_run_launcher.launch_run(LaunchRunContext(run, workspace))
@@ -361,7 +361,7 @@ def test_launcher_with_k8s_config(kubeconfig_file):
             run = create_run_for_test(
                 instance,
                 job_name=job_name,
-                external_job_origin=fake_external_job.get_external_origin(),
+                external_job_origin=fake_external_job.get_remote_origin(),
                 job_code_origin=python_origin,
                 tags=run_tags,
             )
@@ -456,7 +456,7 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
                 instance,
                 job_name=job_name,
                 tags=tags,
-                external_job_origin=fake_external_job.get_external_origin(),
+                external_job_origin=fake_external_job.get_remote_origin(),
                 job_code_origin=fake_external_job.get_python_origin(),
             )
             k8s_run_launcher.register_instance(instance)
@@ -536,7 +536,7 @@ def test_raise_on_error(kubeconfig_file):
             run = create_run_for_test(
                 instance,
                 job_name=job_name,
-                external_job_origin=fake_external_job.get_external_origin(),
+                external_job_origin=fake_external_job.get_remote_origin(),
                 job_code_origin=fake_external_job.get_python_origin(),
             )
             k8s_run_launcher.register_instance(instance)
@@ -597,7 +597,7 @@ def test_no_postgres(kubeconfig_file):
             run = create_run_for_test(
                 instance,
                 job_name=job_name,
-                external_job_origin=fake_external_job.get_external_origin(),
+                external_job_origin=fake_external_job.get_remote_origin(),
                 job_code_origin=fake_external_job.get_python_origin(),
             )
             k8s_run_launcher.register_instance(instance)
@@ -664,14 +664,14 @@ def test_check_run_health(kubeconfig_file):
             started_run = create_run_for_test(
                 instance,
                 job_name=job_name,
-                external_job_origin=fake_external_job.get_external_origin(),
+                external_job_origin=fake_external_job.get_remote_origin(),
                 job_code_origin=fake_external_job.get_python_origin(),
                 status=DagsterRunStatus.STARTED,
             )
             finished_run = create_run_for_test(
                 instance,
                 job_name=job_name,
-                external_job_origin=fake_external_job.get_external_origin(),
+                external_job_origin=fake_external_job.get_remote_origin(),
                 job_code_origin=fake_external_job.get_python_origin(),
                 status=DagsterRunStatus.FAILURE,
             )
@@ -798,7 +798,7 @@ def test_get_run_worker_debug_info(kubeconfig_file):
             started_run = create_run_for_test(
                 instance,
                 job_name=job_name,
-                external_job_origin=fake_external_job.get_external_origin(),
+                external_job_origin=fake_external_job.get_remote_origin(),
                 job_code_origin=fake_external_job.get_python_origin(),
                 status=DagsterRunStatus.STARTING,
             )

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_terminate.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_terminate.py
@@ -70,7 +70,7 @@ def test_terminate_kills_subproc():
             )
             dagster_run = instance.create_run_for_job(
                 job_def=sleepy_job,
-                external_job_origin=external_job.get_external_origin(),
+                external_job_origin=external_job.get_remote_origin(),
                 job_code_origin=external_job.get_python_origin(),
             )
 


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/9004

Rename on all `External*` classes:

- `get_external_origin` -> `get_remote_origin`
- `get_external_origin_id` -> `get_remote_origin_id`

This is a followup from renaming the corresponding `*Origin*` classes from `External` -> `Remote` 

## How I Tested These Changes

Existing test suite.