### PR TITLE
[ui] Add context menu to non-global asset graphs, direction option to lineage

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphBackgroundContextMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphBackgroundContextMenu.tsx
@@ -1,0 +1,90 @@
+import {Box, Menu, MenuItem} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {ContextMenuWrapper} from './ContextMenuWrapper';
+import {KeyboardTag} from './KeyboardTag';
+
+export const AssetGraphBackgroundContextMenu = ({
+  direction,
+  setDirection,
+  allGroups,
+  expandedGroups,
+  setExpandedGroups,
+  children,
+}: {
+  direction: 'vertical' | 'horizontal';
+  setDirection: (dir: 'vertical' | 'horizontal') => void;
+  children: React.ReactNode;
+
+  allGroups?: string[];
+  expandedGroups?: string[];
+  setExpandedGroups?: (groups: string[]) => void;
+}) => {
+  const areAllGroupsCollapsed = !expandedGroups || expandedGroups.length === 0;
+  const areAllGroupsExpanded =
+    !expandedGroups ||
+    !allGroups ||
+    allGroups.length === 1 ||
+    expandedGroups.length === allGroups.length;
+
+  return (
+    <ContextMenuWrapper
+      wrapperOuterStyles={{width: '100%', height: '100%'}}
+      wrapperInnerStyles={{width: '100%', height: '100%'}}
+      menu={
+        <Menu>
+          {areAllGroupsCollapsed ? null : (
+            <MenuItem
+              text={
+                <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+                  Collapse all groups <KeyboardTag>⌥E</KeyboardTag>
+                </Box>
+              }
+              icon="unfold_less"
+              onClick={() => {
+                setExpandedGroups?.([]);
+              }}
+            />
+          )}
+          {areAllGroupsExpanded ? null : (
+            <MenuItem
+              text={
+                <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+                  Expand all groups
+                  {areAllGroupsCollapsed ? <KeyboardTag>⌥E</KeyboardTag> : null}
+                </Box>
+              }
+              icon="unfold_more"
+              onClick={() => {
+                setExpandedGroups?.(allGroups!);
+              }}
+            />
+          )}
+          {direction === 'horizontal' ? (
+            <MenuItem
+              text={
+                <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+                  Vertical orientation <KeyboardTag>⌥O</KeyboardTag>
+                </Box>
+              }
+              icon="graph_vertical"
+              onClick={() => setDirection?.('vertical')}
+            />
+          ) : (
+            <MenuItem
+              text={
+                <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+                  Horizontal orientation <KeyboardTag>⌥O</KeyboardTag>
+                </Box>
+              }
+              icon="graph_horizontal"
+              onClick={() => setDirection?.('horizontal')}
+            />
+          )}
+        </Menu>
+      }
+    >
+      {children}
+    </ContextMenuWrapper>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -5,8 +5,6 @@ import {
   Colors,
   ErrorBoundary,
   Icon,
-  Menu,
-  MenuItem,
   NonIdealState,
   SplitPanelContainer,
   TextInputContainer,
@@ -20,14 +18,15 @@ import {useMemo} from 'react';
 import styled from 'styled-components';
 
 import {AssetEdges} from './AssetEdges';
+import {AssetGraphBackgroundContextMenu} from './AssetGraphBackgroundContextMenu';
 import {useAssetGraphExplorerFilters} from './AssetGraphExplorerFilters';
 import {AssetGraphJobSidebar} from './AssetGraphJobSidebar';
 import {AssetNode, AssetNodeContextMenuWrapper, AssetNodeMinimal} from './AssetNode';
 import {AssetNodeMenuProps} from './AssetNodeMenu';
 import {CollapsedGroupNode} from './CollapsedGroupNode';
-import {ContextMenuWrapper} from './ContextMenuWrapper';
 import {ExpandedGroupNode, GroupOutline} from './ExpandedGroupNode';
 import {AssetNodeLink} from './ForeignNode';
+import {ToggleDirectionButton, ToggleGroupsButton, useLayoutDirectionState} from './GraphSettings';
 import {SidebarAssetInfo} from './SidebarAssetInfo';
 import {
   GraphData,
@@ -38,12 +37,11 @@ import {
   tokenForAssetKey,
 } from './Utils';
 import {assetKeyTokensInRange} from './assetKeyTokensInRange';
-import {AssetGraphLayout, AssetLayoutDirection, GroupLayout} from './layout';
+import {AssetGraphLayout, GroupLayout} from './layout';
 import {AssetGraphExplorerSidebar} from './sidebar/Sidebar';
 import {AssetNodeForGraphQueryFragment} from './types/useAssetGraphData.types';
 import {AssetGraphFetchScope, AssetGraphQueryItem, useAssetGraphData} from './useAssetGraphData';
 import {AssetLocation, useFindAssetLocation} from './useFindAssetLocation';
-import {ShortcutHandler} from '../app/ShortcutHandler';
 import {AssetLiveDataRefreshButton} from '../asset-data/AssetLiveDataProvider';
 import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
 import {LaunchAssetObservationButton} from '../assets/LaunchAssetObservationButton';
@@ -53,7 +51,6 @@ import {DEFAULT_MAX_ZOOM, SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
 import {closestNodeInDirection, isNodeOffscreen} from '../graph/common';
 import {useQueryAndLocalStoragePersistedState} from '../hooks/useQueryAndLocalStoragePersistedState';
-import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {PageLoadTrace} from '../performance';
 import {
   GraphExplorerOptions,
@@ -193,10 +190,7 @@ const AssetGraphExplorerWithData = ({
     return {allGroups: Object.keys(groupedAssets), allGroupCounts: counts, groupedAssets};
   }, [assetGraphData]);
 
-  const [direction, setDirection] = useStateWithStorage<AssetLayoutDirection>(
-    'asset-graph-direction',
-    (json) => (['vertical', 'horizontal'].includes(json) ? json : 'horizontal'),
-  );
+  const [direction, setDirection] = useLayoutDirectionState();
   const [expandedGroups, setExpandedGroups] = useQueryAndLocalStoragePersistedState<string[]>({
     localStorageKey: `asset-graph-open-graph-nodes-${isGlobalGraph}-${explorerPath.pipelineName}`,
     encode: (arr) => ({expanded: arr.length ? arr.join(',') : undefined}),
@@ -440,9 +434,6 @@ const AssetGraphExplorerWithData = ({
     ]);
   };
 
-  const areAllGroupsCollapsed = expandedGroups.length === 0;
-  const areAllGroupsExpanded = expandedGroups.length === allGroups.length;
-
   const svgViewport = layout ? (
     <SVGViewport
       ref={(r) => (viewportEl.current = r || undefined)}
@@ -648,67 +639,16 @@ const AssetGraphExplorerWithData = ({
           ) : undefined}
           {loading || !layout ? (
             <LoadingNotice async={async} nodeType="asset" />
-          ) : allGroups.length > 1 ? (
-            <ContextMenuWrapper
-              wrapperOuterStyles={{width: '100%', height: '100%'}}
-              wrapperInnerStyles={{width: '100%', height: '100%'}}
-              menu={
-                <Menu>
-                  {areAllGroupsCollapsed ? null : (
-                    <MenuItem
-                      text={
-                        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-                          Collapse all groups <KeyboardTag>⌥E</KeyboardTag>
-                        </Box>
-                      }
-                      icon="unfold_less"
-                      onClick={() => {
-                        setExpandedGroups([]);
-                      }}
-                    />
-                  )}
-                  {areAllGroupsExpanded ? null : (
-                    <MenuItem
-                      text={
-                        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-                          Expand all groups
-                          {areAllGroupsCollapsed ? <KeyboardTag>⌥E</KeyboardTag> : null}
-                        </Box>
-                      }
-                      icon="unfold_more"
-                      onClick={() => {
-                        setExpandedGroups(allGroups);
-                      }}
-                    />
-                  )}
-                  {direction === 'horizontal' ? (
-                    <MenuItem
-                      text={
-                        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-                          Vertical orientation <KeyboardTag>⌥O</KeyboardTag>
-                        </Box>
-                      }
-                      icon="graph_vertical"
-                      onClick={() => setDirection?.('vertical')}
-                    />
-                  ) : (
-                    <MenuItem
-                      text={
-                        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-                          Horizontal orientation <KeyboardTag>⌥O</KeyboardTag>
-                        </Box>
-                      }
-                      icon="graph_horizontal"
-                      onClick={() => setDirection?.('horizontal')}
-                    />
-                  )}
-                </Menu>
-              }
+          ) : (
+            <AssetGraphBackgroundContextMenu
+              direction={direction}
+              setDirection={setDirection}
+              allGroups={allGroups}
+              expandedGroups={expandedGroups}
+              setExpandedGroups={setExpandedGroups}
             >
               {svgViewport}
-            </ContextMenuWrapper>
-          ) : (
-            svgViewport
+            </AssetGraphBackgroundContextMenu>
           )}
           {setOptions && (
             <OptionsOverlay>
@@ -846,21 +786,6 @@ export interface AssetGroup {
   repositoryLocationName: string;
 }
 
-interface KeyboardTagProps {
-  $withinTooltip?: boolean;
-}
-
-const KeyboardTag = styled.div<KeyboardTagProps>`
-  ${(props) => {
-    return props.$withinTooltip ? `color: ${Colors.accentWhite()}` : `color: ${Colors.textLight()}`;
-  }};
-  background: ${Colors.backgroundGray()};
-  border-radius: 4px;
-  padding: 2px 4px;
-  margin-left: 6px;
-  font-size: 12px;
-`;
-
 const SVGContainer = styled.svg`
   overflow: visible;
   border-radius: 0;
@@ -895,93 +820,3 @@ const GraphQueryInputFlexWrap = styled.div`
     }
   }
 `;
-
-const ToggleGroupsButton = ({
-  expandedGroups,
-  setExpandedGroups,
-  allGroups,
-}: {
-  expandedGroups: string[];
-  setExpandedGroups: (v: string[]) => void;
-  allGroups: string[];
-}) => (
-  <ShortcutHandler
-    shortcutLabel="⌥E"
-    onShortcut={() => setExpandedGroups(expandedGroups.length === 0 ? allGroups : [])}
-    shortcutFilter={(e) => e.altKey && e.code === 'KeyE'}
-  >
-    {expandedGroups.length === 0 ? (
-      <Tooltip
-        content={
-          <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-            Expand all groups <KeyboardTag $withinTooltip>⌥E</KeyboardTag>
-          </Box>
-        }
-      >
-        <Button
-          icon={<Icon name="unfold_more" />}
-          onClick={() => setExpandedGroups(allGroups)}
-          style={{background: Colors.backgroundDefault()}}
-        />
-      </Tooltip>
-    ) : (
-      <Tooltip
-        content={
-          <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-            Collapse all groups <KeyboardTag $withinTooltip>⌥E</KeyboardTag>
-          </Box>
-        }
-      >
-        <Button
-          icon={<Icon name="unfold_less" />}
-          onClick={() => setExpandedGroups([])}
-          style={{background: Colors.backgroundDefault()}}
-        />
-      </Tooltip>
-    )}
-  </ShortcutHandler>
-);
-
-const ToggleDirectionButton = ({
-  direction,
-  setDirection,
-}: {
-  direction: AssetLayoutDirection;
-  setDirection: (d: AssetLayoutDirection) => void;
-}) => (
-  <ShortcutHandler
-    shortcutLabel="⌥O"
-    onShortcut={() => setDirection(direction === 'vertical' ? 'horizontal' : 'vertical')}
-    shortcutFilter={(e) => e.altKey && e.code === 'KeyO'}
-  >
-    {direction === 'horizontal' ? (
-      <Tooltip
-        content={
-          <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-            Change graph to vertical orientation <KeyboardTag $withinTooltip>⌥O</KeyboardTag>
-          </Box>
-        }
-      >
-        <Button
-          icon={<Icon name="graph_vertical" />}
-          onClick={() => setDirection('vertical')}
-          style={{background: Colors.backgroundDefault()}}
-        />
-      </Tooltip>
-    ) : (
-      <Tooltip
-        content={
-          <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-            Change graph to horizontal orientation <KeyboardTag $withinTooltip>⌥O</KeyboardTag>
-          </Box>
-        }
-      >
-        <Button
-          icon={<Icon name="graph_horizontal" />}
-          onClick={() => setDirection('horizontal')}
-          style={{background: Colors.backgroundDefault()}}
-        />
-      </Tooltip>
-    )}
-  </ShortcutHandler>
-);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/GraphSettings.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/GraphSettings.tsx
@@ -1,0 +1,101 @@
+import {Box, Button, Colors, Icon, Tooltip} from '@dagster-io/ui-components';
+
+import {KeyboardTag} from './KeyboardTag';
+import {AssetLayoutDirection} from './layout';
+import {ShortcutHandler} from '../app/ShortcutHandler';
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
+
+export const ToggleGroupsButton = ({
+  expandedGroups,
+  setExpandedGroups,
+  allGroups,
+}: {
+  expandedGroups: string[];
+  setExpandedGroups: (v: string[]) => void;
+  allGroups: string[];
+}) => (
+  <ShortcutHandler
+    shortcutLabel="⌥E"
+    onShortcut={() => setExpandedGroups(expandedGroups.length === 0 ? allGroups : [])}
+    shortcutFilter={(e) => e.altKey && e.code === 'KeyE'}
+  >
+    {expandedGroups.length === 0 ? (
+      <Tooltip
+        content={
+          <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+            Expand all groups <KeyboardTag $withinTooltip>⌥E</KeyboardTag>
+          </Box>
+        }
+      >
+        <Button
+          icon={<Icon name="unfold_more" />}
+          onClick={() => setExpandedGroups(allGroups)}
+          style={{background: Colors.backgroundDefault()}}
+        />
+      </Tooltip>
+    ) : (
+      <Tooltip
+        content={
+          <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+            Collapse all groups <KeyboardTag $withinTooltip>⌥E</KeyboardTag>
+          </Box>
+        }
+      >
+        <Button
+          icon={<Icon name="unfold_less" />}
+          onClick={() => setExpandedGroups([])}
+          style={{background: Colors.backgroundDefault()}}
+        />
+      </Tooltip>
+    )}
+  </ShortcutHandler>
+);
+
+export const useLayoutDirectionState = () =>
+  useStateWithStorage<AssetLayoutDirection>('asset-graph-direction', (json) =>
+    ['vertical', 'horizontal'].includes(json) ? json : 'horizontal',
+  );
+
+export const ToggleDirectionButton = ({
+  direction,
+  setDirection,
+}: {
+  direction: AssetLayoutDirection;
+  setDirection: (d: AssetLayoutDirection) => void;
+}) => (
+  <ShortcutHandler
+    shortcutLabel="⌥O"
+    onShortcut={() => setDirection(direction === 'vertical' ? 'horizontal' : 'vertical')}
+    shortcutFilter={(e) => e.altKey && e.code === 'KeyO'}
+  >
+    {direction === 'horizontal' ? (
+      <Tooltip
+        content={
+          <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+            Change graph to vertical orientation <KeyboardTag $withinTooltip>⌥O</KeyboardTag>
+          </Box>
+        }
+      >
+        <Button
+          icon={<Icon name="graph_vertical" />}
+          onClick={() => setDirection('vertical')}
+          style={{background: Colors.backgroundDefault()}}
+        />
+      </Tooltip>
+    ) : (
+      <Tooltip
+        content={
+          <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+            Change graph to horizontal orientation <KeyboardTag $withinTooltip>⌥O</KeyboardTag>
+          </Box>
+        }
+      >
+        <Button
+          icon={<Icon name="graph_horizontal" />}
+          onClick={() => setDirection('horizontal')}
+          style={{background: Colors.backgroundDefault()}}
+        />
+      </Tooltip>
+    )}
+  </ShortcutHandler>
+);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/KeyboardTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/KeyboardTag.tsx
@@ -1,0 +1,17 @@
+import {Colors} from '@dagster-io/ui-components';
+import styled from 'styled-components';
+
+interface KeyboardTagProps {
+  $withinTooltip?: boolean;
+}
+
+export const KeyboardTag = styled.div<KeyboardTagProps>`
+  ${(props) => {
+    return props.$withinTooltip ? `color: ${Colors.accentWhite()}` : `color: ${Colors.textLight()}`;
+  }};
+  background: ${Colors.backgroundGray()};
+  border-radius: 4px;
+  padding: 2px 4px;
+  margin-left: 6px;
+  font-size: 12px;
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -7,18 +7,17 @@ import {SVGSaveZoomLevel, useLastSavedZoomLevel} from './SavedZoomLevel';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {AssetKey, AssetViewParams} from './types';
 import {AssetEdges} from '../asset-graph/AssetEdges';
+import {AssetGraphBackgroundContextMenu} from '../asset-graph/AssetGraphBackgroundContextMenu';
 import {MINIMAL_SCALE} from '../asset-graph/AssetGraphExplorer';
 import {AssetNode, AssetNodeContextMenuWrapper, AssetNodeMinimal} from '../asset-graph/AssetNode';
 import {ExpandedGroupNode, GroupOutline} from '../asset-graph/ExpandedGroupNode';
 import {AssetNodeLink} from '../asset-graph/ForeignNode';
+import {ToggleDirectionButton, useLayoutDirectionState} from '../asset-graph/GraphSettings';
 import {GraphData, GraphNode, groupIdForNode, toGraphId} from '../asset-graph/Utils';
-import {LayoutAssetGraphOptions} from '../asset-graph/layout';
 import {DEFAULT_MAX_ZOOM, SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
 import {isNodeOffscreen} from '../graph/common';
 import {AssetKeyInput} from '../graphql/types';
-
-const LINEAGE_GRAPH_OPTIONS: LayoutAssetGraphOptions = {direction: 'horizontal'};
 
 export type AssetNodeLineageGraphProps = {
   assetKey: AssetKeyInput;
@@ -44,8 +43,13 @@ export const AssetNodeLineageGraph = ({
   }, [assetGraphData]);
 
   const [highlighted, setHighlighted] = useState<string[] | null>(null);
+  const [direction, setDirection] = useLayoutDirectionState();
 
-  const {layout, loading} = useAssetLayout(assetGraphData, allGroups, LINEAGE_GRAPH_OPTIONS);
+  const {layout, loading} = useAssetLayout(
+    assetGraphData,
+    allGroups,
+    useMemo(() => ({direction}), [direction]),
+  );
   const viewportEl = useRef<SVGViewport>();
   const history = useHistory();
 
@@ -66,107 +70,116 @@ export const AssetNodeLineageGraph = ({
   }
 
   return (
-    <SVGViewport
-      ref={(r) => (viewportEl.current = r || undefined)}
-      interactor={SVGViewport.Interactors.PanAndZoom}
-      defaultZoom="zoom-to-fit"
-      graphWidth={layout.width}
-      graphHeight={layout.height}
-      onDoubleClick={(e) => {
-        viewportEl.current?.autocenter(true);
-        e.stopPropagation();
-      }}
-      maxZoom={DEFAULT_MAX_ZOOM}
-      maxAutocenterZoom={DEFAULT_MAX_ZOOM}
-    >
-      {({scale}, viewportRect) => (
-        <SVGContainer width={layout.width} height={layout.height}>
-          {viewportEl.current && <SVGSaveZoomLevel scale={scale} />}
-
-          {Object.values(layout.groups)
-            .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
-            .sort((a, b) => a.id.length - b.id.length)
-            .map((group) => (
-              <foreignObject
-                {...group.bounds}
-                key={`${group.id}-outline`}
-                onDoubleClick={(e) => {
-                  e.stopPropagation();
-                }}
-              >
-                <GroupOutline $minimal={scale < MINIMAL_SCALE} />
-              </foreignObject>
-            ))}
-
-          <AssetEdges
-            selected={null}
-            highlighted={highlighted}
-            edges={layout.edges}
-            viewportRect={viewportRect}
-            direction="horizontal"
+    <AssetGraphBackgroundContextMenu direction={direction} setDirection={setDirection}>
+      <SVGViewport
+        ref={(r) => (viewportEl.current = r || undefined)}
+        interactor={SVGViewport.Interactors.PanAndZoom}
+        defaultZoom="zoom-to-fit"
+        graphWidth={layout.width}
+        graphHeight={layout.height}
+        onDoubleClick={(e) => {
+          viewportEl.current?.autocenter(true);
+          e.stopPropagation();
+        }}
+        maxZoom={DEFAULT_MAX_ZOOM}
+        maxAutocenterZoom={DEFAULT_MAX_ZOOM}
+        additionalToolbarElements={
+          <ToggleDirectionButton
+            key="toggle-direction"
+            direction={direction}
+            setDirection={setDirection}
           />
+        }
+      >
+        {({scale}, viewportRect) => (
+          <SVGContainer width={layout.width} height={layout.height}>
+            {viewportEl.current && <SVGSaveZoomLevel scale={scale} />}
 
-          {Object.values(layout.groups)
-            .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
-            .sort((a, b) => a.id.length - b.id.length)
-            .map((group) => (
-              <foreignObject {...group.bounds} key={group.id}>
-                <ExpandedGroupNode
-                  group={{...group, assets: groupedAssets[group.id]!}}
-                  minimal={scale < MINIMAL_SCALE}
-                  setHighlighted={setHighlighted}
-                />
-              </foreignObject>
-            ))}
-
-          {Object.values(layout.nodes)
-            .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
-            .map(({id, bounds}) => {
-              const graphNode = assetGraphData.nodes[id];
-              const path = JSON.parse(id);
-
-              const contextMenuProps = {
-                graphData: assetGraphData,
-                node: graphNode!,
-              };
-
-              return (
+            {Object.values(layout.groups)
+              .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
+              .sort((a, b) => a.id.length - b.id.length)
+              .map((group) => (
                 <foreignObject
-                  {...bounds}
-                  key={id}
-                  style={{overflow: 'visible'}}
-                  onMouseEnter={() => setHighlighted([id])}
-                  onMouseLeave={() => setHighlighted(null)}
-                  onClick={() => onClickAsset({path})}
+                  {...group.bounds}
+                  key={`${group.id}-outline`}
                   onDoubleClick={(e) => {
-                    viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
                     e.stopPropagation();
                   }}
                 >
-                  {!graphNode ? (
-                    <AssetNodeLink assetKey={{path}} />
-                  ) : scale < MINIMAL_SCALE ? (
-                    <AssetNodeContextMenuWrapper {...contextMenuProps}>
-                      <AssetNodeMinimal
-                        definition={graphNode.definition}
-                        selected={graphNode.id === assetGraphId}
-                        height={bounds.height}
-                      />
-                    </AssetNodeContextMenuWrapper>
-                  ) : (
-                    <AssetNodeContextMenuWrapper {...contextMenuProps}>
-                      <AssetNode
-                        definition={graphNode.definition}
-                        selected={graphNode.id === assetGraphId}
-                      />
-                    </AssetNodeContextMenuWrapper>
-                  )}
+                  <GroupOutline $minimal={scale < MINIMAL_SCALE} />
                 </foreignObject>
-              );
-            })}
-        </SVGContainer>
-      )}
-    </SVGViewport>
+              ))}
+
+            <AssetEdges
+              selected={null}
+              highlighted={highlighted}
+              edges={layout.edges}
+              viewportRect={viewportRect}
+              direction={direction}
+            />
+
+            {Object.values(layout.groups)
+              .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
+              .sort((a, b) => a.id.length - b.id.length)
+              .map((group) => (
+                <foreignObject {...group.bounds} key={group.id}>
+                  <ExpandedGroupNode
+                    group={{...group, assets: groupedAssets[group.id]!}}
+                    minimal={scale < MINIMAL_SCALE}
+                    setHighlighted={setHighlighted}
+                  />
+                </foreignObject>
+              ))}
+
+            {Object.values(layout.nodes)
+              .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
+              .map(({id, bounds}) => {
+                const graphNode = assetGraphData.nodes[id];
+                const path = JSON.parse(id);
+
+                const contextMenuProps = {
+                  graphData: assetGraphData,
+                  node: graphNode!,
+                };
+
+                return (
+                  <foreignObject
+                    {...bounds}
+                    key={id}
+                    style={{overflow: 'visible'}}
+                    onMouseEnter={() => setHighlighted([id])}
+                    onMouseLeave={() => setHighlighted(null)}
+                    onClick={() => onClickAsset({path})}
+                    onDoubleClick={(e) => {
+                      viewportEl.current?.zoomToSVGBox(bounds, true, 1.2);
+                      e.stopPropagation();
+                    }}
+                  >
+                    {!graphNode ? (
+                      <AssetNodeLink assetKey={{path}} />
+                    ) : scale < MINIMAL_SCALE ? (
+                      <AssetNodeContextMenuWrapper {...contextMenuProps}>
+                        <AssetNodeMinimal
+                          definition={graphNode.definition}
+                          selected={graphNode.id === assetGraphId}
+                          height={bounds.height}
+                        />
+                      </AssetNodeContextMenuWrapper>
+                    ) : (
+                      <AssetNodeContextMenuWrapper {...contextMenuProps}>
+                        <AssetNode
+                          definition={graphNode.definition}
+                          selected={graphNode.id === assetGraphId}
+                        />
+                      </AssetNodeContextMenuWrapper>
+                    )}
+                  </foreignObject>
+                );
+              })}
+          </SVGContainer>
+        )}
+      </SVGViewport>
+    </AssetGraphBackgroundContextMenu>
   );
 };
 


### PR DESCRIPTION
## Summary & Motivation

Fixes FE-210 - previously the "background-click" context menu was only available if groups were present in the graph.  It's now available in the single-group asset graph and the lineage asset graph as well.

In the lineage graph, you couldn't change the orientation OR expand/collapse groups.  I added the horizontal / vertical option so that the context menu has something to display.  We'll need to add this to the column lineage graph as well, but I'll do that in a follow-up in cloud since it'll re-use helpers in this PR.

## How I Tested These Changes

- Right click backgrounds of global, group, and lineage graphs
- Verify new horizontal vs. vertical toggle works as expected in the lineage graph