### PR TITLE
[DRAFT] Prototype for ObserverDefinition class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/observer_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/observer_definition.py
@@ -1,0 +1,77 @@
+import random
+from abc import ABC, abstractmethod
+from typing import Optional, Sequence
+
+import dagster._check as check
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.data_version import DATA_VERSION_TAG
+from dagster._core.definitions.decorators.sensor_decorator import sensor
+from dagster._core.definitions.events import AssetObservation
+from dagster._core.definitions.external_asset import external_assets_from_specs
+from dagster._core.definitions.run_request import SensorResult
+from dagster._core.definitions.sensor_definition import SensorDefinition, SensorEvaluationContext
+from dagster._model import DagsterModel
+
+
+class ObserverEvaluationContext(DagsterModel):
+    cursor: Optional[str]
+
+    @staticmethod
+    def from_sensor_evaluation_context(
+        context: SensorEvaluationContext,
+    ) -> "ObserverEvaluationContext":
+        return ObserverEvaluationContext(cursor=context.cursor)
+
+
+class ObserverEvaluationResult(DagsterModel):
+    cursor: str
+    updated: bool
+
+
+class ObserverDefinition(ABC):
+    name: str
+    specs: Sequence[AssetSpec]
+
+    def __init__(self, name: Optional[str] = None, specs: Optional[Sequence[AssetSpec]] = None):
+        self.name = name or self.__class__.__name__
+        self.specs = specs or [AssetSpec(key=AssetKey(["_dagster_external", self.name]))]
+
+    @property
+    def spec(self) -> AssetSpec:
+        check.invariant(len(self.specs) == 1)
+        return self.specs[0]
+
+    @abstractmethod
+    def observe(self, context: ObserverEvaluationContext) -> ObserverEvaluationResult:
+        pass
+
+    def _get_sensor_result(self, observe_result: ObserverEvaluationResult) -> SensorResult:
+        if observe_result.updated:
+            return SensorResult(
+                cursor=observe_result.cursor,
+                asset_events=[
+                    AssetObservation(
+                        asset_key=self.spec.key,
+                        tags={DATA_VERSION_TAG: str(random.randint(0, 100000000))},
+                    )
+                ],
+            )
+        else:
+            return SensorResult(cursor=observe_result.cursor)
+
+    def sensor(self) -> SensorDefinition:
+        """Creates a SensorDefinition to periodically evaluate the observer."""
+
+        @sensor(name=self.name)
+        def _sensor(context: SensorEvaluationContext) -> SensorResult:
+            observe_context = ObserverEvaluationContext.from_sensor_evaluation_context(context)
+            observe_result = self.observe(observe_context)
+            return self._get_sensor_result(observe_result)
+
+        return _sensor
+
+    def _external_assets(self) -> Sequence[AssetsDefinition]:
+        """Creates external assets for the observed specs."""
+        return external_assets_from_specs(self.specs)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observer.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observer.py
@@ -106,6 +106,11 @@ def test_multi_observer() -> None:
     }
 
 
