### PR TITLE
Update Asset `RecentUpdatesTimeline` to have a minimum time range to handle single event case.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
@@ -80,9 +80,12 @@ export const RecentUpdatesTimeline = ({
     );
   }, [materializations, observations]);
 
-  const startTimestamp = parseInt(sortedMaterializations[0]?.timestamp ?? '0');
   const endTimestamp = parseInt(
     sortedMaterializations[sortedMaterializations.length - 1]?.timestamp ?? '0',
+  );
+  const startTimestamp = Math.min(
+    parseInt(sortedMaterializations[0]?.timestamp ?? '0'),
+    endTimestamp - 100,
   );
   const timeRange = endTimestamp - startTimestamp;
   const bucketTimeRange = timeRange / buckets;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/RecentUpdatesTimeline.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/RecentUpdatesTimeline.stories.tsx
@@ -1,0 +1,44 @@
+import {buildAssetKey, buildMaterializationEvent} from '../../graphql/types';
+import {PartitionHealthSummary} from '../PartitionHealthSummary';
+import {RecentUpdatesTimeline} from '../RecentUpdatesTimeline';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Assets/RecentUpdatesTimeline',
+  component: PartitionHealthSummary,
+};
+
+export const Single = () => (
+  <RecentUpdatesTimeline
+    assetKey={buildAssetKey()}
+    loading={false}
+    materializations={[buildMaterializationEvent({timestamp: '1'})]}
+  />
+);
+
+export const Multiple = () => (
+  <RecentUpdatesTimeline
+    assetKey={buildAssetKey()}
+    loading={false}
+    materializations={[
+      buildMaterializationEvent({
+        timestamp: '1',
+      }),
+      buildMaterializationEvent({
+        timestamp: '2',
+      }),
+      buildMaterializationEvent({
+        timestamp: '4',
+      }),
+      buildMaterializationEvent({
+        timestamp: '5',
+      }),
+      buildMaterializationEvent({
+        timestamp: '9',
+      }),
+      buildMaterializationEvent({
+        timestamp: '12',
+      }),
+    ]}
+  />
+);


### PR DESCRIPTION
## Summary & Motivation

Before when there's a single event nothing is rendered, now we render the single tick.

## How I Tested These Changes

storybook:
<img width="1494" alt="Screenshot 2024-04-09 at 12 52 31 PM" src="https://github.com/dagster-io/dagster/assets/2286579/29ae9d50-b03b-4ff6-9a0f-d4c6e8a2586e">

