### PR TITLE
during backfill, check that asset graph has key during serialization validation

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -278,8 +278,11 @@ class AssetGraphSubset(NamedTuple):
 
         for key, value in serialized_dict["partitions_subsets_by_asset_key"].items():
             asset_key = AssetKey.from_user_string(key)
-            partitions_def = asset_graph.get(asset_key).partitions_def
+            if not asset_graph.has(asset_key):
+                # Asset had a partitions definition at storage time, but no longer does
+                return False
 
+            partitions_def = asset_graph.get(asset_key).partitions_def
             if partitions_def is None:
                 # Asset had a partitions definition at storage time, but no longer does
                 return False

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -279,7 +279,7 @@ class AssetGraphSubset(NamedTuple):
         for key, value in serialized_dict["partitions_subsets_by_asset_key"].items():
             asset_key = AssetKey.from_user_string(key)
             if not asset_graph.has(asset_key):
-                # Asset had a partitions definition at storage time, but no longer does
+                # Asset had a definition at storage time, but no longer does
                 return False
 
             partitions_def = asset_graph.get(asset_key).partitions_def

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -828,6 +828,19 @@ def test_serialization(static_serialization, time_window_serialization):
 
     assert AssetBackfillData.is_valid_serialization(static_serialization, asset_graph) is True
 
+    @asset(partitions_def=static_partitions)
+    def daily_asset_renamed():
+        return 1
+
+    asset_graph_renamed = external_asset_graph_from_assets_by_repo_name(
+        {"repo": [daily_asset_renamed, static_asset]}
+    )
+
+    assert (
+        AssetBackfillData.is_valid_serialization(time_window_serialization, asset_graph_renamed)
+        is False
+    )
+
 
 def test_asset_backfill_status_counts():
     @asset


### PR DESCRIPTION
## Summary & Motivation

Backfill is currently failing when an asset key has been changed since the serialized asset graph was constructed. Instead it should indicate that the serialization is invalid.

## How I Tested These Changes

Added a unit test checking that `is_valid_serialization` doesn't fail when an asset is renamed (and verified that this unit test fails before the change in asset_graph_subset.py)