### PR TITLE
Add string repr for check keys

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -600,6 +600,11 @@ class AssetCheckKeysSelection(AssetSelection):
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return self
 
+    def __str__(self) -> str:
+        if len(self.selected_asset_check_keys) == 1:
+            return f"asset_check:{self.selected_asset_check_keys[0].to_user_string()}"
+        return f"asset_check:({' or '.join(k.to_user_string() for k in self.selected_asset_check_keys)})"
+
 
 @whitelist_for_serdes
 class AndAssetSelection(AssetSelection):

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -653,6 +653,17 @@ def test_to_string_basic():
         str(AssetSelection.key_prefixes("marketing", ["foo", "bar"]))
         == "key_prefix:(marketing or foo/bar)"
     )
+    assert (
+        str(AssetSelection.checks(AssetCheckKey(AssetKey("foo"), "bar"))) == "asset_check:foo:bar"
+    )
+    assert (
+        str(
+            AssetSelection.checks(
+                AssetCheckKey(AssetKey("foo"), "bar"), AssetCheckKey(AssetKey("baz"), "qux")
+            )
+        )
+        == "asset_check:(foo:bar or baz:qux)"
+    )
 
 
 def test_to_string_binary_operators():


### PR DESCRIPTION
Adds a reasonable string representation for asset check selections.

Puts under test. I think we're not okay with the double colon thing we have going on here for the selection; will be resolved with another PR.
