### PR TITLE
[dagster-embedded-elt][dlt] support usage of DagsterDltResource from ops

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
@@ -144,6 +144,24 @@ class DagsterDltResource(ConfigurableResource):
             for dlt_source_resource in dlt_source.resources.values()
         }
 
+        # Filter sources by asset key sub-selection
+        if context.is_subset:
+            asset_key_dlt_source_resource_mapping = {
+                asset_key: asset_dlt_source_resource
+                for (
+                    asset_key,
+                    asset_dlt_source_resource,
+                ) in asset_key_dlt_source_resource_mapping.items()
+                if asset_key in context.selected_asset_keys
+            }
+            dlt_source = dlt_source.with_resources(
+                *[
+                    dlt_source_resource.name
+                    for dlt_source_resource in asset_key_dlt_source_resource_mapping.values()
+                    if dlt_source_resource
+                ]
+            )
+
         load_info = dlt_pipeline.run(dlt_source, **kwargs)
 
         has_asset_def: bool = bool(context and context.has_assets_def)

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
@@ -130,13 +130,12 @@ class DagsterDltResource(ConfigurableResource):
                 first_asset_metadata.get(META_KEY_TRANSLATOR), DagsterDltTranslator
             )
 
-        else:
-            dlt_source = check.not_none(
-                dlt_source, "dlt_source is a required parameter in an op context"
-            )
-            dlt_pipeline = check.not_none(
-                dlt_pipeline, "dlt_pipeline is a required parameter in an op context"
-            )
+        dlt_source = check.not_none(
+            dlt_source, "dlt_source is a required parameter in an op context"
+        )
+        dlt_pipeline = check.not_none(
+            dlt_pipeline, "dlt_pipeline is a required parameter in an op context"
+        )
 
         # Default to base translator if undefined
         dagster_dlt_translator = dagster_dlt_translator or DagsterDltTranslator()

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
@@ -1,4 +1,4 @@
-from typing import Any, Generator, Mapping, Optional, Union
+from typing import Any, Iterator, Mapping, Optional, Union
 
 from dagster import (
     AssetExecutionContext,
@@ -103,7 +103,7 @@ class DagsterDltResource(ConfigurableResource):
         dlt_pipeline: Optional[Pipeline] = None,
         dagster_dlt_translator: Optional[DagsterDltTranslator] = None,
         **kwargs,
-    ) -> Generator[Union[MaterializeResult, AssetMaterialization], None, None]:
+    ) -> Iterator[Union[MaterializeResult, AssetMaterialization]]:
         """Runs the dlt pipeline with subset support.
 
         Args:
@@ -114,7 +114,7 @@ class DagsterDltResource(ConfigurableResource):
             **kwargs (dict[str, Any]): Keyword args passed to pipeline `run` method
 
         Returns:
-            Generator[Union[MaterializeResult, AssetMaterialization], None, None]: A generator of MaterializeResult or AssetMaterialization
+            Iterator[Union[MaterializeResult, AssetMaterialization]]: An iterator of MaterializeResult or AssetMaterialization
 
         """
         # This resource can be used in both `asset` and `op` definitions. In the context of an asset

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
@@ -131,10 +131,12 @@ class DagsterDltResource(ConfigurableResource):
             )
 
         else:
-            if dlt_source is None or dlt_pipeline is None:
-                raise ValueError(
-                    "dlt_source, and dlt_pipeline parameters must be provided in an `op` context"
-                )
+            dlt_source = check.not_none(
+                dlt_source, "dlt_source is a required parameter in an op context"
+            )
+            dlt_pipeline = check.not_none(
+                dlt_pipeline, "dlt_pipeline is a required parameter in an op context"
+            )
 
         # Default to base translator if undefined
         dagster_dlt_translator = dagster_dlt_translator or DagsterDltTranslator()

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_op.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_op.py
@@ -1,0 +1,39 @@
+import dlt
+import duckdb
+from dagster import OpExecutionContext, job, op
+from dagster_embedded_elt.dlt import DagsterDltResource
+
+from .dlt_test_sources.duckdb_with_transformer import pipeline
+
+EXAMPLE_PIPELINE_DUCKDB = "example_pipeline.duckdb"
+
+
+def test_base_dlt_op():
+    @op(out={})
+    def my_dlt_op_yield_events(context: OpExecutionContext, dlt_resource: DagsterDltResource):
+        yield from dlt_resource.run(
+            context=context,
+            dlt_source=pipeline(),
+            dlt_pipeline=dlt.pipeline(
+                pipeline_name="example_pipeline",
+                dataset_name="example",
+                destination="duckdb",
+            ),
+        )
+
+    @job
+    def my_dlt_op_yield_events_job():
+        my_dlt_op_yield_events()
+
+    res = my_dlt_op_yield_events_job.execute_in_process(
+        resources={"dlt_resource": DagsterDltResource()}
+    )
+    assert res.success
+    assert len(res.get_asset_materialization_events()) == 2
+
+    with duckdb.connect(database=EXAMPLE_PIPELINE_DUCKDB, read_only=True) as conn:
+        row = conn.execute("select count(*) from example.repos").fetchone()
+        assert row and row[0] == 3
+
+        row = conn.execute("select count(*) from example.repo_issues").fetchone()
+        assert row and row[0] == 7


### PR DESCRIPTION
## Summary & Motivation

Support the ability of using the _dlt_ integration from an `@op`; see similar implementation for Sling below:

- https://github.com/dagster-io/dagster/pull/20564/files#diff-7fd29d4a7e3c4781fd2b55054095105ac002207d0daaa593e76ff192fecaaab9R8-R40

If running from an op context the dlt source, pipeline, and translator are retrieved from the `run` function parameters, otherwise they are taken from the Asset metadata.

## How I Tested These Changes

- Introduced unit test
