### PR TITLE
asset checks on dbt models with dotted names

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -128,7 +128,7 @@ class AssetCheckSpec(
         """Returns a string uniquely identifying the asset check, that uses only the characters
         allowed in a Python identifier.
         """
-        return f"{self.asset_key.to_python_identifier()}_{self.name}"
+        return f"{self.asset_key.to_python_identifier()}_{self.name}".replace(".", "_")
 
     @property
     def key(self) -> AssetCheckKey:


### PR DESCRIPTION
We build check output names off of check keys, which may contain periods https://github.com/dagster-io/dagster/blob/johann/03-29-asset_checks_on_dbt_models_with_dotted_names/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py#L1450. Filter these out, akin to https://github.com/dagster-io/dagster/pull/19769