### PR TITLE
Lazily evaluate build_asset_job in the run worker for the specific job being executed

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/materialize.py
@@ -100,6 +100,10 @@ def materialize(
         assets=assets,
         resources=resources,
     )
+
+    # validate input asset graph and resources
+    defs.get_all_job_defs()
+
     return check.not_none(
         defs.get_job_def(EPHEMERAL_JOB_NAME),
         "This should always return a job",

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -249,12 +249,13 @@ def build_caching_repository_data_from_list(
         key: checks_def for checks_def in asset_checks_defs for key in checks_def.check_keys
     }
     if assets_defs or asset_checks_defs or source_assets:
-        for job_def in get_base_asset_jobs(
+        for job_name, job_def in get_base_asset_jobs(
             asset_graph=asset_graph,
             executor_def=default_executor_def,
             resource_defs=top_level_resources,
-        ):
-            jobs[job_def.name] = job_def
+            logger_defs=default_logger_defs,
+        ).items():
+            jobs[job_name] = job_def
 
     for name, sensor_def in sensors.items():
         if sensor_def.has_loadable_targets():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
@@ -1973,15 +1973,21 @@ def test_get_base_asset_jobs_multiple_partitions_defs():
         ),
         executor_def=None,
         resource_defs={},
+        logger_defs={},
     )
     assert len(jobs) == 3
-    assert {job_def.name for job_def in jobs} == {
+    assert jobs.keys() == {"__ASSET_JOB_0", "__ASSET_JOB_1", "__ASSET_JOB_2"}
+
+    resolved_jobs = {job_name: job_lambda() for job_name, job_lambda in jobs.items()}
+
+    assert {job_def.name for job_name, job_def in resolved_jobs.items()} == {
         "__ASSET_JOB_0",
         "__ASSET_JOB_1",
         "__ASSET_JOB_2",
     }
     assert {
-        frozenset([node_def.name for node_def in job_def.all_node_defs]) for job_def in jobs
+        frozenset([node_def.name for node_def in job_def.all_node_defs])
+        for job_name, job_def in resolved_jobs.items()
     } == {
         frozenset(["daily_asset", "daily_asset2", "unpartitioned_asset"]),
         frozenset(["hourly_asset", "unpartitioned_asset"]),
@@ -2016,12 +2022,10 @@ def test_get_base_asset_jobs_multiple_partitions_defs_and_observable_assets():
         ),
         executor_def=None,
         resource_defs={},
+        logger_defs={},
     )
     assert len(jobs) == 2
-    assert {job_def.name for job_def in jobs} == {
-        "__ASSET_JOB_0",
-        "__ASSET_JOB_1",
-    }
+    assert jobs.keys() == {"__ASSET_JOB_0", "__ASSET_JOB_1"}
 
 
 def test_get_base_asset_jobs_multiple_partitions_defs_and_asset_checks_and_observables():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -693,7 +693,7 @@ def test_conflicting_asset_resource_defs():
             "provided to assets must match by reference equality for a given key."
         ),
     ):
-        Definitions([the_asset, other_asset])
+        Definitions([the_asset, other_asset]).get_all_job_defs()
 
 
 def test_graph_backed_asset_resources():
@@ -731,7 +731,7 @@ def test_graph_backed_asset_resources():
             " reference equality for a given key."
         ),
     ):
-        Definitions([the_asset, other_asset])
+        Definitions([the_asset, other_asset]).get_all_job_defs()
 
 
 def test_job_with_reserved_name():
@@ -766,4 +766,4 @@ def test_asset_cycle():
 
     s = SourceAsset(key="s")
     with pytest.raises(CircularDependencyError):
-        Definitions(assets=[a, b, c, s])
+        Definitions(assets=[a, b, c, s]).get_all_job_defs()

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
@@ -718,14 +718,15 @@ def test_direct_asset_unsatified_resource():
     def asset1():
         pass
 
+    @repository
+    def my_repo():
+        return [asset1]
+
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match="resource with key 'a' required by op 'asset1' was not provided.",
     ):
-
-        @repository
-        def my_repo():
-            return [asset1]
+        my_repo.get_all_jobs()
 
 
 def test_direct_asset_unsatified_resource_transitive():
