### PR TITLE
[ui] Fix theming on breadcrumb popover

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import {BreadcrumbProps, Breadcrumbs} from '@blueprintjs/core';
+import {BreadcrumbProps, Breadcrumbs2 as Breadcrumbs} from '@blueprintjs/popover2';
 import {
   Box,
   Colors,
@@ -73,6 +73,7 @@ export const AssetPageHeader = ({assetKey, headerBreadcrumbs, ...extra}: Props) 
               </Heading>
             )}
             $numHeaderBreadcrumbs={headerBreadcrumbs.length}
+            popoverProps={{popoverClassName: 'dagster-popover'}}
           />
           {copyableString ? (
             <Tooltip placement="bottom" content="Copy asset key">


### PR DESCRIPTION
## Summary & Motivation

The Blueprint Breadcrumb component needed to have the `dagster-popover` class applied to it to get themed styles. By changing to the newer `Breadcrumbs2` (as suggested by Blueprint deprecation) we get the bp4 targeted classnames that are already in place on our existing popovers, and the styles just work.

<img width="234" alt="Screenshot 2024-04-17 at 13 53 10" src="https://github.com/dagster-io/dagster/assets/2823852/3c3cee87-17a0-4aa1-b048-84c6d234065f">
<img width="229" alt="Screenshot 2024-04-17 at 13 52 54" src="https://github.com/dagster-io/dagster/assets/2823852/16be9b2d-eeaf-4605-a6fc-cba39467f919">


## How I Tested These Changes

Force breadcrumbs to appear on asset page header, click on breadcrumb popover button. Verify themed styling matches the app in both light and dark mode.