### PR TITLE
Create DepSchedulingCondition base class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/dep_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/dep_condition.py
@@ -1,0 +1,145 @@
+from abc import abstractmethod
+from enum import Enum
+from typing import Any, Callable, Optional, Sequence
+
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_subset import AssetSubset, ValidAssetSubset
+from dagster._core.definitions.events import AssetKeyPartitionKey
+
+from .asset_condition import AssetCondition, AssetConditionResult
+from .asset_condition_evaluation_context import AssetConditionEvaluationContext
+
+
+class DepSelectionType(Enum):
+    ALL = "ALL"
+    ANY = "ANY"
+
+    @property
+    def method(self) -> Callable[[Any], bool]:
+        """Method to be used for aggregating results across a dep."""
+        if self == DepSelectionType.ALL:
+            return all
+        else:
+            return any
+
+
+class DepSchedulingCondition(AssetCondition):
+    """DepSchedulingCondition is a base class for conditions which examine the state of the given
+    asset's dependencies. At minimum, the subclass must implement `evaluate_for_dep_asset_partition`.
+    This class caches the results of all evaluations between ticks. By default, an asset partition
+    will be re-evaluated whenever a dependency is updated, or will update on a given tick. At this
+    point in time, all of the dependencies will be re-evaluated. This is technically somewhat
+    inefficient, but significantly simpler to implement.
+    """
+
+    dep_keys: Optional[Sequence[AssetKey]] = None
+    dep_selection_type: DepSelectionType = DepSelectionType.ANY
+    dep_partition_selection_type: DepSelectionType = DepSelectionType.ANY
+
+    def select_dep_keys(self, dep_keys: Sequence[AssetKey]) -> "DepSchedulingCondition":
+        return self.copy(update={"dep_keys": dep_keys})
+
+    def all_deps(self) -> "DepSchedulingCondition":
+        return self.copy(update={"dep_selection_type": DepSelectionType.ALL})
+
+    def all_dep_partitions(self) -> "DepSchedulingCondition":
+        return self.copy(update={"dep_partition_selection_type": DepSelectionType.ALL})
+
+    @property
+    def description(self) -> str:
+        if self.dep_partition_selection_type == DepSelectionType.ALL:
+            dep_partitions_str = "All partitions "
+            has_or_have = "have"
+        else:
+            dep_partitions_str = "Any partition "
+            has_or_have = "has"
+
+        if self.dep_selection_type == DepSelectionType.ALL:
+            dep_str = "all dependencies"
+        else:
+            dep_str = "any dependency"
+
+        if self.dep_keys is not None:
+            dep_str += f" within ({', '.join(k.to_user_string() for k in self.dep_keys)})"
+
+        return f"{dep_partitions_str} of {dep_str} {has_or_have} {self.dep_description}"
+
+    @property
+    @abstractmethod
+    def dep_description(self) -> str:
+        """Description of the condition that will be evaluated for each dependency."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def evaluate_for_dep_asset_partition(
+        self,
+        context: AssetConditionEvaluationContext,
+        dep_asset_partition: AssetKeyPartitionKey,
+    ) -> bool:
+        """This method should be implemented to evaluate if the given dep asset partition satisfies
+        the condition.
+        """
+        raise NotImplementedError()
+
+    def evaluate_for_dep(
+        self,
+        context: AssetConditionEvaluationContext,
+        dep: AssetKey,
+        candidate_asset_partition: AssetKeyPartitionKey,
+    ) -> bool:
+        """For a given dep of a candidate asset partition, evaluate if this rule is satisfied."""
+        dep_asset_partitions = (
+            context.asset_graph_view.create_slice_for_asset_partition(candidate_asset_partition)
+            .compute_parent_slice(dep)
+            .compute_asset_partitions()
+        )
+        return self.dep_partition_selection_type.method(
+            self.evaluate_for_dep_asset_partition(context, ap) for ap in dep_asset_partitions
+        )
+
+    def evaluate_for_candidate(
+        self,
+        context: AssetConditionEvaluationContext,
+        candidate_asset_partition: AssetKeyPartitionKey,
+    ) -> bool:
+        """Returns if the condition is satisfied for the given candidate asset partition."""
+        return self.dep_selection_type.method(
+            self.evaluate_for_dep(context, dep, candidate_asset_partition)
+            for dep in self.get_dep_keys(context)
+        )
+
+    def get_subset_to_evaluate(self, context: AssetConditionEvaluationContext) -> ValidAssetSubset:
+        """Typically, we only need to evaluate the net-new candidates and candidates whose parents
+        have updated since the previous tick. This method can be overridden to change this behavior.
+        """
+        return (
+            context.candidates_not_evaluated_on_previous_tick_subset
+            | context.candidate_parent_has_or_will_update_subset
+        )
+
+    def get_dep_keys(self, context: AssetConditionEvaluationContext) -> Sequence[AssetKey]:
+        """Returns the set of dependency keys that must be evaluated."""
+        parent_keys = context.asset_graph.get(context.asset_key).parent_keys
+        if self.dep_keys is None:
+            return parent_keys
+        else:
+            return sorted(list(set(self.dep_keys) - set(parent_keys)))
+
+    def evaluate(self, context: AssetConditionEvaluationContext) -> "AssetConditionResult":
+        to_evaluate_subset = self.get_subset_to_evaluate(context)
+        new_true_subset = AssetSubset.from_asset_partitions_set(
+            context.asset_key,
+            context.partitions_def,
+            {
+                candidate
+                for candidate in to_evaluate_subset.asset_partitions
+                if self.evaluate_for_candidate(context, candidate)
+            },
+        )
+        # something is true now if it was true before and was not re-evaluated, or if it was
+        # evaluated as true on this tick
+        true_subset = (
+            context.previous_true_subset.as_valid(context.partitions_def) - to_evaluate_subset
+        ) | new_true_subset
+
+        return AssetConditionResult.create(context, true_subset)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
@@ -1,0 +1,138 @@
+from enum import Enum
+from typing import Optional, Sequence
+
+import pytest
+from dagster._core.definitions.asset_condition.asset_condition_evaluation_context import (
+    AssetConditionEvaluationContext,
+)
+from dagster._core.definitions.asset_condition.dep_condition import (
+    DepSchedulingCondition,
+    DepSelectionType,
+)
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.partition import PartitionsDefinition
+
+from ..scenario_specs import one_asset_depends_on_two, two_partitions_def
+from .asset_condition_scenario import AssetConditionScenarioState
+
+
+class TruePartitions(Enum):
+    NONE = "NONE"
+    ONE = "ONE"
+    ALL = "ALL"
+
+    def asset_partitions(
+        self, asset_key: AssetKey, partitions_def: Optional[PartitionsDefinition]
+    ) -> Sequence[AssetKeyPartitionKey]:
+        if self == TruePartitions.NONE:
+            return []
+
+        if partitions_def is None:
+            return [AssetKeyPartitionKey(asset_key, None)]
+
+        partition_keys = partitions_def.get_partition_keys()
+        if self == TruePartitions.ONE:
+            return [AssetKeyPartitionKey(asset_key, partition_keys[1])]
+        else:
+            return [
+                AssetKeyPartitionKey(asset_key, partition_key) for partition_key in partition_keys
+            ]
+
+
+@pytest.mark.parametrize(
+    [
+        "A_partitioned",
+        "B_partitioned",
+        "C_partitioned",
+        "A_true_partitions",
+        "B_true_partitions",
+        "expected_result_sizes",
+    ],
+    [
+        # (all, all), (all, any), (any, all), (any, any)
+        # ALL PARTITIONED
+        (True, True, True, TruePartitions.ALL, TruePartitions.ALL, [2, 2, 2, 2]),
+        (True, True, True, TruePartitions.ALL, TruePartitions.ONE, [1, 1, 2, 2]),
+        (True, True, True, TruePartitions.ALL, TruePartitions.NONE, [0, 0, 2, 2]),
+        (True, True, True, TruePartitions.ONE, TruePartitions.ONE, [1, 1, 1, 1]),
+        (True, True, True, TruePartitions.ONE, TruePartitions.NONE, [0, 0, 1, 1]),
+        (True, True, True, TruePartitions.NONE, TruePartitions.NONE, [0, 0, 0, 0]),
+        # PARTITIONED -> UNPARTITIONED
+        (True, True, False, TruePartitions.ALL, TruePartitions.ALL, [1, 1, 1, 1]),
+        (True, True, False, TruePartitions.ALL, TruePartitions.ONE, [0, 1, 1, 1]),
+        (True, True, False, TruePartitions.ALL, TruePartitions.NONE, [0, 0, 1, 1]),
+        (True, True, False, TruePartitions.ONE, TruePartitions.ONE, [0, 1, 0, 1]),
+        (True, True, False, TruePartitions.ONE, TruePartitions.NONE, [0, 0, 0, 1]),
+        (True, True, False, TruePartitions.NONE, TruePartitions.NONE, [0, 0, 0, 0]),
+        # UNPARTITIONED -> PARTITIONED
+        (False, False, True, TruePartitions.ALL, TruePartitions.ALL, [2, 2, 2, 2]),
+        (False, False, True, TruePartitions.ALL, TruePartitions.NONE, [0, 0, 2, 2]),
+        (False, False, True, TruePartitions.NONE, TruePartitions.NONE, [0, 0, 0, 0]),
+        # MIXED -> UNPARTITIONED
+        (True, False, False, TruePartitions.ALL, TruePartitions.ALL, [1, 1, 1, 1]),
+        (True, False, False, TruePartitions.ALL, TruePartitions.NONE, [0, 0, 1, 1]),
+        (True, False, False, TruePartitions.NONE, TruePartitions.ALL, [0, 0, 1, 1]),
+        (True, False, False, TruePartitions.ONE, TruePartitions.ALL, [0, 1, 1, 1]),
+        (True, False, False, TruePartitions.ONE, TruePartitions.NONE, [0, 0, 0, 1]),
+        # MIXED -> PARTITIONED
+        (True, False, True, TruePartitions.ALL, TruePartitions.ALL, [2, 2, 2, 2]),
+        (True, False, True, TruePartitions.ALL, TruePartitions.NONE, [0, 0, 2, 2]),
+    ],
+)
+def test_logic(
+    A_partitioned: bool,
+    B_partitioned: bool,
+    C_partitioned: bool,
+    A_true_partitions: TruePartitions,
+    B_true_partitions: TruePartitions,
+    expected_result_sizes: Sequence[int],
+) -> None:
+    partitions_def_A = two_partitions_def if A_partitioned else None
+    partitions_def_B = two_partitions_def if B_partitioned else None
+    partitions_def_C = two_partitions_def if C_partitioned else None
+
+    class TestDepCondition(DepSchedulingCondition):
+        def dep_description(self) -> str:
+            return "matches one of the provided asset partitions"
+
+        def evaluate_for_dep_asset_partition(
+            self,
+            context: AssetConditionEvaluationContext,
+            dep_asset_partition: AssetKeyPartitionKey,
+        ) -> bool:
+            return dep_asset_partition in {
+                *A_true_partitions.asset_partitions(AssetKey("A"), partitions_def_A),
+                *B_true_partitions.asset_partitions(AssetKey("B"), partitions_def_B),
+            }
+
+    for i, (dep, dep_partition) in enumerate(
+        [
+            (DepSelectionType.ALL, DepSelectionType.ALL),
+            (DepSelectionType.ALL, DepSelectionType.ANY),
+            (DepSelectionType.ANY, DepSelectionType.ALL),
+            (DepSelectionType.ANY, DepSelectionType.ANY),
+        ]
+    ):
+        dep_condition = TestDepCondition(
+            dep_selection_type=dep,
+            dep_partition_selection_type=dep_partition,
+        )
+        scenario_spec = (
+            one_asset_depends_on_two.with_asset_properties(
+                "A",
+                partitions_def=partitions_def_A,
+            )
+            .with_asset_properties(
+                "B",
+                partitions_def=partitions_def_B,
+            )
+            .with_asset_properties(
+                "C",
+                partitions_def=partitions_def_C,
+            )
+        )
+        state = AssetConditionScenarioState(scenario_spec, asset_condition=dep_condition)
+        state, result = state.evaluate("C")
+
+        assert result.true_subset.size == expected_result_sizes[i], f"{dep}, {dep_partition}"


### PR DESCRIPTION
## Summary & Motivation

Creates a base class that handles the repetitive work of implementing all the possible permutations of "all upstream partitions of all deps match", "any upstream partition of all deps match", "any upstream partition of any dep matches", etc.

All the subclasser has to do is implement a single method and that will get invoked properly given the configuration. See next PR in the stack for an example usage.

## How I Tested These Changes
