### PR TITLE
[ui] Fix line chart colors and gradients

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsLineChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsLineChart.tsx
@@ -104,14 +104,14 @@ export const InsightsLineChart = (props: Props) => {
           borderColor:
             key === highlightKey || highlightKey === null
               ? rgbLineColor
-              : rgbLineColor.replace(/, 1\)/, ', 0.2)'),
+              : rgbLineColor.replace(/, ?1\)/, ', 0.2)'),
           fill: key === highlightKey,
           pointBackgroundColor: backgroundDefaultRGB,
           pointHoverBackgroundColor: backgroundDefaultHoverRGB,
           pointBorderColor:
             key === highlightKey || highlightKey === null
               ? rgbLineColor
-              : rgbLineColor.replace(/, 1\)/, ', 0.2)'),
+              : rgbLineColor.replace(/, ?1\)/, ', 0.2)'),
           pointRadius: key === highlightKey || highlightKey === null ? 3 : 0,
           tension: 0.1,
           // Render highlighted lines above non-highlighted lines, to avoid confusion at
@@ -330,7 +330,8 @@ export const InsightsLineChart = (props: Props) => {
 
 const buildFillGradient = (ctx: CanvasRenderingContext2D, lineColor: string) => {
   const gradient = ctx.createLinearGradient(0, 0, 0, 400);
-  gradient.addColorStop(0, lineColor.replace(/, 1\)/, ', 0.2)'));
-  gradient.addColorStop(1, lineColor.replace(/, 1\)/, ', 0.0)'));
+  gradient.addColorStop(0, lineColor.replace(/, ?1\)/, ', 0.2)'));
+  gradient.addColorStop(1, lineColor.replace(/, ?1\)/, ', 0.0)'));
+  console.log(lineColor);
   return gradient;
 };


### PR DESCRIPTION
## Summary & Motivation

The var-derived RGB strings are formatted `rgba(100,100,100,1)`, which means that the regexes for line chart fading and gradients are missing them. Fix this.

## How I Tested These Changes

View Insights line chart, hover on lines. Verify correct colors.