### PR TITLE
feat(dbt): support singular tests with `ref` meta

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -425,7 +425,7 @@ def get_dbt_multi_asset_args(
         ]
         for test_unique_id in test_unique_ids:
             check_spec = default_asset_check_fn(
-                manifest, dbt_nodes, dagster_dbt_translator, asset_key, unique_id, test_unique_id
+                manifest, dbt_nodes, dagster_dbt_translator, asset_key, test_unique_id
             )
             if check_spec:
                 check_specs.append(check_spec)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_check_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_check_selection.py
@@ -10,6 +10,8 @@ from dagster_dbt import (
 )
 from dagster_dbt.asset_decorator import dbt_assets
 
+pytest.importorskip("dbt.version", "1.6")
+
 dagster_dbt_translator_with_checks = DagsterDbtTranslator(
     settings=DagsterDbtTranslatorSettings(enable_asset_checks=True)
 )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -21,6 +21,8 @@ from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, DagsterDbtT
 
 from ..dbt_projects import test_asset_checks_path
 
+pytest.importorskip("dbt.version", "1.6")
+
 dagster_dbt_translator_with_checks = DagsterDbtTranslator(
     settings=DagsterDbtTranslatorSettings(enable_asset_checks=True)
 )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_checks/tests/singular_test_with_meta_and_multiple_dependencies.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_checks/tests/singular_test_with_meta_and_multiple_dependencies.sql
@@ -2,7 +2,9 @@
     config(
         meta={
             'dagster': {
-                'asset_key': ['customers']
+                'ref': {
+                    'name': 'customers',
+                },
             }
         }
     )


### PR DESCRIPTION
## Summary & Motivation
A follow up to https://github.com/dagster-io/dagster/pull/20698.

Support the following syntax for configuring a dbt `ref` as the attached node:

```yaml
meta:
  dagster:
    ref:
      name: ...
      version: ...
      package_name: ...
```

This way, a user does not need to know what an a dbt resource's `AssetKey` is ahead of time when
they are configuring their singular tests as Dagster asset checks.

## How I Tested These Changes
pytest
