### PR TITLE
enforce that custom run ids are UUIDs

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -73,7 +73,7 @@ from dagster._core.storage.tags import (
 )
 from dagster._serdes import ConfigurableClass
 from dagster._seven import get_current_datetime_in_utc
-from dagster._utils import PrintFn, traced
+from dagster._utils import PrintFn, is_uuid, traced
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.merger import merge_dicts
 from dagster._utils.warnings import (
@@ -1513,8 +1513,8 @@ class DagsterInstance(DynamicPartitionsStore):
             execution_plan_snapshot, "execution_plan_snapshot", ExecutionPlanSnapshot
         )
 
-        if run_id:
-            raise
+        if run_id and not is_uuid(run_id):
+            check.failed(f"run_id must be a valid UUID. Got {run_id}")
 
         if root_run_id or parent_run_id:
             check.invariant(

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1513,6 +1513,9 @@ class DagsterInstance(DynamicPartitionsStore):
             execution_plan_snapshot, "execution_plan_snapshot", ExecutionPlanSnapshot
         )
 
+        if run_id:
+            raise
+
         if root_run_id or parent_run_id:
             check.invariant(
                 root_run_id and parent_run_id,

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 import threading
 import time
+import uuid
 from datetime import timezone
 from enum import Enum
 from signal import Signals
@@ -771,3 +772,11 @@ def tail_file(path_or_fd: Union[str, int], should_stop: Callable[[], bool]) -> I
                 break
             else:
                 time.sleep(0.01)
+
+
+def is_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(value)
+        return True
+    except ValueError:
+        return False

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -780,3 +780,12 @@ def test_report_runless_asset_event():
             limit=1,
         )
         assert len(records) == 1
+
+
+def test_invalid_run_id():
+    with instance_for_test() as instance:
+        with pytest.raises(
+            CheckError,
+            match="run_id must be a valid UUID. Got invalid_run_id",
+        ):
+            create_run_for_test(instance, job_name="foo_job", run_id="invalid_run_id")


### PR DESCRIPTION
## Summary & Motivation
Enforces at the instance level that custom run ids are valid UUIDs.

Depends on all of our internal tests being converted over to using UUIDs.

## How I Tested These Changes
BK
