### PR TITLE
[rfc][Dagre] layout disconnected graphs independently. [do not merge]

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -296,3 +296,41 @@ export const getUpstreamNodes = memoize(
   },
   (key, data) => JSON.stringify({key, data}),
 );
+
+export function findUnconnectedGraphs(graphData: GraphData): GraphData[] {
+  const visited = new Set<string>();
+  const unconnectedGraphs: GraphData[] = [];
+
+  const dfs = (currentId: string, currentGraph: GraphData) => {
+    visited.add(currentId);
+    currentGraph.nodes[currentId] = graphData.nodes[currentId]!;
+
+    // Traverse downstream
+    if (graphData.downstream[currentId]) {
+      for (const childId of Object.keys(graphData.downstream[currentId])) {
+        if (!visited.has(childId)) {
+          dfs(childId, currentGraph);
+        }
+      }
+    }
+
+    // Traverse upstream
+    if (graphData.upstream[currentId]) {
+      for (const parentId of Object.keys(graphData.upstream[currentId])) {
+        if (!visited.has(parentId)) {
+          dfs(parentId, currentGraph);
+        }
+      }
+    }
+  };
+
+  for (const nodeId of Object.keys(graphData.nodes)) {
+    if (!visited.has(nodeId)) {
+      const newGraph: GraphData = {nodes: {}, downstream: {}, upstream: {}};
+      dfs(nodeId, newGraph);
+      unconnectedGraphs.push(newGraph);
+    }
+  }
+
+  return unconnectedGraphs;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -106,7 +106,7 @@ export const layoutAssetGraph = (
   console.log({graphs});
   const layouts = graphs.map((graph) => layoutAssetGraphImpl(graph, opts));
   // try {
-  return layouts[0]!;
+  return layouts;
   // } catch (e) {
   //   try {
   //     return layoutAssetGraphImpl(graphData, {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -1,6 +1,13 @@
 import * as dagre from 'dagre';
 
-import {GraphData, GraphId, GraphNode, groupIdForNode, isGroupId} from './Utils';
+import {
+  GraphData,
+  GraphId,
+  GraphNode,
+  findUnconnectedGraphs,
+  groupIdForNode,
+  isGroupId,
+} from './Utils';
 import {IBounds, IPoint} from '../graph/common';
 import {ChangeReason} from '../graphql/types';
 
@@ -95,20 +102,23 @@ export const layoutAssetGraph = (
   graphData: GraphData,
   opts: LayoutAssetGraphOptions,
 ): AssetGraphLayout => {
-  try {
-    return layoutAssetGraphImpl(graphData, opts);
-  } catch (e) {
-    try {
-      return layoutAssetGraphImpl(graphData, {
-        ...opts,
-        overrides: {
-          ranker: 'longest-path',
-        },
-      });
-    } catch (e) {
-      return layoutAssetGraphImpl(graphData, {...opts, overrides: {ranker: 'network-simplex'}});
-    }
-  }
+  const graphs = findUnconnectedGraphs(graphData);
+  console.log({graphs});
+  const layouts = graphs.map((graph) => layoutAssetGraphImpl(graph, opts));
+  // try {
+  return layouts[0]!;
+  // } catch (e) {
+  //   try {
+  //     return layoutAssetGraphImpl(graphData, {
+  //       ...opts,
+  //       overrides: {
+  //         ranker: 'longest-path',
+  //       },
+  //     });
+  //   } catch (e) {
+  //     return layoutAssetGraphImpl(graphData, {...opts, overrides: {ranker: 'network-simplex'}});
+  //   }
+  // }
 };
 
 export const layoutAssetGraphImpl = (

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -10,7 +10,7 @@ import {AssetGraphLayout, LayoutAssetGraphOptions, layoutAssetGraph} from '../as
 const ASYNC_LAYOUT_SOLID_COUNT = 50;
 
 // If you're working on the layout logic, set to false so hot-reloading re-computes the layout
-const CACHING_ENABLED = true;
+const CACHING_ENABLED = false;
 
 // Op Graph
 


### PR DESCRIPTION
## Summary & Motivation

Sometimes dagre chokes on disconnected graphs with [this error ](https://github.com/dagrejs/dagre/issues/234). Laying out the disconnected graphs independently circumvents the issue, but each disconnected graph could share the same group(s) as one of the neighboring disconnected graphs meaning if we were to stack these graphs on top of each other then there would be multiple boxes for each group. IMO this would result in easier to understand graphs. Another option is to force the graphs to be connected by adding dummy nodes/edges that we then don't render.
