### PR TITLE
Fetch staleStatus separately in AssetGraphLiveQuery

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetBaseDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetBaseDataProvider.tsx
@@ -1,0 +1,164 @@
+import {ApolloClient, gql, useApolloClient} from '@apollo/client';
+import React from 'react';
+
+import {
+  AssetGraphLiveQuery,
+  AssetGraphLiveQueryVariables,
+} from './types/AssetBaseDataProvider.types';
+import {buildLiveDataForNode, tokenForAssetKey, tokenToAssetKey} from '../asset-graph/Utils';
+import {AssetKeyInput} from '../graphql/types';
+import {liveDataFactory} from '../live-data-provider/Factory';
+import {LiveDataThreadID} from '../live-data-provider/LiveDataThread';
+
+function init() {
+  return liveDataFactory(
+    () => {
+      return useApolloClient();
+    },
+    async (keys, client: ApolloClient<any>) => {
+      const {data} = await client.query<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>({
+        query: ASSETS_GRAPH_LIVE_QUERY,
+        fetchPolicy: 'network-only',
+        variables: {
+          assetKeys: keys.map(tokenToAssetKey),
+        },
+      });
+      const nodesByKey = Object.fromEntries(
+        data.assetNodes.map((node) => [tokenForAssetKey(node.assetKey), node]),
+      );
+
+      const liveDataByKey = Object.fromEntries(
+        data.assetsLatestInfo.map((assetLatestInfo) => {
+          const id = tokenForAssetKey(assetLatestInfo.assetKey);
+          return [id, buildLiveDataForNode(nodesByKey[id]!, assetLatestInfo)];
+        }),
+      );
+      return liveDataByKey;
+    },
+  );
+}
+export const AssetBaseData = init();
+
+export function useAssetBaseData(assetKey: AssetKeyInput, thread: LiveDataThreadID = 'default') {
+  return AssetBaseData.useLiveDataSingle(tokenForAssetKey(assetKey), thread);
+}
+
+export function useAssetsBaseData(
+  assetKeys: AssetKeyInput[],
+  thread: LiveDataThreadID = 'default',
+) {
+  return AssetBaseData.useLiveData(
+    React.useMemo(() => assetKeys.map((key) => tokenForAssetKey(key)), [assetKeys]),
+    thread,
+  );
+}
+
+export function AssetBaseDataRefreshButton() {
+  return <AssetBaseData.LiveDataRefresh />;
+}
+
+export const ASSET_LATEST_INFO_FRAGMENT = gql`
+  fragment AssetLatestInfoFragment on AssetLatestInfo {
+    id
+    assetKey {
+      path
+    }
+    unstartedRunIds
+    inProgressRunIds
+    latestRun {
+      id
+      ...AssetLatestInfoRun
+    }
+  }
+
+  fragment AssetLatestInfoRun on Run {
+    status
+    endTime
+    id
+  }
+`;
+
+export const ASSET_NODE_LIVE_FRAGMENT = gql`
+  fragment AssetNodeLiveFragment on AssetNode {
+    id
+    opNames
+    repository {
+      id
+    }
+    assetKey {
+      path
+    }
+    assetMaterializations(limit: 1) {
+      ...AssetNodeLiveMaterialization
+    }
+    assetObservations(limit: 1) {
+      ...AssetNodeLiveObservation
+    }
+    assetChecksOrError {
+      ... on AssetChecks {
+        checks {
+          ...AssetCheckLiveFragment
+        }
+      }
+    }
+    freshnessInfo {
+      ...AssetNodeLiveFreshnessInfo
+    }
+    partitionStats {
+      numMaterialized
+      numMaterializing
+      numPartitions
+      numFailed
+    }
+  }
+
+  fragment AssetNodeLiveFreshnessInfo on AssetFreshnessInfo {
+    currentMinutesLate
+  }
+
+  fragment AssetNodeLiveMaterialization on MaterializationEvent {
+    timestamp
+    runId
+  }
+
+  fragment AssetNodeLiveObservation on ObservationEvent {
+    timestamp
+    runId
+  }
+
+  fragment AssetCheckLiveFragment on AssetCheck {
+    name
+    canExecuteIndividually
+    executionForLatestMaterialization {
+      id
+      runId
+      status
+      timestamp
+      stepKey
+      evaluation {
+        severity
+      }
+    }
+  }
+`;
+
+export const ASSETS_GRAPH_LIVE_QUERY = gql`
+  query AssetGraphLiveQuery($assetKeys: [AssetKeyInput!]!) {
+    assetNodes(assetKeys: $assetKeys, loadMaterializations: true) {
+      id
+      ...AssetNodeLiveFragment
+    }
+    assetsLatestInfo(assetKeys: $assetKeys) {
+      id
+      ...AssetLatestInfoFragment
+    }
+  }
+
+  ${ASSET_NODE_LIVE_FRAGMENT}
+  ${ASSET_LATEST_INFO_FRAGMENT}
+`;
+
+// For tests
+export function __resetForJest() {
+  Object.assign(AssetBaseData, init());
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -147,6 +147,7 @@ export const AssetLiveDataProvider = ({children}: {children: React.ReactNode}) =
         )
       ) {
         AssetBaseData.manager.invalidateCache();
+        AssetStaleStatusData.manager.invalidateCache();
       }
     });
     return unobserve;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -1,92 +1,130 @@
-import {ApolloClient, gql, useApolloClient} from '@apollo/client';
 import uniq from 'lodash/uniq';
-import React from 'react';
+import React, {useCallback, useMemo, useRef} from 'react';
 
+import {AssetBaseData, __resetForJest as __resetBaseData} from './AssetBaseDataProvider';
 import {
-  AssetGraphLiveQuery,
-  AssetGraphLiveQueryVariables,
-} from './types/AssetLiveDataProvider.types';
+  AssetStaleStatusData,
+  __resetForJest as __resetStaleData,
+} from './AssetStaleStatusDataProvider';
 import {SUBSCRIPTION_MAX_POLL_RATE} from './util';
 import {observeAssetEventsInRuns} from '../asset-graph/AssetRunLogObserver';
-import {
-  LiveDataForNode,
-  buildLiveDataForNode,
-  tokenForAssetKey,
-  tokenToAssetKey,
-} from '../asset-graph/Utils';
+import {LiveDataForNodeWithStaleData, tokenForAssetKey} from '../asset-graph/Utils';
 import {AssetKeyInput} from '../graphql/types';
-import {liveDataFactory} from '../live-data-provider/Factory';
 import {LiveDataPollRateContext} from '../live-data-provider/LiveDataProvider';
 import {LiveDataThreadID} from '../live-data-provider/LiveDataThread';
 import {useDidLaunchEvent} from '../runs/RunUtils';
 
