### PR TITLE
Create InProgressCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -355,6 +355,12 @@ class AssetGraphView:
             ),
         )
 
+    def compute_in_progress_slice(self, asset_key: AssetKey) -> "AssetSlice":
+        """Return an AssetSlice with only AssetPartitions which are currently in progress."""
+        return _slice_from_subset(
+            self, self._queryer.get_in_progress_asset_subset(asset_key=asset_key)
+        )
+
     def compute_intersection_with_partition_keys(
         self, partition_keys: AbstractSet[str], asset_slice: AssetSlice
     ) -> "AssetSlice":

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
@@ -417,6 +417,15 @@ class AssetCondition(ABC, DagsterModel):
 
         return RecentTimePartitionsCondition(lookback_duration=lookback_duration)
 
+    @staticmethod
+    def in_progress() -> "AssetCondition":
+        """Returns an AssetCondition that is true for an asset partition when it is targeted by an
+        in-progress run.
+        """
+        from .in_progress_condition import InProgressRunCondition
+
+        return InProgressRunCondition()
+
 
 @experimental
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/in_progress_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/in_progress_condition.py
@@ -1,0 +1,17 @@
+from .asset_condition import AssetCondition, AssetConditionResult
+from .asset_condition_evaluation_context import AssetConditionEvaluationContext
+
+
+class InProgressRunCondition(AssetCondition):
+    @property
+    def description(self) -> str:
+        return "Asset partition is targeted by an in-progress run."
+
+    def evaluate(self, context: AssetConditionEvaluationContext) -> AssetConditionResult:
+        in_progress_subset = context.asset_graph_view.compute_in_progress_slice(
+            context.asset_key
+        ).convert_to_valid_asset_subset()
+
+        return AssetConditionResult.create(
+            context=context, true_subset=context.candidate_subset & in_progress_subset
+        )

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -43,6 +43,7 @@ from dagster._core.event_api import AssetRecordsFilter, EventRecordsFilter
 from dagster._core.events import DagsterEventType
 from dagster._core.instance import DagsterInstance, DynamicPartitionsStore
 from dagster._core.storage.dagster_run import (
+    IN_PROGRESS_RUN_STATUSES,
     DagsterRun,
     RunRecord,
 )
@@ -169,6 +170,33 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
                 AssetKeyPartitionKey(asset_key)
             )
         return AssetSubset(asset_key=asset_key, value=value)
+
+    @cached_method
+    def get_in_progress_asset_subset(self, *, asset_key: AssetKey) -> ValidAssetSubset:
+        """Returns an AssetSubset representing the subset of the asset that is currently in progress."""
+        partitions_def = self.asset_graph.get(asset_key).partitions_def
+        if partitions_def:
+            cache_value = self._get_updated_cache_value(asset_key=asset_key)
+            if cache_value is None:
+                value = partitions_def.empty_subset()
+            else:
+                value = cache_value.deserialize_in_progress_partition_subsets(partitions_def)
+        else:
+            # NOTE: this computation is not correct in all cases for unpartitioned assets. it is
+            # possible (though rare) for run A to be launched targeting an asset, then later run B
+            # be launched, and then run B completes before run A. In these cases, the computation
+            # below will consider the asset to not be in progress, as the latest planned event
+            # will be associated with a completed run.
+            planned_materialization_info = (
+                self.instance.event_log_storage.get_latest_planned_materialization_info(asset_key)
+            )
+            if not planned_materialization_info:
+                value = False
+            else:
+                dagster_run = self.instance.get_run_by_id(planned_materialization_info.run_id)
+                value = dagster_run is not None and dagster_run.status in IN_PROGRESS_RUN_STATUSES
+
+        return ValidAssetSubset(asset_key=asset_key, value=value)
 
     ####################
     # ASSET RECORDS / STORAGE IDS

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_in_progress.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_in_progress.py
@@ -1,0 +1,67 @@
+from dagster._core.definitions.asset_condition.asset_condition import (
+    AssetCondition,
+)
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.events import AssetKeyPartitionKey
+
+from ..scenario_specs import (
+    one_asset,
+    two_partitions_def,
+)
+from .asset_condition_scenario import AssetConditionScenarioState
+
+
+def test_in_progress_unpartitioned() -> None:
+    state = AssetConditionScenarioState(one_asset, asset_condition=AssetCondition.in_progress())
+
+    # no run in progress
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 0
+
+    # run now in progress
+    state = state.with_in_progress_run_for_asset("A")
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+    # run completes
+    state = state.with_in_progress_runs_completed()
+    _, result = state.evaluate("A")
+    assert result.true_subset.size == 0
+
+
+def test_in_progress_static_partitioned() -> None:
+    state = AssetConditionScenarioState(
+        one_asset, asset_condition=AssetCondition.in_progress()
+    ).with_asset_properties(partitions_def=two_partitions_def)
+
+    # no run in progress
+    state, result = state.evaluate("A")
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 0
+
+    # now in progress
+    state = state.with_in_progress_run_for_asset("A", partition_key="1")
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+    assert result.true_subset.asset_partitions == {AssetKeyPartitionKey(AssetKey("A"), "1")}
+
+    # run completes
+    state = state.with_in_progress_runs_completed()
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 0
+
+    # now both in progress
+    state = state.with_in_progress_run_for_asset(
+        "A",
+        partition_key="1",
+    ).with_in_progress_run_for_asset(
+        "A",
+        partition_key="2",
+    )
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 2
+
+    # both runs complete
+    state = state.with_in_progress_runs_completed()
+    _, result = state.evaluate("A")
+    assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_state.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_state.py
@@ -259,7 +259,9 @@ class ScenarioState:
             self, scenario_spec=self.scenario_spec.with_asset_properties(keys, **kwargs)
         )
 
