### PR TITLE
Create RecentTimePartitionsCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
@@ -31,6 +31,7 @@ from ..auto_materialize_rule import AutoMaterializeRule
 
 if TYPE_CHECKING:
     from .asset_condition_evaluation_context import AssetConditionEvaluationContext
+    from .recent_time_partitions import Duration
 
 
 T = TypeVar("T")
@@ -406,6 +407,15 @@ class AssetCondition(ABC, DagsterModel):
         from .latest_time_partition import LatestTimePartitionCondition
 
         return LatestTimePartitionCondition()
+
+    @staticmethod
+    def recent_time_partitions(lookback_duration: "Duration") -> "AssetCondition":
+        """Returns an AssetCondition that is true for the latest time partition of a time-partitioned
+        asset, or all partitions if the asset is not time-partitioned.
+        """
+        from .recent_time_partitions import RecentTimePartitionsCondition
+
+        return RecentTimePartitionsCondition(lookback_duration=lookback_duration)
 
 
 @experimental

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/recent_time_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/recent_time_partitions.py
@@ -1,0 +1,54 @@
+import datetime
+
+from dagster._core.definitions.time_window_partitions import TimeWindow
+from dagster._model import DagsterModel
+
+from .asset_condition import AssetCondition, AssetConditionResult
+from .asset_condition_evaluation_context import AssetConditionEvaluationContext
+
+
+class Duration(DagsterModel):
+    days: float = 0
+    hours: float = 0
+    minutes: float = 0
+
+    def __repr__(self) -> str:
+        if self.days == self.hours == self.minutes == 0:
+            return "0 minutes"
+
+        return ", ".join(
+            f"{v} {unit}"
+            for v, unit in (
+                (self.days, "days"),
+                (self.hours, "hours"),
+                (self.minutes, "minutes"),
+            )
+            if v != 0
+        )
+
+    def to_timedelta(self) -> datetime.timedelta:
+        return datetime.timedelta(
+            days=self.days,
+            hours=self.hours,
+            minutes=self.minutes,
+        )
+
+
+class RecentTimePartitionsCondition(AssetCondition):
+    lookback_duration: Duration
+
+    @property
+    def description(self) -> str:
+        return f"Asset partition is within a time window starting {self.lookback_duration} before the current time, or is not time-partitioned."
+
+    def evaluate(self, context: AssetConditionEvaluationContext) -> AssetConditionResult:
+        return AssetConditionResult.create(
+            context,
+            true_subset=context.asset_graph_view.create_time_window_slice(
+                asset_key=context.asset_key,
+                time_window=TimeWindow(
+                    start=context.evaluation_time - self.lookback_duration.to_timedelta(),
+                    end=context.evaluation_time,
+                ),
+            ).convert_to_valid_asset_subset(),
+        )

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -727,9 +727,20 @@ class TimeWindowPartitionsDefinition(
 
     @functools.lru_cache(maxsize=5)
     def get_partition_keys_in_time_window(self, time_window: TimeWindow) -> Sequence[str]:
+        """Returns the set of partition keys for this definition which fall within the given
+        TimeWindow. Will only return keys that exist within the start and end times of the definition.
+        """
         result: List[str] = []
-        for partition_time_window in self._iterate_time_windows(time_window.start):
-            if partition_time_window.start.timestamp() < time_window.end.timestamp():
+
+        # ensure that we don't start iterating before the start of the partitions definition
+        start_time = max(time_window.start, self.start)
+        # ensure that we don't iterate past the end of the partitions definition
+        end_timestamp = min(
+            time_window.end.timestamp(), self.end.timestamp() if self.end else float("inf")
+        )
+
+        for partition_time_window in self._iterate_time_windows(start_time):
+            if partition_time_window.end.timestamp() <= end_timestamp:
                 result.append(
                     dst_safe_strftime(
                         partition_time_window.start, self.timezone, self.fmt, self.cron_schedule

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_recent_time_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_recent_time_partitions.py
@@ -1,0 +1,75 @@
+from dagster._core.definitions.asset_condition.asset_condition import (
+    AssetCondition,
+)
+from dagster._core.definitions.asset_condition.recent_time_partitions import Duration
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+
+from ..scenario_specs import (
+    daily_partitions_def,
+    day_partition_key,
+    one_asset,
+    time_partitions_start_datetime,
+    two_partitions_def,
+)
+from .asset_condition_scenario import AssetConditionScenarioState
+
+
+def test_recent_time_partitions_unpartitioned() -> None:
+    state = AssetConditionScenarioState(
+        one_asset,
+        asset_condition=AssetCondition.recent_time_partitions(lookback_duration=Duration(days=1)),
+    )
+
+    # always true for unpartitioned
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+    # still true
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+
+def test_recent_time_partitions_static_partitioned() -> None:
+    state = AssetConditionScenarioState(
+        one_asset,
+        asset_condition=AssetCondition.recent_time_partitions(lookback_duration=Duration(days=1)),
+    ).with_asset_properties(partitions_def=two_partitions_def)
+
+    # true for all static partitions
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 2
+
+    # still true
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 2
+
+
+def test_recent_time_partitions_time_partitioned() -> None:
+    state = (
+        AssetConditionScenarioState(
+            one_asset,
+            asset_condition=AssetCondition.recent_time_partitions(
+                lookback_duration=Duration(days=3)
+            ),
+        )
+        .with_asset_properties(partitions_def=daily_partitions_def)
+        .with_current_time(time_partitions_start_datetime)
+        .with_current_time_advanced(days=6, minutes=1)
+    )
+
+    # only 2 full days are within the lookback window
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 2
+    assert result.true_subset.asset_partitions == {
+        AssetKeyPartitionKey(AssetKey("A"), day_partition_key(time_partitions_start_datetime, 5)),
+        AssetKeyPartitionKey(AssetKey("A"), day_partition_key(time_partitions_start_datetime, 6)),
+    }
+
+    # now the next day, latest partition increments
+    state = state.with_current_time_advanced(days=1)
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 2
+    assert result.true_subset.asset_partitions == {
+        AssetKeyPartitionKey(AssetKey("A"), day_partition_key(time_partitions_start_datetime, 6)),
+        AssetKeyPartitionKey(AssetKey("A"), day_partition_key(time_partitions_start_datetime, 7)),
+    }


### PR DESCRIPTION
## Summary & Motivation

Does some rearranging to let us create slices consisting of arbitrary time windows.

Not confident on this "Duration" thing -- other options:

- Just provide lookback_days, lookback_hours, lookback_seconds arguments: don't like this as we may need to repeat that pattern for similar rules in the future, lotta boilerplate on our end
- Just let users supply a `datetime.timedelta`: maybe better, we'll just need to come up with a good way of letting that survive the serdes layer (probably not too hard)

## How I Tested These Changes
