### PR TITLE
[ui] Materialize unsynced should never include source assets

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/CalculateUnsyncedDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/CalculateUnsyncedDialog.tsx
@@ -55,7 +55,7 @@ export const CalculateUnsyncedDialog = React.memo(
     const unsynced = React.useMemo(
       () =>
         (data?.assetNodes || [])
-          .filter((node) => isAssetStale(node) || isAssetMissing(node))
+          .filter((node) => !node.isSource && (isAssetStale(node) || isAssetMissing(node)))
           .map(asAssetKeyInput),
       [data],
     );
@@ -208,6 +208,7 @@ const ASSET_STALE_STATUS_QUERY = gql`
       assetKey {
         path
       }
+      isSource
       staleStatus
       partitionStats {
         numMaterialized

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/CalculateUnsyncedDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/CalculateUnsyncedDialog.types.ts
@@ -11,6 +11,7 @@ export type AssetStaleStatusQuery = {
   assetNodes: Array<{
     __typename: 'AssetNode';
     id: string;
+    isSource: boolean;
     staleStatus: Types.StaleStatus | null;
     assetKey: {__typename: 'AssetKey'; path: Array<string>};
     partitionStats: {


### PR DESCRIPTION
## Summary & Motivation

This is a quick fix for https://github.com/dagster-io/dagster/issues/21040

## How I Tested These Changes

Verify that partitioned source assets no longer qualify as "unsynced" because they have partitionStats