### PR TITLE
Clarify code location resource limits in serverless docs

### DIFF
--- a/docs/content/dagster-plus/deployment/serverless.mdx
+++ b/docs/content/dagster-plus/deployment/serverless.mdx
@@ -30,7 +30,7 @@ Serverless is subject to the following limitations:
 - Maximum of 100 GB of bandwidth per day
 - Maximum of 4500 step-minutes per day
 - Runs receive 4 vCPU cores, 16 GB of RAM and 128 GB of ephemeral disk
-- Sensors receive 0.25 vCPU cores and 1 GB of RAM
+- Code locations receive 0.25 vCPU cores and 1 GB of RAM
 - All Serverless jobs run in the United States
 
 Pro customers may request a quota increase by [contacting Sales](mailto:sales@dagsterlabs.com).


### PR DESCRIPTION
Summary:
The current serverless docs aren't clear if the limits are per-sensor or per-code-location (they are the latter).

Test Plan: Inspection

## Summary & Motivation

## How I Tested These Changes
