### PR TITLE
More practical annotation for direct asset invocation

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -427,7 +427,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             owners_by_key=owners_by_key,
         )
 
-    def __call__(self, *args: object, **kwargs: object) -> object:
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
         from .composition import is_in_composition
         from .graph_definition import GraphDefinition
 


### PR DESCRIPTION
## Summary & Motivation
It is impractical that type checkers do not accept annotated test code such as
```Python
@asset
def int_returning_asset() -> int:
    return 3

an_int: int = int_returning_asset()  # error: Expression of type "object" cannot be assigned to declared type "int"
```
Annotating with `Any` instead of `object` removes this type of false positive

## How I Tested These Changes
Checked that they remove the false positive, whether using Pyright or Mypy