### PR TITLE
[dbt] guard against concurrent project prep

### DIFF
--- a/python_modules/dagster/dagster_tests/utils_tests/test_file_lock.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_file_lock.py
@@ -1,0 +1,77 @@
+import multiprocessing
+import os
+import time
+from functools import partial
+from pathlib import Path
+from signal import SIGSEGV
+
+from dagster._utils import run_with_concurrent_update_guard, segfault
+
+
+def _update_file(file_path: Path):
+    time.sleep(0.01)  # fake computation
+    file_path.open("a").write(f"write-from-{os.getpid()}\n")
+
+
+def test_basic(tmp_path: str):
+    test_file_path = Path(tmp_path) / "test.txt"
+
+    with multiprocessing.Pool(3) as pool:
+        pool.starmap(
+            run_with_concurrent_update_guard,
+            [(test_file_path, partial(_update_file, test_file_path))] * 3,
+        )
+    assert test_file_path.read_text()
+
+
+def test_crashes(tmp_path: str):
+    test_file_path = Path(tmp_path) / "test.txt"
+    run_guarded = run_with_concurrent_update_guard
+    crashing_proc = multiprocessing.Process(
+        target=run_guarded,
+        args=(test_file_path, segfault),
+    )
+    crashing_proc.start()
+    crashing_proc.join(timeout=1)
+    assert crashing_proc.exitcode == -SIGSEGV
+
+    # ensure success can occur with abandoned lock file
+    with multiprocessing.Pool(3) as pool:
+        pool.starmap(
+            run_with_concurrent_update_guard,
+            [(test_file_path, partial(_update_file, test_file_path))] * 3,
+        )
+
+    assert test_file_path.read_text()
+
+
+def _maybe(file_path: Path, skip: bool):
+    if not skip:
+        _update_file(file_path)
+    else:
+        time.sleep(0.05)
+
+
+def test_staggered_no_ops(tmp_path: str):
+    test_file_path = Path(tmp_path) / "test.txt"
+    procs = [
+        multiprocessing.Process(
+            target=run_with_concurrent_update_guard,
+            args=(test_file_path, _maybe),
+            kwargs={
+                "file_path": test_file_path,
+                "skip": i % 2 == 0,
+            },
+        )
+        for i in range(6)
+    ]
+
+    for proc in procs:
+        proc.start()
+        time.sleep(0.025)
+
+    for proc in procs:
+        proc.join(timeout=1)
+        assert proc.exitcode == 0
+
+    assert test_file_path.read_text()

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -115,6 +115,7 @@ setup(
         # https://github.com/pydantic/pydantic/issues/5821
         "pydantic>1.10.0,!= 1.10.7,<3",
         "rich",
+        "filelock",
         f"dagster-pipes{pin}",
     ],
     extras_require={

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
@@ -1,19 +1,61 @@
+import multiprocessing
+
+import pytest
 from dagster._core.test_utils import environ
 from dagster._utils.test import copy_directory
+from dagster_dbt.dbt_manifest import validate_manifest
 from dagster_dbt.dbt_project import DbtProject
 
 from ..dbt_projects import test_jaffle_shop_path
 
 
-def test_local_dev() -> None:
-    with environ({"DAGSTER_IS_DEV_CLI": "1"}), copy_directory(test_jaffle_shop_path) as project_dir:
+@pytest.fixture(scope="session")
+def shared_project_dir():
+    with copy_directory(test_jaffle_shop_path) as project_dir:
+        yield project_dir
+
+
+@pytest.fixture(scope="function")
+def project_dir(shared_project_dir):
+    manifest_path = DbtProject(shared_project_dir).manifest_path
+    if manifest_path.exists():
+        manifest_path.unlink()
+    yield shared_project_dir
+
+
+def test_local_dev(project_dir) -> None:
+    my_project = DbtProject(project_dir)
+    assert not my_project.manifest_path.exists()
+    with environ({"DAGSTER_IS_DEV_CLI": "1"}):
         my_project = DbtProject(project_dir)
         assert my_project.manifest_path.exists()
 
 
-def test_opt_in_env_var() -> None:
-    with environ({"DAGSTER_DBT_PARSE_PROJECT_ON_LOAD": "1"}), copy_directory(
-        test_jaffle_shop_path
-    ) as project_dir:
+def test_opt_in_env_var(project_dir) -> None:
+    my_project = DbtProject(project_dir)
+    assert not my_project.manifest_path.exists()
+    with environ({"DAGSTER_DBT_PARSE_PROJECT_ON_LOAD": "1"}):
         my_project = DbtProject(project_dir)
+        assert my_project.manifest_path.exists()
+
+
+def _init(project_dir):
+    my_project = DbtProject(project_dir)
+    assert my_project.manifest_path.exists()
+    assert validate_manifest(my_project.manifest_path)
+    return
+
+
+def test_concurrent_processes(project_dir):
+    my_project = DbtProject(project_dir)
+    assert not my_project.manifest_path.exists()
+    with environ({"DAGSTER_IS_DEV_CLI": "1"}):
+        procs = [multiprocessing.Process(target=_init, args=(project_dir,)) for _ in range(4)]
+        for proc in procs:
+            proc.start()
+
+        for proc in procs:
+            proc.join(timeout=30)
+            assert proc.exitcode == 0
+
         assert my_project.manifest_path.exists()


### PR DESCRIPTION
what happens rarely with manifest preperation but easily with dbt deps resolution is concurrent operations happening between for example the two code server processes beneath the webserver and daemon in `dagster dev` having problems with files in weird states.

This problem can also occur in concurrent processes from the default multiprocess executor.

## How I Tested These Changes

I added a test that I was able to get failing (at least a couple times) before the change but not after using `--count 100` with pytest 

