### PR TITLE
[graph diffing] add metadata change reason

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -71,6 +71,7 @@ export const AssetNodeFragmentBasic: AssetNodeFragment = buildAssetNode({
     ChangeReason.DEPENDENCIES,
     ChangeReason.PARTITIONS_DEFINITION,
     ChangeReason.TAGS,
+    ChangeReason.METADATA,
   ],
 });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/ChangedReasons.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/ChangedReasons.tsx
@@ -64,6 +64,8 @@ export const ChangedReasonsPopover = ({
         return 'has a changed partition definition';
       case ChangeReason.TAGS:
         return 'has changed tags';
+      case ChangeReason.METADATA:
+        return 'has changed metadata'
     }
   }
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/ChangedReasons.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/ChangedReasons.tsx
@@ -65,7 +65,7 @@ export const ChangedReasonsPopover = ({
       case ChangeReason.TAGS:
         return 'has changed tags';
       case ChangeReason.METADATA:
-        return 'has changed metadata'
+        return 'has changed metadata';
     }
   }
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -720,6 +720,7 @@ enum ChangeReason {
   DEPENDENCIES
   PARTITIONS_DEFINITION
   TAGS
+  METADATA
 }
 
 type AssetDependency {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -746,6 +746,7 @@ export enum ChangeReason {
   NEW = 'NEW',
   PARTITIONS_DEFINITION = 'PARTITIONS_DEFINITION',
   TAGS = 'TAGS',
+  METADATA = 'METADATA'
 }
 
 export type ClaimedConcurrencySlot = {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -743,10 +743,10 @@ export type CapturedLogsMetadata = {
 export enum ChangeReason {
   CODE_VERSION = 'CODE_VERSION',
   DEPENDENCIES = 'DEPENDENCIES',
+  METADATA = 'METADATA',
   NEW = 'NEW',
   PARTITIONS_DEFINITION = 'PARTITIONS_DEFINITION',
   TAGS = 'TAGS',
-  METADATA = 'METADATA'
 }
 
 export type ClaimedConcurrencySlot = {

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -19,6 +19,7 @@ class ChangeReason(Enum):
     DEPENDENCIES = "DEPENDENCIES"
     PARTITIONS_DEFINITION = "PARTITIONS_DEFINITION"
     TAGS = "TAGS"
+    METADATA = "METADATA"
 
 
 def _get_external_repo_from_context(
@@ -144,6 +145,9 @@ class AssetGraphDiffer:
 
         if branch_asset.tags != base_asset.tags:
             changes.append(ChangeReason.TAGS)
+
+        if branch_asset.metadata != base_asset.metadata:
+            changes.append(ChangeReason.METADATA)
 
         return changes
 

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/metadata_asset_graph/base_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/metadata_asset_graph/base_asset_graph.py
@@ -1,7 +1,7 @@
 from dagster import Definitions, asset
 
 
-@asset(metadata={"foo": "bar"})
+@asset(metadata={"foo": "bar", "one": "two"})
 def upstream():
     return 1
 
@@ -11,4 +11,19 @@ def downstream(upstream):
     return upstream + 1
 
 
-defs = Definitions(assets=[upstream, downstream])
+@asset(metadata={"red": "apple", "yellow": "banana"})
+def fruits():
+    return 1
+
+
+@asset(metadata={"a": "A", "b": "B"})
+def letters():
+    return 1
+
+
+@asset(metadata={"one": "1", "two": "2", "three": "3"})
+def numbers():
+    return 1
+
+
+defs = Definitions(assets=[upstream, downstream, numbers, letters, fruits])

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/metadata_asset_graph/base_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/metadata_asset_graph/base_asset_graph.py
@@ -1,0 +1,14 @@
+from dagster import Definitions, asset
+
+
+@asset(metadata={"foo": "bar"})
+def upstream():
+    return 1
+
+
+@asset(metadata={"baz": "qux"})
+def downstream(upstream):
+    return upstream + 1
+
+
+defs = Definitions(assets=[upstream, downstream])

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/metadata_asset_graph/branch_deployment_change_metadata.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/metadata_asset_graph/branch_deployment_change_metadata.py
@@ -1,14 +1,29 @@
 from dagster import Definitions, asset
 
 
-@asset(metadata={"foo": "buz"})
+@asset(metadata={"foo": "bar"})  # removing a tag should be detected
 def upstream():
     return 1
 
 
-@asset(metadata={"bar": "qux"})
+@asset(metadata={"baz": "foo"})  # changing a tag value should be detected
 def downstream(upstream):
     return upstream + 1
 
 
-defs = Definitions(assets=[upstream, downstream])
+@asset(metadata={"green": "apple", "yellow": "banana"})  # changing a tag key should be detected
+def fruits():
+    return 1
+
+
+@asset(metadata={"a": "A", "b": "B", "c": "C"})  # adding a tag value should be detected
+def letters():
+    return 1
+
+
+@asset(metadata={"three": "3", "one": "1", "two": "2"})  # ordering changes should not be detected
+def numbers():
+    return 1
+
+
+defs = Definitions(assets=[upstream, downstream, numbers, letters, fruits])

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/metadata_asset_graph/branch_deployment_change_metadata.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/metadata_asset_graph/branch_deployment_change_metadata.py
@@ -1,0 +1,14 @@
+from dagster import Definitions, asset
+
+
+@asset(metadata={"foo": "buz"})
+def upstream():
+    return 1
+
+
+@asset(metadata={"bar": "qux"})
+def downstream(upstream):
+    return upstream + 1
+
+
+defs = Definitions(assets=[upstream, downstream])

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -315,3 +315,16 @@ def test_change_tags(instance):
     assert differ.get_changes_for_asset(AssetKey("fruits")) == [ChangeReason.TAGS]
     assert differ.get_changes_for_asset(AssetKey("letters")) == [ChangeReason.TAGS]
     assert len(differ.get_changes_for_asset(AssetKey("numbers"))) == 0
+
+
+def test_change_metadata(instance):
+    differ = get_asset_graph_differ(
+        instance=instance,
+        code_location_to_diff="metadata_asset_graph",
+        base_code_locations=["metadata_asset_graph"],
+        branch_code_location_to_definitions={
+            "metadata_asset_graph": "branch_deployment_change_metadata"
+        },
+    )
+    assert differ.get_changes_for_asset(AssetKey("upstream")) == [ChangeReason.METADATA]
+    assert differ.get_changes_for_asset(AssetKey("downstream")) == [ChangeReason.METADATA]

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -328,3 +328,6 @@ def test_change_metadata(instance):
     )
     assert differ.get_changes_for_asset(AssetKey("upstream")) == [ChangeReason.METADATA]
     assert differ.get_changes_for_asset(AssetKey("downstream")) == [ChangeReason.METADATA]
+    assert differ.get_changes_for_asset(AssetKey("fruits")) == [ChangeReason.METADATA]
+    assert differ.get_changes_for_asset(AssetKey("letters")) == [ChangeReason.METADATA]
+    assert len(differ.get_changes_for_asset(AssetKey("numbers"))) == 0


### PR DESCRIPTION
## Summary & Motivation
Change Tracking can detect changes in the definition metadata on an asset

## How I Tested These Changes
new unit test, ran shadow dagit against our deployment and saw metadata changes detected