### PR TITLE
[ui] Show alert for users in experimental nav flag

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/App.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/App.tsx
@@ -1,8 +1,10 @@
+import {Alert, Box} from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled from 'styled-components';
 
 import {useFeatureFlags} from './Flags';
 import {LayoutContext} from './LayoutProvider';
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {LEFT_NAV_WIDTH, LeftNav} from '../nav/LeftNav';
 
 interface Props {
@@ -12,7 +14,13 @@ interface Props {
 
 export const App = ({banner, children}: Props) => {
   const {nav} = React.useContext(LayoutContext);
+
+  // todo dish: Remove flag and alert once this change has shipped.
   const {flagSettingsPage} = useFeatureFlags();
+  const [didDismissNavAlert, setDidDismissNavAlert] = useStateWithStorage<boolean>(
+    'new_navigation_alert',
+    (json) => !!json,
+  );
 
   const onClickMain = React.useCallback(() => {
     if (nav.isSmallScreen) {
@@ -29,6 +37,29 @@ export const App = ({banner, children}: Props) => {
         onClick={onClickMain}
       >
         <div>{banner}</div>
+        {flagSettingsPage && !didDismissNavAlert ? (
+          <Box padding={8} border="top-and-bottom">
+            <Alert
+              title={
+                <>
+                  <span>Experimental navigation is enabled.</span>
+                  <span style={{fontWeight: 'normal'}}>
+                    {' '}
+                    We&apos;re testing some changes to the navigation to make it easier to explore.{' '}
+                    <a
+                      href="https://github.com/dagster-io/dagster/discussions/21370"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Learn more and share feedback
+                    </a>
+                  </span>
+                </>
+              }
+              onClose={() => setDidDismissNavAlert(true)}
+            />
+          </Box>
+        ) : null}
         <ChildContainer>{children}</ChildContainer>
       </Main>
     </Container>

--- a/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
@@ -25,7 +25,20 @@ export const getVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagUseNewOverviewPage,
   },
   {
-    key: 'New navigation (experimental)',
+    key: 'New navigation',
+    label: (
+      <>
+        Experimental navigation (
+        <a
+          href="https://github.com/dagster-io/dagster/discussions/21370"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Learn more
+        </a>
+        )
+      </>
+    ),
     flagType: FeatureFlag.flagSettingsPage,
   },
 ];


### PR DESCRIPTION
## Summary & Motivation

Show a dismissable alert banner on the top of the app for users who are in the new navigation flag, with a link to the relevant GH discussion.

<img width="1255" alt="Screenshot 2024-04-23 at 12 08 29" src="https://github.com/dagster-io/dagster/assets/2823852/5487c798-81bc-473d-b17c-002c7716841f">

<img width="505" alt="Screenshot 2024-04-23 at 12 15 18" src="https://github.com/dagster-io/dagster/assets/2823852/89d0ea0d-4247-4552-b900-e40ddf435755">

## How I Tested These Changes

View app, verify that the banner appears. Open user settings, verify that the link appears on the dialog.