### PR TITLE
take SourceAssets out of cons list in multiple projects doc

### DIFF
--- a/docs/content/dagster-plus/best-practices/managing-multiple-projects-and-teams.mdx
+++ b/docs/content/dagster-plus/best-practices/managing-multiple-projects-and-teams.mdx
@@ -268,15 +268,6 @@ height={384}
           >
             No isolation between execution environments
           </li>
-          <li>
-            You need to use{" "}
-            <code>
-              <a href="/concepts/io-management/io-managers#using-io-managers-to-load-source-data">
-                SourceAssets
-              </a>
-            </code>{" "}
-            to share assets across code locations
-          </li>
         </ul>
       </td>
     </tr>


### PR DESCRIPTION
## Summary & Motivation

The docs currently make it seem like "You need to use SourceAssets to share assets across code locations" is a con that's specific to the "Code location isolation" option, however, all the options presented here share this.

## How I Tested These Changes
