### PR TITLE
fix(dbt): silence logs from registering adapter

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -53,6 +53,7 @@ from dbt.adapters.factory import get_adapter, register_adapter, reset_adapters
 from dbt.config import RuntimeConfig
 from dbt.config.runtime import load_profile, load_project
 from dbt.contracts.results import NodeStatus, TestStatus
+from dbt.events.functions import cleanup_event_logger
 from dbt.flags import get_flags, set_from_args
 from dbt.node_types import NodeType
 from dbt.version import __version__ as dbt_version
@@ -1083,6 +1084,7 @@ class DbtCliResource(ConfigurableResource):
         project = load_project(self.project_dir, False, profile, {})
         config = RuntimeConfig.from_parts(project, profile, flags)
 
+        cleanup_event_logger()
         register_adapter(config)
         adapter = cast(BaseAdapter, get_adapter(config))
         # reset the adapter since the dummy flags may be different from the flags for the actual subcommand


### PR DESCRIPTION
## Summary & Motivation

Noticed that adapter registration logs were coming into the console, even though we are running `dbt --quiet parse`. This is because we are invoking the adapter registration logic manually, and so an event is fired.

Silence those logs by ensuring "--quiet" is threaded through.

```diff
Downloads/projects/jaffle_dagster 🐍 (dagster) took 12s
❯ DAGSTER_DBT_PARSE_PROJECT_ON_LOAD=1 dagster dev
2024-04-03 15:36:34 -0400 - dagster - INFO - Using temporary directory /Users/rexledesma/Downloads/projects/jaffle_dagster/tmpfexh_df6 for storage. This will be removed when dagster dev exits.
2024-04-03 15:36:34 -0400 - dagster - INFO - To persist information across sessions, set the environment variable DAGSTER_HOME to a directory to use.
2024-04-03 15:36:34 -0400 - dagster - INFO - Launching Dagster services...
+ 19:36:37  Registered adapter: duckdb=1.7.3
+ 19:36:37  Registered adapter: duckdb=1.7.3
2024-04-03 15:36:39 -0400 - dagster.daemon - INFO - Instance is configured with the following daemons: ['AssetDaemon', 'BackfillDaemon', 'SchedulerDaemon', 'SensorDaemon']
2024-04-03 15:36:39 -0400 - dagster-webserver - INFO - Serving dagster-webserver on http://127.0.0.1:3000 in process 4431
^C2024-04-03 15:36:48 -0400 - dagster.daemon - INFO - Received interrupt, shutting down daemon threads...
2024-04-03 15:36:48 -0400 - dagster - INFO - KeyboardInterrupt received
2024-04-03 15:36:48 -0400 - dagster - INFO - Shutting down Dagster services...
2024-04-03 15:36:48 -0400 - dagster.daemon - INFO - Daemon threads shut down.
2024-04-03 15:36:48 -0400 - dagster-webserver - INFO - Server for dagster-webserver was shut down.
2024-04-03 15:36:48 -0400 - dagster - INFO - Dagster services shut down.
```

## How I Tested These Changes
Local, see no more logs after this change.