### PR TITLE
Make type Non-nullable

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/activePathMatchers.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/activePathMatchers.tsx
@@ -1,7 +1,7 @@
 import {ComponentProps} from 'react';
 import {NavLink} from 'react-router-dom';
 
-type MatcherFn = ComponentProps<typeof NavLink>['isActive'];
+type MatcherFn = NonNullable<ComponentProps<typeof NavLink>['isActive']>;
 
 export const assetsPathMatcher: MatcherFn = (_, currentLocation) => {
   const {pathname} = currentLocation;


### PR DESCRIPTION
## Summary & Motivation

We use `MatcherFn` as the type of the functions we're exporting. Technically  MatcherFn could be undefined which means when importing these functions in cloud typescript thinks they're potentially undefined. Mark them as NonNullable to fix this.

## How I Tested These Changes

👀 