### PR TITLE
[docs][infra] fix apidocs build

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -34,6 +34,7 @@ paths = [
     "../../python_modules/libraries/dagster-docker",
     "../../python_modules/libraries/dagster-embedded-elt",
     "../../python_modules/libraries/dagster-embedded-elt/sling",
+    "../../python_modules/libraries/dagster-embedded-elt/dlt",
     "../../python_modules/libraries/dagster-fivetran",
     "../../python_modules/libraries/dagster-github",
     "../../python_modules/libraries/dagster-k8s",

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -140,6 +140,7 @@ autodoc_mock_imports = [
     "databricks_api",
     "databricks_cli",
     "datadog",
+    "dlt",
     "docker",
     "docker_image",
     "gevent",


### PR DESCRIPTION
## Summary & Motivation
add 'dlt' to mock import to resolve this error when running `make apidoc-build`:
```bash
WARNING: autodoc: failed to import decorator 'dlt.dlt_assets' from module 'dagster_embedded_elt'; the following exception was raised:
No module named 'dlt'
WARNING: autodoc: failed to import class 'dlt.DagsterDltTranslator' from module 'dagster_embedded_elt'; the following exception was raised:
No module named 'dlt'
WARNING: autodoc: failed to import class 'dlt.DagsterDltResource' from module 'dagster_embedded_elt'; the following exception was raised:
No module named 'dlt'
make: *** [json] Error 1
ERROR: InvocationError for command /usr/bin/make --directory=sphinx json 'SPHINXOPTS=-W --keep-going' (exited with code 2)
_______________________________________________________________________________ summary _______________________________________________________________________________
ERROR:   sphinx: commands failed
make: *** [apidoc-build] Error 1
```

## How I Tested These Changes
`make apidoc-build` succeeded