+"""
+This section exists to allow you to dagster dev this_file.py to see everything work together.
+"""
+
+
 class WebhookObserver(ObserverDefinition):
     def observe(self, context: ObserverEvaluationContext) -> ObserverEvaluationResult:
         cursor_val = int(context.cursor) + 1 if context.cursor else 1

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observer.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observer.py
@@ -1,0 +1,130 @@
+from typing import Sequence
+
+from dagster import AssetKey, AssetSpec, Definitions, asset
+from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from dagster._core.definitions.observer_definition import (
+    ObserverDefinition,
+    ObserverEvaluationContext,
+    ObserverEvaluationResult,
+)
+from dagster._core.definitions.sensor_definition import build_sensor_context
+
+
+def test_simplest_observer() -> None:
+    class HardcodedObserver(ObserverDefinition):
+        def observe(self, context: ObserverEvaluationContext) -> ObserverEvaluationResult:
+            cursor_val = int(context.cursor) + 1 if context.cursor else 1
+
+            return ObserverEvaluationResult(cursor=str(cursor_val), updated=cursor_val % 3 == 0)
+
+    hardcoded_observer = HardcodedObserver()
+
+    @asset(deps=[hardcoded_observer.spec])
+    def downstream(): ...
+
+    defs = Definitions(
+        assets=[downstream],
+        sensors=[hardcoded_observer.sensor()],
+    )
+
+    def _evaluate_tick(cursor: str):
+        return (
+            defs.get_sensor_def("HardcodedObserver")
+            .evaluate_tick(build_sensor_context(cursor=cursor))
+            .asset_events
+        )
+
+    asset_events_1 = _evaluate_tick("1")
+    assert asset_events_1 == []
+
+    asset_events_2 = _evaluate_tick("2")
+    assert len(asset_events_2) == 1
+    assert asset_events_2[0].asset_key == AssetKey(["_dagster_external", "HardcodedObserver"])
+
+
+def test_single_observer() -> None:
+    class S3BucketObserver(ObserverDefinition):
+        def __init__(self, s3_bucket: str):
+            super().__init__(
+                name=f"s3_bucket_{s3_bucket}_observer",
+                specs=[AssetSpec(key=AssetKey(["s3", s3_bucket]))],
+            )
+
+        def observe(self, context: ObserverEvaluationContext) -> ObserverEvaluationResult:
+            cursor_val = int(context.cursor) + 1 if context.cursor else 1
+
+            return ObserverEvaluationResult(cursor=str(cursor_val), updated=cursor_val % 3 == 0)
+
+    xyz_bucket_observer = S3BucketObserver("some_bucket")
+
+    @asset(deps=[xyz_bucket_observer.spec])
+    def downstream(): ...
+
+    defs = Definitions(
+        assets=[downstream],
+        sensors=[xyz_bucket_observer.sensor()],
+    )
+
+    assert defs.get_sensor_def("s3_bucket_some_bucket_observer")
+
+    asset_graph = defs.get_asset_graph()
+    assert asset_graph.get(AssetKey(["s3", "some_bucket"])).child_keys == {downstream.key}
+    assert asset_graph.get(downstream.key).parent_keys == {AssetKey(["s3", "some_bucket"])}
+
+
+def test_multi_observer() -> None:
+    class S3BucketsObserver(ObserverDefinition):
+        def __init__(self, name: str, s3_buckets: Sequence[str]):
+            super().__init__(
+                name=name,
+                specs=[AssetSpec(key=AssetKey(["s3", b])) for b in s3_buckets],
+            )
+
+        def observe(self, context: ObserverEvaluationContext) -> ObserverEvaluationResult:
+            cursor_val = int(context.cursor) + 1 if context.cursor else 1
+
+            return ObserverEvaluationResult(cursor=str(cursor_val), updated=cursor_val % 3 == 0)
+
+    multi_observer = S3BucketsObserver("multi_observer", ["a", "b"])
+
+    @asset(deps=[*multi_observer.specs])
+    def downstream(): ...
+
+    defs = Definitions(
+        assets=[downstream],
+        sensors=[multi_observer.sensor()],
+    )
+
+    assert defs.get_sensor_def("multi_observer")
+
+    asset_graph = defs.get_asset_graph()
+    assert asset_graph.get(AssetKey(["s3", "a"])).child_keys == {downstream.key}
+    assert asset_graph.get(AssetKey(["s3", "b"])).child_keys == {downstream.key}
+    assert asset_graph.get(downstream.key).parent_keys == {
+        AssetKey(["s3", "a"]),
+        AssetKey(["s3", "b"]),
+    }
+
+
+class WebhookObserver(ObserverDefinition):
+    def observe(self, context: ObserverEvaluationContext) -> ObserverEvaluationResult:
+        cursor_val = int(context.cursor) + 1 if context.cursor else 1
+
+        return ObserverEvaluationResult(cursor=str(cursor_val), updated=cursor_val % 3 == 0)
+
+
+my_webhook_observer = WebhookObserver()
+
+
+@asset(deps=[my_webhook_observer.spec], auto_materialize_policy=AutoMaterializePolicy.eager())
+def downstream() -> None: ...
+
+
+@asset(deps=[downstream], auto_materialize_policy=AutoMaterializePolicy.eager())
+def downerstream() -> None: ...
+
+
+defs = Definitions(
+    assets=[downstream, downerstream],
+    sensors=[my_webhook_observer.sensor()],
+)


### PR DESCRIPTION
## Summary & Motivation

Tried a few things, and it turns out life is way simpler if we just have users pass in a sensor to sensors and deps into deps, rather than trying to scrape a sensor off of deps. Sean's work in the past means that external, totally unexecutable assets are already created for us for free, so just adding specs to deps is enough for us to get a node in the asset graph that we can refer to.

The mental model of passing in an observer's sensor feels mostly reasonable to me, although I am tempted to just call this an "ObservationSensor" (bad name) or something of the sort and have that get passed directly into `sensors`, rather than having to convert this into a SensorDefinition first.

Note there are some weird changes to caching_instance_queryer.py because we were making some assumptions that if an asset was not explicitly marked as "observable", then we would never expect to see asset observations for it, which is not the case. This changes things to just look for asset observations for any asset which is not materializable. This likely has some secondary effects that we'll need to think about, just wanted to get a working demo going.

## How I Tested These Changes
