### PR TITLE
Switch to rust stable build

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -113,7 +113,7 @@ def build_repo_wide_pyright_steps() -> List[BuildkiteStep]:
                 CommandStepBuilder(":pyright: make pyright")
                 .run(
                     "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y",
-                    "pip install -U uv",
+                    "pip install -U uv==1.29",
                     "make install_pyright",
                     "make pyright",
                 )
@@ -123,7 +123,7 @@ def build_repo_wide_pyright_steps() -> List[BuildkiteStep]:
                 CommandStepBuilder(":pyright: make rebuild_pyright_pins")
                 .run(
                     "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y",
-                    "pip install -U uv",
+                    "pip install -U uv==1.29",
                     "make install_pyright",
                     "make rebuild_pyright_pins",
                 )

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -113,7 +113,7 @@ def build_repo_wide_pyright_steps() -> List[BuildkiteStep]:
                 CommandStepBuilder(":pyright: make pyright")
                 .run(
                     "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y",
-                    "pip install -U uv==1.29",
+                    "pip install -U uv==0.1.29",
                     "make install_pyright",
                     "make pyright",
                 )
@@ -123,7 +123,7 @@ def build_repo_wide_pyright_steps() -> List[BuildkiteStep]:
                 CommandStepBuilder(":pyright: make rebuild_pyright_pins")
                 .run(
                     "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y",
-                    "pip install -U uv==1.29",
+                    "pip install -U uv==0.1.29",
                     "make install_pyright",
                     "make rebuild_pyright_pins",
                 )

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -112,7 +112,7 @@ def build_repo_wide_pyright_steps() -> List[BuildkiteStep]:
             steps=[
                 CommandStepBuilder(":pyright: make pyright")
                 .run(
-                    "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y",
+                    "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y",
                     "pip install -U uv",
                     "make install_pyright",
                     "make pyright",
@@ -122,7 +122,7 @@ def build_repo_wide_pyright_steps() -> List[BuildkiteStep]:
                 .build(),
                 CommandStepBuilder(":pyright: make rebuild_pyright_pins")
                 .run(
-                    "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y",
+                    "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y",
                     "pip install -U uv",
                     "make install_pyright",
                     "make rebuild_pyright_pins",


### PR DESCRIPTION
Our `make rebuild_pyright_pins` step started failing at the same time it started picking up a new nightly build. Last pass:

```
[2024-04-08T16:32:44Z] info: latest update on 2024-04-08, rust version 1.79.0-nightly (9d5cdf75a 2024-04-07)
```

First failure:

```
[2024-04-09T16:51:00Z] info: latest update on 2024-04-09, rust version 1.79.0-nightly (ab5bda1aa 2024-04-08)
```

I'm switching this to stable (which will pick up 1.77.1 at time of writing) to see if that fixes the issue and protects us from similar bleeding-edge breakages in the future.
