### PR TITLE
[ui] HelpMenu optional link for sending feedback within app

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/HelpMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/HelpMenu.tsx
@@ -4,6 +4,7 @@ import {
   Menu,
   MenuDivider,
   MenuExternalLink,
+  MenuItem,
   Popover,
   ProductTour,
   ProductTourPosition,
@@ -16,7 +17,12 @@ import {TooltipShortcutInfo, TopNavButton} from './TopNavButton';
 import DagsterUniversityImage from './dagster_university.svg';
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
 
-export const HelpMenu = ({showContactSales = true}: {showContactSales?: boolean}) => {
+interface Props {
+  showContactSales?: boolean;
+  onShareFeedback?: () => void;
+}
+
+export const HelpMenu = ({showContactSales = true, onShareFeedback}: Props) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const onInteraction = useCallback((open: boolean) => setIsOpen(open), []);
@@ -64,6 +70,9 @@ export const HelpMenu = ({showContactSales = true}: {showContactSales?: boolean}
                 text="View changelog"
               />
               <MenuDivider title="Help" />
+              {onShareFeedback ? (
+                <MenuItem icon="send" text="Share feedback" onClick={onShareFeedback} />
+              ) : null}
               <MenuExternalLink
                 href="https://dagster.io/slack"
                 icon="slack"


### PR DESCRIPTION
## Summary & Motivation

Add a prop to `HelpMenu` to allow showing a "Share feedback" item, to be used in Cloud.

## How I Tested These Changes

View Cloud, verify that the item appears and behaves correctly when clicked when the handler is provided.