### PR TITLE
[ui] Plots: Fix label and tick colors

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetValueGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetValueGraph.tsx
@@ -71,12 +71,16 @@ export const AssetValueGraph = (props: {
       x: {
         id: 'x',
         display: true,
+        ticks: {
+          color: Colors.textLighter(),
+        },
         ...(props.data.xAxis === 'time'
           ? {
               type: 'time',
               title: {
                 display: true,
                 text: 'Timestamp',
+                color: Colors.textLighter(),
               },
             }
           : {
@@ -84,10 +88,18 @@ export const AssetValueGraph = (props: {
               title: {
                 display: true,
                 text: 'Partition',
+                color: Colors.textLighter(),
               },
             }),
       },
-      y: {id: 'y', display: true, title: {display: true, text: props.yAxisLabel || 'Value'}},
+      y: {
+        id: 'y',
+        display: true,
+        ticks: {
+          color: Colors.textLighter(),
+        },
+        title: {display: true, color: Colors.textLighter(), text: props.yAxisLabel || 'Value'},
+      },
     },
     plugins: {
       legend: {


### PR DESCRIPTION
## Summary & Motivation

Fix tick and label colors for Plots axes. These have just been the default gray until now.

<img width="789" alt="Screenshot 2024-04-01 at 11 00 25" src="https://github.com/dagster-io/dagster/assets/2823852/d1077ebc-59ac-4da6-8ab3-f36c149a41b7">

## How I Tested These Changes

View asset plots, verify text colors.