### PR TITLE
test(dbt): expect no deps for column with ambiguous aggregate

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -352,6 +352,11 @@ def test_column_lineage(
                 ],
             }
         ),
+        AssetKey(["count_star_customers"]): TableColumnLineage(
+            deps_by_column={
+                "count_star": [],
+            }
+        ),
     }
     if asset_key_selection:
         expected_column_lineage_by_asset_key = {

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/count_star_customers.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/count_star_customers.sql
@@ -1,0 +1,1 @@
+select count(*) as count_star from {{ ref('customers') }}


### PR DESCRIPTION
## Summary & Motivation
When using `*` in an aggregate function, `sqlglot` doesn't refine the output to show that the resulting column is dependent on all of columns found in the `FROM` statement. Instead, the resulting upstream lineage for that column is empty.

So doing something like `count(*) as num_customers from {{ ref("customers") }}` would give an empty column lineage for `num_customers`.

For now, I agree with this assessment, as the use of `*` is ambiguous here and inferring that the lineage of column is "dependent" on all of the columns feels wrong as it is potentially superfluous information. In this PR, I am writing an explicit test case for it to ensure that everyone else is on the same page with this behavior.

We could perhaps emit a warning in this case. We could recommend that the user uses an explicit column name in their aggregation (e.g `count(user_id)`) to ensure that the lineage flows properly.

## How I Tested These Changes
pytest