### PR TITLE
Change user string delimiter for asset checks to ?

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
     from dagster._core.definitions.assets import AssetsDefinition
     from dagster._core.definitions.source_asset import SourceAsset
 
+ASSET_CHECK_KEY_USER_STRING_DELIMITER = "?"
+
 
 @whitelist_for_serdes
 class AssetCheckSeverity(Enum):
@@ -51,7 +53,9 @@ class AssetCheckKey(NamedTuple):
         return self._replace(asset_key=self.asset_key.with_prefix(prefix))
 
     def to_user_string(self) -> str:
-        return f"{self.asset_key.to_user_string()}:{self.name}"
+        return (
+            f"{self.asset_key.to_user_string()}{ASSET_CHECK_KEY_USER_STRING_DELIMITER}{self.name}"
+        )
 
 
 class AssetCheckSpec(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -654,7 +654,7 @@ def test_to_string_basic():
         == "key_prefix:(marketing or foo/bar)"
     )
     assert (
-        str(AssetSelection.checks(AssetCheckKey(AssetKey("foo"), "bar"))) == "asset_check:foo:bar"
+        str(AssetSelection.checks(AssetCheckKey(AssetKey("foo"), "bar"))) == "asset_check:foo?bar"
     )
     assert (
         str(
@@ -662,7 +662,7 @@ def test_to_string_basic():
                 AssetCheckKey(AssetKey("foo"), "bar"), AssetCheckKey(AssetKey("baz"), "qux")
             )
         )
-        == "asset_check:(foo:bar or baz:qux)"
+        == "asset_check:(foo?bar or baz?qux)"
     )
 
     assert (


### PR DESCRIPTION
Changes the delimiter for asset checks to ?. Will eventually be clearer for asset selection when we let that happen via string.

We'll see which tests I have to change from this.