### PR TITLE
[daggy-u] add pyarrow dependency to dbt course; required for pandas

### DIFF
--- a/examples/project_du_dbt_starter/setup.py
+++ b/examples/project_du_dbt_starter/setup.py
@@ -18,6 +18,7 @@ setup(
         "s3fs",
         "smart_open",
         "boto3",
+        "pyarrow",
     ],
     extras_require={"dev": ["dagster-webserver", "pytest"]},
 )


### PR DESCRIPTION
- `pyarrow` is required for pandas when reading duckdb/parquet