### PR TITLE
Add in_process_executor use-case to Kubernetes deploy documentation.

### DIFF
--- a/docs/content/deployment/guides/kubernetes/customizing-your-deployment.mdx
+++ b/docs/content/deployment/guides/kubernetes/customizing-your-deployment.mdx
@@ -116,6 +116,9 @@ def my_job():
 
 Other run launchers will ignore the `dagster-k8s/config` tag.
 
+If your Dagster job is short in duration and/or the time to produce its assets is relative the overhead time, consider avoiding the creation of a new pod for each step by using the <PyObject module="dagster" object="in_process_executor" /> executor, which runs each step serially in a single pod.
+For short jobs, this can be more efficient than creating a new pod for each step and creates less stress on the Kubernetes API server. This can be especially useful where parallelism is obtained through a <PyObject object="PartitionsDefinition" /> and parallelism within the job is unnecessary.
+
 If your Dagster job is configured with the <PyObject module="dagster_k8s" object="k8s_job_executor" /> that runs each step in its own pod, configuration that you set on a job using the `dagster-k8s/config` tag will _not_ be propagated to any of those step pods.
 
 ### Kubernetes configuration on every step in a run


### PR DESCRIPTION
## Summary & Motivation

We have a partitioned job running on our Kubernetes cluster which benefited greatly by switching from the default executor to the `in_process_executor`.

Other Kubernetes deployed users may benefit from the same setup and this in not covered in the kubernetes deploy docs.

In our case, we went from this being typical:

![image](https://github.com/dagster-io/dagster/assets/95671524/98118f90-189d-4880-90f4-83517eb304e7)

to this:

![image](https://github.com/dagster-io/dagster/assets/95671524/32cac97d-581e-4859-a9e8-474d8c9a2315)

Resulting in our jobs running in a third of the time, and using fewer resources.

## How I Tested These Changes

By deploying the user code to our production server with only the single change from the default executor to the `in_process_executor`.
