### PR TITLE
move pydantic compat layer to dagster._models

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -33,19 +33,19 @@ from dagster._core.errors import (
     DagsterInvalidInvocationError,
     DagsterInvalidPythonicConfigDefinitionError,
 )
-from dagster._utils.cached_method import CACHED_METHOD_FIELD_SUFFIX
-
-from .attach_other_object_to_context import (
-    IAttachDifferentObjectToOpContext as IAttachDifferentObjectToOpContext,
-)
-from .conversion_utils import _convert_pydantic_field, safe_is_subclass
-from .pydantic_compat_layer import (
+from dagster._model.pydantic_compat_layer import (
     USING_PYDANTIC_2,
     ModelFieldCompat,
     PydanticUndefined,
     model_config,
     model_fields,
 )
+from dagster._utils.cached_method import CACHED_METHOD_FIELD_SUFFIX
+
+from .attach_other_object_to_context import (
+    IAttachDifferentObjectToOpContext as IAttachDifferentObjectToOpContext,
+)
+from .conversion_utils import _convert_pydantic_field, safe_is_subclass
 from .type_check_utils import is_literal
 from .typing_utils import BaseConfigMeta
 

--- a/python_modules/dagster/dagster/_config/pythonic_config/conversion_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/conversion_utils.py
@@ -53,8 +53,8 @@ from dagster._config.field_utils import (
     Map,
     convert_potential_field,
 )
+from dagster._model.pydantic_compat_layer import ModelFieldCompat, PydanticUndefined, model_fields
 
-from .pydantic_compat_layer import ModelFieldCompat, PydanticUndefined, model_fields
 from .type_check_utils import is_optional, safe_is_subclass
 
 

--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -35,13 +35,13 @@ from dagster._core.definitions.definition_config_schema import (
 )
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.execution.context.init import InitResourceContext, build_init_resource_context
+from dagster._model.pydantic_compat_layer import (
+    model_fields,
+)
 from dagster._utils.cached_method import cached_method
 
 from .attach_other_object_to_context import (
     IAttachDifferentObjectToOpContext as IAttachDifferentObjectToOpContext,
-)
-from .pydantic_compat_layer import (
-    model_fields,
 )
 from .type_check_utils import is_optional
 

--- a/python_modules/dagster/dagster/_model/pydantic_compat_layer.py
+++ b/python_modules/dagster/dagster/_model/pydantic_compat_layer.py
@@ -10,10 +10,6 @@ from typing import (
 import pydantic
 from pydantic import BaseModel
 
-from .attach_other_object_to_context import (
-    IAttachDifferentObjectToOpContext as IAttachDifferentObjectToOpContext,
-)
-
 USING_PYDANTIC_1 = int(pydantic.__version__.split(".")[0]) == 1
 USING_PYDANTIC_2 = int(pydantic.__version__.split(".")[0]) >= 2
 

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_constraints.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_constraints.py
@@ -2,7 +2,7 @@ from typing import List
 
 import pytest
 from dagster._config.pythonic_config import Config
-from dagster._config.pythonic_config.pydantic_compat_layer import USING_PYDANTIC_2
+from dagster._model.pydantic_compat_layer import USING_PYDANTIC_2
 from pydantic import Field, ValidationError, conlist, constr
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
@@ -11,7 +11,6 @@ from dagster import (
     sensor,
 )
 from dagster._config.pythonic_config import ConfigurableResource, ConfigurableResourceFactory
-from dagster._config.pythonic_config.pydantic_compat_layer import USING_PYDANTIC_2
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import (
     DagsterInvalidDagsterTypeInPythonicConfigDefinitionError,
@@ -19,6 +18,7 @@ from dagster._core.errors import (
     DagsterInvalidInvocationError,
     DagsterInvalidPythonicConfigDefinitionError,
 )
+from dagster._model.pydantic_compat_layer import USING_PYDANTIC_2
 
 
 def test_invalid_config_type_basic() -> None:

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -32,7 +32,6 @@ from dagster import (
     op,
     resource,
 )
-from dagster._config.pythonic_config.pydantic_compat_layer import USING_PYDANTIC_1
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import get_time_partitions_def
 from dagster._core.errors import (
@@ -50,6 +49,7 @@ from dagster._core.execution.context.invocation import (
     DirectOpExecutionContext,
     build_asset_context,
 )
+from dagster._model.pydantic_compat_layer import USING_PYDANTIC_1
 from dagster._utils.test import wrap_op_in_graph_and_execute
 
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
@@ -6,8 +6,8 @@ from dagster import (
     IAttachDifferentObjectToOpContext,
     resource,
 )
-from dagster._config.pythonic_config.pydantic_compat_layer import compat_model_validator
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
+from dagster._model.pydantic_compat_layer import compat_model_validator
 from pydantic import Field
 
 from .databricks import DatabricksClient

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -43,11 +43,11 @@ from dagster import (
     get_dagster_logger,
 )
 from dagster._annotations import public
-from dagster._config.pythonic_config.pydantic_compat_layer import compat_model_validator
 from dagster._core.definitions.metadata import (
     TableMetadataSet,
 )
 from dagster._core.errors import DagsterExecutionInterruptedError, DagsterInvalidPropertyError
+from dagster._model.pydantic_compat_layer import compat_model_validator
 from dagster._utils.warnings import disable_dagster_warnings
 from dbt.adapters.base.impl import BaseAdapter
 from dbt.adapters.factory import get_adapter, register_adapter, reset_adapters

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -15,9 +15,9 @@ from dagster import (
     resource,
 )
 from dagster._annotations import public
-from dagster._config.pythonic_config.pydantic_compat_layer import compat_model_validator
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.storage.event_log.sql_event_log import SqlDbConnection
+from dagster._model.pydantic_compat_layer import compat_model_validator
 from dagster._utils.cached_method import cached_method
 from pydantic import Field, validator
 


### PR DESCRIPTION
## Summary & Motivation

This will allow `DagsterModel` to depend on it

[INTERNAL_BRANCH=mv-pydantic-compat-layer]

## How I Tested These Changes
