### PR TITLE
Expose the job's underlying RepositoryDefinition on OpExecutionContext / AssetExecutionContext

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_base.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_base.py
@@ -6,6 +6,7 @@ from dagster._core.definitions.events import AssetKey
 
 if TYPE_CHECKING:
     from .job_definition import JobDefinition
+    from .repository_definition import RepositoryDefinition
 
 
 class IJob(ABC):
@@ -17,6 +18,10 @@ class IJob(ABC):
 
     @abstractmethod
     def get_definition(self) -> "JobDefinition":
+        pass
+
+    @abstractmethod
+    def get_repository_definition(self) -> Optional["RepositoryDefinition"]:
         pass
 
     @abstractmethod
@@ -58,6 +63,9 @@ class InMemoryJob(IJob):
 
     def get_definition(self) -> "JobDefinition":
         return self._job_def
+
+    def get_repository_definition(self) -> Optional["RepositoryDefinition"]:
+        return None
 
     def get_subset(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -254,11 +254,15 @@ class ReconstructableJob(
     ) -> "ReconstructableJob":
         return self._replace(repository=self.repository.with_repository_load_data(metadata))
 
+    @lru_cache(maxsize=1)
+    def get_repository_definition(self) -> Optional["RepositoryDefinition"]:
+        return self.repository.get_definition()
+
     # Keep the most recent 1 definition (globally since this is a NamedTuple method)
     # This allows repeated calls to get_definition in execution paths to not reload the job
     @lru_cache(maxsize=1)
     def get_definition(self) -> "JobDefinition":
-        return self.repository.get_definition().get_maybe_subset_job_def(
+        return check.not_none(self.get_repository_definition()).get_maybe_subset_job_def(
             self.job_name,
             self.op_selection,
             self.asset_selection,

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -44,6 +44,9 @@ from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
+from dagster._core.definitions.repository_definition.repository_definition import (
+    RepositoryDefinition,
+)
 from dagster._core.definitions.step_launcher import StepLauncher
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.errors import (
@@ -93,6 +96,11 @@ class AbstractComputeExecutionContext(ABC, metaclass=AbstractComputeMetaclass):
     @abstractmethod
     def job_def(self) -> JobDefinition:
         """The job being executed."""
+
+    @property
+    @abstractmethod
+    def repository_def(self) -> RepositoryDefinition:
+        """The Dagster repository containing the job being executed."""
 
     @property
     @abstractmethod
@@ -233,8 +241,13 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
     @public
     @property
     def job_def(self) -> JobDefinition:
-        """JobDefinition: The currently executing pipeline."""
+        """JobDefinition: The currently executing job."""
         return self._step_execution_context.job_def
+
+    @property
+    def repository_def(self) -> RepositoryDefinition:
+        """RepositoryDefinition: The Dagster repository for the currently executing job."""
+        return self._step_execution_context.repository_def
 
     @public
     @property
@@ -1441,6 +1454,11 @@ class AssetExecutionContext(OpExecutionContext):
         """
         return self.op_execution_context.job_def
 
+    @property
+    def repository_def(self) -> RepositoryDefinition:
+        """RepositoryDefinition: The Dagster repository for the currently executing job."""
+        return self.op_execution_context.repository_def
+
     ######## Deprecated methods
 
     @deprecated(**_get_deprecation_kwargs("dagster_run"))
@@ -1848,6 +1866,11 @@ class AssetCheckExecutionContext:
         Returns: JobDefinition.
         """
         return self.op_execution_context.job_def
+
+    @property
+    def repository_def(self) -> RepositoryDefinition:
+        """RepositoryDefinition: The Dagster repository for the currently executing job."""
+        return self.op_execution_context.repository_def
 
     #### check related
     @public

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -30,6 +30,7 @@ from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
+from dagster._core.definitions.repository_definition import RepositoryDefinition
 from dagster._core.definitions.resource_definition import (
     IContainsGenerator,
     ResourceDefinition,
@@ -444,6 +445,10 @@ class DirectOpExecutionContext(OpExecutionContext, BaseDirectExecutionContext):
     @property
     def job_def(self) -> JobDefinition:
         raise DagsterInvalidPropertyError(_property_msg("job_def", "property"))
+
+    @property
+    def repository_def(self) -> RepositoryDefinition:
+        raise DagsterInvalidPropertyError(_property_msg("repository_def", "property"))
 
     @property
     def job_name(self) -> str:

--- a/python_modules/dagster/dagster/_core/execution/context_creation_job.py
+++ b/python_modules/dagster/dagster/_core/execution/context_creation_job.py
@@ -26,6 +26,9 @@ import dagster._check as check
 from dagster._core.definitions import ExecutorDefinition, JobDefinition
 from dagster._core.definitions.executor_definition import check_cross_process_constraints
 from dagster._core.definitions.job_base import IJob
+from dagster._core.definitions.repository_definition.repository_definition import (
+    RepositoryDefinition,
+)
 from dagster._core.definitions.resource_definition import ScopedResourcesBuilder
 from dagster._core.errors import DagsterError, DagsterUserCodeExecutionError
 from dagster._core.events import DagsterEvent, RunFailureReason
@@ -94,6 +97,10 @@ class ContextCreationData(NamedTuple):
     def job_def(self) -> JobDefinition:
         return self.job.get_definition()
 
+    @property
+    def repository_def(self) -> Optional[RepositoryDefinition]:
+        return self.job.get_repository_definition()
+
 
 def create_context_creation_data(
     job: IJob,
@@ -139,6 +146,7 @@ def create_execution_data(
         scoped_resources_builder=scoped_resources_builder,
         resolved_run_config=context_creation_data.resolved_run_config,
         job_def=context_creation_data.job_def,
+        repository_def=context_creation_data.repository_def,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_execution_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_execution_context.py
@@ -90,6 +90,7 @@ def test_deprecation_warnings():
         "partition_keys",
         "retry_number",
         "op_execution_context",
+        "repository_def",
     ]
 
     other_ignores = [

--- a/python_modules/libraries/dagstermill/dagstermill/context.py
+++ b/python_modules/libraries/dagstermill/dagstermill/context.py
@@ -8,6 +8,9 @@ from dagster import (
 )
 from dagster._annotations import public
 from dagster._core.definitions.dependency import Node, NodeHandle
+from dagster._core.definitions.repository_definition.repository_definition import (
+    RepositoryDefinition,
+)
 from dagster._core.execution.context.compute import AbstractComputeExecutionContext
 from dagster._core.execution.context.system import PlanExecutionContext, StepExecutionContext
 from dagster._core.log_manager import DagsterLogManager
@@ -99,6 +102,11 @@ class DagstermillExecutionContext(AbstractComputeExecutionContext):
         This will be a dagstermill-specific shim.
         """
         return self._job_def
+
+    @property
+    def repository_def(self) -> RepositoryDefinition:
+        """:class:`dagster.RepositoryDefinition`: The repository definition for the context."""
+        raise NotImplementedError
 
     @property
     def resources(self) -> Any:


### PR DESCRIPTION
Summary:
Provides a way to obtain the RepositoryDefinition object that produced the job. Right now the only way to get this information for advanced use cases (for example, introspecting the asset graph in the body of an asset or op) is to either re-import it inline (potentially incurring a slow import again since it won't be cached by Python due to being imported in a different way) or rely on private APIs.

## How I Tested These Changes
BK