### PR TITLE
[ui] Fix asset header wrapping

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.tsx
@@ -141,6 +141,7 @@ const BreadcrumbsWithSlashes = styled(Breadcrumbs)<{$numHeaderBreadcrumbs: numbe
 
 const BreadcrumbLink = styled(Link)`
   color: ${Colors.textLight()};
+  white-space: nowrap;
 
   :hover,
   :active {


### PR DESCRIPTION
Asset header is displaying like this:
<img width="212" alt="image" src="https://github.com/dagster-io/dagster/assets/29110579/cf3d2ba9-877b-46a3-ac3d-ca57e3b0ca5f">

This PR fixes.
