### PR TITLE
Suspensify `PermissionsProvider` using `useWrappedQuery`

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/src/App.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/App.tsx
@@ -41,23 +41,25 @@ const appCache = createAppCache();
 // eslint-disable-next-line import/no-default-export
 export default function AppPage() {
   return (
-    <RecoilRoot>
-      <InjectedComponents>
-        <LiveDataPollRateContext.Provider value={liveDataPollRate ?? 2000}>
-          <AppProvider appCache={appCache} config={config}>
-            <AppTopNav allowGlobalReload>
-              <HelpMenu showContactSales={false} />
-              <UserSettingsButton />
-            </AppTopNav>
-            <App>
-              <ContentRoot />
-              <Suspense>
-                <CommunityNux />
-              </Suspense>
-            </App>
-          </AppProvider>
-        </LiveDataPollRateContext.Provider>
-      </InjectedComponents>
-    </RecoilRoot>
+    <Suspense fallback={<div />}>
+      <RecoilRoot>
+        <InjectedComponents>
+          <LiveDataPollRateContext.Provider value={liveDataPollRate ?? 2000}>
+            <AppProvider appCache={appCache} config={config}>
+              <AppTopNav allowGlobalReload>
+                <HelpMenu showContactSales={false} />
+                <UserSettingsButton />
+              </AppTopNav>
+              <App>
+                <ContentRoot />
+                <Suspense>
+                  <CommunityNux />
+                </Suspense>
+              </App>
+            </AppProvider>
+          </LiveDataPollRateContext.Provider>
+        </InjectedComponents>
+      </RecoilRoot>
+    </Suspense>
   );
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
@@ -1,7 +1,8 @@
 import {ErrorBoundary, MainContent} from '@dagster-io/ui-components';
-import {Suspense, lazy, memo, useEffect, useRef} from 'react';
+import {lazy, memo, useEffect, useRef} from 'react';
 import {Route, Switch, useLocation} from 'react-router-dom';
 
+import {TrackedSuspense} from './TrackedSuspense';
 import {AssetFeatureProvider} from '../assets/AssetFeatureContext';
 import {AssetsOverview} from '../assets/AssetsOverview';
 
@@ -35,97 +36,101 @@ export const ContentRoot = memo(() => {
       <ErrorBoundary region="page" resetErrorOnChange={[pathname]}>
         <Switch>
           <Route path="/asset-groups(/?.*)">
-            <Suspense fallback={<div />}>
+            <TrackedSuspense fallback={<div />} id={id('asset-groups')}>
               <AssetsGroupsGlobalGraphRoot />
-            </Suspense>
+            </TrackedSuspense>
           </Route>
           <Route path="/assets(/?.*)">
-            <Suspense fallback={<div />}>
+            <TrackedSuspense fallback={<div />} id={id('assets')}>
               <AssetFeatureProvider>
                 <AssetsOverview
                   headerBreadcrumbs={[{text: 'Assets', href: '/assets'}]}
                   documentTitlePrefix="Assets"
                 />
               </AssetFeatureProvider>
-            </Suspense>
+            </TrackedSuspense>
           </Route>
           <Route path="/runs" exact>
-            <Suspense fallback={<div />}>
+            <TrackedSuspense fallback={<div />} id={id('runs')}>
               <RunsRoot />
-            </Suspense>
+            </TrackedSuspense>
           </Route>
           <Route path="/runs/scheduled" exact>
-            <Suspense fallback={<div />}>
+            <TrackedSuspense fallback={<div />} id={id('runs/scheduled')}>
               <ScheduledRunListRoot />
-            </Suspense>
+            </TrackedSuspense>
           </Route>
           <Route path="/runs/:runId" exact>
-            <Suspense fallback={<div />}>
+            <TrackedSuspense fallback={<div />} id={id('runs/:runId')}>
               <RunRoot />
-            </Suspense>
+            </TrackedSuspense>
           </Route>
           <Route path="/snapshots/:pipelinePath/:tab?">
-            <Suspense fallback={<div />}>
+            <TrackedSuspense fallback={<div />} id={id('snapshots')}>
               <SnapshotRoot />
-            </Suspense>
+            </TrackedSuspense>
           </Route>
           <Route path="/health">
-            <Suspense fallback={<div />}>
+            <TrackedSuspense fallback={<div />} id={id('health')}>
               <InstanceHealthPage />
-            </Suspense>
+            </TrackedSuspense>
           </Route>
           <Route path="/concurrency">
-            <Suspense fallback={<div />}>
+            <TrackedSuspense fallback={<div />} id={id('concurrency')}>
               <InstanceConcurrencyPage />
-            </Suspense>
+            </TrackedSuspense>
           </Route>
           <Route path="/config">
-            <Suspense fallback={<div />}>
+            <TrackedSuspense fallback={<div />} id={id('config')}>
               <InstanceConfig />
-            </Suspense>
+            </TrackedSuspense>
           </Route>
           <Route path="/locations" exact>
-            <Suspense fallback={<div />}>
+            <TrackedSuspense fallback={<div />} id={id('"locations"')}>
               <CodeLocationsPage />
-            </Suspense>
+            </TrackedSuspense>
           </Route>
           <Route path="/locations">
-            <Suspense fallback={<div />}>
+            <TrackedSuspense fallback={<div />} id={id('locations')}>
               <WorkspaceRoot />
-            </Suspense>
+            </TrackedSuspense>
           </Route>
           <Route path="/guess/:jobPath">
-            <Suspense fallback={<div />}>
+            <TrackedSuspense fallback={<div />} id={id('guess/:jobPath')}>
               <GuessJobLocationRoot />
-            </Suspense>
+            </TrackedSuspense>
           </Route>
           <Route path="/overview">
-            <Suspense fallback={<div />}>
+            <TrackedSuspense id={id('Overview')} fallback={<div />}>
               <OverviewRoot />
-            </Suspense>
+            </TrackedSuspense>
           </Route>
           <Route path="/jobs">
-            <Suspense fallback={<div />}>
+            <TrackedSuspense id={id('JobsRoot')} fallback={<div />}>
               <JobsRoot />
-            </Suspense>
+            </TrackedSuspense>
           </Route>
           <Route path="/automation">
-            <Suspense fallback={<div />}>
+            <TrackedSuspense fallback={<div />} id={id('automation')}>
               <AutomationRoot />
-            </Suspense>
+            </TrackedSuspense>
           </Route>
           <Route path="/settings">
-            <Suspense fallback={<div />}>
+            <TrackedSuspense fallback={<div />} id={id('settings')}>
               <SettingsRoot />
-            </Suspense>
+            </TrackedSuspense>
           </Route>
           <Route path="*">
-            <Suspense fallback={<div />}>
+            <TrackedSuspense fallback={<div />} id={id('*')}>
               <FallthroughRoot />
-            </Suspense>
+            </TrackedSuspense>
           </Route>
         </Switch>
       </ErrorBoundary>
     </MainContent>
   );
 });
