### PR TITLE
Make freshness check sensor work for all freshness checks

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -53,6 +53,11 @@ class AssetCheckKey(NamedTuple):
     def to_user_string(self) -> str:
         return f"{self.asset_key.to_user_string()}:{self.name}"
 
+    @staticmethod
+    def from_user_string(user_string: str) -> "AssetCheckKey":
+        asset_key_str, name = user_string.split(":")
+        return AssetCheckKey(AssetKey.from_user_string(asset_key_str), name)
+
 
 class AssetCheckSpec(
     NamedTuple(

--- a/python_modules/dagster/dagster/_core/definitions/freshness_checks/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_checks/utils.py
@@ -167,15 +167,6 @@ def get_last_updated_timestamp(
         check.failed("Expected record to be an observation or materialization")
 
 
-def ensure_freshness_checks(checks: Sequence[AssetChecksDefinition]) -> None:
-    for check_def in checks:
-        for check_spec in check_def.check_specs:
-            check.invariant(
-                check_spec.metadata and check_spec.metadata.get(FRESHNESS_PARAMS_METADATA_KEY),
-                f"Asset check {check_spec.key} didn't have expected metadata. Please ensure that the asset check is a freshness check.",
-            )
-
-
 def get_description_for_freshness_check_result(
     passed: bool,
     update_timestamp: Optional[float],

--- a/python_modules/dagster/dagster/_core/events/log.py
+++ b/python_modules/dagster/dagster/_core/events/log.py
@@ -2,6 +2,7 @@ from typing import Callable, Mapping, NamedTuple, Optional, Union
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, public
+from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.events import AssetMaterialization, AssetObservation
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.events import DagsterEvent, DagsterEventType
@@ -152,6 +153,18 @@ class EventLogEntry(
             observation = self.dagster_event.asset_observation_data.asset_observation
             if isinstance(observation, AssetObservation):
                 return observation
+
+        return None
+
+    @property
+    def asset_check_evaluation(self) -> Optional[AssetCheckEvaluation]:
+        if (
+            self.dagster_event
+            and self.dagster_event.event_type_value == DagsterEventType.ASSET_CHECK_EVALUATION
+        ):
+            evaluation = self.dagster_event.asset_check_evaluation_data
+            if isinstance(evaluation, AssetCheckEvaluation):
+                return evaluation
 
         return None
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -156,7 +156,10 @@ if TYPE_CHECKING:
         ExecutionStepSnap,
         JobSnapshot,
     )
-    from dagster._core.storage.asset_check_execution_record import AssetCheckInstanceSupport
+    from dagster._core.storage.asset_check_execution_record import (
+        AssetCheckExecutionRecord,
+        AssetCheckInstanceSupport,
+    )
     from dagster._core.storage.compute_log_manager import ComputeLogManager
     from dagster._core.storage.daemon_cursor import DaemonCursorStorage
     from dagster._core.storage.event_log import EventLogStorage
@@ -1989,6 +1992,14 @@ class DagsterInstance(DynamicPartitionsStore):
                 key, or `None` if the asset has not been materialized.
         """
         return self._event_storage.get_latest_materialization_events([asset_key]).get(asset_key)
+
+    @traced
+    def get_latest_asset_check_evaluation_record(
+        self, asset_check_key: "AssetCheckKey"
+    ) -> Optional["AssetCheckExecutionRecord"]:
+        return self._event_storage.get_latest_asset_check_execution_by_key([asset_check_key]).get(
+            asset_check_key
+        )
 
     @public
     @traced

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_sensor.py
@@ -7,20 +7,26 @@ import pytest
 from dagster import (
     AssetCheckKey,
     AssetKey,
+    DagsterInstance,
     asset,
 )
 from dagster._check import CheckError
+from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
+from dagster._core.definitions.asset_out import AssetOut
+from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.freshness_checks.last_update import (
     build_last_update_freshness_checks,
 )
 from dagster._core.definitions.freshness_checks.sensor import (
-    FreshnessCheckSensorCursor,
     build_sensor_for_freshness_checks,
 )
+from dagster._core.definitions.freshness_checks.utils import (
+    FRESH_UNTIL_METADATA_KEY,
+)
+from dagster._core.definitions.metadata import FloatMetadataValue
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.sensor_definition import build_sensor_context
-from dagster._serdes.serdes import deserialize_value
 from dagster._seven.compat.pendulum import pendulum_freeze_time
 
 
@@ -60,251 +66,83 @@ def test_params() -> None:
         )
 
 
-def test_lower_bound_delta() -> None:
-    """Test the case where we have an asset partitioned with a lower bound delta. Ensure that the sensor
-    provides expected run requests in all cases.
+def test_sensor_multi_asset_different_states(
+    instance: DagsterInstance, pendulum_aware_report_dagster_event: None
+) -> None:
+    """Test the case where we have multiple assets in the same multi asset in different states. Ensure that the sensor
+    handles each state correctly.
     """
 
-    @asset
+    @multi_asset(
+        outs={
+            "never_eval": AssetOut(),
+            "failed_eval": AssetOut(),
+            "success_eval_unexpired": AssetOut(),
+            "success_eval_expired": AssetOut(),
+        },
+    )
     def my_asset():
         pass
 
-    @asset
-    def my_other_asset():
-        pass
-
-    ten_minute_check = build_last_update_freshness_checks(
+    freshness_checks = build_last_update_freshness_checks(
         assets=[my_asset], lower_bound_delta=datetime.timedelta(minutes=10)
     )
-    twenty_minute_check = build_last_update_freshness_checks(
-        assets=[my_other_asset], lower_bound_delta=datetime.timedelta(minutes=20)
-    )
 
-    sensor = build_sensor_for_freshness_checks(
-        freshness_checks=[ten_minute_check, twenty_minute_check],
-    )
+    freeze_time = pendulum.now("UTC")
+    with pendulum_freeze_time(freeze_time):
+        instance.report_runless_asset_event(
+            AssetCheckEvaluation(
+                asset_key=AssetKey("failed_eval"),
+                check_name="freshness_check",
+                passed=False,
+                metadata={},
+            )
+        )
+        instance.report_runless_asset_event(
+            AssetCheckEvaluation(
+                asset_key=AssetKey("success_eval_expired"),
+                check_name="freshness_check",
+                passed=True,
+                metadata={
+                    FRESH_UNTIL_METADATA_KEY: FloatMetadataValue(
+                        freeze_time.subtract(minutes=5).timestamp()
+                    )
+                },
+            )
+        )
+        instance.report_runless_asset_event(
+            AssetCheckEvaluation(
+                asset_key=AssetKey("success_eval_unexpired"),
+                check_name="freshness_check",
+                passed=True,
+                metadata={
+                    FRESH_UNTIL_METADATA_KEY: FloatMetadataValue(
+                        freeze_time.add(minutes=5).timestamp()
+                    )
+                },
+            )
+        )
 
-    defs = Definitions(
-        sensors=[sensor],
-        assets=[my_asset, my_other_asset],
-        asset_checks=[ten_minute_check, twenty_minute_check],
-    )
+        sensor = build_sensor_for_freshness_checks(
+            freshness_checks=[freshness_checks],
+        )
+        defs = Definitions(
+            asset_checks=[freshness_checks],
+            assets=[my_asset],
+            sensors=[sensor],
+        )
 
-    context = build_sensor_context(
-        definitions=defs,
-    )
+        context = build_sensor_context(
+            instance=instance,
+            definitions=defs,
+        )
 
-    # First evaluation, we should get run requests for both checks
-    freeze_datetime = pendulum.now("UTC")
-    with pendulum_freeze_time(freeze_datetime):
+        # Upon evaluation, we should get a run request for never_eval and success_eval_expired.
         run_request = sensor(context)
         assert isinstance(run_request, RunRequest)
         assert run_request.asset_check_keys == [
-            AssetCheckKey(AssetKey("my_asset"), "freshness_check"),
-            AssetCheckKey(AssetKey("my_other_asset"), "freshness_check"),
+            AssetCheckKey(AssetKey("never_eval"), "freshness_check"),
+            AssetCheckKey(AssetKey("success_eval_expired"), "freshness_check"),
         ]
-        assert context.cursor
-        cursor = deserialize_value(context.cursor, FreshnessCheckSensorCursor)
-        assert cursor == FreshnessCheckSensorCursor(
-            evaluation_timestamps_by_check_key={
-                AssetCheckKey(AssetKey("my_asset"), "freshness_check"): freeze_datetime.timestamp(),
-                AssetCheckKey(
-                    AssetKey("my_other_asset"), "freshness_check"
-                ): freeze_datetime.timestamp(),
-            }
-        )
-
-        # Run the sensor again, and ensure that we do not get a run request
-        result = sensor(context)
-        assert result is None
-        assert context.cursor
-        cursor = deserialize_value(context.cursor, FreshnessCheckSensorCursor)
-        assert cursor == FreshnessCheckSensorCursor(
-            evaluation_timestamps_by_check_key={
-                AssetCheckKey(AssetKey("my_asset"), "freshness_check"): freeze_datetime.timestamp(),
-                AssetCheckKey(
-                    AssetKey("my_other_asset"), "freshness_check"
-                ): freeze_datetime.timestamp(),
-            }
-        )
-
-    # Advance time within the lower_bound_delta window, and ensure we don't get a run_request.
-    freeze_datetime = freeze_datetime.add(minutes=5)
-    with pendulum_freeze_time(freeze_datetime):
-        result = sensor(context)
-        assert result is None
-        assert context.cursor
-        cursor = deserialize_value(context.cursor, FreshnessCheckSensorCursor)
-        assert cursor == FreshnessCheckSensorCursor(
-            evaluation_timestamps_by_check_key={
-                AssetCheckKey(AssetKey("my_asset"), "freshness_check"): freeze_datetime.subtract(
-                    minutes=5
-                ).timestamp(),
-                AssetCheckKey(
-                    AssetKey("my_other_asset"), "freshness_check"
-                ): freeze_datetime.subtract(minutes=5).timestamp(),
-            }
-        )
-
-    # Advance time past the lower_bound_delta window for the first asset, and ensure we get a run_request.
-    freeze_datetime = freeze_datetime.add(minutes=6)
-    with pendulum_freeze_time(freeze_datetime):
-        result = sensor(context)
-        assert isinstance(result, RunRequest)
-        assert result.asset_check_keys == [AssetCheckKey(AssetKey("my_asset"), "freshness_check")]
-        assert context.cursor
-        cursor = deserialize_value(context.cursor, FreshnessCheckSensorCursor)
-        assert cursor == FreshnessCheckSensorCursor(
-            evaluation_timestamps_by_check_key={
-                AssetCheckKey(AssetKey("my_asset"), "freshness_check"): freeze_datetime.timestamp(),
-                AssetCheckKey(
-                    AssetKey("my_other_asset"), "freshness_check"
-                ): freeze_datetime.subtract(minutes=11).timestamp(),
-            }
-        )
-
-
-def test_freshness_cron() -> None:
-    """Test the case where we have a freshness cron and we have not executed, not passed the
-    threshold time-wise, and then we have passed the threshold.
-    """
-
-    @asset
-    def my_behind_asset():
-        pass
-
-    @asset
-    def my_utc_asset():
-        pass
-
-    @asset
-    def my_ahead_asset():
-        pass
-
-    utc_check = build_last_update_freshness_checks(
-        assets=[my_utc_asset],
-        deadline_cron="0 0 * * *",
-        lower_bound_delta=datetime.timedelta(minutes=10),
-    )
-    behind_check = build_last_update_freshness_checks(
-        assets=[my_behind_asset],
-        deadline_cron="0 0 * * *",
-        lower_bound_delta=datetime.timedelta(minutes=10),
-        timezone="Etc/GMT-5",
-    )
-    ahead_check = build_last_update_freshness_checks(
-        assets=[my_ahead_asset],
-        deadline_cron="0 0 * * *",
-        lower_bound_delta=datetime.timedelta(minutes=10),
-        timezone="Etc/GMT+5",
-    )
-
-    sensor = build_sensor_for_freshness_checks(
-        freshness_checks=[utc_check, behind_check, ahead_check],
-    )
-
-    defs = Definitions(
-        sensors=[sensor],
-        assets=[my_utc_asset, my_behind_asset, my_ahead_asset],
-        asset_checks=[utc_check, behind_check, ahead_check],
-    )
-
-    context = build_sensor_context(
-        definitions=defs,
-    )
-
-    # First evaluation, we should get a run request
-    freeze_datetime = pendulum.datetime(2022, 1, 1, 0, 0, 0, tz="UTC")
-    with pendulum_freeze_time(freeze_datetime):
-        run_request = sensor(context)
-        assert isinstance(run_request, RunRequest)
-        assert run_request.asset_check_keys == [
-            AssetCheckKey(AssetKey("my_utc_asset"), "freshness_check"),
-            AssetCheckKey(AssetKey("my_behind_asset"), "freshness_check"),
-            AssetCheckKey(AssetKey("my_ahead_asset"), "freshness_check"),
-        ]
-        assert context.cursor
-        cursor = deserialize_value(context.cursor, FreshnessCheckSensorCursor)
-        assert cursor == FreshnessCheckSensorCursor(
-            evaluation_timestamps_by_check_key={
-                AssetCheckKey(
-                    AssetKey("my_utc_asset"), "freshness_check"
-                ): freeze_datetime.timestamp(),
-                AssetCheckKey(
-                    AssetKey("my_behind_asset"), "freshness_check"
-                ): freeze_datetime.timestamp(),
-                AssetCheckKey(
-                    AssetKey("my_ahead_asset"), "freshness_check"
-                ): freeze_datetime.timestamp(),
-            }
-        )
-
-        # Run the sensor again, and ensure that we do not get a run request
-        result = sensor(context)
-        assert result is None
-        assert context.cursor
-        cursor = deserialize_value(context.cursor, FreshnessCheckSensorCursor)
-        assert cursor == FreshnessCheckSensorCursor(
-            evaluation_timestamps_by_check_key={
-                AssetCheckKey(
-                    AssetKey("my_utc_asset"), "freshness_check"
-                ): freeze_datetime.timestamp(),
-                AssetCheckKey(
-                    AssetKey("my_behind_asset"), "freshness_check"
-                ): freeze_datetime.timestamp(),
-                AssetCheckKey(
-                    AssetKey("my_ahead_asset"), "freshness_check"
-                ): freeze_datetime.timestamp(),
-            }
-        )
-
-    # Advance time past the freshness cron in GMT+5 and GMT-5. In both cases, we should have moved to a new tick of the cron.
-    # Advance time 20 hours, since the cron is currently at 0:00 UTC (5:00 GMT+5).
-    freeze_datetime = freeze_datetime.add(hours=20)
-    with pendulum_freeze_time(freeze_datetime):
-        result = sensor(context)
-        assert isinstance(result, RunRequest)
-        assert result.asset_check_keys == [
-            AssetCheckKey(AssetKey("my_behind_asset"), "freshness_check"),
-            AssetCheckKey(AssetKey("my_ahead_asset"), "freshness_check"),
-        ]
-        assert context.cursor
-        cursor = deserialize_value(context.cursor, FreshnessCheckSensorCursor)
-        assert cursor == FreshnessCheckSensorCursor(
-            evaluation_timestamps_by_check_key={
-                AssetCheckKey(
-                    AssetKey("my_utc_asset"), "freshness_check"
-                ): freeze_datetime.subtract(hours=20).timestamp(),
-                AssetCheckKey(
-                    AssetKey("my_behind_asset"), "freshness_check"
-                ): freeze_datetime.timestamp(),
-                AssetCheckKey(
-                    AssetKey("my_ahead_asset"), "freshness_check"
-                ): freeze_datetime.timestamp(),
-            }
-        )
-
-    # Advance time past the freshness cron in UTC. Ensure we get a new run request only for the UTC
-    # asset.
-    freeze_datetime = freeze_datetime.add(hours=5)
-    with pendulum_freeze_time(freeze_datetime):
-        result = sensor(context)
-        assert isinstance(result, RunRequest)
-        assert result.asset_check_keys == [
-            AssetCheckKey(AssetKey("my_utc_asset"), "freshness_check")
-        ]
-        assert context.cursor
-        cursor = deserialize_value(context.cursor, FreshnessCheckSensorCursor)
-        assert cursor == FreshnessCheckSensorCursor(
-            evaluation_timestamps_by_check_key={
-                AssetCheckKey(
-                    AssetKey("my_utc_asset"), "freshness_check"
-                ): freeze_datetime.timestamp(),
-                AssetCheckKey(
-                    AssetKey("my_behind_asset"), "freshness_check"
-                ): freeze_datetime.subtract(hours=5).timestamp(),
-                AssetCheckKey(
-                    AssetKey("my_ahead_asset"), "freshness_check"
-                ): freeze_datetime.subtract(hours=5).timestamp(),
-            }
-        )
+        # Cursor should be None, since we made it through all assets.
+        assert context.cursor is None


### PR DESCRIPTION
Using the improved metadata from the previous PR, make it so that any freshness check can be passed into build_freshness_check_sensor.

We greatly simplify the decisions the sensor makes. Essentially:
- If the previous check result was a success and has expired, check again.
- Otherwise, don't check again.

We then only ever run checks when there is the possibility of state change. Notice that if the check failed we won't ever run it again until it succeeds (presumably when it runs right after a materialization or observation), meaning a user won't get spammed with failures.

Revamped the test to cover all the cases that an asset check can be in (success but expired, success and unexpired, never evaluated, failed evaluation)

Since we're now using the DB to make decisions, and retrieving a row per asset check key, I took special consideration for timeouts. We cursor on the last unevaluated asset key once we reach 35 seconds of evaluation, and then pick up from that point on the next eval.

Things that make me think this is a good change:
- Drastic decrease in LOC
- Provides guidelines for what a "freshness check" is. That is, any check where, when it passes, we get fresh_until metadata.
