### PR TITLE
[ui] Settings page: Repair scrolling for daemons, concurrency

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
@@ -84,7 +84,7 @@ export const InstanceConcurrencyPageContent = React.memo(() => {
   const {data} = queryResult;
 
   return (
-    <>
+    <div style={{overflowY: 'auto'}}>
       {data ? (
         <>
           <Box margin={{bottom: 64}}>
@@ -110,7 +110,7 @@ export const InstanceConcurrencyPageContent = React.memo(() => {
           <Spinner purpose="section" />
         </Box>
       )}
-    </>
+    </div>
   );
 });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceHealthPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceHealthPage.tsx
@@ -42,7 +42,7 @@ export const InstanceHealthPageContent = () => {
   };
 
   return (
-    <>
+    <div style={{overflowY: 'auto'}}>
       <Box
         padding={{vertical: 16, horizontal: 24}}
         flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
@@ -53,7 +53,7 @@ export const InstanceHealthPageContent = () => {
         </div>
       </Box>
       {daemonContent()}
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary & Motivation

Repair scrolling on Concurrency and Agents pages in the new Settings section.

## How I Tested These Changes

View these pages within Settings with a small viewport, verify that I can scroll.

Repeat in the non-flagged pages, verify that scrolling behaves correctly.