### PR TITLE
[ui] Fix asset graph group padding in vertical layout with unsynced tag

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -85,8 +85,8 @@ export const Config = {
     nodesep: 40,
     edgesep: 10,
     nodeHeight: 'auto',
-    groupPaddingTop: 40,
-    groupPaddingBottom: -20,
+    groupPaddingTop: 55,
+    groupPaddingBottom: -5,
     groupRendering: 'if-varied',
   },
 };


### PR DESCRIPTION
## Summary & Motivation

This prevents an asset from overlapping with the top group header if the asset has an unsynced tag, and ensures assets with kind tags fit within the bottom border of the group box.

https://linear.app/dagster-labs/issue/FE-263/asset-node-exceedsoverlaps-with-bounds-of-group

## How I Tested These Changes
