### PR TITLE
Tweak freshness toys

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/freshness_checks.py
+++ b/python_modules/dagster-test/dagster_test/toys/freshness_checks.py
@@ -23,7 +23,7 @@ from dagster._core.definitions.asset_selection import (
 
 @observable_source_asset(group_name="freshness_checks")
 def unreliable_source_events():
-    """An asset which has a .5 probability of being updated every minute.
+    """An asset which has a .8 probability of being updated every minute.
 
     We expect an update every 3 minutes, and the asset could have arrived within the last 2 minutes.
     """
@@ -36,7 +36,7 @@ def unreliable_source_events():
 def derived_asset(context: AssetExecutionContext) -> None:
     """An asset that depends on the unreliable source.
 
-    We also expect this asset to be updated every 3 minutes.
+    We also expect this asset to be updated every 4 minutes.
     """
     latest_observations = context.instance.fetch_observations(
         records_filter=unreliable_source_events.key, limit=1
@@ -47,19 +47,19 @@ def derived_asset(context: AssetExecutionContext) -> None:
         .value,
         "latest_updated_timestamp",
     )
-    if latest_updated_timestamp < pendulum.now().subtract(minutes=3).timestamp():
+    if latest_updated_timestamp < pendulum.now().subtract(minutes=4).timestamp():
         raise Exception("source is stale, so I am going to fail :(")
 
 
 source_checks = build_last_update_freshness_checks(
     assets=[unreliable_source_events],
     deadline_cron="*/3 * * * *",
-    lower_bound_delta=timedelta(minutes=3),
+    lower_bound_delta=timedelta(minutes=2),
 )
 
 derived_checks = build_last_update_freshness_checks(
     assets=[derived_asset],
-    deadline_cron="*/3 * * * *",
+    deadline_cron="*/4 * * * *",
     lower_bound_delta=timedelta(minutes=3),
 )
 
@@ -92,13 +92,13 @@ def get_last_updated_timestamp_unreliable_source() -> TimestampMetadataValue:
         records_filter=context.asset_key, limit=1
     )
 
-    if random.random() < 0.5 and len(latest_observations.records) > 1:
+    if random.random() < 0.3 and len(latest_observations.records) > 1:
         return check.not_none(latest_observations.records[0].asset_observation).metadata[
             "dagster/last_updated_timestamp"
         ]  # type: ignore
     else:
         now = pendulum.now()
-        rounded_minute = math.floor((now.minute - 1) / 3) * 3
+        rounded_minute = max(math.floor((now.minute - 1) / 3) * 3, 0)
         return MetadataValue.timestamp(now.replace(minute=rounded_minute))
 
 


### PR DESCRIPTION
This toy was failing too often to usefully check the results; so tweaking the parameters so that there's more of a mix of failures and successes.