### PR TITLE
[DRAFT] Trigger exploration 2

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/auto_materializing/trigger_condition.py
+++ b/python_modules/dagster-test/dagster_test/toys/auto_materializing/trigger_condition.py
@@ -1,0 +1,42 @@
+from dagster import AssetKey, AutoMaterializePolicy, Definitions, asset
+from dagster._core.definitions.sensor_definition import SensorEvaluationContext
+from dagster._core.definitions.trigger_definition import TriggerDefinition, TriggerResult
+
+
+def has_new_s3_data(context: SensorEvaluationContext):
+    cursor = int(context.cursor) if context.cursor else 0
+    return TriggerResult(
+        is_updated=cursor == 1,
+        cursor=str((cursor + 1) % 5),
+    )
+
+
+s3_trigger = TriggerDefinition(
+    key=AssetKey("s3_trigger"),
+    # cron_schedule="*/5 * * * *",
+    minimum_interval_seconds=60,
+    evaluation_fn=has_new_s3_data,
+)
+
+
+@asset(auto_materialize_policy=AutoMaterializePolicy.eager(), deps=[s3_trigger])
+def a():
+    return 1
+
+
+@asset(auto_materialize_policy=AutoMaterializePolicy.eager())
+def b(a):
+    return a + 1
+
+
+@asset(auto_materialize_policy=AutoMaterializePolicy.eager())
+def c(a):
+    return a + 1
+
+
+@asset(auto_materialize_policy=AutoMaterializePolicy.eager())
+def d(b, c):
+    return b + c
+
+
+defs = Definitions(assets=[a, b, c, d])

