### PR TITLE
Replace RawMetadataMapping with Mapping[str, Any] in AssetOut and AssetSpec

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_out.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_out.py
@@ -11,7 +11,6 @@ from dagster._core.definitions.events import (
 )
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.input import NoValueSentinel
-from dagster._core.definitions.metadata import RawMetadataMapping
 from dagster._core.definitions.output import Out
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster._core.types.dagster_type import DagsterType, resolve_dagster_type
@@ -85,7 +84,7 @@ class AssetOut(
         description: Optional[str] = None,
         is_required: bool = True,
         io_manager_key: Optional[str] = None,
-        metadata: Optional[RawMetadataMapping] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
         group_name: Optional[str] = None,
         code_version: Optional[str] = None,
         freshness_policy: Optional[FreshnessPolicy] = None,

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -11,7 +11,6 @@ from .events import (
     CoercibleToAssetKey,
 )
 from .freshness_policy import FreshnessPolicy
-from .metadata import RawMetadataMapping
 from .utils import validate_definition_tags
 
 if TYPE_CHECKING:
@@ -110,7 +109,7 @@ class AssetSpec(
         *,
         deps: Optional[Iterable["CoercibleToAssetDep"]] = None,
         description: Optional[str] = None,
-        metadata: Optional[RawMetadataMapping] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
         skippable: bool = False,
         group_name: Optional[str] = None,
         code_version: Optional[str] = None,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -404,7 +404,7 @@ def get_dbt_multi_asset_args(
             io_manager_key=io_manager_key,
             description=dagster_dbt_translator.get_description(dbt_resource_props),
             is_required=False,
-            metadata={  # type: ignore
+            metadata={
                 **dagster_dbt_translator.get_metadata(dbt_resource_props),
                 DAGSTER_DBT_MANIFEST_METADATA_KEY: DbtManifestWrapper(manifest=manifest),
                 DAGSTER_DBT_TRANSLATOR_METADATA_KEY: dagster_dbt_translator,


### PR DESCRIPTION
## Summary & Motivation

Right now the `metadata` argument on `asset` is different from `AssetOut` and `AssetSpec`, which is inconsistent. You get type errors when passing vanilla Python objects as metadata dictionary values to `AssetOut` and do not when passing to `asset`. We should be consistent.

Indeed I was confused how this works with dbt as it passes in vanilla objects, and when I went to look I found a `type: ignore`. We should just loosen the type constraint to acknowledge the reality of the interface

## How I Tested These Changes

BK