### PR TITLE
fix(dbt): switch to jinja comments

### DIFF
--- a/python_modules/libraries/dagster-dbt/dbt_packages/dagster/macros/log_column_level_metadata.sql
+++ b/python_modules/libraries/dagster-dbt/dbt_packages/dagster/macros/log_column_level_metadata.sql
@@ -1,9 +1,9 @@
 {% macro log_column_level_metadata(enable_parent_relation_metadata_collection=true) %}
-    -- This macro should only be run in the context of a `dagster-dbt` invocation.
+    {#/* This macro should only be run in the context of a `dagster-dbt` invocation. */#}
     {%- set is_dagster_dbt_cli = env_var('DAGSTER_DBT_CLI', '') == 'true' -%}
 
     {%- if execute and is_dagster_dbt_cli -%}
-        -- Retrieve the column metadata of the current node.
+        {#/* Retrieve the column metadata of the current node. */#}
         {%- set columns = adapter.get_columns_in_relation(this) -%}
         {%- set column_schema = {} -%}
 
@@ -12,8 +12,10 @@
             {%- set _ = column_schema.update(serializable_column) -%}
         {%- endfor -%}
 
-        -- For column level lineage, retrieve the column metadata of the current node's parents.
-        -- The parents are defined by the current node's dbt refs and sources.
+        {#/*
+            For column level lineage, retrieve the column metadata of the current node's parents.
+            The parents are defined by the current node's dbt refs and sources.
+        */#}
         {%- set parent_relations = [] -%}
 
         {%- for ref_args in model.refs -%}
@@ -27,27 +29,29 @@
             {%- set _ = parent_relations.append(source_relation) -%}
         {%- endfor -%}
 
-        -- Return a structured log of
-        -- {
-        --     "relation_name": str,
-        --     "columns": {
-        --         <column_name>: {
-        --             "data_type": str
-        --         }
-        --     },
-        --     "parents": {
-        --         <relation_name>: {
-        --             "columns": {
-        --                 <column_name>: {
-        --                     "data_type": str
-        --                 }
-        --             }
-        --         }
-        --     }
-        -- }
-        --
-        -- If `enable_parent_relation_metadata_collection` is set to `false`, the structured log
-        -- will only contain the current node's column metadata.
+        {#/*
+            Return a structured log of
+            {
+                "relation_name": str,
+                "columns": {
+                    <column_name>: {
+                        "data_type": str
+                    }
+                },
+                "parents": {
+                    <relation_name>: {
+                        "columns": {
+                            <column_name>: {
+                                "data_type": str
+                            }
+                        }
+                    }
+                }
+            }
+
+            If `enable_parent_relation_metadata_collection` is set to `false`, the structured log
+            will only contain the current node's column metadata.
+        */#}
         {%- set structured_log = {'relation_name': this.render(), 'columns': column_schema} -%}
 
         {%- if enable_parent_relation_metadata_collection -%}


### PR DESCRIPTION
## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/20798.

Rather than using SQL comments, we'll use Jinja comments to avoid any templating mishap altogether.

## How I Tested These Changes
Seems to be a dialect-specific issue, so will wait to hear back from our user after this fix has landed.

Can confirm that there are no more comments in the compiled jinja macro.
