### PR TITLE
[ui] Repair chart grid lines

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsBarChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsBarChart.tsx
@@ -120,6 +120,9 @@ export const InsightsBarChart = (props: Props) => {
   const yAxis = useMemo(() => {
     return {
       display: showYAxis,
+      grid: {
+        color: Colors.keylineDefault(),
+      },
       title: {
         display: true,
         text: metricLabel,

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsLineChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsLineChart.tsx
@@ -138,6 +138,9 @@ export const InsightsLineChart = (props: Props) => {
   const yCount = useMemo(() => {
     return {
       display: showYAxis,
+      grid: {
+        color: Colors.keylineDefault(),
+      },
       title: {
         display: true,
         text: metricLabel,
@@ -170,6 +173,9 @@ export const InsightsLineChart = (props: Props) => {
     const yCostMax = yMax * Number(costMultiplier);
     return {
       display: !!(showYAxis && costMultiplier),
+      grid: {
+        display: false,
+      },
       position: 'right' as const,
       title: {
         display: true,


### PR DESCRIPTION
## Summary & Motivation

Fix grid line rendering -- in dark mode in particular -- by using `keylineDefault`.

Also hide the grid lines for the cost axis, since we'll already have grid lines for the main y axis.

<img width="1158" alt="Screenshot 2024-04-10 at 15 35 59" src="https://github.com/dagster-io/dagster/assets/2823852/bf11791f-d637-4b64-9d54-88e88d65c4cf">
<img width="1156" alt="Screenshot 2024-04-10 at 15 35 31" src="https://github.com/dagster-io/dagster/assets/2823852/32555117-ce47-4c8d-877c-32a1a13ed548">


## How I Tested These Changes

View Insights, verify grid line rendering in light and dark modes.