### PR TITLE
[ui] Add infinite-scroll to the Asset > Events left sidebar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventList.tsx
@@ -62,8 +62,7 @@ export const AssetEventList = ({
           if (
             !loading &&
             e.currentTarget.scrollHeight > e.currentTarget.clientHeight &&
-            e.currentTarget.clientHeight + e.currentTarget.scrollTop ===
-              e.currentTarget.scrollHeight
+            e.currentTarget.clientHeight + e.currentTarget.scrollTop >= e.currentTarget.scrollHeight
           ) {
             onLoadMore();
           }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventList.tsx
@@ -1,4 +1,4 @@
-import {Box, Caption, Colors, Icon, Tag} from '@dagster-io/ui-components';
+import {Box, Caption, Colors, Icon, Spinner, Tag} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import {useEffect, useRef} from 'react';
 import styled from 'styled-components';
@@ -21,12 +21,17 @@ export const AssetEventList = ({
   setFocused,
   xAxis,
   assetKey,
+  loading,
+  onLoadMore,
 }: {
   xAxis: 'time' | 'partition';
   groups: AssetEventGroup[];
   assetKey: AssetKeyInput;
   focused?: AssetEventGroup;
   setFocused?: (item: AssetEventGroup | undefined) => void;
+
+  loading: boolean;
+  onLoadMore: () => void;
 }) => {
   const parentRef = useRef<HTMLDivElement | null>(null);
   const focusedRowRef = useRef<HTMLDivElement | null>(null);
@@ -47,47 +52,78 @@ export const AssetEventList = ({
         el.scrollIntoView({block: 'nearest'});
       }
     }
-  }, [focused]);
+  }, [focused?.timestamp, focused?.partition]);
 
   return (
-    <AssetListContainer ref={parentRef}>
-      <Inner $totalHeight={totalHeight}>
-        {items.map(({index, key, size, start}) => {
-          const group = groups[index]!;
-          return (
-            <AssetListRow
-              key={key}
-              $height={size}
-              $start={start}
-              $focused={group === focused}
-              ref={group === focused ? focusedRowRef : undefined}
-              onClick={(e) => {
-                // If you're interacting with something in the row, don't trigger a focus change.
-                // Since focus is stored in the URL bar this overwrites any link click navigation.
-                // We could alternatively e.preventDefault() on every link but it's easy to forget.
-                if (e.target instanceof HTMLElement && e.target.closest('a')) {
-                  return;
-                }
-                setFocused?.(focused !== group ? group : undefined);
-              }}
-            >
-              <Box
-                style={{height: size}}
-                padding={{left: 24, right: 12}}
-                flex={{direction: 'column', justifyContent: 'center', gap: 8}}
-                border="bottom"
+    <Box style={{position: 'relative', flex: 1, minHeight: 0}}>
+      <AssetListContainer
+        ref={parentRef}
+        onScroll={(e) => {
+          if (
+            !loading &&
+            e.currentTarget.scrollHeight > e.currentTarget.clientHeight &&
+            e.currentTarget.clientHeight + e.currentTarget.scrollTop ===
+              e.currentTarget.scrollHeight
+          ) {
+            onLoadMore();
+          }
+        }}
+      >
+        <Inner $totalHeight={totalHeight}>
+          {items.map(({index, key, size, start}) => {
+            const group = groups[index]!;
+            return (
+              <AssetListRow
+                key={key}
+                $height={size}
+                $start={start}
+                $focused={group === focused}
+                ref={group === focused ? focusedRowRef : undefined}
+                onClick={(e) => {
+                  // If you're interacting with something in the row, don't trigger a focus change.
+                  // Since focus is stored in the URL bar this overwrites any link click navigation.
+                  // We could alternatively e.preventDefault() on every link but it's easy to forget.
+                  if (e.target instanceof HTMLElement && e.target.closest('a')) {
+                    return;
+                  }
+                  setFocused?.(focused !== group ? group : undefined);
+                }}
               >
-                {xAxis === 'partition' ? (
-                  <AssetEventListPartitionRow group={group} />
-                ) : (
-                  <AssetEventListEventRow group={group} assetKey={assetKey} />
-                )}
-              </Box>
-            </AssetListRow>
-          );
-        })}
-      </Inner>
-    </AssetListContainer>
+                <Box
+                  style={{height: size}}
+                  padding={{left: 24, right: 12}}
+                  flex={{direction: 'column', justifyContent: 'center', gap: 8}}
+                  border="bottom"
+                >
+                  {xAxis === 'partition' ? (
+                    <AssetEventListPartitionRow group={group} />
+                  ) : (
+                    <AssetEventListEventRow group={group} assetKey={assetKey} />
+                  )}
+                </Box>
+              </AssetListRow>
+            );
+          })}
+        </Inner>
+      </AssetListContainer>
+
+      {loading ? (
+        <Box
+          style={{position: 'absolute', bottom: 12, left: 0, right: 0}}
+          flex={{alignItems: 'center', justifyContent: 'center'}}
+        >
+          <Box
+            style={{borderRadius: 6}}
+            padding={{vertical: 8, horizontal: 12}}
+            flex={{gap: 4, alignItems: 'center', justifyContent: 'center'}}
+            background={Colors.backgroundLighter()}
+          >
+            <Spinner purpose="body-text" />
+            Loading...
+          </Box>
+        </Box>
+      ) : undefined}
+    </Box>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/groupByPartition.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/groupByPartition.tsx
@@ -19,10 +19,6 @@ export type AssetEventGroup = {
 
 const sortByEventTimestamp = (a: Event, b: Event) => Number(b?.timestamp) - Number(a?.timestamp);
 
-/**
- * A hook that can bucket a list of materializations by partition, if any, with the `latest`
- * materialization separated from predecessor materializations.
- */
 const groupByPartition = (events: Event[], definedPartitionKeys: string[]): AssetEventGroup[] => {
   const grouped = groupBy(events, (m) => m.partition || NO_PARTITION_KEY);
   const orderedPartitionKeys = [...definedPartitionKeys].reverse();
@@ -47,6 +43,10 @@ const groupByPartition = (events: Event[], definedPartitionKeys: string[]): Asse
     });
 };
 