@@ -737,20 +738,25 @@ def test_direct_asset_unsatified_resource_transitive():
     def asset1():
         pass
 
+    @repository
+    def my_repo():
+        return [asset1]
+
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match="resource with key 'b' required by resource with key 'a' was not provided.",
     ):
-
-        @repository
-        def my_repo():
-            return [asset1]
+        my_repo.get_all_jobs()
 
 
 def test_source_asset_unsatisfied_resource():
     @io_manager(required_resource_keys={"foo"})
     def the_manager():
         pass
+
+    @repository
+    def the_repo():
+        return [SourceAsset("foo", io_manager_def=the_manager)]
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
@@ -759,10 +765,7 @@ def test_source_asset_unsatisfied_resource():
             " provided."
         ),
     ):
-
-        @repository
-        def the_repo():
-            return [SourceAsset("foo", io_manager_def=the_manager)]
+        the_repo.get_all_jobs()
 
 
 def test_source_asset_unsatisfied_resource_transitive():
@@ -774,20 +777,21 @@ def test_source_asset_unsatisfied_resource_transitive():
     def foo_resource():
         pass
 
+    @repository
+    def the_repo():
+        return [
+            SourceAsset(
+                "foo",
+                io_manager_def=the_manager,
+                resource_defs={"foo": foo_resource},
+            )
+        ]
+
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match="resource with key 'bar' required by resource with key 'foo' was not provided.",
     ):
-
-        @repository
-        def the_repo():
-            return [
-                SourceAsset(
-                    "foo",
-                    io_manager_def=the_manager,
-                    resource_defs={"foo": foo_resource},
-                )
-            ]
+        the_repo.get_all_jobs()
 
 
 def test_direct_asset_resource_conflicts():
@@ -799,14 +803,15 @@ def test_direct_asset_resource_conflicts():
     def second():
         pass
 
+    @repository
+    def the_repo():
+        return [first, second]
+
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match="Conflicting versions of resource with key 'foo' were provided to different assets.",
     ):
-
-        @repository
-        def the_repo():
-            return [first, second]
+        the_repo.get_all_jobs()
 
 
 def test_source_asset_resource_conflicts():
@@ -824,14 +829,15 @@ def test_source_asset_resource_conflicts():
         resource_defs={"foo": ResourceDefinition.hardcoded_resource("2")},
     )
 
+    @repository
+    def the_repo():
+        return [the_asset, the_source]
+
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match="Conflicting versions of resource with key 'foo' were provided to different assets.",
     ):
-
-        @repository
-        def the_repo():
-            return [the_asset, the_source]
+        the_repo.get_all_jobs()
 
     other_source = SourceAsset(
         key=AssetKey("other_key"),
@@ -839,14 +845,15 @@ def test_source_asset_resource_conflicts():
         resource_defs={"foo": ResourceDefinition.hardcoded_resource("3")},
     )
 
+    @repository
+    def other_repo():
+        return [other_source, the_source]
+
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match="Conflicting versions of resource with key 'foo' were provided to different assets.",
     ):
-
-        @repository
-        def other_repo():
-            return [other_source, the_source]
+        other_repo.get_all_jobs()
 
 
 def test_assets_different_io_manager_defs():

--- a/python_modules/dagster/dagster_tests/general_tests/test_pending_repository.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_pending_repository.py
@@ -187,7 +187,7 @@ def test_resolve_no_resources():
                     ),
                 ]
 
-            resource_dependent_repo_no_resources.compute_repository_definition()
+            resource_dependent_repo_no_resources.compute_repository_definition().get_all_jobs()
         except DagsterInvalidDefinitionError as e:
             # Make sure we get an error for the cacheable asset in particular
             assert "res_midstream" in str(e)


### PR DESCRIPTION
Summary:
We have some profiling data that suggests that build_asset_job can be the bottleneck when loading code with many different partitions definitions. Similar to https://github.com/dagster-io/dagster/pull/19313, which moved the expensive part of evaluation of certain jobs to a lambda, move the building of each of the base asset jobs to a lambda as well.

Test Plan: BK, verify with a log call in build_asset_job that when launching a run, only build_asset_job on its particular run is evaluted.

## Summary & Motivation

## How I Tested These Changes
