### PR TITLE
Add accurate BackfillPolicy warning info when backfilling an asset job

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/BackfillPreviewModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/BackfillPreviewModal.tsx
@@ -29,14 +29,19 @@ interface BackfillPreviewModalProps {
   }[];
   keysFiltered: string[];
   setOpen: (isOpen: boolean) => void;
+  showBackfillPolicies?: boolean;
 }
-const TEMPLATE_COLUMNS = '1fr 1fr 1fr 1fr';
+
+const getTemplateColumns = (showBackfillPolicies: boolean) => {
+  return showBackfillPolicies ? '1fr 1fr 1fr 1fr' : '1fr 1fr 1fr';
+};
 
 export const BackfillPreviewModal = ({
   isOpen,
   setOpen,
   assets,
   keysFiltered,
+  showBackfillPolicies = true,
 }: BackfillPreviewModalProps) => {
   const assetKeys = useMemo(() => assets.map(asAssetKeyInput), [assets]);
   const parentRef = useRef<HTMLDivElement | null>(null);
@@ -80,7 +85,7 @@ export const BackfillPreviewModal = ({
         style={{maxHeight: '50vh'}}
         data-testid={testId('backfill-preview-modal-content')}
       >
-        <BackfillPreviewTableHeader />
+        <BackfillPreviewTableHeader showBackfillPolicies={showBackfillPolicies} />
         <Inner $totalHeight={totalHeight}>
           {items.map(({index, size, start}) => {
             const {assetKey, partitionDefinition, backfillPolicy} = assets[index]!;
@@ -89,17 +94,22 @@ export const BackfillPreviewModal = ({
 
             return (
               <Row key={token} $height={size} $start={start}>
-                <RowGrid border={index < assets.length - 1 ? 'bottom' : undefined}>
+                <RowGrid
+                  showBackfillPolicies={showBackfillPolicies}
+                  border={index < assets.length - 1 ? 'bottom' : undefined}
+                >
                   <RowCell>
                     <AssetLink path={assetKey.path} textStyle="middle-truncate" icon="asset" />
                   </RowCell>
-                  {backfillPolicy ? (
-                    <RowCell style={{color: Colors.textDefault()}}>
-                      {backfillPolicy?.description}
-                    </RowCell>
-                  ) : (
-                    <RowCell>{'\u2013'}</RowCell>
-                  )}
+                  {showBackfillPolicies ? (
+                    backfillPolicy ? (
+                      <RowCell style={{color: Colors.textDefault()}}>
+                        {backfillPolicy?.description}
+                      </RowCell>
+                    ) : (
+                      <RowCell>{'\u2013'}</RowCell>
+                    )
+                  ) : null}
                   {partitionDefinition ? (
                     <RowCell style={{color: Colors.textDefault()}}>
                       {partitionDefinition?.description}
@@ -129,26 +139,30 @@ export const BackfillPreviewModal = ({
   );
 };
 
-const RowGrid = styled(Box)`
+const RowGrid = styled(Box)<{showBackfillPolicies: boolean}>`
   display: grid;
-  grid-template-columns: ${TEMPLATE_COLUMNS};
+  grid-template-columns: ${({showBackfillPolicies}) => getTemplateColumns(showBackfillPolicies)};
   height: 100%;
 `;
 
-export const BackfillPreviewTableHeader = () => {
+export const BackfillPreviewTableHeader = ({
+  showBackfillPolicies,
+}: {
+  showBackfillPolicies: boolean;
+}) => {
   return (
     <Box
       border="bottom"
       style={{
         display: 'grid',
-        gridTemplateColumns: TEMPLATE_COLUMNS,
+        gridTemplateColumns: getTemplateColumns(showBackfillPolicies),
         height: '32px',
         fontSize: '12px',
         color: Colors.textLight(),
       }}
     >
       <HeaderCell>Asset key</HeaderCell>
-      <HeaderCell>Backfill policy</HeaderCell>
+      {showBackfillPolicies ? <HeaderCell>Backfill policy</HeaderCell> : null}
       <HeaderCell>Partition definition</HeaderCell>
       <HeaderCell>Partitions to launch</HeaderCell>
     </Box>


### PR DESCRIPTION
## Summary & Motivation

Make backfill modal warning and preview accurate when dealing with asset jobs. Currently, we give plainly wrong information in this dialog when a user attempts to backfill some assets with an asset job. This codepath completely ignores asset backfill policies, but our messaging misleads users into thinking this is not the case. Consequently the preview info about how many runs will be launched is simply wrong.

This PR does two things:

- Changes the warning text to explain that backfill policies will be ignored, advising users to use the asset graph view if they want to them taken into account.
- Removes the backfill policy column from the preview table when previewing an assets job.

Code:

```
from dagster import (
    asset,
    Definitions,
    AssetExecutionContext,
)
from dagster._core.definitions.backfill_policy import BackfillPolicy
from dagster._core.definitions.partition import StaticPartitionsDefinition
from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job

parts = StaticPartitionsDefinition(["a", "b"])

@asset(partitions_def=parts, backfill_policy=BackfillPolicy.single_run())
def foo(context: AssetExecutionContext):
    ...

foo_job = define_asset_job("foo_job", [foo])


defs = Definitions(
    assets=[foo],
    jobs=[foo_job],
)
```

Before:

<img width="1240" alt="image" src="https://github.com/dagster-io/dagster/assets/1531373/7d85b5ef-dcd5-4cca-92d3-6e1f56fad44a">

<img width="1240" alt="image" src="https://github.com/dagster-io/dagster/assets/1531373/a4397c0b-4df4-457a-8523-84091ce42399">


After:

<img width="807" alt="image" src="https://github.com/dagster-io/dagster/assets/1531373/799664b9-1257-4755-86c5-5696474dc686">

<img width="1240" alt="image" src="https://github.com/dagster-io/dagster/assets/1531373/5b775ccf-7310-4f8f-bfd8-caba1e111fc8">

## How I Tested These Changes

Manual testing in UI.