### PR TITLE
[ui] Repair "object can not be found" error

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTag.tsx
@@ -95,7 +95,7 @@ export const RunTag = ({tag, actions}: IRunTagProps) => {
   }, [key, value]);
 
   const ValueWrapper = ({children}: {children: React.ReactNode}) =>
-    tag.link ? <Link to={tag.link}>{children}</Link> : <>{children}</>;
+    tag.link ? <Link to={tag.link}>{children}</Link> : <span>{children}</span>;
 
   const tooltipValue = displayedKey ? `${displayedKey}: ${displayValue}` : displayValue;
 


### PR DESCRIPTION
## Summary & Motivation

Try to resolve a `The object can not be found here.` error that shows up occasionally in the Runs page. [DD link](https://app.datadoghq.com/rum/error-tracking/issue/a7fbc3a6-6961-11ee-b358-da7ad0900002?fromUser=false&refresh_mode=sliding&view=spans&from_ts=1710862775309&to_ts=1712072325670&live=true)

It seems like this might be occurring when a run tag is being updated in such a way that the child element of `ValueWrapper` is conditionally added or removed. When `ValueWrapper` is rendered as a fragment (e.g. when there is no `link` value on the run tag), the error can occur because there is no target DOM node to update.

I'm not actually able to repro the bug as it appears in DD, but this eliminates the fragment and gives `ValueWrapper` a DOM node to target for updates.

## How I Tested These Changes

View Runs table, verify that the newly added `span` renders correctly for non-linked tags.