### PR TITLE
[Fix] Cross-code-location partition mapping

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -1745,7 +1745,9 @@ def external_asset_nodes_from_defs(
         partition_mappings: Dict[AssetKey, Optional[PartitionMapping]] = {}
         builtin_partition_mapping_types = get_builtin_partition_mapping_types()
         for pk in asset_node.parent_keys:
-            partition_mapping = asset_graph.get_partition_mapping(key, pk)
+            # directly access the partition mapping to avoid the inference step of
+            # get_partition_mapping, as we want to defer the inference to the global RemoteAssetGraph
+            partition_mapping = asset_graph.get(key).partition_mappings.get(pk)
             if (asset_node.partitions_def or asset_graph.get(pk).partitions_def) and isinstance(
                 partition_mapping, builtin_partition_mapping_types
             ):


### PR DESCRIPTION
## Summary & Motivation

Fixes: https://github.com/dagster-io/dagster/issues/21306

The `asset_graph.get_partition_mapping()` method sneakily infers a PartitionMapping if no explicit PartitionMapping is applied. This is usually desirable, but when packaging up our external data, this means that ALL dependencies will have a PartitionMapping defined (i.e. the PartitionMapping will never be None). In many cases with cross-code-location dependencies, users will not create a corresponding SourceAsset object with the included PartitionsDefinition information, and so the default inferred PartitionMapping between an (e.g.) TimePartitioned asset and an (assumed-to-be-at-serialization-time) unpartitioned dependency is the AllPartitionMapping.

This partition mapping then gets serialized, meaning that later on, when we load multiple code locations worth of ExternalAssetNodes, we now have an explicit partition mapping encoded, where one originally didn't exist. This means that when we do the inference step again (now with the true parent PartitionsDefinition), we are stuck with the originally-serialized value of AllPartitionsMapping.

## How I Tested These Changes

Repro in the linked issue no longer repros, test failed before and passes now.