### PR TITLE
Whitelist AssetCondition and subclasses

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
@@ -309,6 +309,7 @@ class AssetConditionEvaluationWithRunIds(NamedTuple):
 
 # Adding the NamedTuple inheritance to avoid bugs with the experimental decorator and subclasses.
 @experimental
+@whitelist_for_serdes
 class AssetCondition(NamedTuple("_AssetCondition", []), ABC):
     """An AssetCondition represents some state of the world that can influence if an asset
     partition should be materialized or not. AssetConditions can be combined to create
@@ -445,6 +446,7 @@ class AssetCondition(NamedTuple("_AssetCondition", []), ABC):
 
 
 @experimental
+@whitelist_for_serdes
 class RuleCondition(  # type: ignore # related to AssetCondition being experimental
     NamedTuple("_RuleCondition", [("rule", "AutoMaterializeRule")]),
     AssetCondition,
@@ -473,6 +475,7 @@ class RuleCondition(  # type: ignore # related to AssetCondition being experimen
 
 
 @experimental
+@whitelist_for_serdes
 class AndAssetCondition(  # type: ignore # related to AssetCondition being experimental
     NamedTuple("_AndAssetCondition", [("children", Sequence[AssetCondition])]),
     AssetCondition,
@@ -495,6 +498,7 @@ class AndAssetCondition(  # type: ignore # related to AssetCondition being exper
 
 
 @experimental
+@whitelist_for_serdes
 class OrAssetCondition(  # type: ignore # related to AssetCondition being experimental
     NamedTuple("_OrAssetCondition", [("children", Sequence[AssetCondition])]),
     AssetCondition,
@@ -519,6 +523,7 @@ class OrAssetCondition(  # type: ignore # related to AssetCondition being experi
 
 
 @experimental
+@whitelist_for_serdes
 class NotAssetCondition(  # type: ignore # related to AssetCondition being experimental
     NamedTuple("_NotAssetCondition", [("children", Sequence[AssetCondition])]),
     AssetCondition,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_asset_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_asset_condition.py
@@ -60,11 +60,8 @@ def test_missing_time_partitioned() -> None:
 
 
 def test_serialize_definitions_with_asset_condition():
-    amp = AutoMaterializePolicy(
-        rules=set(),
-        asset_condition=AssetCondition.parent_newer()
-        & ~AssetCondition.updated_since_cron("0 * * * *"),
-        max_materializations_per_minute=None,
+    amp = AutoMaterializePolicy.from_asset_condition(
+        AssetCondition.parent_newer() & ~AssetCondition.updated_since_cron("0 * * * *")
     )
 
     @asset(auto_materialize_policy=amp)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_asset_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_asset_condition.py
@@ -1,4 +1,7 @@
+from dagster import AutoMaterializePolicy, Definitions, asset
 from dagster._core.definitions.asset_condition.asset_condition import AssetCondition
+from dagster._core.remote_representation.external_data import external_repository_data_from_def
+from dagster._serdes import serialize_value
 
 from ..base_scenario import run_request
 from ..scenario_specs import (
@@ -54,3 +57,21 @@ def test_missing_time_partitioned() -> None:
     # if we evaluate from scratch, they're still False
     _, result = state.without_previous_evaluation_state().evaluate("A")
     assert result.true_subset.size == 4
+
+
+def test_serialize_definitions_with_asset_condition():
+    amp = AutoMaterializePolicy(
+        rules=set(),
+        asset_condition=AssetCondition.parent_newer()
+        & ~AssetCondition.updated_since_cron("0 * * * *"),
+        max_materializations_per_minute=None,
+    )
+
+    @asset(auto_materialize_policy=amp)
+    def my_asset():
+        return 0
+
+    result = serialize_value(
+        external_repository_data_from_def(Definitions(assets=[my_asset]).get_repository_def())
+    )
+    assert isinstance(result, str)


### PR DESCRIPTION
## Summary & Motivation

The following error is raised when classes are not whitelisted. This PR fixes it.

```
dagster._serdes.errors.SerializationError: Can only serialize whitelisted namedtuples
```

## How I Tested These Changes

Locally + BK
