### PR TITLE
in upath_io_manager, set no path metadata when obj is None

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/numbers_example/number_x.py
@@ -10,4 +10,6 @@ with open_dagster_pipes() as context:
     store_asset_value("number_x", storage_root, value)
 
     context.log.info(f"{context.asset_key}: {2} * {multiplier} = {value}")
-    context.report_asset_materialization(data_version=compute_data_version(value))
+    context.report_asset_materialization(
+        data_version=compute_data_version(value), metadata={"foo": "bar"}
+    )

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -445,7 +445,13 @@ class UPathIOManager(MemoizableIOManager):
         context.log.debug(self.get_writing_output_log_message(path))
         self.dump_to_path(context=context, obj=obj, path=path)
 
-        metadata = {"path": MetadataValue.path(str(path))}
+        # Usually, when the value is None, it means that the user didn't intend to use an IO manager
+        # at all, but ended up with one because they didn't set None as their return type
+        # annotation. In these cases, seeing a "path" metadata value can be very confusing, because
+        # often they're actually writing data to a different location within their op. We omit
+        # the metadata when "obj is None", in order to avoid this confusion in the common case.
+        # This comes at the cost of this metadata not being present in these edge cases.
+        metadata = {"path": MetadataValue.path(str(path))} if obj is not None else {}
         custom_metadata = self.get_metadata(context=context, obj=obj)
         metadata.update(custom_metadata)  # type: ignore
 

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_pipes.py
@@ -50,7 +50,7 @@ def test_default():
     )
     assert result.success
     mats = result.asset_materializations_for_node(number_x.op.name)
-    assert mats[0].metadata["path"]
+    assert mats[0].metadata["foo"]
 
 
 @pytest.mark.integration
@@ -115,7 +115,7 @@ def test_file_io():
         )
         assert result.success
         mats = result.asset_materializations_for_node(number_x.op.name)
-        assert mats[0].metadata["path"]
+        assert mats[0].metadata["foo"]
 
 
 _print_script = """


### PR DESCRIPTION
## Summary & Motivation

Usually, when an op or asset returns `None`, it means that the user didn't intend to use an IO manager, but ended up with one because they didn't set `-> None` as their return type annotation. In these cases, seeing a "path" metadata value can be very confusing, because usually the body of their op is actually writing data to a different location.

We've discussed solutions at length that involved bypassing the IO manager, but ultimately backed off from them due to backwards compatibility concerns.

This PR proposes a smaller step: omitting the metadata when the outputted in object is `None`. This avoids the confusion in the common case. There's a tradeoff here: this comes at the cost of consistency. And it means that, in the rare cases where people actually intend to return `None` and have it written to a file, they won't see the metadata for that file.

## How I Tested These Changes
