### PR TITLE
Don't reset the cursor or timestamps when resetting a sensor's status

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2876,13 +2876,14 @@ class DagsterInstance(DynamicPartitionsStore):
         stored_state = self.get_instigator_state(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
         )
-        new_instigator_data = SensorInstigatorData(
-            min_interval=external_sensor.min_interval_seconds,
-            sensor_type=external_sensor.sensor_type,
-        )
         new_status = InstigatorStatus.DECLARED_IN_CODE
 
         if not stored_state:
+            new_instigator_data = SensorInstigatorData(
+                min_interval=external_sensor.min_interval_seconds,
+                sensor_type=external_sensor.sensor_type,
+            )
+
             reset_state = self.add_instigator_state(
                 state=InstigatorState(
                     external_sensor.get_external_origin(),
@@ -2892,9 +2893,7 @@ class DagsterInstance(DynamicPartitionsStore):
                 )
             )
         else:
-            reset_state = self.update_instigator_state(
-                state=stored_state.with_status(new_status).with_data(new_instigator_data)
-            )
+            reset_state = self.update_instigator_state(state=stored_state.with_status(new_status))
 
         return reset_state
 

--- a/python_modules/dagster/dagster/_core/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_core/scheduler/scheduler.py
@@ -171,13 +171,14 @@ class Scheduler(abc.ABC):
         stored_state = instance.get_instigator_state(
             external_schedule.get_external_origin_id(), external_schedule.selector_id
         )
-        new_instigator_data = ScheduleInstigatorData(
-            external_schedule.cron_schedule,
-            start_timestamp=None,
-        )
+
         new_status = InstigatorStatus.DECLARED_IN_CODE
 
         if not stored_state:
+            new_instigator_data = ScheduleInstigatorData(
+                external_schedule.cron_schedule,
+                start_timestamp=None,
+            )
             reset_state = instance.add_instigator_state(
                 state=InstigatorState(
                     external_schedule.get_external_origin(),
@@ -188,7 +189,7 @@ class Scheduler(abc.ABC):
             )
         else:
             reset_state = instance.update_instigator_state(
-                state=stored_state.with_status(new_status).with_data(new_instigator_data)
+                state=stored_state.with_status(new_status)
             )
 
         return reset_state

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -2790,6 +2790,12 @@ def test_status_in_code_sensor(executor, instance):
 
             evaluate_sensors(workspace_context, executor)
 
+            # time hasn't advanced, so tick count shouldn't change either
+            ticks = instance.get_ticks(
+                running_sensor.get_external_origin_id(), running_sensor.selector_id
+            )
+            assert len(ticks) == 1
+
         freeze_datetime = freeze_datetime.add(seconds=30)
         with pendulum_freeze_time(freeze_datetime):
             evaluate_sensors(workspace_context, executor)
@@ -2800,7 +2806,8 @@ def test_status_in_code_sensor(executor, instance):
             ticks = instance.get_ticks(
                 running_sensor.get_external_origin_id(), running_sensor.selector_id
             )
-            assert len(ticks) == 3
+
+            assert len(ticks) == 2
 
             expected_datetime = create_pendulum_time(
                 year=2019, month=2, day=28, hour=0, minute=0, second=29


### PR DESCRIPTION
Summary:
Right now pressing the "Reset Sensor Status" button resets other state in addition to the status (for example, the various timestamps stored on SensorInstigatorData, and the cursor). Instead, just update the status.

Test Plan: BK (note changes to test, which before would have failed)

