### PR TITLE
Create DepInProgress condition

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -171,6 +171,10 @@ class AssetSlice:
         """Return a new AssetSlice with only the given partition keys if they are in the slice."""
         return self._asset_graph_view.compute_intersection_with_partition_keys(partition_keys, self)
 
+    def contains_asset_partition(self, asset_partition: AssetKeyPartitionKey) -> bool:
+        """Determines if a given asset partition is in the slice."""
+        return asset_partition in self._compatible_subset
+
     @property
     def time_windows(self) -> Sequence[TimeWindow]:
         """Get the time windows for the asset slice. Only supports explicitly time-windowed partitions for now."""

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition.py
@@ -31,6 +31,7 @@ from ..auto_materialize_rule import AutoMaterializeRule
 
 if TYPE_CHECKING:
     from .asset_condition_evaluation_context import AssetConditionEvaluationContext
+    from .dep_condition import DepSchedulingCondition
     from .recent_time_partitions import Duration
 
 
@@ -425,6 +426,12 @@ class AssetCondition(ABC, DagsterModel):
         from .in_progress_condition import InProgressRunCondition
 
         return InProgressRunCondition()
+
+    @staticmethod
+    def dep() -> Type["DepSchedulingCondition"]:
+        from .dep_condition import DepSchedulingCondition
+
+        return DepSchedulingCondition
 
 
 @experimental

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/dep_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/dep_condition.py
@@ -45,6 +45,12 @@ class DepSchedulingCondition(AssetCondition):
     def all_dep_partitions(self) -> "DepSchedulingCondition":
         return self.copy(update={"dep_partition_selection_type": DepSelectionType.ALL})
 
+    @staticmethod
+    def dep_in_progress() -> "DepSchedulingCondition":
+        from .dep_in_progress_condition import DepInProgressCondition
+
+        return DepInProgressCondition()
+
     @property
     def description(self) -> str:
         if self.dep_partition_selection_type == DepSelectionType.ALL:

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/dep_in_progress_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/dep_in_progress_condition.py
@@ -1,0 +1,26 @@
+from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView, AssetSlice
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._utils.cached_method import cached_method
+
+from .asset_condition_evaluation_context import AssetConditionEvaluationContext
+from .dep_condition import DepSchedulingCondition
+
+
+class DepInProgressCondition(DepSchedulingCondition):
+    def dep_description(self) -> str:
+        return "in progress"
+
+    @cached_method
+    def get_computed_in_progress_slice(
+        self, *, asset_graph_view: AssetGraphView, dep: AssetKey
+    ) -> AssetSlice:
+        # caching layer to avoid recomputing the in-progress slice multiple times
+        return asset_graph_view.compute_in_progress_slice(dep)
+
+    def evaluate_for_dep_asset_partition(
+        self, context: AssetConditionEvaluationContext, dep_asset_partition: AssetKeyPartitionKey
+    ) -> bool:
+        dep_in_progress_slice = self.get_computed_in_progress_slice(
+            asset_graph_view=context.asset_graph_view, dep=dep_asset_partition.asset_key
+        )
+        return dep_in_progress_slice.contains_asset_partition(dep_asset_partition)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_in_progress.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_in_progress.py
@@ -1,0 +1,63 @@
+from dagster._core.definitions.asset_condition.asset_condition import AssetCondition
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.events import AssetKeyPartitionKey
+
+from ..scenario_specs import two_assets_in_sequence, two_partitions_def
+from .asset_condition_scenario import AssetConditionScenarioState
+
+
+def test_dep_in_progress_unpartitioned() -> None:
+    state = AssetConditionScenarioState(
+        two_assets_in_sequence, asset_condition=AssetCondition.dep().in_progress()
+    )
+
+    # no run in progress
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # run now in progress
+    state = state.with_in_progress_run_for_asset("A")
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 1
+
+    # run completes
+    state = state.with_in_progress_runs_completed()
+    _, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+
+def test_dep_in_progress_static_partitioned() -> None:
+    state = AssetConditionScenarioState(
+        two_assets_in_sequence, asset_condition=AssetCondition.dep().in_progress()
+    ).with_asset_properties(partitions_def=two_partitions_def)
+
+    # no run in progress
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # now in progress
+    state = state.with_in_progress_run_for_asset("A", partition_key="1")
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 1
+    assert result.true_subset.asset_partitions == {AssetKeyPartitionKey(AssetKey("B"), "1")}
+
+    # run completes
+    state = state.with_in_progress_runs_completed()
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # now both in progress
+    state = state.with_in_progress_run_for_asset(
+        "A",
+        partition_key="1",
+    ).with_in_progress_run_for_asset(
+        "A",
+        partition_key="2",
+    )
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 2
+
+    # both runs complete
+    state = state.with_in_progress_runs_completed()
+    _, result = state.evaluate("B")
+    assert result.true_subset.size == 0


### PR DESCRIPTION
## Summary & Motivation

Uses the DepSchedulingCondition class to very easily implement a condition that checks for in progress dependencies.

Curious on your thoughts re: this AssetCondition.dep().in_progress pattern -- I like that it organizes the conditions pretty nicely (as if you're looking for something that has to do with the state of your dependencies, you can just look under that heading), but it's a bit weird

## How I Tested These Changes
