### PR TITLE
[Dagre bug workaround] Fallback to longest-path and network-simplex in asset graph in case of dagre bug

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -51,6 +51,7 @@ export type LayoutAssetGraphConfig = dagre.GraphLabel & {
   /** Supported in Dagre, just not documented. Additional spacing between group nodes */
   clusterpaddingtop?: number;
   clusterpaddingbottom?: number;
+  ranker?: 'tight-tree' | 'longest-path' | 'network-simplex';
 };
 
 export type LayoutAssetGraphOptions = {
@@ -91,6 +92,26 @@ export const Config = {
 };
 
 export const layoutAssetGraph = (
+  graphData: GraphData,
+  opts: LayoutAssetGraphOptions,
+): AssetGraphLayout => {
+  try {
+    return layoutAssetGraphImpl(graphData, opts);
+  } catch (e) {
+    try {
+      return layoutAssetGraphImpl(graphData, {
+        ...opts,
+        overrides: {
+          ranker: 'longest-path',
+        },
+      });
+    } catch (e) {
+      return layoutAssetGraphImpl(graphData, {...opts, overrides: {ranker: 'network-simplex'}});
+    }
+  }
+};
+
+export const layoutAssetGraphImpl = (
   graphData: GraphData,
   opts: LayoutAssetGraphOptions,
 ): AssetGraphLayout => {

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -10,7 +10,7 @@ import {AssetGraphLayout, LayoutAssetGraphOptions, layoutAssetGraph} from '../as
 const ASYNC_LAYOUT_SOLID_COUNT = 50;
 
 // If you're working on the layout logic, set to false so hot-reloading re-computes the layout
-const CACHING_ENABLED = false;
+const CACHING_ENABLED = true;
 
 // Op Graph
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -10,7 +10,7 @@ import {AssetGraphLayout, LayoutAssetGraphOptions, layoutAssetGraph} from '../as
 const ASYNC_LAYOUT_SOLID_COUNT = 50;
 
 // If you're working on the layout logic, set to false so hot-reloading re-computes the layout
-const CACHING_ENABLED = true;
+const CACHING_ENABLED = false;
 
 // Op Graph
 


### PR DESCRIPTION
## Summary & Motivation

I was able to successfully render a buggy asset graph by falling all the way back to network-simplex, which is slow, but better than nothing.

## How I Tested These Changes

Tested this with a customer's graph that is running into this issue