### PR TITLE
[daggy-u][dbt] remove strptime for incremental model

### DIFF
--- a/docs/dagster-university/pages/dagster-dbt/lesson-6/3-creating-a-partitioned-dbt-asset.md
+++ b/docs/dagster-university/pages/dagster-dbt/lesson-6/3-creating-a-partitioned-dbt-asset.md
@@ -193,10 +193,10 @@ Finally, we’ll modify the `daily_metrics.sql` file to reflect that dbt knows w
 In `analytics/models/marts/daily_metrics.sql`, update the contents of the model's incremental logic (`% if is_incremental %}`) to the following:
 
 ```sql
-where date_of_business >= strptime('{{ var('min_date') }}', '%c') and date_of_business < strptime('{{ var('max_date') }}', '%c')
+where date_of_business >= '{{ var('min_date') }}' and date_of_business < '{{ var('max_date') }}'
 ```
 
-Here, we’ve changed the logic to say that we only want to select rows between the `min_date` and the `max_date`. Note that we are turning the variables into timestamps using `strptime` because they’re loaded as strings.
+Here, we’ve changed the logic to say that we only want to select rows between the `min_date` and the `max_date`.
 
 ---
 

--- a/docs/dagster-university/pages/dagster-dbt/lesson-6/3-creating-a-partitioned-dbt-asset.md
+++ b/docs/dagster-university/pages/dagster-dbt/lesson-6/3-creating-a-partitioned-dbt-asset.md
@@ -86,8 +86,8 @@ First, add the following to the `@dbt_assets` function body, before the `yield`:
 ```bash
 time_window = context.partition_time_window
 dbt_vars = {
-    "min_date": time_window.start.isoformat(),
-    "max_date": time_window.end.isoformat()
+    "min_date": time_window.start.strftime('%Y-%m-%d'),
+    "max_date": time_window.end.strftime('%Y-%m-%d')
 }
 ```
 
@@ -174,8 +174,8 @@ def dbt_analytics(context: AssetExecutionContext, dbt: DbtCliResource):
 def incremental_dbt_models(context: AssetExecutionContext, dbt: DbtCliResource):
     time_window = context.partition_time_window
     dbt_vars = {
-        "min_date": time_window.start.isoformat(),
-        "max_date": time_window.end.isoformat(),
+        "min_date": time_window.start.strftime('%Y-%m-%d'),
+        "max_date": time_window.end.strftime('%Y-%m-%d')
     }
 
     yield from dbt.cli(
@@ -193,7 +193,7 @@ Finally, we’ll modify the `daily_metrics.sql` file to reflect that dbt knows w
 In `analytics/models/marts/daily_metrics.sql`, update the contents of the model's incremental logic (`% if is_incremental %}`) to the following:
 
 ```sql
-where date_of_business >= '{{ var('min_date') }}' and date_of_business < '{{ var('max_date') }}'
+where date_of_business between '{{ var('min_date') }}' and '{{ var('max_date') }}'
 ```
 
 Here, we’ve changed the logic to say that we only want to select rows between the `min_date` and the `max_date`.


### PR DESCRIPTION
## Summary & Motivation

- the `%c` format string being used with `strptime` in this context does not appropriately parse `pendulum.datetime` ISO timestampsa

linked: https://github.com/dagster-io/project-dagster-university/pull/23

## How I Tested These Changes

- Ran backfill of partitioned model

```python
>>> pendulum.now().isoformat()
'2024-04-25T11:45:47.749103-04:00'
```
```sql
D select strptime('2024-04-25T11:29:18.217685', '%c');
Invalid Input Error: Could not parse string "2024-04-25T11:29:18.217685" according to format specifier "%c"
2024-04-25T11:29:18.217685
          ^
Error: Space does not match, expected
```