### PR TITLE
[insights][docs] add brief insights alert docs

### DIFF
--- a/docs/content/dagster-cloud/managing-deployments/alerts.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/alerts.mdx
@@ -104,7 +104,7 @@ Alert policies are configured on a **per-deployment basis**. This means, for exa
     </tr>
     <tr>
       <td>
-        <strong>Insights metric alert</strong>
+        <strong>Insights metric alert</strong> <Experimental />
       </td>
       <td>
         <strong>
@@ -123,10 +123,12 @@ Alert policies are configured on a **per-deployment basis**. This means, for exa
           <li>Spend on external tools such as Snowflake or BigQuery credits</li>
         </ul>
         Alerts can be scoped to the sum of any metric across an entire
-        deployment, or for a specific job, asset group, or asset key.{" "}
+        deployment, or for a specific job, asset group, or asset key.
+        <br />
         <strong>Note</strong>: Alerts are sent only when the threshold is first
         crossed, and will not be sent again until the value returns to expected
-        levels.
+        levels. Insights data may become available up to 24 hours after run
+        completion.
       </td>
     </tr>
   </tbody>

--- a/docs/content/dagster-cloud/managing-deployments/alerts.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/alerts.mdx
@@ -110,10 +110,11 @@ Alert policies are configured on a **per-deployment basis**. This means, for exa
         <strong>
           A Dagster Cloud Pro plan is required to use this feature.
         </strong>
-        Sends a notification when a <a href="/dagster-cloud/insights">
-          Dagster Cloud Insights
-        </a> metric exceeds or falls below a specified threshold over a specified
-        time window. This can be used to alert on:
+        <br />
+        Sends a notification when a{" "}
+        <a href="/dagster-cloud/insights">Dagster Cloud Insights</a> metric
+        exceeds or falls below a specified threshold over a specified time
+        window. This can be used to alert on:
         <ul>
           <li>
             Dagster credit usage across a deployment or for a specific job
@@ -121,10 +122,11 @@ Alert policies are configured on a **per-deployment basis**. This means, for exa
           <li>Performance regressions on asset or job runtime</li>
           <li>Spend on external tools such as Snowflake or BigQuery credits</li>
         </ul>
-        Alerts can be scoped to the sum of any metric across an entire deployment,
-        or for a specific job, asset group, or asset key. <strong>Note</strong>:
-        Alerts are sent only when the threshold is first crossed, and will not be
-        sent again until the value returns to expected levels.
+        Alerts can be scoped to the sum of any metric across an entire
+        deployment, or for a specific job, asset group, or asset key.{" "}
+        <strong>Note</strong>: Alerts are sent only when the threshold is first
+        crossed, and will not be sent again until the value returns to expected
+        levels.
       </td>
     </tr>
   </tbody>

--- a/docs/content/dagster-cloud/managing-deployments/alerts.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/alerts.mdx
@@ -104,7 +104,7 @@ Alert policies are configured on a **per-deployment basis**. This means, for exa
     </tr>
     <tr>
       <td>
-        <strong>Insights metric usage alert</strong>
+        <strong>Insights metric alert</strong>
       </td>
       <td>
         <strong>

--- a/docs/content/dagster-cloud/managing-deployments/alerts.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/alerts.mdx
@@ -102,6 +102,31 @@ Alert policies are configured on a **per-deployment basis**. This means, for exa
         <a href="/dagster-cloud/deployment/hybrid">Hybrid deployments</a> only.
       </td>
     </tr>
+    <tr>
+      <td>
+        <strong>Insights metric usage alert</strong>
+      </td>
+      <td>
+        <Note>A Dagster Cloud Pro plan is required to use this feature.</Note>
+        Sends a notification when a <a href="/dagster-cloud/insights">Dagster Cloud Insights</a> metric's total
+        usage exceeds or falls below a specified threshold. This can be used to alert on:
+        <ul>
+          <li>
+            Dagster credit usage across a deployment or for a specific job
+          </li>
+          <li>
+            Performance regressions on asset or job runtime
+          </li>
+          <li>
+            Spend on external tools such as Snowflake or BigQuery credits
+          </li>
+        </ul>
+        Alerts can be scoped to usage across an entire deployment, or to usage for a specific job,
+        asset group, or asset key. <strong>Note</strong>: Alerts are sent only
+        when the threshold is first crossed, and will not be sent again until usage
+        returns to expected levels.
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/docs/content/dagster-cloud/managing-deployments/alerts.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/alerts.mdx
@@ -107,24 +107,24 @@ Alert policies are configured on a **per-deployment basis**. This means, for exa
         <strong>Insights metric usage alert</strong>
       </td>
       <td>
-        <Note>A Dagster Cloud Pro plan is required to use this feature.</Note>
-        Sends a notification when a <a href="/dagster-cloud/insights">Dagster Cloud Insights</a> metric's total
-        usage exceeds or falls below a specified threshold. This can be used to alert on:
+        <strong>
+          A Dagster Cloud Pro plan is required to use this feature.
+        </strong>
+        Sends a notification when a <a href="/dagster-cloud/insights">
+          Dagster Cloud Insights
+        </a> metric exceeds or falls below a specified threshold over a specified
+        time window. This can be used to alert on:
         <ul>
           <li>
             Dagster credit usage across a deployment or for a specific job
           </li>
-          <li>
-            Performance regressions on asset or job runtime
-          </li>
-          <li>
-            Spend on external tools such as Snowflake or BigQuery credits
-          </li>
+          <li>Performance regressions on asset or job runtime</li>
+          <li>Spend on external tools such as Snowflake or BigQuery credits</li>
         </ul>
-        Alerts can be scoped to usage across an entire deployment, or to usage for a specific job,
-        asset group, or asset key. <strong>Note</strong>: Alerts are sent only
-        when the threshold is first crossed, and will not be sent again until usage
-        returns to expected levels.
+        Alerts can be scoped to the sum of any metric across an entire deployment,
+        or for a specific job, asset group, or asset key. <strong>Note</strong>:
+        Alerts are sent only when the threshold is first crossed, and will not be
+        sent again until the value returns to expected levels.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Summary
Adds brief Insights alerting docs which lay out what can be alerted on and provides some examples of use-cases.





<img width="731" alt="Screenshot 2024-04-04 at 3 12 42 PM" src="https://github.com/dagster-io/dagster/assets/10215173/ba6e3d26-e7b7-4a60-8fe2-91217aab67f8">

## Test Plan

Local docs.
