### PR TITLE
[ui] Improve treatment of multiple run IDs in “in progress” banner

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/CurrentRunsBanner.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/CurrentRunsBanner.tsx
@@ -71,9 +71,11 @@ export const CurrentRunsBanner = ({
 };
 
 const RunIdLinks = ({ids}: {ids: string[]}) =>
-  ids.map((id, idx) => (
-    <Fragment key={id}>
-      <Link to={`/runs/${id}`}>{titleForRun({id})}</Link>
-      {idx < ids.length - 1 ? ', ' : ' '}
-    </Fragment>
-  ));
+  ids.length <= 4
+    ? ids.map((id, idx) => (
+        <Fragment key={id}>
+          <Link to={`/runs/${id}`}>{titleForRun({id})}</Link>
+          {idx < ids.length - 1 ? ', ' : ' '}
+        </Fragment>
+      ))
+    : '';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/CurrentRunsBanner.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/CurrentRunsBanner.tsx
@@ -47,6 +47,7 @@ export const CurrentRunsBanner = ({
                       Run <RunIdLinks ids={inProgressRunIds} /> is currently refreshing this asset.
                     </>
                   )}
+                  {inProgressRunIds.length && unstartedRunIds.length ? ' ' : ''}
                   {unstartedRunIds.length > 1 && (
                     <>
                       Runs <RunIdLinks ids={unstartedRunIds} /> have started and will refresh this

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/CurrentRunsBanner.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/CurrentRunsBanner.tsx
@@ -36,25 +36,26 @@ export const CurrentRunsBanner = ({
               icon={<Spinner purpose="body-text" />}
               title={
                 <div style={{fontWeight: 400}}>
-                  {inProgressRunIds.length > 0 && (
+                  {inProgressRunIds.length > 1 && (
                     <>
-                      {inProgressRunIds.map((id) => (
-                        <Fragment key={id}>
-                          Run <Link to={`/runs/${id}`}>{titleForRun({id})}</Link>
-                        </Fragment>
-                      ))}{' '}
-                      {inProgressRunIds.length === 1 ? 'is' : 'are'} currently refreshing this
+                      Runs <RunIdLinks ids={inProgressRunIds} /> are currently refreshing this
                       asset.
                     </>
                   )}
-                  {unstartedRunIds.length > 0 && (
+                  {inProgressRunIds.length === 1 && (
                     <>
-                      {unstartedRunIds.map((id) => (
-                        <Fragment key={id}>
-                          Run <Link to={`/runs/${id}`}>{titleForRun({id})}</Link>
-                        </Fragment>
-                      ))}{' '}
-                      {unstartedRunIds.length === 1 ? 'has' : 'have'} started and will refresh this
+                      Run <RunIdLinks ids={inProgressRunIds} /> is currently refreshing this asset.
+                    </>
+                  )}
+                  {unstartedRunIds.length > 1 && (
+                    <>
+                      Runs <RunIdLinks ids={unstartedRunIds} /> have started and will refresh this
+                      asset.
+                    </>
+                  )}
+                  {unstartedRunIds.length === 1 && (
+                    <>
+                      Run <RunIdLinks ids={unstartedRunIds} /> has started and will refresh this
                       asset.
                     </>
                   )}
@@ -68,3 +69,11 @@ export const CurrentRunsBanner = ({
     </>
   );
 };
+
+const RunIdLinks = ({ids}: {ids: string[]}) =>
+  ids.map((id, idx) => (
+    <Fragment key={id}>
+      <Link to={`/runs/${id}`}>{titleForRun({id})}</Link>
+      {idx < ids.length - 1 ? ', ' : ' '}
+    </Fragment>
+  ));


### PR DESCRIPTION
## Summary & Motivation

Old version:
![image](https://github.com/dagster-io/dagster/assets/1037212/8a4b7542-4b80-401f-9f14-6f614b13cb31)


New version:

<img width="1055" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/54903f63-0559-479a-87a6-018e5b62cc71">


## How I Tested These Changes
