### PR TITLE
[ui] Enable persisting default expansion state

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/usePersistedExpansionStateWithDefault.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/usePersistedExpansionStateWithDefault.tsx
@@ -1,0 +1,50 @@
+import {useCallback, useContext, useMemo} from 'react';
+
+import {AppContext} from '../app/AppContext';
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
+
+const validateExpandedKeys = (parsed: unknown): {[key: string]: boolean} =>
+  !!parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? (parsed as {[key: string]: boolean})
+    : {};
+
+/**
+ * Use localStorage to persist the expanded/collapsed visual state of rows.
+ */
+export const usePersistedExpansionStateWithDefault = (
+  storageKey: string,
+  defaultValue: boolean,
+) => {
+  const {basePath} = useContext(AppContext);
+  const [expandedKeys, setExpandedKeys] = useStateWithStorage<{[key: string]: boolean}>(
+    `${basePath}:dagster.${storageKey}`,
+    validateExpandedKeys,
+  );
+
+  const onToggle = useCallback(
+    (key: string) => {
+      setExpandedKeys((current) => {
+        const nextExpandedKeys = current
+          ? {...current, [key]: key in current ? !current[key] : !defaultValue}
+          : {[key]: !defaultValue};
+        return nextExpandedKeys;
+      });
+    },
+    [setExpandedKeys, defaultValue],
+  );
+
+  const isExpanded = useCallback(
+    (key: string) => {
+      return key in expandedKeys ? expandedKeys[key]! : defaultValue;
+    },
+    [expandedKeys, defaultValue],
+  );
+
+  return useMemo(
+    () => ({
+      isExpanded,
+      onToggle,
+    }),
+    [isExpanded, onToggle],
+  );
+};


### PR DESCRIPTION
Adds logic to fetch and persist expansion state with a default setting.

This requires us to persist a key/value pairing containing a section name and a bool representing whether it is expanded or not in local storage.

When the section name has not been persisted, fall back to the default setting.

Used in https://github.com/dagster-io/internal/pull/9110.
