### PR TITLE
Wrap suspense api

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/TrackedSuspense.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/TrackedSuspense.tsx
@@ -25,6 +25,7 @@ const TrackedSuspenseContext = createContext({
 
 type Boundary = {
   id: string;
+  name: string;
 };
 
 export const TrackedSuspenseProvider = ({

--- a/js_modules/dagster-ui/packages/ui-core/src/app/TrackedSuspense.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/TrackedSuspense.tsx
@@ -1,0 +1,99 @@
+import {
+  ComponentProps,
+  ReactNode,
+  Suspense,
+  createContext,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+} from 'react';
+
+// Context to store the active suspense count and a method to manipulate it
+const TrackedSuspenseContext = createContext({
+  useBoundary: (_id: string) => {
+    return {
+      onFallbackRendered: () => {
+        return () => {};
+      },
+      onContentRendered: () => {
+        return () => {};
+      },
+    };
+  },
+});
+
+type Boundary = {
+  id: string;
+};
+
+export const TrackedSuspenseProvider = ({
+  children,
+  onContentRendered,
+  onContentRemoved,
+  onFallbackRendered,
+  onFallbackRemoved,
+}: {
+  children: ReactNode;
+  onContentRendered: (boundary: Boundary) => void;
+  onContentRemoved: (boundary: Boundary) => void;
+  onFallbackRendered: (boundary: Boundary) => void;
+  onFallbackRemoved: (boundary: Boundary) => void;
+}) => {
+  const useBoundary = useCallback(
+    (name: string) => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      const boundary: Boundary = useMemo(() => ({name, id: uniqueId()}), [name]);
+
+      return {
+        onFallbackRendered: () => {
+          onFallbackRendered(boundary);
+          return () => {
+            onFallbackRemoved(boundary);
+          };
+        },
+        onContentRendered: () => {
+          onContentRendered(boundary);
+          return () => {
+            onContentRemoved(boundary);
+          };
+        },
+      };
+    },
+    [onContentRemoved, onContentRendered, onFallbackRemoved, onFallbackRendered],
+  );
+
+  return (
+    <TrackedSuspenseContext.Provider value={useMemo(() => ({useBoundary}), [useBoundary])}>
+      {children}
+    </TrackedSuspenseContext.Provider>
+  );
+};
+
+export const TrackedSuspense = (props: ComponentProps<typeof Suspense> & {id: string}) => {
+  const {useBoundary} = useContext(TrackedSuspenseContext);
+  const boundary = useBoundary(props.id);
+  return (
+    <Suspense
+      {...props}
+      fallback={<OnRendered onRendered={boundary.onFallbackRendered}>{props.fallback}</OnRendered>}
+    >
+      <OnRendered onRendered={boundary.onContentRendered}>{props.children}</OnRendered>
+    </Suspense>
+  );
+};
+const OnRendered = ({
+  onRendered,
+  children,
+}: {
+  children: React.ReactNode;
+  onRendered: () => () => void;
+}) => {
+  useLayoutEffect(onRendered, [onRendered]);
+  return children;
+};
+
+let id = 0;
+function uniqueId() {
+  return `boundaryId${id++}`;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/app/TrackedSuspense.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/TrackedSuspense.tsx
@@ -23,7 +23,7 @@ const TrackedSuspenseContext = createContext({
   },
 });
 
-type Boundary = {
+export type Boundary = {
   id: string;
   name: string;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/TrackedSuspense.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/TrackedSuspense.test.tsx
@@ -54,19 +54,23 @@ describe('TrackedSuspenseProvider', () => {
     // test1 is rendered since it doesn't suspend
     expect(mockContentRendered).toHaveBeenCalledTimes(1);
     expect(mockContentRendered).toHaveBeenNthCalledWith(1, {
-      id: 'test1',
+      name: 'test1',
+      id: 'boundaryId0',
     });
 
     expect(mockFallbackRendered).toHaveBeenCalledTimes(3);
 
     expect(mockFallbackRendered).toHaveBeenNthCalledWith(1, {
-      id: 'test2',
+      name: 'test2',
+      id: 'boundaryId1',
     });
     expect(mockFallbackRendered).toHaveBeenNthCalledWith(2, {
-      id: 'test3',
+      name: 'test3',
+      id: 'boundaryId2',
     });
     expect(mockFallbackRendered).toHaveBeenNthCalledWith(3, {
-      id: 'test4',
+      name: 'test4',
+      id: 'boundaryId3',
     });
     expect(mockFallbackRemoved).toHaveBeenCalledTimes(0);
     act(() => {
@@ -76,7 +80,8 @@ describe('TrackedSuspenseProvider', () => {
       expect(mockFallbackRemoved).toHaveBeenCalledTimes(1);
       expect(mockContentRendered).toHaveBeenCalledTimes(2);
       expect(mockContentRendered).toHaveBeenNthCalledWith(2, {
-        id: 'test2',
+        name: 'test2',
+        id: 'boundaryId1',
       });
     });
     act(() => {
@@ -86,7 +91,8 @@ describe('TrackedSuspenseProvider', () => {
       expect(mockFallbackRemoved).toHaveBeenCalledTimes(2);
       expect(mockContentRendered).toHaveBeenCalledTimes(3);
       expect(mockContentRendered).toHaveBeenNthCalledWith(3, {
-        id: 'test3',
+        name: 'test3',
+        id: 'boundaryId2',
       });
     });
     act(() => {
@@ -96,7 +102,8 @@ describe('TrackedSuspenseProvider', () => {
       expect(mockFallbackRemoved).toHaveBeenCalledTimes(3);
       expect(mockContentRendered).toHaveBeenCalledTimes(4);
       expect(mockContentRendered).toHaveBeenNthCalledWith(4, {
-        id: 'test4',
+        name: 'test4',
+        id: 'boundaryId3',
       });
     });
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/TrackedSuspense.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/TrackedSuspense.test.tsx
@@ -1,0 +1,103 @@
+import {act, render, waitFor} from '@testing-library/react';
+
+import {TrackedSuspense, TrackedSuspenseProvider} from '../TrackedSuspense';
+
+describe('TrackedSuspenseProvider', () => {
+  it('manages boundaries correctly', async () => {
+    const mockContentRendered = jest.fn();
+    const mockContentRemoved = jest.fn();
+    const mockFallbackRendered = jest.fn();
+    const mockFallbackRemoved = jest.fn();
+
+    const state = {
+      promises: {} as Record<string, Promise<any>>,
+      resolvers: {} as Record<string, (value: any) => void>,
+      resolved: {} as Record<string, boolean>,
+    };
+
+    function Suspender({id}: {id: string}) {
+      if (!state.promises[id]) {
+        state.promises[id] = new Promise((res) => {
+          state.resolvers[id] = (value: any) => {
+            state.resolved[id] = true;
+            res(value);
+          };
+        });
+      }
+      if (!state.resolved[id]) {
+        throw state.promises[id];
+      }
+      return id;
+    }
+
+    render(
+      <TrackedSuspenseProvider
+        onContentRendered={mockContentRendered}
+        onContentRemoved={mockContentRemoved}
+        onFallbackRendered={mockFallbackRendered}
+        onFallbackRemoved={mockFallbackRemoved}
+      >
+        <TrackedSuspense id="test1" fallback={<div>Loading 1...</div>}>
+          <TrackedSuspense id="test2" fallback={<div>Loading 2...</div>}>
+            <Suspender id="test2" />
+          </TrackedSuspense>
+          <TrackedSuspense id="test3" fallback={<div>Loading 3...</div>}>
+            <Suspender id="test3" />
+          </TrackedSuspense>
+        </TrackedSuspense>
+        <TrackedSuspense id="test4" fallback={<div>Loading 4...</div>}>
+          <Suspender id="test4" />
+        </TrackedSuspense>
+      </TrackedSuspenseProvider>,
+    );
+
+    // test1 is rendered since it doesn't suspend
+    expect(mockContentRendered).toHaveBeenCalledTimes(1);
+    expect(mockContentRendered).toHaveBeenNthCalledWith(1, {
+      id: 'test1',
+    });
+
+    expect(mockFallbackRendered).toHaveBeenCalledTimes(3);
+
+    expect(mockFallbackRendered).toHaveBeenNthCalledWith(1, {
+      id: 'test2',
+    });
+    expect(mockFallbackRendered).toHaveBeenNthCalledWith(2, {
+      id: 'test3',
+    });
+    expect(mockFallbackRendered).toHaveBeenNthCalledWith(3, {
+      id: 'test4',
+    });
+    expect(mockFallbackRemoved).toHaveBeenCalledTimes(0);
+    act(() => {
+      state.resolvers['test2']!(1);
+    });
+    await waitFor(() => {
+      expect(mockFallbackRemoved).toHaveBeenCalledTimes(1);
+      expect(mockContentRendered).toHaveBeenCalledTimes(2);
+      expect(mockContentRendered).toHaveBeenNthCalledWith(2, {
+        id: 'test2',
+      });
+    });
+    act(() => {
+      state.resolvers['test3']!(1);
+    });
+    await waitFor(() => {
+      expect(mockFallbackRemoved).toHaveBeenCalledTimes(2);
+      expect(mockContentRendered).toHaveBeenCalledTimes(3);
+      expect(mockContentRendered).toHaveBeenNthCalledWith(3, {
+        id: 'test3',
+      });
+    });
+    act(() => {
+      state.resolvers['test4']!(1);
+    });
+    await waitFor(() => {
+      expect(mockFallbackRemoved).toHaveBeenCalledTimes(3);
+      expect(mockContentRendered).toHaveBeenCalledTimes(4);
+      expect(mockContentRendered).toHaveBeenNthCalledWith(4, {
+        id: 'test4',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary & Motivation

We're planning to use Suspense in order to track pageload performance. 

In order to accomplish that we need to know when Suspense boundaries are suspended (when their fallbacks are rendered) and when they have completed (the fallback was removed and the content was rendered). That's where `TrackedSuspenseProvider` and `TrackedSuspense` come in. As long as we use `TrackedSuspsense` in place of `Suspense` then the cloud app can use this to track how many suspense boundaries are active and to know when all suspense boundaries have resolved.

## How I Tested These Changes
jest