### PR TITLE
Use mousedown for determining whether to close filter dialog.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/FilterDropdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/FilterDropdown.tsx
@@ -314,9 +314,9 @@ export const FilterDropdownButton = React.memo(({filters}: FilterDropdownButtonP
       }
       setIsOpen(false);
     };
-    document.body.addEventListener('click', listener);
+    document.body.addEventListener('mousedown', listener);
     return () => {
-      document.body.removeEventListener('click', listener);
+      document.body.removeEventListener('mousedown', listener);
     };
   }, [setIsOpen]);
 


### PR DESCRIPTION
## Summary & Motivation

Instead of listening to click (which fires on the mouseup target), lets only listen to mousedown. This allows a user to drag their mouse while holding mousedown to select text and then mouseup outside of the filter dialog without closing the dialog.

## How I Tested These Changes

locally with shadow-dagit in the asset graph.