### PR TITLE
[dagster-plus rename] Backcompat between dagster-plus and dagster-cloud

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -381,6 +381,8 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             "cli_tests",
             "core_tests_pydantic1",
             "core_tests_pydantic2",
+            "backcompat_cloud_instance_tests",
+            "dagster_plus_instance_tests",
             "storage_tests_sqlalchemy_1_3",
             "storage_tests_sqlalchemy_1_4",
             "daemon_sensor_tests",

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -686,3 +686,7 @@ class DagsterDefinitionChangedDeserializationError(DagsterError):
 
 class DagsterPipesExecutionError(DagsterError):
     """Indicates that an error occurred during the execution of an external process."""
+
+
+class DagsterImportClassFromCodePointerError(DagsterError):
+    """Indicates that an error occurred while importing a class from a code pointer."""

--- a/python_modules/dagster/dagster/_core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/_core/executor/multiprocess.py
@@ -337,6 +337,7 @@ def execute_step_out_of_process(
     known_state: KnownExecutionState,
     repository_load_data: Optional[RepositoryLoadData],
 ) -> Iterator[Optional[DagsterEvent]]:
+    # here?
     command = MultiprocessExecutorChildProcessCommand(
         run_config=step_context.run_config,
         dagster_run=step_context.dagster_run,

--- a/python_modules/dagster/dagster/_core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/_core/executor/multiprocess.py
@@ -337,7 +337,6 @@ def execute_step_out_of_process(
     known_state: KnownExecutionState,
     repository_load_data: Optional[RepositoryLoadData],
 ) -> Iterator[Optional[DagsterEvent]]:
-    # here?
     command = MultiprocessExecutorChildProcessCommand(
         run_config=step_context.run_config,
         dagster_run=step_context.dagster_run,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -546,14 +546,8 @@ class DagsterInstance(DynamicPartitionsStore):
             settings=settings,
         )
 
-    @public
     @staticmethod
-    def get() -> "DagsterInstance":
-        """Get the current `DagsterInstance` as specified by the ``DAGSTER_HOME`` environment variable.
-
-        Returns:
-            DagsterInstance: The current DagsterInstance.
-        """
+    def get_validated_dagster_home_path() -> str:
         dagster_home_path = os.getenv("DAGSTER_HOME")
 
         if not dagster_home_path:
@@ -588,7 +582,17 @@ class DagsterInstance(DynamicPartitionsStore):
                 )
             )
 
-        return DagsterInstance.from_config(dagster_home_path)
+        return dagster_home_path
+
+    @public
+    @staticmethod
+    def get() -> "DagsterInstance":
+        """Get the current `DagsterInstance` as specified by the ``DAGSTER_HOME`` environment variable.
+
+        Returns:
+            DagsterInstance: The current DagsterInstance.
+        """
+        return DagsterInstance.from_config(DagsterInstance.get_validated_dagster_home_path())
 
     @public
     @staticmethod
@@ -621,8 +625,11 @@ class DagsterInstance(DynamicPartitionsStore):
     def from_config(
         config_dir: str,
         config_filename: str = DAGSTER_CONFIG_YAML_FILENAME,
+        overrides: Optional[DagsterInstanceOverrides] = None,
     ) -> "DagsterInstance":