-function makeFactory() {
-  return liveDataFactory(
-    () => {
-      return useApolloClient();
-    },
-    async (keys, client: ApolloClient<any>) => {
-      const {data} = await client.query<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>({
-        query: ASSETS_GRAPH_LIVE_QUERY,
-        fetchPolicy: 'network-only',
-        variables: {
-          assetKeys: keys.map(tokenToAssetKey),
-        },
-      });
-      const nodesByKey = Object.fromEntries(
-        data.assetNodes.map((node) => [tokenForAssetKey(node.assetKey), node]),
-      );
-
-      const liveDataByKey = Object.fromEntries(
-        data.assetsLatestInfo.map((assetLatestInfo) => {
-          const id = tokenForAssetKey(assetLatestInfo.assetKey);
-          return [id, buildLiveDataForNode(nodesByKey[id]!, assetLatestInfo)];
-        }),
-      );
-      return liveDataByKey;
-    },
-  );
-}
-export const factory = makeFactory();
-
 export function useAssetLiveData(assetKey: AssetKeyInput, thread: LiveDataThreadID = 'default') {
-  return factory.useLiveDataSingle(tokenForAssetKey(assetKey), thread);
+  const key = tokenForAssetKey(assetKey);
+  const {
+    liveData: staleData,
+    refresh: refreshStaleData,
+    refreshing: staleDataRefreshing,
+  } = AssetStaleStatusData.useLiveDataSingle(key, thread);
+  const {
+    liveData: baseData,
+    refresh: refreshBaseData,
+    refreshing: baseDataRefreshing,
+  } = AssetBaseData.useLiveDataSingle(key, thread);
+
+  const refresh = useCallback(() => {
+    refreshBaseData();
+    refreshStaleData();
+  }, [refreshBaseData, refreshStaleData]);
+  const refreshing = baseDataRefreshing || staleDataRefreshing;
+
+  if (baseData && staleData) {
+    return {
+      liveData: {
+        ...staleData,
+        ...baseData,
+      },
+      refresh,
+      refreshing,
+    };
+  }
+  return {liveData: undefined, refresh, refreshing};
 }
 
 export function useAssetsLiveData(
   assetKeys: AssetKeyInput[],
   thread: LiveDataThreadID = 'default',
 ) {
-  return factory.useLiveData(
-    React.useMemo(() => assetKeys.map((key) => tokenForAssetKey(key)), [assetKeys]),
-    thread,
-  );
+  const keys = React.useMemo(() => assetKeys.map((key) => tokenForAssetKey(key)), [assetKeys]);
+  const {
+    liveDataByNode: staleDataByNode,
+    refresh: refreshStaleData,
+    refreshing: staleDataRefreshing,
+  } = AssetStaleStatusData.useLiveData(keys, thread);
+  const {
+    liveDataByNode: baseDataByNode,
+    refresh: refreshBaseData,
+    refreshing: baseDataRefreshing,
+  } = AssetBaseData.useLiveData(keys, thread);
+  const completeDataByNode = useMemo(() => {
+    const data: Record<string, LiveDataForNodeWithStaleData> = {};
+    Object.keys(baseDataByNode).forEach((key) => {
+      if (staleDataByNode[key] && baseDataByNode[key]) {
+        data[key] = {
+          ...staleDataByNode[key],
+          ...baseDataByNode[key],
+        };
+      }
+    });
+    return data;
+  }, [baseDataByNode, staleDataByNode]);
+  const refresh = useCallback(() => {
+    refreshBaseData();
+    refreshStaleData();
+  }, [refreshBaseData, refreshStaleData]);
+  const refreshing = baseDataRefreshing || staleDataRefreshing;
+
+  return {
+    liveDataByNode: completeDataByNode,
+    refresh,
+    refreshing,
+  };
 }
 
 export const AssetLiveDataProvider = ({children}: {children: React.ReactNode}) => {
   const [allObservedKeys, setAllObservedKeys] = React.useState<AssetKeyInput[]>([]);
 
+  const staleKeysObserved = useRef<string[]>([]);
+  const baseKeysObserved = useRef<string[]>([]);
+
   React.useEffect(() => {
-    factory.manager.setOnSubscriptionsChangedCallback((keys) =>
-      setAllObservedKeys(keys.map((key) => ({path: key.split('/')}))),
-    );
+    const onSubscriptionsChanged = () => {
+      const keys = Array.from(new Set(...staleKeysObserved.current, ...baseKeysObserved.current));
+      setAllObservedKeys(keys.map((key) => ({path: key.split('/')})));
+    };
+
+    AssetStaleStatusData.manager.setOnSubscriptionsChangedCallback((keys) => {
+      staleKeysObserved.current = keys;
+      onSubscriptionsChanged();
+    });
+    AssetBaseData.manager.setOnSubscriptionsChangedCallback((keys) => {
+      baseKeysObserved.current = keys;
+      onSubscriptionsChanged();
+    });
   }, []);
 
   const pollRate = React.useContext(LiveDataPollRateContext);
 
   React.useEffect(() => {
-    factory.manager.setPollRate(pollRate);
+    AssetStaleStatusData.manager.setPollRate(pollRate);
+    AssetBaseData.manager.setPollRate(pollRate);
   }, [pollRate]);
 
   useDidLaunchEvent(() => {
-    factory.manager.invalidateCache();
+    AssetStaleStatusData.manager.invalidateCache();
+    AssetBaseData.manager.invalidateCache();
   }, SUBSCRIPTION_MAX_POLL_RATE);
 
   React.useEffect(() => {
     const assetKeyTokens = new Set(allObservedKeys.map(tokenForAssetKey));
     const dataForObservedKeys = allObservedKeys
-      .map((key) => factory.manager.getCacheEntry(tokenForAssetKey(key)))
-      .filter((n) => n) as LiveDataForNode[];
+      .map((key) => AssetBaseData.manager.getCacheEntry(tokenForAssetKey(key))!)
+      .filter((n) => n);
 
     const assetStepKeys = new Set(dataForObservedKeys.flatMap((n) => n.opNames));
 
@@ -109,132 +147,24 @@ export const AssetLiveDataProvider = ({children}: {children: React.ReactNode}) =
             (e.stepKey && assetStepKeys.has(e.stepKey)),
         )
       ) {
-        factory.manager.invalidateCache();
+        AssetBaseData.manager.invalidateCache();
       }
     });
     return unobserve;
   }, [allObservedKeys]);
 
-  return <factory.LiveDataProvider>{children}</factory.LiveDataProvider>;
+  return (
+    <AssetBaseData.LiveDataProvider>
+      <AssetStaleStatusData.LiveDataProvider>{children}</AssetStaleStatusData.LiveDataProvider>
+    </AssetBaseData.LiveDataProvider>
+  );
 };
 
 export function AssetLiveDataRefreshButton() {
-  return <factory.LiveDataRefresh />;
+  return <AssetBaseData.LiveDataRefresh />;
 }
 
