### PR TITLE
Only create the specific GrapheneAssetNodes that you need when fetching an asset node with a given key

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -263,8 +263,8 @@ def get_asset_nodes_by_asset_key(
     }
 
 
-def get_asset_nodes(graphene_info: "ResolveInfo"):
-    return get_asset_nodes_by_asset_key(graphene_info).values()
+def get_asset_nodes(graphene_info: "ResolveInfo", asset_keys: Optional[Sequence[AssetKey]] = None):
+    return get_asset_nodes_by_asset_key(graphene_info, asset_keys=asset_keys).values()
 
 
 def get_asset_node(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -927,7 +927,10 @@ class GrapheneQuery(graphene.ObjectType):
                 else []
             )
         else:
-            results = get_asset_nodes(graphene_info)
+            results = get_asset_nodes(
+                graphene_info,
+                asset_keys=(None if use_all_asset_keys else check.not_none(resolved_asset_keys)),
+            )
 
         # Filter down to requested asset keys
         results = [


### PR DESCRIPTION
Summary:
Right now we construct a GrapheneAssetNode for every asset, then filter it down to the specific asset that we are looking for. Instead, pass the list of asset keys all the way through.

This isn't a substantial perf improvement yet, but future improvements that make the GrapheneAssetNode do less work when it is constructed would require this to be in place.

## Summary & Motivation

## How I Tested These Changes
