### PR TITLE
Docs adjustment with supported Python version and Apple silicon chips

### DIFF
--- a/docs/content/community/contributing.mdx
+++ b/docs/content/community/contributing.mdx
@@ -50,7 +50,7 @@ We love to see our community members get involved! If you are planning to contri
    make dev_install
    ```
 
-   **Note for Macs with an M1 or M2 chip**: Some users have reported installation problems due to missing wheels for arm64 Macs when installing the `grpcio` package. To install the `dagster` development environment using our pre-built wheel of the `grpcio` package for M1 and M2 machines, run `make dev_install_m1_grpcio_wheel` instead of `make dev_install`.
+   **Note for Macs with an Apple silicon chip**: Some users have reported installation problems due to missing wheels for arm64 Macs when installing the `grpcio` package. To install the `dagster` development environment using our pre-built wheel of the `grpcio` package for M1, M2, and M3 machines, run `make dev_install_m1_grpcio_wheel` instead of `make dev_install`.
 
 6. Run some tests manually to make sure things are working:
 

--- a/docs/next/pages/getting-started/install.md
+++ b/docs/next/pages/getting-started/install.md
@@ -34,7 +34,7 @@ To install the latest stable version of the core Dagster packages in your curren
 pip install dagster dagster-webserver
 ```
 
-**Using a Mac with an M1 or M2 chip**? Some users have reported installation errors due to missing wheels for arm64 Macs when installing the `grpcio` package. You can avoid these errors by installing `dagster` using our pre-built wheel of the `grpcio` package for M1 and M2 machines:
+**Using a Mac with an Apple silicon chip**? Some users have reported installation errors due to missing wheels for arm64 Macs when installing the `grpcio` package. You can avoid these errors by installing `dagster` using our pre-built wheel of the `grpcio` package for M1, M2, and M3 machines:
 
 ```bash
 pip install dagster dagster-webserver --find-links=https://github.com/dagster-io/build-grpcio/wiki/Wheels
@@ -56,7 +56,7 @@ To install Dagster and the Dagster webserver/UI into an existing [Poetry](https:
 poetry add dagster dagster-webserver
 ```
 
-**Using a Mac with an M1 or M2 chip**? Some users have reported installation problems due to missing wheels for arm64 Macs when installing the `grpcio` package. You can avoid these errors by installing `dagster` using our pre-built wheel of the `grpcio` package for M1 and M2 machines:
+**Using a Mac with an Apple silicon chip**? Some users have reported installation problems due to missing wheels for arm64 Macs when installing the `grpcio` package. You can avoid these errors by installing `dagster` using our pre-built wheel of the `grpcio` package for M1, M2, and M3 machines:
 
 ```bash
 poetry source add grpcio https://github.com/dagster-io/build-grpcio/wiki/Wheels

--- a/python_modules/dagster/README.md
+++ b/python_modules/dagster/README.md
@@ -70,7 +70,7 @@ Dagster is built to be used at every stage of the data development lifecycle - l
 
 If you're new to Dagster, we recommend reading about its [core concepts](https://docs.dagster.io/concepts) or learning with the hands-on [tutorial](https://docs.dagster.io/tutorial).
 
-Dagster is available on PyPI and officially supports Python 3.8, Python 3.9, Python 3.10, and Python 3.11.
+Dagster is available on PyPI and officially supports Python 3.8 through Python 3.12.
 
 ```bash
 pip install dagster dagster-webserver
@@ -81,7 +81,7 @@ This installs two packages:
 - `dagster`: The core programming model.
 - `dagster-webserver`: The server that hosts Dagster's web UI for developing and operating Dagster jobs and assets.
 
-Running on Using a Mac with an M1 or M2 chip? Check the [install details here](https://docs.dagster.io/getting-started/install#installing-dagster-into-an-existing-python-environment).
+Running on Using a Mac with an Apple silicon chip? Check the [install details here](https://docs.dagster.io/getting-started/install#installing-dagster-into-an-existing-python-environment).
 
 ## Documentation
 


### PR DESCRIPTION
## Summary & Motivation
Included Python 3.12 in the list of Dagster's supported Python versions, as reflected in the [official docs](https://docs.dagster.io/getting-started/install) and [pypi](https://pypi.org/project/dagster/).

Additionally, the same installation error and fix due to missing wheels for M1 and M2 was observed on Macs with M3. Hence, I grouped the chips together and labeled them "Apple silicon" chips. 

_Note: Apple **silicon** is spelled using lowercase **"s"**, according to [Apple's official webpage](https://support.apple.com/en-au/116943), [Wikipedia](https://en.wikipedia.org/wiki/Apple_silicon), and [Apple's news release](https://www.apple.com/au/newsroom/2020/06/apple-announces-mac-transition-to-apple-silicon/)._

## How I Tested These Changes
Previewed the markdown files after I edited them.