### PR TITLE
RFC: default_asset_attrs

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -177,6 +177,9 @@ from dagster._core.definitions.decorators.source_asset_decorator import (
     multi_observable_source_asset as multi_observable_source_asset,
     observable_source_asset as observable_source_asset,
 )
+from dagster._core.definitions.default_asset_attrs import (
+    default_asset_attrs as default_asset_attrs,
+)
 from dagster._core.definitions.definitions_class import (
     BindResourcesToJobs as BindResourcesToJobs,
     Definitions as Definitions,

--- a/python_modules/dagster/dagster/_core/definitions/default_asset_attrs.py
+++ b/python_modules/dagster/dagster/_core/definitions/default_asset_attrs.py
@@ -1,0 +1,50 @@
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Generator, Optional
+
+from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from dagster._core.definitions.backfill_policy import BackfillPolicy
+from dagster._model import DagsterModel
+
+
+@contextmanager
+def default_asset_attrs(
+    group_name: Optional[str] = None,
+    auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
+    backfill_policy: Optional[BackfillPolicy] = None,
+) -> Generator[Any, None, None]:
+    obj = DefaultAssetAttrs(
+        group_name=group_name,
+        auto_materialize_policy=auto_materialize_policy,
+        backfill_policy=backfill_policy,
+    )
+    outer = default_asset_attrs_context.get()
+    inner = outer.merge(obj)
+    default_asset_attrs_context.set(inner)
+    try:
+        yield
+    finally:
+        default_asset_attrs_context.set(outer)
+
+
+class DefaultAssetAttrs(DagsterModel):
+    group_name: Optional[str]
+    auto_materialize_policy: Optional[AutoMaterializePolicy]
+    backfill_policy: Optional[BackfillPolicy]
+
+    def merge(self, other: "DefaultAssetAttrs") -> "DefaultAssetAttrs":
+        return DefaultAssetAttrs(
+            group_name=other.group_name or self.group_name,
+            auto_materialize_policy=other.auto_materialize_policy or self.auto_materialize_policy,
+            backfill_policy=other.backfill_policy or self.backfill_policy,
+        )
+
+
+default_asset_attrs_context: ContextVar[DefaultAssetAttrs] = ContextVar(
+    "default_asset_attrs_context",
+    default=DefaultAssetAttrs(
+        group_name=None,
+        auto_materialize_policy=None,
+        backfill_policy=None,
+    ),
+)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_default_asset_attrs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_default_asset_attrs.py
@@ -1,0 +1,57 @@
+from dagster import AutoMaterializePolicy, asset, default_asset_attrs
+
+
+def test_default_asset_attrs():
+    with default_asset_attrs(
+        group_name="marketing", auto_materialize_policy=AutoMaterializePolicy.eager()
+    ):
+
+        @asset
+        def asset1(): ...
+
+        @asset(group_name="override")
+        def asset2(): ...
+
+    @asset
+    def asset3(): ...
+
+    assert next(iter(asset1.group_names_by_key.values())) == "marketing"
+    assert next(iter(asset2.group_names_by_key.values())) == "override"
+    assert next(iter(asset3.group_names_by_key.values())) == "default"
+    assert (
+        next(iter(asset1.auto_materialize_policies_by_key.values()))
+        == AutoMaterializePolicy.eager()
+    )
+    assert (
+        next(iter(asset2.auto_materialize_policies_by_key.values()))
+        == AutoMaterializePolicy.eager()
+    )
+    assert len(asset3.auto_materialize_policies_by_key) == 0
+
+
+def test_default_asset_attrs_nested():
+    with default_asset_attrs(group_name="marketing"):
+        with default_asset_attrs(auto_materialize_policy=AutoMaterializePolicy.eager()):
+
+            @asset
+            def asset1(): ...
+
+            @asset(group_name="marketing_override")
+            def asset1_and_half(): ...
+
+        @asset
+        def asset2(): ...
+
+    @asset
+    def asset3(): ...
+
+    assert next(iter(asset1.group_names_by_key.values())) == "marketing"
+    assert next(iter(asset1_and_half.group_names_by_key.values())) == "marketing_override"
+    assert next(iter(asset2.group_names_by_key.values())) == "marketing"
+    assert next(iter(asset3.group_names_by_key.values())) == "default"
+    assert (
+        next(iter(asset1.auto_materialize_policies_by_key.values()))
+        == AutoMaterializePolicy.eager()
+    )
+    assert len(asset2.auto_materialize_policies_by_key) == 0
+    assert len(asset3.auto_materialize_policies_by_key) == 0


### PR DESCRIPTION
## Summary & Motivation

It's a pain to apply the same attribute to a bunch of different assets. As we make auto-materialize policies / scheduling conditions more central, this pain will show up more often.

This PR proposes using a context manager to set asset attributes in bulk. This is not an idea I am entirely convinced is a good one yet, but wanted to float it and get reactions.

```python
with default_asset_attrs(
    group_name="marketing", auto_materialize_policy=AutoMaterializePolicy.eager()
):

    @asset
    def asset1(): ...

    @asset
    def asset2(): ...
```

I just wanted to get the idea across, so, out of laziness, I only implemented a couple asset attributes. But the idea would be to make this work for at least the following asset attributes:
- partitions_def
- tags
- metadata
- io_manager_key
- compute_kind
- owners
- group_name
- auto_materiallze_policy
- backfill_policy


## How I Tested These Changes
