### PR TITLE
fix(docs) support command-click of sidebar links

### DIFF
--- a/docs/next/components/Sidebar.tsx
+++ b/docs/next/components/Sidebar.tsx
@@ -87,19 +87,17 @@ const MenuItem = React.forwardRef<HTMLAnchorElement, React.PropsWithChildren<Men
     }
 
     const linkElement = (
-      <div className={itemClassName}>
-        <a
-          className={innerClassName}
-          href={item.path}
-          ref={ref}
-          target={item.isExternalLink ? '_blank' : '_self'}
-          rel="noopener noreferrer"
-          onClick={onClick}
-        >
-          {itemContents}
-        </a>
-        {rightIcon()}
-      </div>
+      <a
+        className={innerClassName}
+        href={item.path}
+        ref={ref}
+        target={item.isExternalLink ? '_blank' : '_self'}
+        rel="noopener noreferrer"
+        onClick={onClick}
+      >
+        {itemContents}
+        <span>{rightIcon()}</span>
+      </a>
     );
 
     if (item.isExternalLink) {

--- a/docs/next/components/Sidebar.tsx
+++ b/docs/next/components/Sidebar.tsx
@@ -86,28 +86,20 @@ const MenuItem = React.forwardRef<HTMLAnchorElement, React.PropsWithChildren<Men
       );
     }
 
-    const linkElement = (
-      <a
-        className={innerClassName}
-        href={item.path}
-        ref={ref}
-        target={item.isExternalLink ? '_blank' : '_self'}
-        rel="noopener noreferrer"
-        onClick={onClick}
-      >
-        {itemContents}
-        <span>{rightIcon()}</span>
-      </a>
-    );
-
-    if (item.isExternalLink) {
-      return linkElement;
-    }
-
     return (
-      <NextLink href={item.path} passHref legacyBehavior>
-        {linkElement}
-      </NextLink>
+      <div className={itemClassName}>
+        <NextLink
+          className={innerClassName}
+          href={item.path}
+          ref={ref}
+          target={item.isExternalLink ? '_blank' : '_self'}
+          rel="noopener noreferrer"
+          onClick={onClick}
+        >
+          {itemContents}
+        </NextLink>
+        {rightIcon()}
+      </div>
     );
   },
 );


### PR DESCRIPTION
- Having a `<div>` element in the `<NextLink>` breaks the  ability to do a middle-click or command-click to open an href in a new tab