### PR TITLE
include input loading time in step duration

### DIFF
--- a/python_modules/dagster/dagster_tests/execution_tests/test_timing.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_timing.py
@@ -2,7 +2,7 @@ import sys
 import time
 
 import pytest
-from dagster import GraphDefinition, Output, op
+from dagster import GraphDefinition, In, Output, input_manager, op
 
 
 @pytest.mark.skipif(
@@ -46,6 +46,27 @@ def test_event_timing_direct_return():
         return None
 
     job_def = GraphDefinition(node_defs=[direct_return_op], name="test").to_job()
+    result = job_def.execute_in_process()
+    success_event = result.get_step_success_events()[0]
+    assert success_event.event_specific_data.duration_ms >= 10.0
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="https://github.com/dagster-io/dagster/issues/1421"
+)
+def test_event_timing_include_input_loading():
+    @op(ins={"in1": In(input_manager_key="foo")})
+    def direct_return_op(in1):
+        return None
+
+    @input_manager
+    def my_input_manager():
+        time.sleep(0.01)
+        return None
+
+    job_def = GraphDefinition(node_defs=[direct_return_op], name="test").to_job(
+        resource_defs={"foo": my_input_manager}
+    )
     result = job_def.execute_in_process()
     success_event = result.get_step_success_events()[0]
     assert success_event.event_specific_data.duration_ms >= 10.0


### PR DESCRIPTION
## Summary & Motivation

The step duration we report oddly included `handle_output` time, but not `load_input` time. This PR makes it include both. This was reported by a user.

## How I Tested These Changes