+
+function id(str: string) {
+  return `ContentRoot:${str}`;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Permissions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Permissions.tsx
@@ -115,7 +115,7 @@ export type PermissionsState = {
   disabledReasons: PermissionDisabledReasons;
 };
 
-type PermissionsResult = {
+export type PermissionsResult = {
   error?: ApolloError;
   unscopedPermissions: PermissionsMap;
   locationPermissions: Record<string, PermissionsMap>;
@@ -126,7 +126,12 @@ type PermissionsContextType = ReturnType<typeof wrapPromise<PermissionsResult>>;
 
 export const PermissionsContext = React.createContext<PermissionsContextType>({
   read() {
-    throw new Error('Expected a permissions provider to override the default context');
+    return {
+      error: undefined,
+      unscopedPermissions: extractPermissions([]),
+      rawUnscopedData: [],
+      locationPermissions: {},
+    };
   },
 });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/CustomConfirmationProvider.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/CustomConfirmationProvider.test.tsx
@@ -1,8 +1,7 @@
 import {Button} from '@dagster-io/ui-components';
-import {render, screen, waitFor} from '@testing-library/react';
+import {act, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {useState} from 'react';
-import {act} from 'react-dom/test-utils';
 
 import {CustomConfirmationProvider, useConfirmation} from '../CustomConfirmationProvider';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jest/expect-expect */
 import {MockedProvider, MockedResponse} from '@apollo/client/testing';
-import {act, render, screen, waitFor} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {CustomAlertProvider} from '../../app/CustomAlertProvider';
@@ -302,9 +302,7 @@ describe('LaunchAssetExecutionButton', () => {
         launchMock,
       });
       await clickMaterializeButton();
-      await act(async () => {
-        await userEvent.click(await screen.findByTestId('latest-partition-button'));
-      });
+      await userEvent.click(await screen.findByTestId('latest-partition-button'));
 
       await expectLaunchExecutesMutationAndCloses('Launch 1 run', launchMock);
     });
@@ -394,9 +392,7 @@ describe('LaunchAssetExecutionButton', () => {
       });
       await clickMaterializeButton();
       await screen.findByTestId('choose-partitions-dialog');
-      await act(async () => {
-        await userEvent.click(await screen.findByTestId('latest-partition-button'));
-      });
+      await userEvent.click(await screen.findByTestId('latest-partition-button'));
       await expectLaunchExecutesMutationAndCloses('Launch 1 run', launchMock);
     });
 
