### PR TITLE
Handle different casing of tables passed into fetch_last_update_timestamps

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -740,6 +740,7 @@ def fetch_last_updated_timestamps(
         Mapping[str, datetime]: A dictionary of table names to their last updated time in UTC.
     """
     check.invariant(len(tables) > 0, "Must provide at least one table name to query upon.")
+    tables = [table.upper() for table in tables]
     tables_str = ", ".join([f"'{table_name}'" for table_name in tables])
     fully_qualified_table_name = (
         f"{database}.information_schema.tables" if database else "information_schema.tables"
@@ -764,6 +765,6 @@ def fetch_last_updated_timestamps(
 
     for table_name in tables:
         if table_name not in last_updated_times:
-            raise ValueError(f"Table {table_name} does not exist in Snowflake.")
+            raise ValueError(f"Table {table_name} could not be found.")
 
     return last_updated_times

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
@@ -294,7 +294,7 @@ def test_fetch_last_updated_timestamps_empty():
 
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
 @pytest.mark.integration
-@pytest.mark.parametrize("db_str", [None, "TESTDB"])
+@pytest.mark.parametrize("db_str", [None, "TESTDB"], ids=["db_from_resource", "db_from_param"])
 def test_fetch_last_updated_timestamps(db_str: str):
     start_time = pendulum.now("UTC").timestamp()
     table_name = "the_table"
@@ -306,7 +306,9 @@ def test_fetch_last_updated_timestamps(db_str: str):
                 freshness_for_table = fetch_last_updated_timestamps(
                     snowflake_connection=conn,
                     database="TESTDB",
-                    tables=[table_name],
+                    tables=[
+                        table_name.lower()
+                    ],  # Snowflake table names are expected uppercase. Test that lowercase also works.
                     schema="TESTSCHEMA",
                 )[table_name].timestamp()
                 return ObserveResult(


### PR DESCRIPTION
Previously, case had to match (aka be uppercase) or things would fail. Now, we auto convert to upper case.

How I tested this:
- changed the test to have the call to fn use lowercase table name, ensure it still works.

Confirmed that uppercase is how all information_schema table names are converted in snowflake.
Fwiw, also confirmed that table names are case sensitive by default in bigquery, so shouldn't have to make changes there.
