### PR TITLE
fix(dlt) correctly subset selected resources when using `source.with_resources(...)`

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/asset_decorator.py
@@ -94,6 +94,6 @@ def dlt_assets(
                     META_KEY_TRANSLATOR: dlt_dagster_translator,
                 },
             )
-            for dlt_source_resource in dlt_source.resources.values()
+            for dlt_source_resource in dlt_source.selected_resources.values()
         ],
     )

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
@@ -142,7 +142,7 @@ class DagsterDltResource(ConfigurableResource):
 
         asset_key_dlt_source_resource_mapping = {
             dagster_dlt_translator.get_asset_key(dlt_source_resource): dlt_source_resource
-            for dlt_source_resource in dlt_source.resources.values()
+            for dlt_source_resource in dlt_source.selected_resources.values()
         }
 
         # Filter sources by asset key sub-selection

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_dlt.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_dlt.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 import duckdb
-import pytest
 from dagster import (
     AssetExecutionContext,
     AssetKey,
@@ -149,11 +148,9 @@ def test_example_pipeline_subselection(dlt_pipeline: Pipeline) -> None:
     assert found_asset_keys == [AssetKey(["dlt_pipeline_repo_issues"])]
 
 
-# Expected to fail until issue has been resolved - https://github.com/dlt-hub/dlt/issues/1249
-@pytest.mark.xfail
 def test_subset_pipeline_using_with_resources(dlt_pipeline: Pipeline) -> None:
     @dlt_assets(dlt_source=pipeline().with_resources("repos"), dlt_pipeline=dlt_pipeline)
     def example_pipeline_assets() -> None: ...
 
     assert len(example_pipeline_assets.keys) == 1
-    assert example_pipeline_assets.keys == [AssetKey("dlt_example_pipeline_repos")]
+    assert example_pipeline_assets.keys == {AssetKey("dlt_pipeline_repos")}

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_dlt.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_dlt.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import duckdb
+import pytest
 from dagster import (
     AssetExecutionContext,
     AssetKey,
@@ -146,3 +147,13 @@ def test_example_pipeline_subselection(dlt_pipeline: Pipeline) -> None:
         for mat in asset_materializations
     ]
     assert found_asset_keys == [AssetKey(["dlt_pipeline_repo_issues"])]
+
+
+# Expected to fail until issue has been resolved - https://github.com/dlt-hub/dlt/issues/1249
+@pytest.mark.xfail
+def test_subset_pipeline_using_with_resources(dlt_pipeline: Pipeline) -> None:
+    @dlt_assets(dlt_source=pipeline().with_resources("repos"), dlt_pipeline=dlt_pipeline)
+    def example_pipeline_assets() -> None: ...
+
+    assert len(example_pipeline_assets.keys) == 1
+    assert example_pipeline_assets.keys == [AssetKey("dlt_example_pipeline_repos")]

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_dlt.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_dlt.py
@@ -150,7 +150,21 @@ def test_example_pipeline_subselection(dlt_pipeline: Pipeline) -> None:
 
 def test_subset_pipeline_using_with_resources(dlt_pipeline: Pipeline) -> None:
     @dlt_assets(dlt_source=pipeline().with_resources("repos"), dlt_pipeline=dlt_pipeline)
-    def example_pipeline_assets() -> None: ...
+    def example_pipeline_assets(
+        context: AssetExecutionContext, dlt_pipeline_resource: DagsterDltResource
+    ):
+        yield from dlt_pipeline_resource.run(context=context)
 
     assert len(example_pipeline_assets.keys) == 1
     assert example_pipeline_assets.keys == {AssetKey("dlt_pipeline_repos")}
+
+    res = materialize(
+        [example_pipeline_assets],
+        resources={"dlt_pipeline_resource": DagsterDltResource()},
+    )
+    assert res.success
+
+    temporary_duckdb_path = f"{dlt_pipeline.pipeline_name}.duckdb"
+    with duckdb.connect(database=temporary_duckdb_path, read_only=True) as conn:
+        row = conn.execute("select count(*) from example.repos").fetchone()
+        assert row and row[0] == 3


### PR DESCRIPTION
This resolves an issue where subset selections of a `DltSource` were not appropriately handled, for example using `my_source.with_resources(...), by using the `selected_resources` attribute.

---

- ~When subsetting a `DltSource` using `with_resources` we would expect only that selection to run from Dagster. Presently, all assets are run as the `.resources` call still returns all resources.~
- ~An issue (https://github.com/dlt-hub/dlt/issues/1249) has been opened to find an alternative API, or possible fix.~