### PR TITLE
[ui] Settings flag: Repair empty left space

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/App.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/App.tsx
@@ -23,7 +23,11 @@ export const App = ({banner, children}: Props) => {
   return (
     <Container>
       {flagSettingsPage ? null : <LeftNav />}
-      <Main $smallScreen={nav.isSmallScreen} $navOpen={nav.isOpen} onClick={onClickMain}>
+      <Main
+        $smallScreen={nav.isSmallScreen}
+        $navOpen={nav.isOpen && !flagSettingsPage}
+        onClick={onClickMain}
+      >
         <div>{banner}</div>
         <ChildContainer>{children}</ChildContainer>
       </Main>


### PR DESCRIPTION
## Summary & Motivation

I missed a spot for the removal of the left nav in the Settings flag, where we render the contents of the app with a left margin when the left nav is open.

## How I Tested These Changes

With the flag turned off, make the viewport wide, open the left nav. Turn on the Settings flag, verify that the left nav is gone and that there is no extra space to the left of the app contents.