### PR TITLE
[external-renames] ExternalResourceData -> ResourceSnap

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/resources.py
@@ -5,10 +5,10 @@ import graphene
 from dagster._core.definitions.selector import ResourceSelector
 from dagster._core.remote_representation.external import ExternalResource
 from dagster._core.remote_representation.external_data import (
-    ExternalResourceConfigEnvVar,
-    ExternalResourceValue,
     NestedResourceType,
+    ResourceConfigEnvVarSnap,
     ResourceJobUsageEntry,
+    ResourceValueSnap,
 )
 
 from dagster_graphql.schema.asset_key import GrapheneAssetKey
@@ -37,11 +37,11 @@ class GrapheneConfiguredValue(graphene.ObjectType):
     class Meta:
         name = "ConfiguredValue"
 
-    def __init__(self, key: str, external_resource_value: ExternalResourceValue):
+    def __init__(self, key: str, external_resource_value: ResourceValueSnap):
         super().__init__()
 
         self.key = key
-        if isinstance(external_resource_value, ExternalResourceConfigEnvVar):
+        if isinstance(external_resource_value, ResourceConfigEnvVarSnap):
             self.type = GrapheneConfiguredValueType.ENV_VAR
             self.value = external_resource_value.name
         else:

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -50,12 +50,12 @@ from dagster._core.remote_representation.external_data import (
     ExternalJobRef,
     ExternalPresetData,
     ExternalRepositoryData,
-    ExternalResourceData,
-    ExternalResourceValue,
     ExternalSensorMetadata,
     NestedResource,
     PartitionSetSnap,
     ResourceJobUsageEntry,
+    ResourceSnap,
+    ResourceValueSnap,
     ScheduleSnap,
     SensorSnap,
     TargetSnap,
@@ -751,9 +751,9 @@ class ExternalExecutionPlan:
 class ExternalResource:
     """Represents a top-level resource in a repository, e.g. one passed through the Definitions API."""
 
-    def __init__(self, external_resource_data: ExternalResourceData, handle: RepositoryHandle):
+    def __init__(self, external_resource_data: ResourceSnap, handle: RepositoryHandle):
         self._external_resource_data = check.inst_param(
-            external_resource_data, "external_resource_data", ExternalResourceData
+            external_resource_data, "external_resource_data", ResourceSnap
         )
         self._handle = InstigatorHandle(
             self._external_resource_data.name, check.inst_param(handle, "handle", RepositoryHandle)
@@ -772,7 +772,7 @@ class ExternalResource:
         return self._external_resource_data.config_field_snaps
 
     @property
-    def configured_values(self) -> Dict[str, ExternalResourceValue]:
+    def configured_values(self) -> Dict[str, ResourceValueSnap]:
         return self._external_resource_data.configured_values
 
     @property

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -25,7 +25,7 @@ from typing import (
     cast,
 )
 
-from typing_extensions import Final, Self
+from typing_extensions import Final, Self, TypeAlias
 
 from dagster import (
     StaticPartitionsDefinition,
@@ -125,7 +125,7 @@ class ExternalRepositoryData(IHaveNew):
     external_asset_graph_data: Sequence["AssetNodeSnap"]
     external_job_datas: Optional[Sequence["ExternalJobData"]]
     external_job_refs: Optional[Sequence["ExternalJobRef"]]
-    external_resource_data: Optional[Sequence["ExternalResourceData"]]
+    external_resource_data: Optional[Sequence["ResourceSnap"]]
     external_asset_checks: Optional[Sequence["AssetCheckNodeSnap"]]
     metadata: Optional[MetadataMapping]
     utilized_env_vars: Optional[Mapping[str, Sequence["EnvVarConsumer"]]]
@@ -139,7 +139,7 @@ class ExternalRepositoryData(IHaveNew):
         external_asset_graph_data: Optional[Sequence["AssetNodeSnap"]] = None,
         external_job_datas: Optional[Sequence["ExternalJobData"]] = None,
         external_job_refs: Optional[Sequence["ExternalJobRef"]] = None,
-        external_resource_data: Optional[Sequence["ExternalResourceData"]] = None,
+        external_resource_data: Optional[Sequence["ResourceSnap"]] = None,
         external_asset_checks: Optional[Sequence["AssetCheckNodeSnap"]] = None,
         metadata: Optional[MetadataMapping] = None,
         utilized_env_vars: Optional[Mapping[str, Sequence["EnvVarConsumer"]]] = None,
@@ -861,13 +861,13 @@ class AssetChildEdgeSnap:
     output_name: Optional[str] = None
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(storage_name="ExternalResourceConfigEnvVar")
 @record
-class ExternalResourceConfigEnvVar:
+class ResourceConfigEnvVarSnap:
     name: str
 
 
-ExternalResourceValue = Union[str, ExternalResourceConfigEnvVar]
+ResourceValueSnap: TypeAlias = Union[str, ResourceConfigEnvVarSnap]
 
 
 UNKNOWN_RESOURCE_TYPE = "Unknown"
@@ -882,9 +882,9 @@ class ResourceJobUsageEntry:
     node_handles: List[NodeHandle]
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(storage_name="ExternalResourceData")
 @record_custom
-class ExternalResourceData(IHaveNew):
+class ResourceSnap(IHaveNew):
     """Serializable data associated with a top-level resource in a Repository, e.g. one bound using the Definitions API.
 
     Includes information about the resource definition and config schema, user-passed values, etc.
@@ -892,7 +892,7 @@ class ExternalResourceData(IHaveNew):
 
     name: str
     resource_snapshot: ResourceDefSnap
-    configured_values: Dict[str, ExternalResourceValue]
+    configured_values: Dict[str, ResourceValueSnap]
     config_field_snaps: List[ConfigFieldSnap]
     config_schema_snap: ConfigSchemaSnapshot
     nested_resources: Dict[str, NestedResource]
@@ -909,7 +909,7 @@ class ExternalResourceData(IHaveNew):
         cls,
         name: str,
         resource_snapshot: ResourceDefSnap,
-        configured_values: Mapping[str, ExternalResourceValue],
+        configured_values: Mapping[str, ResourceValueSnap],
         config_field_snaps: Sequence[ConfigFieldSnap],
         config_schema_snap: ConfigSchemaSnapshot,
         nested_resources: Optional[Mapping[str, NestedResource]] = None,
@@ -931,7 +931,7 @@ class ExternalResourceData(IHaveNew):
                     configured_values,
                     "configured_values",
                     key_type=str,
-                    value_type=(str, ExternalResourceConfigEnvVar),
+                    value_type=(str, ResourceConfigEnvVarSnap),
                 )
             ),
             config_field_snaps=config_field_snaps,
@@ -963,6 +963,102 @@ class ExternalResourceData(IHaveNew):
             sensors_using=list(
                 check.opt_sequence_param(sensors_using, "sensors_using", of_type=str)
             ),
+        )
+
+    @classmethod
+    def from_def(
+        cls,
+        resource_def: ResourceDefinition,
+        name: str,
+        nested_resources: Mapping[str, NestedResource],
+        parent_resources: Mapping[str, str],
+        resource_asset_usage_map: Mapping[str, List[AssetKey]],
+        resource_job_usage_map: "ResourceJobUsageMap",
+        resource_schedule_usage_map: Mapping[str, List[str]],
+        resource_sensor_usage_map: Mapping[str, List[str]],
+    ) -> Self:
+        check.inst_param(resource_def, "resource_def", ResourceDefinition)
+
+        # Once values on a resource object are bound, the config schema for those fields is no
+        # longer visible. We walk up the list of parent schemas to find the base, unconfigured
+        # schema so we can display all fields in the UI.
+        unconfigured_config_schema = resource_def.config_schema
+        while (
+            isinstance(unconfigured_config_schema, ConfiguredDefinitionConfigSchema)
+            and unconfigured_config_schema.parent_def.config_schema
+        ):
+            unconfigured_config_schema = unconfigured_config_schema.parent_def.config_schema
+
+        config_type = check.not_none(unconfigured_config_schema.config_type)
+        unconfigured_config_type_snap = snap_from_config_type(config_type)
+
+        config_schema_default = cast(
+            Mapping[str, Any],
+            (
+                json.loads(resource_def.config_schema.default_value_as_json_str)
+                if resource_def.config_schema.default_provided
+                else {}
+            ),
+        )
+
+        # Right now, .configured sets the default value of the top-level Field
+        # we parse the JSON and break it out into defaults for each individual nested Field
+        # for display in the UI
+        configured_values = {
+            k: external_resource_value_from_raw(v) for k, v in config_schema_default.items()
+        }
+
+        resource_type_def = resource_def
+
+        # use the resource function name as the resource type if it's a function resource
+        # (ie direct instantiation of ResourceDefinition or IOManagerDefinition)
+        if type(resource_type_def) in (ResourceDefinition, IOManagerDefinition):
+            original_resource_fn = (
+                resource_type_def._hardcoded_resource_type  # noqa: SLF001
+                if resource_type_def._hardcoded_resource_type  # noqa: SLF001
+                else resource_type_def.resource_fn
+            )
+            module_name = check.not_none(inspect.getmodule(original_resource_fn)).__name__
+            resource_type = f"{module_name}.{original_resource_fn.__name__}"
+        # if it's a Pythonic resource, get the underlying Pythonic class name
+        elif isinstance(
+            resource_type_def,
+            (
+                ConfigurableResourceFactoryResourceDefinition,
+                ConfigurableIOManagerFactoryResourceDefinition,
+            ),
+        ):
+            resource_type = _get_class_name(resource_type_def.configurable_resource_cls)
+        else:
+            resource_type = _get_class_name(type(resource_type_def))
+
+        dagster_maintained = (
+            resource_type_def._is_dagster_maintained()  # noqa: SLF001
+            if type(resource_type_def)
+            in (
+                ResourceDefinition,
+                IOManagerDefinition,
+                ConfigurableResourceFactoryResourceDefinition,
+                ConfigurableIOManagerFactoryResourceDefinition,
+            )
+            else False
+        )
+
+        return cls(
+            name=name,
+            resource_snapshot=build_resource_def_snap(name, resource_def),
+            configured_values=configured_values,
+            config_field_snaps=unconfigured_config_type_snap.fields or [],
+            config_schema_snap=config_type.get_schema_snapshot(),
+            nested_resources=nested_resources,
+            parent_resources=parent_resources,
+            is_top_level=True,
+            asset_keys_using=resource_asset_usage_map.get(name, []),
+            job_ops_using=resource_job_usage_map.get(name, []),
+            schedules_using=resource_schedule_usage_map.get(name, []),
+            sensors_using=resource_sensor_usage_map.get(name, []),
+            resource_type=resource_type,
+            dagster_maintained=dagster_maintained,
         )
 
 
@@ -1216,7 +1312,7 @@ class AssetNodeSnap(IHaveNew):
             return None
 
 
-ResourceJobUsageMap = Dict[str, List[ResourceJobUsageEntry]]
+ResourceJobUsageMap: TypeAlias = Dict[str, List[ResourceJobUsageEntry]]
 
 
 class NodeHandleResourceUse(NamedTuple):
@@ -1350,9 +1446,9 @@ def external_repository_data_from_def(
         external_job_refs=job_refs,
         external_resource_data=sorted(
             [
-                external_resource_data_from_def(
-                    res_name,
+                ResourceSnap.from_def(
                     res_data,
+                    res_name,
                     nested_resource_map[res_name],
                     inverted_nested_resources_map[res_name],
                     resource_asset_usage_map,
@@ -1544,9 +1640,9 @@ def external_job_ref_from_def(job_def: JobDefinition) -> ExternalJobRef:
     )
 
 
-def external_resource_value_from_raw(v: Any) -> ExternalResourceValue:
+def external_resource_value_from_raw(v: Any) -> ResourceValueSnap:
     if isinstance(v, dict) and set(v.keys()) == {"env"}:
-        return ExternalResourceConfigEnvVar(name=v["env"])
+        return ResourceConfigEnvVarSnap(name=v["env"])
     return json.dumps(v)
 
 
@@ -1606,101 +1702,6 @@ def _get_nested_resources(
 def _get_class_name(cls: Type) -> str:
     """Returns the fully qualified class name of the given class."""
     return str(cls)[8:-2]
-
-
-def external_resource_data_from_def(
-    name: str,
-    resource_def: ResourceDefinition,
-    nested_resources: Mapping[str, NestedResource],
-    parent_resources: Mapping[str, str],
-    resource_asset_usage_map: Mapping[str, List[AssetKey]],
-    resource_job_usage_map: ResourceJobUsageMap,
-    resource_schedule_usage_map: Mapping[str, List[str]],
-    resource_sensor_usage_map: Mapping[str, List[str]],
-) -> ExternalResourceData:
-    check.inst_param(resource_def, "resource_def", ResourceDefinition)
-
-    # Once values on a resource object are bound, the config schema for those fields is no
-    # longer visible. We walk up the list of parent schemas to find the base, unconfigured
-    # schema so we can display all fields in the UI.
-    unconfigured_config_schema = resource_def.config_schema
-    while (
-        isinstance(unconfigured_config_schema, ConfiguredDefinitionConfigSchema)
-        and unconfigured_config_schema.parent_def.config_schema
-    ):
-        unconfigured_config_schema = unconfigured_config_schema.parent_def.config_schema
-
-    config_type = check.not_none(unconfigured_config_schema.config_type)
-    unconfigured_config_type_snap = snap_from_config_type(config_type)
-
-    config_schema_default = cast(
-        Mapping[str, Any],
-        (
-            json.loads(resource_def.config_schema.default_value_as_json_str)
-            if resource_def.config_schema.default_provided
-            else {}
-        ),
-    )
-
-    # Right now, .configured sets the default value of the top-level Field
-    # we parse the JSON and break it out into defaults for each individual nested Field
-    # for display in the UI
-    configured_values = {
-        k: external_resource_value_from_raw(v) for k, v in config_schema_default.items()
-    }
-
-    resource_type_def = resource_def
-
-    # use the resource function name as the resource type if it's a function resource
-    # (ie direct instantiation of ResourceDefinition or IOManagerDefinition)
-    if type(resource_type_def) in (ResourceDefinition, IOManagerDefinition):
-        original_resource_fn = (
-            resource_type_def._hardcoded_resource_type  # noqa: SLF001
-            if resource_type_def._hardcoded_resource_type  # noqa: SLF001
-            else resource_type_def.resource_fn
-        )
-        module_name = check.not_none(inspect.getmodule(original_resource_fn)).__name__
-        resource_type = f"{module_name}.{original_resource_fn.__name__}"
-    # if it's a Pythonic resource, get the underlying Pythonic class name
-    elif isinstance(
-        resource_type_def,
-        (
-            ConfigurableResourceFactoryResourceDefinition,
-            ConfigurableIOManagerFactoryResourceDefinition,
-        ),
-    ):
-        resource_type = _get_class_name(resource_type_def.configurable_resource_cls)
-    else:
-        resource_type = _get_class_name(type(resource_type_def))
-
-    dagster_maintained = (
-        resource_type_def._is_dagster_maintained()  # noqa: SLF001
-        if type(resource_type_def)
-        in (
-            ResourceDefinition,
-            IOManagerDefinition,
-            ConfigurableResourceFactoryResourceDefinition,
-            ConfigurableIOManagerFactoryResourceDefinition,
-        )
-        else False
-    )
-
-    return ExternalResourceData(
-        name=name,
-        resource_snapshot=build_resource_def_snap(name, resource_def),
-        configured_values=configured_values,
-        config_field_snaps=unconfigured_config_type_snap.fields or [],
-        config_schema_snap=config_type.get_schema_snapshot(),
-        nested_resources=nested_resources,
-        parent_resources=parent_resources,
-        is_top_level=True,
-        asset_keys_using=resource_asset_usage_map.get(name, []),
-        job_ops_using=resource_job_usage_map.get(name, []),
-        schedules_using=resource_schedule_usage_map.get(name, []),
-        sensors_using=resource_sensor_usage_map.get(name, []),
-        resource_type=resource_type,
-        dagster_maintained=dagster_maintained,
-    )
 
 
 def external_partitions_definition_from_def(

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -28,10 +28,10 @@ from dagster._core.definitions.unresolved_asset_job_definition import define_ass
 from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.remote_representation import ExternalJobData, external_repository_data_from_def
 from dagster._core.remote_representation.external_data import (
-    ExternalResourceData,
     NestedResource,
     NestedResourceType,
     ResourceJobUsageEntry,
+    ResourceSnap,
 )
 from dagster._core.snap import JobSnapshot
 
@@ -749,20 +749,20 @@ def test_repository_snap_definitions_resources_schedule_sensor_usage():
     foo = [data for data in external_repo_data.external_resource_data if data.name == "foo"]
     assert len(foo) == 1
 
-    assert set(cast(ExternalResourceData, foo[0]).schedules_using) == {
+    assert set(cast(ResourceSnap, foo[0]).schedules_using) == {
         "my_schedule",
         "my_schedule_two",
     }
-    assert set(cast(ExternalResourceData, foo[0]).sensors_using) == {"my_sensor", "my_sensor_two"}
+    assert set(cast(ResourceSnap, foo[0]).sensors_using) == {"my_sensor", "my_sensor_two"}
 
     bar = [data for data in external_repo_data.external_resource_data if data.name == "bar"]
     assert len(bar) == 1
 
-    assert set(cast(ExternalResourceData, bar[0]).schedules_using) == set()
-    assert set(cast(ExternalResourceData, bar[0]).sensors_using) == {"my_sensor_two"}
+    assert set(cast(ResourceSnap, bar[0]).schedules_using) == set()
+    assert set(cast(ResourceSnap, bar[0]).sensors_using) == {"my_sensor_two"}
 
     baz = [data for data in external_repo_data.external_resource_data if data.name == "baz"]
     assert len(baz) == 1
 
-    assert set(cast(ExternalResourceData, baz[0]).schedules_using) == set({"my_schedule_two"})
-    assert set(cast(ExternalResourceData, baz[0]).sensors_using) == set()
+    assert set(cast(ResourceSnap, baz[0]).schedules_using) == set({"my_schedule_two"})
+    assert set(cast(ResourceSnap, baz[0]).sensors_using) == set()


### PR DESCRIPTION
## Summary & Motivation

Renames:

- `ExternalResourceData` -> `ResourceSnap`
- `ExternalResourceValue` -> `ResourceValueSnap`
- `ExternalResourceConfigEnvVar` -> `ResourceConfigEnvVarSnap`
- `external_resource_data_from_def` -> `ResourceSnap.from_def`

## How I Tested These Changes

Existing test suite.