### PR TITLE
deprecate FreshnessPolicy

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_out.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_out.py
@@ -65,8 +65,8 @@ class AssetOut(
         group_name (Optional[str]): A string name used to organize multiple assets into groups. If
             not provided, the name "default" is used.
         code_version (Optional[str]): The version of the code that generates this asset.
-        freshness_policy (Optional[FreshnessPolicy]): A policy which indicates how up to date this
-            asset is intended to be.
+        freshness_policy (Optional[FreshnessPolicy]): (Deprecated) A policy which indicates how up
+            to date this asset is intended to be.
         auto_materialize_policy (Optional[AutoMaterializePolicy]): AutoMaterializePolicy to apply to
             the specified asset.
         backfill_policy (Optional[BackfillPolicy]): BackfillPolicy to apply to the specified asset.

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -92,8 +92,8 @@ class AssetSpec(
             not provided, the name "default" is used.
         code_version (Optional[str]): The version of the code for this specific asset,
             overriding the code version of the materialization function
-        freshness_policy (Optional[FreshnessPolicy]): A policy which indicates how up to date this
-            asset is intended to be.
+        freshness_policy (Optional[FreshnessPolicy]): (Deprecated) A policy which indicates how up
+            to date this asset is intended to be.
         auto_materialize_policy (Optional[AutoMaterializePolicy]): AutoMaterializePolicy to apply to
             the specified asset.
         backfill_policy (Optional[BackfillPolicy]): BackfillPolicy to apply to the specified asset.

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, AbstractSet, Dict, FrozenSet, NamedTuple, Optional, Sequence
 
 import dagster._check as check
-from dagster._annotations import experimental, public
+from dagster._annotations import deprecated, experimental, public
 from dagster._serdes.serdes import (
     NamedTupleSerializer,
     UnpackContext,
@@ -215,8 +215,14 @@ class AutoMaterializePolicy(
 
     @public
     @staticmethod
+    @deprecated(
+        breaking_version="1.8",
+        additional_warn_text="Lazy auto-materialize is deprecated, in favor of explicit cron-based "
+        "scheduling rules. Additional alternatives to replicate more of the lazy behavior will be "
+        "provided before this is fully removed.",
+    )
     def lazy(max_materializations_per_minute: Optional[int] = 1) -> "AutoMaterializePolicy":
-        """Constructs a lazy AutoMaterializePolicy.
+        """(Deprecated) Constructs a lazy AutoMaterializePolicy.
 
         Args:
             max_materializations_per_minute (Optional[int]): The maximum number of

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -218,8 +218,8 @@ class AutoMaterializePolicy(
     @deprecated(
         breaking_version="1.8",
         additional_warn_text="Lazy auto-materialize is deprecated, in favor of explicit cron-based "
-        "scheduling rules. Additional alternatives to replicate more of the lazy behavior will be "
-        "provided before this is fully removed.",
+        "scheduling rules. Additional alternatives to replicate more of the lazy auto-materialize "
+        "behavior will be provided before this is fully removed.",
     )
     def lazy(max_materializations_per_minute: Optional[int] = 1) -> "AutoMaterializePolicy":
         """(Deprecated) Constructs a lazy AutoMaterializePolicy.

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -259,8 +259,8 @@ class AutoMaterializeRule(ABC):
 @deprecated(
     breaking_version="1.8",
     additional_warn_text="Lazy auto-materialize is deprecated, in favor of explicit cron-based "
-    "scheduling rules. Additional alternatives to replicate more of the lazy behavior will be "
-    "provided before this is fully removed.",
+    "scheduling rules. Additional alternatives to replicate more of the lazy auto-materialize "
+    "behavior will be provided before this is fully removed.",
 )
 @whitelist_for_serdes
 class MaterializeOnRequiredForFreshnessRule(

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -16,7 +16,7 @@ from typing import (
 import pytz
 
 import dagster._check as check
-from dagster._annotations import experimental, public
+from dagster._annotations import deprecated, experimental, public
 from dagster._core.definitions.asset_subset import AssetSubset, ValidAssetSubset
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeDecisionType,
@@ -99,7 +99,7 @@ class AutoMaterializeRule(ABC):
     @public
     @staticmethod
     def materialize_on_required_for_freshness() -> "MaterializeOnRequiredForFreshnessRule":
-        """Materialize an asset partition if it is required to satisfy a freshness policy of this
+        """(Deprecated) Materialize an asset partition if it is required to satisfy a freshness policy of this
         asset or one of its downstream assets.
 
         Note: This rule has no effect on partitioned assets.
@@ -256,6 +256,12 @@ class AutoMaterializeRule(ABC):
         return hash(hash(type(self)) + super().__hash__())
 
 
+@deprecated(
+    breaking_version="1.8",
+    additional_warn_text="Lazy auto-materialize is deprecated, in favor of explicit cron-based "
+    "scheduling rules. Additional alternatives to replicate more of the lazy behavior will be "
+    "provided before this is fully removed.",
+)
 @whitelist_for_serdes
 class MaterializeOnRequiredForFreshnessRule(
     AutoMaterializeRule, NamedTuple("_MaterializeOnRequiredForFreshnessRule", [])

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -198,8 +198,8 @@ def asset(
         output_required (bool): Whether the decorated function will always materialize an asset.
             Defaults to True. If False, the function can return None, which will not be materialized to
             storage and will halt execution of downstream assets.
-        freshness_policy (FreshnessPolicy): A constraint telling Dagster how often this asset is intended to be updated
-            with respect to its root data.
+        freshness_policy (FreshnessPolicy): (Deprecated) A constraint telling Dagster how often this
+            asset is intended to be updated with respect to its root data.
         auto_materialize_policy (AutoMaterializePolicy): (Experimental) Configure Dagster to automatically materialize
             this asset according to its FreshnessPolicy and when upstream dependencies change.
         backfill_policy (BackfillPolicy): (Experimental) Configure Dagster to backfill this asset according to its

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -27,9 +27,9 @@ class FreshnessMinutes(NamedTuple):
 
 @deprecated(
     breaking_version="1.8",
-    additional_warn_text="For monitoring freshness, use freshness checks instead. "
-    "For lazy auto-materialize, using FreshnessPolicys is still recommended - a substitute will be "
-    "provided before it's removed.",
+    additional_warn_text="For monitoring freshness, use freshness checks instead. If using lazy "
+    "auto-materialize, using FreshnessPolicys is still required, and an alternative system will "
+    "be provided before this class is fully removed.",
 )
 @whitelist_for_serdes
 class FreshnessPolicy(

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -2,7 +2,7 @@ import datetime
 from typing import AbstractSet, NamedTuple, Optional
 
 import dagster._check as check
-from dagster._annotations import experimental
+from dagster._annotations import deprecated
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._serdes import whitelist_for_serdes
 from dagster._seven.compat.pendulum import pendulum_create_timezone
@@ -25,7 +25,12 @@ class FreshnessMinutes(NamedTuple):
     lag_minutes: float
 
 
-@experimental
+@deprecated(
+    breaking_version="1.8",
+    additional_warn_text="For monitoring freshness, use freshness checks instead. "
+    "For lazy auto-materialize, using FreshnessPolicys is still recommended - a substitute will be "
+    "provided before it's removed.",
+)
 @whitelist_for_serdes
 class FreshnessPolicy(
     NamedTuple(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -876,7 +876,7 @@ def test_graph_asset_decorator_no_args():
     assert my_graph.keys_by_output_name["result"] == AssetKey("my_graph")
 
 
-@ignore_warning("Class `FreshnessPolicy` is experimental")
+@ignore_warning("Class `FreshnessPolicy` is deprecated")
 @ignore_warning("Class `AutoMaterializePolicy` is experimental")
 @ignore_warning("Parameter `resource_defs` .* is experimental")
 def test_graph_asset_with_args():
@@ -1041,7 +1041,7 @@ def test_graph_asset_w_config_mapping():
     assert result.output_for_node("bar", "first_asset") == 1
 
 
-@ignore_warning("Class `FreshnessPolicy` is experimental")
+@ignore_warning("Class `FreshnessPolicy` is deprecated")
 @ignore_warning("Class `AutoMaterializePolicy` is experimental")
 @ignore_warning("Parameter `resource_defs`")
 def test_graph_multi_asset_decorator():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -878,6 +878,8 @@ def test_graph_asset_decorator_no_args():
 
 @ignore_warning("Class `FreshnessPolicy` is deprecated")
 @ignore_warning("Class `AutoMaterializePolicy` is experimental")
+@ignore_warning("Class `MaterializeOnRequiredForFreshnessRule` is deprecated")
+@ignore_warning("Function `AutoMaterializePolicy.lazy` is deprecated")
 @ignore_warning("Parameter `resource_defs` .* is experimental")
 def test_graph_asset_with_args():
     @resource
@@ -1043,6 +1045,8 @@ def test_graph_asset_w_config_mapping():
 
 @ignore_warning("Class `FreshnessPolicy` is deprecated")
 @ignore_warning("Class `AutoMaterializePolicy` is experimental")
+@ignore_warning("Class `MaterializeOnRequiredForFreshnessRule` is deprecated")
+@ignore_warning("Function `AutoMaterializePolicy.lazy` is deprecated")
 @ignore_warning("Parameter `resource_defs`")
 def test_graph_multi_asset_decorator():
     @resource
@@ -1228,6 +1232,8 @@ def test_multi_asset_with_bare_resource():
 
 
 @ignore_warning("Class `AutoMaterializePolicy` is experimental")
+@ignore_warning("Class `MaterializeOnRequiredForFreshnessRule` is deprecated")
+@ignore_warning("Function `AutoMaterializePolicy.lazy` is deprecated")
 def test_multi_asset_with_auto_materialize_policy():
     @multi_asset(
         outs={


### PR DESCRIPTION
## Summary & Motivation

I think we need to be careful with the messaging here, so very open to suggestions on how to improve it. The situation we're in, as I see it:
- For users who just want to monitor freshness and aren't using lazy auto-materialize, they should definitely use freshness checks. New users should only encounter freshness checks, and existing users of `FreshnessPolicy` should be encouraged to migrate.
- We don't want new users to start using `FreshnessPolicy`, even for auto-materialize.
- We have some important users who are using `FreshnessPolicy` for auto-materialize. They should continue to do so until we provide them a substitute.
- This change is going to likely cause them some anxiety, because we're telling them it's going away, without yet providing a substitute.
- We don't yet have full alignment on what the substitute will be. Options include:
  - Expecting users to put cron `AssetCondition`s on all of their non-eager assets.
  - Introducing an `AssetCondition` that works similarly to `AutoMaterializePolicy.lazy`, but isn't globally scoped and bases its decisions on different downstream metadata than `FreshnessPolicy`.
  - Introducing some sort of demand/defer semantics to the auto-materialize system.

## How I Tested These Changes
