### PR TITLE
log concurrency blocked info in run queue daemon

### DIFF
--- a/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
+++ b/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
@@ -127,7 +127,7 @@ class GlobalOpConcurrencyLimitsCounter:
         # if we reached here, then every root concurrency key is blocked, so we should not dequeue
         return True
 
-    def blocked_run_info(self, run: DagsterRun) -> Mapping:
+    def get_blocked_run_debug_info(self, run: DagsterRun) -> Mapping:
         if not run.run_op_concurrency:
             return {}
 

--- a/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
+++ b/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
@@ -127,6 +127,27 @@ class GlobalOpConcurrencyLimitsCounter:
         # if we reached here, then every root concurrency key is blocked, so we should not dequeue
         return True
 
+    def blocked_run_info(self, run: DagsterRun) -> Mapping:
+        if not run.run_op_concurrency:
+            return {}
+
+        log_info = {}
+        for concurrency_key in run.run_op_concurrency.root_key_counts.keys():
+            concurrency_info = self._concurrency_info_by_key.get(concurrency_key)
+            if not concurrency_info:
+                continue
+
+            log_info[concurrency_key] = {
+                "slot_count": concurrency_info.slot_count,
+                "pending_step_count": len(concurrency_info.pending_steps),
+                "pending_step_run_ids": list(
+                    {step.run_id for step in concurrency_info.pending_steps}
+                ),
+                "launched_count": self._launched_concurrency_key_counts[concurrency_key],
+                "in_progress_count": self._in_progress_concurrency_key_counts[concurrency_key],
+            }
+        return log_info
+
     def update_counters_with_launched_item(self, run: DagsterRun):
         if not run.run_op_concurrency:
             return

--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import threading
 import time
@@ -292,6 +293,12 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
                     global_concurrency_limits_counter
                     and global_concurrency_limits_counter.is_blocked(run)
                 ):
+                    concurrency_blocked_info = json.dumps(
+                        global_concurrency_limits_counter.blocked_run_info(run)
+                    )
+                    self._logger.debug(
+                        f"Run {run.run_id} is blocked by global concurrency limits: {concurrency_blocked_info}"
+                    )
                     to_remove.append(run)
                     continue
                 elif global_concurrency_limits_counter:

--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -294,9 +294,9 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
                     and global_concurrency_limits_counter.is_blocked(run)
                 ):
                     concurrency_blocked_info = json.dumps(
-                        global_concurrency_limits_counter.blocked_run_info(run)
+                        global_concurrency_limits_counter.get_blocked_run_debug_info(run)
                     )
-                    self._logger.debug(
+                    self._logger.info(
                         f"Run {run.run_id} is blocked by global concurrency limits: {concurrency_blocked_info}"
                     )
                     to_remove.append(run)


### PR DESCRIPTION
## Summary & Motivation
Need more visibility into the run queue daemon keeping runs queued due to run concurrency.

One potential downside is that this could be extremely noisy, as the queued run coordinator daemon runs in a tight loop.  But not sure if we actually want to suppress error logs here since the underlying slot conditions might change.

## How I Tested These Changes
BK