### PR TITLE
[ui] Repair run bucketing bug related to sort order

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/batchRunsForTimeline.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/batchRunsForTimeline.test.tsx
@@ -151,9 +151,9 @@ describe('batchRunsForTimeline', () => {
       const batched = getBatch(runs);
       expect(batched.length).toBe(2);
 
-      // Batch A contains the later run due to sorting.
-      const batchB = batched[0]!;
-      const batchA = batched[1]!;
+      // Batch A contains the earlier run due to sorting.
+      const batchA = batched[0]!;
+      const batchB = batched[1]!;
 
       expect(batchA.startTime).toBe(10);
       expect(batchA.endTime).toBe(30);
@@ -182,10 +182,9 @@ describe('batchRunsForTimeline', () => {
       const batched = getBatch(runs);
       expect(batched.length).toBe(3);
 
-      // Sorting results in later runs being in the first batch.
-      const batchC = batched[0]!;
+      const batchA = batched[0]!;
       const batchB = batched[1]!;
-      const batchA = batched[2]!;
+      const batchC = batched[2]!;
 
       expect(batchA.startTime).toBe(10);
       expect(batchA.endTime).toBe(30);
@@ -281,8 +280,8 @@ describe('batchRunsForTimeline', () => {
       const batched = getBatch(runs);
       expect(batched.length).toBe(2);
 
-      const batchB = batched[0]!;
-      const batchA = batched[1]!;
+      const batchA = batched[0]!;
+      const batchB = batched[1]!;
 
       expect(batchA.startTime).toBe(10);
       expect(batchA.endTime).toBe(40);
@@ -295,6 +294,44 @@ describe('batchRunsForTimeline', () => {
       expect(batchB.left).toBe(40);
       expect(batchB.width).toBe(30);
       expect(batchB.runs).toContain(runB);
+    });
+  });
+
+  describe('Pre-batch sort order', () => {
+    // This is a case where sort by descending `start` value results in
+    // incorrect batching, but sort by ascending `start` value results in correct
+    // batching.
+    it('batches correctly for the strange sorting case', () => {
+      Date.now = jest.fn(() => 82600000);
+
+      const runs = [
+        // Here's a batch:
+        {startTime: 82167812, endTime: 82247921},
+        {startTime: 82194099, endTime: 82264135},
+        {startTime: 82225412, endTime: 82403992},
+        {startTime: 82318006, endTime: 82447677},
+
+        // Here's another batch, taking place after all the others:
+        {startTime: 82467775, endTime: 82559004},
+        {startTime: 82495068, endTime: 82560063},
+
+        // Here's a run that would be in a separate batch, before the others...
+        {startTime: 81181571, endTime: 81227100},
+
+        // ...except that this run bridges it together with the first batch
+        {startTime: 80172146, endTime: 82195103},
+      ];
+
+      const batched = batchRunsForTimeline({
+        runs,
+        start: 80000000,
+        end: 82600000,
+        width: 1000,
+        minChunkWidth,
+        minMultipleWidth,
+      });
+
+      expect(batched.length).toBe(2);
     });
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/batchRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/batchRunsForTimeline.tsx
@@ -32,8 +32,12 @@ export const batchRunsForTimeline = <R extends RunWithTime>(config: Config<R>) =
   const rangeLength = end - start;
 
   const now = Date.now();
-  const nowLeft = ((now - start) / (end - start)) * width;
 
+  // Give a pixel of breathing room for the "now" position.
+  const nowLeft = ((now - start) / (end - start)) * width + 1;
+
+  // Sort all runs by start time (via `left` value), ascending. Then iterate through
+  // them, batching them together.
   const batches: RunBatch<R>[] = runs
     .map((run) => {
       const startTime = run.startTime;
@@ -55,7 +59,7 @@ export const batchRunsForTimeline = <R extends RunWithTime>(config: Config<R>) =
         width: runWidth,
       };
     })
-    .sort((a, b) => b.left - a.left);
+    .sort((a, b) => a.left - b.left);
 
   const consolidated = [];
 


### PR DESCRIPTION
## Summary & Motivation

Repair a batching bug in the run timeline.

The list of runs is sorted by start time (via the `left` pixel value) prior to batching, but the current (descending) order of this value can lead to incorrect batching, where batches that should overlap are not bucketed together. The result is that rendered chunks can end up visually sitting on top of each other.

Flip the sort order to fix the batching, and add a pixel of breathing room on the "now" line to repair  batching adjacent to that side.

## How I Tested These Changes

Added a Jest test for a case that passes with the ascending sort and fails with descending sort.

View timeline with some of the known broken batching, verify that it is now correct.