### PR TITLE
[dagster-embedded-elt][dlt] fix get_asset_key docstring

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/translator.py
@@ -16,8 +16,7 @@ class DagsterDltTranslator:
         """Defines asset key for a given dlt resource key and dataset name.
 
         Args:
-            resource_key (str): key of dlt resource
-            dataset_name (str): name of dlt dataset
+            resource (DltResource): dlt resource / transformer
 
         Returns:
             AssetKey of Dagster asset derived from dlt resource


### PR DESCRIPTION
## Summary & Motivation

Correct doc-string for `DagsterDltTranslator.get_asset_key`.

## How I Tested These Changes
