### PR TITLE
[rfc] Add metadata to freshness check results

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/freshness_checks/last_update.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_checks/last_update.py
@@ -50,6 +50,16 @@ def build_last_update_freshness_checks(
     parameter to "3 hours". This would mean that the check will expect the most recent observation
     record to indicate data no older than 3 hours, relative to the current time, regardless of when it runs.
 
+    The check result will contain the following metadata:
+    "dagster/freshness_params": A dictionary containing the parameters used to construct the
+    check
+    "dagster/last_updated_time": The time of the most recent update to the asset
+    "dagster/overdue_seconds": (Only present if asset is overdue) The number of seconds that the
+    asset is overdue by.
+    "dagster/overdue_deadline_timestamp": The timestamp that we are expecting the asset to have
+    arrived by. In the case of a provided deadline_cron, this is the timestamp of the most recent
+    tick of the cron schedule. In the case of no deadline_cron, this is the current time.
+
     Examples:
         .. code-block:: python
 

--- a/python_modules/dagster/dagster/_core/definitions/freshness_checks/time_partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_checks/time_partition.py
@@ -47,6 +47,16 @@ def build_time_partition_freshness_checks(
 
     The check will fail at runtime if a non-time-window partitioned asset is passed in.
 
+    The check result will contain the following metadata:
+    "dagster/freshness_params": A dictionary containing the parameters used to construct the
+    check.
+    "dagster/last_updated_time": (Only present if the asset has been observed/materialized before)
+    The time of the most recent update to the asset.
+    "dagster/overdue_seconds": (Only present if asset is overdue) The number of seconds that the
+    asset is overdue by.
+    "dagster/overdue_deadline_timestamp": The timestamp that we are expecting the asset to have
+    arrived by. This is the timestamp of the most recent tick of the cron schedule.
+
     Examples:
         .. code-block:: python
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/conftest.py
@@ -80,6 +80,7 @@ def assert_check_result(
     severity: AssetCheckSeverity,
     expected_pass: bool,
     description_match: Optional[str] = None,
+    metadata_match: Optional[dict] = None,
 ) -> None:
     result = execute_check_for_asset(
         assets=[the_asset],
@@ -94,6 +95,10 @@ def assert_check_result(
         description = result.get_asset_check_evaluations()[0].description
         assert description
         assert description_match in description
+    if metadata_match:
+        metadata = result.get_asset_check_evaluations()[0].metadata
+        assert metadata
+        assert metadata == metadata_match
 
 
 def add_new_event(


### PR DESCRIPTION
Adds some metadata to check results.
- Freshness parameters (so we can tie the evaluation history to a parameterization).
- dagster/overdue_deadline_timestamp: when can the asset officially become overdue?
- dagster/overdue_seconds: how long is the asset overdue by?

There's some shared code/cleanup to do here I think.
- Add a "timedelta" metadata value type so that we can display something coherent about how out of date your asset is when the number of seconds gets large.