### PR TITLE
[ui] Show “Observe” instead of “Materialize” in context menus for source assets

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
@@ -1,16 +1,14 @@
-import {Box, Menu, MenuDivider, MenuItem, Spinner} from '@dagster-io/ui-components';
+import {Box, Menu, MenuDivider, MenuItem} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {GraphData, GraphNode, tokenForAssetKey} from './Utils';
 import {StatusDot} from './sidebar/StatusDot';
-import {CloudOSSContext} from '../app/CloudOSSContext';
-import {showSharedToaster} from '../app/DomUtils';
+import {useExecuteAssetMenuItem} from '../assets/AssetActionMenu';
 import {
   AssetKeysDialog,
   AssetKeysDialogEmptyState,
   AssetKeysDialogHeader,
 } from '../assets/AutoMaterializePolicyPage/AssetKeysDialog';
-import {useMaterializationAction} from '../assets/LaunchAssetExecutionButton';
 import {ExplorerPath} from '../pipelines/PipelinePathUtils';
 import {VirtualizedItemListForDialog} from '../ui/VirtualizedItemListForDialog';
 
@@ -32,7 +30,10 @@ export const useAssetNodeMenu = ({
   const upstream = Object.keys(graphData.upstream[node.id] ?? {});
   const downstream = Object.keys(graphData.downstream[node.id] ?? {});
 
-  const {onClick, loading, launchpadElement} = useMaterializationAction();
+  const {executeItem, launchpadElement} = useExecuteAssetMenuItem(
+    node.assetKey.path,
+    node.definition,
+  );
 
   const [showParents, setShowParents] = React.useState(false);
 
@@ -46,35 +47,11 @@ export const useAssetNodeMenu = ({
     onChangeExplorerPath({...explorerPath, opsQuery: nextOpsQuery}, 'push');
   }
 
-  const {
-    featureContext: {canSeeMaterializeAction},
-  } = React.useContext(CloudOSSContext);
-
   return {
     menu: (
       <Menu>
-        {canSeeMaterializeAction ? (
-          <>
-            <MenuItem
-              icon="materialization"
-              text={
-                <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-                  <span>Materialize</span>
-                  {loading ? <Spinner purpose="body-text" /> : null}
-                </Box>
-              }
-              onClick={async (e) => {
-                await showSharedToaster({
-                  intent: 'primary',
-                  message: 'Initiating materialization',
-                  icon: 'materialization',
-                });
-                onClick([node.assetKey], e, false);
-              }}
-            />
-            {upstream.length || downstream.length ? <MenuDivider /> : null}
-          </>
-        ) : null}
+        {executeItem}
+        {upstream.length || downstream.length ? <MenuDivider /> : null}
         {upstream.length ? (
           <MenuItem
             text={`View parents (${upstream.length})`}


### PR DESCRIPTION
Fixes #20459

## Summary & Motivation

It turns out there's a lot of inconsistency in the context menus + asset list menus:

- We now show the same Materialize or Observe menu item in the context menus and the asset catalog's list action menus.

- For executable source assets, "Observe" is shown and does the same thing that clicking "Observe sources" does on the graph via a new "useObserveAction" hook that matches "useMaterializeAction"

- The menus all observe both `canSeeMaterializeAction` and `asset.hasMaterializePermission` and use the same messaging for disabled states

## How I Tested These Changes

Just manually ran through these cases with materializable / observable assets