### PR TITLE
refactor(dbt): rename `XXX_dir` to `XXX_path`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
@@ -66,7 +66,7 @@ class DagsterDbtManifestPreparer(DbtManifestPreparer):
             DbtCliResource(project_dir=project)
             .cli(
                 self._generate_cli_args,
-                target_path=project.target_dir,
+                target_path=project.target_path,
             )
             .wait()
         )
@@ -75,10 +75,10 @@ class DagsterDbtManifestPreparer(DbtManifestPreparer):
 @experimental
 class DbtProject(DagsterModel):
     project_dir: Path
-    target_dir: Path
-    manifest_path: Path
+    target_path: Path
     target: Optional[str]
-    state_dir: Optional[Path]
+    manifest_path: Path
+    state_path: Optional[Path]
     packaged_project_dir: Optional[Path]
     manifest_preparer: DbtManifestPreparer
 
@@ -86,9 +86,9 @@ class DbtProject(DagsterModel):
         self,
         project_dir: Union[Path, str],
         *,
-        target_dir: Union[Path, str] = "target",
+        target_path: Union[Path, str] = Path("target"),
         target: Optional[str] = None,
-        state_dir: Optional[Union[Path, str]] = None,
+        state_path: Optional[Union[Path, str]] = None,
         packaged_project_dir: Optional[Union[Path, str]] = None,
         manifest_preparer: DbtManifestPreparer = DagsterDbtManifestPreparer(),
     ):
@@ -97,13 +97,13 @@ class DbtProject(DagsterModel):
         Args:
             project_path (Union[str, Path]):
                 The directory of the dbt project.
-            target_dir (Union[str, Path]):
-                The folder in the project directory to output artifacts.
+            target_path (Union[str, Path]):
+                The path, relative to the project directory, to output artifacts.
                 Default: "target"
             target (Optional[str]):
                 The target from your dbt `profiles.yml` to use for execution, if it should be explicitly set.
-            state_dir (Optional[Union[str, Path]]):
-                The folder in the project directory to reference artifacts from another run.
+            state_path (Optional[Union[str, Path]]):
+                The path, relative to the project directory, to reference artifacts from another run.
             manifest_preparer (Optional[DbtManifestPreparer]):
                 A object for ensuring that manifest.json is in the right state at
                 the right times.
@@ -123,14 +123,14 @@ class DbtProject(DagsterModel):
         if not using_dagster_dev() and packaged_project_dir and packaged_project_dir.exists():
             project_dir = packaged_project_dir
 
-        manifest_path = project_dir.joinpath(target_dir, "manifest.json")
+        manifest_path = project_dir.joinpath(target_path, "manifest.json")
 
         super().__init__(
             project_dir=project_dir,
-            target_dir=target_dir,
-            manifest_path=manifest_path,
+            target_path=target_path,
             target=target,
-            state_dir=project_dir.joinpath(state_dir) if state_dir else None,
+            manifest_path=manifest_path,
+            state_path=project_dir.joinpath(state_path) if state_path else None,
             packaged_project_dir=packaged_project_dir,
             manifest_preparer=manifest_preparer,
         )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_prepare_for_deployment.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_prepare_for_deployment.py
@@ -95,7 +95,7 @@ def test_prepare_for_deployment_with_state(
 
         _ = DbtProject(
             project_dir="{project_dir}",
-            state_dir="prod_artifacts",
+            state_path="prod_artifacts",
         )
 
     with tmp_script(
@@ -106,8 +106,8 @@ def test_prepare_for_deployment_with_state(
             ["project", "prepare-for-deployment", "--file", os.fspath(tmp_script_path)],
         )
 
-    project = DbtProject(dbt_project_dir, state_dir="prod_artifacts")
-    assert project.state_dir
+    project = DbtProject(dbt_project_dir, state_path="prod_artifacts")
+    assert project.state_path
 
     dbt = DbtCliResource(project)
 
@@ -130,8 +130,8 @@ def test_prepare_for_deployment_with_state(
     assert not result.success
 
     # Once the state directory is populated, the subselected asset can be produced.
-    project.state_dir.mkdir(exist_ok=True)
-    shutil.copyfile(project.manifest_path, project.state_dir.joinpath("manifest.json"))
+    project.state_path.mkdir(exist_ok=True)
+    shutil.copyfile(project.manifest_path, project.state_path.joinpath("manifest.json"))
 
     with tmp_script(
         script_fn, tmp_path=tmp_path, dbt_project_dir=dbt_project_dir

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -434,10 +434,10 @@ def test_dbt_cli_default_selection(
 def test_dbt_cli_defer_args(monkeypatch: pytest.MonkeyPatch, testrun_uid: str) -> None:
     monkeypatch.setenv("DAGSTER_DBT_JAFFLE_SCHEMA", "prod")
 
-    project = DbtProject(project_dir=test_jaffle_shop_path, state_dir=Path("state", testrun_uid))
+    project = DbtProject(project_dir=test_jaffle_shop_path, state_path=Path("state", testrun_uid))
     dbt = DbtCliResource(project_dir=project)
 
-    dbt.cli(["--quiet", "parse"], target_path=project.target_dir).wait()
+    dbt.cli(["--quiet", "parse"], target_path=project.target_path).wait()
 
     @dbt_assets(manifest=project.manifest_path)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
@@ -454,9 +454,9 @@ def test_dbt_cli_defer_args(monkeypatch: pytest.MonkeyPatch, testrun_uid: str) -
     assert not result.success
 
     # Defer works after copying the manifest into the state directory.
-    assert project.state_dir
-    project.state_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copy(project.manifest_path, project.state_dir.joinpath("manifest.json"))
+    assert project.state_path
+    project.state_path.mkdir(parents=True, exist_ok=True)
+    shutil.copy(project.manifest_path, project.state_path.joinpath("manifest.json"))
 
     result = materialize([my_dbt_assets], resources={"dbt": dbt}, selection="orders")
     assert result.success


### PR DESCRIPTION
## Summary & Motivation
This is known canonically as `target_path`: https://docs.getdbt.com/reference/dbt_project.yml, https://docs.getdbt.com/reference/global-configs/json-artifacts#target-path.

Rename it.

Also do the same thing for `state_path`.

## How I Tested These Changes
bk