### PR TITLE
Fix helper webserver command

### DIFF
--- a/helm/dagster/templates/deployment-webserver.yaml
+++ b/helm/dagster/templates/deployment-webserver.yaml
@@ -4,6 +4,6 @@
 
 {{- if $_.Values.dagsterWebserver.enableReadOnly -}}
 ---
-{{$data := dict "Values" .Values "Release" .Release "Chart" .Chart "Template" .Template "webserverReadOnly" true}}
+{{- $data := dict "Values" .Values "Release" .Release "Chart" .Chart "Template" .Template "webserverReadOnly" true -}}
 {{- include "deployment-webserver" $data -}}
 {{- end -}}

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -43,7 +43,7 @@ If release name contains chart name it will be used as a full name.
 {{- define "dagster.webserver.dagsterWebserverCommand" -}}
 {{- $_ := include "dagster.backcompat" . | mustFromJson -}}
 {{- $userDeployments := index .Values "dagster-user-deployments" }}
-dagster-webserver -h 0.0.0.0 -p {{ $_.Values.dagsterWebserver.service.port }}
+{{- printf "dagster-webserver -h 0.0.0.0 -p"}} {{ $_.Values.dagsterWebserver.service.port }}
 {{- if $userDeployments.enabled }} -w /dagster-workspace/workspace.yaml {{- end -}}
 {{- with $_.Values.dagsterWebserver.dbStatementTimeout }} --db-statement-timeout {{ . }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.dbPoolRecycle }} --db-pool-recycle {{ . }} {{- end -}}


### PR DESCRIPTION
## Summary & Motivation
Helm rendering has a breaking indentation, making Dagster incompatible with programmtic synthetization tools like cdk8s https://github.com/cdk8s-team/cdk8s/issues/1679

## How I Tested These Changes
Create a values-valid.yaml

```
ingress:
  apiVersion: 'networking.k8s.io/v1/Ingress'
  enabled: true
  ingressClassName: nginx
  dagsterWebserver:
    host: '$hostname'
```

Execute helm template:

`helm template . --values values-valid.yaml --debug > debug.yaml`

With PR fix, indentation is probably rendered in deployment-webserver.yaml

![image](https://github.com/dagster-io/dagster/assets/162576391/5d200407-ddd9-4deb-83e7-e361403f3408)

