### PR TITLE
fix(dbt): mark implicitly aliased columns with an empty set of column dependencies

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -369,6 +369,11 @@ def test_column_lineage(
                 "count_star": [],
             }
         ),
+        AssetKey(["count_star_implicit_alias_customers"]): TableColumnLineage(
+            deps_by_column={
+                "count_star()": [],
+            }
+        ),
     }
     if asset_key_selection:
         expected_column_lineage_by_asset_key = {

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/count_star_implicit_alias_customers.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/count_star_implicit_alias_customers.sql
@@ -1,0 +1,1 @@
+select count(*) from {{ ref('customers') }}


### PR DESCRIPTION
## Summary & Motivation
During qualification, `sqlglot`'s implicit aliasing logic isn't guaranteed to match that of the underlying engine's (e.g. `duckdb`, `snowflake`, etc).

Since we fetch the table's column schema, we know its exact columns after aliasing has occurred. However, we're unable to match the known columns with those that are implicitly aliased in the ast.

When this occurs, emit a warning and mark those implicitly aliased columns with an empty list of column dependencies. But continue to build the other column dependencies.

## How I Tested These Changes
pytest