### PR TITLE
feat(dbt): create a symlink for `packaged_project_dir` on local dev

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
@@ -106,7 +106,6 @@ def copy_scaffold(
     project_name: str,
     dagster_project_dir: Path,
     dbt_project_dir: Path,
-    use_dbt_project_package_data_dir: bool,
     use_experimental_dbt_state: bool,
     use_experimental_dbt_project: bool,
 ) -> None:
@@ -159,7 +158,6 @@ def copy_scaffold(
                 dbt_assets_name=f"{dbt_project_name}_dbt_assets",
                 dbt_adapter_packages=dbt_adapter_packages,
                 project_name=project_name,
-                use_dbt_project_package_data_dir=use_dbt_project_package_data_dir,
                 use_experimental_dbt_state=use_experimental_dbt_state,
                 use_experimental_dbt_project=use_experimental_dbt_project,
             ).dump(destination_path)
@@ -237,15 +235,6 @@ def project_scaffold_command(
             hidden=True,
         ),
     ] = False,
-    use_dbt_project_package_data_dir: Annotated[
-        bool,
-        typer.Option(
-            default=...,
-            help="Controls whether `DbtProject` is used with a dbt project package data directory.",
-            is_flag=True,
-            hidden=True,
-        ),
-    ] = False,
     use_experimental_dbt_state: Annotated[
         bool,
         typer.Option(
@@ -258,7 +247,9 @@ def project_scaffold_command(
     use_experimental_dbt_project: Annotated[
         bool,
         typer.Option(
-            default=...,
+            ...,
+            "--use-dbt-project-package-data-dir",
+            "--use-experimental-dbt-project",
             help="Controls whether `DbtProject` is used.",
             is_flag=True,
             hidden=True,
@@ -280,18 +271,14 @@ def project_scaffold_command(
     )
 
     dagster_project_dir = Path.cwd().joinpath(project_name)
+    use_experimental_dbt_project = use_experimental_dbt_project or use_experimental_dbt_state
 
     copy_scaffold(
         project_name=project_name,
         dagster_project_dir=dagster_project_dir,
         dbt_project_dir=dbt_project_dir,
-        use_dbt_project_package_data_dir=use_dbt_project_package_data_dir,
         use_experimental_dbt_state=use_experimental_dbt_state,
-        use_experimental_dbt_project=(
-            use_experimental_dbt_project
-            or use_dbt_project_package_data_dir
-            or use_experimental_dbt_state
-        ),
+        use_experimental_dbt_project=use_experimental_dbt_project,
     )
 
     dagster_dev_command = "DAGSTER_DBT_PARSE_PROJECT_ON_LOAD=1 dagster dev"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/.gitignore.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/.gitignore.jinja
@@ -1,0 +1,1 @@
+dbt-project

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/project.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/project.py.jinja
@@ -4,10 +4,8 @@ from dagster_dbt import DbtProject
 
 {{ dbt_project_name }} = DbtProject(
     project_dir=Path(__file__).joinpath({{ dbt_project_dir_relative_path_parts | join(', ')}}).resolve(),
+    packaged_project_dir=Path(__file__).joinpath("..", "..").resolve().joinpath("dbt-project"),
     {%- if use_experimental_dbt_state %}
     state_path=Path("target", "state"),
-    {%- endif %}
-    {%- if use_dbt_project_package_data_dir %}
-    packaged_project_dir=Path(__file__).joinpath("..", "..", "dbt-project").resolve(),
     {%- endif %}
 )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/setup.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/setup.py.jinja
@@ -4,7 +4,7 @@ setup(
     name="{{ project_name }}",
     version="0.0.1",
     packages=find_packages(),
-    {%- if use_dbt_project_package_data_dir %}
+    {%- if use_experimental_dbt_project %}
     package_data={
         "{{ project_name }}": [
             "dbt-project/**/*",


### PR DESCRIPTION
## Summary & Motivation
Simplify the scheme a bit by merging `--use-experimental-dbt-project` and `--use-dbt-project-package-data-dir`.

Here, we will always scaffold a project with `package_data`.

We will always expect this package data to be populated.

- In local dev, the package data will be a symlink to the dbt project directory.
- In a deployed context, the package data will be a hard copy of dbt project directory, so that it is included as part of the built package.

## How I Tested These Changes
pytest
