### PR TITLE
[docs] - Add external assets disclaimer to Insights docs (DOC-197)

### DIFF
--- a/docs/content/dagster-plus/managing-deployments/alerts.mdx
+++ b/docs/content/dagster-plus/managing-deployments/alerts.mdx
@@ -117,8 +117,7 @@ Alert policies are configured on a **per-deployment basis**. This means, for exa
         <strong>Insights metric alert</strong> <Experimental />
       </td>
       <td>
-        <strong>A Dagster+ Pro plan is required to use this feature.</strong>
-        <br />
+        <strong>A Dagster+ Pro plan is required to use this feature.</strong>{" "}
         Sends a notification when a{" "}
         <a href="/dagster-plus/insights">Dagster+ Insights</a> metric exceeds or
         falls below a specified threshold over a specified time window. This can
@@ -133,10 +132,10 @@ Alert policies are configured on a **per-deployment basis**. This means, for exa
         Alerts can be scoped to the sum of any metric across an entire
         deployment, or for a specific job, asset group, or asset key.
         <br />
-        <strong>Note</strong>: Alerts are sent only when the threshold is first
-        crossed, and will not be sent again until the value returns to expected
-        levels. Insights data may become available up to 24 hours after run
-        completion.
+        <br />
+        <strong>Note</strong>: Alerts are sent only when the threshold is first crossed,
+        and will not be sent again until the value returns to expected levels. Insights
+        data may become available up to 24 hours after run completion.
       </td>
     </tr>
   </tbody>

--- a/docs/content/dagster-plus/managing-deployments/alerts.mdx
+++ b/docs/content/dagster-plus/managing-deployments/alerts.mdx
@@ -66,7 +66,11 @@ Alert policies are configured on a **per-deployment basis**. This means, for exa
         <a href="/concepts/metadata-tags/asset-metadata#asset-owners">
           asset owners
         </a>
-        .
+        .<br />
+        <br />
+        <strong>Note:</strong> <a href="/concepts/assets/external-assets">
+          External assets
+        </a> do not trigger asset alerts.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
## Summary & Motivation

 This PR adds a note about external assets not triggering alerts to the Insights docs.

## How I Tested These Changes

👀 
