### PR TITLE
[ui] When clicking through lineage, reset depth to 1 layer of neighbors

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -50,7 +50,9 @@ export const AssetNodeLineageGraph = ({
   const history = useHistory();
 
   const onClickAsset = (key: AssetKey) => {
-    history.push(assetDetailsPathForKey(key, {...params, lineageScope: 'neighbors'}));
+    history.push(
+      assetDetailsPathForKey(key, {...params, lineageScope: 'neighbors', lineageDepth: 1}),
+    );
   };
 
   useLastSavedZoomLevel(viewportEl, layout, assetGraphId);


### PR DESCRIPTION
## Summary & Motivation

Per https://dagsterlabs.slack.com/archives/C05S9HV8Q9K/p1713226613965459, when you click an asset in the lineage tab, jumping to that asset's lineage page, we reset the depth of the graph to avoid landing you on a super complex view.

## How I Tested These Changes

Click around lineage views