### PR TITLE
Adjust padding on active filters bar on "All assets" page.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -276,7 +276,7 @@ export const AssetsCatalogTable = ({
         activeFiltersJsx.length ? (
           <Box
             border="top-and-bottom"
-            padding={12}
+            padding={{vertical: 12, left: 24, right: 12}}
             flex={{direction: 'row', gap: 4, alignItems: 'center'}}
           >
             {activeFiltersJsx}


### PR DESCRIPTION
## How I Tested These Changes
before:
<img width="291" alt="Screenshot 2024-04-03 at 9 54 41 AM" src="https://github.com/dagster-io/dagster/assets/2286579/2192be35-c77a-4e87-9684-85324ab3eead">

after:
<img width="349" alt="Screenshot 2024-04-03 at 9 53 23 AM" src="https://github.com/dagster-io/dagster/assets/2286579/afdb2031-4724-4a8b-bbb2-0e15465f5906">
