### PR TITLE
[k8s] Handle "none" reason when pod startup 

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -635,7 +635,9 @@ class DagsterKubernetesClient:
                     self.sleeper(wait_time_between_attempts)
                     continue
                 elif state.waiting.reason == None:
-                    self.logger(f'Pod "{pod_name}" is waiting with reason "None" - this is temporary/transition state')
+                    self.logger(
+                        f'Pod "{pod_name}" is waiting with reason "None" - this is temporary/transition state'
+                    )
                     self.sleeper(wait_time_between_attempts)
                     continue
                 elif state.waiting.reason in [

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -634,6 +634,10 @@ class DagsterKubernetesClient:
                     self.logger("Waiting for container creation...")
                     self.sleeper(wait_time_between_attempts)
                     continue
+                elif state.waiting.reason == None:
+                    self.logger(f'Pod "{pod_name}" is waiting with reason "None" - this is temporary/transition state')
+                    self.sleeper(wait_time_between_attempts)
+                    continue
                 elif state.waiting.reason in [
                     KubernetesWaitingReasons.ErrImagePull,
                     KubernetesWaitingReasons.ImagePullBackOff,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -634,7 +634,7 @@ class DagsterKubernetesClient:
                     self.logger("Waiting for container creation...")
                     self.sleeper(wait_time_between_attempts)
                     continue
-                elif state.waiting.reason == None:
+                elif state.waiting.reason is None:
                     self.logger(
                         f'Pod "{pod_name}" is waiting with reason "None" - this is temporary/transition state'
                     )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -1,4 +1,3 @@
-from email import message
 import time
 from collections import namedtuple
 from unittest import mock
@@ -875,6 +874,7 @@ def test_valid_failure_waiting_reasons():
             mock_client.wait_for_pod(pod_name=pod_name, namespace="namespace")
         assert f'Failed: Reason="{reason}" Message="bad things"' in str(exc_info.value)
 
+
 def test_waiting_reason_none():
     mock_client = create_mocked_client()
     single_waiting_pod = _pod_list_for_container_status(
@@ -900,6 +900,7 @@ def test_waiting_reason_none():
         ],
     )
     assert len(mock_client.sleeper.mock_calls) == 1
+
 
 def test_bad_waiting_state():
     mock_client = create_mocked_client(timer=create_timing_out_timer(num_good_ticks=2))


### PR DESCRIPTION
## Summary & Motivation
Quick solution for bug https://github.com/dagster-io/dagster/issues/21021 that makes k8s pipeline unreliable with greater number of pods.

## How I Tested These Changes
Local minikube and synthetic test 