### PR TITLE
feat(dbt): use `state_path` in `dagster-dbt project scaffold --use-experimental-dbt-state`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
@@ -107,6 +107,7 @@ def copy_scaffold(
     dagster_project_dir: Path,
     dbt_project_dir: Path,
     use_dbt_project_package_data_dir: bool,
+    use_experimental_dbt_state: bool,
     use_experimental_dbt_project: bool,
 ) -> None:
     dbt_project_yaml_path = dbt_project_dir.joinpath(DBT_PROJECT_YML_NAME)
@@ -159,6 +160,7 @@ def copy_scaffold(
                 dbt_adapter_packages=dbt_adapter_packages,
                 project_name=project_name,
                 use_dbt_project_package_data_dir=use_dbt_project_package_data_dir,
+                use_experimental_dbt_state=use_experimental_dbt_state,
                 use_experimental_dbt_project=use_experimental_dbt_project,
             ).dump(destination_path)
 
@@ -244,6 +246,15 @@ def project_scaffold_command(
             hidden=True,
         ),
     ] = False,
+    use_experimental_dbt_state: Annotated[
+        bool,
+        typer.Option(
+            default=...,
+            help="Controls whether `DbtProject` is used with dbt state.",
+            is_flag=True,
+            hidden=True,
+        ),
+    ] = False,
     use_experimental_dbt_project: Annotated[
         bool,
         typer.Option(
@@ -275,8 +286,11 @@ def project_scaffold_command(
         dagster_project_dir=dagster_project_dir,
         dbt_project_dir=dbt_project_dir,
         use_dbt_project_package_data_dir=use_dbt_project_package_data_dir,
+        use_experimental_dbt_state=use_experimental_dbt_state,
         use_experimental_dbt_project=(
-            use_experimental_dbt_project or use_dbt_project_package_data_dir
+            use_experimental_dbt_project
+            or use_dbt_project_package_data_dir
+            or use_experimental_dbt_state
         ),
     )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/assets.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/assets.py.jinja
@@ -13,4 +13,9 @@ from .constants import dbt_manifest_path
 @dbt_assets(manifest=dbt_manifest_path)
 {% endif -%}
 def {{ dbt_assets_name }}(context: AssetExecutionContext, dbt: DbtCliResource):
+    {% if use_experimental_dbt_state -%}
+    # When dbt state is available, pass it to the dbt invocation.
+    yield from dbt.cli(["build", *dbt.get_defer_args()], context=context).stream()
+    {% else -%}
     yield from dbt.cli(["build"], context=context).stream()
+    {% endif -%}

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/project.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/project.py.jinja
@@ -4,6 +4,9 @@ from dagster_dbt import DbtProject
 
 {{ dbt_project_name }} = DbtProject(
     project_dir=Path(__file__).joinpath({{ dbt_project_dir_relative_path_parts | join(', ')}}).resolve(),
+    {%- if use_experimental_dbt_state %}
+    state_path=Path("target", "state"),
+    {%- endif %}
     {%- if use_dbt_project_package_data_dir %}
     packaged_project_dir=Path(__file__).joinpath("..", "..", "dbt-project").resolve(),
     {%- endif %}

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_prepare_for_deployment.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_prepare_for_deployment.py
@@ -1,37 +1,18 @@
-import inspect
+import importlib
 import os
 import shutil
-import textwrap
-from contextlib import contextmanager
+import sys
 from pathlib import Path
-from typing import Any, Callable, Iterator, Optional
+from typing import cast
 
 import pytest
-from dagster import AssetExecutionContext, materialize
-from dagster_dbt.asset_decorator import dbt_assets
+from dagster import AssetsDefinition, materialize
 from dagster_dbt.cli.app import app
 from dagster_dbt.core.resources_v2 import DbtCliResource
 from dagster_dbt.dbt_project import DbtProject
 from typer.testing import CliRunner
 
 runner = CliRunner()
-
-
-@contextmanager
-def tmp_script(
-    script_fn: Callable[[], Any],
-    *,
-    tmp_path: Path,
-    dbt_project_dir: Path,
-    packaged_project_dir: Optional[Path] = None,
-) -> Iterator[Path]:
-    source = textwrap.dedent(inspect.getsource(script_fn).partition("\n")[-1])
-    source = source.format(project_dir=dbt_project_dir, packaged_project_dir=packaged_project_dir)
-
-    tmp_script_path = tmp_path.joinpath("definitions.py")
-    tmp_script_path.write_text(source)
-
-    yield tmp_script_path
 
 
 @pytest.mark.parametrize("use_dbt_project_package_data_dir", [True, False])
@@ -86,37 +67,42 @@ def test_prepare_for_deployment(
 
 
 def test_prepare_for_deployment_with_state(
-    monkeypatch: pytest.MonkeyPatch, dbt_project_dir: Path, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, dbt_project_dir: Path
 ) -> None:
     monkeypatch.setenv("DAGSTER_DBT_JAFFLE_SCHEMA", "prod")
+    monkeypatch.chdir(dbt_project_dir)
+    sys.path.append(os.fspath(dbt_project_dir))
 
-    def script_fn() -> None:
-        from dagster_dbt.dbt_project import DbtProject
+    project_name = "jaffle_dagster"
+    dagster_project_dir = dbt_project_dir.joinpath(project_name)
+    dbt_project_file_path = dagster_project_dir.joinpath(project_name, "project.py")
 
-        _ = DbtProject(
-            project_dir="{project_dir}",
-            state_path="prod_artifacts",
-        )
+    result = runner.invoke(
+        app,
+        [
+            "project",
+            "scaffold",
+            "--project-name",
+            project_name,
+            "--dbt-project-dir",
+            os.fspath(dbt_project_dir),
+            "--use-experimental-dbt-state",
+        ],
+    )
+    assert result.exit_code == 0
 
-    with tmp_script(
-        script_fn, tmp_path=tmp_path, dbt_project_dir=dbt_project_dir
-    ) as tmp_script_path:
-        runner.invoke(
-            app,
-            ["project", "prepare-for-deployment", "--file", os.fspath(tmp_script_path)],
-        )
+    result = runner.invoke(
+        app,
+        ["project", "prepare-for-deployment", "--file", os.fspath(dbt_project_file_path)],
+    )
+    assert result.exit_code == 0
 
-    project = DbtProject(dbt_project_dir, state_path="prod_artifacts")
-    assert project.state_path
+    scaffold_defs_module = importlib.import_module(f"{project_name}.{project_name}.definitions")
+    my_dbt_assets = cast(AssetsDefinition, getattr(scaffold_defs_module, "jaffle_shop_dbt_assets"))
+    project = cast(DbtProject, getattr(scaffold_defs_module, "jaffle_shop_project"))
+    dbt = DbtCliResource(project_dir=project)
 
-    dbt = DbtCliResource(project)
-
-    @dbt_assets(manifest=project.manifest_path)
-    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        if os.getenv("DAGSTER_DBT_JAFFLE_SCHEMA") == "staging":
-            assert dbt.get_defer_args()
-
-        yield from dbt.cli(["build", *dbt.get_defer_args()], context=context).stream()
+    assert dbt.state_path
 
     # Running in production produces all the assets.
     result = materialize([my_dbt_assets], resources={"dbt": dbt})
@@ -130,16 +116,14 @@ def test_prepare_for_deployment_with_state(
     assert not result.success
 
     # Once the state directory is populated, the subselected asset can be produced.
-    project.state_path.mkdir(exist_ok=True)
-    shutil.copyfile(project.manifest_path, project.state_path.joinpath("manifest.json"))
+    Path(dbt.state_path).mkdir(exist_ok=True)
+    shutil.copyfile(project.manifest_path, Path(dbt.state_path).joinpath("manifest.json"))
 
-    with tmp_script(
-        script_fn, tmp_path=tmp_path, dbt_project_dir=dbt_project_dir
-    ) as tmp_script_path:
-        runner.invoke(
-            app,
-            ["project", "prepare-for-deployment", "--file", os.fspath(tmp_script_path)],
-        )
+    result = runner.invoke(
+        app,
+        ["project", "prepare-for-deployment", "--file", os.fspath(dbt_project_file_path)],
+    )
+    assert result.exit_code == 0
 
     result = materialize([my_dbt_assets], selection="orders", resources={"dbt": dbt})
     assert result.success


### PR DESCRIPTION
## Summary & Motivation
Introduce a flag, `--use-experimental-dbt-state`, to opt-in to scaffolding a `DbtProject` with `state_path`.

## How I Tested These Changes
pytest