--- a/python_modules/dagster/dagster/_core/definitions/asset_dep.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_dep.py
@@ -7,6 +7,7 @@ from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.source_asset import SourceAsset
+from dagster._core.definitions.trigger_definition import TriggerDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 
 from .events import (
@@ -15,7 +16,7 @@ from .events import (
 )
 
 CoercibleToAssetDep = Union[
-    CoercibleToAssetKey, AssetSpec, AssetsDefinition, SourceAsset, "AssetDep"
+    CoercibleToAssetKey, AssetSpec, AssetsDefinition, SourceAsset, "AssetDep", TriggerDefinition
 ]
 
 
@@ -87,12 +88,14 @@ class AssetDep(
 
     @staticmethod
     def from_coercible(arg: "CoercibleToAssetDep") -> "AssetDep":
+        if isinstance(arg, TriggerDefinition):
+            return AssetDep(asset=arg.key)
         # if arg is AssetDep, return the original object to retain partition_mapping
         return arg if isinstance(arg, AssetDep) else AssetDep(asset=arg)
 
 
 def _get_asset_key(arg: "CoercibleToAssetDep") -> AssetKey:
-    if isinstance(arg, (AssetsDefinition, SourceAsset, AssetSpec)):
+    if isinstance(arg, (AssetsDefinition, SourceAsset, AssetSpec, TriggerDefinition)):
         return arg.key
     elif isinstance(arg, AssetDep):
         return arg.asset_key

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -51,6 +51,7 @@ from ..output import GraphOut, Out
 from ..partition import PartitionsDefinition
 from ..policy import RetryPolicy
 from ..resource_definition import ResourceDefinition
+from ..trigger_definition import TriggerDefinition
 from ..utils import (
     DEFAULT_IO_MANAGER_KEY,
     DEFAULT_OUTPUT,
@@ -257,6 +258,7 @@ def asset(
             check_specs=check_specs,
             key=key,
             owners=owners,
+            triggers=[dep for dep in deps if isinstance(dep, TriggerDefinition)] if deps else deps,
         )
 
     if compute_fn is not None:
@@ -331,6 +333,7 @@ class _Asset:
         key: Optional[CoercibleToAssetKey] = None,
         check_specs: Optional[Sequence[AssetCheckSpec]] = None,
         owners: Optional[Sequence[str]] = None,
+        triggers: Optional[Sequence[TriggerDefinition]] = None,
     ):
         self.name = name
         self.key_prefix = key_prefix
@@ -360,6 +363,7 @@ class _Asset:
         self.check_specs = check_specs
         self.key = key
         self.owners = owners
+        self.triggers = triggers
 
     def __call__(self, fn: Callable[..., Any]) -> AssetsDefinition:
         from dagster._config.pythonic_config import (
@@ -506,6 +510,7 @@ class _Asset:
             selected_asset_check_keys=None,  # no subselection in decorator
             is_subset=False,
             owners_by_key={out_asset_key: self.owners} if self.owners else None,
+            triggers=self.triggers,
         )
 
 
@@ -928,6 +933,7 @@ def multi_asset(
             selected_asset_check_keys=None,  # no subselection in decorator
             is_subset=False,
             owners_by_key=owners_by_key,
+            triggers=[],
         )
 
     return inner

--- a/python_modules/dagster/dagster/_core/definitions/trigger_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/trigger_definition.py
@@ -1,0 +1,78 @@
+import hashlib
+import random
+from dataclasses import dataclass
+from functools import cached_property
+from typing import TYPE_CHECKING, Callable, Optional
+
+from dagster._core.definitions.data_version import DataVersion
+from dagster._core.definitions.result import ObserveResult
+from dagster._core.definitions.run_request import RunRequest
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.sensor_definition import (
+        RawSensorEvaluationFunction,
+        SensorDefinition,
+        SensorEvaluationContext,
+    )
+from dagster._core.definitions.source_asset import SourceAsset
+
+from .events import AssetKey
+
+
+@dataclass
+class TriggerResult:
+    is_updated: bool
+    cursor: Optional[str] = None
+
+
+@dataclass
+class TriggerDefinition:
+    key: AssetKey
+    # cron_schedule: str
+    # would like this to be a cron schedule, but we need to build on top of the sensor system at
+    # the moment in order to fire off runs for specific assets
+    minimum_interval_seconds: int
+    evaluation_fn: Callable[["SensorEvaluationContext"], TriggerResult]
+
+    def _random_data_version(self) -> str:
+        return hashlib.md5(str(random.random()).encode("utf-8")).hexdigest()[:24]
+
+    def _get_sensor_evaluation_fn(self) -> "RawSensorEvaluationFunction":
+        from dagster import SensorEvaluationContext, SensorResult
+
+        def fn(context: SensorEvaluationContext) -> SensorResult:
+            trigger_result = self.evaluation_fn(context)
+            # request a run of the observe asset if the trigger is updated
+            # TODO: maybe just directly yield an AssetObservation here
+            run_requests = [RunRequest()] if trigger_result.is_updated else []
+            return SensorResult(
+                run_requests=run_requests,
+                cursor=trigger_result.cursor,
+            )
+
+        return fn
+
+    @cached_property
+    def sensor(self) -> "SensorDefinition":
+        from dagster import SensorDefinition
+
+        return SensorDefinition(
+            name=f"trigger__{self.key.to_python_identifier()}",
+            minimum_interval_seconds=self.minimum_interval_seconds,
+            evaluation_fn=self._get_sensor_evaluation_fn(),
+            asset_selection=[self.key],
+        )
+
+    @cached_property
+    def asset(self) -> SourceAsset:
+        # whenever this asset is observed, it gets a new data version
+        def _observe_fn() -> ObserveResult:
+            return ObserveResult(
+                asset_key=self.key,
+                data_version=DataVersion(self._random_data_version()),
+            )
+
+        return SourceAsset(
+            key=self.key,
+            observe_fn=_observe_fn,
+        )


### PR DESCRIPTION
## Summary & Motivation

Alternative to: https://github.com/dagster-io/dagster/pull/21113/files

My feeling after writing this is that this felt like a roundabout way to "hide" an observable source asset, and that for this sort of use case, I'd much rather treat this as an observable source asset directly, and focus on making the experience of combining custom cursoring / scheduling / data versioning logic into a single definition better (current day you need to separately create a sensor / schedule for any observable_source_asset).

## How I Tested These Changes
