### PR TITLE
[ui] Highlight Assets in top nav when viewing asset group

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavLinks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavLinks.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {useHistory} from 'react-router-dom';
 
 import {TopNavLink} from './AppTopNav';
+import {assetsPathMatcher, locationPathMatcher, settingsPathMatcher} from './activePathMatchers';
 import {DeploymentStatusIcon} from '../../nav/DeploymentStatusIcon';
 import {FeatureFlag, featureEnabled} from '../Flags';
 import {ShortcutHandler} from '../ShortcutHandler';
@@ -64,10 +65,7 @@ export const navLinks = (history: ReturnType<typeof useHistory>) => {
           <TopNavLink
             to="/assets"
             data-cy="AppTopNav_AssetsLink"
-            isActive={(_, location) => {
-              const {pathname} = location;
-              return pathname.startsWith('/assets') || pathname.startsWith('/asset-groups');
-            }}
+            isActive={assetsPathMatcher}
             exact={false}
           >
             Assets
@@ -88,10 +86,7 @@ export const navLinks = (history: ReturnType<typeof useHistory>) => {
               <TopNavLink
                 to="/settings"
                 data-cy="AppTopNav_SettingsLink"
-                isActive={(_, location) => {
-                  const {pathname} = location;
-                  return pathname.startsWith('/settings') || pathname.startsWith('/locations');
-                }}
+                isActive={settingsPathMatcher}
               >
                 <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
                   Settings
@@ -113,14 +108,7 @@ export const navLinks = (history: ReturnType<typeof useHistory>) => {
               <TopNavLink
                 to="/locations"
                 data-cy="AppTopNav_StatusLink"
-                isActive={(_, location) => {
-                  const {pathname} = location;
-                  return (
-                    pathname.startsWith('/locations') ||
-                    pathname.startsWith('/health') ||
-                    pathname.startsWith('/config')
-                  );
-                }}
+                isActive={locationPathMatcher}
               >
                 <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
                   Deployment

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/activePathMatchers.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/activePathMatchers.tsx
@@ -1,0 +1,31 @@
+import {ComponentProps} from 'react';
+import {NavLink} from 'react-router-dom';
+
+type MatcherFn = ComponentProps<typeof NavLink>['isActive'];
+
+export const assetsPathMatcher: MatcherFn = (_, currentLocation) => {
+  const {pathname} = currentLocation;
+  return (
+    pathname.startsWith('/catalog') ||
+    pathname.startsWith('/assets') ||
+    pathname.startsWith('/asset-groups') ||
+    (pathname.startsWith('/locations') && pathname.includes('/asset-groups/'))
+  );
+};
+
+export const settingsPathMatcher: MatcherFn = (_, currentLocation) => {
+  const {pathname} = currentLocation;
+  return (
+    pathname.startsWith('/settings') ||
+    (pathname.startsWith('/locations') && !pathname.includes('/asset-groups/'))
+  );
+};
+
+export const locationPathMatcher: MatcherFn = (_, currentLocation) => {
+  const {pathname} = currentLocation;
+  return (
+    (pathname.startsWith('/locations') && !pathname.includes('/asset-groups/')) ||
+    pathname.startsWith('/health') ||
+    pathname.startsWith('/config')
+  );
+};


### PR DESCRIPTION
## Summary & Motivation

Highlight "Assets" in the top nav when viewing an asset group, even though it is located at a `/locations/...` object path.

I made a couple of utility functions for determining whether an item should be highlighted based on the current pathname.

## How I Tested These Changes

View an asset group, verify that "Assets" is highlighted in the top nav.