### PR TITLE
docs: remove AssetMaterialization mentions from observation page

### DIFF
--- a/docs/content/concepts/assets/asset-observations.mdx
+++ b/docs/content/concepts/assets/asset-observations.mdx
@@ -55,7 +55,7 @@ height={917}
 There are a variety of types of metadata that can be associated with an observation event, all through the <PyObject object="MetadataValue" /> class. Each observation event optionally takes a dictionary of metadata that is then displayed in the event log and the [Asset Details](/concepts/webserver/ui#asset-details) page. Check our API docs for <PyObject object="MetadataValue" /> for more details on the types of event metadata available.
 
 ```python file=concepts/assets/observations.py startafter=start_observation_asset_marker_2 endbefore=end_observation_asset_marker_2
-from dagster import AssetMaterialization, AssetObservation, MetadataValue, op
+from dagster import AssetObservation, MetadataValue, op
 
 
 @op
@@ -75,7 +75,6 @@ def observes_dataset_op(context: OpExecutionContext):
             },
         )
     )
-    context.log_event(AssetMaterialization(asset_key="my_dataset"))
     return remote_storage_path
 ```
 
@@ -93,7 +92,7 @@ height={1146}
 If you are observing a single slice of an asset (e.g. a single day's worth of data on a larger table), rather than mutating or creating it entirely, you can indicate this to Dagster by including the `partition` argument on the object.
 
 ```python file=/concepts/assets/observations.py startafter=start_partitioned_asset_observation endbefore=end_partitioned_asset_observation
-from dagster import AssetMaterialization, Config, op, OpExecutionContext
+from dagster import Config, op, OpExecutionContext
 
 
 class MyOpConfig(Config):

--- a/examples/docs_snippets/docs_snippets/concepts/assets/observations.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/observations.py
@@ -35,7 +35,7 @@ def observation_op(context: OpExecutionContext):
 # end_observation_asset_marker_0
 
 # start_partitioned_asset_observation
-from dagster import AssetMaterialization, Config, op, OpExecutionContext
+from dagster import Config, op, OpExecutionContext
 
 
 class MyOpConfig(Config):
@@ -56,7 +56,7 @@ def partitioned_dataset_op(context: OpExecutionContext, config: MyOpConfig):
 
 
 # start_observation_asset_marker_2
-from dagster import AssetMaterialization, AssetObservation, MetadataValue, op
+from dagster import AssetObservation, MetadataValue, op
 
 
 @op
@@ -76,7 +76,6 @@ def observes_dataset_op(context: OpExecutionContext):
             },
         )
     )
-    context.log_event(AssetMaterialization(asset_key="my_dataset"))
     return remote_storage_path
 
 


### PR DESCRIPTION
## Summary & Motivation
this causes confusion and users (including myself) thought asset materialization was somehow needed here.
is my understanding correct that no AssetMaterialization is needed here?
## How I Tested These Changes
https://dagster-docs-civkvec16-elementl.vercel.app/concepts/assets/asset-observations#attaching-metadata-to-an-assetobservation