### PR TITLE
fix(dbt): set `PYTHONLEGACYWINDOWSSTDIO=1` to allow log streaming in Windows

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -1182,6 +1182,10 @@ class DbtCliResource(ConfigurableResource):
 
         target_path = target_path or self._get_unique_target_path(context=context)
         env = {
+            # Allow IO streaming when running in Windows.
+            # Also, allow it to be overriden by the current environment.
+            "PYTHONLEGACYWINDOWSSTDIO": "1",
+            # Pass the current environment variables to the dbt CLI invocation.
             **os.environ.copy(),
             # An environment variable to indicate that the dbt CLI is being invoked from Dagster.
             "DAGSTER_DBT_CLI": "true",


### PR DESCRIPTION
## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/20992.

https://docs.python.org/3/using/cmdline.html#envvar-PYTHONLEGACYWINDOWSSTDIO

## How I Tested These Changes
N/A
