### PR TITLE
Feature/subset-sling-assets

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
@@ -88,7 +88,7 @@ def sling_assets(
         name=name,
         compute_kind="sling",
         partitions_def=partitions_def,
-        can_subset=False,
+        can_subset=True,
         op_tags=op_tags,
         backfill_policy=backfill_policy,
         specs=[

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
@@ -25,7 +25,6 @@ def get_streams_from_replication(
     default_config = replication_config.get("defaults", {})
     for stream, stream_config in replication_config.get("streams", {}).items():
         config = deep_merge_dicts(default_config, stream_config)
-    for stream, config in replication_config.get("streams", {}).items():
         if config and config.get("disabled", False):
             continue
         yield {"name": stream, "config": config}

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
@@ -11,6 +11,8 @@ from dagster._utils.security import non_secure_md5_hash_str
 
 from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
 from dagster_embedded_elt.sling.sling_replication import SlingReplicationParam, validate_replication
+from dagster._utils.merger import deep_merge_dicts
+
 
 METADATA_KEY_TRANSLATOR = "dagster_embedded_elt/dagster_sling_translator"
 METADATA_KEY_REPLICATION_CONFIG = "dagster_embedded_elt/sling_replication_config"
@@ -20,6 +22,9 @@ def get_streams_from_replication(
     replication_config: Mapping[str, Any],
 ) -> Iterable[Mapping[str, Any]]:
     """Returns a list of streams and their configs from a Sling replication config."""
+    default_config = replication_config.get("defaults", {})
+    for stream, stream_config in replication_config.get("streams", {}).items():
+        config = deep_merge_dicts(default_config, stream_config)
     for stream, config in replication_config.get("streams", {}).items():
         if config and config.get("disabled", False):
             continue

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -279,9 +279,8 @@ class SlingResource(ConfigurableResource):
                     if dagster_sling_translator.get_asset_key(stream) == asset_key:
                         name = stream["name"]
                         config = stream["config"]
-                        context_streams.update({name: config})
+                        context_streams[name] = config
                         break
-        context.log.info(f"Effective streams for current execution context: {context_streams}")
         return context_streams
 
     @classmethod

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -251,12 +251,16 @@ class SlingResource(ConfigurableResource):
             metadata_by_key = assets_def.metadata_by_key
             first_asset_metadata = next(iter(metadata_by_key.values()))
             replication_config = first_asset_metadata.get(METADATA_KEY_REPLICATION_CONFIG)
-            dagster_sling_translator: DagsterSlingTranslator = first_asset_metadata.get(METADATA_KEY_TRANSLATOR)
+            dagster_sling_translator: DagsterSlingTranslator = first_asset_metadata.get(
+                METADATA_KEY_TRANSLATOR
+            )
             streams = get_streams_from_replication(replication_config)
             for asset_key in context.selected_asset_keys:
                 for stream in streams:
                     if dagster_sling_translator.get_asset_key(stream) == asset_key:
-                        context_streams.update(stream)
+                        name = stream["name"]
+                        config = stream["config"]
+                        context_streams.update({name: config})
                         break
 
         return context_streams


### PR DESCRIPTION
## Summary & Motivation

This PR aims to enable subsetting a sling assets definition (#20215). Moreover, due to being related and quite handy for achieving this PR goal, it also ensures that the `defaults` section of the `replication.yaml` is not ignored in the stream definition from the asset perspective (#21075).

## How I Tested These Changes

I installed the library from the forked branch in a local dagster project and configured 3 sling assets via replication.yaml, defining both assets and resources as in the official docs example.

Then I manually triggered a single asset via UI, being successful. After that, I selected the remaining 2 assets for a single run, which succeeded as well.

In addition, I successfully ran the following commands locally:

```bash
make pyright
make ruff
python -m pytest python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests
```