### PR TITLE
avoid pydantic warnings

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -11,7 +11,7 @@ from typing import (
     cast,
 )
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing_extensions import TypeVar
 
 import dagster._check as check
@@ -85,19 +85,19 @@ class MakeConfigCacheable(BaseModel):
     all in one go.
     """
 
-    # Pydantic config for this class
-    # Cannot use kwargs for base class as this is not support for pydnatic<1.8
-    class Config:
-        # Various pydantic model config (https://docs.pydantic.dev/usage/model_config/)
-        # Necessary to allow for caching decorators
-        arbitrary_types_allowed = True
-        # Avoid pydantic reading a cached property class as part of the schema
-        if USING_PYDANTIC_2:
-            ignored_types = (cached_property,)
-        else:
+    # - Frozen, to avoid complexity caused by mutation.
+    # - arbitrary_types_allowed, to allow non-model class params to be validated with isinstance.
+    # - Avoid pydantic reading a cached property class as part of the schema.
+    if USING_PYDANTIC_2:
+        model_config = ConfigDict(  # type: ignore
+            frozen=True, arbitrary_types_allowed=True, ignored_types=(cached_property,)
+        )
+    else:
+
+        class Config:
+            frozen = True
+            arbitrary_types_allowed = True
             keep_untouched = (cached_property,)
-        # Ensure the class is serializable, for caching purposes
-        frozen = True
 
     def __setattr__(self, name: str, value: Any):
         from .resource import ConfigurableResourceFactory
@@ -400,8 +400,12 @@ class PermissiveConfig(Config):
 
     # Pydantic config for this class
     # Cannot use kwargs for base class as this is not support for pydantic<1.8
-    class Config:
-        extra = "allow"
+    if USING_PYDANTIC_2:
+        model_config = ConfigDict(extra="allow")  # type: ignore
+    else:
+
+        class Config:
+            extra = "allow"
 
 
 def infer_schema_from_config_class(


### PR DESCRIPTION
## Summary & Motivation

I noticed Dagster raising Pydantic 2 deprecation warnings when I was running tests.

I suspect that there's a way to guard against this in future with new tests, and it would be very good to do so, but this is a tangent of a tangent of a tangent for me, so chose to stop here.

## How I Tested These Changes

Before these changes
```
======================================================================== warnings summary =========================================================================
../.pyenv/versions/3.10.4/envs/dagster-3.10.4/lib/python3.10/site-packages/pydantic/_internal/_config.py:272
../.pyenv/versions/3.10.4/envs/dagster-3.10.4/lib/python3.10/site-packages/pydantic/_internal/_config.py:272
../.pyenv/versions/3.10.4/envs/dagster-3.10.4/lib/python3.10/site-packages/pydantic/_internal/_config.py:272
../.pyenv/versions/3.10.4/envs/dagster-3.10.4/lib/python3.10/site-packages/pydantic/_internal/_config.py:272
  /Users/sryza/.pyenv/versions/3.10.4/envs/dagster-3.10.4/lib/python3.10/site-packages/pydantic/_internal/_config.py:272: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.6/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

../.pyenv/versions/3.10.4/envs/dagster-3.10.4/lib/python3.10/site-packages/pydantic/_internal/_config.py:322
  /Users/sryza/.pyenv/versions/3.10.4/envs/dagster-3.10.4/lib/python3.10/site-packages/pydantic/_internal/_config.py:322: UserWarning: Valid config keys have changed in V2:
  * 'keep_untouched' has been renamed to 'ignored_types'
    warnings.warn(message, UserWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

After these changes, all these disappear.