### PR TITLE
[DagsterModel] support @cached_method

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -40,7 +40,7 @@ from dagster._model.pydantic_compat_layer import (
     model_config,
     model_fields,
 )
-from dagster._utils.cached_method import CACHED_METHOD_FIELD_SUFFIX
+from dagster._utils.cached_method import CACHED_METHOD_CACHE_FIELD
 
 from .attach_other_object_to_context import (
     IAttachDifferentObjectToOpContext as IAttachDifferentObjectToOpContext,
@@ -65,7 +65,7 @@ def _is_field_internal(name: str) -> bool:
 
 
 # ensure that this ends with the internal marker so we can do a single check
-assert CACHED_METHOD_FIELD_SUFFIX.endswith(INTERNAL_MARKER)
+assert CACHED_METHOD_CACHE_FIELD.endswith(INTERNAL_MARKER)
 
 
 def _is_frozen_pydantic_error(e: Exception) -> bool:

--- a/python_modules/dagster/dagster/_model/__init__.py
+++ b/python_modules/dagster/dagster/_model/__init__.py
@@ -1,7 +1,7 @@
 from functools import cached_property
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Hashable, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, PrivateAttr
 from typing_extensions import Self
 
 from .pydantic_compat_layer import USING_PYDANTIC_2
@@ -14,6 +14,8 @@ class DagsterModel(BaseModel):
     - arbitrary_types_allowed, to allow non-model class params to be validated with isinstance.
     - Avoid pydantic reading a cached property class as part of the schema.
     """
+
+    _cached_method_cache__internal__: Dict[Hashable, Any] = PrivateAttr(default_factory=dict)
 
     def __init__(self, **data: Any) -> None:
         super().__init__(**data)

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_cached_method.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_cached_method.py
@@ -4,7 +4,7 @@ import gc
 from typing import Dict, NamedTuple, Tuple
 
 import objgraph
-from dagster._utils.cached_method import CACHED_METHOD_FIELD_SUFFIX, cached_method
+from dagster._utils.cached_method import CACHED_METHOD_CACHE_FIELD, cached_method
 
 
 def test_cached_method() -> None:
@@ -130,4 +130,4 @@ def test_scenario_documented_in_cached_method_doc_block() -> None:
 
     # only one entry
     assert len(obj.__dict__) == 1
-    assert len(obj.__dict__["a_method" + CACHED_METHOD_FIELD_SUFFIX]) == 1
+    assert len(obj.__dict__[CACHED_METHOD_CACHE_FIELD][MyClass.a_method.__name__]) == 1

--- a/python_modules/dagster/dagster_tests/model_tests/test_dagster_model.py
+++ b/python_modules/dagster/dagster_tests/model_tests/test_dagster_model.py
@@ -1,5 +1,6 @@
 import pytest
 from dagster._model import DagsterModel
+from dagster._utils.cached_method import CACHED_METHOD_CACHE_FIELD, cached_method
 from pydantic import ValidationError
 
 
@@ -63,3 +64,22 @@ def test_non_model_param():
 
     with pytest.raises(ValidationError):
         MyModel(some_class=SomeClass)  # forgot ()
+
+
+def test_cached_method() -> None:
+    assert DagsterModel._cached_method_cache__internal__.__name__ == CACHED_METHOD_CACHE_FIELD  # noqa # type: ignore
+
+    class CoolModel(DagsterModel):
+        name: str
+
+        @cached_method
+        def calculate(self, n: int):
+            return {self.name: n}
+
+        @cached_method
+        def reticulate(self, n: int):
+            return {self.name: n}
+
+    m = CoolModel(name="bob")
+    assert m.calculate(4) is m.calculate(4)
+    assert m.calculate(4) is not m.reticulate(4)


### PR DESCRIPTION
The desired settings for `DagsterModel` prevent the `setattr` approach from working, so set up a private attr on `DagsterModel` to hold on to the cache

## How I Tested These Changes

added test
