### PR TITLE
Batch fetch assetObservations(limit:1) across multiple asset keys when possible

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -657,6 +657,25 @@ class GrapheneAssetNode(graphene.ObjectType):
             )
         except ValueError:
             before_timestamp = None
+
+        if (
+            graphene_info.context.instance.event_log_storage.asset_records_have_last_observation
+            and self._asset_record_loader
+            and limit == 1
+            and not partitions
+            and not before_timestamp
+        ):
+            latest_observation_event = (
+                self._asset_record_loader.get_latest_observation_for_asset_key(
+                    self._external_asset_node.asset_key
+                )
+            )
+
+            if not latest_observation_event:
+                return []
+
+            return [GrapheneObservationEvent(event=latest_observation_event)]
+
         return [
             GrapheneObservationEvent(event=event)
             for event in get_asset_observations(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1580,6 +1580,7 @@ hanging_partition_asset_job = define_asset_job(
 @asset
 def asset_yields_observation():
     yield AssetObservation(asset_key=AssetKey("asset_yields_observation"), metadata={"text": "FOO"})
+    yield AssetObservation(asset_key=AssetKey("asset_yields_observation"), metadata={"text": "BAR"})
     yield AssetMaterialization(asset_key=AssetKey("asset_yields_observation"))
     yield Output(5)
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -97,6 +97,12 @@ class AssetEntry(
         return self.last_materialization_record.event_log_entry
 
     @property
+    def last_observation(self) -> Optional["EventLogEntry"]:
+        if self.last_observation_record is None:
+            return None
+        return self.last_observation_record.event_log_entry
+
+    @property
     def last_materialization_storage_id(self) -> Optional[int]:
         if self.last_materialization_record is None:
             return None

--- a/python_modules/dagster/dagster/_core/workspace/batch_asset_record_loader.py
+++ b/python_modules/dagster/dagster/_core/workspace/batch_asset_record_loader.py
@@ -53,6 +53,18 @@ class BatchAssetRecordLoader:
 
         return asset_record.asset_entry.last_materialization
 
+    def get_latest_observation_for_asset_key(self, asset_key: AssetKey) -> Optional[EventLogEntry]:
+        check.invariant(
+            self._instance.event_log_storage.asset_records_have_last_observation,
+            "Event log storage must support fetching the last observation from asset records",
+        )
+
+        asset_record = self.get_asset_record(asset_key)
+        if not asset_record:
+            return None
+
+        return asset_record.asset_entry.last_observation
+
     def _fetch(self) -> None:
         if not self._unfetched_asset_keys:
             return


### PR DESCRIPTION
Summary:
Once storages that use the last_observation_record field on AssetEntry are ready to go and backfilled/etc. - we can land this and speed up the process of fetching the last observation across multiple asset keys at once.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
