### PR TITLE
update ChangeReason.INPUTS to ChangeReason.DEPENDENCIES

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -68,7 +68,7 @@ export const AssetNodeFragmentBasic: AssetNodeFragment = buildAssetNode({
   changedReasons: [
     ChangeReason.NEW,
     ChangeReason.CODE_VERSION,
-    ChangeReason.INPUTS,
+    ChangeReason.DEPENDENCIES,
     ChangeReason.PARTITIONS_DEFINITION,
   ],
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/ChangedReasons.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/ChangedReasons.tsx
@@ -58,7 +58,7 @@ export const ChangedReasonsPopover = ({
         return '';
       case ChangeReason.CODE_VERSION:
         return 'has a changed code version';
-      case ChangeReason.INPUTS:
+      case ChangeReason.DEPENDENCIES:
         return 'has changed dependencies';
       case ChangeReason.PARTITIONS_DEFINITION:
         return 'has a changed partition definition';

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -717,7 +717,7 @@ enum BackfillPolicyType {
 enum ChangeReason {
   NEW
   CODE_VERSION
-  INPUTS
+  DEPENDENCIES
   PARTITIONS_DEFINITION
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -740,7 +740,7 @@ export type CapturedLogsMetadata = {
 
 export enum ChangeReason {
   CODE_VERSION = 'CODE_VERSION',
-  INPUTS = 'INPUTS',
+  DEPENDENCIES = 'DEPENDENCIES',
   NEW = 'NEW',
   PARTITIONS_DEFINITION = 'PARTITIONS_DEFINITION',
 }

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 class ChangeReason(Enum):
     NEW = "NEW"
     CODE_VERSION = "CODE_VERSION"
-    INPUTS = "INPUTS"
+    DEPENDENCIES = "DEPENDENCIES"
     PARTITIONS_DEFINITION = "PARTITIONS_DEFINITION"
 
 
@@ -130,15 +130,15 @@ class AssetGraphDiffer:
             self.branch_asset_graph.get(asset_key).parent_keys
             != self.base_asset_graph.get(asset_key).parent_keys
         ):
-            changes.append(ChangeReason.INPUTS)
+            changes.append(ChangeReason.DEPENDENCIES)
         else:
-            # if the set of inputs is different, then we don't need to check if the partition mappings
-            # for inputs have changed since ChangeReason.INPUTS is already in the list of changes
+            # if the set of upstream dependencies is different, then we don't need to check if the partition mappings
+            # for dependencies have changed since ChangeReason.DEPENDENCIES is already in the list of changes
             for upstream_asset in self.branch_asset_graph.get(asset_key).parent_keys:
                 if self.branch_asset_graph.get_partition_mapping(
                     asset_key, upstream_asset
                 ) != self.base_asset_graph.get_partition_mapping(asset_key, upstream_asset):
-                    changes.append(ChangeReason.INPUTS)
+                    changes.append(ChangeReason.DEPENDENCIES)
                     break
 
         if (

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -130,7 +130,7 @@ def test_new_asset_connected(instance):
     )
 
     assert differ.get_changes_for_asset(AssetKey("new_asset")) == [ChangeReason.NEW]
-    assert differ.get_changes_for_asset(AssetKey("downstream")) == [ChangeReason.INPUTS]
+    assert differ.get_changes_for_asset(AssetKey("downstream")) == [ChangeReason.DEPENDENCIES]
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
 
 
@@ -158,7 +158,7 @@ def test_change_inputs(instance):
         },
     )
 
-    assert differ.get_changes_for_asset(AssetKey("downstream")) == [ChangeReason.INPUTS]
+    assert differ.get_changes_for_asset(AssetKey("downstream")) == [ChangeReason.DEPENDENCIES]
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
 
 
@@ -174,7 +174,7 @@ def test_multiple_changes_for_one_asset(instance):
 
     assert differ.get_changes_for_asset(AssetKey("downstream")) == [
         ChangeReason.CODE_VERSION,
-        ChangeReason.INPUTS,
+        ChangeReason.DEPENDENCIES,
     ]
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
 
@@ -215,7 +215,7 @@ def test_large_asset_graph(instance):
 
     for i in range(6, 1000):
         key = AssetKey(f"asset_{i}")
-        assert differ.get_changes_for_asset(key) == [ChangeReason.INPUTS]
+        assert differ.get_changes_for_asset(key) == [ChangeReason.DEPENDENCIES]
 
     for i in range(6):
         key = AssetKey(f"asset_{i}")
@@ -237,7 +237,7 @@ def test_multiple_code_locations(instance):
 
     # if the code_versions_asset_graph were in the diff computation, ChangeReason.CODE_VERSION would be in the list
     assert differ.get_changes_for_asset(AssetKey("new_asset")) == [ChangeReason.NEW]
-    assert differ.get_changes_for_asset(AssetKey("downstream")) == [ChangeReason.INPUTS]
+    assert differ.get_changes_for_asset(AssetKey("downstream")) == [ChangeReason.DEPENDENCIES]
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
 
 
@@ -292,10 +292,12 @@ def test_change_partition_mapping(instance):
         },
     )
     assert len(differ.get_changes_for_asset(AssetKey("daily_upstream"))) == 0
-    assert differ.get_changes_for_asset(AssetKey("daily_downstream")) == [ChangeReason.INPUTS]
+    assert differ.get_changes_for_asset(AssetKey("daily_downstream")) == [ChangeReason.DEPENDENCIES]
     assert len(differ.get_changes_for_asset(AssetKey("static_upstream"))) == 0
-    assert differ.get_changes_for_asset(AssetKey("static_downstream")) == [ChangeReason.INPUTS]
+    assert differ.get_changes_for_asset(AssetKey("static_downstream")) == [
+        ChangeReason.DEPENDENCIES
+    ]
     assert len(differ.get_changes_for_asset(AssetKey("multi_partitioned_upstream"))) == 0
     assert differ.get_changes_for_asset(AssetKey("multi_partitioned_downstream")) == [
-        ChangeReason.INPUTS
+        ChangeReason.DEPENDENCIES
     ]


### PR DESCRIPTION
## Summary & Motivation
we should refer to the INPUTS change reason as a DEPENDENCIES change reason since dependencies is I/O manager agnostic and inputs carries a heavier connotation that it in input data that has changed

internal pr https://github.com/dagster-io/internal/pull/9030

## How I Tested These Changes
updated unit tests, ran shadow dagit on our deployment and saw the name update