### PR TITLE
Resolve precedence issues when top-level k8s configuration options are combined with raw manifest options

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
@@ -312,6 +312,7 @@ def test_k8s_job_op_with_deep_merge(namespace, cluster_provider):
                             "namespace": namespace,
                             "load_incluster_config": False,
                             "kubeconfig_file": cluster_provider.kubeconfig_file,
+                            "merge_behavior": "SHALLOW",
                         }
                     }
                 }
@@ -322,7 +323,7 @@ def test_k8s_job_op_with_deep_merge(namespace, cluster_provider):
 
         assert "FOO IS  AND BAR IS 2" in _get_pod_logs(cluster_provider, job_name, namespace)
 
-        # now with deep merge, both are set
+        # now with default deep merge, both are set
 
         execute_result = with_config_job.execute_in_process(
             instance=instance,
@@ -344,7 +345,6 @@ def test_k8s_job_op_with_deep_merge(namespace, cluster_provider):
                             "namespace": namespace,
                             "load_incluster_config": False,
                             "kubeconfig_file": cluster_provider.kubeconfig_file,
-                            "merge_behavior": "DEEP",
                         }
                     }
                 }

--- a/python_modules/dagster-test/dagster_test/test_project/__init__.py
+++ b/python_modules/dagster-test/dagster_test/test_project/__init__.py
@@ -112,7 +112,7 @@ def find_local_test_image(docker_image):
 def build_and_tag_test_image(tag):
     check.str_param(tag, "tag")
 
-    base_python = "3.8.8"
+    base_python = "3.11"
 
     # Build and tag local dagster test image
     return subprocess.check_output(["./build.sh", base_python, tag], cwd=get_test_repo_path())

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -292,7 +292,6 @@ class K8sStepHandler(StepHandler):
                     "value": run.job_name,
                 },
                 {"name": "DAGSTER_RUN_STEP_KEY", "value": step_key},
-                *container_context.env,
             ],
         )
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -256,7 +256,6 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
                     "name": "DAGSTER_RUN_JOB_NAME",
                     "value": job_origin.job_name,
                 },
-                *container_context.env,
             ],
         )
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
@@ -570,7 +570,7 @@ def test_construct_dagster_k8s_job_with_deep_merge():
         pass
 
     job_user_defined_k8s_config = get_user_defined_k8s_config(user_defined_deep_merge_job.tags)
-    assert job_user_defined_k8s_config.merge_behavior == K8sConfigMergeBehavior.SHALLOW
+    assert job_user_defined_k8s_config.merge_behavior == K8sConfigMergeBehavior.DEEP
 
     @op(
         tags={


### PR DESCRIPTION
## Summary & Motivation
This PR resolves an issue in the new "test_env_var_precedence" test case - if you set env vars in two different places, one as a top-level "env_vars" option and one as an inner "container_config.env" option, they are merged in a counterintuitive way. First all the top-level configuration is merged, then the inner manifest-level configuration options are merged.

Fixing this required a fairly substantial revamp of the inner tracking of K8sContainerContext. Now, top-level fields aren't stored separately at all, and everything is combined together into a k8s manifest dictionary when the container context object is constructed.

For this to work cleanly, we also have to change the default merge behavior for manifest-level configuration. Before, things were pretty confusing - top-level configuration was merged DEEPly (nested merges), but manifest-level configuration was merged shallowly (dictionaries and lists replace each other). This behavior is quite confusing and arguably just presents as a bug - instead, we make everything merge the way top-level fields do by default, where list values are appended and dictionary values are merged.

Test Plan BK
