### PR TITLE
skip_on_run_in_progress support partitioned if all_partitions=true

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -243,6 +243,14 @@ class AutoMaterializeRule(ABC):
     def skip_on_run_in_progress(
         all_partitions: bool = False,
     ) -> "SkipOnRunInProgressRule":
+        """Skip an asset if targeted by an in-progress run.
+
+        Args:
+            all_partitions (bool): If True, skips all partitions of the asset that is in-progress,
+                regardless of whether the specific partition is targeted by the specific run.
+                False is currently not supported on Non partitioned runs.
+        """
+
         return SkipOnRunInProgressRule(all_partitions)
 
     def to_snapshot(self) -> AutoMaterializeRuleSnapshot:

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/basic_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/basic_scenarios.py
@@ -297,7 +297,7 @@ basic_scenarios = [
         initial_spec=two_assets_in_sequence.with_asset_properties(
             keys=["B"],
             auto_materialize_policy=AutoMaterializePolicy.eager().with_rules(
-                SkipOnRunInProgressRule()
+                SkipOnRunInProgressRule(all_partitions=True)
             ),
         ),
         execution_fn=lambda state: state.with_runs(run_request(["A"]))


### PR DESCRIPTION
## Summary & Motivation
We have a bunch of partitioned assets that currently are triggered too often. (see #19593 )

We don't want to rely on schedules or very advanced sensors (if I can help it), so this limits the duplicated runs. It does have the downside that this will block any partition on that asset while a run is in progress - I'd argue, however, that it's more like a concurrency throttle, as the other partitions will be triggered eventually. It's not the ideal long term solution, as the feature of skipping only running partitions is preferred too, however this DOES create one of the two features for now.

## How I Tested These Changes
I created a new scenario for the automaterializations. I'd love to create a test that ensures that the expected exception is thrown, but no existing tests seem to cover those cases, and I am not sure what conventions you'd like to follow for that, so 