### PR TITLE
[ui] Remove min size on second launchpad panel

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
@@ -839,7 +839,6 @@ const LaunchpadSession = (props: LaunchpadSessionProps) => {
             />
           </>
         }
-        secondMinSize={240}
       />
 
       <LaunchButtonContainer launchpadType={launchpadType}>


### PR DESCRIPTION
## Summary & Motivation

Remove the minimum size on the second panel of the Launchpad split panel, allowing the bottom panel (errors, etc) to be dragged all the way to zero.

It appears that some of our users are expecting to be able to hide this panel, so the minimum was reducing the amount of visible config editor space in undesirable ways.

https://github.com/dagster-io/dagster/assets/2823852/08f63bc9-456d-4114-a6aa-0b980f461cb0

## How I Tested These Changes

View Launchpad, drag the bottom panel to be essentially hidden. Verify that it can be dragged back into being visible.