### PR TITLE
Remove add_input_metadata from UPathIOManager

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -273,8 +273,6 @@ class UPathIOManager(MemoizableIOManager):
         if asyncio.iscoroutine(obj):
             obj = asyncio.run(obj)
 
-        context.add_input_metadata({"path": MetadataValue.path(str(path))})
-
         return obj
 
     def _load_partition_from_path(

--- a/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
@@ -80,7 +80,6 @@ def test_fs_io_manager():
 
         loaded_input_events = list(filter(lambda evt: evt.is_loaded_input, result.all_events))
         metadata = loaded_input_events[0].event_specific_data.metadata
-        assert metadata["path"] == MetadataValue.path(filepath_a)
         assert len(loaded_input_events) == 1
         assert loaded_input_events[0].event_specific_data.upstream_step_key == "op_a"
 


### PR DESCRIPTION
## Summary & Motivation

The current behavior of Dagster is that when `add_input_metadata` is called on an input the in reality refers to an asset key, it generates an AssetObservation for the asset. 

I do think that behavior is suspect for a couple reasons since it generates a ton of events and degrades perf, and I don't think downstream assets should be generating asset observations for upstream assets as a default behavior. The event stream for that asset will be "polluted" by downstream assets that the user does not necessarily control.

This PR does not re-examine that core behavior. However what it does to is eliminate the "path" metadata from inputs for UPathIOManager. For this IOManager the metadata is already encoded in the system, in the corresponding upstream materialization. And this generates a ton of low-value observation events in the default case.

## How I Tested These Changes

BK