### PR TITLE
Hde partition selection if asset selection doesnt include a partitio…

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -276,7 +276,7 @@ const ConfigEditorPartitionPicker = React.memo((props: ConfigEditorPartitionPick
     });
   }
 
-  if (assetSelection.length && !doesAnyAssetHavePartitions) {
+  if (assetSelection?.length && !doesAnyAssetHavePartitions) {
     return null;
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -276,7 +276,7 @@ const ConfigEditorPartitionPicker = React.memo((props: ConfigEditorPartitionPick
     });
   }
 
-  if (!doesAnyAssetHavePartitions) {
+  if (assetSelection.length && !doesAnyAssetHavePartitions) {
     return null;
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -179,7 +179,7 @@ const ConfigEditorPartitionPicker = React.memo((props: ConfigEditorPartitionPick
   );
 
   const doesAnyAssetHavePartitions = React.useMemo(
-    () => !!data?.assetNodes?.find((node) => !!node.partitionDefinition),
+    () => data?.assetNodes?.some((node) => !!node.partitionDefinition),
     [data],
   );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -178,6 +178,11 @@ const ConfigEditorPartitionPicker = React.memo((props: ConfigEditorPartitionPick
     value === undefined ? 'asc' : value,
   );
 
+  const doesAnyAssetHavePartitions = React.useMemo(
+    () => !!data?.assetNodes?.find((node) => !!node.partitionDefinition),
+    [data],
+  );
+
   const partitions: Partition[] = React.useMemo(() => {
     const retrieved =
       data?.partitionSetOrError.__typename === 'PartitionSet' &&
@@ -269,6 +274,10 @@ const ConfigEditorPartitionPicker = React.memo((props: ConfigEditorPartitionPick
     showCustomAlert({
       body: <PythonErrorInfo error={error} />,
     });
+  }
+
+  if (!doesAnyAssetHavePartitions) {
+    return null;
   }
 
   // Note: We don't want this Suggest to be a fully "controlled" React component.


### PR DESCRIPTION
## Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/14579

## How I Tested These Changes

Tested with a non-partitioned asset that is part of an asset job that includes partitioned assets. Confirmed that previously it showed the partition selection input and now it doesn't.