### PR TITLE
Add `DagsterInstance.use_transitive_stale_causes` to disable transitivity of unsynced (i.e. stale) status

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/data_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_version.py
@@ -517,7 +517,10 @@ class CachingStaleStatusResolver:
         partition_deps = self._get_partition_dependencies(key=key)
         for dep_key in sorted(partition_deps):
             dep_asset = self.asset_graph.get(dep_key.asset_key)
-            if self._get_status(key=dep_key) == StaleStatus.STALE:
+            if (
+                self._instance.use_transitive_stale_causes
+                and self._get_status(key=dep_key) == StaleStatus.STALE
+            ):
                 yield StaleCause(
                     key,
                     StaleCauseCategory.DATA,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -966,6 +966,10 @@ class DagsterInstance(DynamicPartitionsStore):
     def global_op_concurrency_default_limit(self) -> Optional[int]:
         return self.get_settings("concurrency").get("default_op_concurrency_limit")
 
+    @property
+    def use_transitive_stale_causes(self) -> bool:
+        return True
+
     # python logs
 
     @property

--- a/python_modules/dagster/dagster/_utils/test/data_versions.py
+++ b/python_modules/dagster/dagster/_utils/test/data_versions.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union, c
 from typing_extensions import Literal
 
 from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_selection import CoercibleToAssetSelection
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import (
     CODE_VERSION_TAG,
@@ -186,6 +187,7 @@ def materialize_assets(
     partition_key: Optional[str] = None,
     run_config: Optional[Mapping[str, Any]] = None,
     tags: Optional[Mapping[str, str]] = None,
+    selection: Optional[CoercibleToAssetSelection] = None,
 ) -> MaterializationTable:
     result = materialize(
         assets,
@@ -194,6 +196,7 @@ def materialize_assets(
         partition_key=partition_key,
         run_config=run_config,
         tags=tags,
+        selection=selection,
     )
     return get_mats_from_result(result, assets)
 


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/9454

Add a new `DagsterInstance.use_transitive_stale_causes` property that can be used to turn off transitivity of the stale status in the `CachingStaleStatusResolver` (Eventually we will change the internal terminology to match synced/unsynced).

In OSS this just returns True, maintaining default behavior, but with `DeploymentScopedHostInstance` it reads a private org setting (defined in the companion PR), allowing us to toggle this setting for specific organizations.

## How I Tested These Changes

New unit test.
