### PR TITLE
fix(dlt) support py38 pendulum dependency

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
@@ -36,7 +36,7 @@ class DagsterDltResource(ConfigurableResource):
         from pendulum import DateTime
 
         try:
-            from pendulum import Timezone
+            from pendulum import Timezone  # type: ignore
 
             casted_instance_types = (DateTime, Timezone)
         except ImportError:

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
@@ -33,14 +33,21 @@ class DagsterDltResource(ConfigurableResource):
             Mapping[Any, Any]: Metadata with pendulum DateTime and Timezone values casted to strings
 
         """
-        from pendulum import DateTime, Timezone  # type: ignore
+        from pendulum import DateTime
+
+        try:
+            from pendulum import Timezone
+
+            casted_instance_types = (DateTime, Timezone)
+        except ImportError:
+            casted_instance_types = DateTime
 
         def _recursive_cast(value: Any):
             if isinstance(value, dict):
                 return {k: _recursive_cast(v) for k, v in value.items()}
             elif isinstance(value, list):
                 return [_recursive_cast(item) for item in value]
-            elif isinstance(value, (DateTime, Timezone)):
+            elif isinstance(value, casted_instance_types):
                 return str(value)
             else:
                 return value


### PR DESCRIPTION
## Summary & Motivation

- tests were failing on Python 3.8 due to `Timezone` missing on `pendulum` module. This adds conditional import logic.

## How I Tested These Changes

```
$ pytest -s
===================================================== test session starts ======================================================
platform darwin -- Python 3.8.18, pytest-8.1.1, pluggy-1.4.0
rootdir: /Users/colton/src/dagster
configfile: pyproject.toml
collected 50 items
...

======================================================= warnings summary =======================================================
.direnv/python-3.8/lib/python3.8/site-packages/pydantic/_internal/_config.py:272
.direnv/python-3.8/lib/python3.8/site-packages/pydantic/_internal/_config.py:272
  /Users/colton/src/dagster/python_modules/libraries/dagster-embedded-elt/.direnv/python-3.8/lib/python3.8/site-packages/pydantic/_internal/_config.py:272: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.6/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================ 50 passed, 2 warnings in 7.42s ================================================
```