### PR TITLE
Fix error when a sensor that has an invalid asset selection is checked to see if it is targeting a given asset

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Set, Union, cas
 import graphene
 from dagster import (
     AssetKey,
+    DagsterError,
     _check as check,
 )
 from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer, ChangeReason
@@ -913,10 +914,14 @@ class GrapheneAssetNode(graphene.ObjectType):
     ) -> bool:
         asset_key = self._external_asset_node.asset_key
 
-        if sensor.asset_selection is not None and (
-            asset_key in sensor.asset_selection.resolve(asset_graph)
-        ):
-            return True
+        if sensor.asset_selection is not None:
+            try:
+                asset_selection = sensor.asset_selection.resolve(asset_graph)
+            except DagsterError:
+                return False
+
+            if asset_key in asset_selection:
+                return True
 
         return any(target.job_name in job_names for target in sensor.get_external_targets())
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_sensors.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_sensors.ambr
@@ -189,6 +189,71 @@
     dict({
       'description': None,
       'minIntervalSeconds': 30,
+      'name': 'invalid_asset_selection_error',
+      'sensorState': dict({
+        'runs': list([
+        ]),
+        'runsCount': 0,
+        'status': 'STOPPED',
+        'ticks': list([
+        ]),
+      }),
+      'targets': list([
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_0',
+          'solidSelection': None,
+        }),
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_1',
+          'solidSelection': None,
+        }),
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_2',
+          'solidSelection': None,
+        }),
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_3',
+          'solidSelection': None,
+        }),
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_4',
+          'solidSelection': None,
+        }),
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_5',
+          'solidSelection': None,
+        }),
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_6',
+          'solidSelection': None,
+        }),
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_7',
+          'solidSelection': None,
+        }),
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_8',
+          'solidSelection': None,
+        }),
+        dict({
+          'mode': 'default',
+          'pipelineName': '__ASSET_JOB_9',
+          'solidSelection': None,
+        }),
+      ]),
+    }),
+    dict({
+      'description': None,
+      'minIntervalSeconds': 30,
       'name': 'logging_sensor',
       'sensorState': dict({
         'runs': list([

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1197,6 +1197,10 @@ def define_sensors():
     def every_asset_sensor(_):
         return SkipReason("just kidding")
 
+    @sensor(asset_selection=AssetSelection.keys("does_not_exist"))
+    def invalid_asset_selection_error(_):
+        return SkipReason("just kidding")
+
     @run_status_sensor(run_status=DagsterRunStatus.SUCCESS, request_job=no_config_job)
     def run_status(_):
         return SkipReason("always skip")
@@ -1240,6 +1244,7 @@ def define_sensors():
         the_failure_sensor,
         auto_materialize_sensor,
         every_asset_sensor,
+        invalid_asset_selection_error,
     ]
 
 


### PR DESCRIPTION
Summary:
This method is raising an exception when a sensor with an invalid asset selection is uploaded as part of Definitions.

We should investigate other places that we are calling .resolve() in an asset_selection to check validity of things (or do this resolution at definitions time)

## Summary & Motivation

## How I Tested These Changes
