### PR TITLE
chore(embedded-elt): add `py.typed`

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/MANIFEST.in
+++ b/python_modules/libraries/dagster-embedded-elt/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
 include LICENSE
 include integration.yaml
+include dagster_embedded_elt/py.typed

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/py.typed
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/py.typed
@@ -1,0 +1,1 @@
+partial


### PR DESCRIPTION
## Summary & Motivation
Trying to diagnose why `dagster_embedded_elt` is giving me `pyright` errors in my editor. Noticed this was missing, so add it.

## How I Tested These Changes
bk
