### PR TITLE
feat: allow run_config in asset materialize CLI command

### DIFF
--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -5,6 +5,7 @@ import click
 import dagster._check as check
 from dagster._cli.workspace.cli_target import (
     get_repository_python_origin_from_kwargs,
+    python_job_config_argument,
     python_origin_target_argument,
 )
 from dagster._core.definitions.asset_selection import AssetSelection
@@ -19,6 +20,7 @@ from dagster._utils.hosted_user_process import (
     recon_repository_from_origin,
 )
 from dagster._utils.interrupts import capture_interrupts
+from python_modules.dagster.dagster._cli.job import get_config_from_args
 
 from .utils import get_instance_for_cli, get_possibly_temporary_instance_for_cli
 
@@ -32,6 +34,12 @@ def asset_cli():
 @python_origin_target_argument
 @click.option("--select", help="Asset selection to target", required=True)
 @click.option("--partition", help="Asset partition to target", required=False)
+@python_job_config_argument("launch")
+@click.option(
+    "--config-json",
+    type=click.STRING,
+    help="JSON string of run config to use for this job run. Cannot be used with -c / --config.",
+)
 def asset_materialize_command(**kwargs):
     with capture_interrupts():
         with get_possibly_temporary_instance_for_cli(
@@ -42,6 +50,7 @@ def asset_materialize_command(**kwargs):
 
 @telemetry_wrapper
 def execute_materialize_command(instance: DagsterInstance, kwargs: Mapping[str, str]) -> None:
+    config = get_config_from_args(kwargs)
     repository_origin = get_repository_python_origin_from_kwargs(kwargs)
 
     recon_repo = recon_repository_from_origin(repository_origin)
@@ -76,7 +85,7 @@ def execute_materialize_command(instance: DagsterInstance, kwargs: Mapping[str, 
         tags = {}
 
     result = execute_job(
-        job=reconstructable_job, asset_selection=list(asset_keys), instance=instance, tags=tags
+        job=reconstructable_job, asset_selection=list(asset_keys), instance=instance, tags=tags, run_config=config
     )
     if not result.success:
         raise click.ClickException("Materialization failed.")

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -431,7 +431,7 @@ def do_execute_command(
     ),
 )
 @job_target_argument
-@python_job_config_argument("launch")
+@python_job_config_argument("materialize")
 @click.option(
     "--config-json",
     type=click.STRING,


### PR DESCRIPTION
Closes: #16802

## Summary & Motivation

This change adds support for `-c`, `--config` and `--config-json` in the `dagster asset materialize` CLI command.

Our motivation is to simply materialize a whole graph as part of CI/CD and use `run_config` to specify parameters that scope down that materialization for the sake of CI/CD. A single partition of our asset graph can take a long time to run and for CI/CD we don't need the whole thing.

## How I Tested These Changes

- [ ] Not sure how to add tests in the repo. Need guidance.
