### PR TITLE
feat(dbt): allow state directory containing no manifest

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
@@ -134,12 +134,6 @@ class DbtProject(DagsterModel):
     def prepare_for_deployment(self) -> None:
         prepare_for_deployment(self)
 
-    def get_state_dir_if_populated(self) -> Optional[Path]:
-        if self.state_dir and self.state_dir.joinpath("manifest.json").exists():
-            return self.state_dir
-
-        return None
-
 
 def prepare_for_deployment(project: DbtProject) -> None:
     """A method that can be called as part of the deployment process which runs the

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
@@ -75,10 +75,9 @@ def test_state_defer(tmp_path) -> None:
     with copy_directory(test_jaffle_shop_path) as project_dir:
         # simulate deploying and running prod
         with environ({"DAGSTER_DBT_JAFFLE_SCHEMA": "prod"}):
-            my_project = DbtProject(
-                project_dir,
-                state_dir="prod_artifacts",
-            )
+            state_dir = Path(project_dir).joinpath("prod_artifacts")
+            state_dir.mkdir()
+            my_project = DbtProject(project_dir, state_dir=state_dir.name)
             dbt_resource = DbtCliResource(my_project)
 
             dbt_resource.cli(["seed"]).wait()  # test set-up

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -18,6 +18,7 @@ from dagster_dbt.core.resources_v2 import (
     PARTIAL_PARSE_FILE_NAME,
     DbtCliResource,
 )
+from dagster_dbt.dbt_project import DbtProject
 from dagster_dbt.errors import DagsterDbtCliRuntimeError
 from dbt.version import __version__ as dbt_version
 from packaging import version
@@ -420,6 +421,39 @@ def test_dbt_cli_default_selection(
         yield from dbt_cli_invocation.stream()
 
     result = materialize([my_dbt_assets], resources={"dbt": dbt})
+    assert result.success
+
+
+def test_dbt_cli_defer_args(monkeypatch: pytest.MonkeyPatch, testrun_uid: str) -> None:
+    monkeypatch.setenv("DAGSTER_DBT_JAFFLE_SCHEMA", "prod")
+
+    state_dir = Path("state", testrun_uid)
+    test_jaffle_shop_path.joinpath(state_dir).mkdir(parents=True, exist_ok=True)
+
+    project = DbtProject(project_dir=test_jaffle_shop_path, state_dir=state_dir)
+    dbt = DbtCliResource(project_dir=project)
+
+    dbt.cli(["--quiet", "parse"], target_path=project.target_dir).wait()
+
+    @dbt_assets(manifest=project.manifest_path)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        yield from dbt.cli(["build", *dbt.get_defer_args()], context=context).stream()
+
+    result = materialize([my_dbt_assets], resources={"dbt": dbt})
+    assert result.success
+
+    # Defer will not work since the manifest is not in the state directory.
+    monkeypatch.setenv("DAGSTER_DBT_JAFFLE_SCHEMA", "staging")
+    result = materialize(
+        [my_dbt_assets], resources={"dbt": dbt}, selection="orders", raise_on_error=False
+    )
+    assert not result.success
+
+    # Defer works after copying the manifest into the state directory.
+    assert project.state_dir
+    shutil.copy(project.manifest_path, project.state_dir.joinpath("manifest.json"))
+
+    result = materialize([my_dbt_assets], resources={"dbt": dbt}, selection="orders")
     assert result.success
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/.gitignore
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/.gitignore
@@ -10,3 +10,4 @@ env/
 **/*.duckdb
 **/*.duckdb.wal
 tmp/
+state/


### PR DESCRIPTION
## Summary & Motivation
Instead, we can throw an error at run time if the user tries to build defer arguments without a valid manifest in the state directory.

We shouldn't enforce that state is known at definition time -- it can be generated at run time as well.

## How I Tested These Changes
pytest