### PR TITLE
Change instance concurrency table to be virtualized

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/VirtualizedInstanceConcurrencyTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/VirtualizedInstanceConcurrencyTable.tsx
@@ -54,7 +54,7 @@ export const ConcurrencyTable = ({
         <Container ref={parentRef}>
           <Inner $totalHeight={totalHeight}>
             {items.map(({index, key, size, start}) => {
-              const concurrencyKey: string = concurrencyKeys[index]!;
+              const concurrencyKey = concurrencyKeys[index]!;
               return (
                 <ConcurrencyRow
                   key={key}
@@ -148,8 +148,8 @@ const ConcurrencyRow = ({
         </RowCell>
         <RowCell>
           {limit ? (
-            <Box>
-              <span style={{marginRight: 16}}>{limit.pendingSteps.length}</span>
+            <Box flex={{direction: 'row', gap: 16, alignItems: 'center'}}>
+              <span>{limit.pendingSteps.length}</span>
               <Tag intent="primary" interactive>
                 <ButtonLink
                   onClick={() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/VirtualizedInstanceConcurrencyTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/VirtualizedInstanceConcurrencyTable.tsx
@@ -1,0 +1,235 @@
+import {gql, useLazyQuery} from '@apollo/client';
+import {
+  Box,
+  Button,
+  ButtonLink,
+  Colors,
+  Icon,
+  Menu,
+  MenuItem,
+  Popover,
+  Tag,
+} from '@dagster-io/ui-components';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import {useRef} from 'react';
+import styled from 'styled-components';
+
+import {
+  SingleConcurrencyKeyQuery,
+  SingleConcurrencyKeyQueryVariables,
+} from './types/VirtualizedInstanceConcurrencyTable.types';
+import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {Container, HeaderCell, Inner, Row, RowCell} from '../ui/VirtualizedTable';
+import {LoadingOrNone, useDelayedRowQuery} from '../workspace/VirtualizedWorkspaceTable';
+
+const TEMPLATE_COLUMNS = '1fr 150px 150px 150px 150px 150px';
+
+export const ConcurrencyTable = ({
+  concurrencyKeys,
+  onEdit,
+  onDelete,
+  onSelect,
+}: {
+  concurrencyKeys: string[];
+  onEdit: (key: string) => void;
+  onDelete: (key: string) => void;
+  onSelect: (key: string | undefined) => void;
+}) => {
+  const parentRef = useRef<HTMLDivElement | null>(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: concurrencyKeys.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 64,
+    overscan: 10,
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const items = rowVirtualizer.getVirtualItems();
+
+  return (
+    <>
+      <ConcurrencyHeader />
+      <div style={{overflow: 'hidden'}}>
+        <Container ref={parentRef}>
+          <Inner $totalHeight={totalHeight}>
+            {items.map(({index, key, size, start}) => {
+              const concurrencyKey: string = concurrencyKeys[index]!;
+              return (
+                <ConcurrencyRow
+                  key={key}
+                  concurrencyKey={concurrencyKey}
+                  onEdit={onEdit}
+                  onDelete={onDelete}
+                  onSelect={onSelect}
+                  height={size}
+                  start={start}
+                />
+              );
+            })}
+          </Inner>
+        </Container>
+      </div>
+    </>
+  );
+};
+
+const ConcurrencyHeader = () => {
+  return (
+    <Box
+      border="top-and-bottom"
+      style={{
+        display: 'grid',
+        gridTemplateColumns: TEMPLATE_COLUMNS,
+        height: '32px',
+        fontSize: '12px',
+        color: Colors.textLight(),
+      }}
+    >
+      <HeaderCell>Concurrency key</HeaderCell>
+      <HeaderCell>Total slots</HeaderCell>
+      <HeaderCell>Assigned steps</HeaderCell>
+      <HeaderCell>Pending steps</HeaderCell>
+      <HeaderCell>All steps</HeaderCell>
+      <HeaderCell></HeaderCell>
+    </Box>
+  );
+};
+const ConcurrencyRow = ({
+  concurrencyKey,
+  onEdit,
+  onDelete,
+  onSelect,
+  height,
+  start,
+}: {
+  concurrencyKey: string;
+  onDelete: (key: string) => void;
+  onEdit: (key: string) => void;
+  onSelect: (key: string | undefined) => void;
+  height: number;
+  start: number;
+}) => {
+  const [queryJob, queryResult] = useLazyQuery<
+    SingleConcurrencyKeyQuery,
+    SingleConcurrencyKeyQueryVariables
+  >(SINGLE_CONCURRENCY_KEY_QUERY, {
+    variables: {concurrencyKey},
+  });
+
+  useDelayedRowQuery(queryJob);
+  useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
+
+  const {data} = queryResult;
+  const limit = data?.instance.concurrencyLimit;
+
+  return (
+    <Row $height={height} $start={start}>
+      <RowGrid border="bottom">
+        <RowCell>
+          <>{concurrencyKey}</>
+        </RowCell>
+        <RowCell>
+          {limit ? <div>{limit.slotCount}</div> : <LoadingOrNone queryResult={queryResult} />}
+        </RowCell>
+        <RowCell>
+          {limit ? (
+            <>{limit.pendingSteps.filter((x) => !!x.assignedTimestamp).length}</>
+          ) : (
+            <LoadingOrNone queryResult={queryResult} />
+          )}
+        </RowCell>
+        <RowCell>
+          {limit ? (
+            <>{limit.pendingSteps.filter((x) => !x.assignedTimestamp).length}</>
+          ) : (
+            <LoadingOrNone queryResult={queryResult} />
+          )}
+        </RowCell>
+        <RowCell>
+          {limit ? (
+            <Box>
+              <span style={{marginRight: 16}}>{limit.pendingSteps.length}</span>
+              <Tag intent="primary" interactive>
+                <ButtonLink
+                  onClick={() => {
+                    onSelect(limit.concurrencyKey);
+                  }}
+                >
+                  View all
+                </ButtonLink>
+              </Tag>
+            </Box>
+          ) : (
+            <LoadingOrNone queryResult={queryResult} />
+          )}
+        </RowCell>
+        <RowCell>
+          <ConcurrencyLimitActionMenu
+            concurrencyKey={concurrencyKey}
+            onEdit={onEdit}
+            onDelete={onDelete}
+          />
+        </RowCell>
+      </RowGrid>
+    </Row>
+  );
+};
+
+const ConcurrencyLimitActionMenu = ({
+  concurrencyKey,
+  onDelete,
+  onEdit,
+}: {
+  concurrencyKey: string;
+  onEdit: (key: string) => void;
+  onDelete: (key: string) => void;
+}) => {
+  return (
+    <Popover
+      content={
+        <Menu>
+          <MenuItem icon="edit" text="Edit" onClick={() => onEdit(concurrencyKey)} />
+          <MenuItem
+            icon="delete"
+            intent="danger"
+            text="Delete"
+            onClick={() => onDelete(concurrencyKey)}
+          />
+        </Menu>
+      }
+      position="bottom-left"
+    >
+      <Button icon={<Icon name="expand_more" />} />
+    </Popover>
+  );
+};
+
+const SINGLE_CONCURRENCY_KEY_QUERY = gql`
+  query SingleConcurrencyKeyQuery($concurrencyKey: String!) {
+    instance {
+      id
+      concurrencyLimit(concurrencyKey: $concurrencyKey) {
+        concurrencyKey
+        slotCount
+        claimedSlots {
+          runId
+          stepKey
+        }
+        pendingSteps {
+          runId
+          stepKey
+          enqueuedTimestamp
+          assignedTimestamp
+          priority
+        }
+      }
+    }
+  }
+`;
+
+const RowGrid = styled(Box)`
+  display: grid;
+  grid-template-columns: ${TEMPLATE_COLUMNS};
+  height: 100%;
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceConcurrency.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceConcurrency.types.ts
@@ -49,20 +49,7 @@ export type InstanceConcurrencyLimitsQuery = {
       maxConcurrentRuns: number;
       tagConcurrencyLimitsYaml: string | null;
     } | null;
-    concurrencyLimits: Array<{
-      __typename: 'ConcurrencyKeyInfo';
-      concurrencyKey: string;
-      slotCount: number;
-      claimedSlots: Array<{__typename: 'ClaimedConcurrencySlot'; runId: string; stepKey: string}>;
-      pendingSteps: Array<{
-        __typename: 'PendingConcurrencyStep';
-        runId: string;
-        stepKey: string;
-        enqueuedTimestamp: number;
-        assignedTimestamp: number | null;
-        priority: number | null;
-      }>;
-    }>;
+    concurrencyLimits: Array<{__typename: 'ConcurrencyKeyInfo'; concurrencyKey: string}>;
   };
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/VirtualizedInstanceConcurrencyTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/VirtualizedInstanceConcurrencyTable.types.ts
@@ -1,0 +1,29 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type SingleConcurrencyKeyQueryVariables = Types.Exact<{
+  concurrencyKey: Types.Scalars['String']['input'];
+}>;
+
+export type SingleConcurrencyKeyQuery = {
+  __typename: 'Query';
+  instance: {
+    __typename: 'Instance';
+    id: string;
+    concurrencyLimit: {
+      __typename: 'ConcurrencyKeyInfo';
+      concurrencyKey: string;
+      slotCount: number;
+      claimedSlots: Array<{__typename: 'ClaimedConcurrencySlot'; runId: string; stepKey: string}>;
+      pendingSteps: Array<{
+        __typename: 'PendingConcurrencyStep';
+        runId: string;
+        stepKey: string;
+        enqueuedTimestamp: number;
+        assignedTimestamp: number | null;
+        priority: number | null;
+      }>;
+    };
+  };
+};

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
@@ -14,7 +14,6 @@ from dagster._daemon.asset_daemon import get_auto_materialize_paused
 from dagster._daemon.types import DaemonStatus
 from dagster._utils.concurrency import (
     ClaimedSlotInfo,
-    ConcurrencyKeyInfo,
     PendingStepInfo,
     get_max_concurrency_limit_value,
 )
@@ -150,25 +149,52 @@ class GrapheneConcurrencyKeyInfo(graphene.ObjectType):
     class Meta:
         name = "ConcurrencyKeyInfo"
 
-    def __init__(self, concurrency_key_info: ConcurrencyKeyInfo):
-        self._claimed_slots = concurrency_key_info.claimed_slots
-        self._pending_steps = concurrency_key_info.pending_steps
-        super().__init__(
-            concurrencyKey=concurrency_key_info.concurrency_key,
-            slotCount=concurrency_key_info.slot_count,
-            activeSlotCount=concurrency_key_info.active_slot_count,
-            activeRunIds=list(concurrency_key_info.active_run_ids),
-            pendingStepCount=concurrency_key_info.pending_step_count,
-            pendingStepRunIds=list(concurrency_key_info.pending_run_ids),
-            assignedStepCount=concurrency_key_info.assigned_step_count,
-            assignedStepRunIds=list(concurrency_key_info.assigned_run_ids),
-        )
+    def __init__(self, concurrency_key: str):
+        self._concurrency_key = concurrency_key
+        self._concurrency_key_info = None
+        super().__init__(concurrencyKey=concurrency_key)
 
-    def resolve_claimedSlots(self, _graphene_info: ResolveInfo):
-        return [GrapheneClaimedConcurrencySlot(slot) for slot in self._claimed_slots]
+    def _get_concurrency_key_info(self, graphene_info: ResolveInfo):
+        if not self._concurrency_key_info:
+            self._concurrency_key_info = (
+                graphene_info.context.instance.event_log_storage.get_concurrency_info(
+                    self._concurrency_key
+                )
+            )
+        return self._concurrency_key_info
 
-    def resolve_pendingSteps(self, _graphene_info: ResolveInfo):
-        return [GraphenePendingConcurrencyStep(step) for step in self._pending_steps]
+    def resolve_claimedSlots(self, graphene_info: ResolveInfo):
+        return [
+            GrapheneClaimedConcurrencySlot(slot)
+            for slot in self._get_concurrency_key_info(graphene_info).claimed_slots
+        ]
+
+    def resolve_pendingSteps(self, graphene_info: ResolveInfo):
+        return [
+            GraphenePendingConcurrencyStep(step)
+            for step in self._get_concurrency_key_info(graphene_info).pending_steps
+        ]
+
+    def resolve_slotCount(self, graphene_info: ResolveInfo):
+        return self._get_concurrency_key_info(graphene_info).slot_count
+
+    def resolve_activeSlotCount(self, graphene_info: ResolveInfo):
+        return self._get_concurrency_key_info(graphene_info).active_slot_count
+
+    def resolve_activeRunIds(self, graphene_info: ResolveInfo):
+        return list(self._get_concurrency_key_info(graphene_info).active_run_ids)
+
+    def resolve_pendingStepCount(self, graphene_info: ResolveInfo):
+        return self._get_concurrency_key_info(graphene_info).pending_step_count
+
+    def resolve_pendingStepRunIds(self, graphene_info: ResolveInfo):
+        return list(self._get_concurrency_key_info(graphene_info).pending_run_ids)
+
+    def resolve_assignedStepCount(self, graphene_info: ResolveInfo):
+        return self._get_concurrency_key_info(graphene_info).assigned_step_count
+
+    def resolve_assignedStepRunIds(self, graphene_info: ResolveInfo):
+        return list(self._get_concurrency_key_info(graphene_info).assigned_run_ids)
 
 
 class GrapheneRunQueueConfig(graphene.ObjectType):
@@ -282,13 +308,11 @@ class GrapheneInstance(graphene.ObjectType):
     def resolve_concurrencyLimits(self, _graphene_info: ResolveInfo):
         res = []
         for key in self._instance.event_log_storage.get_concurrency_keys():
-            key_info = self._instance.event_log_storage.get_concurrency_info(key)
-            res.append(GrapheneConcurrencyKeyInfo(key_info))
+            res.append(GrapheneConcurrencyKeyInfo(key))
         return res
 
     def resolve_concurrencyLimit(self, _graphene_info: ResolveInfo, concurrencyKey):
-        key_info = self._instance.event_log_storage.get_concurrency_info(concurrencyKey)
-        return GrapheneConcurrencyKeyInfo(key_info)
+        return GrapheneConcurrencyKeyInfo(concurrencyKey)
 
     def resolve_minConcurrencyLimitValue(self, _graphene_info: ResolveInfo):
         if isinstance(


### PR DESCRIPTION
## Summary & Motivation
We want to make the initial load of the page to be cheaper, so that instances with a lot of concurrency keys can find and debug specific issues more quickly

## How I Tested These Changes
BK