### PR TITLE
Improve asset graph panning + zooming performance + IndexedDB cache for asset catalog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetEdges.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetEdges.tsx
@@ -1,5 +1,5 @@
 import {Colors} from '@dagster-io/ui-components';
-import {Fragment, useMemo, memo} from 'react';
+import {Fragment, memo, useMemo} from 'react';
 
 import {buildSVGPathHorizontal, buildSVGPathVertical} from './Utils';
 import {AssetLayoutDirection, AssetLayoutEdge} from './layout';
@@ -13,6 +13,8 @@ interface AssetEdgesProps {
   viewportRect: {top: number; left: number; right: number; bottom: number};
 }
 
+const MAX_EDGES = 30;
+
 export const AssetEdges = ({
   edges,
   selected,
@@ -25,14 +27,13 @@ export const AssetEdges = ({
   // all the edges in it can remain memoized.
 
   // Round to the nearest 100px to avoid recalculating edges too often (could be an array of 1,000+ edges)
-  const rectRounded = {
-    left: Math.floor(viewportRect.left / 100) * 100,
-    right: Math.ceil(viewportRect.right / 100) * 100,
-    top: Math.floor(viewportRect.top / 100) * 100,
-    bottom: Math.ceil(viewportRect.bottom / 100) * 100,
-  };
+  const left = Math.floor(viewportRect.left / 100) * 100;
+  const right = Math.ceil(viewportRect.right / 100) * 100;
+  const top = Math.floor(viewportRect.top / 100) * 100;
+  const bottom = Math.ceil(viewportRect.bottom / 100) * 100;
 
   const edgesToShow = useMemo(() => {
+    const rectRounded = {left, right, top, bottom};
     const intersectedEdges = edges.filter((edge) => doesViewportContainEdge(edge, rectRounded));
     if (intersectedEdges.length <= 10) {
       return intersectedEdges;
@@ -57,10 +58,11 @@ export const AssetEdges = ({
       ),
     }));
     edgesWithDistance.sort((a, b) => a.distance - b.distance);
-    return edgesWithDistance.slice(0, 20).map((item) => item.edge);
-  }, [rectRounded.bottom, rectRounded.top, rectRounded.left, rectRounded.right, edges]);
+    return edgesWithDistance.slice(0, MAX_EDGES).map((item) => item.edge);
+  }, [left, right, top, bottom, edges]);
 
   const selectedOrHighlightedEdges = useMemo(() => {
+    const rectRounded = {left, right, top, bottom};
     const selectedOrHighlighted = edges.filter(
       ({fromId, toId}) =>
         selected?.includes(fromId) ||
@@ -80,16 +82,8 @@ export const AssetEdges = ({
       ),
     }));
     edgesWithDistance.sort((a, b) => a.distance - b.distance);
-    return edgesWithDistance.slice(0, 20).map((item) => item.edge);
-  }, [
-    selected,
-    highlighted,
-    edges,
-    rectRounded.left,
-    rectRounded.bottom,
-    rectRounded.right,
-    rectRounded.top,
-  ]);
+    return edgesWithDistance.slice(0, MAX_EDGES).map((item) => item.edge);
+  }, [selected, highlighted, edges, left, right, top, bottom]);
 
   // Show up to 50 edges....
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetEdges.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetEdges.tsx
@@ -34,7 +34,7 @@ export const AssetEdges = ({
     <Fragment>
       <AssetEdgeSet
         color={Colors.lineageEdge()}
-        edges={intersectedEdges.length > 50 ? visibleToFromEdges : intersectedEdges}
+        edges={intersectedEdges.length > 10 ? visibleToFromEdges : intersectedEdges}
         strokeWidth={strokeWidth}
         viewportRect={viewportRect}
         direction={direction}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -79,8 +79,6 @@ export function useAllAssets(groupSelector?: AssetGroupSelector) {
     }
   }, [assetsOrError]);
 
-  console.log({assets, error});
-
   const groupQuery = useCallback(async () => {
     if (!groupSelector) {
       return;

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
@@ -119,7 +119,7 @@ const PanAndZoomInteractor: SVGViewportInteractor = {
     document.addEventListener('click', onCancelClick, {capture: true});
   },
 
-  onWheel(viewport: SVGViewport, event: WheelEvent) {
+  onWheel: throttle((viewport: SVGViewport, event: WheelEvent) => {
     const viewportEl = viewport.element.current;
     if (!viewportEl) {
       return;
@@ -163,7 +163,7 @@ const PanAndZoomInteractor: SVGViewportInteractor = {
     } else {
       viewport.shiftXY(-event.deltaX * panSpeed, -event.deltaY * panSpeed);
     }
-  },
+  }, 1000 / 60),
 
   render(viewport: SVGViewport) {
     return (

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
@@ -1,5 +1,6 @@
 import {Box, Colors, Icon, Slider, Tooltip} from '@dagster-io/ui-components';
 import animate from 'amator';
+import throttle from 'lodash/throttle';
 import * as React from 'react';
 import styled from 'styled-components';
 
@@ -78,7 +79,7 @@ const PanAndZoomInteractor: SVGViewportInteractor = {
     let lastY: number = start.y;
     const travel = {x: 0, y: 0};
 
-    const onMove = (e: MouseEvent) => {
+    const onMove = throttle((e: MouseEvent) => {
       const offset = viewport.getOffsetXY(e);
       if (!offset) {
         return;
@@ -93,7 +94,7 @@ const PanAndZoomInteractor: SVGViewportInteractor = {
       travel.y += Math.abs(delta.y);
       lastX = offset.x;
       lastY = offset.y;
-    };
+    }, 1000 / 60);
 
     viewport.setState({isClickHeld: true});
     const onCancelClick = (e: MouseEvent) => {


### PR DESCRIPTION
## Summary & Motivation

- Prune edges more aggressively since they slow down the asset graph re-rendering 
- throttle panning updates to 60fps. 
- throttle zooming updates to 60fps.
- IndexedDB cache for asset catalog table query

There's probably some low hanging fruit to speed up the render frames, I can look at that next but it seems much better with these minor changes.

## How I Tested These Changes

Tested with the giant asset graph from the toys repo