### PR TITLE
Update dbt tutorial with dbt command note

### DIFF
--- a/docs/content/integrations/dbt/using-dbt-with-dagster/set-up-dbt-project.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/set-up-dbt-project.mdx
@@ -83,8 +83,7 @@ This will run all the models, seeds, and snapshots in the project and store a se
 
 <Note>
   <strong>Heads up!</strong> For other dbt projects, you may need to run
-  additional command lines before building the project. For instance, a project
-  with{" "}
+  additional commands before building the project. For instance, a project with{" "}
   <a href="https://docs.getdbt.com/docs/collaborate/govern/project-dependencies">
     dependencies
   </a>{" "}

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/set-up-dbt-project.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/set-up-dbt-project.mdx
@@ -87,7 +87,8 @@ This will run all the models, seeds, and snapshots in the project and store a se
   with{" "}
   <a href="https://docs.getdbt.com/docs/collaborate/govern/project-dependencies">
     dependencies
-  </a>{" "}will require you to run{" "}
+  </a>{" "}
+  will require you to run{" "}
   <a href="https://docs.getdbt.com/reference/commands/deps">
     <code>dbt deps</code>
   </a>{" "}

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/set-up-dbt-project.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/set-up-dbt-project.mdx
@@ -87,8 +87,7 @@ This will run all the models, seeds, and snapshots in the project and store a se
   with{" "}
   <a href="https://docs.getdbt.com/docs/collaborate/govern/project-dependencies">
     dependencies
-  </a>{" "}
-  in <code>dependencies.yml</code> will require you to run{" "}
+  </a>{" "}will require you to run{" "}
   <a href="https://docs.getdbt.com/reference/commands/deps">
     <code>dbt deps</code>
   </a>{" "}

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/set-up-dbt-project.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/set-up-dbt-project.mdx
@@ -84,12 +84,19 @@ This will run all the models, seeds, and snapshots in the project and store a se
 <Note>
   <strong>Heads up!</strong> For other dbt projects, you may need to run
   additional command lines before building the project. For instance, a project
-  with
-  [dependencies](https://docs.getdbt.com/docs/collaborate/govern/project-dependencies)
-  in `dependencies.yml` will require you to run [dbt
-  deps](https://docs.getdbt.com/reference/commands/deps) before building the
-  project. Visit [the official dbt Command reference
-  page](https://docs.getdbt.com/reference/dbt-commands) for more information.
+  with{" "}
+  <a href="https://docs.getdbt.com/docs/collaborate/govern/project-dependencies">
+    dependencies
+  </a>{" "}
+  in <code>dependencies.yml</code> will require you to run{" "}
+  <a href="https://docs.getdbt.com/reference/commands/deps">
+    <code>dbt deps</code>
+  </a>{" "}
+  before building the project. Visit{" "}
+  <a href="https://docs.getdbt.com/reference/dbt-commands">
+    the official dbt Command reference page
+  </a>{" "}
+  for more information.
 </Note>
 
 ---

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/set-up-dbt-project.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/set-up-dbt-project.mdx
@@ -81,6 +81,17 @@ dbt build
 
 This will run all the models, seeds, and snapshots in the project and store a set of tables in your DuckDB database.
 
+<Note>
+  <strong>Heads up!</strong> For other dbt projects, you may need to run
+  additional command lines before building the project. For instance, a project
+  with
+  [dependencies](https://docs.getdbt.com/docs/collaborate/govern/project-dependencies)
+  in `dependencies.yml` will require you to run [dbt
+  deps](https://docs.getdbt.com/reference/commands/deps) before building the
+  project. Visit [the official dbt Command reference
+  page](https://docs.getdbt.com/reference/dbt-commands) for more information.
+</Note>
+
 ---
 
 ## What's next?


### PR DESCRIPTION
## Summary & Motivation

Fixes [DS-163](https://linear.app/dagster-labs/issue/DS-163/update-dbt-tutorial-for-dbt-setup-dbt-deps)

This PR adds a note about the of [dbt command line](https://docs.getdbt.com/reference/dbt-commands) workflow when building a dbt project.

When testing the dbt scaffold with our [dagster-open-platform](https://github.com/dagster-io/dagster-open-platform/tree/main), we had an exception related to `dbt deps` not being executed before running `dagster dev`. That is because our scaffold code doesn't run `dbt deps`, unlike `dbt parse`, which makes sense because dependencies should be pulled before running `dagster dev`.

The note is to make it clear to user that each dbt project has its command line workflow required for building the project.

## How I Tested These Changes

Docs with BK
