### PR TITLE
Allow metadata sets to have fields that are subtypes of `MetadataValue`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/metadata_set.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/metadata_set.py
@@ -7,7 +7,7 @@ from typing_extensions import TypeVar
 from dagster import _check as check
 from dagster._model import DagsterModel
 from dagster._model.pydantic_compat_layer import model_fields
-from dagster._utils.typing_api import flatten_annotation_unions
+from dagster._utils.typing_api import flatten_unions
 
 from .metadata_value import MetadataValue, TableColumnLineage, TableSchema
 
@@ -124,7 +124,7 @@ class NamespacedMetadataSet(ABC, DagsterModel):
         """
         if isinstance(value, MetadataValue):
             annotation = model_fields(cls)[field_name].annotation
-            annotation_acceptable_types = set(flatten_annotation_unions(annotation))
+            annotation_acceptable_types = flatten_unions(annotation)
             if (
                 type(value) not in annotation_acceptable_types
                 and type(value.value) in annotation_acceptable_types
@@ -135,10 +135,10 @@ class NamespacedMetadataSet(ABC, DagsterModel):
         return value
 
     @classmethod
-    @lru_cache(maxsize=128)
+    @lru_cache(maxsize=None)  # this avoids wastefully recomputing this once per instance
     def _get_accepted_types_for_field(cls, field_name: str) -> AbstractSet[Type]:
         annotation = model_fields(cls)[field_name].annotation
-        return set(flatten_annotation_unions(annotation))
+        return flatten_unions(annotation)
 
 
 class TableMetadataSet(NamespacedMetadataSet):

--- a/python_modules/dagster/dagster/_utils/typing_api.py
+++ b/python_modules/dagster/dagster/_utils/typing_api.py
@@ -128,3 +128,17 @@ def is_typing_type(ttype):
         or ttype is typing.Dict
         or ttype is typing.List
     )
+
+
+def flatten_annotation_unions(annotation: typing.Type) -> typing.Iterable[typing.Type]:
+    """Accepts a type annotation that may be a Union of other types, and returns those other types.
+    In addition to explicit Union annotations, works for Optional, which is represented as
+    Union[T, None] under the covers.
+
+    E.g. Optional[Union[str, Union[int, float]]] would result in (str, int, float)
+    """
+    if get_origin(annotation) is typing.Union:
+        for arg in get_args(annotation):
+            yield from flatten_annotation_unions(arg)
+    else:
+        yield annotation

--- a/python_modules/dagster/dagster/_utils/typing_api.py
+++ b/python_modules/dagster/dagster/_utils/typing_api.py
@@ -130,15 +130,19 @@ def is_typing_type(ttype):
     )
 
 
-def flatten_annotation_unions(annotation: typing.Type) -> typing.Iterable[typing.Type]:
-    """Accepts a type annotation that may be a Union of other types, and returns those other types.
+def flatten_unions(ttype: typing.Type) -> typing.AbstractSet[typing.Type]:
+    """Accepts a type that may be a Union of other types, and returns those other types.
     In addition to explicit Union annotations, works for Optional, which is represented as
     Union[T, None] under the covers.
 
-    E.g. Optional[Union[str, Union[int, float]]] would result in (str, int, float)
+    E.g. Optional[Union[str, Union[int, float]]] would result in (str, int, float, type(None))
     """
-    if get_origin(annotation) is typing.Union:
-        for arg in get_args(annotation):
-            yield from flatten_annotation_unions(arg)
+    return set(_flatten_unions_inner(ttype))
+
+
+def _flatten_unions_inner(ttype: typing.Type) -> typing.Iterable[typing.Type]:
+    if get_origin(ttype) is typing.Union:
+        for arg in get_args(ttype):
+            yield from flatten_unions(arg)
     else:
-        yield annotation
+        yield ttype

