### PR TITLE
fix(dbt): build column dependencies with compiled code

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -394,12 +394,14 @@ class DbtCliEventMessage:
             )
 
         node_sql_path = target_path.joinpath(
-            "run", manifest["metadata"]["project_name"], dbt_resource_props["original_file_path"]
+            "compiled",
+            manifest["metadata"]["project_name"],
+            dbt_resource_props["original_file_path"],
         )
         optimized_node_ast = cast(
             exp.Query,
             optimize(
-                parse_one(sql=node_sql_path.read_text(), dialect=sql_dialect).expression,
+                parse_one(sql=node_sql_path.read_text(), dialect=sql_dialect),
                 schema=sqlglot_mapping_schema,
                 dialect=sql_dialect,
             ),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -301,6 +301,13 @@ def test_column_lineage(
                 "amount_2x": [TableColumnDep(asset_key=AssetKey(["orders"]), column_name="amount")],
             }
         ),
+        AssetKey(["incremental_orders"]): TableColumnLineage(
+            deps_by_column={
+                "order_id": [
+                    TableColumnDep(asset_key=AssetKey(["orders"]), column_name="order_id")
+                ],
+            }
+        ),
         AssetKey(["customers"]): TableColumnLineage(
             deps_by_column={
                 "customer_id": [

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/incremental_orders.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/incremental_orders.sql
@@ -1,0 +1,9 @@
+{{
+  config(
+    materialized='incremental',
+    unique_key='order_id',
+    incremental_strategy='append',
+  )
+}}
+
+select order_id from {{ ref('orders') }}


### PR DESCRIPTION
## Summary & Motivation
The `run/` directory of compiled SQL is not friendly for parsing column lineage. Switch to use the `compiled` directory.

For example, with incremental models, we were trying to parse something equivalent to:

```sql
insert into "gw6_jaffle_shop"."main"."incremental_orders" ("order_id")
    (
        select "order_id"
        from "incremental_orders__dbt_tmp20240405000047433579"
    )
```

This is full of dbt-specific logic related to incremental strategy, and the original query has been obfuscated by some temporary table.

We instead want to gather lineage from just the compiled model:

```sql
select order_id from "gw6_jaffle_shop"."main"."orders"
```

## How I Tested These Changes
pytest