### PR TITLE
[external-renames] Rename ExternalAssetCheck -> AssetCheckNodeSnap

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
@@ -5,7 +5,7 @@ from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.selector import RepositorySelector
 from dagster._core.remote_representation.code_location import CodeLocation
 from dagster._core.remote_representation.external import ExternalRepository
-from dagster._core.remote_representation.external_data import ExternalAssetCheck
+from dagster._core.remote_representation.external_data import AssetCheckNodeSnap
 from dagster._core.storage.asset_check_execution_record import (
     AssetCheckExecutionRecord,
     AssetCheckExecutionRecordStatus,
@@ -39,14 +39,14 @@ class AssetChecksLoader:
 
     def _get_external_checks(
         self, pipeline: Optional[GraphenePipelineSelector]
-    ) -> Iterator[Tuple[CodeLocation, ExternalRepository, ExternalAssetCheck]]:
+    ) -> Iterator[Tuple[CodeLocation, ExternalRepository, AssetCheckNodeSnap]]:
         if pipeline is None:
             entries = self._context.get_code_location_entries().values()
             for entry in entries:
                 code_loc = entry.code_location
                 if code_loc:
                     for repo in code_loc.get_repositories().values():
-                        for check in repo.get_external_asset_checks():
+                        for check in repo.get_asset_check_node_snaps():
                             yield (code_loc, repo, check)
 
         else:
@@ -54,9 +54,9 @@ class AssetChecksLoader:
             repo_sel = RepositorySelector.from_graphql_input(pipeline)
             location = self._context.get_code_location(repo_sel.location_name)
             repo = location.get_repository(repo_sel.repository_name)
-            external_asset_checks = repo.get_external_asset_checks(job_name=job_name)
-            for external_asset_check in external_asset_checks:
-                yield (location, repo, external_asset_check)
+            asset_check_node_snaps = repo.get_asset_check_node_snaps(job_name=job_name)
+            for snap in asset_check_node_snaps:
+                yield (location, repo, snap)
 
     def _fetch_checks(
         self, limit_per_asset: Optional[int], pipeline: Optional[GraphenePipelineSelector]
@@ -83,7 +83,7 @@ class AssetChecksLoader:
                 f"Unexpected asset check support status {asset_check_support}",
             )
 
-        external_checks_by_asset_key: Mapping[AssetKey, List[ExternalAssetCheck]] = {}
+        external_checks_by_asset_key: Mapping[AssetKey, List[AssetCheckNodeSnap]] = {}
         errors: Mapping[AssetKey, GrapheneAssetCheckNeedsUserCodeUpgrade] = {}
 
         for location, _, external_check in self._get_external_checks(pipeline=pipeline):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -10,7 +10,7 @@ from dagster._core.definitions.asset_check_evaluation import (
 from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSeverity
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.events import DagsterEventType
-from dagster._core.remote_representation.external_data import ExternalAssetCheck
+from dagster._core.remote_representation.external_data import AssetCheckNodeSnap
 from dagster._core.storage.asset_check_execution_record import (
     AssetCheckExecutionRecord,
     AssetCheckExecutionResolvedStatus,
@@ -136,7 +136,7 @@ class GrapheneAssetCheck(graphene.ObjectType):
     class Meta:
         name = "AssetCheck"
 
-    def __init__(self, asset_check: ExternalAssetCheck, can_execute_individually):
+    def __init__(self, asset_check: AssetCheckNodeSnap, can_execute_individually):
         self._asset_check = asset_check
         self._can_execute_individually = can_execute_individually
 

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -43,9 +43,9 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.origin import JobPythonOrigin, RepositoryPythonOrigin
 from dagster._core.remote_representation.external_data import (
     DEFAULT_MODE_NAME,
+    AssetCheckNodeSnap,
     AssetNodeSnap,
     EnvVarConsumer,
-    ExternalAssetCheck,
     ExternalJobData,
     ExternalJobRef,
     ExternalPresetData,
@@ -163,10 +163,10 @@ class ExternalRepository:
             for job_name in asset_node.job_names:
                 self._asset_jobs.setdefault(job_name, []).append(asset_node)
 
-        self._asset_check_jobs: Dict[str, List[ExternalAssetCheck]] = {}
-        for asset_check in external_repository_data.external_asset_checks or []:
-            for job_name in asset_check.job_names:
-                self._asset_check_jobs.setdefault(job_name, []).append(asset_check)
+        self._asset_check_jobs: Dict[str, List[AssetCheckNodeSnap]] = {}
+        for asset_check_node_snap in external_repository_data.external_asset_checks or []:
+            for job_name in asset_check_node_snap.job_names:
+                self._asset_check_jobs.setdefault(job_name, []).append(asset_check_node_snap)
 
         # memoize job instances to share instances
         self._memo_lock: RLock = RLock()
@@ -413,9 +413,9 @@ class ExternalRepository:
         ]
         return matching[0] if matching else None
 
-    def get_external_asset_checks(
+    def get_asset_check_node_snaps(
         self, job_name: Optional[str] = None
-    ) -> Sequence[ExternalAssetCheck]:
+    ) -> Sequence[AssetCheckNodeSnap]:
         if job_name:
             return self._asset_check_jobs.get(job_name, [])
         else:
@@ -435,7 +435,7 @@ class ExternalRepository:
             ],
             repo_handle_asset_checks=[
                 (self.handle, asset_check_node)
-                for asset_check_node in self.get_external_asset_checks()
+                for asset_check_node in self.get_asset_check_node_snaps()
             ],
         )
 

