### PR TITLE
Allow hiding actions in OSS

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/activePathMatchers.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/activePathMatchers.tsx
@@ -1,7 +1,7 @@
 import {ComponentProps} from 'react';
 import {NavLink} from 'react-router-dom';
 
-type MatcherFn = ComponentProps<typeof NavLink>['isActive'];
+type MatcherFn = NonNullable<ComponentProps<typeof NavLink>['isActive']>;
 
 export const assetsPathMatcher: MatcherFn = (_, currentLocation) => {
   const {pathname} = currentLocation;

--- a/js_modules/dagster-ui/packages/ui-core/src/app/CloudOSSContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/CloudOSSContext.tsx
@@ -1,7 +1,23 @@
 import React from 'react';
 
+type FeatureContext = {
+  canSeeMaterializeAction: boolean;
+  canSeeWipeMaterializationAction: boolean;
+  canSeeToggleScheduleAction: boolean;
+  canSeeToggleSensorAction: boolean;
+  canSeeExecuteChecksAction: boolean;
+};
+
 export const CloudOSSContext = React.createContext<{
   isBranchDeployment: boolean;
+  featureContext: FeatureContext;
 }>({
   isBranchDeployment: false,
+  featureContext: {
+    canSeeMaterializeAction: true,
+    canSeeToggleScheduleAction: true,
+    canSeeToggleSensorAction: true,
+    canSeeWipeMaterializationAction: true,
+    canSeeExecuteChecksAction: true,
+  },
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetActionMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetActionMenu.tsx
@@ -1,4 +1,5 @@
 import {Button, Icon, Menu, MenuItem, Popover, Spinner, Tooltip} from '@dagster-io/ui-components';
+import {useContext} from 'react';
 
 import {
   executionDisabledMessageForAssets,
@@ -6,6 +7,7 @@ import {
 } from './LaunchAssetExecutionButton';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {AssetTableDefinitionFragment} from './types/AssetTableFragment.types';
+import {CloudOSSContext} from '../app/CloudOSSContext';
 import {usePermissionsForLocation} from '../app/Permissions';
 import {AssetKeyInput} from '../graphql/types';
 import {MenuLink} from '../ui/MenuLink';
@@ -30,25 +32,31 @@ export const AssetActionMenu = (props: Props) => {
     ? executionDisabledMessageForAssets([definition])
     : 'Asset definition not found in a code location';
 
+  const {
+    featureContext: {canSeeMaterializeAction, canSeeWipeMaterializationAction},
+  } = useContext(CloudOSSContext);
+
   return (
     <>
       <Popover
         position="bottom-right"
         content={
           <Menu>
-            <Tooltip
-              content={disabledMessage || 'Shift+click to add configuration'}
-              placement="left"
-              display="block"
-              useDisabledButtonTooltipFix
-            >
-              <MenuItem
-                text="Materialize"
-                icon={loading ? <Spinner purpose="body-text" /> : 'materialization'}
-                disabled={!!disabledMessage || loading}
-                onClick={(e) => onClick([{path}], e)}
-              />
-            </Tooltip>
+            {canSeeMaterializeAction ? (
+              <Tooltip
+                content={disabledMessage || 'Shift+click to add configuration'}
+                placement="left"
+                display="block"
+                useDisabledButtonTooltipFix
+              >
+                <MenuItem
+                  text="Materialize"
+                  icon={loading ? <Spinner purpose="body-text" /> : 'materialization'}
+                  disabled={!!disabledMessage || loading}
+                  onClick={(e) => onClick([{path}], e)}
+                />
+              </Tooltip>
+            ) : null}
             <MenuLink
               text="Show in group"
               to={
@@ -77,13 +85,15 @@ export const AssetActionMenu = (props: Props) => {
               disabled={!definition}
               icon="graph_downstream"
             />
-            <MenuItem
-              text="Wipe materializations"
-              icon="delete"
-              disabled={!onWipe || !canWipeAssets}
-              intent="danger"
-              onClick={() => canWipeAssets && onWipe && onWipe([{path}])}
-            />
+            {canSeeWipeMaterializationAction ? (
+              <MenuItem
+                text="Wipe materializations"
+                icon="delete"
+                disabled={!onWipe || !canWipeAssets}
+                intent="danger"
+                onClick={() => canWipeAssets && onWipe && onWipe([{path}])}
+              />
+            ) : null}
           </Menu>
         }
       >

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
@@ -13,11 +13,13 @@ import {
 } from '@dagster-io/ui-components';
 import groupBy from 'lodash/groupBy';
 import * as React from 'react';
+import {useContext} from 'react';
 
 import {AssetWipeDialog} from './AssetWipeDialog';
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
 import {AssetTableFragment} from './types/AssetTableFragment.types';
 import {AssetViewType} from './useAssetView';
+import {CloudOSSContext} from '../app/CloudOSSContext';
 import {useUnscopedPermissions} from '../app/Permissions';
 import {QueryRefreshCountdown, RefreshState} from '../app/QueryRefresh';
 import {AssetKeyInput} from '../graphql/types';
@@ -197,7 +199,11 @@ const MoreActionsDropdown = React.memo((props: MoreActionsDropdownProps) => {
     permissions: {canWipeAssets},
   } = useUnscopedPermissions();
 
-  if (!canWipeAssets) {
+  const {
+    featureContext: {canSeeWipeMaterializationAction},
+  } = useContext(CloudOSSContext);
+
+  if (!canWipeAssets || !canSeeWipeMaterializationAction) {
     return null;
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -11,7 +11,7 @@ import {
 } from '@dagster-io/ui-components';
 import pick from 'lodash/pick';
 import uniq from 'lodash/uniq';
-import React from 'react';
+import React, {useContext} from 'react';
 import {Link} from 'react-router-dom';
 
 import {ASSET_NODE_CONFIG_FRAGMENT} from './AssetConfig';
@@ -36,6 +36,7 @@ import {
   LaunchAssetLoaderResourceQuery,
   LaunchAssetLoaderResourceQueryVariables,
 } from './types/LaunchAssetExecutionButton.types';
+import {CloudOSSContext} from '../app/CloudOSSContext';
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {useConfirmation} from '../app/CustomConfirmationProvider';
 import {IExecutionSession} from '../app/ExecutionSessionStorage';
@@ -189,6 +190,14 @@ export const LaunchAssetExecutionButton = ({
 
   const [showCalculatingChangedAndMissingDialog, setShowCalculatingChangedAndMissingDialog] =
     React.useState<boolean>(false);
+
+  const {
+    featureContext: {canSeeMaterializeAction},
+  } = useContext(CloudOSSContext);
+
+  if (!canSeeMaterializeAction) {
+    return null;
+  }
 
   const options = optionsForButton(scope);
   const firstOption = options[0]!;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetObservationButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetObservationButton.tsx
@@ -1,6 +1,6 @@
 import {ApolloClient, useApolloClient} from '@apollo/client';
 import {Button, Icon, Spinner, Tooltip} from '@dagster-io/ui-components';
-import * as React from 'react';
+import {useContext, useState} from 'react';
 
 import {
   AssetsInScope,
@@ -15,6 +15,7 @@ import {
   LaunchAssetLoaderQuery,
   LaunchAssetLoaderQueryVariables,
 } from './types/LaunchAssetExecutionButton.types';
+import {CloudOSSContext} from '../app/CloudOSSContext';
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
 import {LaunchPipelineExecutionMutationVariables} from '../runs/types/RunUtils.types';
@@ -42,10 +43,19 @@ export const LaunchAssetObservationButton = ({
   const {useLaunchWithTelemetry} = useLaunchPadHooks();
   const launchWithTelemetry = useLaunchWithTelemetry();
 
-  const [state, setState] = React.useState<ObserveAssetsState>({type: 'none'});
+  const [state, setState] = useState<ObserveAssetsState>({type: 'none'});
   const client = useApolloClient();
 
   const scopeAssets = 'selected' in scope ? scope.selected : scope.all;
+
+  const {
+    featureContext: {canSeeMaterializeAction},
+  } = useContext(CloudOSSContext);
+
+  if (!canSeeMaterializeAction) {
+    return null;
+  }
+
   if (!scopeAssets.length) {
     return <></>;
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -157,8 +157,6 @@ export const AssetChecks = ({
   const lastExecution = selectedCheck.executionForLatestMaterialization;
   const targetMaterialization = lastExecution?.evaluation?.targetMaterialization;
 
-  console.log({lastExecution});
-
   return (
     <Box flex={{grow: 1, direction: 'column'}}>
       <Box flex={{direction: 'row', grow: 1}} style={{position: 'relative'}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/ExecuteChecksButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/ExecuteChecksButton.tsx
@@ -1,11 +1,12 @@
 import {gql} from '@apollo/client';
 import {Button, Icon, Spinner, Tooltip} from '@dagster-io/ui-components';
-import {useState} from 'react';
+import {useContext, useState} from 'react';
 
 import {
   ExecuteChecksButtonAssetNodeFragment,
   ExecuteChecksButtonCheckFragment,
 } from './types/ExecuteChecksButton.types';
+import {CloudOSSContext} from '../../app/CloudOSSContext';
 import {usePermissionsForLocation} from '../../app/Permissions';
 import {AssetCheckCanExecuteIndividually, ExecutionParams} from '../../graphql/types';
 import {useLaunchPadHooks} from '../../launchpad/LaunchpadHooksContext';
@@ -44,6 +45,14 @@ export const ExecuteChecksButton = ({
     : checks.length === 0
     ? 'No checks are defined on this asset.'
     : '';
+
+  const {
+    featureContext: {canSeeExecuteChecksAction},
+  } = useContext(CloudOSSContext);
+
+  if (!canSeeExecuteChecksAction) {
+    return null;
+  }
 
   if (disabledReason) {
     return (


### PR DESCRIPTION
## Summary & Motivation

This is going to be used in catalog mode to hide actions in the UI. 

Note: We originally considered building this into the permission system but ultimately decided it wasn't worth trying to jam this into it when it can be a separate concept that could later down the line be controlled by the permission system if we think it makes sense.

## How I Tested These Changes

shadow-dagit dogfood-test-1