--- a/python_modules/dagster/dagster_tests/definitions_tests/metadata_tests/test_namespaced_metadata_set.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/metadata_tests/test_namespaced_metadata_set.py
@@ -1,0 +1,73 @@
+from typing import Optional, Union
+
+import pytest
+from dagster import FloatMetadataValue, IntMetadataValue, UrlMetadataValue
+from dagster._check import CheckError
+from dagster._core.definitions.metadata import NamespacedMetadataSet
+from pydantic import ValidationError
+
+
+def test_extract_primitive_coercion():
+    class MyMetadataSet(NamespacedMetadataSet):
+        primitive_int: Optional[int] = None
+        primitive_float: Optional[float] = None
+        int_metadata_value: Optional[IntMetadataValue] = None
+        url_metadata_value: Optional[UrlMetadataValue] = None
+        url_or_str_metadata_value: Optional[Union[UrlMetadataValue, str]] = None
+        url_or_str_order_reversed_metadata_value: Optional[Union[str, UrlMetadataValue]] = None
+
+        @classmethod
+        def namespace(cls) -> str:
+            return "foo"
+
+    assert MyMetadataSet.extract({"foo/primitive_int": 5}).primitive_int == 5
+    assert MyMetadataSet.extract({"foo/primitive_float": 5}).primitive_float == 5
+    assert MyMetadataSet.extract({"foo/primitive_int": IntMetadataValue(5)}).primitive_int == 5
+    assert (
+        MyMetadataSet.extract({"foo/primitive_float": FloatMetadataValue(5.0)}).primitive_float == 5
+    )
+    assert MyMetadataSet.extract(
+        {"foo/int_metadata_value": IntMetadataValue(5)}
+    ).int_metadata_value == IntMetadataValue(5)
+
+    assert MyMetadataSet.extract(
+        {"foo/url_or_str_metadata_value": UrlMetadataValue("dagster.io")}
+    ).url_or_str_metadata_value == UrlMetadataValue("dagster.io")
+    assert (
+        MyMetadataSet.extract(
+            {"foo/url_or_str_metadata_value": "dagster.io"}
+        ).url_or_str_metadata_value
+        == "dagster.io"
+    )
+
+    assert MyMetadataSet.extract(
+        {"foo/url_or_str_order_reversed_metadata_value": UrlMetadataValue("dagster.io")}
+    ).url_or_str_order_reversed_metadata_value == UrlMetadataValue("dagster.io")
+    assert (
+        MyMetadataSet.extract(
+            {"foo/url_or_str_order_reversed_metadata_value": "dagster.io"}
+        ).url_or_str_order_reversed_metadata_value
+        == "dagster.io"
+    )
+
+    with pytest.raises(
+        ValidationError, match="Input should be a valid dictionary or instance of IntMetadataValue"
+    ):
+        MyMetadataSet.extract({"foo/int_metadata_value": 5})
+
+
+def test_unsupported_type_annotations():
+    class MyClass: ...
+
+    class MyMetadataSet(NamespacedMetadataSet):
+        unsupported: Optional[MyClass] = None
+
+        @classmethod
+        def namespace(cls) -> str:
+            return "foo"
+
+    with pytest.raises(
+        CheckError,
+        match=r"Type annotation for field 'unsupported' includes invalid metadata type\(s\).+MyClass",
+    ):
+        MyMetadataSet(unsupported=MyClass())

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_typing_api.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_typing_api.py
@@ -1,6 +1,7 @@
 import typing
 
 from dagster._utils.typing_api import (
+    flatten_unions,
     get_optional_inner_type,
     is_closed_python_dict_type,
     is_closed_python_list_type,
@@ -131,3 +132,21 @@ def test_is_typing_type():
     assert is_typing_type(typing.Tuple[str, typing.List]) is True
     assert is_typing_type(typing.Tuple[str, typing.Optional[typing.Dict]]) is True
     assert is_typing_type(typing.Tuple[str, typing.Tuple]) is True
+
+
+def test_flatten_unions() -> None:
+    assert flatten_unions(str) == {str}
+    assert flatten_unions(typing.Union[str, float]) == {str, float}
+    assert flatten_unions(typing.Union[str, float, int]) == {str, float, int}
+    assert flatten_unions(typing.Optional[str]) == {str, type(None)}
+    assert flatten_unions(typing.Optional[typing.Union[str, float]]) == {
+        str,
+        float,
+        type(None),
+    }
+    assert flatten_unions(typing.Union[typing.Union[str, float], int]) == {
+        str,
+        float,
+        int,
+    }
+    assert flatten_unions(typing.Any) == {typing.Any}  # type: ignore


### PR DESCRIPTION
## Summary & Motivation

The current implementation of `NamespacedMetadataSet.extract` assumes that the types of all fields are not subclasses `MetadataValue`.  When it comes across a value of type `MetadataValue`, it auto-extracts the primitive value from inside it.

This is problematic if you want to specify that a field on a metadata set is, e.g., a URL. The return type of `UrlMetadataValue.value` is `str`.

This PR makes the implementation of `NamespacedMetadataSet.extract` more sophisticated: it now looks at the type annotation on the field to determine whether to pull out the value.

Alternatives to consider here:
- Require that the `value` property on all subclasses of `MetadataValue` returns a unique type.  E.g. make `UrlMetadataValue` return a `Url` instead of a `str`. This would reduce the need for `NamespacedMetadataSet` subclasses to have values with types that are subclasses of `MetadataValue`. However, this would be a breaking change, as well as require introducing new types like `Url`.
- Require that all fields on metadata sets have types that are subclasses of `MetadataValue`. However, barring primitive types would make the API significantly more clunky to use.

## How I Tested These Changes
