### PR TITLE
Use dataclass instead of NamedTuple for serializing AssetCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -298,26 +298,26 @@ class AutoMaterializePolicy(
             return self.asset_condition
 
         materialize_condition = OrAssetCondition(
-            children=[
+            operands=[
                 rule.to_asset_condition()
                 for rule in sorted(self.materialize_rules, key=lambda rule: rule.description)
             ]
         )
         skip_condition = OrAssetCondition(
-            children=[
+            operands=[
                 rule.to_asset_condition()
                 for rule in sorted(self.skip_rules, key=lambda rule: rule.description)
             ]
         )
         children = [
             materialize_condition,
-            NotAssetCondition([skip_condition]),
+            NotAssetCondition(skip_condition),
         ]
         if self.max_materializations_per_minute:
             discard_condition = DiscardOnMaxMaterializationsExceededRule(
                 self.max_materializations_per_minute
             ).to_asset_condition()
-            children.append(NotAssetCondition([discard_condition]))
+            children.append(NotAssetCondition(discard_condition))
 
         # results in an expression of the form (m1 | m2 | ... | mn) & ~(s1 | s2 | ... | sn) & ~d
         return AndAssetCondition(children)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
@@ -45,7 +45,7 @@ class AssetConditionScenarioState(ScenarioState):
         # ensure that the top level condition never returns any asset partitions, as otherwise the
         # next evaluation will assume that those asset partitions were requested by the machinery
         asset_condition = AndAssetCondition(
-            children=[check.not_none(self.asset_condition), FalseAssetCondition()]
+            operands=[check.not_none(self.asset_condition), FalseAssetCondition()]
         )
 
         with pendulum_freeze_time(self.current_time):


### PR DESCRIPTION
## Summary & Motivation

We're about to start serializing these things, so making a diving save to allow us to use the nicer dataclass API instead of NamedTuples.

In the process of doing this, I realized that we had a weird setup with a `children` property on the base AssetCondition class that didn't work when using dataclasses. Previously, using NamedTuples meant that the NamedTuple property management stuff would handle the case where you added an explicit `children` field on the child class, but dataclasses don't work in the same way.

Basically we want a few things:
- To have a property on all AssetConditions that lists all sub-conditions (if any)
- To not have to explicitly store a set of sub-conditions in serialized form if there aren't any (mostly a dev ergonomics thing, it's a pain to add a guaranteed-to-be-empty "children" property to all child classes)
- To make it easy to set invariants that certain AssetConditions will only have a single child, etc.

This new system makes it so that AssetConditions that *do* have sub-conditions just store them in a field with a different name (currently we're just doing boolean expressions, so I've used "operand" / "operands"), and then implement an explicit "children" property on top of that field. AssetConditions without sub-conditions just use the default "children" implementation, which returns an empty list.

Overall, this setup works a lot nicer and simplifies the class definitions for all these subclasses.

## How I Tested These Changes
