### PR TITLE
perf(dbt): use `--dist loadscope` when executing `pytest-xdist`

### DIFF
--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -24,6 +24,6 @@ allowlist_externals =
   uv
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-  cloud: pytest --numprocesses 6 --durations 10 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
-  core: pytest --numprocesses 6 --durations 10 -c ../../../pyproject.toml -m "core" -vv {posargs}
+  cloud: pytest --numprocesses 6 --dist loadscope --durations 10 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
+  core: pytest --numprocesses 6 --dist loadscope --durations 10 -c ../../../pyproject.toml -m "core" -vv {posargs}
   legacy: pytest --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}


### PR DESCRIPTION
## Summary & Motivation
https://pytest-xdist.readthedocs.io/en/latest/changelog.html#pytest-xdist-3-5-0-2023-11-21

## How I Tested These Changes
bk
