### PR TITLE
[embedded-elt] Default to None for dlt_dagster_translator in dlt_assets

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/asset_decorator.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Optional
 from dagster import (
     AssetsDefinition,
     AssetSpec,
+    _check as check,
     multi_asset,
 )
 from dlt.extract.source import DltSource
@@ -18,7 +19,7 @@ def dlt_assets(
     dlt_pipeline: Pipeline,
     name: Optional[str] = None,
     group_name: Optional[str] = None,
-    dlt_dagster_translator: DagsterDltTranslator = DagsterDltTranslator(),
+    dlt_dagster_translator: Optional[DagsterDltTranslator] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Asset Factory for using data load tool (dlt).
 
@@ -76,6 +77,13 @@ def dlt_assets(
                 yield from dlt.run(context=context)
 
     """
+    dlt_dagster_translator = (
+        check.opt_inst_param(
+            dlt_dagster_translator, "dagster_sling_translator", DagsterDltTranslator
+        )
+        or DagsterDltTranslator()
+    )
+
     return multi_asset(
         name=name,
         group_name=group_name,


### PR DESCRIPTION
## Summary & Motivation

- Mimicks https://github.com/dagster-io/dagster/pull/21340
- Default to `None` for `DagsterDltTranslator` as to not share instance across invocations