### PR TITLE
Reduce the number of asset keys that we consider when fetching asset latest status info

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -4,7 +4,6 @@ from typing import (
     AbstractSet,
     Any,
     Dict,
-    KeysView,
     List,
     Mapping,
     Optional,
@@ -27,7 +26,7 @@ from dagster._core.storage.tags import TagType, get_tag_type
 from .external import ensure_valid_config, get_external_job_or_raise
 
 if TYPE_CHECKING:
-    from ..schema.asset_graph import GrapheneAssetLatestInfo, GrapheneAssetNode
+    from ..schema.asset_graph import GrapheneAssetLatestInfo
     from ..schema.errors import GrapheneRunNotFoundError
     from ..schema.execution import GrapheneExecutionPlan
     from ..schema.logs.events import GrapheneRunStepStats
@@ -158,26 +157,6 @@ IN_PROGRESS_STATUSES = [
 ]
 
 
-def add_all_upstream_keys(
-    all_asset_nodes: Mapping[AssetKey, "GrapheneAssetNode"],
-    requested_asset_keys: KeysView[AssetKey],
-) -> Sequence[AssetKey]:
-    required: Dict[AssetKey, bool] = {}
-
-    def append_key_and_upstream(key: AssetKey):
-        if required.get(key):
-            return
-        required[key] = True
-        asset_node = all_asset_nodes[key].external_asset_node
-        for dep in asset_node.dependencies:
-            append_key_and_upstream(dep.upstream_asset_key)
-
-    for asset_key in requested_asset_keys:
-        append_key_and_upstream(asset_key)
-
-    return list(required.keys())
-
-
 def get_assets_latest_info(
     graphene_info: "ResolveInfo", step_keys_by_asset: Mapping[AssetKey, Sequence[str]]
 ) -> Sequence["GrapheneAssetLatestInfo"]:
@@ -189,12 +168,14 @@ def get_assets_latest_info(
 
     instance = graphene_info.context.instance
 
-    asset_nodes = get_asset_nodes_by_asset_key(graphene_info)
-    asset_record_keys_needed = add_all_upstream_keys(asset_nodes, step_keys_by_asset.keys())
-    if not asset_record_keys_needed:
+    asset_keys = list(step_keys_by_asset.keys())
+
+    if not asset_keys:
         return []
 
-    asset_records = instance.get_asset_records(asset_record_keys_needed)
+    asset_nodes = get_asset_nodes_by_asset_key(graphene_info, asset_keys)
+
+    asset_records = instance.get_asset_records(asset_keys)
 
     latest_materialization_by_asset = {
         asset_record.asset_entry.asset_key: (


### PR DESCRIPTION
Summary:
It appears that in https://github.com/dagster-io/dagster/pull/8835 we scoped this down from fetching all asset records to only fetching the set up upstream nodes (which is still pretty big since it fetches every upstream asset key)

But then we removed the computeStatus field in https://github.com/dagster-io/dagster/pull/10556 - but we left the recursive upstream node fetch! As far as I can tell, this resolver only needs information about the current asset keys under consideration and does not need to do recursion at all anymore.

Also only pass in the asset keys under consideration to get_asset_nodes_by_asset_key - not sure what the exact perf impact there is but it certainly can't hurt.

Still need to measure but I could imagine this having a substantial perf win for assets that are low in the asset graph?

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
