### PR TITLE
add editable_mode config for pip install command

### DIFF
--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -141,6 +141,8 @@ def main(
     if quiet is not None:
         cmd.append(f'-{"q" * quiet}')
 
+    cmd.append("--config-settings editable_mode=compat")
+
     p = subprocess.Popen(
         " ".join(cmd), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True
     )


### PR DESCRIPTION
## Summary & Motivation
Was running into weird behaviors where the editable installs were caching stale versions.

Got here via: https://dagsterlabs.slack.com/archives/C04JWF4EKNF/p1708035375608989

## How I Tested These Changes
BK, set up fresh install, fresh virtualenv