### PR TITLE
feat(looker): represent looker dashboards as assets

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker/asset_decorator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/asset_decorator.py
@@ -1,0 +1,31 @@
+import itertools
+from pathlib import Path
+from typing import Any, Callable
+
+import yaml
+from dagster import AssetKey, AssetsDefinition, AssetSpec, multi_asset
+
+
+def looker_assets(*, project_dir: Path) -> Callable[[Callable[..., Any]], AssetsDefinition]:
+    lookml_dashboard_specs = [
+        AssetSpec(
+            key=AssetKey(lookml_dashboard["dashboard"]),
+            deps={AssetKey(dashboard_element["explore"])},
+        )
+        for dashboard_path in project_dir.rglob("*.dashboard.lookml")
+        # Each dashboard file can contain multiple dashboards.
+        for lookml_dashboard in yaml.safe_load(dashboard_path.read_bytes())
+        # For each dashboard, we create an asset. An `explore` in the dashboard is a dependency.
+        for dashboard_element in itertools.chain(
+            lookml_dashboard.get("elements", []),
+            lookml_dashboard.get("filters", []),
+        )
+        if dashboard_element.get("explore")
+    ]
+
+    return multi_asset(
+        compute_kind="looker",
+        specs=[
+            *lookml_dashboard_specs,
+        ],
+    )

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/looker_projects/__init__.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/looker_projects/__init__.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+projects_path = Path(__file__).joinpath("..").resolve()
+
+test_retail_demo_path = projects_path.joinpath("retail_demo")

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/test_asset_decorator.py
@@ -1,0 +1,20 @@
+from dagster import AssetKey
+from dagster_looker.asset_decorator import looker_assets
+
+from .looker_projects import test_retail_demo_path
+
+
+def test_asset_deps() -> None:
+    @looker_assets(project_dir=test_retail_demo_path)
+    def my_looker_assets(): ...
+
+    assert my_looker_assets.asset_deps == {
+        AssetKey(["address_deepdive"]): {AssetKey(["transactions"])},
+        AssetKey(["campaign_activation"]): {AssetKey(["omni_channel_transactions"])},
+        AssetKey(["customer_360"]): {AssetKey(["omni_channel_transactions"])},
+        AssetKey(["customer_deep_dive"]): {AssetKey(["customer_transaction_fact"])},
+        AssetKey(["customer_segment_deepdive"]): {AssetKey(["transactions"])},
+        AssetKey(["group_overview"]): {AssetKey(["transactions"])},
+        AssetKey(["item_affinity_analysis"]): {AssetKey(["order_purchase_affinity"])},
+        AssetKey(["store_deepdive"]): {AssetKey(["transactions"])},
+    }


### PR DESCRIPTION
## Summary & Motivation
As the title. We'll represent the views as assets next.

Also, probably won't use a `multi_asset` decorator since these are "external" assets (naming tbd), so that will also probably change. But that's an easy refactor later.

## How I Tested These Changes
pytest, local

<img width="2560" alt="Screenshot 2024-04-18 at 4 35 43 PM" src="https://github.com/dagster-io/dagster/assets/16431325/a8e2ef24-a71a-430e-808e-d7caee62c549">
