### PR TITLE
[docs] Revert more dagster-plus CLI references

### DIFF
--- a/docs/content/concepts/assets/asset-auto-execution.mdx
+++ b/docs/content/concepts/assets/asset-auto-execution.mdx
@@ -207,7 +207,7 @@ You can break up the evaluation of your auto-materialization policies into multi
 
 How to enable auto-materialize sensors depends on whether you're using Dagster+ or Dagster Open Source:
 
-- **Dagster+**: Use the [Dagster+ UI or the dagster-plus CLI](/dagster-plus/managing-deployments/managing-deployments#configuring-deployment-settings) to set `auto_materialize.use_sensors` to `true` in your deployment settings.
+- **Dagster+**: Use the [Dagster+ UI or the dagster-cloud CLI](/dagster-plus/managing-deployments/managing-deployments#configuring-deployment-settings) to set `auto_materialize.use_sensors` to `true` in your deployment settings.
 - **Dagster Open Source**: Add the following to your instance's `dagster.yaml` file:
 
   ```yaml

--- a/docs/content/dagster-plus.mdx
+++ b/docs/content/dagster-plus.mdx
@@ -124,7 +124,7 @@ Learn how to deploy your code to Dagster+, use command line tools, set up CI/CD,
     href="/dagster-plus/managing-deployments/code-locations"
   ></ArticleListItem>
   <ArticleListItem
-    title="Using the dagster-plus CLI"
+    title="Using the dagster-cloud CLI"
     href="/dagster-plus/managing-deployments/dagster-plus-cli"
   ></ArticleListItem>
 </ArticleList>
@@ -141,7 +141,7 @@ Learn how to deploy your code to Dagster+, use command line tools, set up CI/CD,
     href="/dagster-plus/managing-deployments/alerts/managing-alerts-in-ui"
   ></ArticleListItem>
   <ArticleListItem
-    title="Managing alerts using the dagster-plus CLI"
+    title="Managing alerts using the dagster-cloud CLI"
     href="/dagster-plus/managing-deployments/alerts/managing-alerts-cli"
   ></ArticleListItem>
   <ArticleListItem
@@ -187,7 +187,7 @@ Learn how to deploy your code to Dagster+, use command line tools, set up CI/CD,
     href="/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments-with-github"
   ></ArticleListItem>
   <ArticleListItem
-    title="Setting up Branch Deployments with the dagster-plus CLI"
+    title="Setting up Branch Deployments with the dagster-cloud CLI"
     href="/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/dagster-plus/account/authentication/setting-up-onelogin-saml-sso.mdx
+++ b/docs/content/dagster-plus/account/authentication/setting-up-onelogin-saml-sso.mdx
@@ -22,7 +22,7 @@ To complete the steps in this guide, you'll need:
 - **The following in OneLogin:**
   - An existing OneLogin account
   - Admin permissions
-- **To install the [`dagster-plus` CLI](/dagster-plus/managing-deployments/dagster-plus-cli)**
+- **To install the [`dagster-cloud` CLI](/dagster-plus/managing-deployments/dagster-plus-cli)**
 - **The following in Dagster+:**
   - A Pro plan
   - [Access to a user token](/dagster-plus/account/managing-user-agent-tokens#managing-user-tokens)

--- a/docs/content/dagster-plus/getting-started.mdx
+++ b/docs/content/dagster-plus/getting-started.mdx
@@ -163,7 +163,7 @@ For **Serverless deployments**, there are two ways to deploy your code to Dagste
 
 - [**Start from a template**](#use-a-template) - Use one of our quickstart templates to get up and running. All templates come with CI/CD already configured and will be cloned to a new GitHub repository.
 
-- [**Import an existing project**](#import-an-existing-project) - Import an existing GitHub repository using our GitHub integration or the [dagster-plus CLI](/dagster-plus/managing-deployments/dagster-plus-cli). **Note**: If using the GitHub integration, Dagster+ will automatically set up CI/CD for you.
+- [**Import an existing project**](#import-an-existing-project) - Import an existing GitHub repository using our GitHub integration or the [dagster-cloud CLI](/dagster-plus/managing-deployments/dagster-plus-cli). **Note**: If using the GitHub integration, Dagster+ will automatically set up CI/CD for you.
 
 #### Use a template
 
@@ -206,7 +206,7 @@ When finished, [continue to Step 5](#step-5-set-up-environment-variables-and-sec
 
 #### Import an existing project
 
-If you have existing Dagster code, you can use Dagster's GitHub / Gitlab app or the `dagster-plus` CLI.
+If you have existing Dagster code, you can use Dagster's GitHub / Gitlab app or the `dagster-cloud` CLI.
 
 <TabGroup>
 <TabItem name="GitHub">
@@ -455,7 +455,7 @@ Ensure that you have created a `dagster_cloud.yaml` file as described in [the qu
 
    This command updates the code locations in Dagster+. Once this finishes successfully, you should be able to see the code locations under the **Deployments** tab in Dagster+.
 
-**Note**: Creating Branch Deployments using the CLI requires some additional steps. Refer to the [Branch Deployments with the dagster-plus CLI guide](/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments) for more info.
+**Note**: Creating Branch Deployments using the CLI requires some additional steps. Refer to the [Branch Deployments with the dagster-cloud CLI guide](/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments) for more info.
 
 When finished, [continue to the next step](#step-5-set-up-environment-variables-and-secrets).
 

--- a/docs/content/dagster-plus/managing-deployments.mdx
+++ b/docs/content/dagster-plus/managing-deployments.mdx
@@ -20,7 +20,7 @@ Learn how to deploy your code to Dagster+, use command line tools, set up CI/CD,
     href="/dagster-plus/managing-deployments/code-locations"
   ></ArticleListItem>
   <ArticleListItem
-    title="Using the dagster-plus CLI"
+    title="Using the dagster-cloud CLI"
     href="/dagster-plus/managing-deployments/dagster-plus-cli"
   ></ArticleListItem>
 </ArticleList>
@@ -39,7 +39,7 @@ Learn how to deploy your code to Dagster+, use command line tools, set up CI/CD,
     href="/dagster-plus/managing-deployments/alerts/managing-alerts-in-ui"
   ></ArticleListItem>
   <ArticleListItem
-    title="Managing alerts using the dagster-plus CLI"
+    title="Managing alerts using the dagster-cloud CLI"
     href="/dagster-plus/managing-deployments/alerts/managing-alerts-cli"
   ></ArticleListItem>
   <ArticleListItem
@@ -89,7 +89,7 @@ Learn how to deploy your code to Dagster+, use command line tools, set up CI/CD,
     href="/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments-with-github"
   ></ArticleListItem>
   <ArticleListItem
-    title="Setting up Branch Deployments with the dagster-plus CLI"
+    title="Setting up Branch Deployments with the dagster-cloud CLI"
     href="/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/dagster-plus/managing-deployments/alerts.mdx
+++ b/docs/content/dagster-plus/managing-deployments/alerts.mdx
@@ -154,7 +154,7 @@ Dagster+ can send notifications via:
 Managing alert policies can be accomplished by using:
 
 - [The Dagster+ UI](/dagster-plus/managing-deployments/alerts/managing-alerts-in-ui)
-- [The `dagster-plus` command-line interface (CLI)](/dagster-plus/managing-deployments/alerts/managing-alerts-cli)
+- [The `dagster-cloud` command-line interface (CLI)](/dagster-plus/managing-deployments/alerts/managing-alerts-cli)
 
 ---
 

--- a/docs/content/dagster-plus/managing-deployments/alerts/email.mdx
+++ b/docs/content/dagster-plus/managing-deployments/alerts/email.mdx
@@ -98,7 +98,7 @@ Refer to the [Managing alerts using the `dagster-cloud` CLI](/dagster-plus/manag
     href="/dagster-plus/managing-deployments/alerts/managing-alerts-in-ui"
   ></ArticleListItem>
   <ArticleListItem
-    title="Managing alerts using the dagster-plus CLI"
+    title="Managing alerts using the dagster-cloud CLI"
     href="/dagster-plus/managing-deployments/alerts/managing-alerts-cli"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/dagster-plus/managing-deployments/alerts/managing-alerts-in-ui.mdx
+++ b/docs/content/dagster-plus/managing-deployments/alerts/managing-alerts-in-ui.mdx
@@ -151,7 +151,7 @@ To delete an alert policy, click the **Delete** button next to the policy. When 
     href="/dagster-plus/managing-deployments/alerts"
   ></ArticleListItem>
   <ArticleListItem
-    title="Managing alerts using the dagster-plus CLI"
+    title="Managing alerts using the dagster-cloud CLI"
     href="/dagster-plus/managing-deployments/alerts/managing-alerts-cli"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/dagster-plus/managing-deployments/alerts/microsoft-teams.mdx
+++ b/docs/content/dagster-plus/managing-deployments/alerts/microsoft-teams.mdx
@@ -101,7 +101,7 @@ Refer to the [Managing alerts using the `dagster-cloud` CLI](/dagster-plus/manag
     href="/dagster-plus/managing-deployments/deployment-settings-reference"
   ></ArticleListItem>
   <ArticleListItem
-    title="dagster-plus CLI"
+    title="dagster-cloud CLI"
     href="/dagster-plus/managing-deployments/dagster-plus-cli"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/dagster-plus/managing-deployments/alerts/pagerduty.mdx
+++ b/docs/content/dagster-plus/managing-deployments/alerts/pagerduty.mdx
@@ -146,7 +146,7 @@ To uninstall PagerDuty, click the **Delete** button next to the policy. When pro
     href="/dagster-plus/managing-deployments/alerts/managing-alerts-in-ui"
   ></ArticleListItem>
   <ArticleListItem
-    title="Managing alerts using the dagster-plus CLI"
+    title="Managing alerts using the dagster-cloud CLI"
     href="/dagster-plus/managing-deployments/alerts/managing-alerts-cli"
   ></ArticleListItem>
   <ArticleListItem
@@ -154,7 +154,7 @@ To uninstall PagerDuty, click the **Delete** button next to the policy. When pro
     href="/dagster-plus/managing-deployments/deployment-settings-reference"
   ></ArticleListItem>
   <ArticleListItem
-    title="dagster-plus CLI"
+    title="dagster-cloud CLI"
     href="/dagster-plus/managing-deployments/dagster-plus-cli"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/dagster-plus/managing-deployments/alerts/slack.mdx
+++ b/docs/content/dagster-plus/managing-deployments/alerts/slack.mdx
@@ -118,7 +118,7 @@ Once the app is removed, refresh the **Alerts** page in Dagster+ and the **Conne
     href="/dagster-plus/managing-deployments/alerts/managing-alerts-in-ui"
   ></ArticleListItem>
   <ArticleListItem
-    title="Managing alerts using the dagster-plus CLI"
+    title="Managing alerts using the dagster-cloud CLI"
     href="/dagster-plus/managing-deployments/alerts/managing-alerts-cli"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/dagster-plus/managing-deployments/branch-deployments.mdx
+++ b/docs/content/dagster-plus/managing-deployments/branch-deployments.mdx
@@ -159,7 +159,7 @@ There are currently two ways to set up Branch Deployments for Dagster+. In the t
       </td>
       <td>
         <a href="/dagster-plus/managing-deployments/dagster-plus-cli">
-          dagster-plus CLI
+          dagster-cloud CLI
         </a>
       </td>
       <td>

--- a/docs/content/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments-with-github.mdx
+++ b/docs/content/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments-with-github.mdx
@@ -14,7 +14,7 @@ Using this approach to branch deployments may be a good fit if:
 - You use GitHub for version control
 - You want Dagster to fully automate Branch Deployments
 
-**If you don't use GitHub for version control or want full control over your setup**, check out the [Branch deployments with the `dagster-plus CLI` guide](/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments).
+**If you don't use GitHub for version control or want full control over your setup**, check out the [Branch deployments with the `dagster-cloud CLI` guide](/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments).
 
 ---
 

--- a/docs/content/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments-with-gitlab.mdx
+++ b/docs/content/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments-with-gitlab.mdx
@@ -14,7 +14,7 @@ Using this approach to branch deployments may be a good fit if:
 - You use Gitlab for version control
 - You want Dagster to fully automate Branch Deployments
 
-**If you don't use Gitlab for version control or want full control over your setup**, check out the [Branch deployments with the `dagster-plus CLI` guide](/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments).
+**If you don't use Gitlab for version control or want full control over your setup**, check out the [Branch deployments with the `dagster-cloud CLI` guide](/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments).
 
 ---
 

--- a/docs/content/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments.mdx
+++ b/docs/content/dagster-plus/managing-deployments/branch-deployments/using-branch-deployments.mdx
@@ -93,7 +93,7 @@ After the above has occurred:
 
    ```shell
    BRANCH_DEPLOYMENT_NAME=$(
-       dagster-plus branch-deployment create-or-update \
+       dagster-cloud branch-deployment create-or-update \
            --organization $ORGANIZATION_NAME \
            --api-token $DAGSTER_CLOUD_API_TOKEN \
            --git-repo-name $REPOSITORY_NAME \
@@ -106,7 +106,7 @@ After the above has occurred:
 2. Deploy the code to the branch deployment:
 
    ```shell
-   dagster-plus workspace add-location \
+   dagster-cloud workspace add-location \
        --organization $ORGANIZATION_NAME \
        --deployment $BRANCH_DEPLOYMENT_NAME \
        --api-token $DAGSTER_CLOUD_API_TOKEN \

--- a/docs/content/dagster-plus/managing-deployments/code-locations.mdx
+++ b/docs/content/dagster-plus/managing-deployments/code-locations.mdx
@@ -192,7 +192,7 @@ You can also use the `dagster-cloud workspace` CLI commands to:
 - [Delete code locations](#deleting-code-locations-1)
 - [Sync the workspace and remote](#syncing-the-workspace)
 
-These commands perform the same underlying operations as editing your code locations in the **Deployment** tab in Dagster+. Refer to the [dagster-plus CLI guide](/dagster-plus/managing-deployments/dagster-plus-cli) for more info and installation instructions.
+These commands perform the same underlying operations as editing your code locations in the **Deployment** tab in Dagster+. Refer to the [dagster-cloud CLI guide](/dagster-plus/managing-deployments/dagster-plus-cli) for more info and installation instructions.
 
 ### Adding and updating code locations
 

--- a/docs/content/dagster-plus/managing-deployments/deployment-settings-reference.mdx
+++ b/docs/content/dagster-plus/managing-deployments/deployment-settings-reference.mdx
@@ -9,7 +9,7 @@ description: "Detailed info about configurable settings for Dagster+ deployments
 
 This reference describes the settings that can be configured for full deployments in [Dagster+](/dagster-plus).
 
-Refer to the [Managing deployments in Dagster+ guide](/dagster-plus/managing-deployments/managing-deployments#configuring-deployment-settings) for info about configuring settings in the Dagster+ interface or using the `dagster-plus` CLI.
+Refer to the [Managing deployments in Dagster+ guide](/dagster-plus/managing-deployments/managing-deployments#configuring-deployment-settings) for info about configuring settings in the Dagster+ interface or using the `dagster-cloud` CLI.
 
 ---
 

--- a/docs/content/dagster-plus/managing-deployments/managing-deployments.mdx
+++ b/docs/content/dagster-plus/managing-deployments/managing-deployments.mdx
@@ -188,7 +188,7 @@ dagster-cloud deployment settings get
     href="/guides/dagster/branch_deployments"
   ></ArticleListItem>
   <ArticleListItem
-    title="Using the dagster-plus CLI"
+    title="Using the dagster-cloud CLI"
     href="/dagster-plus/managing-deployments/dagster-plus-cli"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/deployment/run-retries.mdx
+++ b/docs/content/deployment/run-retries.mdx
@@ -11,7 +11,7 @@ If you configure run retries, a new run will be kicked off whenever a run fails 
 
 How to configure run retries depends on whether you're using Dagster+ or Dagster Open Source:
 
-- **Dagster+**: Use the [Dagster+ UI or the dagster-plus CLI](/dagster-plus/managing-deployments/managing-deployments#configuring-deployment-settings) to set a default maximum number of retries. Run retries do not need to be explicitly enabled.
+- **Dagster+**: Use the [Dagster+ UI or the dagster-cloud CLI](/dagster-plus/managing-deployments/managing-deployments#configuring-deployment-settings) to set a default maximum number of retries. Run retries do not need to be explicitly enabled.
 - **Dagster Open Source**: Use your instance's `dagster.yaml` to enable run retries.
 
 For example, the following will set a default maximum number of retries of `3` for all runs:

--- a/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
+++ b/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
@@ -134,7 +134,7 @@ These methods of limiting concurrency can be used individually or together. For 
 
 How you limit the overall number of concurrent runs in a deployment depends on whether you're using Dagster+ or Dagster Open Source:
 
-- **Dagster+**: Use the [Dagster+ UI or the `dagster-plus` CLI][cloud-deployment-settings]
+- **Dagster+**: Use the [Dagster+ UI or the `dagster-cloud` CLI][cloud-deployment-settings]
 - **Dagster Open Source**: Use your instance's `dagster.yaml`
 
 To enable this limit, use `run_queue.max_concurrent_runs`. For example, the following would limit the number of concurrent runs for the deployment to 15:
@@ -157,7 +157,7 @@ When defining a value for `max_concurrent_runs`, keep the following in mind:
 
 How you limit specific runs based on tags depends on whether you're using Dagster+ or Dagster Open Source:
 
-- **Dagster+**: Use the [Dagster+ UI or the `dagster-plus` CLI][cloud-deployment-settings]
+- **Dagster+**: Use the [Dagster+ UI or the `dagster-cloud` CLI][cloud-deployment-settings]
 - **Dagster Open Source**: Use your instance's `dagster.yaml`
 
 To enable this limit, use `run_queue.tag_concurrency_limits`. This key accepts a list of tags and their corresponding concurrency limits.
@@ -423,7 +423,7 @@ The concurrency key should match the name that the op/asset is tagged with. For 
 
 A default concurrency limit can be configured for the instance, for any concurrency keys that do not have an explicit limit set:
 
-- **Dagster+**: Use the [Dagster+ UI or the `dagster-plus` CLI][cloud-deployment-settings]
+- **Dagster+**: Use the [Dagster+ UI or the `dagster-cloud` CLI][cloud-deployment-settings]
 - **Dagster Open Source**: Use your instance's `dagster.yaml`
 
 To enable this default value, use `concurrency.default_op_concurrency_limit`. For example, the following would set the default concurrency value for the deployment to 1:

--- a/docs/content/guides/understanding-dagster-project-files.mdx
+++ b/docs/content/guides/understanding-dagster-project-files.mdx
@@ -100,7 +100,7 @@ Let's take a look at what each of these files and directories does:
         For example, you can put all analytics-related assets in a <code>my_dagster_project/assets/analytics/</code>
         folder and use <PyObject object="load_assets_from_package_module" /> in the top-level definitions
         to load them, rather than needing to manually add assets to the top-level definitions every time
-        you define one. 
+        you define one.
         <br />
         <br />
         Similarly, you can also use <PyObject object="load_assets_from_modules" /> to
@@ -154,7 +154,7 @@ Let's take a look at what each of these files and directories does:
         A build script with Python package dependencies for your new project as
         a package. Use this file to specify dependencies.
         <br /><br />
-        <strong>Note</strong>: If using Dagster+, add <code>dagster-plus</code> as a dependency.
+        <strong>Note</strong>: If using Dagster+, add <code>dagster-cloud</code> as a dependency.
       </td>
     </tr>
     <tr>

--- a/docs/content/integrations/airflow/migrating-to-dagster.mdx
+++ b/docs/content/integrations/airflow/migrating-to-dagster.mdx
@@ -202,7 +202,7 @@ In this step, you'll set up your project for use with Dagster+.
 
 <!-- Once you have your dagster cloud organization setup you can either choose to adapt your existing airflow repository to use the Dagster+ CI/CD deployment or copy over your code to the quickstart repository you made as part of the Dagster+ onboarding. -->
 
-1. Complete the steps in the [Dagster+ Getting Started guide](/dagster-plus/getting-started), if you haven't already. Proceed to the next step when your account is set up and you have the `dagster-plus` CLI installed.
+1. Complete the steps in the [Dagster+ Getting Started guide](/dagster-plus/getting-started), if you haven't already. Proceed to the next step when your account is set up and you have the `dagster-cloud` CLI installed.
 
 2. In the root of your project, create or modify the [`dagster_cloud.yaml` file](/dagster-plus/managing-deployments/dagster-cloud-yaml) with the following code:
 


### PR DESCRIPTION
We haven't released dagster-plus yet, so doing a second pass after https://github.com/dagster-io/dagster/pull/21249 and renaming the remaining `dagster-cloud` references.