### PR TITLE
[Asset graph] Add "View asset details" and "View latest execution" menu items to asset node context menu

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
@@ -429,7 +429,7 @@ describe('AssetLiveDataProvider', () => {
         mocks={[mockedQuery, mockedQuery2]}
         hooks={[
           {keys: assetKeys, thread: 'default', hookResult},
-          {keys: assetKeys2, thread: 'asset-graph', hookResult: hookResult2},
+          {keys: assetKeys2, thread: 'context-menu', hookResult: hookResult2},
         ]}
       />,
     );

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
@@ -72,7 +72,7 @@ export const useAssetNodeMenu = ({
             text={
               <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
                 View latest {isSource ? 'observation' : 'materialization'}
-                {liveData ? null : <Spinner purpose="body-text" />}
+                {liveData ? null : <Spinner purpose="caption-text" />}
               </Box>
             }
           />

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
@@ -1,15 +1,18 @@
-import {Box, Menu, MenuDivider, MenuItem} from '@dagster-io/ui-components';
+import {Box, Menu, MenuDivider, MenuItem, Spinner} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {GraphData, GraphNode, tokenForAssetKey} from './Utils';
 import {StatusDot} from './sidebar/StatusDot';
+import {useAssetLiveData} from '../asset-data/AssetLiveDataProvider';
 import {useExecuteAssetMenuItem} from '../assets/AssetActionMenu';
 import {
   AssetKeysDialog,
   AssetKeysDialogEmptyState,
   AssetKeysDialogHeader,
 } from '../assets/AutoMaterializePolicyPage/AssetKeysDialog';
+import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {ExplorerPath} from '../pipelines/PipelinePathUtils';
+import {MenuLink} from '../ui/MenuLink';
 import {VirtualizedItemListForDialog} from '../ui/VirtualizedItemListForDialog';
 
 export type AssetNodeMenuProps = {
@@ -47,11 +50,30 @@ export const useAssetNodeMenu = ({
     onChangeExplorerPath({...explorerPath, opsQuery: nextOpsQuery}, 'push');
   }
 
+  const {liveData} = useAssetLiveData(node.assetKey, 'context-menu');
+  const lastExecutionRunID = liveData?.lastMaterialization?.runId;
+
   return {
     menu: (
       <Menu>
+        <MenuLink
+          to={assetDetailsPathForKey(node.assetKey)}
+          text="View asset details"
+          icon="asset"
+        />
+        <MenuLink
+          icon="history"
+          disabled={!lastExecutionRunID}
+          to={`/runs/${lastExecutionRunID}`}
+          text={
+            <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+              View latest execution {liveData ? null : <Spinner purpose="body-text" />}
+            </Box>
+          }
+        />
+        {executeItem ? <MenuDivider /> : null}
         {executeItem}
-        {upstream.length || downstream.length ? <MenuDivider /> : null}
+        {executeItem && (upstream.length || downstream.length) ? <MenuDivider /> : null}
         {upstream.length ? (
           <MenuItem
             text={`View parents (${upstream.length})`}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
@@ -71,7 +71,7 @@ export const useAssetNodeMenu = ({
             </Box>
           }
         />
-        {executeItem ? <MenuDivider /> : null}
+        <MenuDivider />
         {executeItem}
         {executeItem && (upstream.length || downstream.length) ? <MenuDivider /> : null}
         {upstream.length ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
@@ -51,7 +51,10 @@ export const useAssetNodeMenu = ({
   }
 
   const {liveData} = useAssetLiveData(node.assetKey, 'context-menu');
+
+  const isSource = node.definition?.isExecutable && node.definition.isSource;
   const lastMaterializationRunID = liveData?.lastMaterialization?.runId;
+  const lastObservationID = liveData?.lastObservation?.runId;
 
   return {
     menu: (
@@ -61,16 +64,19 @@ export const useAssetNodeMenu = ({
           text="View asset details"
           icon="asset"
         />
-        <MenuLink
-          icon="history"
-          disabled={!lastMaterializationRunID}
-          to={`/runs/${lastMaterializationRunID}`}
-          text={
-            <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-              View latest materialization {liveData ? null : <Spinner purpose="body-text" />}
-            </Box>
-          }
-        />
+        {node.definition?.isExecutable ? (
+          <MenuLink
+            icon="history"
+            disabled={!lastMaterializationRunID && !lastObservationID}
+            to={`/runs/${lastMaterializationRunID || lastObservationID}`}
+            text={
+              <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+                View latest {isSource ? 'observation' : 'materialization'}
+                {liveData ? null : <Spinner purpose="body-text" />}
+              </Box>
+            }
+          />
+        ) : null}
         <MenuDivider />
         {executeItem}
         {executeItem && (upstream.length || downstream.length) ? <MenuDivider /> : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
@@ -52,7 +52,7 @@ export const useAssetNodeMenu = ({
 
   const {liveData} = useAssetLiveData(node.assetKey, 'context-menu');
 
-  const isSource = node.definition?.isExecutable && node.definition.isSource;
+  const isSource = node.definition.isSource;
   const lastMaterializationRunID = liveData?.lastMaterialization?.runId;
   const lastObservationID = liveData?.lastObservation?.runId;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
@@ -51,7 +51,7 @@ export const useAssetNodeMenu = ({
   }
 
   const {liveData} = useAssetLiveData(node.assetKey, 'context-menu');
-  const lastExecutionRunID = liveData?.lastMaterialization?.runId;
+  const lastMaterializationRunID = liveData?.lastMaterialization?.runId;
 
   return {
     menu: (
@@ -63,11 +63,11 @@ export const useAssetNodeMenu = ({
         />
         <MenuLink
           icon="history"
-          disabled={!lastExecutionRunID}
-          to={`/runs/${lastExecutionRunID}`}
+          disabled={!lastMaterializationRunID}
+          to={`/runs/${lastMaterializationRunID}`}
           text={
             <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-              View latest execution {liveData ? null : <Spinner purpose="body-text" />}
+              View latest materialization {liveData ? null : <Spinner purpose="body-text" />}
             </Box>
           }
         />

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -44,7 +44,7 @@ import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 export const SidebarAssetInfo = ({graphNode}: {graphNode: GraphNode}) => {
   const {assetKey, definition} = graphNode;
-  const {liveData} = useAssetLiveData(assetKey);
+  const {liveData} = useAssetLiveData(assetKey, 'sidebar');
   const partitionHealthRefreshHint = healthRefreshHintFromLiveData(liveData);
   const partitionHealthData = usePartitionHealthData(
     [assetKey],

--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThread.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThread.tsx
@@ -1,12 +1,7 @@
 import {LiveDataThreadManager} from './LiveDataThreadManager';
 import {BATCHING_INTERVAL} from './util';
 
-export type LiveDataThreadID =
-  | 'default'
-  | 'sidebar'
-  | 'asset-graph'
-  | 'group-node'
-  | 'context-menu';
+export type LiveDataThreadID = 'default' | 'sidebar' | 'group-node' | 'context-menu';
 
 export class LiveDataThread<T> {
   private isFetching: boolean = false;

--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThread.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThread.tsx
@@ -1,7 +1,12 @@
 import {LiveDataThreadManager} from './LiveDataThreadManager';
 import {BATCHING_INTERVAL} from './util';
 
-export type LiveDataThreadID = 'default' | 'sidebar' | 'asset-graph' | 'group-node';
+export type LiveDataThreadID =
+  | 'default'
+  | 'sidebar'
+  | 'asset-graph'
+  | 'group-node'
+  | 'context-menu';
 
 export class LiveDataThread<T> {
   private isFetching: boolean = false;


### PR DESCRIPTION
## Summary & Motivation
To link to the latest execution we need to fetch data so that menu item has a spinner while the data is being fetched. To get the data asap I added another live data thread ID so that we can start fetching this data immediately if its not already being fetched as part of a batched fetch.

## How I Tested These Changes
Shadow dagit:
<img width="246" alt="Screenshot 2024-04-03 at 11 47 05 AM" src="https://github.com/dagster-io/dagster/assets/2286579/35d43d25-7167-400d-a251-30082fbb708f">
<img width="266" alt="Screenshot 2024-04-03 at 11 46 24 AM" src="https://github.com/dagster-io/dagster/assets/2286579/c8357a1f-ed17-42b2-9c75-e44417de2fe5">