+/**
+ * A hook that can bucket a list of materializations by partition, if any, with the `latest`
+ * materialization separated from predecessor materializations.
+ */
 export function useGroupedEvents(
   xAxis: 'partition' | 'time',
   materializations: Event[],

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/usePaginatedAssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/usePaginatedAssetEvents.tsx
@@ -1,0 +1,92 @@
+import {useApolloClient} from '@apollo/client';
+import min from 'lodash/min';
+import uniq from 'lodash/uniq';
+import uniqBy from 'lodash/uniqBy';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
+
+import {AssetKey, AssetViewParams} from './types';
+import {
+  AssetEventsQuery,
+  AssetEventsQueryVariables,
+  AssetMaterializationFragment,
+  AssetObservationFragment,
+} from './types/useRecentAssetEvents.types';
+import {ASSET_EVENTS_QUERY} from './useRecentAssetEvents';
+
+/** Note: This hook paginates through an asset's events, optionally beginning at ?asOf=.
+ * This could re-use useCursorPaginatedQuery in the future if we made the API use a `cursor`
+ * var instead of `before` but we also want this hook to refresh the results when new events
+ * arrive without discarding your pagination state.
+ *
+ * This hook exposes both a `fetchMore` and a `fetchLatest`, and we take advantage of the
+ * fact that the events are a write-only log - we can safely re-fetch the latest events
+ * and as long as we de-dupe we're ok!
+ *
+ * This hook expects that `useGroupedEvents` will do the sorting downstream.
+ */
+export function usePaginatedAssetEvents(
+  assetKey: AssetKey | undefined,
+  params: Pick<AssetViewParams, 'asOf'>,
+) {
+  const initialAsOf = params.asOf ? `${Number(params.asOf) + 1}` : undefined;
+
+  const [observations, setObservations] = React.useState<AssetObservationFragment[]>([]);
+  const [materializations, setMaterializations] = React.useState<AssetMaterializationFragment[]>(
+    [],
+  );
+
+  const client = useApolloClient();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setObservations([]);
+    setMaterializations([]);
+  }, [assetKey]);
+
+  const fetch = useCallback(
+    async (before = initialAsOf) => {
+      if (!assetKey) {
+        return;
+      }
+      setLoading(true);
+      const {data} = await client.query<AssetEventsQuery, AssetEventsQueryVariables>({
+        query: ASSET_EVENTS_QUERY,
+        variables: {
+          assetKey: {path: assetKey.path},
+          limit: 3,
+          before,
+        },
+      });
+      setLoading(false);
+
+      const asset = data?.assetOrError.__typename === 'Asset' ? data?.assetOrError : null;
+      const materializations = asset?.assetMaterializations || [];
+      const observations = asset?.assetObservations || [];
+
+      setMaterializations((loaded) =>
+        uniqBy([...loaded, ...materializations], (e) => `${e.runId}${e.timestamp}`),
+      );
+      setObservations((loaded) =>
+        uniqBy([...loaded, ...observations], (e) => `${e.runId}${e.timestamp}`),
+      );
+    },
+    [assetKey, client, initialAsOf],
+  );
+
+  return useMemo(() => {
+    const all = [...materializations, ...observations];
+
+    // Note: If we "discover" more partition keys of a non-SDA as more events are loaded, we want
+    // those to be appended to the end so things don't jump around, so there is no sort() here.
+    const loadedPartitionKeys = uniq(all.map((p) => p.partition!).filter(Boolean)).reverse();
+
+    return {
+      loading,
+      materializations,
+      observations,
+      loadedPartitionKeys,
+      fetchLatest: fetch,
+      fetchMore: () => fetch(`${min(all.map((e) => Number(e.timestamp)))}`),
+    };
+  }, [materializations, observations, loading, fetch]);
+}


### PR DESCRIPTION
Fixes FE-313, as you scroll down the left column of the events tab, more events load! When we see the latest materialization change, we still re-fetch "page 0" to make sure that new events appear at the top.

This was a bit more complicated than it seemed at first because the Asset > Events tab still allows users of non-SDAs to view their events grouped by partition. For those assets there is no “Partitions” tab. I updated some old comments and tested that the non-SDA path still works.

This PR also memoizes the assetKey passed to the asset views — I noticed some useMemos were re-computing when unrelated params changed because the assetKey was rebuilt from the path string.

## How I Tested These Changes

- Scenario where list is short and does not scroll
- Scenario where list is long and infinite scrolls, then reaches the bottom 
- Scenario where asset is non-SDA and partitions option is present on the page