### PR TITLE
feat(asset-overview): allow injection of document title

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
@@ -42,7 +42,10 @@ export const ContentRoot = memo(() => {
           <Route path="/assets(/?.*)">
             <Suspense fallback={<div />}>
               <AssetFeatureProvider>
-                <AssetsOverview headerBreadcrumbs={[{text: 'Assets', href: '/assets'}]} />
+                <AssetsOverview
+                  headerBreadcrumbs={[{text: 'Assets', href: '/assets'}]}
+                  documentTitlePrefix="Assets"
+                />
               </AssetFeatureProvider>
             </Suspense>
           </Route>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverviewRoot.tsx
@@ -23,9 +23,11 @@ import {ReloadAllButton} from '../workspace/ReloadAllButton';
 export const AssetsOverviewRoot = ({
   writeAssetVisit,
   headerBreadcrumbs,
+  documentTitlePrefix,
 }: {
   writeAssetVisit?: (assetKey: AssetKey) => void;
   headerBreadcrumbs: BreadcrumbProps[];
+  documentTitlePrefix: string;
 }) => {
   useTrackPageView();
 
@@ -46,8 +48,8 @@ export const AssetsOverviewRoot = ({
 
   useDocumentTitle(
     currentPath && currentPath.length
-      ? `Assets: ${displayNameForAssetKey({path: currentPath})}`
-      : 'Assets',
+      ? `${documentTitlePrefix}: ${displayNameForAssetKey({path: currentPath})}`
+      : documentTitlePrefix,
   );
 
   const trace = usePageLoadTrace(


### PR DESCRIPTION
## Summary & Motivation
As the title. We can switch this title if another component is injected.

## How I Tested These Changes
local