### PR TITLE
feat(dbt): do not require that `state_dir` exists

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -1070,7 +1070,7 @@ class DbtCliResource(ConfigurableResource):
         if state_dir is None:
             return None
 
-        return os.fspath(cls._validate_absolute_path_exists(state_dir))
+        return os.fspath(Path(state_dir).absolute().resolve())
 
     def _get_unique_target_path(self, *, context: Optional[OpExecutionContext]) -> Path:
         """Get a unique target path for the dbt CLI invocation.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_prepare_for_deployment.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_prepare_for_deployment.py
@@ -101,10 +101,7 @@ def test_prepare_for_deployment_with_state(
             ["project", "prepare-for-deployment", "--file", os.fspath(tmp_script_path)],
         )
 
-    state_dir = dbt_project_dir.joinpath("prod_artifacts")
-    state_dir.mkdir()
-
-    project = DbtProject(dbt_project_dir, state_dir=state_dir.name)
+    project = DbtProject(dbt_project_dir, state_dir="prod_artifacts")
     assert project.state_dir
 
     dbt = DbtCliResource(project)
@@ -128,6 +125,7 @@ def test_prepare_for_deployment_with_state(
     assert not result.success
 
     # Once the state directory is populated, the subselected asset can be produced.
+    project.state_dir.mkdir(exist_ok=True)
     shutil.copyfile(project.manifest_path, project.state_dir.joinpath("manifest.json"))
 
     with tmp_script(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -427,10 +427,7 @@ def test_dbt_cli_default_selection(
 def test_dbt_cli_defer_args(monkeypatch: pytest.MonkeyPatch, testrun_uid: str) -> None:
     monkeypatch.setenv("DAGSTER_DBT_JAFFLE_SCHEMA", "prod")
 
-    state_dir = Path("state", testrun_uid)
-    test_jaffle_shop_path.joinpath(state_dir).mkdir(parents=True, exist_ok=True)
-
-    project = DbtProject(project_dir=test_jaffle_shop_path, state_dir=state_dir)
+    project = DbtProject(project_dir=test_jaffle_shop_path, state_dir=Path("state", testrun_uid))
     dbt = DbtCliResource(project_dir=project)
 
     dbt.cli(["--quiet", "parse"], target_path=project.target_dir).wait()
@@ -451,6 +448,7 @@ def test_dbt_cli_defer_args(monkeypatch: pytest.MonkeyPatch, testrun_uid: str) -
 
     # Defer works after copying the manifest into the state directory.
     assert project.state_dir
+    project.state_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(project.manifest_path, project.state_dir.joinpath("manifest.json"))
 
     result = materialize([my_dbt_assets], resources={"dbt": dbt}, selection="orders")


### PR DESCRIPTION
## Summary & Motivation
Assume that `DbtProject`, with `state_dir` populated, and `DbtCliResource` are defined in the same file.

Currently, if you try to load the definitions in this file, things will error if `state_dir` does not exist.

I think that's a bit too harsh. Relax it.

## How I Tested These Changes
pytest