### PR TITLE
refactor concurrency graphql endpoints to defer expensive fetches

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
@@ -14,7 +14,6 @@ from dagster._daemon.asset_daemon import get_auto_materialize_paused
 from dagster._daemon.types import DaemonStatus
 from dagster._utils.concurrency import (
     ClaimedSlotInfo,
-    ConcurrencyKeyInfo,
     PendingStepInfo,
     get_max_concurrency_limit_value,
 )
@@ -150,25 +149,52 @@ class GrapheneConcurrencyKeyInfo(graphene.ObjectType):
     class Meta:
         name = "ConcurrencyKeyInfo"
 
-    def __init__(self, concurrency_key_info: ConcurrencyKeyInfo):
-        self._claimed_slots = concurrency_key_info.claimed_slots
-        self._pending_steps = concurrency_key_info.pending_steps
-        super().__init__(
-            concurrencyKey=concurrency_key_info.concurrency_key,
-            slotCount=concurrency_key_info.slot_count,
-            activeSlotCount=concurrency_key_info.active_slot_count,
-            activeRunIds=list(concurrency_key_info.active_run_ids),
-            pendingStepCount=concurrency_key_info.pending_step_count,
-            pendingStepRunIds=list(concurrency_key_info.pending_run_ids),
-            assignedStepCount=concurrency_key_info.assigned_step_count,
-            assignedStepRunIds=list(concurrency_key_info.assigned_run_ids),
-        )
+    def __init__(self, concurrency_key: str):
+        self._concurrency_key = concurrency_key
+        self._concurrency_key_info = None
+        super().__init__(concurrencyKey=concurrency_key)
 
-    def resolve_claimedSlots(self, _graphene_info: ResolveInfo):
-        return [GrapheneClaimedConcurrencySlot(slot) for slot in self._claimed_slots]
+    def _get_concurrency_key_info(self, graphene_info: ResolveInfo):
+        if not self._concurrency_key_info:
+            self._concurrency_key_info = (
+                graphene_info.context.instance.event_log_storage.get_concurrency_info(
+                    self._concurrency_key
+                )
+            )
+        return self._concurrency_key_info
 
-    def resolve_pendingSteps(self, _graphene_info: ResolveInfo):
-        return [GraphenePendingConcurrencyStep(step) for step in self._pending_steps]
+    def resolve_claimedSlots(self, graphene_info: ResolveInfo):
+        return [
+            GrapheneClaimedConcurrencySlot(slot)
+            for slot in self._get_concurrency_key_info(graphene_info).claimed_slots
+        ]
+
+    def resolve_pendingSteps(self, graphene_info: ResolveInfo):
+        return [
+            GraphenePendingConcurrencyStep(step)
+            for step in self._get_concurrency_key_info(graphene_info).pending_steps
+        ]
+
+    def resolve_slotCount(self, graphene_info: ResolveInfo):
+        return self._get_concurrency_key_info(graphene_info).slot_count
+
+    def resolve_activeSlotCount(self, graphene_info: ResolveInfo):
+        return self._get_concurrency_key_info(graphene_info).active_slot_count
+
+    def resolve_activeRunIds(self, graphene_info: ResolveInfo):
+        return list(self._get_concurrency_key_info(graphene_info).active_run_ids)
+
+    def resolve_pendingStepCount(self, graphene_info: ResolveInfo):
+        return self._get_concurrency_key_info(graphene_info).pending_step_count
+
+    def resolve_pendingStepRunIds(self, graphene_info: ResolveInfo):
+        return list(self._get_concurrency_key_info(graphene_info).pending_run_ids)
+
+    def resolve_assignedStepCount(self, graphene_info: ResolveInfo):
+        return self._get_concurrency_key_info(graphene_info).assigned_step_count
+
+    def resolve_assignedStepRunIds(self, graphene_info: ResolveInfo):
+        return list(self._get_concurrency_key_info(graphene_info).assigned_run_ids)
 
 
 class GrapheneRunQueueConfig(graphene.ObjectType):
@@ -282,13 +308,11 @@ class GrapheneInstance(graphene.ObjectType):
     def resolve_concurrencyLimits(self, _graphene_info: ResolveInfo):
         res = []
         for key in self._instance.event_log_storage.get_concurrency_keys():
-            key_info = self._instance.event_log_storage.get_concurrency_info(key)
-            res.append(GrapheneConcurrencyKeyInfo(key_info))
+            res.append(GrapheneConcurrencyKeyInfo(key))
         return res
 
     def resolve_concurrencyLimit(self, _graphene_info: ResolveInfo, concurrencyKey):
-        key_info = self._instance.event_log_storage.get_concurrency_info(concurrencyKey)
-        return GrapheneConcurrencyKeyInfo(key_info)
+        return GrapheneConcurrencyKeyInfo(concurrencyKey)
 
     def resolve_minConcurrencyLimitValue(self, _graphene_info: ResolveInfo):
         if isinstance(


### PR DESCRIPTION
## Summary & Motivation
The initial request for the concurrency limits should initially just fetch the keys, so that we can virtualize the concurrency info table.

We can defer the slot / pending step info for the individual row fetches

## How I Tested These Changes
BK, manually loaded the instance concurrency page.