### PR TITLE
Convert from NamedTuple to DagsterModel for AssetCondition and friends

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -513,7 +513,9 @@ class TestAssetConditionEvaluations(ExecutingGraphQLContextTestMatrix):
     ) -> AssetConditionEvaluation:
         return AssetConditionEvaluation(
             condition_snapshot=AssetConditionSnapshot(
-                "...", description, str(random.randint(0, 100000000))
+                class_name="...",
+                description=description,
+                unique_id=str(random.randint(0, 100000000)),
             ),
             true_subset=AssetSubset(
                 asset_key=asset_key,
@@ -607,7 +609,9 @@ class TestAssetConditionEvaluations(ExecutingGraphQLContextTestMatrix):
         ).add_auto_materialize_asset_evaluations(
             evaluation_id=10,
             asset_evaluations=[
-                AssetConditionEvaluationWithRunIds(evaluation, frozenset({"runid1", "runid2"}))
+                AssetConditionEvaluationWithRunIds(
+                    evaluation=evaluation, run_ids=frozenset({"runid1", "runid2"})
+                )
             ],
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
@@ -27,6 +27,7 @@ from dagster._model import DagsterModel
 from dagster._serdes.serdes import PackableValue, whitelist_for_serdes
 
 from ..asset_subset import AssetSubset, ValidAssetSubset
+from ..auto_materialize_rule import AutoMaterializeRule
 
 if TYPE_CHECKING:
     from .asset_condition_evaluation_context import AssetConditionEvaluationContext
@@ -357,8 +358,6 @@ class AssetCondition(ABC, DagsterModel):
         """Returns an AssetCondition that is true for an asset partition when at least one parent
         asset partition is newer than it.
         """
-        from ..auto_materialize_rule import AutoMaterializeRule
-
         return RuleCondition(rule=AutoMaterializeRule.materialize_on_parent_updated())
 
     @staticmethod
@@ -407,8 +406,6 @@ class AssetCondition(ABC, DagsterModel):
 @whitelist_for_serdes
 class RuleCondition(AssetCondition):
     """This class represents the condition that a particular AutoMaterializeRule is satisfied."""
-
-    from ..auto_materialize_rule import AutoMaterializeRule
 
     rule: AutoMaterializeRule
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition_evaluation_context.py
@@ -197,7 +197,7 @@ class AssetConditionEvaluationContext:
             if not parent_info:
                 continue
             parent_subset = parent_info.true_subset.as_valid(self.partitions_def)
-            subset |= parent_subset._replace(asset_key=self.asset_key)
+            subset |= parent_subset.copy(update={"asset_key": self.asset_key})
         return subset
 
     @functools.cached_property
@@ -393,7 +393,7 @@ class AssetConditionEvaluationContext:
         return (
             self.candidate_subset & true_subset,
             [
-                AssetSubsetWithMetadata(subset, dict(metadata))
+                AssetSubsetWithMetadata(subset=subset, metadata=dict(metadata))
                 for metadata, subset in mapping.items()
             ],
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime
 import logging
 import time
@@ -277,12 +278,15 @@ class AssetDaemonContext:
                     # the subset of all required neighbors
                     if neighbor_key in evaluation_state_by_key:
                         neighbor_evaluation_state = evaluation_state_by_key[neighbor_key]
-                        evaluation_state_by_key[neighbor_key] = neighbor_evaluation_state._replace(
-                            previous_evaluation=neighbor_evaluation_state.previous_evaluation._replace(
-                                true_subset=neighbor_evaluation_state.true_subset._replace(
-                                    asset_key=neighbor_key
-                                )
-                            )
+                        evaluation_state_by_key[neighbor_key] = dataclasses.replace(
+                            neighbor_evaluation_state,
+                            previous_evaluation=neighbor_evaluation_state.previous_evaluation.copy(
+                                update={
+                                    "true_subset": neighbor_evaluation_state.true_subset.copy(
+                                        update={"asset_key": neighbor_key}
+                                    )
+                                }
+                            ),
                         )
                     to_request |= {
                         ap._replace(asset_key=neighbor_key)

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -160,7 +160,7 @@ def get_backcompat_asset_condition_evaluation_state(
         max_storage_id=latest_storage_id,
         # the only information we need to preserve from the previous cursor is the handled subset
         extra_state_by_unique_id={
-            RuleCondition(MaterializeOnMissingRule()).unique_id: handled_root_subset,
+            RuleCondition(rule=MaterializeOnMissingRule()).unique_id: handled_root_subset,
         }
         if handled_root_subset and handled_root_subset.size > 0
         else {},
@@ -241,7 +241,9 @@ def backcompat_deserialize_asset_daemon_cursor_str(
         if not latest_evaluation_result:
             partitions_def = asset_graph.get(asset_key).partitions_def if asset_graph else None
             latest_evaluation_result = AssetConditionEvaluation(
-                condition_snapshot=AssetConditionSnapshot("", "", ""),
+                condition_snapshot=AssetConditionSnapshot(
+                    class_name="", description="", unique_id=""
+                ),
                 true_subset=AssetSubset.empty(asset_key, partitions_def),
                 candidate_subset=AssetSubset.empty(asset_key, partitions_def),
                 start_timestamp=None,

--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -5,7 +5,6 @@ from typing import (
     AbstractSet,
     Any,
     Callable,
-    NamedTuple,
     Optional,
     Union,
     cast,
@@ -21,8 +20,9 @@ from dagster._core.definitions.partition import (
 from dagster._core.definitions.time_window_partitions import (
     BaseTimeWindowPartitionsSubset,
 )
+from dagster._model import DagsterModel
 from dagster._serdes.serdes import (
-    NamedTupleSerializer,
+    PydanticModelSerializer,
     whitelist_for_serdes,
 )
 
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from dagster._core.instance import DynamicPartitionsStore
 
 
-class AssetSubsetSerializer(NamedTupleSerializer):
+class AssetSubsetSerializer(PydanticModelSerializer):
     """Ensures that the inner PartitionsSubset is converted to a serializable form if necessary."""
 
     def get_storage_name(self) -> str:
@@ -39,12 +39,12 @@ class AssetSubsetSerializer(NamedTupleSerializer):
 
     def before_pack(self, value: "AssetSubset") -> "AssetSubset":
         if value.is_partitioned:
-            return value._replace(value=value.subset_value.to_serializable_subset())
+            return value.copy(update={"value": value.subset_value.to_serializable_subset()})
         return value
 
 
 @whitelist_for_serdes(serializer=AssetSubsetSerializer)
-class AssetSubset(NamedTuple):
+class AssetSubset(DagsterModel):
     """Represents a set of AssetKeyPartitionKeys for a given AssetKey. For partitioned assets, this
     class uses a PartitionsSubset to represent the set of partitions, enabling lazy evaluation of the
     underlying partition keys. For unpartitioned assets, this class uses a bool to represent whether
@@ -109,7 +109,7 @@ class AssetSubset(NamedTuple):
         if it is compatible with the given PartitionsDefinition, otherwise returns an empty subset.
         """
         if self._is_compatible_with_partitions_def(partitions_def):
-            return ValidAssetSubset(*self)
+            return ValidAssetSubset(asset_key=self.asset_key, value=self.value)
         else:
             return ValidAssetSubset.empty(self.asset_key, partitions_def)
 
@@ -177,6 +177,12 @@ class AssetSubset(NamedTuple):
         else:
             return item.asset_key == self.asset_key and item.partition_key in self.subset_value
 
+    def dict(self, **kwargs) -> dict:
+        # Must be overridden as the Pydantic implementation errors when encountering NamedTuples
+        # which have different fields than their __new__ method, which TimeWindowPartitionsSubset
+        # unfortunately has.
+        return {"asset_key": self.asset_key, "value": self.value}
+
 
 @whitelist_for_serdes(serializer=AssetSubsetSerializer)
 class ValidAssetSubset(AssetSubset):
@@ -199,7 +205,7 @@ class ValidAssetSubset(AssetSubset):
     ) -> "ValidAssetSubset":
         """Returns the AssetSubset containing all asset partitions which are not in this AssetSubset."""
         if partitions_def is None:
-            return self._replace(value=not self.bool_value)
+            return self.copy(update={"value": not self.bool_value})
         else:
             value = partitions_def.subset_with_partition_keys(
                 self.subset_value.get_partition_keys_not_in_subset(
@@ -208,17 +214,17 @@ class ValidAssetSubset(AssetSubset):
                     dynamic_partitions_store=dynamic_partitions_store,
                 )
             )
-            return self._replace(value=value)
+            return self.copy(update={"value": value})
 
     def _oper(self, other: "ValidAssetSubset", oper: Callable[..., Any]) -> "ValidAssetSubset":
         value = oper(self.value, other.value)
-        return self._replace(value=value)
+        return self.copy(update={"value": value})
 
     def __sub__(self, other: AssetSubset) -> "ValidAssetSubset":
         """Returns an AssetSubset representing self.asset_partitions - other.asset_partitions."""
         valid_other = self.get_valid(other)
         if not self.is_partitioned:
-            return self._replace(value=self.bool_value and not valid_other.bool_value)
+            return self.copy(update={"value": self.bool_value and not valid_other.bool_value})
         return self._oper(valid_other, operator.sub)
 
     def __and__(self, other: AssetSubset) -> "ValidAssetSubset":
@@ -234,10 +240,14 @@ class ValidAssetSubset(AssetSubset):
         AssetSubset if it is compatible with this AssetSubset, otherwise returns an empty subset.
         """
         if self._is_compatible_with_subset(other):
-            return ValidAssetSubset(*other)
+            return ValidAssetSubset(asset_key=other.asset_key, value=other.value)
         else:
-            return self._replace(
+            return self.copy(
                 # unfortunately, this is the best way to get an empty partitions subset of an unknown
                 # type if you don't have access to the partitions definition
-                value=(self.subset_value - self.subset_value) if self.is_partitioned else False
+                update={
+                    "value": (self.subset_value - self.subset_value)
+                    if self.is_partitioned
+                    else False
+                }
             )

--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -181,6 +181,7 @@ class AssetSubset(DagsterModel):
         # Must be overridden as the Pydantic implementation errors when encountering NamedTuples
         # which have different fields than their __new__ method, which TimeWindowPartitionsSubset
         # unfortunately has.
+        # This can likely be removed once TimeWindowPartitionsSubset is converted into a DagsterModel
         return {"asset_key": self.asset_key, "value": self.value}
 
 

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -311,13 +311,13 @@ class AutoMaterializePolicy(
         )
         children = [
             materialize_condition,
-            NotAssetCondition(skip_condition),
+            NotAssetCondition(operand=skip_condition),
         ]
         if self.max_materializations_per_minute:
             discard_condition = DiscardOnMaxMaterializationsExceededRule(
                 self.max_materializations_per_minute
             ).to_asset_condition()
-            children.append(NotAssetCondition(discard_condition))
+            children.append(NotAssetCondition(operand=discard_condition))
 
         # results in an expression of the form (m1 | m2 | ... | mn) & ~(s1 | s2 | ... | sn) & ~d
-        return AndAssetCondition(children)
+        return AndAssetCondition(operands=children)

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -1033,7 +1033,8 @@ class SkipOnNotAllParentsUpdatedSinceCronRule(
                 ).partitions_subset
 
                 non_updated_parent_asset_partitions = (
-                    ValidAssetSubset(parent_asset_key, parent_subset) - updated_parent_subset
+                    ValidAssetSubset(asset_key=parent_asset_key, value=parent_subset)
+                    - updated_parent_subset
                 ).asset_partitions
 
             return not any(

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
@@ -23,6 +23,7 @@ from dagster._serdes.serdes import (
     _WHITELIST_MAP,
     NamedTupleSerializer,
     PackableValue,
+    PydanticModelSerializer,
     UnpackContext,
     UnpackedValue,
     WhitelistMap,
@@ -182,10 +183,10 @@ def deserialize_serialized_partitions_subset_to_asset_subset(
         # partitions def has changed since storage time
         return AssetSubset.empty(asset_key, partitions_def)
 
-    return AssetSubset(asset_key, value=serialized.deserialize(partitions_def))
+    return AssetSubset(asset_key=asset_key, value=serialized.deserialize(partitions_def))
 
 
-class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
+class BackcompatAutoMaterializeAssetEvaluationSerializer(PydanticModelSerializer):
     """This handles backcompat for the old AutoMaterializeAssetEvaluation objects, turning them into
     AssetConditionEvaluationWithRunIds objects.
     """
@@ -205,7 +206,7 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
         if serialized is None:
             # Confusingly, we used `None` to indicate "all of an unpartitioned asset" in the old
             # serialization scheme
-            return AssetSubset(asset_key, True)
+            return AssetSubset(asset_key=asset_key, value=True)
         return deserialize_serialized_partitions_subset_to_asset_subset(
             serialized, asset_key, self.partitions_def
         )
@@ -348,8 +349,8 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
             # since the evaluation was stored. Instead, we just use an empty subset.
             true_subset = AssetSubset.empty(asset_key, self.partitions_def)
         else:
-            true_subset = evaluation.true_subset._replace(
-                value=not evaluation.true_subset.bool_value
+            true_subset = evaluation.true_subset.copy(
+                update={"value": not evaluation.true_subset.bool_value}
             )
         return AssetConditionEvaluation(
             condition_snapshot=AssetConditionSnapshot(

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -351,7 +351,7 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
         parent_partitions_def = self.get(parent_asset_key).partitions_def
 
         if parent_partitions_def is None:
-            return ValidAssetSubset(parent_asset_key, value=child_asset_subset.size > 0)
+            return ValidAssetSubset(asset_key=parent_asset_key, value=child_asset_subset.size > 0)
 
         partition_mapping = self.get_partition_mapping(child_asset_key, parent_asset_key)
         parent_partitions_subset = (
@@ -364,7 +364,7 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
             )
         ).partitions_subset
 
-        return ValidAssetSubset(parent_asset_key, value=parent_partitions_subset)
+        return ValidAssetSubset(asset_key=parent_asset_key, value=parent_partitions_subset)
 
     def get_child_asset_subset(
         self,
@@ -389,7 +389,7 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
                 return ValidAssetSubset.empty(child_asset_key, child_partitions_def)
 
         if child_partitions_def is None:
-            return ValidAssetSubset(child_asset_key, value=parent_asset_subset.size > 0)
+            return ValidAssetSubset(asset_key=child_asset_key, value=parent_asset_subset.size > 0)
         else:
             partition_mapping = self.get_partition_mapping(child_asset_key, parent_asset_key)
             child_partitions_subset = partition_mapping.get_downstream_partitions_for_partitions(
@@ -399,7 +399,7 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
                 dynamic_partitions_store=dynamic_partitions_store,
                 current_time=current_time,
             )
-            return ValidAssetSubset(child_asset_key, value=child_partitions_subset)
+            return ValidAssetSubset(asset_key=child_asset_key, value=child_partitions_subset)
 
     def get_children_partitions(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -226,7 +226,7 @@ def freshness_evaluation_results_for_asset_key(
         all_subset = AssetSubset.all(asset_key, None)
         return (
             AssetSubset.all(asset_key, None),
-            [AssetSubsetWithMetadata(all_subset, evaluation_data.metadata)],
+            [AssetSubsetWithMetadata(subset=all_subset, metadata=evaluation_data.metadata)],
         )
     else:
         return context.empty_subset(), []

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -983,8 +983,8 @@ class AssetDaemon(DagsterDaemon):
                 # asset keys for observation runs don't have evaluations
                 if asset_key in evaluations_by_asset_key:
                     evaluation = evaluations_by_asset_key[asset_key]
-                    evaluations_by_asset_key[asset_key] = evaluation._replace(
-                        run_ids=evaluation.run_ids | {submitted_run.run_id}
+                    evaluations_by_asset_key[asset_key] = evaluation.copy(
+                        update={"run_ids": evaluation.run_ids | {submitted_run.run_id}}
                     )
                     updated_evaluation_asset_keys.add(asset_key)
 

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -168,7 +168,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             value = self.asset_partition_has_materialization_or_observation(
                 AssetKeyPartitionKey(asset_key)
             )
-        return AssetSubset(asset_key, value)
+        return AssetSubset(asset_key=asset_key, value=value)
 
     ####################
     # ASSET RECORDS / STORAGE IDS
@@ -825,7 +825,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         partitions_def = self.asset_graph.get(asset_key).partitions_def
         if partitions_def is None:
             return ValidAssetSubset(
-                asset_key,
+                asset_key=asset_key,
                 value=self.asset_partition_has_materialization_or_observation(
                     AssetKeyPartitionKey(asset_key), after_cursor=after_cursor
                 ),

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -732,7 +732,9 @@ class TestScheduleStorage:
         if not self.can_store_auto_materialize_asset_evaluations():
             pytest.skip("Storage cannot store auto materialize asset evaluations")
 
-        condition_snapshot = AssetConditionSnapshot("foo", "bar", "")
+        condition_snapshot = AssetConditionSnapshot(
+            class_name="foo", description="bar", unique_id=""
+        )
 
         for _ in range(2):  # test idempotency
             storage.add_auto_materialize_asset_evaluations(
@@ -755,8 +757,8 @@ class TestScheduleStorage:
                         end_timestamp=1,
                         subsets_with_metadata=[
                             AssetSubsetWithMetadata(
-                                AssetSubset(asset_key=AssetKey("asset_two"), value=True),
-                                {"foo": MetadataValue.text("bar")},
+                                subset=AssetSubset(asset_key=AssetKey("asset_two"), value=True),
+                                metadata={"foo": MetadataValue.text("bar")},
                             )
                         ],
                         child_evaluations=[],
@@ -836,7 +838,9 @@ class TestScheduleStorage:
         # add a mix of keys - one that already is using the unique index and one that is not
 
         eval_one = AssetConditionEvaluation(
-            condition_snapshot=AssetConditionSnapshot("foo", "bar", ""),
+            condition_snapshot=AssetConditionSnapshot(
+                class_name="foo", description="bar", unique_id=""
+            ),
             start_timestamp=0,
             end_timestamp=1,
             true_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=True),
@@ -846,7 +850,9 @@ class TestScheduleStorage:
         ).with_run_ids(set())
 
         eval_asset_three = AssetConditionEvaluation(
-            condition_snapshot=AssetConditionSnapshot("foo", "bar", ""),
+            condition_snapshot=AssetConditionSnapshot(
+                class_name="foo", description="bar", unique_id=""
+            ),
             start_timestamp=0,
             end_timestamp=1,
             true_subset=AssetSubset(asset_key=AssetKey("asset_three"), value=True),
@@ -886,15 +892,20 @@ class TestScheduleStorage:
         subset = partitions_def.empty_subset().with_partition_keys(["a"])
         asset_subset = AssetSubset(asset_key=AssetKey("asset_two"), value=subset)
         asset_subset_with_metadata = AssetSubsetWithMetadata(
-            asset_subset,
-            {"foo": MetadataValue.text("bar"), "baz": MetadataValue.asset(AssetKey("asset_one"))},
+            subset=asset_subset,
+            metadata={
+                "foo": MetadataValue.text("bar"),
+                "baz": MetadataValue.asset(AssetKey("asset_one")),
+            },
         )
 
         storage.add_auto_materialize_asset_evaluations(
             evaluation_id=10,
             asset_evaluations=[
                 AssetConditionEvaluation(
-                    condition_snapshot=AssetConditionSnapshot("foo", "bar", ""),
+                    condition_snapshot=AssetConditionSnapshot(
+                        class_name="foo", description="bar", unique_id=""
+                    ),
                     start_timestamp=0,
                     end_timestamp=1,
                     true_subset=asset_subset,
@@ -928,7 +939,9 @@ class TestScheduleStorage:
             evaluation_id=11,
             asset_evaluations=[
                 AssetConditionEvaluation(
-                    condition_snapshot=AssetConditionSnapshot("foo", "bar", ""),
+                    condition_snapshot=AssetConditionSnapshot(
+                        class_name="foo", description="bar", unique_id=""
+                    ),
                     start_timestamp=0,
                     end_timestamp=1,
                     true_subset=AssetSubset(asset_key=AssetKey("asset_one"), value=True),

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_subset.py
@@ -132,9 +132,9 @@ def test_operations(
 )
 def test_serialization(value, use_valid_asset_subset) -> None:
     if use_valid_asset_subset:
-        asset_subset = ValidAssetSubset(AssetKey("foo"), value=value)
+        asset_subset = ValidAssetSubset(asset_key=AssetKey("foo"), value=value)
     else:
-        asset_subset = AssetSubset(AssetKey("foo"), value=value)
+        asset_subset = AssetSubset(asset_key=AssetKey("foo"), value=value)
 
     serialized_asset_subset = serialize_value(asset_subset)
     assert "ValidAssetSubset" not in serialized_asset_subset

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
@@ -26,6 +26,7 @@ from ..scenario_state import ScenarioState
 class FalseAssetCondition(AssetCondition):
     """Always returns the empty subset."""
 
+    @property
     def description(self) -> str:
         return ""
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario.py
@@ -446,7 +446,7 @@ class AssetDaemonScenarioState(ScenarioState):
                     leaf_eval.subsets_with_metadata
                     # backcompat as previously we stored None metadata for any true evaluation
                     or (
-                        [AssetSubsetWithMetadata(leaf_eval.true_subset, {})]
+                        [AssetSubsetWithMetadata(subset=leaf_eval.true_subset, metadata={})]
                         if leaf_eval.true_subset.size
                         else []
                     )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
@@ -17,8 +17,8 @@ custom_condition_scenarios = [
                 # not ((not missing) | (parent_updated)) ->
                 # it starts missing, and with no parents updated, so this evaluates to true
                 ~(
-                    ~RuleCondition(AutoMaterializeRule.materialize_on_missing())
-                    & RuleCondition(AutoMaterializeRule.materialize_on_parent_updated())
+                    ~RuleCondition(rule=AutoMaterializeRule.materialize_on_missing())
+                    & RuleCondition(rule=AutoMaterializeRule.materialize_on_parent_updated())
                 )
             )
         ),


### PR DESCRIPTION
## Summary & Motivation

This spiraled into a larger-than-expected effort for a couple reasons:

1. Pydantic does not support recursive models, which is a used across a few different AssetCondition-related things
2. Pydantic does not support fields with a NamedTuple type, which meant that I needed to update other dependent classes as well
3. Had to update a bunch of callsites where non-keyword args were being used
4. Stumbled on a weird bug with the dict() behavior 

## How I Tested These Changes
