### PR TITLE
Switch freshness check implementation to use multi asset checks.

### DIFF
--- a/docs/content/concepts/assets/asset-checks/checking-for-data-freshness.mdx
+++ b/docs/content/concepts/assets/asset-checks/checking-for-data-freshness.mdx
@@ -163,7 +163,7 @@ from dagster import Definitions, EnvVar
 
 defs = Definitions(
     assets=[source_tables],
-    asset_checks=[*source_table_freshness_checks],
+    asset_checks=[source_table_freshness_checks],
     schedules=[source_tables_observation_schedule],
     resources={
         "snowflake": SnowflakeResource(
@@ -238,7 +238,7 @@ source_table_freshness_checks = build_last_update_freshness_checks(
 
 defs = Definitions(
     assets=[source_tables],
-    asset_checks=[*source_table_freshness_checks],
+    asset_checks=[source_table_freshness_checks],
     schedules=[source_tables_observation_schedule],
     resources={
         "snowflake": SnowflakeResource(
@@ -287,7 +287,7 @@ In this example, we'll use <PyObject object="build_sensor_for_freshness_checks" 
 from dagster import build_sensor_for_freshness_checks
 
 freshness_checks_sensor = build_sensor_for_freshness_checks(
-    freshness_checks=[*asset1_freshness_checks]
+    freshness_checks=[asset1_freshness_checks]
 )
 ```
 
@@ -300,7 +300,7 @@ from dagster import Definitions
 
 defs = Definitions(
     assets=[my_asset],
-    asset_checks=[*asset1_freshness_checks],
+    asset_checks=[asset1_freshness_checks],
     sensors=[freshness_checks_sensor],
 )
 ```
@@ -326,11 +326,11 @@ asset1_freshness_checks = build_last_update_freshness_checks(
     assets=[my_asset], lower_bound_delta=timedelta(hours=2)
 )
 freshness_checks_sensor = build_sensor_for_freshness_checks(
-    freshness_checks=[*asset1_freshness_checks]
+    freshness_checks=[asset1_freshness_checks]
 )
 defs = Definitions(
     assets=[my_asset],
-    asset_checks=[*asset1_freshness_checks],
+    asset_checks=[asset1_freshness_checks],
     sensors=[freshness_checks_sensor],
 )
 ```

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/materializable_freshness_complete.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/materializable_freshness_complete.py
@@ -16,10 +16,10 @@ asset1_freshness_checks = build_last_update_freshness_checks(
     assets=[my_asset], lower_bound_delta=timedelta(hours=2)
 )
 freshness_checks_sensor = build_sensor_for_freshness_checks(
-    freshness_checks=[*asset1_freshness_checks]
+    freshness_checks=[asset1_freshness_checks]
 )
 defs = Definitions(
     assets=[my_asset],
-    asset_checks=[*asset1_freshness_checks],
+    asset_checks=[asset1_freshness_checks],
     sensors=[freshness_checks_sensor],
 )

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/materializable_freshness_in_pieces.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/materializable_freshness_in_pieces.py
@@ -17,7 +17,7 @@ asset1_freshness_checks = build_last_update_freshness_checks(
 from dagster import build_sensor_for_freshness_checks
 
 freshness_checks_sensor = build_sensor_for_freshness_checks(
-    freshness_checks=[*asset1_freshness_checks]
+    freshness_checks=[asset1_freshness_checks]
 )
 # end_sensor_marker
 
@@ -26,7 +26,7 @@ from dagster import Definitions
 
 defs = Definitions(
     assets=[my_asset],
-    asset_checks=[*asset1_freshness_checks],
+    asset_checks=[asset1_freshness_checks],
     sensors=[freshness_checks_sensor],
 )
 # end_defs_marker

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/source_data_freshness_complete.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/source_data_freshness_complete.py
@@ -58,7 +58,7 @@ source_table_freshness_checks = build_last_update_freshness_checks(
 
 defs = Definitions(
     assets=[source_tables],
-    asset_checks=[*source_table_freshness_checks],
+    asset_checks=[source_table_freshness_checks],
     schedules=[source_tables_observation_schedule],
     resources={
         "snowflake": SnowflakeResource(

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/source_data_freshness_in_pieces.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/source_data_freshness_in_pieces.py
@@ -64,7 +64,7 @@ from dagster import Definitions, EnvVar
 
 defs = Definitions(
     assets=[source_tables],
-    asset_checks=[*source_table_freshness_checks],
+    asset_checks=[source_table_freshness_checks],
     schedules=[source_tables_observation_schedule],
     resources={
         "snowflake": SnowflakeResource(

--- a/python_modules/dagster/dagster/_core/definitions/freshness_checks/last_update.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_checks/last_update.py
@@ -22,8 +22,8 @@ def build_last_update_freshness_checks(
     deadline_cron: Optional[str] = None,
     timezone: str = DEFAULT_FRESHNESS_TIMEZONE,
     severity: AssetCheckSeverity = DEFAULT_FRESHNESS_SEVERITY,
-) -> Sequence[AssetChecksDefinition]:
-    r"""For each provided asset, constructs a freshness check definition.
+) -> AssetChecksDefinition:
+    r"""Constructs an `AssetChecksDefinition` that checks the freshness of the provided assets.
 
     This check passes if the asset is found to be "fresh", and fails if the asset is found to be
     "overdue". An asset is considered fresh if a record (i.e. a materialization or observation)
@@ -58,7 +58,7 @@ def build_last_update_freshness_checks(
             from dagster import build_last_update_freshness_checks, AssetKey
             from .somewhere import my_daily_scheduled_assets_def
 
-            checks = build_last_update_freshness_checks(
+            checks_def = build_last_update_freshness_checks(
                 [my_daily_scheduled_assets_def, AssetKey("my_other_daily_asset_key")],
                 lower_bound_delta=datetime.timedelta(minutes=45),
                 deadline_cron="0 9 * * *",
@@ -68,7 +68,7 @@ def build_last_update_freshness_checks(
             from dagster import build_last_update_freshness_checks, AssetKey
             from .somewhere import my_observable_source_asset
 
-            checks = build_last_update_freshness_checks(
+            checks_def = build_last_update_freshness_checks(
                 [my_observable_source_asset, AssetKey("my_other_observable_asset_key")],
                 lower_bound_delta=datetime.timedelta(hours=3),
             )
@@ -76,8 +76,8 @@ def build_last_update_freshness_checks(
 
     Args:
         assets (Sequence[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]): The assets to
-            construct checks for. For each individual asset (of which there can be multiple per
-            `AssetsDefinition`, there will be a corresponding constructed `AssetChecksDefinition`.
+            construct checks for. All checks are incorporated into the same `AssetChecksDefinition`,
+            which can be subsetted to run checks for specific assets.
         lower_bound_delta (datetime.timedelta): The check will pass if the asset was updated within
             lower_bound_delta of the current_time (no cron) or the most recent tick of the cron
             (cron provided).
@@ -87,8 +87,8 @@ def build_last_update_freshness_checks(
             not provided, defaults to "UTC".
 
     Returns:
-        Sequence[AssetChecksDefinition]: A list of `AssetChecksDefinition` objects, each
-            corresponding to an asset in the `assets` parameter.
+        AssetChecksDefinition: An `AssetChecksDefinition` object, which can execute a freshness check
+            for all provided assets.
     """
     return build_freshness_checks_for_assets(
         assets=assets,

--- a/python_modules/dagster/dagster/_core/definitions/freshness_checks/time_partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_checks/time_partition.py
@@ -22,8 +22,8 @@ def build_time_partition_freshness_checks(
     deadline_cron: str,
     timezone: str = DEFAULT_FRESHNESS_TIMEZONE,
     severity: AssetCheckSeverity = DEFAULT_FRESHNESS_SEVERITY,
-) -> Sequence[AssetChecksDefinition]:
-    r"""For each provided time-window partitioned asset, constructs a freshness check definition.
+) -> AssetChecksDefinition:
+    r"""Construct an `AssetChecksDefinition` that checks the freshness of the provided assets.
 
     This check passes if the asset is considered "fresh" by the time that execution begins. We
     consider an asset to be "fresh" if there exists a record for the most recent partition, once
@@ -55,7 +55,7 @@ def build_time_partition_freshness_checks(
             # of 9:00 AM UTC
             from .somewhere import my_daily_scheduled_assets_def
 
-            checks = build_time_partition_freshness_checks(
+            checks_def = build_time_partition_freshness_checks(
                 [my_daily_scheduled_assets_def],
                 deadline_cron="0 9 * * *",
             )
@@ -71,8 +71,8 @@ def build_time_partition_freshness_checks(
             not provided, defaults to "UTC".
 
     Returns:
-        Sequence[AssetChecksDefinition]: A list of `AssetChecksDefinition` objects, each
-            corresponding to an asset in the `assets` parameter.
+        AssetChecksDefinition: An `AssetChecksDefinition` object, which can execute a freshness
+            check for each provided asset.
     """
     return build_freshness_checks_for_assets(
         assets=assets,

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_last_update_freshness.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_last_update_freshness.py
@@ -1,6 +1,7 @@
 # pyright: reportPrivateImportUsage=false
 
 import datetime
+import hashlib
 
 import pendulum
 import pytest
@@ -8,10 +9,14 @@ from dagster import (
     asset,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
+from dagster._core.definitions.asset_checks import AssetChecksDefinition
+from dagster._core.definitions.asset_selection import AssetChecksForAssetKeysSelection
+from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.freshness_checks.last_update import (
     build_last_update_freshness_checks,
 )
 from dagster._core.definitions.source_asset import SourceAsset
+from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.instance import DagsterInstance
 from dagster._seven.compat.pendulum import pendulum_freeze_time
 
@@ -23,24 +28,40 @@ def test_params() -> None:
     def my_asset():
         pass
 
-    result = build_last_update_freshness_checks(
+    check = build_last_update_freshness_checks(
         assets=[my_asset], lower_bound_delta=datetime.timedelta(minutes=10)
     )
-    assert len(result) == 1
-    check = result[0]
+    assert (
+        check.node_def.name
+        == f"freshness_check_{hashlib.md5(str(my_asset.key).encode()).hexdigest()[:8]}"
+    )
+    check_specs = list(check.check_specs)
+    assert len(check_specs) == 1
+
+    assert isinstance(check, AssetChecksDefinition)
     assert next(iter(check.check_keys)).asset_key == my_asset.key
-    assert next(iter(check.check_specs)).metadata == {
+    assert next(iter(check_specs)).metadata == {
         "dagster/freshness_params": {
             "dagster/lower_bound_delta": 600,
         }
     }
 
-    result = build_last_update_freshness_checks(
+    @asset
+    def other_asset():
+        pass
+
+    other_check = build_last_update_freshness_checks(
+        assets=[other_asset], lower_bound_delta=datetime.timedelta(minutes=10)
+    )
+    assert isinstance(other_check, AssetChecksDefinition)
+    assert check.node_def.name != other_check.node_def.name
+
+    check = build_last_update_freshness_checks(
         assets=[my_asset],
         deadline_cron="0 0 * * *",
         lower_bound_delta=datetime.timedelta(minutes=10),
     )
-    check = result[0]
+    assert isinstance(check, AssetChecksDefinition)
     assert next(iter(check.check_specs)).metadata == {
         "dagster/freshness_params": {
             "dagster/lower_bound_delta": 600,
@@ -49,39 +70,38 @@ def test_params() -> None:
         }
     }
 
-    result = build_last_update_freshness_checks(
+    check = build_last_update_freshness_checks(
         assets=[my_asset.key], lower_bound_delta=datetime.timedelta(minutes=10)
     )
-    assert len(result) == 1
-    assert next(iter(result[0].check_keys)).asset_key == my_asset.key
+    assert isinstance(check, AssetChecksDefinition)
+    assert next(iter(check.check_keys)).asset_key == my_asset.key
 
     src_asset = SourceAsset("source_asset")
-    result = build_last_update_freshness_checks(
+    check = build_last_update_freshness_checks(
         assets=[src_asset], lower_bound_delta=datetime.timedelta(minutes=10)
     )
-    assert len(result) == 1
-    assert next(iter(result[0].check_keys)).asset_key == src_asset.key
+    assert isinstance(check, AssetChecksDefinition)
+    assert next(iter(check.check_keys)).asset_key == src_asset.key
 
-    result = build_last_update_freshness_checks(
+    check = build_last_update_freshness_checks(
         assets=[my_asset, src_asset], lower_bound_delta=datetime.timedelta(minutes=10)
     )
-
-    assert len(result) == 2
-    assert next(iter(result[0].check_keys)).asset_key == my_asset.key
+    assert isinstance(check, AssetChecksDefinition)
+    assert {check_key.asset_key for check_key in check.check_keys} == {my_asset.key, src_asset.key}
 
     with pytest.raises(Exception, match="Found duplicate assets"):
         build_last_update_freshness_checks(
             assets=[my_asset, my_asset], lower_bound_delta=datetime.timedelta(minutes=10)
         )
 
-    result = build_last_update_freshness_checks(
+    check = build_last_update_freshness_checks(
         assets=[my_asset],
         lower_bound_delta=datetime.timedelta(minutes=10),
         deadline_cron="0 0 * * *",
         timezone="UTC",
     )
-    assert len(result) == 1
-    assert next(iter(result[0].check_keys)).asset_key == my_asset.key
+    assert isinstance(check, AssetChecksDefinition)
+    assert next(iter(check.check_keys)).asset_key == my_asset.key
 
 
 @pytest.mark.parametrize(
@@ -104,11 +124,11 @@ def test_different_event_types(
     with pendulum_freeze_time(start_time.subtract(minutes=(lower_bound_delta.seconds // 60) - 1)):
         add_new_event(instance, my_asset.key, is_materialization=use_materialization)
     with pendulum_freeze_time(start_time):
-        freshness_checks = build_last_update_freshness_checks(
+        check = build_last_update_freshness_checks(
             assets=[my_asset],
             lower_bound_delta=lower_bound_delta,
         )
-        assert_check_result(my_asset, instance, freshness_checks, AssetCheckSeverity.WARN, True)
+        assert_check_result(my_asset, instance, [check], AssetCheckSeverity.WARN, True)
 
 
 def test_check_result_cron_non_partitioned(
@@ -126,7 +146,7 @@ def test_check_result_cron_non_partitioned(
     timezone = "UTC"
     lower_bound_delta = datetime.timedelta(minutes=10)
 
-    freshness_checks = build_last_update_freshness_checks(
+    check = build_last_update_freshness_checks(
         assets=[my_asset],
         deadline_cron=deadline_cron,
         lower_bound_delta=lower_bound_delta,
@@ -139,7 +159,7 @@ def test_check_result_cron_non_partitioned(
         assert_check_result(
             my_asset,
             instance,
-            freshness_checks,
+            [check],
             AssetCheckSeverity.WARN,
             False,
             description_match="Asset is overdue. Expected an update within the last 1 hours, 10 minutes.",
@@ -150,7 +170,7 @@ def test_check_result_cron_non_partitioned(
     with pendulum_freeze_time(lower_bound.subtract(minutes=1)):
         add_new_event(instance, my_asset.key)
     with pendulum_freeze_time(freeze_datetime):
-        assert_check_result(my_asset, instance, freshness_checks, AssetCheckSeverity.WARN, False)
+        assert_check_result(my_asset, instance, [check], AssetCheckSeverity.WARN, False)
 
     # Go back in time and add an event within cron-lower_bound_delta.
     with pendulum_freeze_time(lower_bound.add(minutes=1)):
@@ -160,7 +180,7 @@ def test_check_result_cron_non_partitioned(
         assert_check_result(
             my_asset,
             instance,
-            freshness_checks,
+            [check],
             AssetCheckSeverity.WARN,
             True,
             # This looks weird at first, but notice that we're one hours, after the last cron tick already.
@@ -171,7 +191,7 @@ def test_check_result_cron_non_partitioned(
     # Since that is not the case, we expect the check to fail.
     freeze_datetime = freeze_datetime.add(days=1)
     with pendulum_freeze_time(freeze_datetime):
-        assert_check_result(my_asset, instance, freshness_checks, AssetCheckSeverity.WARN, False)
+        assert_check_result(my_asset, instance, [check], AssetCheckSeverity.WARN, False)
 
     # Again, go back in time, and add an event within the time window we're checking.
     with pendulum_freeze_time(
@@ -180,7 +200,7 @@ def test_check_result_cron_non_partitioned(
         add_new_event(instance, my_asset.key)
     # Now we expect the check to pass.
     with pendulum_freeze_time(freeze_datetime):
-        assert_check_result(my_asset, instance, freshness_checks, AssetCheckSeverity.WARN, True)
+        assert_check_result(my_asset, instance, [check], AssetCheckSeverity.WARN, True)
 
 
 def test_check_result_bound_only(
@@ -198,7 +218,7 @@ def test_check_result_bound_only(
     start_time = pendulum.datetime(2021, 1, 1, 1, 0, 0, tz="UTC")
     lower_bound_delta = datetime.timedelta(minutes=10)
 
-    freshness_checks = build_last_update_freshness_checks(
+    check = build_last_update_freshness_checks(
         assets=[my_asset],
         lower_bound_delta=lower_bound_delta,
     )
@@ -209,7 +229,7 @@ def test_check_result_bound_only(
         assert_check_result(
             my_asset,
             instance,
-            freshness_checks,
+            [check],
             AssetCheckSeverity.WARN,
             False,
             description_match="Asset is overdue. Expected an update within the last 10 minutes.",
@@ -220,7 +240,7 @@ def test_check_result_bound_only(
     with pendulum_freeze_time(lower_bound.subtract(minutes=1)):
         add_new_event(instance, my_asset.key)
     with pendulum_freeze_time(freeze_datetime):
-        assert_check_result(my_asset, instance, freshness_checks, AssetCheckSeverity.WARN, False)
+        assert_check_result(my_asset, instance, [check], AssetCheckSeverity.WARN, False)
 
     # Go back in time and add an event within the allowed time window.
     with pendulum_freeze_time(lower_bound.add(minutes=1)):
@@ -230,8 +250,40 @@ def test_check_result_bound_only(
         assert_check_result(
             my_asset,
             instance,
-            freshness_checks,
+            [check],
             AssetCheckSeverity.WARN,
             True,
             description_match="Asset is fresh. Expected an update within the last 10 minutes, and found an update 9 minutes ago.",
         )
+
+
+def test_subset_freshness_checks(instance: DagsterInstance):
+    """Test the multi asset case, ensure that the freshness check can be subsetted to execute only
+    on a subset of assets.
+    """
+
+    @asset
+    def my_asset():
+        pass
+
+    @asset
+    def my_other_asset():
+        pass
+
+    check = build_last_update_freshness_checks(
+        assets=[my_asset, my_other_asset],
+        lower_bound_delta=datetime.timedelta(minutes=10),
+    )
+    single_check_job = define_asset_job(
+        "the_job", selection=AssetChecksForAssetKeysSelection(selected_asset_keys=[my_asset.key])
+    )
+    defs = Definitions(
+        assets=[my_asset, my_other_asset], asset_checks=[check], jobs=[single_check_job]
+    )
+    job_def = defs.get_job_def("the_job")
+    result = job_def.execute_in_process(instance=instance)
+    assert result.success
+    # Only one asset check should have occurred, and it should be for `my_asset`.
+    assert len(result.get_asset_check_evaluations()) == 1
+    assert result.get_asset_check_evaluations()[0].asset_key == my_asset.key
+    assert not result.get_asset_check_evaluations()[0].passed

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_time_partition_freshness.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_time_partition_freshness.py
@@ -1,5 +1,6 @@
 # pyright: reportPrivateImportUsage=false
 
+import hashlib
 import time
 from typing import Iterator
 
@@ -10,8 +11,11 @@ from dagster import (
 )
 from dagster._check import CheckError
 from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
+from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_out import AssetOut
+from dagster._core.definitions.asset_selection import AssetChecksForAssetKeysSelection
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
+from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness_checks.time_partition import (
     build_time_partition_freshness_checks,
@@ -20,7 +24,9 @@ from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.time_window_partitions import (
     DailyPartitionsDefinition,
+    HourlyPartitionsDefinition,
 )
+from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.instance import DagsterInstance
 from dagster._seven.compat.pendulum import pendulum_freeze_time
 from dagster._utils.env import environ
@@ -39,11 +45,11 @@ def test_params() -> None:
     def my_partitioned_asset():
         pass
 
-    result = build_time_partition_freshness_checks(
+    check = build_time_partition_freshness_checks(
         assets=[my_partitioned_asset], deadline_cron="0 0 * * *"
     )
-    assert len(result) == 1
-    check = result[0]
+
+    assert isinstance(check, AssetChecksDefinition)
     assert next(iter(check.check_keys)).asset_key == my_partitioned_asset.key
     assert next(iter(check.check_specs)).metadata == {
         "dagster/freshness_params": {
@@ -51,27 +57,45 @@ def test_params() -> None:
             "dagster/freshness_timezone": "UTC",
         }
     }
+    assert (
+        check.node_def.name
+        == f"freshness_check_{hashlib.md5(str(my_partitioned_asset.key).encode()).hexdigest()[:8]}"
+    )
 
-    result = build_time_partition_freshness_checks(
+    @asset(
+        partitions_def=DailyPartitionsDefinition(
+            start_date=pendulum.datetime(2020, 1, 1, 0, 0, 0, tz="UTC")
+        )
+    )
+    def other_partitioned_asset():
+        pass
+
+    other_check = build_time_partition_freshness_checks(
+        assets=[other_partitioned_asset], deadline_cron="0 0 * * *", timezone="UTC"
+    )
+    assert isinstance(other_check, AssetChecksDefinition)
+    assert not check.node_def.name == other_check.node_def.name
+
+    check = build_time_partition_freshness_checks(
         assets=[my_partitioned_asset.key], deadline_cron="0 0 * * *", timezone="UTC"
     )
-    assert len(result) == 1
-    assert next(iter(result[0].check_keys)).asset_key == my_partitioned_asset.key
+    assert isinstance(check, AssetChecksDefinition)
+    assert next(iter(check.check_keys)).asset_key == my_partitioned_asset.key
 
     src_asset = SourceAsset("source_asset")
-    result = build_time_partition_freshness_checks(
+    check = build_time_partition_freshness_checks(
         assets=[src_asset], deadline_cron="0 0 * * *", timezone="UTC"
     )
-    assert len(result) == 1
-    assert next(iter(result[0].check_keys)).asset_key == src_asset.key
+    assert isinstance(check, AssetChecksDefinition)
+    assert {check_key.asset_key for check_key in check.check_keys} == {src_asset.key}
 
-    result = build_time_partition_freshness_checks(
+    check = build_time_partition_freshness_checks(
         assets=[my_partitioned_asset, src_asset],
         deadline_cron="0 0 * * *",
         timezone="UTC",
     )
-    assert len(result) == 2
-    assert {next(iter(checks_def.check_keys)).asset_key for checks_def in result} == {
+    assert isinstance(check, AssetChecksDefinition)
+    assert {check_key.asset_key for check_key in check.check_keys} == {
         my_partitioned_asset.key,
         src_asset.key,
     }
@@ -96,13 +120,11 @@ def test_params() -> None:
     def my_multi_asset(context):
         pass
 
-    result = build_time_partition_freshness_checks(
+    check = build_time_partition_freshness_checks(
         assets=[my_multi_asset], deadline_cron="0 0 * * *", timezone="UTC"
     )
-    assert len(result) == 2
-    assert {next(iter(checks_def.check_keys)).asset_key for checks_def in result} == set(
-        my_multi_asset.keys
-    )
+    assert isinstance(check, AssetChecksDefinition)
+    assert {check_key.asset_key for check_key in check.check_keys} == set(my_multi_asset.keys)
 
     with pytest.raises(Exception, match="deadline_cron must be a valid cron string."):
         build_time_partition_freshness_checks(
@@ -124,11 +146,13 @@ def test_params() -> None:
         )
 
     coercible_key = "blah"
-    result = build_time_partition_freshness_checks(
+    check = build_time_partition_freshness_checks(
         assets=[coercible_key], deadline_cron="0 0 * * *", timezone="UTC"
     )
-    assert len(result) == 1
-    assert next(iter(result[0].check_keys)).asset_key == AssetKey.from_coercible(coercible_key)
+    assert isinstance(check, AssetChecksDefinition)
+    assert {check_key.asset_key for check_key in check.check_keys} == {
+        AssetKey.from_coercible(coercible_key)
+    }
 
     with pytest.raises(Exception, match="Found duplicate assets"):
         build_time_partition_freshness_checks(
@@ -138,11 +162,11 @@ def test_params() -> None:
         )
 
     regular_asset_key = AssetKey("regular_asset_key")
-    result = build_time_partition_freshness_checks(
+    check = build_time_partition_freshness_checks(
         assets=[regular_asset_key], deadline_cron="0 0 * * *", timezone="UTC"
     )
-    assert len(result) == 1
-    assert next(iter(result[0].check_keys)).asset_key == regular_asset_key
+    assert isinstance(check, AssetChecksDefinition)
+    assert next(iter(check.check_keys)).asset_key == regular_asset_key
 
     with pytest.raises(Exception, match="Found duplicate assets"):
         build_time_partition_freshness_checks(
@@ -167,7 +191,7 @@ def test_result_cron_param(
 
     start_time = pendulum.datetime(2021, 1, 3, 1, 0, 0, tz="UTC")  # 2021-01-03 at 01:00:00
 
-    freshness_checks = build_time_partition_freshness_checks(
+    check = build_time_partition_freshness_checks(
         assets=[my_asset],
         deadline_cron="0 9 * * *",  # 09:00 UTC
         timezone="UTC",
@@ -179,7 +203,7 @@ def test_result_cron_param(
         assert_check_result(
             my_asset,
             instance,
-            freshness_checks,
+            [check],
             AssetCheckSeverity.WARN,
             False,
             description_match="Partition 2021-01-01 is overdue. Expected the partition to arrive within the last 16 hours.",
@@ -190,7 +214,7 @@ def test_result_cron_param(
         assert_check_result(
             my_asset,
             instance,
-            freshness_checks,
+            [check],
             AssetCheckSeverity.WARN,
             False,
             description_match="Partition 2021-01-01 is overdue. Expected the partition to arrive within the last 16 hours.",
@@ -205,7 +229,7 @@ def test_result_cron_param(
         assert_check_result(
             my_asset,
             instance,
-            freshness_checks,
+            [check],
             AssetCheckSeverity.WARN,
             True,
             description_match="Partition 2021-01-01 is fresh. Expected the partition to arrive within the last 16 hours, 1 seconds, and it arrived 1 seconds ago.",
@@ -218,7 +242,7 @@ def test_result_cron_param(
         assert_check_result(
             my_asset,
             instance,
-            freshness_checks,
+            [check],
             AssetCheckSeverity.WARN,
             False,
             description_match="Partition 2021-01-02 is overdue. Expected the partition to arrive within the last 16 hours, 1 seconds.",
@@ -230,7 +254,7 @@ def test_result_cron_param(
         assert_check_result(
             my_asset,
             instance,
-            freshness_checks,
+            [check],
             AssetCheckSeverity.WARN,
             False,
             description_match="Partition 2021-01-02 is overdue. Expected the partition to arrive within the last 16 hours, 1 seconds.",
@@ -245,7 +269,7 @@ def test_result_cron_param(
         assert_check_result(
             my_asset,
             instance,
-            freshness_checks,
+            [check],
             AssetCheckSeverity.WARN,
             True,
             description_match="Partition 2021-01-02 is fresh. Expected the partition to arrive within the last 16 hours, 2 seconds, and it arrived 1 seconds ago.",
@@ -262,7 +286,7 @@ def test_invalid_runtime_assets(
     def non_partitioned_asset():
         pass
 
-    asset_checks = build_time_partition_freshness_checks(
+    check = build_time_partition_freshness_checks(
         assets=[non_partitioned_asset], deadline_cron="0 9 * * *", timezone="UTC"
     )
 
@@ -270,7 +294,7 @@ def test_invalid_runtime_assets(
         assert_check_result(
             non_partitioned_asset,
             instance,
-            asset_checks,
+            [check],
             AssetCheckSeverity.WARN,
             True,
         )
@@ -279,7 +303,7 @@ def test_invalid_runtime_assets(
     def static_partitioned_asset():
         pass
 
-    asset_checks = build_time_partition_freshness_checks(
+    check = build_time_partition_freshness_checks(
         assets=[static_partitioned_asset], deadline_cron="0 9 * * *", timezone="UTC"
     )
 
@@ -287,7 +311,7 @@ def test_invalid_runtime_assets(
         assert_check_result(
             static_partitioned_asset,
             instance,
-            asset_checks,
+            [check],
             AssetCheckSeverity.WARN,
             True,
         )
@@ -305,7 +329,7 @@ def test_observations(
     def my_asset():
         pass
 
-    freshness_checks = build_time_partition_freshness_checks(
+    check = build_time_partition_freshness_checks(
         assets=[my_asset],
         deadline_cron="0 9 * * *",
         timezone="UTC",  # 09:00 UTC
@@ -317,7 +341,7 @@ def test_observations(
         assert_check_result(
             my_asset,
             instance,
-            freshness_checks,
+            [check],
             AssetCheckSeverity.WARN,
             True,
             description_match="Partition 2021-01-01 is fresh. Expected the partition to arrive within the last 16 hours, 1 seconds, and it arrived 1 seconds ago.",
@@ -347,7 +371,7 @@ def test_differing_timezones(
     def my_chicago_asset():
         pass
 
-    freshness_checks = build_time_partition_freshness_checks(
+    check = build_time_partition_freshness_checks(
         assets=[my_chicago_asset],
         deadline_cron="0 9 * * *",
         timezone="America/Los_Angeles",  # 09:00 Los Angeles time
@@ -363,7 +387,7 @@ def test_differing_timezones(
         assert_check_result(
             my_chicago_asset,
             instance,
-            freshness_checks,
+            [check],
             AssetCheckSeverity.WARN,
             True,
             description_match="Partition 2021-01-01 is fresh. Expected the partition to arrive within the last 14 hours, 1 seconds, and it arrived 1 seconds ago.",
@@ -376,7 +400,7 @@ def test_differing_timezones(
         assert_check_result(
             my_chicago_asset,
             instance,
-            freshness_checks,
+            [check],
             AssetCheckSeverity.WARN,
             True,
             description_match="Partition 2021-01-01 is fresh. Expected the partition to arrive within the last 21 hours, 1 seconds, and it arrived 7 hours, 1 seconds ago.",
@@ -389,7 +413,7 @@ def test_differing_timezones(
         assert_check_result(
             my_chicago_asset,
             instance,
-            freshness_checks,
+            [check],
             AssetCheckSeverity.WARN,
             True,
             description_match="Partition 2021-01-01 is fresh. Expected the partition to arrive within the last 22 hours, 1 seconds, and it arrived 8 hours, 1 seconds ago.",
@@ -402,7 +426,7 @@ def test_differing_timezones(
         assert_check_result(
             my_chicago_asset,
             instance,
-            freshness_checks,
+            [check],
             AssetCheckSeverity.WARN,
             False,
             description_match="Partition 2021-01-02 is overdue. Expected the partition to arrive within the last 1 seconds.",
@@ -413,8 +437,69 @@ def test_differing_timezones(
         assert_check_result(
             my_chicago_asset,
             instance,
-            freshness_checks,
+            [check],
             AssetCheckSeverity.WARN,
             True,
             description_match="Partition 2021-01-02 is fresh. Expected the partition to arrive within the last 2 seconds, and it arrived 1 seconds ago",
         )
+
+
+def test_subset_freshness_checks(instance: DagsterInstance):
+    """Test the multi asset case, ensure that the freshness check can be subsetted to execute only
+    on a subset of assets.
+    """
+
+    @asset(
+        partitions_def=DailyPartitionsDefinition(
+            start_date=pendulum.datetime(2020, 1, 1, 0, 0, 0, tz="UTC")
+        )
+    )
+    def my_asset():
+        pass
+
+    # Test multiple different partition defs
+    @asset(
+        partitions_def=HourlyPartitionsDefinition(
+            start_date=pendulum.datetime(2020, 1, 1, 0, 0, 0, tz="UTC")
+        )
+    )
+    def my_other_asset():
+        pass
+
+    check = build_time_partition_freshness_checks(
+        assets=[my_asset, my_other_asset],
+        deadline_cron="0 9 * * *",
+        timezone="UTC",  # 09:00 UTC
+    )
+    single_check_job = define_asset_job(
+        "the_job", selection=AssetChecksForAssetKeysSelection(selected_asset_keys=[my_asset.key])
+    )
+    both_checks_job = define_asset_job(
+        "both_checks_job",
+        selection=AssetChecksForAssetKeysSelection(
+            selected_asset_keys=[my_asset.key, my_other_asset.key]
+        ),
+    )
+    defs = Definitions(
+        assets=[my_asset, my_other_asset],
+        asset_checks=[check],
+        jobs=[single_check_job, both_checks_job],
+    )
+    job_def = defs.get_job_def("the_job")
+    result = job_def.execute_in_process(instance=instance)
+    assert result.success
+    # Only one asset check should have occurred, and it should be for `my_asset`.
+    assert len(result.get_asset_check_evaluations()) == 1
+    assert result.get_asset_check_evaluations()[0].asset_key == my_asset.key
+    assert not result.get_asset_check_evaluations()[0].passed
+
+    both_checks_job_def = defs.get_job_def("both_checks_job")
+    result = both_checks_job_def.execute_in_process(instance=instance)
+    assert result.success
+    # Both asset checks should have occurred.
+    assert len(result.get_asset_check_evaluations()) == 2
+    assert {evaluation.asset_key for evaluation in result.get_asset_check_evaluations()} == {
+        my_asset.key,
+        my_other_asset.key,
+    }
+    assert not all(evaluation.passed for evaluation in result.get_asset_check_evaluations())


### PR DESCRIPTION
Switches implementation of freshness checks to use multi_asset_check.

This has the benefit of allowing many checks to execute within the same op, saving compute for a user.