-    def with_in_progress_run_for_asset(self, asset_key: CoercibleToAssetKey) -> Self:
+    def with_in_progress_run_for_asset(
+        self, asset_key: CoercibleToAssetKey, partition_key: Optional[str] = None
+    ) -> Self:
         in_progress_run_id = make_new_run_id()
         with pendulum_freeze_time(self.current_time):
             asset_key = AssetKey.from_coercible(asset_key)
@@ -274,6 +276,7 @@ class ScenarioState:
                 status=DagsterRunStatus.STARTED,
                 asset_selection=frozenset({AssetKey.from_coercible(asset_key)}),
                 execution_plan=execution_plan,
+                tags={PARTITION_NAME_TAG: partition_key} if partition_key else None,
             )
             assert self.instance.get_run_by_id(in_progress_run_id)
         return self
@@ -304,15 +307,15 @@ class ScenarioState:
             ),
         )
 
-    def with_not_started_runs(self) -> Self:
-        """Execute all runs in the NOT_STARTED state and delete them from the instance. The scenario
-        adds in the run requests from previous ticks as runs in the NOT_STARTED state, so this method
-        executes requested runs from previous ticks.
+    def _with_runs_with_status(self, status: DagsterRunStatus) -> Self:
+        """Create new runs that will run to completion for all existing runs with the given status,
+        and delete the runs with that status from the instance.
+
+        This allows us to "freeze" runs in a particular state to help observe how conditions react
+        to certain statuses, then have them complete at a time of our choosing.
         """
-        not_started_runs = self.instance.get_runs(
-            filters=RunsFilter(statuses=[DagsterRunStatus.NOT_STARTED])
-        )
-        for run in not_started_runs:
+        runs = self.instance.get_runs(filters=RunsFilter(statuses=[status]))
+        for run in runs:
             self.instance.delete_run(run_id=run.run_id)
         return self.with_runs(
             *[
@@ -320,9 +323,15 @@ class ScenarioState:
                     asset_keys=list(run.asset_selection or set()),
                     partition_key=run.tags.get(PARTITION_NAME_TAG),
                 )
-                for run in not_started_runs
+                for run in runs
             ]
         )
+
+    def with_not_started_runs(self) -> Self:
+        return self._with_runs_with_status(DagsterRunStatus.NOT_STARTED)
+
+    def with_in_progress_runs_completed(self) -> Self:
+        return self._with_runs_with_status(DagsterRunStatus.STARTED)
 
     def with_dynamic_partitions(
         self, partitions_def_name: str, partition_keys: Sequence[str]


### PR DESCRIPTION
## Summary & Motivation

Creates an InProgressCondition -- along the way I just made a unified entrypoint for determining the subset of an asset that is currently in progress, and figured I might as well toss it into the existing rule implementation.

Note that in an ideal world, both partitioned an unpartitioned queries would just go through the partition status cache route.

## How I Tested These Changes