@@ -461,9 +457,7 @@ describe('LaunchAssetExecutionButton', () => {
 
         const rangesAsTags = screen.getByTestId('ranges-as-tags-true-radio');
         await waitFor(async () => expect(rangesAsTags).toBeEnabled());
-        await act(async () => {
-          await userEvent.click(rangesAsTags);
-        });
+        await userEvent.click(rangesAsTags);
         await expectLaunchExecutesMutationAndCloses('Launch 1 run', launchMock);
       });
 
@@ -616,10 +610,8 @@ describe('LaunchAssetExecutionButton', () => {
         await screen.findByText(displayNameForAssetKey(MULTI_ASSET_OUT_2.assetKey)),
       ).toBeDefined();
 
-      await act(async () => {
-        // Click Confirm
-        await userEvent.click(await screen.findByTestId('confirm-button-ok'));
-      });
+      // Click Confirm
+      await userEvent.click(await screen.findByTestId('confirm-button-ok'));
 
       // The launch should contain both MULTI_ASSET_OUT_1 and MULTI_ASSET_OUT_2
       await waitFor(() => expect(launchMock.result).toHaveBeenCalled());
@@ -684,9 +676,7 @@ function renderButton({
 async function clickMaterializeButton() {
   const materializeButton = await screen.findByTestId('materialize-button');
   expect(materializeButton).toBeVisible();
-  await act(async () => {
-    await userEvent.click(materializeButton);
-  });
+  await userEvent.click(materializeButton);
 }
 
 async function expectErrorShown(msg: string) {
@@ -702,9 +692,7 @@ async function expectLaunchExecutesMutationAndCloses(
 ) {
   const launchButton = await waitFor(() => screen.findByTestId('launch-button'));
   expect(launchButton.textContent).toEqual(label);
-  await act(async () => {
-    await userEvent.click(launchButton);
-  });
+  await userEvent.click(launchButton);
 
   // expect that it triggers the mutation (variables checked by mock matching)
   await waitFor(() => expect(mutation.result).toHaveBeenCalled());

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
@@ -401,10 +401,13 @@ export const BackfillStatusTag = ({
       return (
         <Box margin={{bottom: 12}}>
           <TagButton
-            onClick={() =>
-              backfill.error &&
-              showCustomAlert({title: 'Error', body: <PythonErrorInfo error={backfill.error} />})
-            }
+            onClick={() => {
+              console.log('backfill error');
+              if (backfill.error) {
+                console.log('Show custom alert');
+                showCustomAlert({title: 'Error', body: <PythonErrorInfo error={backfill.error} />});
+              }
+            }}
           >
             <Tag intent="danger">Failed</Tag>
           </TagButton>
@@ -429,7 +432,6 @@ export const BackfillStatusTag = ({
     case BulkActionStatus.CANCELED:
       return <Tag>Canceled</Tag>;
   }
-  return <span />;
 };
 
 const TagButton = styled.button`

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
@@ -97,7 +97,7 @@ describe('BackfillPage', () => {
     );
 
     expect(await screen.findByTestId('page-loading-indicator')).toBeInTheDocument();
-    expect(await screen.findByText('assetA')).toBeVisible();
+    await waitFor(async () => expect(await screen.findByText('assetA')).toBeVisible());
   });
 
   it('renders the error state', async () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
@@ -87,7 +87,7 @@ describe('BackfillPage', () => {
         <AnalyticsContext.Provider value={{page: () => {}} as any}>
           <MemoryRouter initialEntries={[`/backfills/${mockBackfillId}`]}>
             <Route path="/backfills/:backfillId">
-              <MockedProvider mocks={mocks}>
+              <MockedProvider mocks={[]}>
                 <BackfillPage />
               </MockedProvider>
             </Route>
@@ -97,7 +97,6 @@ describe('BackfillPage', () => {
     );
 
     expect(await screen.findByTestId('page-loading-indicator')).toBeInTheDocument();
-    await waitFor(async () => expect(await screen.findByText('assetA')).toBeVisible());
   });
 
   it('renders the error state', async () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillTable.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillTable.test.tsx
@@ -1,5 +1,5 @@
 import {MockedProvider} from '@apollo/client/testing';
-import {render, screen} from '@testing-library/react';
+import {act, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {MemoryRouter} from 'react-router-dom';
 
@@ -26,9 +26,11 @@ describe('BackfillTable', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole('table')).toBeVisible();
+    await waitFor(() => expect(screen.getByRole('table')).toBeVisible());
     const statusLabel = await screen.findByText('Failed');
-    await userEvent.click(statusLabel);
-    expect(Alerting.showCustomAlert).toHaveBeenCalled();
+    await act(async () => {
+      await userEvent.click(statusLabel);
+    });
+    await waitFor(() => expect(Alerting.showCustomAlert).toHaveBeenCalled());
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/ReloadRepositoryLocationButton.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/ReloadRepositoryLocationButton.test.tsx
@@ -1,5 +1,6 @@
 import {MockedProvider} from '@apollo/client/testing';
 import {render, screen, waitFor} from '@testing-library/react';
+import {Suspense} from 'react';
 
 import {PermissionsProvider, usePermissionsForLocation} from '../../app/Permissions';
 import {TrackedSuspense} from '../../app/TrackedSuspense';
@@ -30,12 +31,14 @@ describe('ReloadRepositoryLocationButton', () => {
     render(
       <MockedProvider mocks={[buildPermissionsQuery(false)]}>
         <PermissionsProvider>
-          <ReloadRepositoryLocationButton location="foobar" ChildComponent={Test} />
+          <Suspense>
+            <ReloadRepositoryLocationButton location="foobar" ChildComponent={Test} />
+          </Suspense>
         </PermissionsProvider>
       </MockedProvider>,
     );
 
-    const button = screen.getByRole('button', {name: /reload/i});
+    const button = await waitFor(() => screen.getByRole('button', {name: /reload/i}));
 
     await waitFor(() => {
       expect(screen.queryByText(/loading permissions\? no/i)).not.toBeNull();
@@ -48,12 +51,14 @@ describe('ReloadRepositoryLocationButton', () => {
     render(
       <MockedProvider mocks={[buildPermissionsQuery(true)]}>
         <PermissionsProvider>
-          <ReloadRepositoryLocationButton location="foobar" ChildComponent={Test} />
+          <Suspense>
+            <ReloadRepositoryLocationButton location="foobar" ChildComponent={Test} />
+          </Suspense>
         </PermissionsProvider>
       </MockedProvider>,
     );
 
-    const button = screen.getByRole('button', {name: /reload/i});
+    const button = await waitFor(() => screen.getByRole('button', {name: /reload/i}));
 
     await waitFor(() => {
       expect(screen.queryByText(/loading permissions\? no/i)).not.toBeNull();

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/ReloadRepositoryLocationButton.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/ReloadRepositoryLocationButton.test.tsx
@@ -2,16 +2,23 @@ import {MockedProvider} from '@apollo/client/testing';
 import {render, screen, waitFor} from '@testing-library/react';
 
 import {PermissionsProvider, usePermissionsForLocation} from '../../app/Permissions';
+import {TrackedSuspense} from '../../app/TrackedSuspense';
 import {ChildProps, ReloadRepositoryLocationButton} from '../ReloadRepositoryLocationButton';
 import {buildPermissionsQuery} from '../__fixtures__/ReloadRepositoryLocationButton.fixtures';
 
 describe('ReloadRepositoryLocationButton', () => {
   const Test = (props: ChildProps) => {
     const {tryReload, hasReloadPermission} = props;
-    const {loading} = usePermissionsForLocation(props.codeLocation);
+
+    function Component() {
+      usePermissionsForLocation(props.codeLocation);
+      return <div>Loading permissions? No</div>;
+    }
     return (
       <div>
-        <div>Loading permissions? {loading ? 'Yes' : 'No'}</div>
+        <TrackedSuspense id="test" fallback={<div>Loading permissions? Yes</div>}>
+          <Component />
+        </TrackedSuspense>
         <button onClick={tryReload} disabled={!hasReloadPermission}>
           Reload
         </button>

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/__tests__/PipelineNav.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/__tests__/PipelineNav.test.tsx
@@ -1,4 +1,5 @@
-import {render, screen} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
+import {Suspense} from 'react';
 import {MemoryRouter} from 'react-router-dom';
 
 import {PipelineNav} from '../../nav/PipelineNav';
@@ -38,13 +39,15 @@ describe('PipelineNav', () => {
       <JobFeatureProvider>
         <TestPermissionsProvider locationOverrides={locationOverrides}>
           <MemoryRouter initialEntries={['/locations/bar@baz/jobs/foo/overview']}>
-            <PipelineNav repoAddress={repoAddress} />
+            <Suspense>
+              <PipelineNav repoAddress={repoAddress} />
+            </Suspense>
           </MemoryRouter>
         </TestPermissionsProvider>
       </JobFeatureProvider>,
     );
 
-    const launchpadTab = await screen.findByRole('tab', {name: /launchpad/i});
+    const launchpadTab = await waitFor(() => screen.findByRole('tab', {name: /launchpad/i}));
     expect(launchpadTab).toHaveAttribute('aria-disabled', 'false');
   });
 
@@ -59,13 +62,15 @@ describe('PipelineNav', () => {
       <JobFeatureProvider>
         <TestPermissionsProvider locationOverrides={locationOverrides}>
           <MemoryRouter initialEntries={['/locations/bar@baz/jobs/foo/overview']}>
-            <PipelineNav repoAddress={repoAddress} />
+            <Suspense>
+              <PipelineNav repoAddress={repoAddress} />
+            </Suspense>
           </MemoryRouter>
         </TestPermissionsProvider>
       </JobFeatureProvider>,
     );
 
-    const launchpadTab = await screen.findByRole('tab', {name: /launchpad/i});
+    const launchpadTab = await waitFor(() => screen.findByRole('tab', {name: /launchpad/i}));
     expect(launchpadTab).toHaveAttribute('aria-disabled', 'true');
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/__tests__/PipelineNav.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/__tests__/PipelineNav.test.tsx
@@ -47,7 +47,9 @@ describe('PipelineNav', () => {
       </JobFeatureProvider>,
     );
 
-    const launchpadTab = await waitFor(() => screen.findByRole('tab', {name: /launchpad/i}));
+    const launchpadTab = await waitFor(() => screen.findByRole('tab', {name: /launchpad/i}), {
+      timeout: 10000,
+    });
     expect(launchpadTab).toHaveAttribute('aria-disabled', 'false');
   });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/__tests__/PipelineRoot.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/__tests__/PipelineRoot.test.tsx
@@ -1,4 +1,5 @@
-import {render, screen} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
+import {Suspense} from 'react';
 import {MemoryRouter} from 'react-router-dom';
 
 import {TestPermissionsProvider} from '../../testing/TestPermissions';
@@ -53,7 +54,9 @@ describe('PipelineRoot', () => {
     render(
       <JobFeatureProvider>
         <MemoryRouter initialEntries={[path]}>
-          <PipelineRoot repoAddress={repoAddress} />
+          <Suspense>
+            <PipelineRoot repoAddress={repoAddress} />
+          </Suspense>
         </MemoryRouter>
       </JobFeatureProvider>,
     );
@@ -73,7 +76,9 @@ describe('PipelineRoot', () => {
       <JobFeatureProvider>
         <TestPermissionsProvider locationOverrides={locationPermissions}>
           <MemoryRouter initialEntries={[`${path}/playground`]}>
-            <PipelineRoot repoAddress={repoAddress} />
+            <Suspense>
+              <PipelineRoot repoAddress={repoAddress} />
+            </Suspense>
           </MemoryRouter>
         </TestPermissionsProvider>
       </JobFeatureProvider>,
@@ -94,13 +99,17 @@ describe('PipelineRoot', () => {
       <JobFeatureProvider>
         <TestPermissionsProvider locationOverrides={locationPermissions}>
           <MemoryRouter initialEntries={[`${path}/playground`]}>
-            <PipelineRoot repoAddress={repoAddress} />
+            <Suspense>
+              <PipelineRoot repoAddress={repoAddress} />
+            </Suspense>
           </MemoryRouter>
         </TestPermissionsProvider>
       </JobFeatureProvider>,
     );
 
-    const overviewDummy = await screen.findByText(/pipeline or job disambiguation placeholder/i);
+    const overviewDummy = await waitFor(() =>
+      screen.findByText(/pipeline or job disambiguation placeholder/i),
+    );
     expect(overviewDummy).toBeVisible();
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/testing/TestPermissions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/testing/TestPermissions.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import {PermissionsContext, PermissionsMap, extractPermissions} from '../app/Permissions';
+import {wrapPromise} from '../utils/wrapPromise';
 
 type PermissionOverrides = Partial<PermissionsMap>;
 
@@ -29,5 +30,10 @@ export const TestPermissionsProvider = (props: Props) => {
     };
   }, [locationOverrides, unscopedOverrides]);
 
-  return <PermissionsContext.Provider value={value}>{children}</PermissionsContext.Provider>;
+  const promise = React.useMemo(() => {
+    const p = Promise.resolve(value);
+    return wrapPromise(p);
+  }, [value]);
+
+  return <PermissionsContext.Provider value={promise}>{children}</PermissionsContext.Provider>;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/testing/TestPermissions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/testing/TestPermissions.tsx
@@ -30,10 +30,10 @@ export const TestPermissionsProvider = (props: Props) => {
     };
   }, [locationOverrides, unscopedOverrides]);
 
-  const promise = React.useMemo(() => {
+  const wrapped = React.useMemo(() => {
     const p = Promise.resolve(value);
     return wrapPromise(p);
   }, [value]);
 
-  return <PermissionsContext.Provider value={promise}>{children}</PermissionsContext.Provider>;
+  return <PermissionsContext.Provider value={wrapped}>{children}</PermissionsContext.Provider>;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/testing/TestProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/testing/TestProvider.tsx
@@ -4,8 +4,9 @@ import {MemoryRouter, MemoryRouterProps} from 'react-router-dom';
 import {RecoilRoot} from 'recoil';
 
 import {ApolloTestProps, ApolloTestProvider} from './ApolloTestProvider';
+import {TestPermissionsProvider} from './TestPermissions';
 import {AppContext, AppContextValue} from '../app/AppContext';
-import {PermissionsContext, PermissionsFromJSON, extractPermissions} from '../app/Permissions';
+import {PermissionsFromJSON} from '../app/Permissions';
 import {WebSocketContext, WebSocketContextType} from '../app/WebSocketProvider';
 import {AnalyticsContext} from '../app/analytics';
 import {PermissionFragment} from '../app/types/Permissions.types';
@@ -77,14 +78,7 @@ export const TestProvider = (props: Props) => {
     <RecoilRoot>
       <AppContext.Provider value={{...testValue, ...appContextProps}}>
         <WebSocketContext.Provider value={websocketValue}>
-          <PermissionsContext.Provider
-            value={{
-              unscopedPermissions: extractPermissions(permissions),
-              locationPermissions: {}, // Allow all permissions to fall back
-              loading: false,
-              rawUnscopedData: [],
-            }}
-          >
+          <TestPermissionsProvider>
             <AnalyticsContext.Provider value={analytics}>
               <MemoryRouter {...routerProps}>
                 <ApolloTestProvider {...apolloProps} typeDefs={typeDefs as any}>
@@ -92,7 +86,7 @@ export const TestProvider = (props: Props) => {
                 </ApolloTestProvider>
               </MemoryRouter>
             </AnalyticsContext.Provider>
-          </PermissionsContext.Provider>
+          </TestPermissionsProvider>
         </WebSocketContext.Provider>
       </AppContext.Provider>
     </RecoilRoot>

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/__tests__/autolinking.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/__tests__/autolinking.test.tsx
@@ -44,7 +44,7 @@ describe('autolinking', () => {
 
     const rendered = render(<Test message={message} useIdleCallback={false} />);
 
-    waitFor(() => expect(screen.getByRole('link')).toBeDefined());
+    waitFor(() => expect(screen.getAllByRole('link')).toBeDefined());
 
     const links = screen.getAllByRole('link');
     const hrefs = Array.from(links).map((el) => el.getAttribute('href'));


### PR DESCRIPTION
## Summary & Motivation

Suspensify `PermissionsProvider`. Concretely this means instead of returning PermissionsResults, it instead returns a wrappedPromise (an object with a `read` method that suspends (throws a promise) if the data is not available).

The idea here is that we don't want PermissionsProvider itself to suspend because the route being rendered might not use the permission data at all, and because the route being rendered might want to make its own queries in parallel and if we suspended immediately it wouldn't get the chance to do that. Instead a child component reads the data after making their own suspended query and then calls the `read` function which would cause it to suspend.

## How I Tested These Changes

Local dagster dev, navigate the app and make sure things that check permissions (like the assets table) are still correctly obtaining permissions