-        instance_ref = InstanceRef.from_dir(config_dir, config_filename=config_filename)
+        instance_ref = InstanceRef.from_dir(
+            config_dir, config_filename=config_filename, overrides=overrides
+        )
         return DagsterInstance.from_ref(instance_ref)
 
     @staticmethod

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -50,12 +50,14 @@ def dagster_instance_class_from_code_pointer(
             try:
                 return cast(
                     Type["DagsterInstance"],
-                    dagster_instance_class_from_code_pointer(
+                    class_from_code_pointer(
                         ".".join(["dagster_plus", *module_elems[1:]]),
                         class_name,
                     ),
                 )
             except Exception:
+                logger = logging.getLogger("dagster")
+                logger.exception("Error importing DagsterInstance class from dagster_plus module")
                 raise e
         else:
             raise e

--- a/python_modules/dagster/dagster/_core/instance/ref.py
+++ b/python_modules/dagster/dagster/_core/instance/ref.py
@@ -344,6 +344,7 @@ class InstanceRef(
             custom_instance_class_config = {
                 key: val for key, val in config_value.items() if key in config_keys
             }
+            # here custom instance class data is reconstructed
             custom_instance_class_data = ConfigurableClassData(
                 config_value["instance_class"]["module"],
                 config_value["instance_class"]["class"],

--- a/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
+++ b/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
@@ -64,7 +64,6 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
         # defer for perf
         from dagster._grpc.types import ExecuteExternalJobArgs, StartRunResult
 
-        # here?
         instance.add_run_tags(
             run.run_id,
             {

--- a/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
+++ b/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
@@ -64,6 +64,7 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
         # defer for perf
         from dagster._grpc.types import ExecuteExternalJobArgs, StartRunResult
 
+        # here?
         instance.add_run_tags(
             run.run_id,
             {

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -470,11 +470,11 @@ def _process_tick_generator(
                 sensor_debug_crash_flags,
             )
 
-    except Exception:
+    except Exception as e:
         error_info = DaemonErrorCapture.on_exception(
             exc_info=sys.exc_info(),
             logger=logger,
-            log_message=f"Sensor daemon caught an error for sensor {external_sensor.name}",
+            log_message=f"Sensor daemon caught an error for sensor {external_sensor.name}, {e!s}",
         )
 
     yield error_info

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -470,11 +470,11 @@ def _process_tick_generator(
                 sensor_debug_crash_flags,
             )
 
-    except Exception as e:
+    except Exception:
         error_info = DaemonErrorCapture.on_exception(
             exc_info=sys.exc_info(),
             logger=logger,
-            log_message=f"Sensor daemon caught an error for sensor {external_sensor.name}, {e!s}",
+            log_message=f"Sensor daemon caught an error for sensor {external_sensor.name}",
         )
 
     yield error_info

--- a/python_modules/dagster/dagster/_serdes/config_class.py
+++ b/python_modules/dagster/dagster/_serdes/config_class.py
@@ -96,10 +96,20 @@ class ConfigurableClassData(
         try:
             module = importlib.import_module(self.module_name)
         except ModuleNotFoundError:
-            raise DagsterImportClassFromCodePointerError(
-                f"Couldn't import module {self.module_name} when attempting to load the "
-                f"configurable class {self.module_name}.{self.class_name}"
-            )
+            module_elems = self.module_name.split(".")
+            if "dagster_cloud" == module_elems[0]:
+                try:
+                    module = importlib.import_module(".".join(["dagster_plus", *module_elems[1:]]))
+                except Exception:
+                    raise DagsterImportClassFromCodePointerError(
+                        f"Couldn't import module {self.module_name} when attempting to load the "
+                        f"configurable class {self.module_name}.{self.class_name}"
+                    )
+            else:
+                raise DagsterImportClassFromCodePointerError(
+                    f"Couldn't import module {self.module_name} when attempting to load the "
+                    f"configurable class {self.module_name}.{self.class_name}"
+                )
         try:
             # All rehydrated classes are expected to implement the ConfigurableClass interface and
             # will error when we call `klass.from_config_value` and `klass.config_type` below if

--- a/python_modules/dagster/dagster/_serdes/config_class.py
+++ b/python_modules/dagster/dagster/_serdes/config_class.py
@@ -96,20 +96,11 @@ class ConfigurableClassData(
         try:
             module = importlib.import_module(self.module_name)
         except ModuleNotFoundError:
-            module_elems = self.module_name.split(".")
-            if "dagster_cloud" == module_elems[0]:
-                try:
-                    module = importlib.import_module(".".join(["dagster_plus", *module_elems[1:]]))
-                except Exception:
-                    raise DagsterImportClassFromCodePointerError(
-                        f"Couldn't import module {self.module_name} when attempting to load the "
-                        f"configurable class {self.module_name}.{self.class_name}"
-                    )
-            else:
-                raise DagsterImportClassFromCodePointerError(
-                    f"Couldn't import module {self.module_name} when attempting to load the "
-                    f"configurable class {self.module_name}.{self.class_name}"
-                )
+            raise DagsterImportClassFromCodePointerError(
+                f"Couldn't import module {self.module_name} when attempting to load the "
+                f"configurable class {self.module_name}.{self.class_name}"
+            )
+
         try:
             # All rehydrated classes are expected to implement the ConfigurableClass interface and
             # will error when we call `klass.from_config_value` and `klass.config_type` below if

--- a/python_modules/dagster/dagster/_serdes/config_class.py
+++ b/python_modules/dagster/dagster/_serdes/config_class.py
@@ -96,11 +96,20 @@ class ConfigurableClassData(
         try:
             module = importlib.import_module(self.module_name)
         except ModuleNotFoundError:
-            raise DagsterImportClassFromCodePointerError(
-                f"Couldn't import module {self.module_name} when attempting to load the "
-                f"configurable class {self.module_name}.{self.class_name}"
-            )
-
+            module_elems = self.module_name.split(".")
+            if "dagster_cloud" == module_elems[0]:
+                try:
+                    module = importlib.import_module(".".join(["dagster_plus", *module_elems[1:]]))
+                except Exception:
+                    raise DagsterImportClassFromCodePointerError(
+                        f"Couldn't import module {self.module_name} when attempting to load the "
+                        f"configurable class {self.module_name}.{self.class_name}"
+                    )
+            else:
+                raise DagsterImportClassFromCodePointerError(
+                    f"Couldn't import module {self.module_name} when attempting to load the "
+                    f"configurable class {self.module_name}.{self.class_name}"
+                )
         try:
             # All rehydrated classes are expected to implement the ConfigurableClass interface and
             # will error when we call `klass.from_config_value` and `klass.config_type` below if

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_backcompat_dagster_cloud_instance/dagster-cloud/dagster_cloud/instance/__init__.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_backcompat_dagster_cloud_instance/dagster-cloud/dagster_cloud/instance/__init__.py
@@ -1,7 +1,7 @@
 from dagster._core.instance import DagsterInstance, InstanceRef
 
 
-class DagsterCloudAgentInstance(DagsterInstance):
+class MockDagsterCloudAgentInstance(DagsterInstance):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_backcompat_dagster_cloud_instance/dagster-cloud/dagster_cloud/instance/__init__.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_backcompat_dagster_cloud_instance/dagster-cloud/dagster_cloud/instance/__init__.py
@@ -1,0 +1,14 @@
+from dagster._core.instance import DagsterInstance, InstanceRef
+
+
+class DagsterCloudAgentInstance(DagsterInstance):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def config_schema(cls):
+        return {}
+
+    @staticmethod
+    def config_defaults(base_dir):
+        return InstanceRef.config_defaults(base_dir)

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_backcompat_dagster_cloud_instance/dagster-cloud/pyproject.toml
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_backcompat_dagster_cloud_instance/dagster-cloud/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "dagster-cloud"
+version = "0.0.1"
+description = "Mock dagster-cloud package for test."
+readme = "README.md"
+dependencies = []
+
+authors = [
+  { name="Dagster Labs" },
+]
+
+[project.license]
+file = "LICENSE.md"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project.urls]
+Homepage = "https://dagster.io/cloud"

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_backcompat_dagster_cloud_instance/test_no_dagster_plus.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_backcompat_dagster_cloud_instance/test_no_dagster_plus.py
@@ -1,7 +1,7 @@
 import pytest
 from dagster._core.errors import DagsterImportClassFromCodePointerError
 from dagster._core.test_utils import instance_for_test
-from dagster_cloud.instance import DagsterCloudAgentInstance  # type: ignore
+from dagster_cloud.instance import MockDagsterCloudAgentInstance  # type: ignore
 
 
 def test_backcompat_no_dagster_plus():
@@ -9,12 +9,12 @@ def test_backcompat_no_dagster_plus():
         overrides={
             "instance_class": {
                 "module": "dagster_cloud.instance",
-                "class": "DagsterCloudAgentInstance",
+                "class": "MockDagsterCloudAgentInstance",
             }
         }
     ) as instance:
         assert instance.get_ref().custom_instance_class_data.module_name == "dagster_cloud.instance"
-        assert isinstance(instance, DagsterCloudAgentInstance)
+        assert isinstance(instance, MockDagsterCloudAgentInstance)
 
     with pytest.raises(
         DagsterImportClassFromCodePointerError, match="Couldn't import module dagster_plus.instance"
@@ -23,7 +23,7 @@ def test_backcompat_no_dagster_plus():
             overrides={
                 "instance_class": {
                     "module": "dagster_plus.instance",
-                    "class": "DagsterCloudAgentInstance",
+                    "class": "MockDagsterCloudAgentInstance",
                 }
             }
         ) as instance:

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_backcompat_dagster_cloud_instance/test_no_dagster_plus.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_backcompat_dagster_cloud_instance/test_no_dagster_plus.py
@@ -1,0 +1,30 @@
+import pytest
+from dagster._core.errors import DagsterImportClassFromCodePointerError
+from dagster._core.test_utils import instance_for_test
+from dagster_cloud.instance import DagsterCloudAgentInstance  # type: ignore
+
+
+def test_backcompat_no_dagster_plus():
+    with instance_for_test(
+        overrides={
+            "instance_class": {
+                "module": "dagster_cloud.instance",
+                "class": "DagsterCloudAgentInstance",
+            }
+        }
+    ) as instance:
+        assert instance.get_ref().custom_instance_class_data.module_name == "dagster_cloud.instance"
+        assert isinstance(instance, DagsterCloudAgentInstance)
+
+    with pytest.raises(
+        DagsterImportClassFromCodePointerError, match="Couldn't import module dagster_plus.instance"
+    ):
+        with instance_for_test(
+            overrides={
+                "instance_class": {
+                    "module": "dagster_plus.instance",
+                    "class": "DagsterCloudAgentInstance",
+                }
+            }
+        ) as instance:
+            pass

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_dagster_plus_instance/dagster-cloud/pyproject.toml
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_dagster_plus_instance/dagster-cloud/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "dagster-cloud"
+version = "0.0.1"
+description = "Mock dagster-cloud package for test. Depends on dagster-plus"
+readme = "README.md"
+dependencies = ["dagster-plus"]
+
+authors = [
+  { name="Dagster Labs" },
+]
+
+[project.license]
+file = "LICENSE.md"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project.urls]
+Homepage = "https://dagster.io/cloud"

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_dagster_plus_instance/dagster-plus/dagster_plus/instance/__init__.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_dagster_plus_instance/dagster-plus/dagster_plus/instance/__init__.py
@@ -1,7 +1,7 @@
 from dagster._core.instance import DagsterInstance, InstanceRef
 
 
-class DagsterCloudAgentInstance(DagsterInstance):
+class MockDagsterCloudAgentInstance(DagsterInstance):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_dagster_plus_instance/dagster-plus/dagster_plus/instance/__init__.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_dagster_plus_instance/dagster-plus/dagster_plus/instance/__init__.py
@@ -1,0 +1,14 @@
+from dagster._core.instance import DagsterInstance, InstanceRef
+
+
+class DagsterCloudAgentInstance(DagsterInstance):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def config_schema(cls):
+        return {}
+
+    @staticmethod
+    def config_defaults(base_dir):
+        return InstanceRef.config_defaults(base_dir)

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_dagster_plus_instance/dagster-plus/dagster_plus/storage/compute_logs.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_dagster_plus_instance/dagster-plus/dagster_plus/storage/compute_logs.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+from dagster._core.storage.local_compute_log_manager import LocalComputeLogManager
+from dagster._serdes import (
+    ConfigurableClassData,
+)
+
+
+class MockCloudComputeLogStorage(LocalComputeLogManager):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Any
+    ) -> "MockCloudComputeLogStorage":
+        return cls(inst_data=inst_data, **config_value)

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_dagster_plus_instance/dagster-plus/pyproject.toml
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_dagster_plus_instance/dagster-plus/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "dagster-plus"
+version = "0.0.1"
+description = "Mock dagster-plus package for test."
+readme = "README.md"
+dependencies = []
+
+authors = [
+  { name="Dagster Labs" },
+]
+
+[project.license]
+file = "LICENSE.md"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project.urls]
+Homepage = "https://dagster.io/plus"

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_dagster_plus_instance/test_import_dagster_plus_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_dagster_plus_instance/test_import_dagster_plus_instance.py
@@ -6,7 +6,7 @@ from dagster._core.test_utils import instance_for_test
 from dagster._serdes import (
     ConfigurableClassData,
 )
-from dagster_plus.instance import DagsterCloudAgentInstance  # type: ignore
+from dagster_plus.instance import MockDagsterCloudAgentInstance  # type: ignore
 from dagster_plus.storage.compute_logs import MockCloudComputeLogStorage  # type: ignore
 
 
@@ -15,12 +15,12 @@ def test_load_instance_from_dagster_plus():
         overrides={
             "instance_class": {
                 "module": "dagster_cloud.instance",
-                "class": "DagsterCloudAgentInstance",
+                "class": "MockDagsterCloudAgentInstance",
             }
         }
     ) as instance:
         assert instance.get_ref().custom_instance_class_data.module_name == "dagster_cloud.instance"
-        assert isinstance(instance, DagsterCloudAgentInstance)
+        assert isinstance(instance, MockDagsterCloudAgentInstance)
 
 
 def test_load_instance_from_dagster_plus_module():
@@ -28,12 +28,12 @@ def test_load_instance_from_dagster_plus_module():
         overrides={
             "instance_class": {
                 "module": "dagster_plus.instance",
-                "class": "DagsterCloudAgentInstance",
+                "class": "MockDagsterCloudAgentInstance",
             }
         }
     ) as instance:
         assert instance.get_ref().custom_instance_class_data.module_name == "dagster_cloud.instance"
-        assert isinstance(instance, DagsterCloudAgentInstance)
+        assert isinstance(instance, MockDagsterCloudAgentInstance)
 
 
 def test_load_instance_from_ref():
@@ -47,5 +47,5 @@ def test_load_instance_from_ref():
             )
         )
         assert isinstance(ref.compute_log_manager, MockCloudComputeLogStorage)
-        with DagsterCloudAgentInstance.from_ref(ref) as instance:
+        with MockDagsterCloudAgentInstance.from_ref(ref) as instance:
             assert isinstance(instance.compute_log_manager, MockCloudComputeLogStorage)

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_dagster_plus_instance/test_import_dagster_plus_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_dagster_plus_instance/test_import_dagster_plus_instance.py
@@ -1,0 +1,51 @@
+import tempfile
+
+import yaml
+from dagster._core.instance import InstanceRef
+from dagster._core.test_utils import instance_for_test
+from dagster._serdes import (
+    ConfigurableClassData,
+)
+from dagster_plus.instance import DagsterCloudAgentInstance  # type: ignore
+from dagster_plus.storage.compute_logs import MockCloudComputeLogStorage  # type: ignore
+
+
+def test_load_instance_from_dagster_plus():
+    with instance_for_test(
+        overrides={
+            "instance_class": {
+                "module": "dagster_cloud.instance",
+                "class": "DagsterCloudAgentInstance",
+            }
+        }
+    ) as instance:
+        assert instance.get_ref().custom_instance_class_data.module_name == "dagster_cloud.instance"
+        assert isinstance(instance, DagsterCloudAgentInstance)
+
+
+def test_load_instance_from_dagster_plus_module():
+    with instance_for_test(
+        overrides={
+            "instance_class": {
+                "module": "dagster_plus.instance",
+                "class": "DagsterCloudAgentInstance",
+            }
+        }
+    ) as instance:
+        assert instance.get_ref().custom_instance_class_data.module_name == "dagster_cloud.instance"
+        assert isinstance(instance, DagsterCloudAgentInstance)
+
+
+def test_load_instance_from_ref():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        ref = InstanceRef.from_dir(temp_dir)
+        ref = ref._replace(
+            compute_logs_data=ConfigurableClassData(
+                module_name="dagster_cloud.storage.compute_logs",
+                class_name="MockCloudComputeLogStorage",
+                config_yaml=yaml.dump({"base_dir": temp_dir}, default_flow_style=False),
+            )
+        )
+        assert isinstance(ref.compute_log_manager, MockCloudComputeLogStorage)
+        with DagsterCloudAgentInstance.from_ref(ref) as instance:
+            assert isinstance(instance.compute_log_manager, MockCloudComputeLogStorage)

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -10,7 +10,6 @@ from dagster import (
     AssetKey,
     DailyPartitionsDefinition,
     StaticPartitionsDefinition,
-    _check as check,
     _seven,
     asset,
     execute_job,
@@ -28,6 +27,7 @@ from dagster._core.definitions.events import AssetMaterialization, AssetObservat
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.errors import (
     DagsterHomeNotSetError,
+    DagsterImportClassFromCodePointerError,
     DagsterInvalidConfigError,
     DagsterInvariantViolationError,
 )
@@ -532,7 +532,7 @@ def test_dagster_home_not_set():
 
 def test_invalid_configurable_class():
     with pytest.raises(
-        check.CheckError,
+        DagsterImportClassFromCodePointerError,
         match=re.escape(
             "Couldn't find class MadeUpRunLauncher in module when attempting to "
             "load the configurable class dagster.MadeUpRunLauncher"
@@ -546,7 +546,7 @@ def test_invalid_configurable_class():
 
 def test_invalid_configurable_module():
     with pytest.raises(
-        check.CheckError,
+        DagsterImportClassFromCodePointerError,
         match=re.escape(
             "Couldn't import module made_up_module when attempting to load "
             "the configurable class made_up_module.MadeUpRunLauncher",

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -66,8 +66,9 @@ from dagster._core.test_utils import (
 from dagster._daemon.asset_daemon import AssetDaemon
 from dagster._serdes import ConfigurableClass
 from dagster._serdes.config_class import ConfigurableClassData
-from dagster_tests.api_tests.utils import get_bar_workspace
 from typing_extensions import Self
+
+from dagster_tests.api_tests.utils import get_bar_workspace
 
 
 def test_get_run_by_id():

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -2,6 +2,7 @@ import os
 import re
 import tempfile
 from typing import Any, Mapping, Optional
+from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -34,7 +35,7 @@ from dagster._core.errors import (
 from dagster._core.event_api import EventRecordsFilter
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import create_execution_plan
-from dagster._core.instance import DagsterInstance, InstanceRef
+from dagster._core.instance import DagsterInstance, InstanceRef, InstanceType
 from dagster._core.instance.config import DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
 from dagster._core.launcher import LaunchRunContext, RunLauncher
 from dagster._core.run_coordinator.queued_run_coordinator import QueuedRunCoordinator
@@ -727,6 +728,90 @@ def test_configurable_class_missing_methods():
             }
         ) as instance:
             print(instance.run_launcher)  # noqa: T201
+
+
+# Test preserves behavior from dagster-cloud to dagster-plus rename.
+# Retry loading custom instance class from dagster-plus if dagster-cloud fails.
+def test_retry_loading_instance_from_dagster_plus():
+    mock_instance_class = mock.Mock(name="MockDagsterPlusInstanceClass")
+    mock_instance_class.config_schema = mock.Mock(return_value={})
+    mock_instance_class.config_defaults = mock.Mock(return_value=InstanceRef.config_defaults(""))
+
+    # Mock dagster_cloud module being nonexistent by raising an import error
+    def mock_import_module(module_name: str, _class_name: str):
+        if "dagster_cloud" in module_name:
+            raise DagsterImportClassFromCodePointerError()
+        return mock_instance_class
+
+    # Cannot instantiate a mock class, so we return a DagsterInstance with the same ref
+    def mock_construct_instance(instance_ref: InstanceRef):
+        assert instance_ref.custom_instance_class_data
+        assert instance_ref.custom_instance_class_data.module_name == "dagster_cloud.instance"
+        assert mock_instance_class.config_defaults.called
+        assert mock_instance_class.config_schema.called
+        return DagsterInstance(
+            instance_type=InstanceType.PERSISTENT,
+            local_artifact_storage=instance_ref.local_artifact_storage,
+            run_storage=instance_ref.run_storage,  # type: ignore  # (possible none)
+            event_storage=instance_ref.event_storage,  # type: ignore  # (possible none)
+            schedule_storage=instance_ref.schedule_storage,
+            compute_log_manager=None,
+            scheduler=instance_ref.scheduler,
+            run_coordinator=None,
+            run_launcher=None,
+            settings=instance_ref.settings,
+            secrets_loader=instance_ref.secrets_loader,
+            ref=instance_ref,
+        )
+
+    with mock.patch("dagster._core.instance.config.class_from_code_pointer", mock_import_module):
+        with mock.patch("dagster._core.instance.DagsterInstance.from_ref", mock_construct_instance):
+            with instance_for_test(
+                overrides={
+                    "instance_class": {
+                        "module": "dagster_cloud.instance",
+                        "class": "DagsterCloudAgentInstance",
+                    },
+                }
+            ) as instance:
+                assert (
+                    instance.get_ref().custom_instance_class_data.module_name
+                    == "dagster_cloud.instance"
+                )
+
+
+# Test preserves behavior from dagster-cloud to dagster-plus rename.
+# Ensure the instance ref only contains references to dagster-cloud for backcompat.
+def test_overwrite_plus_ref_with_cloud_ref():
+    # Overwrite the ref to point to the dagster_plus module
+    def mock_construct_instance(instance_ref: InstanceRef):
+        instance_ref = instance_ref._replace(
+            custom_instance_class_data=ConfigurableClassData(
+                "dagster_plus.instance", "DagsterCloudAgentInstance", yaml.dump({})
+            )
+        )
+        # Manually create a DagsterInstance because we can't instantiate a mock class
+        return DagsterInstance(
+            instance_type=InstanceType.PERSISTENT,
+            local_artifact_storage=instance_ref.local_artifact_storage,
+            run_storage=instance_ref.run_storage,  # type: ignore  # (possible none)
+            event_storage=instance_ref.event_storage,  # type: ignore  # (possible none)
+            schedule_storage=instance_ref.schedule_storage,
+            compute_log_manager=None,
+            scheduler=instance_ref.scheduler,
+            run_coordinator=None,
+            run_launcher=None,
+            settings=instance_ref.settings,
+            secrets_loader=instance_ref.secrets_loader,
+            ref=instance_ref,
+        )
+
+    with mock.patch("dagster._core.instance.DagsterInstance.from_ref", mock_construct_instance):
+        with instance_for_test() as instance:
+            assert (
+                instance.get_ref().custom_instance_class_data.module_name
+                == "dagster_cloud.instance"
+            )
 
 
 @patch("dagster._core.storage.partition_status_cache.get_and_update_asset_status_cache_value")

--- a/python_modules/dagster/dagster_tests/storage_tests/test_local_instance.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_local_instance.py
@@ -13,11 +13,11 @@ from dagster import (
     In,
     Out,
     Output,
-    _check as check,
     job,
     op,
 )
 from dagster._core.definitions.events import RetryRequested
+from dagster._core.errors import DagsterImportClassFromCodePointerError
 from dagster._core.execution.stats import StepEventStatus
 from dagster._core.instance import DagsterInstance, InstanceRef, InstanceType
 from dagster._core.launcher import DefaultRunLauncher
@@ -103,7 +103,7 @@ def test_init_compute_log_with_bad_config_module():
                 fd,
                 default_flow_style=False,
             )
-        with pytest.raises(check.CheckError, match="Couldn't import module"):
+        with pytest.raises(DagsterImportClassFromCodePointerError, match="Couldn't import module"):
             DagsterInstance.from_ref(  # noqa: B018
                 InstanceRef.from_dir(tmpdir_path)
             ).compute_log_manager

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -25,6 +25,9 @@ deps =
   general_tests_old_protobuf: protobuf<4
   core_tests_pydantic1:  pydantic!=1.10.7,<2.0.0
   core_tests_pydantic2:  pydantic>=2.0.0
+  backcompat_cloud_instance_tests: -e ./dagster_tests/core_tests/instance_tests/test_backcompat_dagster_cloud_instance/dagster-cloud
+  dagster_plus_instance_tests: -e ./dagster_tests/core_tests/instance_tests/test_dagster_plus_instance/dagster-cloud
+  dagster_plus_instance_tests: -e ./dagster_tests/core_tests/instance_tests/test_dagster_plus_instance/dagster-plus
   type_signature_tests:  pydantic!=1.10.7,<2.0.0
   -e ../dagster-test
   -e .[mypy,test,pyright]
@@ -37,9 +40,11 @@ commands =
 
   api_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/api_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   cli_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/cli_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  core_tests_pydantic1: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  core_tests_pydantic2: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  type_signature_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests  {env:COVERAGE_ARGS} --durations 10 {posargs} -m 'typesignature'
+  core_tests_pydantic1: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests --ignore ./dagster_tests/core_tests/instance_tests/test_backcompat_dagster_cloud_instance --ignore ./dagster_tests/core_tests/instance_tests/test_dagster_plus_instance  {env:COVERAGE_ARGS} --durations 10 {posargs}
+  core_tests_pydantic2: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests --ignore ./dagster_tests/core_tests/instance_tests/test_backcompat_dagster_cloud_instance --ignore ./dagster_tests/core_tests/instance_tests/test_dagster_plus_instance {env:COVERAGE_ARGS} --durations 10 {posargs}
+  backcompat_cloud_instance_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests/instance_tests/test_backcompat_dagster_cloud_instance  {env:COVERAGE_ARGS} --durations 10 {posargs}
+  dagster_plus_instance_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests/instance_tests/test_dagster_plus_instance  {env:COVERAGE_ARGS} --durations 10 {posargs}
+  type_signature_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests --ignore ./dagster_tests/core_tests/instance_tests/test_backcompat_dagster_cloud_instance --ignore ./dagster_tests/core_tests/instance_tests/test_dagster_plus_instance  {env:COVERAGE_ARGS} --durations 10 {posargs} -m 'typesignature'
   storage_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/storage_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   definitions_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/definitions_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   definitions_tests_pendulum_1: pytest -c ../../pyproject.toml -vv ./dagster_tests/definitions_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -372,6 +372,8 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
 
         job_origin = check.not_none(context.job_code_origin)
 
+        # here?
+
         # ECS limits overrides to 8192 characters including json formatting
         # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html
         # When container_context is serialized as part of the ExecuteRunArgs, we risk

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -372,8 +372,6 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
 
         job_origin = check.not_none(context.job_code_origin)
 
-        # here?
-
         # ECS limits overrides to 8192 characters including json formatting
         # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html
         # When container_context is serialized as part of the ExecuteRunArgs, we risk


### PR DESCRIPTION
Corresponding internal PR: https://github.com/dagster-io/internal/pull/9129

This PR enables backcompat between host cloud and older versions of agent / user code after the dagster-plus package rename, by passing references to `dagster_cloud` instead of `dagster_plus` across process boundaries.

This PR implements the following behavior:
- If the instance module in `dagster.yaml` is `dagster_cloud`, attempt to import from `dagster_plus` if the package is installed. Otherwise, fall back on importing on the original module.
    - A previous version of this PR retried loading from dagster_plus if the original module failed. After https://github.com/dagster-io/internal/pull/9359 was added, this caused `isinstance` checks to fail as `isinstance(dagster_cloud.DagsterCloudAgentInstance, dagster_plus.DagsterCloudAgentInstance)` returns false.

- If `DagsterInstance.get_ref` is called, return a backcompat version whose module is `dagster_cloud`. This enables older agent / user code versions to continue loading from `dagster_cloud`.
- Modifies `InstanceRef` to load from `dagster_plus` if the package exists when rehydrating storage classes. This code path is hit via `DagsterInstance.from_ref`.