-export const ASSET_LATEST_INFO_FRAGMENT = gql`
-  fragment AssetLatestInfoFragment on AssetLatestInfo {
-    id
-    assetKey {
-      path
-    }
-    unstartedRunIds
-    inProgressRunIds
-    latestRun {
-      id
-      ...AssetLatestInfoRun
-    }
-  }
-
-  fragment AssetLatestInfoRun on Run {
-    status
-    endTime
-    id
-  }
-`;
-
-export const ASSET_NODE_LIVE_FRAGMENT = gql`
-  fragment AssetNodeLiveFragment on AssetNode {
-    id
-    opNames
-    repository {
-      id
-    }
-    assetKey {
-      path
-    }
-    assetMaterializations(limit: 1) {
-      ...AssetNodeLiveMaterialization
-    }
-    assetObservations(limit: 1) {
-      ...AssetNodeLiveObservation
-    }
-    assetChecksOrError {
-      ... on AssetChecks {
-        checks {
-          ...AssetCheckLiveFragment
-        }
-      }
-    }
-    freshnessInfo {
-      ...AssetNodeLiveFreshnessInfo
-    }
-    staleStatus
-    staleCauses {
-      key {
-        path
-      }
-      reason
-      category
-      dependency {
-        path
-      }
-    }
-    partitionStats {
-      numMaterialized
-      numMaterializing
-      numPartitions
-      numFailed
-    }
-  }
-
-  fragment AssetNodeLiveFreshnessInfo on AssetFreshnessInfo {
-    currentMinutesLate
-  }
-
-  fragment AssetNodeLiveMaterialization on MaterializationEvent {
-    timestamp
-    runId
-  }
-
-  fragment AssetNodeLiveObservation on ObservationEvent {
-    timestamp
-    runId
-  }
-
-  fragment AssetCheckLiveFragment on AssetCheck {
-    name
-    canExecuteIndividually
-    executionForLatestMaterialization {
-      id
-      runId
-      status
-      timestamp
-      stepKey
-      evaluation {
-        severity
-      }
-    }
-  }
-`;
-
-export const ASSETS_GRAPH_LIVE_QUERY = gql`
-  query AssetGraphLiveQuery($assetKeys: [AssetKeyInput!]!) {
-    assetNodes(assetKeys: $assetKeys, loadMaterializations: true) {
-      id
-      ...AssetNodeLiveFragment
-    }
-    assetsLatestInfo(assetKeys: $assetKeys) {
-      id
-      ...AssetLatestInfoFragment
-    }
-  }
-
-  ${ASSET_NODE_LIVE_FRAGMENT}
-  ${ASSET_LATEST_INFO_FRAGMENT}
-`;
-
-// For tests
 export function __resetForJest() {
-  Object.assign(factory, makeFactory());
+  __resetBaseData();
+  __resetStaleData();
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -64,11 +64,10 @@ export function useAssetsLiveData(
   const completeDataByNode = useMemo(() => {
     const data: Record<string, LiveDataForNodeWithStaleData> = {};
     Object.keys(baseDataByNode).forEach((key) => {
-      if (staleDataByNode[key] && baseDataByNode[key]) {
-        data[key] = {
-          ...staleDataByNode[key],
-          ...baseDataByNode[key],
-        };
+      const baseData = baseDataByNode[key];
+      const staleData = staleDataByNode[key];
+      if (staleData && baseData) {
+        data[key] = {...staleData, ...baseData};
       }
     });
     return data;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetStaleStatusDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetStaleStatusDataProvider.tsx
@@ -67,7 +67,7 @@ export const ASSET_STALE_STATUS_QUERY = gql`
     }
   }
   query AssetStaleStatusDataQuery($assetKeys: [AssetKeyInput!]!) {
-    assetNodes(assetKeys: $assetKeys, loadMaterializations: true) {
+    assetNodes(assetKeys: $assetKeys) {
       id
       ...AssetStaleDataFragment
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetStaleStatusDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetStaleStatusDataProvider.tsx
@@ -1,0 +1,80 @@
+import {ApolloClient, gql, useApolloClient} from '@apollo/client';
+import React from 'react';
+
+import {
+  AssetStaleStatusDataQuery,
+  AssetStaleStatusDataQueryVariables,
+} from './types/AssetStaleStatusDataProvider.types';
+import {tokenForAssetKey, tokenToAssetKey} from '../asset-graph/Utils';
+import {AssetKeyInput} from '../graphql/types';
+import {liveDataFactory} from '../live-data-provider/Factory';
+import {LiveDataThreadID} from '../live-data-provider/LiveDataThread';
+
+function init() {
+  return liveDataFactory(
+    () => {
+      return useApolloClient();
+    },
+    async (keys, client: ApolloClient<any>) => {
+      const {data} = await client.query<
+        AssetStaleStatusDataQuery,
+        AssetStaleStatusDataQueryVariables
+      >({
+        query: ASSET_STALE_STATUS_QUERY,
+        fetchPolicy: 'network-only',
+        variables: {
+          assetKeys: keys.map(tokenToAssetKey),
+        },
+      });
+      return Object.fromEntries(
+        data.assetNodes.map((node) => [tokenForAssetKey(node.assetKey), node]),
+      );
+    },
+  );
+}
+export const AssetStaleStatusData = init();
+
+export function useAssetStaleData(assetKey: AssetKeyInput, thread: LiveDataThreadID = 'default') {
+  return AssetStaleStatusData.useLiveDataSingle(tokenForAssetKey(assetKey), thread);
+}
+
+export function useAssetsStaleData(
+  assetKeys: AssetKeyInput[],
+  thread: LiveDataThreadID = 'default',
+) {
+  return AssetStaleStatusData.useLiveData(
+    React.useMemo(() => assetKeys.map((key) => tokenForAssetKey(key)), [assetKeys]),
+    thread,
+  );
+}
+
+export const ASSET_STALE_STATUS_QUERY = gql`
+  fragment AssetStaleDataFragment on AssetNode {
+    id
+    assetKey {
+      path
+    }
+    staleStatus
+    staleCauses {
+      key {
+        path
+      }
+      reason
+      category
+      dependency {
+        path
+      }
+    }
+  }
+  query AssetStaleStatusDataQuery($assetKeys: [AssetKeyInput!]!) {
+    assetNodes(assetKeys: $assetKeys, loadMaterializations: true) {
+      id
+      ...AssetStaleDataFragment
+    }
+  }
+`;
+
+// For tests
+export function __resetForJest() {
+  Object.assign(AssetStaleStatusData, init());
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/util.ts
@@ -7,11 +7,11 @@ import {
   buildAssetNode,
 } from '../../graphql/types';
 import {buildQueryMock} from '../../testing/mocking';
-import {ASSETS_GRAPH_LIVE_QUERY} from '../AssetLiveDataProvider';
+import {ASSETS_GRAPH_LIVE_QUERY} from '../AssetBaseDataProvider';
 import {
   AssetGraphLiveQuery,
   AssetGraphLiveQueryVariables,
-} from '../types/AssetLiveDataProvider.types';
+} from '../types/AssetBaseDataProvider.types';
 
 export function buildMockedAssetGraphLiveQuery(
   assetKeys: AssetKeyInput[],

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetBaseDataProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetBaseDataProvider.types.ts
@@ -27,7 +27,6 @@ export type AssetNodeLiveFragment = {
   __typename: 'AssetNode';
   id: string;
   opNames: Array<string>;
-  staleStatus: Types.StaleStatus | null;
   repository: {__typename: 'Repository'; id: string};
   assetKey: {__typename: 'AssetKey'; path: Array<string>};
   assetMaterializations: Array<{
@@ -61,13 +60,6 @@ export type AssetNodeLiveFragment = {
         }>;
       };
   freshnessInfo: {__typename: 'AssetFreshnessInfo'; currentMinutesLate: number | null} | null;
-  staleCauses: Array<{
-    __typename: 'StaleCause';
-    reason: string;
-    category: Types.StaleCauseCategory;
-    key: {__typename: 'AssetKey'; path: Array<string>};
-    dependency: {__typename: 'AssetKey'; path: Array<string>} | null;
-  }>;
   partitionStats: {
     __typename: 'PartitionStats';
     numMaterialized: number;
@@ -119,7 +111,6 @@ export type AssetGraphLiveQuery = {
     __typename: 'AssetNode';
     id: string;
     opNames: Array<string>;
-    staleStatus: Types.StaleStatus | null;
     repository: {__typename: 'Repository'; id: string};
     assetKey: {__typename: 'AssetKey'; path: Array<string>};
     assetMaterializations: Array<{
@@ -153,13 +144,6 @@ export type AssetGraphLiveQuery = {
           }>;
         };
     freshnessInfo: {__typename: 'AssetFreshnessInfo'; currentMinutesLate: number | null} | null;
-    staleCauses: Array<{
-      __typename: 'StaleCause';
-      reason: string;
-      category: Types.StaleCauseCategory;
-      key: {__typename: 'AssetKey'; path: Array<string>};
-      dependency: {__typename: 'AssetKey'; path: Array<string>} | null;
-    }>;
     partitionStats: {
       __typename: 'PartitionStats';
       numMaterialized: number;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetStaleStatusDataProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetStaleStatusDataProvider.types.ts
@@ -1,0 +1,38 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type AssetStaleDataFragment = {
+  __typename: 'AssetNode';
+  id: string;
+  staleStatus: Types.StaleStatus | null;
+  assetKey: {__typename: 'AssetKey'; path: Array<string>};
+  staleCauses: Array<{
+    __typename: 'StaleCause';
+    reason: string;
+    category: Types.StaleCauseCategory;
+    key: {__typename: 'AssetKey'; path: Array<string>};
+    dependency: {__typename: 'AssetKey'; path: Array<string>} | null;
+  }>;
+};
+
+export type AssetStaleStatusDataQueryVariables = Types.Exact<{
+  assetKeys: Array<Types.AssetKeyInput> | Types.AssetKeyInput;
+}>;
+
+export type AssetStaleStatusDataQuery = {
+  __typename: 'Query';
+  assetNodes: Array<{
+    __typename: 'AssetNode';
+    id: string;
+    staleStatus: Types.StaleStatus | null;
+    assetKey: {__typename: 'AssetKey'; path: Array<string>};
+    staleCauses: Array<{
+      __typename: 'StaleCause';
+      reason: string;
+      category: Types.StaleCauseCategory;
+      key: {__typename: 'AssetKey'; path: Array<string>};
+      dependency: {__typename: 'AssetKey'; path: Array<string>} | null;
+    }>;
+  }>;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import {GraphData, GraphNode, tokenForAssetKey} from './Utils';
 import {StatusDot} from './sidebar/StatusDot';
-import {useAssetLiveData} from '../asset-data/AssetLiveDataProvider';
+import {useAssetBaseData} from '../asset-data/AssetBaseDataProvider';
 import {useExecuteAssetMenuItem} from '../assets/AssetActionMenu';
 import {
   AssetKeysDialog,
@@ -50,7 +50,7 @@ export const useAssetNodeMenu = ({
     onChangeExplorerPath({...explorerPath, opsQuery: nextOpsQuery}, 'push');
   }
 
-  const {liveData} = useAssetLiveData(node.assetKey, 'context-menu');
+  const {liveData} = useAssetBaseData(node.assetKey, 'context-menu');
 
   const isSource = node.definition.isSource;
   const lastMaterializationRunID = liveData?.lastMaterialization?.runId;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -13,8 +13,9 @@ import {
   AssetNodeLiveFreshnessInfoFragment,
   AssetNodeLiveMaterializationFragment,
   AssetNodeLiveObservationFragment,
-} from '../asset-data/types/AssetLiveDataProvider.types';
-import {RunStatus, StaleStatus} from '../graphql/types';
+} from '../asset-data/types/AssetBaseDataProvider.types';
+import {AssetStaleDataFragment} from '../asset-data/types/AssetStaleStatusDataProvider.types';
+import {RunStatus} from '../graphql/types';
 
 /**
  * IMPORTANT: This file is used by the WebWorker so make sure we don't indirectly import React or anything that relies on window/document
@@ -151,8 +152,8 @@ export interface LiveDataForNode {
   lastMaterializationRunStatus: RunStatus | null; // only available if runWhichFailedToMaterialize is null
   freshnessInfo: AssetNodeLiveFreshnessInfoFragment | null;
   lastObservation: AssetNodeLiveObservationFragment | null;
-  staleStatus: StaleStatus | null;
-  staleCauses: AssetGraphLiveQuery['assetNodes'][0]['staleCauses'];
+  // staleStatus: StaleStatus | null;
+  // staleCauses: AssetGraphLiveQuery['assetNodes'][0]['staleCauses'];
   assetChecks: AssetCheckLiveFragment[];
   partitionStats: {
     numMaterialized: number;
@@ -163,7 +164,12 @@ export interface LiveDataForNode {
   opNames: string[];
 }
 
-export const MISSING_LIVE_DATA: LiveDataForNode = {
+export type LiveDataForNodeWithStaleData = LiveDataForNode & {
+  staleStatus: AssetStaleDataFragment['staleStatus'];
+  staleCauses: AssetStaleDataFragment['staleCauses'];
+};
+
+export const MISSING_LIVE_DATA: LiveDataForNodeWithStaleData = {
   unstartedRunIds: [],
   inProgressRunIds: [],
   runWhichFailedToMaterialize: null,
@@ -226,8 +232,6 @@ export const buildLiveDataForNode = (
       assetNode.assetChecksOrError.__typename === 'AssetChecks'
         ? assetNode.assetChecksOrError.checks
         : [],
-    staleStatus: assetNode.staleStatus,
-    staleCauses: assetNode.staleCauses,
     stepKey: stepKeyForAsset(assetNode),
     freshnessInfo: assetNode.freshnessInfo,
     inProgressRunIds: assetLatestInfo?.inProgressRunIds || [],

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -152,8 +152,6 @@ export interface LiveDataForNode {
   lastMaterializationRunStatus: RunStatus | null; // only available if runWhichFailedToMaterialize is null
   freshnessInfo: AssetNodeLiveFreshnessInfoFragment | null;
   lastObservation: AssetNodeLiveObservationFragment | null;
-  // staleStatus: StaleStatus | null;
-  // staleCauses: AssetGraphLiveQuery['assetNodes'][0]['staleCauses'];
   assetChecks: AssetCheckLiveFragment[];
   partitionStats: {
     numMaterialized: number;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -15,7 +15,7 @@ import {
   buildMaterializationEvent,
   buildRun,
 } from '../../graphql/types';
-import {LiveDataForNode} from '../Utils';
+import {LiveDataForNodeWithStaleData} from '../Utils';
 import {AssetNodeFragment} from '../types/AssetNode.types';
 
 export const MockStaleReasonData: StaleCause = {
@@ -102,7 +102,7 @@ export const AssetNodeFragmentPartitioned: AssetNodeFragment = buildAssetNode({
   isPartitioned: true,
 });
 
-export const LiveDataForNodeRunStartedNotMaterializing: LiveDataForNode = {
+export const LiveDataForNodeRunStartedNotMaterializing: LiveDataForNodeWithStaleData = {
   stepKey: 'asset2',
   unstartedRunIds: ['ABCDEF'],
   inProgressRunIds: [],
@@ -118,7 +118,7 @@ export const LiveDataForNodeRunStartedNotMaterializing: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodeRunStartedMaterializing: LiveDataForNode = {
+export const LiveDataForNodeRunStartedMaterializing: LiveDataForNodeWithStaleData = {
   stepKey: 'asset3',
   unstartedRunIds: [],
   inProgressRunIds: ['ABCDEF'],
@@ -134,7 +134,7 @@ export const LiveDataForNodeRunStartedMaterializing: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodeRunFailed: LiveDataForNode = {
+export const LiveDataForNodeRunFailed: LiveDataForNodeWithStaleData = {
   stepKey: 'asset4',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -155,7 +155,7 @@ export const LiveDataForNodeRunFailed: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodeNeverMaterialized: LiveDataForNode = {
+export const LiveDataForNodeNeverMaterialized: LiveDataForNodeWithStaleData = {
   stepKey: 'asset5',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -171,7 +171,7 @@ export const LiveDataForNodeNeverMaterialized: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodeMaterialized: LiveDataForNode = {
+export const LiveDataForNodeMaterialized: LiveDataForNodeWithStaleData = {
   stepKey: 'asset6',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -190,7 +190,7 @@ export const LiveDataForNodeMaterialized: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodeMaterializedWithChecks: LiveDataForNode = {
+export const LiveDataForNodeMaterializedWithChecks: LiveDataForNodeWithStaleData = {
   stepKey: 'asset7',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -260,14 +260,14 @@ export const LiveDataForNodeMaterializedWithChecks: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodeMaterializedWithChecksOk: LiveDataForNode = {
+export const LiveDataForNodeMaterializedWithChecksOk: LiveDataForNodeWithStaleData = {
   ...LiveDataForNodeMaterializedWithChecks,
   assetChecks: LiveDataForNodeMaterializedWithChecks.assetChecks.filter(
     (c) => c.executionForLatestMaterialization?.evaluation?.severity !== AssetCheckSeverity.ERROR,
   ),
 };
 
-export const LiveDataForNodeMaterializedAndStale: LiveDataForNode = {
+export const LiveDataForNodeMaterializedAndStale: LiveDataForNodeWithStaleData = {
   stepKey: 'asset8',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -286,7 +286,7 @@ export const LiveDataForNodeMaterializedAndStale: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodeMaterializedAndStaleAndOverdue: LiveDataForNode = {
+export const LiveDataForNodeMaterializedAndStaleAndOverdue: LiveDataForNodeWithStaleData = {
   stepKey: 'asset9',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -308,7 +308,7 @@ export const LiveDataForNodeMaterializedAndStaleAndOverdue: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodeMaterializedAndStaleAndFresh: LiveDataForNode = {
+export const LiveDataForNodeMaterializedAndStaleAndFresh: LiveDataForNodeWithStaleData = {
   stepKey: 'asset10',
 
   unstartedRunIds: [],
@@ -344,7 +344,7 @@ export const LiveDataForNodeMaterializedAndStaleAndFresh: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodeMaterializedAndFresh: LiveDataForNode = {
+export const LiveDataForNodeMaterializedAndFresh: LiveDataForNodeWithStaleData = {
   stepKey: 'asset11',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -366,7 +366,7 @@ export const LiveDataForNodeMaterializedAndFresh: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodeMaterializedAndOverdue: LiveDataForNode = {
+export const LiveDataForNodeMaterializedAndOverdue: LiveDataForNodeWithStaleData = {
   stepKey: 'asset12',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -388,7 +388,7 @@ export const LiveDataForNodeMaterializedAndOverdue: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodeFailedAndOverdue: LiveDataForNode = {
+export const LiveDataForNodeFailedAndOverdue: LiveDataForNodeWithStaleData = {
   stepKey: 'asset13',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -410,7 +410,7 @@ export const LiveDataForNodeFailedAndOverdue: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodeSourceNeverObserved: LiveDataForNode = {
+export const LiveDataForNodeSourceNeverObserved: LiveDataForNodeWithStaleData = {
   stepKey: 'source_asset2',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -427,7 +427,7 @@ export const LiveDataForNodeSourceNeverObserved: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodeSourceObservationRunning: LiveDataForNode = {
+export const LiveDataForNodeSourceObservationRunning: LiveDataForNodeWithStaleData = {
   stepKey: 'source_asset3',
   unstartedRunIds: [],
   inProgressRunIds: ['ABCDEF'],
@@ -442,7 +442,7 @@ export const LiveDataForNodeSourceObservationRunning: LiveDataForNode = {
   partitionStats: null,
   opNames: [],
 };
-export const LiveDataForNodeSourceObservedUpToDate: LiveDataForNode = {
+export const LiveDataForNodeSourceObservedUpToDate: LiveDataForNodeWithStaleData = {
   stepKey: 'source_asset4',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -462,7 +462,7 @@ export const LiveDataForNodeSourceObservedUpToDate: LiveDataForNode = {
   partitionStats: null,
 };
 
-export const LiveDataForNodePartitionedSomeMissing: LiveDataForNode = {
+export const LiveDataForNodePartitionedSomeMissing: LiveDataForNodeWithStaleData = {
   stepKey: 'partitioned_asset1',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -487,7 +487,7 @@ export const LiveDataForNodePartitionedSomeMissing: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodePartitionedSomeFailed: LiveDataForNode = {
+export const LiveDataForNodePartitionedSomeFailed: LiveDataForNodeWithStaleData = {
   stepKey: 'partitioned_asset2',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -512,7 +512,7 @@ export const LiveDataForNodePartitionedSomeFailed: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodePartitionedNoneMissing: LiveDataForNode = {
+export const LiveDataForNodePartitionedNoneMissing: LiveDataForNodeWithStaleData = {
   stepKey: 'partitioned_asset3',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -537,7 +537,7 @@ export const LiveDataForNodePartitionedNoneMissing: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodePartitionedNeverMaterialized: LiveDataForNode = {
+export const LiveDataForNodePartitionedNeverMaterialized: LiveDataForNodeWithStaleData = {
   stepKey: 'asset20',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -558,7 +558,7 @@ export const LiveDataForNodePartitionedNeverMaterialized: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodePartitionedMaterializing: LiveDataForNode = {
+export const LiveDataForNodePartitionedMaterializing: LiveDataForNodeWithStaleData = {
   stepKey: 'asset21',
   unstartedRunIds: ['LMAANO'],
   inProgressRunIds: ['ABCDEF', 'CDEFG', 'HIHKA'],
@@ -579,7 +579,7 @@ export const LiveDataForNodePartitionedMaterializing: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodePartitionedStale: LiveDataForNode = {
+export const LiveDataForNodePartitionedStale: LiveDataForNodeWithStaleData = {
   stepKey: 'asset22',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -604,7 +604,7 @@ export const LiveDataForNodePartitionedStale: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodePartitionedOverdue: LiveDataForNode = {
+export const LiveDataForNodePartitionedOverdue: LiveDataForNodeWithStaleData = {
   stepKey: 'asset23',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -632,7 +632,7 @@ export const LiveDataForNodePartitionedOverdue: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodePartitionedFresh: LiveDataForNode = {
+export const LiveDataForNodePartitionedFresh: LiveDataForNodeWithStaleData = {
   stepKey: 'asset24',
   unstartedRunIds: [],
   inProgressRunIds: [],
@@ -660,7 +660,7 @@ export const LiveDataForNodePartitionedFresh: LiveDataForNode = {
   opNames: [],
 };
 
-export const LiveDataForNodePartitionedLatestRunFailed: LiveDataForNode = {
+export const LiveDataForNodePartitionedLatestRunFailed: LiveDataForNodeWithStaleData = {
   stepKey: 'asset25',
   unstartedRunIds: [],
   inProgressRunIds: [],

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
@@ -2,9 +2,11 @@ import {MockedProvider} from '@apollo/client/testing';
 import {Box} from '@dagster-io/ui-components';
 import React from 'react';
 
-import {AssetLiveDataProvider, factory} from '../../asset-data/AssetLiveDataProvider';
+import {AssetBaseData} from '../../asset-data/AssetBaseDataProvider';
+import {AssetLiveDataProvider} from '../../asset-data/AssetLiveDataProvider';
+import {AssetStaleStatusData} from '../../asset-data/AssetStaleStatusDataProvider';
 import {KNOWN_TAGS} from '../../graph/OpTags';
-import {buildAssetKey} from '../../graphql/types';
+import {buildAssetKey, buildAssetNode, buildStaleCause} from '../../graphql/types';
 import {AssetNode, AssetNodeMinimal} from '../AssetNode';
 import {AssetNodeLink} from '../ForeignNode';
 import {tokenForAssetKey} from '../Utils';
@@ -33,9 +35,17 @@ export const LiveStates = () => {
     const dimensions = getAssetNodeDimensions(definitionCopy);
 
     function SetCacheEntry() {
-      factory.manager._updateCache({
-        [tokenForAssetKey(definitionCopy.assetKey)]: scenario.liveData!,
-      });
+      const entry = {[tokenForAssetKey(definitionCopy.assetKey)]: scenario.liveData!};
+      const {staleStatus, staleCauses} = scenario.liveData!;
+      const staleEntry = {
+        [tokenForAssetKey(definitionCopy.assetKey)]: buildAssetNode({
+          assetKey: definitionCopy.assetKey,
+          staleCauses: staleCauses.map((cause) => buildStaleCause(cause)),
+          staleStatus,
+        }),
+      };
+      AssetStaleStatusData.manager._updateCache(staleEntry);
+      AssetBaseData.manager._updateCache(entry);
       return null;
     }
 
@@ -100,9 +110,19 @@ export const PartnerTags = () => {
     const liveData = Mocks.LiveDataForNodeMaterialized;
 
     function SetCacheEntry() {
-      factory.manager._updateCache({
-        [tokenForAssetKey(buildAssetKey({path: [liveData.stepKey]}))]: liveData!,
-      });
+      const assetKey = buildAssetKey({path: [liveData.stepKey]});
+      const key = tokenForAssetKey(assetKey);
+      const entry = {[key]: liveData!};
+      const {staleStatus, staleCauses} = liveData!;
+      const staleEntry = {
+        [key]: buildAssetNode({
+          assetKey,
+          staleCauses: staleCauses.map((cause) => buildStaleCause(cause)),
+          staleStatus,
+        }),
+      };
+      AssetStaleStatusData.manager._updateCache(staleEntry);
+      AssetBaseData.manager._updateCache(entry);
       return null;
     }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
@@ -35,18 +35,20 @@ describe('AssetNode', () => {
         : JSON.parse(scenario.definition.id);
 
       function SetCacheEntry() {
-        const key = tokenForAssetKey(definitionCopy.assetKey);
-        const entry = {[key]: scenario.liveData!};
-        const {staleStatus, staleCauses} = scenario.liveData!;
-        const staleEntry = {
-          [key]: buildAssetNode({
-            assetKey: definitionCopy.assetKey,
-            staleCauses: staleCauses.map((cause) => buildStaleCause(cause)),
-            staleStatus,
-          }),
-        };
-        AssetStaleStatusData.manager._updateCache(staleEntry);
-        AssetBaseData.manager._updateCache(entry);
+        if (scenario.liveData) {
+          const key = tokenForAssetKey(definitionCopy.assetKey);
+          const entry = {[key]: scenario.liveData!};
+          const {staleStatus, staleCauses} = scenario.liveData!;
+          const staleEntry = {
+            [key]: buildAssetNode({
+              assetKey: definitionCopy.assetKey,
+              staleCauses: staleCauses.map((cause) => buildStaleCause(cause)),
+              staleStatus,
+            }),
+          };
+          AssetStaleStatusData.manager._updateCache(staleEntry);
+          AssetBaseData.manager._updateCache(entry);
+        }
         return null;
       }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
@@ -2,7 +2,10 @@ import {MockedProvider} from '@apollo/client/testing';
 import {render, screen, waitFor} from '@testing-library/react';
 import {MemoryRouter} from 'react-router-dom';
 
-import {AssetLiveDataProvider, factory} from '../../asset-data/AssetLiveDataProvider';
+import {AssetBaseData} from '../../asset-data/AssetBaseDataProvider';
+import {AssetLiveDataProvider} from '../../asset-data/AssetLiveDataProvider';
+import {AssetStaleStatusData} from '../../asset-data/AssetStaleStatusDataProvider';
+import {buildAssetNode, buildStaleCause} from '../../graphql/types';
 import {AssetNode} from '../AssetNode';
 import {tokenForAssetKey} from '../Utils';
 import {
@@ -32,9 +35,18 @@ describe('AssetNode', () => {
         : JSON.parse(scenario.definition.id);
 
       function SetCacheEntry() {
-        factory.manager._updateCache({
-          [tokenForAssetKey(definitionCopy.assetKey)]: scenario.liveData!,
-        });
+        const key = tokenForAssetKey(definitionCopy.assetKey);
+        const entry = {[key]: scenario.liveData!};
+        const {staleStatus, staleCauses} = scenario.liveData!;
+        const staleEntry = {
+          [key]: buildAssetNode({
+            assetKey: definitionCopy.assetKey,
+            staleCauses: staleCauses.map((cause) => buildStaleCause(cause)),
+            staleStatus,
+          }),
+        };
+        AssetStaleStatusData.manager._updateCache(staleEntry);
+        AssetBaseData.manager._updateCache(entry);
         return null;
       }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/StatusDot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/StatusDot.tsx
@@ -1,10 +1,10 @@
 import {StatusCaseDot} from './util';
-import {useAssetLiveData} from '../../asset-data/AssetLiveDataProvider';
+import {useAssetBaseData} from '../../asset-data/AssetBaseDataProvider';
 import {StatusCase, buildAssetNodeStatusContent} from '../AssetNodeStatusContent';
 import {GraphNode} from '../Utils';
 
 export function StatusDot({node}: {node: Pick<GraphNode, 'assetKey' | 'definition'>}) {
-  const {liveData} = useAssetLiveData(node.assetKey);
+  const {liveData} = useAssetBaseData(node.assetKey);
 
   if (!liveData) {
     return <StatusCaseDot statusCase={StatusCase.LOADING} />;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
@@ -34,7 +34,8 @@ import {
 import {AssetObservationFragment} from './types/useRecentAssetEvents.types';
 import {ASSET_MATERIALIZATION_FRAGMENT, ASSET_OBSERVATION_FRAGMENT} from './useRecentAssetEvents';
 import {Timestamp} from '../app/time/Timestamp';
-import {LiveDataForNode, isHiddenAssetGroupJob, stepKeyForAsset} from '../asset-graph/Utils';
+import {AssetStaleDataFragment} from '../asset-data/types/AssetStaleStatusDataProvider.types';
+import {isHiddenAssetGroupJob, stepKeyForAsset} from '../asset-graph/Utils';
 import {ChangeReason, RunStatus, StaleStatus} from '../graphql/types';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {RunStatusWithStats} from '../runs/RunStatusDots';
@@ -191,8 +192,8 @@ export const AssetPartitionDetail = ({
   hasLoadingState?: boolean;
   hasStaleLoadingState?: boolean;
   stepKey?: string;
-  staleCauses?: LiveDataForNode['staleCauses'];
-  staleStatus?: LiveDataForNode['staleStatus'];
+  staleCauses?: AssetStaleDataFragment['staleCauses'];
+  staleStatus?: AssetStaleDataFragment['staleStatus'];
   changedReasons?: ChangeReason[];
 }) => {
   const {latest, partition, all} = group;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -17,13 +17,13 @@ import {ExecuteChecksButton} from './asset-checks/ExecuteChecksButton';
 import {assetDetailsPathForAssetCheck, assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {useGroupedEvents} from './groupByPartition';
 import {RecentAssetEvents} from './useRecentAssetEvents';
-import {LiveDataForNode} from '../asset-graph/Utils';
+import {LiveDataForNodeWithStaleData} from '../asset-graph/Utils';
 import {SidebarAssetFragment} from '../asset-graph/types/SidebarAssetInfo.types';
 import {SidebarSection} from '../pipelines/SidebarComponents';
 
 interface Props {
   asset: SidebarAssetFragment;
-  liveData?: LiveDataForNode;
+  liveData?: LiveDataForNodeWithStaleData;
   isSourceAsset: boolean;
   stepKey: string;
   recentEvents: RecentAssetEvents;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -42,7 +42,7 @@ import {Timestamp} from '../app/time/Timestamp';
 import {AssetLiveDataRefreshButton, useAssetLiveData} from '../asset-data/AssetLiveDataProvider';
 import {
   GraphData,
-  LiveDataForNode,
+  LiveDataForNodeWithStaleData,
   nodeDependsOnSelf,
   toGraphId,
   tokenForAssetKey,
@@ -512,7 +512,7 @@ const AssetViewPageHeaderTags = ({
   onShowUpstream,
 }: {
   definition: AssetViewDefinitionNodeFragment | null;
-  liveData?: LiveDataForNode;
+  liveData?: LiveDataForNodeWithStaleData;
   onShowUpstream: () => void;
 }) => {
   const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/FailedRunSinceMaterializationBanner.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/FailedRunSinceMaterializationBanner.tsx
@@ -6,7 +6,7 @@ import {
 } from '@dagster-io/ui-components/src/components/types';
 import {Link} from 'react-router-dom';
 
-import {AssetLatestInfoRunFragment} from '../asset-data/types/AssetLiveDataProvider.types';
+import {AssetLatestInfoRunFragment} from '../asset-data/types/AssetBaseDataProvider.types';
 import {titleForRun} from '../runs/RunUtils';
 import {useStepLogs} from '../runs/StepLogsDialog';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LastMaterializationMetadata.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LastMaterializationMetadata.tsx
@@ -12,7 +12,7 @@ import {
   AssetObservationFragment,
 } from './types/useRecentAssetEvents.types';
 import {Timestamp} from '../app/time/Timestamp';
-import {LiveDataForNode, isHiddenAssetGroupJob} from '../asset-graph/Utils';
+import {LiveDataForNodeWithStaleData, isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {AssetKeyInput} from '../graphql/types';
 import {MetadataEntry} from '../metadata/MetadataEntry';
 import {isCanonicalColumnLineageEntry} from '../metadata/TableSchema';
@@ -31,7 +31,7 @@ export const LatestMaterializationMetadata = ({
 }: {
   assetKey: AssetKeyInput;
   latest: AssetObservationFragment | AssetMaterializationFragment | undefined;
-  liveData: LiveDataForNode | undefined;
+  liveData: LiveDataForNodeWithStaleData | undefined;
   definition: Pick<AssetViewDefinitionNodeFragment, 'changedReasons'>;
 }) => {
   const latestRun = latest?.runOrError.__typename === 'Run' ? latest?.runOrError : null;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/OverdueTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/OverdueTag.tsx
@@ -13,7 +13,7 @@ import {
 import {OverduePopoverQuery, OverduePopoverQueryVariables} from './types/OverdueTag.types';
 import {Timestamp} from '../app/time/Timestamp';
 import {timestampToString} from '../app/time/timestampToString';
-import {useAssetLiveData} from '../asset-data/AssetLiveDataProvider';
+import {useAssetBaseData} from '../asset-data/AssetBaseDataProvider';
 import {LiveDataForNode} from '../asset-graph/Utils';
 import {AssetKeyInput, FreshnessPolicy} from '../graphql/types';
 import {humanCronString} from '../schedules/humanCronString';
@@ -45,7 +45,7 @@ export const OverdueTag = ({
   policy: Pick<FreshnessPolicy, 'cronSchedule' | 'cronScheduleTimezone' | 'maximumLagMinutes'>;
   assetKey: AssetKeyInput;
 }) => {
-  const {liveData} = useAssetLiveData(assetKey);
+  const {liveData} = useAssetBaseData(assetKey);
 
   if (!liveData?.freshnessInfo) {
     return null;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
@@ -19,13 +19,14 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
+import {AssetStaleDataFragment} from '../asset-data/types/AssetStaleStatusDataProvider.types';
 import {LiveDataForNode, displayNameForAssetKey} from '../asset-graph/Utils';
 import {AssetKeyInput, StaleCauseCategory, StaleStatus} from '../graphql/types';
 import {numberFormatter} from '../ui/formatters';
 
 type StaleDataForNode = {
-  staleCauses: LiveDataForNode['staleCauses'];
-  staleStatus: LiveDataForNode['staleStatus'];
+  staleCauses: AssetStaleDataFragment['staleCauses'];
+  staleStatus: AssetStaleDataFragment['staleStatus'];
 
   // May be omitted when showing staleness for a single partition
   partitionStats?: LiveDataForNode['partitionStats'];

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetTables.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetTables.fixtures.ts
@@ -1,8 +1,8 @@
-import {ASSETS_GRAPH_LIVE_QUERY} from '../../asset-data/AssetLiveDataProvider';
+import {ASSETS_GRAPH_LIVE_QUERY} from '../../asset-data/AssetBaseDataProvider';
 import {
   AssetGraphLiveQuery,
   AssetGraphLiveQueryVariables,
-} from '../../asset-data/types/AssetLiveDataProvider.types';
+} from '../../asset-data/types/AssetBaseDataProvider.types';
 import {MockStaleReasonData} from '../../asset-graph/__fixtures__/AssetNode.fixtures';
 import {
   Asset,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetView.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetView.test.tsx
@@ -2,14 +2,12 @@ import {MockedProvider} from '@apollo/client/testing';
 import {act, render, screen, waitFor} from '@testing-library/react';
 import {MemoryRouter} from 'react-router-dom';
 
-import {
-  ASSETS_GRAPH_LIVE_QUERY,
-  AssetLiveDataProvider,
-} from '../../asset-data/AssetLiveDataProvider';
+import {ASSETS_GRAPH_LIVE_QUERY} from '../../asset-data/AssetBaseDataProvider';
+import {AssetLiveDataProvider} from '../../asset-data/AssetLiveDataProvider';
 import {
   AssetGraphLiveQuery,
   AssetGraphLiveQueryVariables,
-} from '../../asset-data/types/AssetLiveDataProvider.types';
+} from '../../asset-data/types/AssetBaseDataProvider.types';
 import {
   AssetGraphQuery,
   AssetGraphQueryVariables,

--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/Factory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/Factory.tsx
@@ -12,6 +12,7 @@ import {LiveDataThreadManager} from './LiveDataThreadManager';
 export function liveDataFactory<T, R>(
   useHooks: () => R,
   queryKeys: (keys: string[], result: R) => Promise<Record<string, T>>,
+  batchSize?: number,
 ) {
   const resultsFromUseHook: {current: R | undefined} = {current: undefined};
   const manager = new LiveDataThreadManager((keys: string[]) => {
@@ -21,7 +22,7 @@ export function liveDataFactory<T, R>(
       );
     }
     return queryKeys(keys, resultsFromUseHook.current);
-  });
+  }, batchSize);
 
   const LiveDataRefreshContext = React.createContext<{
     isGloballyRefreshing: boolean;

--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThreadManager.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThreadManager.tsx
@@ -15,6 +15,7 @@ export class LiveDataThreadManager<T> {
   private pollRate: number = 30000;
   private listeners: Record<string, undefined | Listener<T>[]>;
   private isPaused: boolean;
+  private batchSize: number;
 
   private onSubscriptionsChanged(_allKeys: string[]) {}
   private onUpdatedOrUpdating() {}
@@ -23,13 +24,14 @@ export class LiveDataThreadManager<T> {
     return {};
   }
 
-  constructor(queryKeys: (keys: string[]) => Promise<Record<string, T>>) {
+  constructor(queryKeys: (keys: string[]) => Promise<Record<string, T>>, batchSize?: number) {
     this.queryKeys = queryKeys;
     this.lastFetchedOrRequested = {};
     this.cache = {};
     this.threads = {};
     this.listeners = {};
     this.isPaused = false;
+    this.batchSize = batchSize || BATCH_SIZE;
   }
 
   public setPollRate(pollRate: number) {
@@ -104,7 +106,7 @@ export class LiveDataThreadManager<T> {
   public determineKeysToFetch(keys: string[]) {
     const keysToFetch: string[] = [];
     const keysWithoutData: string[] = [];
-    while (keys.length && keysWithoutData.length < BATCH_SIZE) {
+    while (keys.length && keysWithoutData.length < this.batchSize) {
       const key = keys.shift()!;
       const isRequested = !!this.lastFetchedOrRequested[key]?.requested;
       if (isRequested) {

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
@@ -19,7 +19,7 @@ import styled from 'styled-components';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
-import {useAssetsLiveData} from '../asset-data/AssetLiveDataProvider';
+import {useAssetsBaseData} from '../asset-data/AssetBaseDataProvider';
 import {StatusCase, buildAssetNodeStatusContent} from '../asset-graph/AssetNodeStatusContent';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {groupAssetsByStatus} from '../asset-graph/util';
@@ -224,7 +224,7 @@ function VirtualRow({height, start, group}: RowProps) {
     [group.assets],
   );
 
-  const {liveDataByNode} = useAssetsLiveData(assetKeys);
+  const {liveDataByNode} = useAssetsBaseData(assetKeys);
 
   const statuses = React.useMemo(() => {
     return groupAssetsByStatus(group.assets, liveDataByNode);


### PR DESCRIPTION
## Summary & Motivation

Splits out the fetching of staleStatus by breaking AssetLiveDataProvider into two: AssetBaseDataProvider and AssetStaleDataProvider. The AssetLiveDataProvider hook uses both and combines the result. For call sites where we don't need the staleStatus we can use `useAssetBaseData` instead of `useAssetLiveData`. Updated a couple of spots to use only the base data.

One weird thing about this approach is that the staleData and baseData would be fetched at different times so it's possible they are not consistent with each other in some respect, I don't think there's anyway to completely solve the problem because they're fetched in independent requests so that could always happen but there might be something we could do to lessen the probability of it happening, I'll take a stab at this in a follow-up.

## How I Tested These Changes
Existing jest tests for AssetLiveDataProvider still pass.

Navigated around the app and made sure things still load, also paid attention to network tab.

shadow dagit