### PR TITLE
Remove codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-/docs/** @erinkcochran87


### PR DESCRIPTION
## Summary & Motivation

This PR removes the `CODEOWNERS` file, which was supposed to add me as a reviewer to all PRs with changes in `/docs/*`. It unfortunately never worked quite right, instead adding me to almost everything.

Removing this because Graphite can now do what GH couldn't - add me as a reviewer to all docs and DU PRs, and add the correct labels. Bless you, Graphite.

## How I Tested These Changes

Graphite!