### PR TITLE
Fix load_asset_checks_from_package_module duplicates

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/load_asset_checks_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_asset_checks_from_modules.py
@@ -1,7 +1,7 @@
 import inspect
 from importlib import import_module
 from types import ModuleType
-from typing import Iterable, Optional, Sequence, cast
+from typing import Iterable, Optional, Sequence, Set, cast
 
 import dagster._check as check
 from dagster._core.definitions.assets import AssetsDefinition
@@ -20,10 +20,12 @@ from .load_assets_from_modules import (
 
 def _checks_from_modules(modules: Iterable[ModuleType]) -> Sequence[AssetChecksDefinition]:
     checks = []
+    ids: Set[int] = set()
     for module in modules:
         for c in find_objects_in_module_of_types(module, AssetsDefinition):
-            if has_only_asset_checks(c):
+            if has_only_asset_checks(c) and id(c) not in ids:
                 checks.append(cast(AssetChecksDefinition, c))
+                ids.add(id(c))
     return checks
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_check_tests/checks_module/__init__.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_check_tests/checks_module/__init__.py
@@ -1,10 +1,10 @@
-from dagster import asset, asset_check
-from dagster._core.definitions.asset_check_result import AssetCheckResult
+from dagster import AssetCheckResult, AssetCheckSpec, Output, asset, asset_check
 
 
-@asset
+@asset(check_specs=[AssetCheckSpec(name="in_op_check", asset="asset_1")])
 def asset_1():
-    pass
+    yield Output(1)
+    yield AssetCheckResult(passed=True)
 
 
 @asset_check(asset=asset_1)

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_check_tests/checks_module/checks_submodule_2/__init__.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_check_tests/checks_module/checks_submodule_2/__init__.py
@@ -1,0 +1,1 @@
+from ..checks_submodule import submodule_check as submodule_check


### PR DESCRIPTION
Use same logic from load_assets_from_package_module to dedup definitions that appear in multiple submodules