### PR TITLE
Add grpcio<1.60.0 pin

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -28,6 +28,10 @@ def get_version() -> str:
 # grpcio 1.44.0 is the min version compatible with both protobuf 3 and 4
 GRPC_VERSION_FLOOR = "1.44.0"
 
+# Pinned due to hangs that appear to have been introduced in later versions of grpcio:
+# https://github.com/grpc/grpc/issues/36256
+GRPC_VERSION_CEILING_EXCLUSIVE = "1.60.0"
+
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
 pin = "" if ver == "1!0+dev" else f"=={ver}"
@@ -85,8 +89,8 @@ setup(
         # pin around issues in specific versions of alembic that broke our migrations
         "alembic>=1.2.1,!=1.6.3,!=1.7.0,!=1.11.0",
         "croniter>=0.3.34",
-        f"grpcio>={GRPC_VERSION_FLOOR}",
-        f"grpcio-health-checking>={GRPC_VERSION_FLOOR}",
+        f"grpcio>={GRPC_VERSION_FLOOR},<{GRPC_VERSION_CEILING_EXCLUSIVE}",
+        f"grpcio-health-checking>={GRPC_VERSION_FLOOR},<{GRPC_VERSION_CEILING_EXCLUSIVE}",
         "packaging>=20.9",
         "pendulum>=3,<4; python_version>='3.12'",
         "pendulum>=0.7.0,<4; python_version>='3.9' and python_version<'3.12'",


### PR DESCRIPTION
Summary:
While we don't have a conclusive answer to the sporadic reports of grpc server hangs,evidence is mounting to support a pin:

- At least one user who was reliably hitting the hang in https://github.com/grpc/grpc/issues/36256 there reported it going away after downgrading to 1.60.0 (I went one version lower here, to 1.59.3, because I didn't want to pin in the middle of a minor version)
- The comments on that issue from other users also report earlier versions helping (although they also reported needing to downgrade some other dependencies too - would want more data points to support that before we add more pins)

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
