### PR TITLE
Refactor ADLS2 IOManager to allow custom lease duration

### DIFF
--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -21,8 +21,6 @@ from upath import UPath
 from dagster_azure.adls2.resources import ADLS2Resource
 from dagster_azure.adls2.utils import ResourceNotFoundError
 
-_LEASE_DURATION = 60  # One minute
-
 
 class PickledObjectADLS2IOManager(UPathIOManager):
     def __init__(
@@ -32,7 +30,11 @@ class PickledObjectADLS2IOManager(UPathIOManager):
         blob_client: Any,
         lease_client_constructor: Any,
         prefix: str = "dagster",
+        lease_duration: int = 60,
     ):
+        if lease_duration != -1 and (lease_duration < 15 or lease_duration > 60):
+            raise ValueError("lease_duration must be -1 (unlimited) or between 15 and 60")
+
         self.adls2_client = adls2_client
         self.file_system_client = self.adls2_client.get_file_system_client(file_system)
         # We also need a blob client to handle copying as ADLS doesn't have a copy API yet
@@ -41,7 +43,7 @@ class PickledObjectADLS2IOManager(UPathIOManager):
         self.prefix = check.str_param(prefix, "prefix")
 
         self.lease_client_constructor = lease_client_constructor
-        self.lease_duration = _LEASE_DURATION
+        self.lease_duration = lease_duration
         self.file_system_client.get_file_system_properties()
         super().__init__(base_path=UPath(self.prefix))
 


### PR DESCRIPTION
## Summary & Motivation
### Summary

This PR introduces the ability to configure the lease duration for `PickledObjectADLS2IOManager` in Dagster's integration with Azure Data Lake Storage Gen2 (ADLS2). The modification allows users to specify a custom lease duration for blob leases, addressing limitations encountered during concurrent pipeline executions that require blob leasing.

### Motivation

In the course of using Dagster with ADLS2 for complex data pipelines, it was identified that the fixed lease duration of 60 seconds on blobs could lead to execution failures under certain conditions. Specifically, the issue arises during lengthy operations that exceed the default lease time, leading to pipeline interruptions and failed runs as described in [dagster-io/dagster#20403](https://github.com/dagster-io/dagster/issues/20403).

To enhance flexibility and reliability in pipeline executions, this PR makes the lease duration configurable. By introducing a `lease_duration` parameter to `PickledObjectADLS2IOManager`, users can now specify a custom lease duration that aligns with their operation times. This change permits a lease duration to be set anywhere between 15 to 60 seconds, or to an unlimited lease duration by specifying `-1`. This adjustment ensures that pipelines can execute without disruptions caused by lease expirations, thereby improving the robustness of data operations on ADLS2.

The validation within the `__init__` method ensures that the lease duration adheres to Azure's constraints, thus maintaining the integrity and reliability of the blob leasing mechanism.

## How I Tested These Changes
I successfully run the dagster-azure tests with `python -m pytest python_modules/libraries/dagster-azure` leading to 19 passed, 3 skipped tests.
