### PR TITLE
[ui] Insights: bar chart tweaks

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsBarChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsBarChart.tsx
@@ -91,7 +91,9 @@ export const InsightsBarChart = (props: Props) => {
     (element: ActiveElement | null) => {
       if (element) {
         const whichBar = values[element.index];
-        console.log('Clicked', whichBar?.href);
+        if (whichBar?.href) {
+          window.open(whichBar.href);
+        }
         return;
       }
     },
@@ -154,6 +156,10 @@ export const InsightsBarChart = (props: Props) => {
 
   const options: ChartOptions<'bar'> = React.useMemo(() => {
     return {
+      // dish: Disable animation until I can figure out why it's acting crazy.
+      // When rendering a responsive grid of charts, it's doing a distracting
+      // zoom-like animation on initial render.
+      animation: false,
       responsive: true,
       maintainAspectRatio: false,
       onClick: (_event, elements) => onClick(elements[0] || null),


### PR DESCRIPTION
## Summary & Motivation

A couple of tweaks to Insights bar charts:

- Open the target `href` of the bar onclick, in a new tab.
- Disable animation. This is behaving weirdly on initial render and I can't really figure out why, and it's better to turn it off while puzzling it out.

## How I Tested These Changes

View asset Insights tab, verify rendering and click behavior.