### PR TITLE
[ui] Include assets with failed/missing partitions in “Materialize unsynced"

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -15,7 +15,7 @@ import {withMiddleTruncation} from '../app/Util';
 import {useAssetLiveData} from '../asset-data/AssetLiveDataProvider';
 import {PartitionCountTags} from '../assets/AssetNodePartitionCounts';
 import {ChangedReasonsTag, MinimalNodeChangedDot} from '../assets/ChangedReasons';
-import {MinimalNodeStaleDot, StaleReasonsTag, isAssetStale} from '../assets/Stale';
+import {MinimalNodeStaleDot, StaleReasonsTag, isAssetStaleFiltered} from '../assets/Stale';
 import {AssetChecksStatusSummary} from '../assets/asset-checks/AssetChecksStatusSummary';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {AssetComputeKindTag} from '../graph/OpTags';
@@ -185,7 +185,7 @@ export const AssetNodeMinimal = ({
   const displayName = assetKey.path[assetKey.path.length - 1]!;
 
   const isChanged = definition.changedReasons.length;
-  const isStale = isAssetStale(assetKey, liveData, 'upstream');
+  const isStale = isAssetStaleFiltered(assetKey, liveData, 'upstream');
 
   const queuedRuns = liveData?.unstartedRunIds.length;
   const inProgressRuns = liveData?.inProgressRunIds.length;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
@@ -21,7 +21,7 @@ import {groupAssetsByStatus} from './util';
 import {CloudOSSContext} from '../app/CloudOSSContext';
 import {withMiddleTruncation} from '../app/Util';
 import {useAssetsLiveData} from '../asset-data/AssetLiveDataProvider';
-import {CalculateChangedAndMissingDialog} from '../assets/CalculateChangedAndMissingDialog';
+import {CalculateUnsyncedDialog} from '../assets/CalculateUnsyncedDialog';
 import {useMaterializationAction} from '../assets/LaunchAssetExecutionButton';
 import {AssetKey} from '../assets/types';
 import {numberFormatter} from '../ui/formatters';
@@ -205,7 +205,7 @@ export const useGroupNodeContextMenu = ({
   preferredJobName?: string;
 }) => {
   const {onClick, launchpadElement} = useMaterializationAction(preferredJobName);
-  const [showCalculatingChangedAndMissingDialog, setShowCalculatingChangedAndMissingDialog] =
+  const [showCalculatingUnsyncedDialog, setShowCalculatingUnsyncedDialog] =
     React.useState<boolean>(false);
 
   const {
@@ -229,7 +229,7 @@ export const useGroupNodeContextMenu = ({
           <MenuItem
             icon="changes_present"
             text="Materialize unsynced"
-            onClick={() => setShowCalculatingChangedAndMissingDialog(true)}
+            onClick={() => setShowCalculatingUnsyncedDialog(true)}
           />
         </>
       ) : null}
@@ -240,10 +240,10 @@ export const useGroupNodeContextMenu = ({
   );
   const dialog = (
     <div>
-      <CalculateChangedAndMissingDialog
-        isOpen={!!showCalculatingChangedAndMissingDialog}
+      <CalculateUnsyncedDialog
+        isOpen={showCalculatingUnsyncedDialog}
         onClose={() => {
-          setShowCalculatingChangedAndMissingDialog(false);
+          setShowCalculatingUnsyncedDialog(false);
         }}
         assets={assets}
         onMaterializeAssets={(assets: AssetKey[], e: React.MouseEvent<any>) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
@@ -252,7 +252,10 @@ export const AssetPartitionDetail = ({
               <Spinner purpose="body-text" />
             ) : (
               <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-                <StaleReasonsTag liveData={{staleCauses, staleStatus}} assetKey={assetKey} />
+                <StaleReasonsTag
+                  liveData={staleCauses && staleStatus ? {staleCauses, staleStatus} : undefined}
+                  assetKey={assetKey}
+                />
                 <ChangedReasonsTag changedReasons={changedReasons} assetKey={assetKey} />
               </Box>
             )}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/CalculateUnsyncedDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/CalculateUnsyncedDialog.tsx
@@ -16,19 +16,19 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
-import {isAssetMissing, isAssetStale} from './Stale';
+import {isAssetMissing, isAssetStaleAll} from './Stale';
 import {asAssetKeyInput} from './asInput';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {AssetKey} from './types';
 import {
   AssetStaleStatusQuery,
   AssetStaleStatusQueryVariables,
-} from './types/CalculateChangedAndMissingDialog.types';
+} from './types/CalculateUnsyncedDialog.types';
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {Container, Inner, Row} from '../ui/VirtualizedTable';
 
-export const CalculateChangedAndMissingDialog = React.memo(
+export const CalculateUnsyncedDialog = React.memo(
   ({
     isOpen,
     onClose,
@@ -52,10 +52,10 @@ export const CalculateChangedAndMissingDialog = React.memo(
       },
     );
 
-    const staleOrMissing = React.useMemo(
+    const unsynced = React.useMemo(
       () =>
-        data?.assetNodes
-          .filter((node) => isAssetStale(node.assetKey, node, 'all') || isAssetMissing(node))
+        (data?.assetNodes || [])
+          .filter((node) => isAssetStaleAll(node) || isAssetMissing(node))
           .map(asAssetKeyInput),
       [data],
     );
@@ -72,7 +72,7 @@ export const CalculateChangedAndMissingDialog = React.memo(
 
     const containerRef = React.useRef<HTMLDivElement | null>(null);
     const virtualizer = useVirtualizer({
-      count: staleOrMissing?.length ?? 0,
+      count: unsynced.length,
       getScrollElement: () => containerRef.current,
       estimateSize: () => 28,
     });
@@ -81,8 +81,8 @@ export const CalculateChangedAndMissingDialog = React.memo(
 
     const [checked, setChecked] = React.useState<Set<AssetKey>>(new Set());
     React.useLayoutEffect(() => {
-      setChecked(new Set(staleOrMissing));
-    }, [staleOrMissing]);
+      setChecked(new Set(unsynced));
+    }, [unsynced]);
 
     const content = () => {
       if (!isOpen) {
@@ -95,19 +95,19 @@ export const CalculateChangedAndMissingDialog = React.memo(
           </Box>
         );
       }
-      if (staleOrMissing?.length) {
+      if (unsynced.length) {
         return (
           <>
             <RowGrid border="bottom" padding={{bottom: 8}}>
               <Checkbox
                 id="check-all"
-                checked={checked.size === staleOrMissing.length}
+                checked={checked.size === unsynced.length}
                 onChange={() => {
                   setChecked((checked) => {
-                    if (checked.size === staleOrMissing.length) {
+                    if (checked.size === unsynced.length) {
                       return new Set();
                     } else {
-                      return new Set(staleOrMissing);
+                      return new Set(unsynced);
                     }
                   });
                 }}
@@ -119,7 +119,7 @@ export const CalculateChangedAndMissingDialog = React.memo(
             <Container ref={containerRef} style={{maxHeight: '400px'}}>
               <Inner $totalHeight={totalHeight}>
                 {items.map(({index, key, size, start}) => {
-                  const item = staleOrMissing[index]!;
+                  const item = unsynced[index]!;
                   return (
                     <Row
                       $height={size}
@@ -180,7 +180,7 @@ export const CalculateChangedAndMissingDialog = React.memo(
           <DialogFooter topBorder>
             {loading ? (
               <Button onClick={onClose}>Cancel</Button>
-            ) : staleOrMissing?.length ? (
+            ) : unsynced.length ? (
               <Button
                 intent="primary"
                 onClick={(e) => {
@@ -209,6 +209,12 @@ const ASSET_STALE_STATUS_QUERY = gql`
         path
       }
       staleStatus
+      partitionStats {
+        numMaterialized
+        numMaterializing
+        numPartitions
+        numFailed
+      }
     }
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -19,7 +19,7 @@ import {
   ADDITIONAL_REQUIRED_KEYS_WARNING,
   MULTIPLE_DEFINITIONS_WARNING,
 } from './AssetDefinedInMultipleReposNotice';
-import {CalculateChangedAndMissingDialog} from './CalculateChangedAndMissingDialog';
+import {CalculateUnsyncedDialog} from './CalculateUnsyncedDialog';
 import {LaunchAssetChoosePartitionsDialog} from './LaunchAssetChoosePartitionsDialog';
 import {partitionDefinitionsEqual} from './MultipartitioningSupport';
 import {asAssetKeyInput, getAssetCheckHandleInputs} from './asInput';
@@ -188,7 +188,7 @@ export const LaunchAssetExecutionButton = ({
 
   const {MaterializeButton} = useLaunchPadHooks();
 
-  const [showCalculatingChangedAndMissingDialog, setShowCalculatingChangedAndMissingDialog] =
+  const [showCalculatingUnsyncedDialog, setShowCalculatingUnsyncedDialog] =
     React.useState<boolean>(false);
 
   const {
@@ -225,10 +225,10 @@ export const LaunchAssetExecutionButton = ({
 
   return (
     <>
-      <CalculateChangedAndMissingDialog
-        isOpen={!!showCalculatingChangedAndMissingDialog}
+      <CalculateUnsyncedDialog
+        isOpen={!!showCalculatingUnsyncedDialog}
         onClose={() => {
-          setShowCalculatingChangedAndMissingDialog(false);
+          setShowCalculatingUnsyncedDialog(false);
         }}
         assets={inScope}
         onMaterializeAssets={(assets: AssetKey[], e: React.MouseEvent<any>) => {
@@ -276,7 +276,7 @@ export const LaunchAssetExecutionButton = ({
                 <MenuItem
                   text="Materialize unsynced"
                   icon="changes_present"
-                  onClick={() => setShowCalculatingChangedAndMissingDialog(true)}
+                  onClick={() => setShowCalculatingUnsyncedDialog(true)}
                 />
               ) : null}
               <MenuItem

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -226,7 +226,7 @@ export const LaunchAssetExecutionButton = ({
   return (
     <>
       <CalculateUnsyncedDialog
-        isOpen={!!showCalculatingUnsyncedDialog}
+        isOpen={showCalculatingUnsyncedDialog}
         onClose={() => {
           setShowCalculatingUnsyncedDialog(false);
         }}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/CalculateUnsyncedDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/CalculateUnsyncedDialog.types.ts
@@ -13,5 +13,12 @@ export type AssetStaleStatusQuery = {
     id: string;
     staleStatus: Types.StaleStatus | null;
     assetKey: {__typename: 'AssetKey'; path: Array<string>};
+    partitionStats: {
+      __typename: 'PartitionStats';
+      numMaterialized: number;
+      numMaterializing: number;
+      numPartitions: number;
+      numFailed: number;
+    } | null;
   }>;
 };


### PR DESCRIPTION
Fixes #20463

## Summary & Motivation

This PR updates the behavior of "Materialize unsynced". In addition to assets with the staleStatus = MISSING, we now include assets with missing or failed partitions.

I also adjusted the types a bit in these code paths -- because `staleCauses` can be undefined in the types passed to `isAssetStale`, you could technically call it with "include=self" and never get anything but false, which felt a little scary.  I broke the function apart into two with stricter types.

## How I Tested These Changes

Tested with a graph that includes some partially materialized partitioned assets!