### PR TITLE
make AssetCheckSpec.blocking not public

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -62,7 +62,10 @@ class AssetCheckSpec(
             ("asset_key", PublicAttr[AssetKey]),
             ("description", PublicAttr[Optional[str]]),
             ("additional_deps", PublicAttr[Optional[Iterable["AssetDep"]]]),
-            ("blocking", bool),
+            (
+                "blocking",  # intentionally not public, see https://github.com/dagster-io/dagster/issues/20659
+                bool,
+            ),
             ("metadata", PublicAttr[Optional[Mapping[str, Any]]]),
         ],
     )

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -62,7 +62,7 @@ class AssetCheckSpec(
             ("asset_key", PublicAttr[AssetKey]),
             ("description", PublicAttr[Optional[str]]),
             ("additional_deps", PublicAttr[Optional[Iterable["AssetDep"]]]),
-            ("blocking", PublicAttr[bool]),
+            ("blocking", bool),
             ("metadata", PublicAttr[Optional[Mapping[str, Any]]]),
         ],
     )
@@ -83,10 +83,6 @@ class AssetCheckSpec(
             the asset specified by `asset`. For example, the check may test that `asset` has
             matching data with an asset in `additional_deps`. This field holds both `additional_deps`
             and `additional_ins` passed to @asset_check.
-        blocking (bool): When enabled, runs that include this check and any downstream assets that
-            depend on `asset` will wait for this check to complete before starting the downstream
-            assets. If the check fails with severity `AssetCheckSeverity.ERROR`, then the downstream
-            assets won't execute.
         metadata (Optional[Mapping[str, Any]]):  A dict of static metadata for this asset check.
     """
 


### PR DESCRIPTION
`blocking` works well with `@asset_check`, but not with `@multi_asset` or `@multi_asset_check`: https://github.com/dagster-io/dagster/issues/20659

To reduce users running in to this, remove `blocking` as a public attr on AssetCheckSpec so that it's only publicly on `@asset_check`.