### PR TITLE
feat(dbt): add `dagster-dbt project prepare-for-deployment`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/conftest.py
@@ -1,0 +1,14 @@
+import shutil
+from pathlib import Path
+
+import pytest
+
+from ..dbt_projects import test_jaffle_shop_path
+
+
+@pytest.fixture(name="dbt_project_dir", scope="function")
+def dbt_project_dir_fixture(tmp_path: Path) -> Path:
+    dbt_project_dir = tmp_path.joinpath("test_jaffle_shop")
+    shutil.copytree(src=test_jaffle_shop_path, dst=dbt_project_dir)
+
+    return dbt_project_dir

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_prepare_for_deployment.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_prepare_for_deployment.py
@@ -1,0 +1,142 @@
+import inspect
+import os
+import shutil
+import textwrap
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Iterator, Optional
+
+import pytest
+from dagster import AssetExecutionContext, materialize
+from dagster_dbt.asset_decorator import dbt_assets
+from dagster_dbt.cli.app import app
+from dagster_dbt.core.resources_v2 import DbtCliResource
+from dagster_dbt.dbt_project import DbtProject
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@contextmanager
+def tmp_script(
+    script_fn: Callable[[], Any],
+    *,
+    tmp_path: Path,
+    dbt_project_dir: Path,
+    packaged_project_dir: Optional[Path] = None,
+) -> Iterator[Path]:
+    source = textwrap.dedent(inspect.getsource(script_fn).partition("\n")[-1])
+    source = source.format(project_dir=dbt_project_dir, packaged_project_dir=packaged_project_dir)
+
+    tmp_script_path = tmp_path.joinpath("definitions.py")
+    tmp_script_path.write_text(source)
+
+    yield tmp_script_path
+
+
+@pytest.mark.parametrize(
+    "packaged_project_dir_name",
+    [
+        "",
+        "dbt-project",
+    ],
+    ids=[
+        "no package data",
+        "with package data",
+    ],
+)
+def test_prepare_for_deployment(
+    dbt_project_dir: Path, tmp_path: Path, packaged_project_dir_name: Optional[str]
+) -> None:
+    def script_fn() -> None:
+        from dagster_dbt.dbt_project import DbtProject
+
+        _ = DbtProject(
+            project_dir="{project_dir}",
+            packaged_project_dir="{packaged_project_dir}",
+        )
+
+    manifest_path = dbt_project_dir.joinpath("target", "manifest.json")
+    packaged_project_dir = (
+        tmp_path.joinpath(packaged_project_dir_name) if packaged_project_dir_name else None
+    )
+
+    with tmp_script(
+        script_fn,
+        tmp_path=tmp_path,
+        dbt_project_dir=dbt_project_dir,
+        packaged_project_dir=packaged_project_dir,
+    ) as tmp_script_path:
+        assert not manifest_path.exists()
+        assert not packaged_project_dir or not packaged_project_dir.exists()
+
+        result = runner.invoke(
+            app,
+            ["project", "prepare-for-deployment", "--file", os.fspath(tmp_script_path)],
+        )
+
+        assert result.exit_code == 0
+        assert manifest_path.exists()
+        assert not packaged_project_dir or packaged_project_dir.exists()
+
+
+def test_prepare_for_deployment_with_state(
+    monkeypatch: pytest.MonkeyPatch, dbt_project_dir: Path, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("DAGSTER_DBT_JAFFLE_SCHEMA", "prod")
+
+    def script_fn() -> None:
+        from dagster_dbt.dbt_project import DbtProject
+
+        _ = DbtProject(
+            project_dir="{project_dir}",
+            state_dir="prod_artifacts",
+        )
+
+    with tmp_script(
+        script_fn, tmp_path=tmp_path, dbt_project_dir=dbt_project_dir
+    ) as tmp_script_path:
+        runner.invoke(
+            app,
+            ["project", "prepare-for-deployment", "--file", os.fspath(tmp_script_path)],
+        )
+
+    state_dir = dbt_project_dir.joinpath("prod_artifacts")
+    state_dir.mkdir()
+
+    project = DbtProject(dbt_project_dir, state_dir=state_dir.name)
+    assert project.state_dir
+
+    dbt = DbtCliResource(project)
+
+    @dbt_assets(manifest=project.manifest_path)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        if os.getenv("DAGSTER_DBT_JAFFLE_SCHEMA") == "staging":
+            assert dbt.get_defer_args()
+
+        yield from dbt.cli(["build", *dbt.get_defer_args()], context=context).stream()
+
+    # Running in production produces all the assets.
+    result = materialize([my_dbt_assets], resources={"dbt": dbt})
+    assert result.success
+
+    # Running in staging should fail because the state directory is empty, so there is no --defer.
+    monkeypatch.setenv("DAGSTER_DBT_JAFFLE_SCHEMA", "staging")
+    result = materialize(
+        [my_dbt_assets], selection="orders", resources={"dbt": dbt}, raise_on_error=False
+    )
+    assert not result.success
+
+    # Once the state directory is populated, the subselected asset can be produced.
+    shutil.copyfile(project.manifest_path, project.state_dir.joinpath("manifest.json"))
+
+    with tmp_script(
+        script_fn, tmp_path=tmp_path, dbt_project_dir=dbt_project_dir
+    ) as tmp_script_path:
+        runner.invoke(
+            app,
+            ["project", "prepare-for-deployment", "--file", os.fspath(tmp_script_path)],
+        )
+
+    result = materialize([my_dbt_assets], selection="orders", resources={"dbt": dbt})
+    assert result.success

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_scaffold.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_scaffold.py
@@ -20,14 +20,6 @@ if TYPE_CHECKING:
 runner = CliRunner()
 
 
-@pytest.fixture(name="dbt_project_dir")
-def dbt_project_dir_fixture(tmp_path: Path) -> Path:
-    dbt_project_dir = tmp_path.joinpath("test_jaffle_shop")
-    shutil.copytree(src=test_jaffle_shop_path, dst=dbt_project_dir)
-
-    return dbt_project_dir
-
-
 def _assert_scaffold_invocation(
     project_name: str,
     dbt_project_dir: Path,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
@@ -1,39 +1,8 @@
-import os
-import shutil
-from pathlib import Path
-
-import pytest
-from dagster import AssetExecutionContext, Definitions, materialize_to_memory
 from dagster._core.test_utils import environ
 from dagster._utils.test import copy_directory
-from dagster_dbt import dbt_assets
-from dagster_dbt.core.resources_v2 import DbtCliResource
-from dagster_dbt.dbt_project import DbtProject, prepare_for_deployment
-from dagster_dbt.errors import DagsterDbtManifestNotFoundError
+from dagster_dbt.dbt_project import DbtProject
 
 from ..dbt_projects import test_jaffle_shop_path
-
-
-def test_deployed() -> None:
-    with copy_directory(test_jaffle_shop_path) as project_dir:
-        my_project = DbtProject(project_dir)
-
-        with pytest.raises(DagsterDbtManifestNotFoundError):
-
-            @dbt_assets(manifest=my_project.manifest_path)
-            def _(): ...
-
-        prepare_for_deployment(my_project)
-        assert my_project.manifest_path.exists()
-
-        @dbt_assets(manifest=my_project.manifest_path)
-        def my_assets(context: AssetExecutionContext, dbt: DbtCliResource): ...
-
-        defs = Definitions(
-            assets=[my_assets],
-            resources={"dbt": DbtCliResource(my_project)},
-        )
-        assert defs.get_all_job_defs()
 
 
 def test_local_dev() -> None:
@@ -48,76 +17,3 @@ def test_opt_in_env_var() -> None:
     ) as project_dir:
         my_project = DbtProject(project_dir)
         assert my_project.manifest_path.exists()
-
-
-def test_state_defer(tmp_path) -> None:
-    def my_deployment_prep(project: DbtProject):
-        prepare_for_deployment(project)
-
-        shuffle_path = Path(tmp_path).joinpath("prod_manifest.json")
-        state_dir = project.state_dir
-        assert state_dir
-        env = os.environ["DAGSTER_DBT_JAFFLE_SCHEMA"]
-        if env == "staging":
-            os.makedirs(state_dir, exist_ok=True)
-            shutil.copyfile(
-                shuffle_path,
-                state_dir.joinpath("manifest.json"),
-            )
-        elif env == "prod":
-            shutil.copyfile(
-                project.manifest_path,
-                shuffle_path,
-            )
-        else:
-            assert False, env  # should not reach
-
-    with copy_directory(test_jaffle_shop_path) as project_dir:
-        # simulate deploying and running prod
-        with environ({"DAGSTER_DBT_JAFFLE_SCHEMA": "prod"}):
-            state_dir = Path(project_dir).joinpath("prod_artifacts")
-            state_dir.mkdir()
-            my_project = DbtProject(project_dir, state_dir=state_dir.name)
-            dbt_resource = DbtCliResource(my_project)
-
-            dbt_resource.cli(["seed"]).wait()  # test set-up
-
-            my_deployment_prep(my_project)
-
-            @dbt_assets(manifest=my_project.manifest_path)
-            def my_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-                defer_args = dbt.get_defer_args()
-                if os.getenv("DAGSTER_DBT_JAFFLE_SCHEMA") == "staging":
-                    assert defer_args, defer_args
-                yield from dbt.cli(
-                    ["run", *defer_args],
-                    context=context,
-                ).stream()
-
-            # produce all prod assets
-            result = materialize_to_memory(
-                [my_assets],
-                resources={"dbt": dbt_resource},
-            )
-            assert result.success
-
-        # and then deploying and running in staging
-        with environ({"DAGSTER_DBT_JAFFLE_SCHEMA": "staging"}):
-            # subselect but no defer fails
-            result = materialize_to_memory(
-                [my_assets],
-                resources={"dbt": DbtCliResource(my_project)},
-                selection="orders",
-                raise_on_error=False,
-            )
-            assert not result.success
-
-            my_deployment_prep(my_project)
-
-            # subselect with defer works
-            result = materialize_to_memory(
-                [my_assets],
-                resources={"dbt": DbtCliResource(my_project)},
-                selection="orders",
-            )
-            assert result.success


### PR DESCRIPTION
## Summary & Motivation
Introduces `dagster-dbt project prepare-for-deployment`. A one-stop shop for creating a manifest from an existing dbt project.

The idea here is that a user will invoke this command in CI/CD to produce all the manifests at build time.

## How I Tested These Changes
pytest: add tests where the project is prepared in different scenarios (e.g. to populate the package data dir, to populate state).
