### PR TITLE
add last observation to asset record named tuple

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -57,6 +57,9 @@ class AssetEntry(
             ("last_run_id", Optional[str]),
             ("asset_details", Optional[AssetDetails]),
             ("cached_status", Optional["AssetStatusCacheValue"]),
+            # This is an optional field which can be used for more performant last observation
+            # queries if the underlying storage supports it
+            ("last_observation_record", Optional[EventLogRecord]),
         ],
     )
 ):
@@ -67,6 +70,7 @@ class AssetEntry(
         last_run_id: Optional[str] = None,
         asset_details: Optional[AssetDetails] = None,
         cached_status: Optional["AssetStatusCacheValue"] = None,
+        last_observation_record: Optional[EventLogRecord] = None,
     ):
         from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
@@ -80,6 +84,9 @@ class AssetEntry(
             asset_details=check.opt_inst_param(asset_details, "asset_details", AssetDetails),
             cached_status=check.opt_inst_param(
                 cached_status, "cached_status", AssetStatusCacheValue
+            ),
+            last_observation_record=check.opt_inst_param(
+                last_observation_record, "last_observation_record", EventLogRecord
             ),
         )
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -422,6 +422,10 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """Indicates that the EventLogStorage supports global concurrency limits."""
         return False
 
+    @property
+    def asset_records_have_last_observation(self) -> bool:
+        return False
+
     @abstractmethod
     def initialize_concurrency_limit_to_default(self, concurrency_key: str) -> bool:
         """Initialize a concurrency limit to the instance default value.  Is a no-op for concurrency


### PR DESCRIPTION
## Summary & Motivation
This allows some storage implementations to provide the last observation event record in the asset record as a performance enhancement.

RFC because depending on the storage implementation, a None value for this value is either significant or not significant, so it doesn't make for a great API.

## How I Tested These Changes
BK