### PR TITLE
fix(dagster-polars): ignore decimal in delta/parquet tests

### DIFF
--- a/python_modules/libraries/dagster-polars/dagster_polars_tests/test_deltalake.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars_tests/test_deltalake.py
@@ -22,6 +22,7 @@ from polars.testing.parametric import dataframes
             pl.UInt32,  # These get casted to int in deltalake whenever it fits
             pl.UInt64,  # These get casted to int in deltalake whenever it fits
             pl.Datetime("ns", None),  # These get casted to datetime('ms')
+            pl.Decimal,  # Delta-RS decimal handling parsing in transaction log is partially broken see #todo(ion): uncomment once arrow-rs fixes upstream parser: https://github.com/apache/arrow-rs/issues/5549
         ],
         min_size=5,
         allow_infinities=False,

--- a/python_modules/libraries/dagster-polars/dagster_polars_tests/test_polars_delta.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars_tests/test_polars_delta.py
@@ -43,6 +43,7 @@ from dagster_polars_tests.utils import get_saved_path
             pl.UInt32,
             pl.UInt64,
             pl.Datetime("ns", None),
+            pl.Decimal,
         ],
         min_size=5,
         allow_infinities=False,

--- a/python_modules/libraries/dagster-polars/dagster_polars_tests/test_polars_parquet.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars_tests/test_polars_parquet.py
@@ -12,7 +12,7 @@ from dagster_polars_tests.utils import get_saved_path
 
 # allowed_dtypes=[pl.List(inner) for inner in
 # list(pl.TEMPORAL_DTYPES | pl.FLOAT_DTYPES | pl.INTEGER_DTYPES) + [pl.Boolean, pl.Utf8]]
-@given(df=dataframes(excluded_dtypes=[pl.Categorical], min_size=5))
+@given(df=dataframes(excluded_dtypes=[pl.Categorical, pl.Decimal], min_size=5))
 @settings(max_examples=100, deadline=None)
 def test_polars_parquet_io_manager_read_write(
     session_polars_parquet_io_manager: PolarsParquetIOManager, df: pl.DataFrame
@@ -36,7 +36,7 @@ def test_polars_parquet_io_manager_read_write(
 
 # allowed_dtypes=[pl.List(inner) for inner in
 # list(pl.TEMPORAL_DTYPES | pl.FLOAT_DTYPES | pl.INTEGER_DTYPES) + [pl.Boolean, pl.Utf8]]
-@given(df=dataframes(excluded_dtypes=[pl.Categorical], min_size=5))
+@given(df=dataframes(excluded_dtypes=[pl.Categorical, pl.Decimal], min_size=5))
 @settings(max_examples=100, deadline=None)
 def test_polars_parquet_io_manager_read_write_full_lazy(
     session_polars_parquet_io_manager: PolarsParquetIOManager, df: pl.DataFrame

--- a/python_modules/libraries/dagster-polars/setup.py
+++ b/python_modules/libraries/dagster-polars/setup.py
@@ -37,7 +37,7 @@ setup(
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",
-        "polars>=0.20.0,<0.20.17",
+        "polars>=0.20.0",
         "pyarrow>=8.0.0",
         "typing-extensions>=4.7.0",
         "universal_pathlib>=0.1.4",


### PR DESCRIPTION
## Summary & Motivation
Decimals in Polars are officially still experimental so should not be included in CI tests. Decimal in Delta-RS at the moment is slightly broken, I have merged some PRs couple days ago to fix most issues but still waiting on an upstream fix in arrow-rs, in the mean time we should ignore roundtripping decimals there as well.