--- a/python_modules/dagster/dagster/_core/workspace/workspace.py
+++ b/python_modules/dagster/dagster/_core/workspace/workspace.py
@@ -10,7 +10,7 @@ from dagster._utils.error import SerializableErrorInfo
 if TYPE_CHECKING:
     from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
     from dagster._core.remote_representation import CodeLocation, CodeLocationOrigin
-    from dagster._core.remote_representation.external_data import AssetNodeSnap, ExternalAssetCheck
+    from dagster._core.remote_representation.external_data import AssetCheckNodeSnap, AssetNodeSnap
     from dagster._core.remote_representation.handle import RepositoryHandle
 
 
@@ -64,13 +64,13 @@ class WorkspaceSnapshot:
             for repo in code_location.get_repositories().values()
         )
         repo_handle_assets: Sequence[Tuple["RepositoryHandle", "AssetNodeSnap"]] = []
-        repo_handle_asset_checks: Sequence[Tuple["RepositoryHandle", "ExternalAssetCheck"]] = []
+        repo_handle_asset_checks: Sequence[Tuple["RepositoryHandle", "AssetCheckNodeSnap"]] = []
 
         for repo in repos:
             for asset_node_snap in repo.get_asset_node_snaps():
                 repo_handle_assets.append((repo.handle, asset_node_snap))
-            for external_asset_check in repo.get_external_asset_checks():
-                repo_handle_asset_checks.append((repo.handle, external_asset_check))
+            for asset_check_node_snap in repo.get_asset_check_node_snaps():
+                repo_handle_asset_checks.append((repo.handle, asset_check_node_snap))
 
         return RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
             repo_handle_assets=repo_handle_assets,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -38,8 +38,8 @@ from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterDefinitionChangedDeserializationError
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.remote_representation.external_data import (
+    asset_check_node_snaps_from_repo,
     asset_node_snaps_from_repo,
-    external_asset_checks_from_defs,
 )
 from dagster._core.test_utils import freeze_time, instance_for_test
 from dagster._time import create_datetime, get_current_datetime
@@ -53,12 +53,7 @@ def to_remote_asset_graph(assets, asset_checks=None) -> RemoteAssetGraph:
     asset_node_snaps = asset_node_snaps_from_repo(repo)
     return RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
         [(MagicMock(), asset_node) for asset_node in asset_node_snaps],
-        [
-            (MagicMock(), asset_check)
-            for asset_check in external_asset_checks_from_defs(
-                repo.get_all_jobs(), repo.asset_graph
-            )
-        ],
+        [(MagicMock(), asset_check) for asset_check in asset_check_node_snaps_from_repo(repo)],
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -748,7 +748,7 @@ def remote_asset_graph_from_assets_by_repo_name(
         )
 
     return RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
-        from_repository_handles_and_asset_node_snaps, []
+        from_repository_handles_and_asset_node_snaps, repo_handle_asset_checks=[]
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
@@ -109,9 +109,11 @@ def test_repository_data_can_reload_without_restarting(
     code_location = request_context.get_code_location("test")
     repo = code_location.get_repository("bar_repo")
 
-    assert repo.has_external_job("foo_5")
+    # get_all_jobs is called 4 times on reload, so now at 6
+    assert repo.has_external_job("foo_6")
+    assert not repo.has_external_job("foo_5")
     assert not repo.has_external_job("foo_4")
     assert not repo.has_external_job("foo_3")
 
-    external_job = repo.get_full_external_job("foo_5")
-    assert external_job.has_node_invocation("do_something_5")
+    external_job = repo.get_full_external_job("foo_6")
+    assert external_job.has_node_invocation("do_something_6")


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/9020

- Rename `ExternalAssetCheck` -> `AssetCheckNodeSnap`. This matches `AssetNodeSnap`. 
- Rename various private methods and local variables that were inflections of "external asset check"

## How I Tested These Changes

Existing test suite.