### PR TITLE
[fully featured] pin snowflake-sqlalchemy

### DIFF
--- a/examples/project_fully_featured/setup.py
+++ b/examples/project_fully_featured/setup.py
@@ -36,7 +36,7 @@ setup(
         "scipy",
         "scikit-learn",
         "sqlalchemy!=1.4.42",  # workaround for https://github.com/snowflakedb/snowflake-sqlalchemy/issues/350
-        "snowflake-sqlalchemy",
+        "snowflake-sqlalchemy<1.5.2",
     ],
     extras_require={"dev": ["dagster-webserver", "pytest"], "tests": ["mypy", "pylint", "pytest"]},
 )


### PR DESCRIPTION
```
ImportError: cannot import name 'string_types' from 'sqlalchemy.util.compat'
```
in the most recent release

## How I Tested These Changes

bk