### PR TITLE
pre-compute window end timestamp in get_partition_keys_in_time_window

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -728,8 +728,9 @@ class TimeWindowPartitionsDefinition(
     @functools.lru_cache(maxsize=5)
     def get_partition_keys_in_time_window(self, time_window: TimeWindow) -> Sequence[str]:
         result: List[str] = []
+        time_window_end_timestamp = time_window.end.timestamp()
         for partition_time_window in self._iterate_time_windows(time_window.start):
-            if partition_time_window.start.timestamp() < time_window.end.timestamp():
+            if partition_time_window.start.timestamp() < time_window_end_timestamp:
                 result.append(
                     dst_safe_strftime(
                         partition_time_window.start, self.timezone, self.fmt, self.cron_schedule


### PR DESCRIPTION
Summary:
When there are enough partitions in the time window, computing this only once is enough to make it show up in perf graphs.

I wonder if there is a faster way to compare datetimes without pre-computing their timestamps?

Test Plan: BK, run py-spy on a large partition window

## Summary & Motivation

## How I Tested These Changes
