### PR TITLE
fix: set postgres timeout args via query

### DIFF
--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -112,19 +112,17 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
     def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagster-webserver, hold an open connection and set statement_timeout
+        kwargs = {
+            "url": self.postgres_url,
+            "isolation_level": "AUTOCOMMIT",
+            "pool_size": 1,
+            "pool_recycle": pool_recycle,
+        }
         existing_options = self._engine.url.query.get("options")
-        timeout_option = pg_statement_timeout(statement_timeout)
         if existing_options:
-            options = f"{timeout_option} {existing_options}"
-        else:
-            options = timeout_option
-        self._engine = create_engine(
-            self.postgres_url,
-            isolation_level="AUTOCOMMIT",
-            pool_size=1,
-            connect_args={"options": options},
-            pool_recycle=pool_recycle,
-        )
+            kwargs["connect_args"] = {"options": existing_options}
+        self._engine = create_engine(**kwargs)
+        self._engine.execute(pg_statement_timeout(statement_timeout))
 
     def upgrade(self) -> None:
         alembic_config = pg_alembic_config(__file__)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -114,7 +114,6 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagster-webserver, hold an open connection and set statement_timeout
         kwargs = {
-            "url": self.postgres_url,
             "isolation_level": "AUTOCOMMIT",
             "pool_size": 1,
             "pool_recycle": pool_recycle,
@@ -122,7 +121,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         existing_options = self._engine.url.query.get("options")
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
-        self._engine = create_engine(**kwargs)
+        self._engine = create_engine(self.postgres_url, **kwargs)
         event.listen(
             self._engine,
             "connect",

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -30,15 +30,16 @@ from dagster._core.storage.sql import (
 )
 from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._serdes import ConfigurableClass, ConfigurableClassData, deserialize_value
+from sqlalchemy import event
 from sqlalchemy.engine import Connection
 
 from ..utils import (
     create_pg_connection,
     pg_alembic_config,
-    pg_statement_timeout,
     pg_url_from_config,
     retry_pg_connection_fn,
     retry_pg_creation_fn,
+    set_pg_statement_timeout,
 )
 
 CHANNEL_NAME = "run_events"
@@ -122,7 +123,11 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
         self._engine = create_engine(**kwargs)
-        self._engine.execute(pg_statement_timeout(statement_timeout))
+        event.listen(
+            self._engine,
+            "connect",
+            lambda connection, _: set_pg_statement_timeout(connection, statement_timeout),
+        )
 
     def upgrade(self) -> None:
         alembic_config = pg_alembic_config(__file__)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -107,20 +107,18 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
                 stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
     def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
-        # When running in dagster-webserver, hold 1 open connection and set statement_timeout
+        # When running in dagster-webserver, hold an open connection and set statement_timeout
+        kwargs = {
+            "url": self.postgres_url,
+            "isolation_level": "AUTOCOMMIT",
+            "pool_size": 1,
+            "pool_recycle": pool_recycle,
+        }
         existing_options = self._engine.url.query.get("options")
-        timeout_option = pg_statement_timeout(statement_timeout)
         if existing_options:
-            options = f"{timeout_option} {existing_options}"
-        else:
-            options = timeout_option
-        self._engine = create_engine(
-            self.postgres_url,
-            isolation_level="AUTOCOMMIT",
-            pool_size=1,
-            connect_args={"options": options},
-            pool_recycle=pool_recycle,
-        )
+            kwargs["connect_args"] = {"options": existing_options}
+        self._engine = create_engine(**kwargs)
+        self._engine.execute(pg_statement_timeout(statement_timeout))
 
     @property
     def inst_data(self) -> Optional[ConfigurableClassData]:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -110,7 +110,6 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
     def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagster-webserver, hold an open connection and set statement_timeout
         kwargs = {
-            "url": self.postgres_url,
             "isolation_level": "AUTOCOMMIT",
             "pool_size": 1,
             "pool_recycle": pool_recycle,
@@ -118,7 +117,7 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
         existing_options = self._engine.url.query.get("options")
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
-        self._engine = create_engine(**kwargs)
+        self._engine = create_engine(self.postgres_url, **kwargs)
         event.listen(
             self._engine,
             "connect",

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -105,7 +105,6 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
     def optimize_for_webserver(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagster-webserver, hold an open connection and set statement_timeout
         kwargs = {
-            "url": self.postgres_url,
             "isolation_level": "AUTOCOMMIT",
             "pool_size": 1,
             "pool_recycle": pool_recycle,
@@ -113,7 +112,7 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         existing_options = self._engine.url.query.get("options")
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
-        self._engine = create_engine(**kwargs)
+        self._engine = create_engine(self.postgres_url, **kwargs)
         event.listen(
             self._engine,
             "connect",

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -24,15 +24,16 @@ from dagster._core.storage.sql import (
     stamp_alembic_rev,
 )
 from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_value
+from sqlalchemy import event
 from sqlalchemy.engine import Connection
 
 from ..utils import (
     create_pg_connection,
     pg_alembic_config,
-    pg_statement_timeout,
     pg_url_from_config,
     retry_pg_connection_fn,
     retry_pg_creation_fn,
+    set_pg_statement_timeout,
 )
 
 
@@ -113,7 +114,11 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
         self._engine = create_engine(**kwargs)
-        self._engine.execute(pg_statement_timeout(statement_timeout))
+        event.listen(
+            self._engine,
+            "connect",
+            lambda connection, _: set_pg_statement_timeout(connection, statement_timeout),
+        )
 
     @property
     def inst_data(self) -> Optional[ConfigurableClassData]:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
@@ -171,4 +171,4 @@ def create_pg_connection(
 
 def pg_statement_timeout(millis: int) -> str:
     check.int_param(millis, "millis")
-    return f"-c statement_timeout={millis}"
+    return f"SET statement_timeout = {millis};"

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
@@ -169,6 +169,8 @@ def create_pg_connection(
             conn.close()
 
 
-def pg_statement_timeout(millis: int) -> str:
+def set_pg_statement_timeout(conn: psycopg2.extensions.connection, millis: int):
     check.int_param(millis, "millis")
-    return f"SET statement_timeout = {millis};"
+    with conn:
+        with conn.cursor() as curs:
+            curs.execute(f"SET statement_timeout = {millis};")


### PR DESCRIPTION
## Summary & Motivation

AWS RDS Proxy does not support cli options, so setting any mandatory connection options via statement improves compatibility.
Any custom options are still passed through as prior

## How I tested changes

- dagster_postgres pytests
- `dagster dev` and connect via rds proxy and directly, storage loads as expected

Resolves: #11762