### PR TITLE
[dagster-airbyte] fix auto materialize policies not getting passed through to underlying asset

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -180,6 +180,11 @@ def _build_airbyte_assets_from_metadata(
                     else None
                 ),
                 dagster_type=Nothing,
+                auto_materialize_policy=assets_defn_meta.auto_materialize_policies_by_output_name.get(
+                    k, None
+                )
+                if assets_defn_meta.auto_materialize_policies_by_output_name
+                else None,
             )
             for k, v in (assets_defn_meta.keys_by_output_name or {}).items()
         },
@@ -227,6 +232,7 @@ def build_airbyte_assets(
     schema_by_table_name: Optional[Mapping[str, TableSchema]] = None,
     freshness_policy: Optional[FreshnessPolicy] = None,
     stream_to_asset_map: Optional[Mapping[str, str]] = None,
+    auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
 ) -> Sequence[AssetsDefinition]:
     """Builds a set of assets representing the tables created by an Airbyte sync operation.
 
@@ -247,6 +253,7 @@ def build_airbyte_assets(
         freshness_policy (Optional[FreshnessPolicy]): A freshness policy to apply to the assets
         stream_to_asset_map (Optional[Mapping[str, str]]): A mapping of an Airbyte stream name to a Dagster asset.
             This allows the use of the "prefix" setting in Airbyte with special characters that aren't valid asset names.
+        auto_materialize_policy (Optional[AutoMaterializePolicy]): An auto materialization policy to apply to the assets.
     """
     if upstream_assets is not None and deps is not None:
         raise DagsterInvalidDefinitionError(
@@ -270,6 +277,7 @@ def build_airbyte_assets(
                 else None
             ),
             freshness_policy=freshness_policy,
+            auto_materialize_policy=auto_materialize_policy,
         )
         for table in tables
     }

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -244,6 +244,8 @@ def test_load_from_instance(
         AutoMaterializePolicy.lazy() if connection_to_auto_materialize_policy_fn else None
     )
     auto_materialize_policies_by_key = ab_assets[0].auto_materialize_policies_by_key
+    if expected_auto_materialize_policy:
+        assert auto_materialize_policies_by_key
     assert all(
         auto_materialize_policies_by_key[key] == expected_auto_materialize_policy
         for key in auto_materialize_policies_by_key


### PR DESCRIPTION
## Summary & Motivation
resolves https://github.com/dagster-io/dagster/issues/18266

auto materialize policies were not being passed to the underlying asset correctly. This didn't show up in tests because we didnt check that the `auto_materialize_policies_by_key` dict was non empty. 

This PR also adds an `auto_materialize_policy` param to `build_airbyte_assets` to bring it to parity with the `from_instance` and `from_project` builders. If there is a reason this wasn't done to begin with let me know and i can remove



## How I Tested These Changes
 unit tests