### PR TITLE
[Sensors] use `assetsOrError` field instead of `assets`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
@@ -55,6 +55,10 @@ export function useQueryRefreshAtInterval(
     );
   }
 
+  if (typeof jest !== 'undefined') {
+    intervalMs = Number.MAX_SAFE_INTEGER;
+  }
+
   const {nextFireMs, nextFireDelay, refetch} = useRefreshAtInterval({
     refresh: useCallback(async () => {
       return await queryResult?.refetch();

--- a/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
@@ -55,10 +55,6 @@ export function useQueryRefreshAtInterval(
     );
   }
 
-  if (typeof jest !== 'undefined') {
-    intervalMs = Number.MAX_SAFE_INTEGER;
-  }
-
   const {nextFireMs, nextFireDelay, refetch} = useRefreshAtInterval({
     refresh: useCallback(async () => {
       return await queryResult?.refetch();

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorRoot.tsx
@@ -230,16 +230,23 @@ export const SENSOR_ASSET_SELECTIONS_QUERY = gql`
 
   fragment SensorAssetSelectionFragment on AssetSelection {
     assetSelectionString
-    assets {
-      id
-      key {
-        path
-      }
-      definition {
-        id
-        autoMaterializePolicy {
-          policyType
+    assetsOrError {
+      ... on AssetConnection {
+        nodes {
+          id
+          key {
+            path
+          }
+          definition {
+            id
+            autoMaterializePolicy {
+              policyType
+            }
+          }
         }
+      }
+      ... on PythonError {
+        ...PythonErrorFragment
       }
     }
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorTargetList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorTargetList.tsx
@@ -83,12 +83,11 @@ const AssetSelectionLink = ({
 }) => {
   const [showAssetSelection, setShowAssetSelection] = React.useState(false);
 
+  const error =
+    assetSelection.assetsOrError.__typename === 'PythonError' ? assetSelection.assetsOrError : null;
+
   const sortedAssets = React.useMemo(() => {
     if (assetSelection.assetsOrError.__typename === 'PythonError') {
-      showCustomAlert({
-        title: 'Error',
-        body: <PythonErrorInfo error={assetSelection.assetsOrError} />,
-      });
       return [];
     }
     return assetSelection.assetsOrError.nodes
@@ -150,11 +149,24 @@ const AssetSelectionLink = ({
       </Dialog>
       <ButtonLink
         onClick={() => {
-          setShowAssetSelection(true);
+          if (error) {
+            showCustomAlert({
+              title: 'Python Error',
+              body: <PythonErrorInfo error={error} />,
+            });
+          } else {
+            setShowAssetSelection(true);
+          }
         }}
       >
-        {assetSelectionString.slice(0, 1).toUpperCase()}
-        {assetSelectionString.slice(1)}
+        {error ? (
+          <>Error loading asset selection</>
+        ) : (
+          <>
+            {assetSelectionString.slice(0, 1).toUpperCase()}
+            {assetSelectionString.slice(1)}
+          </>
+        )}
       </ButtonLink>
     </>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/__stories__/SensorTargetList.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/__stories__/SensorTargetList.stories.tsx
@@ -1,7 +1,9 @@
 import {MockedProvider} from '@apollo/client/testing';
 import {Meta} from '@storybook/react';
 
+import {CustomAlertProvider} from '../../app/CustomAlertProvider';
 import {SensorType, buildAssetSelection, buildPythonError, buildSensor} from '../../graphql/types';
+import {WorkspaceProvider} from '../../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../../workspace/buildRepoAddress';
 import {SensorTargetList} from '../SensorTargetList';
 import {
@@ -17,24 +19,29 @@ export default {
 
 export const SensorTargetListWithError = () => {
   return (
-    <MockedProvider mocks={[buildStartKansasSuccess(1000), buildStartLouisianaError(1000)]}>
-      <SensorTargetList
-        sensorType={SensorType.ASSET}
-        targets={[{pipelineName: 'any'}]}
-        repoAddress={buildRepoAddress('a', 'b')}
-        selectionQueryResult={
-          {
-            data: {
-              __typename: 'Query',
-              sensorOrError: buildSensor({
-                assetSelection: buildAssetSelection({
-                  assetsOrError: buildPythonError(),
-                }),
-              }),
-            },
-          } as any
-        }
-      />
-    </MockedProvider>
+    <>
+      <CustomAlertProvider />
+      <MockedProvider mocks={[buildStartKansasSuccess(1000), buildStartLouisianaError(1000)]}>
+        <WorkspaceProvider>
+          <SensorTargetList
+            sensorType={SensorType.ASSET}
+            targets={[{pipelineName: 'pipelineName'}]}
+            repoAddress={buildRepoAddress('a', 'b')}
+            selectionQueryResult={
+              {
+                data: {
+                  __typename: 'Query',
+                  sensorOrError: buildSensor({
+                    assetSelection: buildAssetSelection({
+                      assetsOrError: buildPythonError(),
+                    }),
+                  }),
+                },
+              } as any
+            }
+          />
+        </WorkspaceProvider>
+      </MockedProvider>
+    </>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/__stories__/SensorTargetList.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/__stories__/SensorTargetList.stories.tsx
@@ -1,0 +1,40 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {Meta} from '@storybook/react';
+
+import {SensorType, buildAssetSelection, buildPythonError, buildSensor} from '../../graphql/types';
+import {buildRepoAddress} from '../../workspace/buildRepoAddress';
+import {SensorTargetList} from '../SensorTargetList';
+import {
+  buildStartKansasSuccess,
+  buildStartLouisianaError,
+} from '../__fixtures__/SensorState.fixtures';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'SensorTargetList',
+  component: SensorTargetList,
+} as Meta;
+
+export const SensorTargetListWithError = () => {
+  return (
+    <MockedProvider mocks={[buildStartKansasSuccess(1000), buildStartLouisianaError(1000)]}>
+      <SensorTargetList
+        sensorType={SensorType.ASSET}
+        targets={[{pipelineName: 'any'}]}
+        repoAddress={buildRepoAddress('a', 'b')}
+        selectionQueryResult={
+          {
+            data: {
+              __typename: 'Query',
+              sensorOrError: buildSensor({
+                assetSelection: buildAssetSelection({
+                  assetsOrError: buildPythonError(),
+                }),
+              }),
+            },
+          } as any
+        }
+      />
+    </MockedProvider>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorRoot.types.ts
@@ -152,19 +152,33 @@ export type SensorAssetSelectionQuery = {
         assetSelection: {
           __typename: 'AssetSelection';
           assetSelectionString: string | null;
-          assets: Array<{
-            __typename: 'Asset';
-            id: string;
-            key: {__typename: 'AssetKey'; path: Array<string>};
-            definition: {
-              __typename: 'AssetNode';
-              id: string;
-              autoMaterializePolicy: {
-                __typename: 'AutoMaterializePolicy';
-                policyType: Types.AutoMaterializePolicyType;
-              } | null;
-            } | null;
-          }>;
+          assetsOrError:
+            | {
+                __typename: 'AssetConnection';
+                nodes: Array<{
+                  __typename: 'Asset';
+                  id: string;
+                  key: {__typename: 'AssetKey'; path: Array<string>};
+                  definition: {
+                    __typename: 'AssetNode';
+                    id: string;
+                    autoMaterializePolicy: {
+                      __typename: 'AutoMaterializePolicy';
+                      policyType: Types.AutoMaterializePolicyType;
+                    } | null;
+                  } | null;
+                }>;
+              }
+            | {
+                __typename: 'PythonError';
+                message: string;
+                stack: Array<string>;
+                errorChain: Array<{
+                  __typename: 'ErrorChainLink';
+                  isExplicitLink: boolean;
+                  error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+                }>;
+              };
         } | null;
       }
     | {__typename: 'SensorNotFoundError'}
@@ -174,17 +188,31 @@ export type SensorAssetSelectionQuery = {
 export type SensorAssetSelectionFragment = {
   __typename: 'AssetSelection';
   assetSelectionString: string | null;
-  assets: Array<{
-    __typename: 'Asset';
-    id: string;
-    key: {__typename: 'AssetKey'; path: Array<string>};
-    definition: {
-      __typename: 'AssetNode';
-      id: string;
-      autoMaterializePolicy: {
-        __typename: 'AutoMaterializePolicy';
-        policyType: Types.AutoMaterializePolicyType;
-      } | null;
-    } | null;
-  }>;
+  assetsOrError:
+    | {
+        __typename: 'AssetConnection';
+        nodes: Array<{
+          __typename: 'Asset';
+          id: string;
+          key: {__typename: 'AssetKey'; path: Array<string>};
+          definition: {
+            __typename: 'AssetNode';
+            id: string;
+            autoMaterializePolicy: {
+              __typename: 'AutoMaterializePolicy';
+              policyType: Types.AutoMaterializePolicyType;
+            } | null;
+          } | null;
+        }>;
+      }
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      };
 };


### PR DESCRIPTION
## Summary & Motivation

use `assetsOrError` field instead of `assets`

context: https://dagsterlabs.slack.com/archives/C06K1DMN81W/p1713456419428399


## How I Tested These Changes
`yarn ts`, existing jest tests. storybook.

This component renders this:
<img width="249" alt="Screenshot 2024-04-23 at 2 06 02 PM" src="https://github.com/dagster-io/dagster/assets/2286579/45acef11-e28a-46a4-9398-123a03cc0e42">
which is rendered in target fields:
1. <img width="390" alt="Screenshot 2024-04-23 at 2 08 32 PM" src="https://github.com/dagster-io/dagster/assets/2286579/b0f6d09e-3a22-42ca-9bd3-62acffaf0d7c">
2. 
<img width="1239" alt="Screenshot 2024-04-23 at 2 09 12 PM" src="https://github.com/dagster-io/dagster/assets/2286579/2769af3a-e34c-4747-a6e4-a0acb46bb07c">


