### PR TITLE
Combine two asset records fetches in AssetsGraphLiveQuery into a single query

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -26,6 +26,8 @@ from dagster._core.storage.tags import TagType, get_tag_type
 from .external import ensure_valid_config, get_external_job_or_raise
 
 if TYPE_CHECKING:
+    from dagster._core.workspace.batch_asset_record_loader import BatchAssetRecordLoader
+
     from ..schema.asset_graph import GrapheneAssetLatestInfo
     from ..schema.errors import GrapheneRunNotFoundError
     from ..schema.execution import GrapheneExecutionPlan
@@ -158,7 +160,9 @@ IN_PROGRESS_STATUSES = [
 
 
 def get_assets_latest_info(
-    graphene_info: "ResolveInfo", step_keys_by_asset: Mapping[AssetKey, Sequence[str]]
+    graphene_info: "ResolveInfo",
+    step_keys_by_asset: Mapping[AssetKey, Sequence[str]],
+    asset_record_loader: "BatchAssetRecordLoader",
 ) -> Sequence["GrapheneAssetLatestInfo"]:
     from dagster_graphql.implementation.fetch_assets import get_asset_nodes_by_asset_key
 
@@ -175,7 +179,7 @@ def get_assets_latest_info(
 
     asset_nodes = get_asset_nodes_by_asset_key(graphene_info, asset_keys)
 
-    asset_records = instance.get_asset_records(asset_keys)
+    asset_records = asset_record_loader.get_asset_records(asset_keys)
 
     latest_materialization_by_asset = {
         asset_record.asset_entry.asset_key: (

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from enum import Enum
 from functools import lru_cache
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 from dagster import (
     DagsterInstance,
@@ -10,7 +10,6 @@ from dagster import (
 from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.data_version import CachingStaleStatusResolver
 from dagster._core.definitions.events import AssetKey
-from dagster._core.events.log import EventLogEntry
 from dagster._core.remote_representation import ExternalRepository
 from dagster._core.remote_representation.external_data import (
     ExternalAssetDependedBy,
@@ -19,7 +18,6 @@ from dagster._core.remote_representation.external_data import (
 )
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorType
 from dagster._core.storage.dagster_run import RunRecord, RunsFilter
-from dagster._core.storage.event_log.base import AssetRecord
 from dagster._core.workspace.context import WorkspaceRequestContext
 
 
@@ -179,46 +177,6 @@ class BatchRunLoader:
         records = self._instance.get_run_records(RunsFilter(run_ids=list(self._run_ids)))
         for record in records:
             self._records[record.dagster_run.run_id] = record
-
-
-class BatchAssetRecordLoader:
-    """A batch loader that fetches asset records.  This loader is expected to be
-    instantiated with a set of asset keys.
-    """
-
-    def __init__(self, instance: DagsterInstance, asset_keys: Iterable[AssetKey]):
-        self._instance = instance
-        self._asset_keys: List[AssetKey] = list(asset_keys)
-        self._fetched = False
-        self._asset_records: Mapping[AssetKey, Optional[AssetRecord]] = {}
-
-    def get_asset_record(self, asset_key: AssetKey) -> Optional[AssetRecord]:
-        if asset_key not in self._asset_keys:
-            check.failed(
-                f"Asset key {asset_key} not recognized for this loader.  Expected one of:"
-                f" {self._asset_keys}"
-            )
-
-        if not self._fetched:
-            self._fetch()
-
-        return self._asset_records.get(asset_key)
-
-    def get_latest_materialization_for_asset_key(
-        self, asset_key: AssetKey
-    ) -> Optional[EventLogEntry]:
-        asset_record = self.get_asset_record(asset_key)
-        if not asset_record:
-            return None
-
-        return asset_record.asset_entry.last_materialization
-
-    def _fetch(self) -> None:
-        self._fetched = True
-        self._asset_records = {
-            record.asset_entry.asset_key: record
-            for record in self._instance.get_asset_records(self._asset_keys)
-        }
 
 
 class CrossRepoAssetDependedByLoader:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -34,6 +34,7 @@ from dagster._core.remote_representation.external_data import (
 )
 from dagster._core.snap.node import GraphDefSnap, OpDefSnap
 from dagster._core.utils import is_valid_email
+from dagster._core.workspace.batch_asset_record_loader import BatchAssetRecordLoader
 from dagster._core.workspace.permissions import Permissions
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
@@ -69,7 +70,6 @@ from ..implementation.fetch_assets import (
     get_partition_subsets,
 )
 from ..implementation.loader import (
-    BatchAssetRecordLoader,
     CrossRepoAssetDependedByLoader,
     StaleStatusLoader,
 )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -92,7 +92,6 @@ from ...implementation.fetch_sensors import get_sensor_or_error, get_sensors_or_
 from ...implementation.fetch_solids import get_graph_or_error
 from ...implementation.fetch_ticks import get_instigation_ticks
 from ...implementation.loader import (
-    BatchAssetRecordLoader,
     CrossRepoAssetDependedByLoader,
     StaleStatusLoader,
 )
@@ -939,10 +938,8 @@ class GrapheneQuery(graphene.ObjectType):
         if not results:
             return []
 
-        asset_record_loader = BatchAssetRecordLoader(
-            instance=graphene_info.context.instance,
-            asset_keys=[node.assetKey for node in results],
-        )
+        asset_record_loader = graphene_info.context.asset_record_loader
+        asset_record_loader.add_asset_keys([node.assetKey for node in results])
         asset_checks_loader = AssetChecksLoader(
             context=graphene_info.context,
             asset_keys=[node.assetKey for node in results],
@@ -1075,7 +1072,10 @@ class GrapheneQuery(graphene.ObjectType):
             if node.assetKey in asset_keys
         }
 
-        return get_assets_latest_info(graphene_info, step_keys_by_asset)
+        asset_record_loader = graphene_info.context.asset_record_loader
+        asset_record_loader.add_asset_keys(asset_keys)
+
+        return get_assets_latest_info(graphene_info, step_keys_by_asset, asset_record_loader)
 
     @capture_error
     def resolve_logsForRun(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -1716,6 +1716,8 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         assert result["asset_1"]["latestRun"] is None
         assert result["asset_1"]["latestMaterialization"] is None
 
+        graphql_context.asset_record_loader.clear_cache()
+
         # Test with 1 run on all assets
         first_run_id = _create_run(graphql_context, "failure_assets_job")
 
@@ -1733,6 +1735,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
 
         assert result.data
         assert result.data["assetsLatestInfo"]
+
         result = get_response_by_asset(result.data["assetsLatestInfo"])
 
         assert result["asset_1"]["latestRun"]["id"] == first_run_id
@@ -1741,6 +1744,8 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         assert result["asset_2"]["latestMaterialization"] is None
         assert result["asset_3"]["latestRun"]["id"] == first_run_id
         assert result["asset_3"]["latestMaterialization"] is None
+
+        graphql_context.asset_record_loader.clear_cache()
 
         # Confirm that asset selection is respected
         run_id = _create_run(

--- a/python_modules/dagster/dagster/_core/workspace/batch_asset_record_loader.py
+++ b/python_modules/dagster/dagster/_core/workspace/batch_asset_record_loader.py
@@ -1,0 +1,69 @@
+from typing import Iterable, Mapping, Optional, Sequence, Set
+
+from dagster import (
+    DagsterInstance,
+    _check as check,
+)
+from dagster._core.definitions.events import AssetKey
+from dagster._core.events.log import EventLogEntry
+from dagster._core.storage.event_log.base import AssetRecord
+
+
+class BatchAssetRecordLoader:
+    """A batch loader that fetches asset records.  This loader is expected to be
+    instantiated with a set of asset keys.
+    """
+
+    def __init__(self, instance: DagsterInstance, asset_keys: Iterable[AssetKey]):
+        self._instance = instance
+        self._unfetched_asset_keys: Set[AssetKey] = set(asset_keys)
+        self._asset_records: Mapping[AssetKey, Optional[AssetRecord]] = {}
+
+    def add_asset_keys(self, asset_keys: Iterable[AssetKey]):
+        unfetched_asset_keys = set(asset_keys).difference(self._asset_records.keys())
+        self._unfetched_asset_keys = self._unfetched_asset_keys.union(unfetched_asset_keys)
+
+    def get_asset_record(self, asset_key: AssetKey) -> Optional[AssetRecord]:
+        if asset_key not in self._asset_records and asset_key not in self._unfetched_asset_keys:
+            check.failed(
+                f"Asset key {asset_key} not recognized for this loader. Expected one of:"
+                f" {self._unfetched_asset_keys.union(self._asset_records.keys())}"
+            )
+
+        if asset_key in self._unfetched_asset_keys:
+            self._fetch()
+
+        return self._asset_records.get(asset_key)
+
+    def clear_cache(self):
+        """For use in tests."""
+        self._unfetched_asset_keys = self._unfetched_asset_keys.union(self._asset_records.keys())
+        self._asset_records = {}
+
+    def get_asset_records(self, asset_keys: Sequence[AssetKey]) -> Sequence[AssetRecord]:
+        records = [self.get_asset_record(asset_key) for asset_key in asset_keys]
+        return [record for record in records if record]
+
+    def get_latest_materialization_for_asset_key(
+        self, asset_key: AssetKey
+    ) -> Optional[EventLogEntry]:
+        asset_record = self.get_asset_record(asset_key)
+        if not asset_record:
+            return None
+
+        return asset_record.asset_entry.last_materialization
+
+    def _fetch(self) -> None:
+        if not self._unfetched_asset_keys:
+            return
+
+        new_records = {
+            record.asset_entry.asset_key: record
+            for record in self._instance.get_asset_records(list(self._unfetched_asset_keys))
+        }
+
+        self._asset_records = {
+            **self._asset_records,
+            **{asset_key: new_records.get(asset_key) for asset_key in self._unfetched_asset_keys},
+        }
+        self._unfetched_asset_keys = set()

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -41,6 +41,7 @@ from dagster._core.remote_representation.origin import (
 )
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
+from .batch_asset_record_loader import BatchAssetRecordLoader
 from .load_target import WorkspaceLoadTarget
 from .permissions import (
     PermissionResult,
@@ -311,6 +312,11 @@ class BaseWorkspaceRequestContext(IWorkspace):
     def get_base_deployment_context(self) -> Optional["BaseWorkspaceRequestContext"]:
         return None
 
+    @property
+    @abstractmethod
+    def asset_record_loader(self) -> BatchAssetRecordLoader:
+        pass
+
 
 class WorkspaceRequestContext(BaseWorkspaceRequestContext):
     def __init__(
@@ -333,6 +339,12 @@ class WorkspaceRequestContext(BaseWorkspaceRequestContext):
             read_only_locations, "read_only_locations"
         )
         self._checked_permissions: Set[str] = set()
+
+        self._asset_record_loader = BatchAssetRecordLoader(self._instance, {})
+
+    @property
+    def asset_record_loader(self) -> BatchAssetRecordLoader:
+        return self._asset_record_loader
 
     @property
     def instance(self) -> DagsterInstance:

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_events.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_events.py
@@ -1,3 +1,4 @@
+import pytest
 from dagster import (
     AssetKey,
     AssetObservation,
@@ -16,6 +17,8 @@ from dagster._core.events import DagsterEventType
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.input_manager import input_manager
 from dagster._core.storage.io_manager import IOManager
+from dagster._core.test_utils import instance_for_test
+from dagster._core.workspace.batch_asset_record_loader import BatchAssetRecordLoader
 
 
 def n_asset_keys(path, n):
@@ -174,3 +177,56 @@ def test_asset_materialization_accessors():
         assert len(records) == 1
         assert records[0].event_log_entry
         assert records[0].event_log_entry.asset_materialization is None
+
+
+def test_batch_asset_records_loader():
+    @asset
+    def return_one():
+        return 1
+
+    @asset
+    def return_two():
+        return 2
+
+    with instance_for_test() as instance:
+        defs = Definitions(assets=[return_one, return_two])
+        defs.get_implicit_global_asset_job_def().execute_in_process(instance=instance)
+
+        asset_records_loader = BatchAssetRecordLoader(instance, asset_keys={return_two.key})
+
+        fake_key = AssetKey(path=["fake_key"])
+
+        assert asset_records_loader._unfetched_asset_keys == {return_two.key}  # noqa
+        assert asset_records_loader._asset_records == {}  # noqa
+
+        assert (
+            asset_records_loader.get_asset_record(return_two.key).asset_entry.asset_key
+            == return_two.key
+        )
+
+        assert asset_records_loader._unfetched_asset_keys == set()  # noqa
+        assert len(asset_records_loader._asset_records) == 1  # noqa
+
+        with pytest.raises(Exception, match="not recognized for this loader"):
+            asset_records_loader.get_asset_record(return_one.key)
+
+        with pytest.raises(Exception, match="not recognized for this loader"):
+            asset_records_loader.get_asset_record(fake_key)
+
+        asset_records_loader.add_asset_keys({return_one.key, return_two.key, fake_key})
+
+        assert asset_records_loader._unfetched_asset_keys == {return_one.key, fake_key}  # noqa
+
+        assert (
+            asset_records_loader.get_asset_record(return_two.key).asset_entry.asset_key
+            == return_two.key
+        )
+        assert (
+            asset_records_loader.get_asset_record(return_one.key).asset_entry.asset_key
+            == return_one.key
+        )
+
+        assert asset_records_loader.get_asset_record(fake_key) is None
+
+        assert asset_records_loader._unfetched_asset_keys == set()  # noqa
+        assert len(asset_records_loader._asset_records) == 3  # noqa


### PR DESCRIPTION
Summary:
AssetsGraphLiveQuery currently fetches the set of asset records for the passed in asset keys twice - once in assetNodes and once in assetsLatestInfo. Use the batch loader class to ensure that that cost is only paid once per query.

Test Plan:
Profile an AssetGraphLiveQuery, see only one db query for get_asset_records now

## Summary & Motivation

## How I Tested These Changes
