### PR TITLE
Fix deadline metadata

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/freshness_checks/shared_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_checks/shared_builder.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Callable, Iterable, Optional, Sequence, Union, cast
+from typing import Any, Callable, Dict, Iterable, Optional, Sequence, Union, cast
 
 import pendulum
 
@@ -10,21 +10,31 @@ from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.decorators.asset_check_decorator import (
     multi_asset_check,
 )
-from dagster._core.definitions.metadata import FloatMetadataValue, TimestampMetadataValue
+from dagster._core.definitions.metadata import (
+    FloatMetadataValue,
+    JsonMetadataValue,
+    MetadataValue,
+    TimestampMetadataValue,
+)
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
 from dagster._core.execution.context.compute import (
     AssetCheckExecutionContext,
 )
-from dagster._utils.schedules import get_latest_completed_cron_tick, is_valid_cron_string
+from dagster._utils.schedules import (
+    get_latest_completed_cron_tick,
+    get_next_cron_tick,
+    is_valid_cron_string,
+)
 
 from ..assets import AssetsDefinition, SourceAsset
 from ..events import AssetKey, CoercibleToAssetKey
 from .utils import (
     DEADLINE_CRON_PARAM_KEY,
+    EXPECTED_BY_TIMESTAMP_METADATA_KEY,
+    FRESH_UNTIL_METADATA_KEY,
     FRESHNESS_PARAMS_METADATA_KEY,
     LAST_UPDATED_TIMESTAMP_METADATA_KEY,
     LOWER_BOUND_DELTA_PARAM_KEY,
-    OVERDUE_DEADLINE_TIMESTAMP_METADATA_KEY,
     OVERDUE_SECONDS_METADATA_KEY,
     TIMEZONE_PARAM_KEY,
     asset_to_keys_iterable,
@@ -84,8 +94,12 @@ def build_freshness_multi_check(
                 "Expected partitions_def to be time-windowed.",
             )
             current_time_in_freshness_tz = pendulum.from_timestamp(current_timestamp, tz=timezone)
-            latest_completed_cron_tick = get_latest_completed_cron_tick(
-                deadline_cron, current_time_in_freshness_tz, timezone
+            latest_completed_cron_tick = (
+                get_latest_completed_cron_tick(
+                    deadline_cron, current_time_in_freshness_tz, timezone
+                )
+                if deadline_cron
+                else None
             )
             deadline = check.inst_param(
                 latest_completed_cron_tick or current_time_in_freshness_tz,
@@ -123,16 +137,38 @@ def build_freshness_multi_check(
                 and update_timestamp >= last_update_time_lower_bound.timestamp()
             )
 
-            metadata = {
-                FRESHNESS_PARAMS_METADATA_KEY: params_metadata,
-                OVERDUE_DEADLINE_TIMESTAMP_METADATA_KEY: TimestampMetadataValue(
-                    deadline.timestamp()
-                ),
+            metadata: Dict[str, MetadataValue] = {
+                FRESHNESS_PARAMS_METADATA_KEY: JsonMetadataValue(params_metadata),
             }
             if not passed:
                 metadata[OVERDUE_SECONDS_METADATA_KEY] = FloatMetadataValue(
                     current_timestamp - deadline.timestamp()
                 )
+                expected_by = (
+                    deadline.timestamp()
+                    if deadline_cron
+                    else update_timestamp + check.not_none(lower_bound_delta).total_seconds()
+                    if update_timestamp
+                    else None
+                )
+                if expected_by:
+                    metadata[EXPECTED_BY_TIMESTAMP_METADATA_KEY] = TimestampMetadataValue(
+                        expected_by
+                    )
+            else:
+                # If the asset is fresh, we can potentially determine when it has the possibility of becoming stale again.
+                # In the case of a deadline cron, this is the next cron tick after the current time.
+                # In the case of just a lower_bound_delta, this is the last update time plus the
+                # lower_bound_delta.
+                fresh_until = (
+                    check.not_none(
+                        get_next_cron_tick(deadline_cron, current_time_in_freshness_tz, timezone)
+                    ).timestamp()
+                    if deadline_cron
+                    else check.not_none(update_timestamp)
+                    + check.not_none(lower_bound_delta).total_seconds()
+                )
+                metadata[FRESH_UNTIL_METADATA_KEY] = TimestampMetadataValue(fresh_until)
             if update_timestamp:
                 metadata[LAST_UPDATED_TIMESTAMP_METADATA_KEY] = TimestampMetadataValue(
                     update_timestamp

--- a/python_modules/dagster/dagster/_core/definitions/freshness_checks/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_checks/utils.py
@@ -20,7 +20,10 @@ DEFAULT_FRESHNESS_TIMEZONE = "UTC"
 # Top-level metadata keys
 LAST_UPDATED_TIMESTAMP_METADATA_KEY = "dagster/last_updated_timestamp"
 FRESHNESS_PARAMS_METADATA_KEY = "dagster/freshness_params"
-OVERDUE_DEADLINE_TIMESTAMP_METADATA_KEY = "dagster/overdue_deadline_timestamp"
+# When an asset is overdue, this represents the timestamp by which the asset was expected to arrive.
+EXPECTED_BY_TIMESTAMP_METADATA_KEY = "dagster/expected_by_timestamp"
+# When an asset is fresh, this represents the timestamp when the asset can become stale again.
+FRESH_UNTIL_METADATA_KEY = "dagster/fresh_until_timestamp"
 OVERDUE_SECONDS_METADATA_KEY = "dagster/overdue_seconds"
 
 # dagster/freshness_params inner keys

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -904,13 +904,21 @@ def schedule_execution_time_iterator(
 
 
 def get_latest_completed_cron_tick(
-    cron_string: Optional[str], current_time: datetime.datetime, timezone: Optional[str]
-) -> Optional[datetime.datetime]:
-    if not cron_string:
-        return None
-
+    cron_string: str, current_time: datetime.datetime, timezone: Optional[str]
+) -> datetime.datetime:
     cron_iter = reverse_cron_string_iterator(
         end_timestamp=current_time.timestamp(),
+        cron_string=cron_string,
+        execution_timezone=timezone,
+    )
+    return pendulum.instance(next(cron_iter))
+
+
+def get_next_cron_tick(
+    cron_string: str, current_time: datetime.datetime, timezone: Optional[str]
+) -> datetime.datetime:
+    cron_iter = cron_string_iterator(
+        start_timestamp=current_time.timestamp(),
         cron_string=cron_string,
         execution_timezone=timezone,
     )


### PR DESCRIPTION
The existing overdue_deadline_timestamp piece of metadata is confusing and inscrutable. I'm replacing it by attempting to give the user the information that they might want upon either a successful or failed check result.

In the case of a successful check result, when's the next time that the asset could potentially be not fresh / when do I next expect the asset?
In the case of a failed check, when did I expect the asset to arrive initially?
