### PR TITLE
Clean up text styles and simplify text style names

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/ErrorBoundary.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/ErrorBoundary.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import {Box} from './Box';
 import {Colors} from './Color';
-import {Body, Subheading} from './Text';
+import {Body, Subtitle} from './Text';
 import {FontFamily} from './styles';
 
 export type ErrorCollectionContextValue = {
@@ -71,7 +71,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
           flex={{direction: 'column', gap: 8}}
           padding={16}
         >
-          <Subheading>Sorry, {this.props.region} can&apos;t be displayed.</Subheading>
+          <Subtitle>Sorry, {this.props.region} can&apos;t be displayed.</Subtitle>
           <Body color={Colors.textLight()}>{errorCollectionMessage}</Body>
           {errorStackIncluded && <Trace>{`${error.message}\n\n${error.stack}`}</Trace>}
         </Box>

--- a/js_modules/dagster-ui/packages/ui-components/src/components/NonIdealState.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/NonIdealState.tsx
@@ -4,7 +4,7 @@ import {Box} from './Box';
 import {Colors} from './Color';
 import {Icon, IconName} from './Icon';
 import {Spinner} from './Spinner';
-import {Subheading} from './Text';
+import {Subtitle} from './Text';
 
 export type NonIdealStateProps = React.DetailedHTMLProps<
   React.InputHTMLAttributes<HTMLInputElement>,
@@ -54,7 +54,7 @@ export const NonIdealState = ({
           grow: 1,
         }}
       >
-        {title && <Subheading style={{color: Colors.textDefault()}}>{title}</Subheading>}
+        {title && <Subtitle style={{color: Colors.textDefault()}}>{title}</Subtitle>}
         {description && <div style={{color: Colors.textDefault()}}>{description}</div>}
         {action}
       </Box>

--- a/js_modules/dagster-ui/packages/ui-components/src/components/ProductTour.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/ProductTour.tsx
@@ -7,7 +7,7 @@ import {Box} from './Box';
 import {Button} from './Button';
 import {Colors} from './Color';
 import {Popover} from './Popover';
-import {Subheading} from './Text';
+import {Subtitle} from './Text';
 
 export enum ProductTourPosition {
   TOP_LEFT = 'top-start',
@@ -89,7 +89,7 @@ export const ProductTour = ({
           <ProductTourContainer flex={{direction: 'column', gap: 4}} padding={16} style={{width}}>
             <Box flex={{direction: 'column', gap: 8}}>
               {media}
-              <Subheading style={{fontSize: '16px'}}>{title}</Subheading>
+              <Subtitle style={{fontSize: '16px'}}>{title}</Subtitle>
             </Box>
             <div>{description}</div>
             {actionsJsx}

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Text.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Text.tsx
@@ -12,80 +12,78 @@ const Text = styled.span<TextProps>`
 `;
 
 export const Title = styled(Text)`
-  font-size: 24px;
+  font-size: 32px;
+  line-height: 36px;
   font-weight: 600;
-  line-height: 30px;
   -webkit-font-smoothing: antialiased;
 `;
 
 export const Heading = styled(Text)`
-  font-size: 18px;
-  font-weight: 500;
+  font-size: 20px;
   line-height: 24px;
-  -webkit-font-smoothing: antialiased;
-`;
-
-export const Headline = styled(Text)`
-  font-size: 18px;
   font-weight: 500;
-  line-height: 24px;
   -webkit-font-smoothing: antialiased;
 `;
 
-export const Subheading = styled(Text)`
-  font-size: 14px;
-  font-weight: 600;
-  line-height: 20px;
-  -webkit-font-smoothing: antialiased;
-`;
-
-export const Subtitle1 = styled(Text)`
+export const SubtitleLarge = styled(Text)`
   font-size: 16px;
-  font-weight: 600;
-  line-height: 24px;
+  line-height: 20px;
+  font-weight: 500;
   -webkit-font-smoothing: antialiased;
 `;
 
-export const Subtitle2 = styled(Text)`
+export const Subtitle = styled(Text)`
   font-size: 14px;
-  font-weight: 600;
   line-height: 20px;
+  font-weight: 500;
   -webkit-font-smoothing: antialiased;
+`;
+
+export const SubtitleSmall = styled(Text)`
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 500;
+`;
+
+export const BodyLarge = styled(Text)`
+  font-size: 16px;
+  line-height: 20px;
+  font-weight: 400;
 `;
 
 export const Body = styled(Text)`
   font-family: ${FontFamily.default};
   font-size: 14px;
-`;
-
-export const Body1 = styled(Text)`
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 24px;
-`;
-
-export const Body2 = styled(Text)`
-  font-family: ${FontFamily.default};
   line-height: 20px;
-  font-size: 14px;
   font-weight: 400;
 `;
 
-export const Caption = styled(Text)`
+export const BodySmall = styled(Text)`
   font-family: ${FontFamily.default};
   font-size: 12px;
-`;
-
-export const CaptionSubtitle = styled(Text)`
-  font-size: 12px;
-  font-weight: 600;
   line-height: 16px;
+  font-weight: 400;
 `;
 
-export const CaptionBolded = styled(Text)`
-  font-family: ${FontFamily.default};
+export const MonoLarge = styled(Text)`
+  font-family: ${FontFamily.monospace};
+  font-size: 16px;
+  line-height: 20px;
+  font-weight: 400;
+`;
+
+export const Mono = styled(Text)`
+  font-family: ${FontFamily.monospace};
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+`;
+
+export const MonoSmall = styled(Text)`
+  font-family: ${FontFamily.monospace};
   font-size: 12px;
-  font-weight: 900;
+  line-height: 16px;
+  font-weight: 400;
 `;
 
 export const Code = styled(Text)`
@@ -96,12 +94,8 @@ export const Code = styled(Text)`
   padding: 2px 4px;
 `;
 
-export const Mono = styled(Text)`
-  font-family: ${FontFamily.monospace};
-  font-size: 14px;
-`;
-
-export const CaptionMono = styled(Text)`
-  font-family: ${FontFamily.monospace};
+//Depricated – Use BodySmall moving forward
+export const Caption = styled(Text)`
+  font-family: ${FontFamily.default};
   font-size: 12px;
 `;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Group.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Group.stories.tsx
@@ -5,7 +5,7 @@ import {Box} from '../Box';
 import {ButtonLink} from '../ButtonLink';
 import {Colors} from '../Color';
 import {Group} from '../Group';
-import {Body, Code, Heading, Subheading} from '../Text';
+import {Body, Code, Heading, Subtitle} from '../Text';
 import {AlignItems, FlexWrap, Spacing} from '../types';
 
 // eslint-disable-next-line import/no-default-export
@@ -119,7 +119,7 @@ export const PointerEventsTest = () => {
             relevant margins.
           </div>
         </Group>
-        <Subheading>Subheading</Subheading>
+        <Subtitle>Subtitle</Subtitle>
       </Group>
     </div>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/app/DagsterPlusLaunchPromotion.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/DagsterPlusLaunchPromotion.tsx
@@ -1,4 +1,11 @@
-import {Body1, Box, Button, Dialog, ExternalAnchorButton, Icon} from '@dagster-io/ui-components';
+import {
+  BodyLarge,
+  Box,
+  Button,
+  Dialog,
+  ExternalAnchorButton,
+  Icon,
+} from '@dagster-io/ui-components';
 import styled from 'styled-components';
 
 import dagster_plus from './dagster_plus.png';
@@ -30,10 +37,10 @@ export const DagsterPlusLaunchPromotion = () => {
       </ImageWrapper>
       <Box flex={{direction: 'column', alignItems: 'center'}} padding={24}>
         <Header>Introducing Dagster+</Header>
-        <Body1>
+        <BodyLarge>
           Join us on <span style={{fontWeight: 600}}>April 17 at 12 ET</span> for the unveiling of
           the next generation of Dagster Cloud.
-        </Body1>
+        </BodyLarge>
         <Box
           flex={{direction: 'row', alignItems: 'center', justifyContent: 'center', gap: 8}}
           padding={{top: 12}}

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/UserPreferences.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/UserPreferences.oss.tsx
@@ -5,7 +5,7 @@ import {
   DAGSTER_THEME_KEY,
   DagsterTheme,
   Icon,
-  Subheading,
+  Subtitle,
 } from '@dagster-io/ui-components';
 import React from 'react';
 
@@ -64,7 +64,7 @@ export const UserPreferences = ({
   return (
     <>
       <Box padding={{bottom: 4}}>
-        <Subheading>Preferences</Subheading>
+        <Subtitle>Preferences</Subtitle>
       </Box>
       <Box flex={{justifyContent: 'space-between', alignItems: 'center'}}>
         <div>Timezone</div>

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/UserSettingsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/UserSettingsDialog.tsx
@@ -5,7 +5,7 @@ import {
   Dialog,
   DialogBody,
   DialogFooter,
-  Subheading,
+  Subtitle,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
 
@@ -79,7 +79,7 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
         </Box>
         <Box padding={{top: 16}} border="top">
           <Box padding={{bottom: 8}}>
-            <Subheading>Experimental features</Subheading>
+            <Subtitle>Experimental features</Subtitle>
           </Box>
           {visibleFlags.map(({key, label, flagType}) => (
             <Box

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Group, Heading, Icon, Mono, Subheading} from '@dagster-io/ui-components';
+import {Box, Colors, Group, Heading, Icon, Mono, Subtitle} from '@dagster-io/ui-components';
 import {Link} from 'react-router-dom';
 
 import {AssetEventMetadataEntriesTable} from './AssetEventMetadataEntriesTable';
@@ -53,7 +53,7 @@ export const AssetEventDetail = ({
         padding={{vertical: 16}}
       >
         <Box flex={{gap: 4, direction: 'column'}}>
-          <Subheading>Event</Subheading>
+          <Subtitle>Event</Subtitle>
           {event.__typename === 'MaterializationEvent' ? (
             <Box flex={{gap: 4}}>
               <Icon name="materialization" />
@@ -68,7 +68,7 @@ export const AssetEventDetail = ({
         </Box>
         {event.partition && (
           <Box flex={{gap: 4, direction: 'column'}}>
-            <Subheading>Partition</Subheading>
+            <Subtitle>Partition</Subtitle>
             {hidePartitionLinks ? (
               event.partition
             ) : (
@@ -95,7 +95,7 @@ export const AssetEventDetail = ({
           </Box>
         )}
         <Box flex={{gap: 4, direction: 'column'}} style={{minHeight: 64}}>
-          <Subheading>Run</Subheading>
+          <Subtitle>Run</Subtitle>
           {run ? (
             <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
               <RunStatusWithStats runId={run.id} status={run.status} />
@@ -108,7 +108,7 @@ export const AssetEventDetail = ({
           )}
         </Box>
         <Box flex={{gap: 4, direction: 'column'}}>
-          <Subheading>Job</Subheading>
+          <Subtitle>Job</Subtitle>
           {run && !isHiddenAssetGroupJob(run.pipelineName) ? (
             <Box>
               <Box>
@@ -133,13 +133,13 @@ export const AssetEventDetail = ({
 
       {event.description && (
         <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
-          <Subheading>Description</Subheading>
+          <Subtitle>Description</Subtitle>
           <Description description={event.description} />
         </Box>
       )}
 
       <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
-        <Subheading>Metadata</Subheading>
+        <Subtitle>Metadata</Subtitle>
         <AssetEventMetadataEntriesTable
           repoAddress={repoAddress}
           assetKey={assetKey}
@@ -150,19 +150,19 @@ export const AssetEventDetail = ({
 
       {event.__typename === 'MaterializationEvent' && (
         <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
-          <Subheading>Source data</Subheading>
+          <Subtitle>Source data</Subtitle>
           <AssetMaterializationUpstreamData timestamp={event.timestamp} assetKey={assetKey} />
         </Box>
       )}
 
       <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
-        <Subheading>System tags</Subheading>
+        <Subtitle>System tags</Subtitle>
         <AssetEventSystemTags event={event} collapsible />
       </Box>
 
       {assetLineage.length > 0 && (
         <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
-          <Subheading>Parent materializations</Subheading>
+          <Subtitle>Parent materializations</Subtitle>
           <AssetLineageElements elements={assetLineage} timestamp={event.timestamp} />
         </Box>
       )}
@@ -185,18 +185,18 @@ export const AssetEventDetailEmpty = () => (
       padding={{vertical: 16}}
     >
       <Box flex={{gap: 4, direction: 'column'}}>
-        <Subheading>Event</Subheading>
+        <Subtitle>Event</Subtitle>
       </Box>
       <Box flex={{gap: 4, direction: 'column'}} style={{minHeight: 64}}>
-        <Subheading>Run</Subheading>—
+        <Subtitle>Run</Subtitle>—
       </Box>
       <Box flex={{gap: 4, direction: 'column'}}>
-        <Subheading>Job</Subheading>—
+        <Subtitle>Job</Subtitle>—
       </Box>
     </Box>
 
     <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
-      <Subheading>Metadata</Subheading>
+      <Subtitle>Metadata</Subtitle>
       <AssetEventMetadataEntriesTable event={null} repoAddress={null} showDescriptions />
     </Box>
   </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
@@ -10,7 +10,7 @@ import {
   MenuItem,
   Popover,
   Spinner,
-  Subheading,
+  Subtitle,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
 
@@ -124,7 +124,7 @@ export const AssetEvents = ({
           padding={{vertical: 16, horizontal: 24}}
           style={{marginBottom: -1}}
         >
-          <Subheading>Asset Events</Subheading>
+          <Subtitle>Asset Events</Subtitle>
           <div style={{margin: '-6px 0 '}}>
             <ButtonGroup
               activeItems={new Set([xAxis])}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMaterializationGraphs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMaterializationGraphs.tsx
@@ -4,7 +4,7 @@ import {
   Colors,
   ExternalAnchorButton,
   NonIdealState,
-  Subheading,
+  Subtitle,
 } from '@dagster-io/ui-components';
 import flatMap from 'lodash/flatMap';
 import uniq from 'lodash/uniq';
@@ -60,7 +60,7 @@ export const AssetMaterializationGraphs = (props: {
                   border="bottom"
                   flex={{justifyContent: 'space-between'}}
                 >
-                  <Subheading>{label}</Subheading>
+                  <Subtitle>{label}</Subtitle>
                 </Box>
               )}
               <Box padding={{horizontal: 24, vertical: 16}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeDefinition.tsx
@@ -7,7 +7,7 @@ import {
   ConfigTypeSchema,
   Icon,
   Mono,
-  Subheading,
+  Subtitle,
 } from '@dagster-io/ui-components';
 import {Link} from 'react-router-dom';
 
@@ -72,7 +72,7 @@ export const AssetNodeDefinition = ({
             border="bottom"
             flex={{justifyContent: 'space-between', gap: 8}}
           >
-            <Subheading>Description</Subheading>
+            <Subtitle>Description</Subtitle>
             <DescriptionAnnotations assetNode={assetNode} repoAddress={repoAddress} />
           </Box>
           <Box
@@ -88,7 +88,7 @@ export const AssetNodeDefinition = ({
           {assetNode.opVersion && (
             <>
               <Box padding={{vertical: 16, horizontal: 24}} border="top-and-bottom">
-                <Subheading>Code version</Subheading>
+                <Subtitle>Code version</Subtitle>
               </Box>
               <Box padding={{vertical: 16, horizontal: 24}} flex={{gap: 12, alignItems: 'center'}}>
                 <Version>{assetNode.opVersion}</Version>
@@ -99,7 +99,7 @@ export const AssetNodeDefinition = ({
           {assetNode.freshnessPolicy && (
             <>
               <Box padding={{vertical: 16, horizontal: 24}} border="top-and-bottom">
-                <Subheading>Freshness policy</Subheading>
+                <Subtitle>Freshness policy</Subtitle>
               </Box>
               <Box
                 padding={{vertical: 16, horizontal: 24}}
@@ -116,7 +116,7 @@ export const AssetNodeDefinition = ({
           {assetNode.backfillPolicy && (
             <>
               <Box padding={{vertical: 16, horizontal: 24}} border="top-and-bottom">
-                <Subheading>Backfill policy</Subheading>
+                <Subtitle>Backfill policy</Subtitle>
               </Box>
               <Box
                 padding={{vertical: 16, horizontal: 24}}
@@ -132,9 +132,7 @@ export const AssetNodeDefinition = ({
             border="top-and-bottom"
             flex={{justifyContent: 'space-between', gap: 8}}
           >
-            <Subheading>
-              Upstream assets{upstream?.length ? ` (${upstream.length})` : ''}
-            </Subheading>
+            <Subtitle>Upstream assets{upstream?.length ? ` (${upstream.length})` : ''}</Subtitle>
             <Link to="?view=lineage&lineageScope=upstream">
               <Box flex={{gap: 4, alignItems: 'center'}}>
                 View upstream graph
@@ -153,9 +151,9 @@ export const AssetNodeDefinition = ({
             border="top-and-bottom"
             flex={{justifyContent: 'space-between', gap: 8}}
           >
-            <Subheading>
+            <Subtitle>
               Downstream assets{downstream?.length ? ` (${downstream.length})` : ''}
-            </Subheading>
+            </Subtitle>
           </Box>
           <AssetNodeList items={downstream} />
           {/** Ensures the line between the left and right columns goes to the bottom of the page */}
@@ -165,7 +163,7 @@ export const AssetNodeDefinition = ({
         <Box border="left-and-right" style={{flex: 0.5, minWidth: 0}} flex={{direction: 'column'}}>
           <>
             <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
-              <Subheading>Required resources</Subheading>
+              <Subtitle>Required resources</Subtitle>
             </Box>
             <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
               {[...assetNode.requiredResources]
@@ -202,7 +200,7 @@ export const AssetNodeDefinition = ({
 
           <>
             <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
-              <Subheading>Config</Subheading>
+              <Subtitle>Config</Subtitle>
             </Box>
             <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
               {assetConfigSchema ? (
@@ -225,7 +223,7 @@ export const AssetNodeDefinition = ({
 
           <>
             <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
-              <Subheading>Type</Subheading>
+              <Subtitle>Type</Subtitle>
             </Box>
             {assetType && assetType.displayName !== 'Any' ? (
               <DagsterTypeSummary type={assetType} />
@@ -247,7 +245,7 @@ export const AssetNodeDefinition = ({
               border="top-and-bottom"
               flex={{justifyContent: 'space-between', gap: 8}}
             >
-              <Subheading>Metadata</Subheading>
+              <Subtitle>Metadata</Subtitle>
             </Box>
             <Box style={{flex: 1}}>
               {assetMetadata.length > 0 ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -1,7 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import {
   Body,
-  Body2,
   Box,
   Button,
   ButtonLink,
@@ -12,7 +11,7 @@ import {
   MiddleTruncate,
   NonIdealState,
   Skeleton,
-  Subtitle2,
+  Subtitle,
   Tag,
 } from '@dagster-io/ui-components';
 import dayjs from 'dayjs';
@@ -121,7 +120,7 @@ export const AssetNodeOverview = ({
     <Box flex={{direction: 'column', gap: 16}}>
       <Box flex={{direction: 'row'}}>
         <Box flex={{direction: 'column', gap: 6}} style={{width: '50%'}}>
-          <Subtitle2>Latest {assetNode?.isSource ? 'observation' : 'materialization'}</Subtitle2>
+          <Subtitle>Latest {assetNode?.isSource ? 'observation' : 'materialization'}</Subtitle>
           <Box flex={{gap: 8, alignItems: 'center'}}>
             {liveData ? (
               <SimpleStakeholderAssetStatus liveData={liveData} assetNode={assetNode} />
@@ -135,7 +134,7 @@ export const AssetNodeOverview = ({
         </Box>
         {liveData?.assetChecks.length ? (
           <Box flex={{direction: 'column', gap: 6}} style={{width: '50%'}}>
-            <Subtitle2>Check results</Subtitle2>
+            <Subtitle>Check results</Subtitle>
             <AssetChecksStatusSummary
               liveData={liveData}
               rendering="tags"
@@ -176,7 +175,7 @@ export const AssetNodeOverview = ({
 
       <Box flex={{direction: 'row'}}>
         <Box flex={{direction: 'column', gap: 6}} style={{width: '50%'}}>
-          <Subtitle2>Upstream assets</Subtitle2>
+          <Subtitle>Upstream assets</Subtitle>
           {upstream?.length ? (
             <AssetLinksWithStatus assets={upstream} />
           ) : (
@@ -186,7 +185,7 @@ export const AssetNodeOverview = ({
           )}
         </Box>
         <Box flex={{direction: 'column', gap: 6}} style={{width: '50%'}}>
-          <Subtitle2>Downstream assets</Subtitle2>
+          <Subtitle>Downstream assets</Subtitle>
           {downstream?.length ? (
             <AssetLinksWithStatus assets={downstream} />
           ) : (
@@ -505,15 +504,15 @@ const AttributeAndValue = ({
 
   return (
     <Box flex={{direction: 'column', gap: 6, alignItems: 'flex-start'}}>
-      <Subtitle2>{label}</Subtitle2>
-      <Body2 style={{maxWidth: '100%'}}>
+      <Subtitle>{label}</Subtitle>
+      <Body style={{maxWidth: '100%'}}>
         <Box flex={{gap: 4, wrap: 'wrap'}}>{children}</Box>
-      </Body2>
+      </Body>
     </Box>
   );
 };
 
-const NoValue = () => <Body2 color={Colors.textLighter()}>–</Body2>;
+const NoValue = () => <Body color={Colors.textLighter()}>–</Body>;
 
 export const AssetNodeOverviewNonSDA = ({
   assetKey,
@@ -619,8 +618,8 @@ const SectionEmptyState = ({
     style={{background: Colors.backgroundLight(), borderRadius: 8}}
     flex={{direction: 'column', gap: 8}}
   >
-    <Subtitle2>{title}</Subtitle2>
-    <Body2>{description}</Body2>
+    <Subtitle>{title}</Subtitle>
+    <Body>{description}</Body>
     {learnMoreLink ? (
       <a href={learnMoreLink} target="_blank" rel="noreferrer">
         Learn more

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
@@ -9,7 +9,7 @@ import {
   MiddleTruncate,
   Mono,
   Spinner,
-  Subheading,
+  Subtitle,
   Tag,
 } from '@dagster-io/ui-components';
 import {useMemo} from 'react';
@@ -294,7 +294,7 @@ export const AssetPartitionDetail = ({
       >
         {!latest ? (
           <Box flex={{gap: 4, direction: 'column'}}>
-            <Subheading>Latest materialization</Subheading>
+            <Subtitle>Latest materialization</Subtitle>
             <Box flex={{gap: 4}}>
               <Icon name="materialization" />
               None
@@ -302,11 +302,11 @@ export const AssetPartitionDetail = ({
           </Box>
         ) : (
           <Box flex={{gap: 4, direction: 'column'}}>
-            <Subheading>
+            <Subtitle>
               {latest.__typename === 'MaterializationEvent'
                 ? 'Latest materialization'
                 : 'Latest observation'}
-            </Subheading>
+            </Subtitle>
             <Box flex={{gap: 4}} style={{whiteSpace: 'nowrap'}}>
               {latest.__typename === 'MaterializationEvent' ? (
                 <Icon name="materialization" />
@@ -318,7 +318,7 @@ export const AssetPartitionDetail = ({
           </Box>
         )}
         <Box flex={{gap: 4, direction: 'column'}}>
-          <Subheading>Run</Subheading>
+          <Subtitle>Run</Subtitle>
           {latestEventRun && latest ? (
             <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
               <RunStatusWithStats runId={latestEventRun.id} status={latestEventRun.status} />
@@ -331,7 +331,7 @@ export const AssetPartitionDetail = ({
           )}
         </Box>
         <Box flex={{gap: 4, direction: 'column'}}>
-          <Subheading>Job</Subheading>
+          <Subtitle>Job</Subtitle>
           {latest && latestEventRun && !isHiddenAssetGroupJob(latestEventRun.pipelineName) ? (
             <Box>
               <Box>
@@ -364,7 +364,7 @@ export const AssetPartitionDetail = ({
         </Box>
       </Box>
       <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
-        <Subheading>Metadata</Subheading>
+        <Subtitle>Metadata</Subtitle>
         <AssetEventMetadataEntriesTable
           event={latest}
           observations={observationsAboutLatest}
@@ -373,11 +373,11 @@ export const AssetPartitionDetail = ({
         />
       </Box>
       <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
-        <Subheading>Source data</Subheading>
+        <Subtitle>Source data</Subtitle>
         <AssetMaterializationUpstreamData timestamp={latest?.timestamp} assetKey={assetKey} />
       </Box>
       <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
-        <Subheading>System tags</Subheading>
+        <Subtitle>System tags</Subtitle>
         <AssetEventSystemTags event={latest} collapsible />
       </Box>
     </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
@@ -6,7 +6,7 @@ import {
   MenuItem,
   Popover,
   Spinner,
-  Subheading,
+  Subtitle,
   Tooltip,
 } from '@dagster-io/ui-components';
 import isEqual from 'lodash/isEqual';
@@ -240,7 +240,7 @@ export const AssetPartitions = ({
                   {selection.dimension.name !== 'default' && (
                     <Box flex={{gap: 8, alignItems: 'center'}}>
                       <Icon name="partition" />
-                      <Subheading>{selection.dimension.name}</Subheading>
+                      <Subtitle>{selection.dimension.name}</Subtitle>
                     </Box>
                   )}
                 </div>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPlotsPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPlotsPage.tsx
@@ -1,4 +1,4 @@
-import {Box, Subheading} from '@dagster-io/ui-components';
+import {Box, Subtitle} from '@dagster-io/ui-components';
 import {useEffect} from 'react';
 
 import {AssetPlots} from './AssetPlots';
@@ -18,7 +18,7 @@ export const AssetPlotsPage = (props: React.ComponentProps<typeof AssetPlots>) =
         padding={{vertical: 16, left: 24, right: 12}}
         style={{marginBottom: -1}}
       >
-        <Subheading>Asset plots</Subheading>
+        <Subtitle>Asset plots</Subtitle>
       </Box>
       <AssetPlots {...props} />
     </div>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeLeftPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeLeftPanel.tsx
@@ -1,12 +1,12 @@
 import {
-  Body2,
+  Body,
   Box,
   Caption,
   Colors,
   CursorPaginationControls,
   Icon,
   MiddleTruncate,
-  Subtitle1,
+  SubtitleLarge,
 } from '@dagster-io/ui-components';
 import React from 'react';
 import {Link} from 'react-router-dom';
@@ -77,7 +77,7 @@ export const AutomaterializeLeftList = (props: ListProps) => {
   return (
     <Box flex={{grow: 1, direction: 'column'}}>
       <Box padding={{vertical: 12, horizontal: 24}} border="bottom">
-        <Subtitle1>Evaluations</Subtitle1>
+        <SubtitleLarge>Evaluations</SubtitleLarge>
       </Box>
       <Box
         padding={{bottom: 8, horizontal: 12}}
@@ -87,7 +87,7 @@ export const AutomaterializeLeftList = (props: ListProps) => {
         <Box border="bottom" padding={{top: 8, bottom: 12, left: 12, right: 8}}>
           <Box flex={{alignItems: 'center', gap: 4}}>
             <Icon name="sensors" color={Colors.accentBlue()} />
-            <Body2>
+            <Body>
               {repoAddress && sensorName ? (
                 <Link
                   to={workspacePathFromAddress(repoAddress, `/sensors/${sensorName}`)}
@@ -98,7 +98,7 @@ export const AutomaterializeLeftList = (props: ListProps) => {
               ) : (
                 <Link to="/overview/automation">{sensorName ?? 'Automation'}</Link>
               )}
-            </Body2>
+            </Body>
           </Box>
         </Box>
         <Box flex={{direction: 'column', gap: 8}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
@@ -1,7 +1,7 @@
 import {gql, useQuery} from '@apollo/client';
 import {
   BaseTag,
-  Body2,
+  Body,
   Box,
   Colors,
   Icon,
@@ -9,8 +9,7 @@ import {
   MiddleTruncate,
   NonIdealState,
   Popover,
-  Subheading,
-  Subtitle2,
+  Subtitle,
   Tag,
   TagSelectorContainer,
   TagSelectorDefaultTagTooltipStyle,
@@ -118,7 +117,7 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
           padding={{horizontal: 16}}
           flex={{alignItems: 'center', justifyContent: 'space-between'}}
         >
-          <Subheading>Result</Subheading>
+          <Subtitle>Result</Subtitle>
         </Box>
       </Box>
     );
@@ -168,12 +167,12 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
             icon="sensors"
             title="No evaluations"
             description={
-              <Body2>
+              <Body>
                 <Box flex={{direction: 'column', gap: 8}}>
-                  <Body2>
+                  <Body>
                     This asset’s automation policy has not been evaluated yet. Make sure your
                     automation sensor is running.
-                  </Body2>
+                  </Body>
                   <div>
                     <AnchorButton
                       to={
@@ -189,7 +188,7 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
                     Learn more about automation policies
                   </a>
                 </Box>
-              </Body2>
+              </Body>
             }
           />
         </Box>
@@ -326,24 +325,24 @@ export const AutomaterializeMiddlePanelWithData = ({
         border="bottom"
         flex={{alignItems: 'center', justifyContent: 'space-between'}}
       >
-        <Subheading>Result</Subheading>
+        <Subtitle>Result</Subtitle>
       </Box>
       {selectedEvaluation ? (
         <Box padding={{horizontal: 24, vertical: 12}}>
           <Box border="bottom" padding={{vertical: 12}} margin={{bottom: 12}}>
             <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 24}}>
               <Box flex={{direction: 'column', gap: 5}}>
-                <Subtitle2>Evaluation result</Subtitle2>
+                <Subtitle>Evaluation result</Subtitle>
                 <div>{statusTag}</div>
               </Box>
               {selectedEvaluation?.timestamp ? (
                 <Box flex={{direction: 'column', gap: 5}}>
-                  <Subtitle2>Timestamp</Subtitle2>
+                  <Subtitle>Timestamp</Subtitle>
                   <Timestamp timestamp={{unix: selectedEvaluation?.timestamp}} />
                 </Box>
               ) : null}
               <Box flex={{direction: 'column', gap: 5}}>
-                <Subtitle2>Duration</Subtitle2>
+                <Subtitle>Duration</Subtitle>
                 <div>
                   {selectedEvaluation?.startTimestamp && selectedEvaluation?.endTimestamp
                     ? formatElapsedTimeWithMsec(
@@ -356,11 +355,11 @@ export const AutomaterializeMiddlePanelWithData = ({
             </div>
           </Box>
           <Box border="bottom" padding={{vertical: 12}} margin={{vertical: 12}}>
-            <Subtitle2>Runs launched ({selectedEvaluation.runIds.length})</Subtitle2>
+            <Subtitle>Runs launched ({selectedEvaluation.runIds.length})</Subtitle>
           </Box>
           <AutomaterializeRunsTable runIds={selectedEvaluation.runIds} />
           <Box border="bottom" padding={{vertical: 12}}>
-            <Subtitle2>Policy evaluation</Subtitle2>
+            <Subtitle>Policy evaluation</Subtitle>
           </Box>
           {definition?.partitionDefinition ? (
             <Box padding={{vertical: 12}} flex={{justifyContent: 'flex-end'}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRunsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRunsTable.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Body2, Box, Colors, Mono, Table} from '@dagster-io/ui-components';
+import {Body, Box, Colors, Mono, Table} from '@dagster-io/ui-components';
 import {Link} from 'react-router-dom';
 
 import {
@@ -26,14 +26,14 @@ export const AutomaterializeRunsTable = ({runIds}: {runIds: string[]}) => {
 
   if (!runIds.length) {
     return (
-      <Body2 color={Colors.textLighter()} style={{paddingBottom: 32}}>
+      <Body color={Colors.textLighter()} style={{paddingBottom: 32}}>
         None
-      </Body2>
+      </Body>
     );
   }
 
   if (error) {
-    return <Body2>An error occurred fetching runs. Check your network status</Body2>;
+    return <Body>An error occurred fetching runs. Check your network status</Body>;
   }
 
   if (loading || !data) {
@@ -45,7 +45,7 @@ export const AutomaterializeRunsTable = ({runIds}: {runIds: string[]}) => {
   }
 
   if (data.runsOrError.__typename === 'InvalidPipelineRunsFilterError') {
-    return <Body2>{data.runsOrError.message}</Body2>;
+    return <Body>{data.runsOrError.message}</Body>;
   }
 
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/CollapsibleSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/CollapsibleSection.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Icon, Subheading, Tooltip} from '@dagster-io/ui-components';
+import {Box, Colors, Icon, Subtitle, Tooltip} from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled from 'styled-components';
 
@@ -21,7 +21,7 @@ export const CollapsibleSection = ({header, details, headerRightSide, children}:
           }}
         >
           <Box flex={{direction: 'row', alignItems: 'center', gap: 8, grow: 1}}>
-            <Subheading>{header}</Subheading>
+            <Subtitle>{header}</Subtitle>
             {details ? (
               <Tooltip content={details} placement="top">
                 <Icon color={Colors.accentGray()} name="info" />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/ChangedReasons.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/ChangedReasons.tsx
@@ -4,7 +4,7 @@ import {
   Colors,
   Icon,
   Popover,
-  Subtitle2,
+  Subtitle,
   Tag,
   ifPlural,
 } from '@dagster-io/ui-components';
@@ -70,10 +70,10 @@ export const ChangedReasonsPopover = ({
       content={
         <Box flex={{direction: 'column'}}>
           <Box padding={{horizontal: 12, vertical: 8}} border="bottom">
-            <Subtitle2>
+            <Subtitle>
               {numberFormatter.format(modifiedChanges.length)}{' '}
               {ifPlural(modifiedChanges.length, 'change', 'changes')} in this branch
-            </Subtitle2>
+            </Subtitle>
           </Box>
           {modifiedChanges.map((change) => {
             return (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LargeCollapsibleSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LargeCollapsibleSection.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import {Collapse} from '@blueprintjs/core';
-import {Box, Icon, IconName, Subtitle1, UnstyledButton} from '@dagster-io/ui-components';
+import {Box, Icon, IconName, SubtitleLarge, UnstyledButton} from '@dagster-io/ui-components';
 import React from 'react';
 
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
@@ -39,10 +39,12 @@ export const LargeCollapsibleSection = ({
           border="bottom"
         >
           {icon && <Icon size={20} name={icon} />}
-          <Subtitle1 style={{flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis'}}>
+          <SubtitleLarge
+            style={{flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis'}}
+          >
             {header}
             {count !== undefined ? ` (${count.toLocaleString()})` : ''}
-          </Subtitle1>
+          </SubtitleLarge>
           {right}
           <Icon
             name="arrow_drop_down"

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -13,7 +13,7 @@ import {
   DialogHeader,
   Icon,
   RadioContainer,
-  Subheading,
+  Subtitle,
   Tooltip,
 } from '@dagster-io/ui-components';
 import reject from 'lodash/reject';
@@ -461,7 +461,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
             isInitiallyOpen={true}
             title={
               <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
-                <Subheading>Partition selection</Subheading>
+                <Subtitle>Partition selection</Subtitle>
                 <span>All partitions</span>
               </Box>
             }
@@ -482,7 +482,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
             isInitiallyOpen={true}
             title={
               <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
-                <Subheading>Partition selection</Subheading>
+                <Subtitle>Partition selection</Subtitle>
                 {target.type === 'pureWithAnchorAsset' ? (
                   <span /> // we won't know until runtime
                 ) : (
@@ -498,7 +498,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
                 data-testid={testId('anchor-asset-label')}
               >
                 <Icon name="asset" />
-                <Subheading>{displayNameForAssetKey(target.anchorAssetKey)}</Subheading>
+                <Subtitle>{displayNameForAssetKey(target.anchorAssetKey)}</Subtitle>
               </Box>
             )}
             {selections.map((range, idx) => (
@@ -507,7 +507,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
                 border={idx < selections.length - 1 ? 'bottom' : undefined}
                 padding={{vertical: 12, horizontal: 20}}
               >
-                <Box as={Subheading} flex={{alignItems: 'center', gap: 8}}>
+                <Box as={Subtitle} flex={{alignItems: 'center', gap: 8}}>
                   <Icon name="partition" />
                   {range.dimension.name}
                 </Box>
@@ -550,7 +550,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
         <ToggleableSection
           title={
             <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
-              <Subheading>Tags</Subheading>
+              <Subtitle>Tags</Subtitle>
               <span>{tags.length} tags</span>
             </Box>
           }
@@ -588,7 +588,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
         {target.type === 'job' && (
           <ToggleableSection
             isInitiallyOpen={true}
-            title={<Subheading data-testid={testId('backfill-options')}>Options</Subheading>}
+            title={<Subtitle data-testid={testId('backfill-options')}>Options</Subtitle>}
           >
             <Box padding={{vertical: 16, horizontal: 20}} flex={{direction: 'column', gap: 12}}>
               <Checkbox
@@ -600,7 +600,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
               />
               {showSingleRunBackfillToggle ? (
                 <RadioContainer>
-                  <Subheading>Launch as...</Subheading>
+                  <Subtitle>Launch as...</Subtitle>
                   <Radio
                     data-testid={testId('ranges-as-tags-true-radio')}
                     checked={canLaunchWithRangesAsTags && launchWithRangesAsTags}
@@ -826,7 +826,7 @@ const Warnings = ({
         >
           <Box flex={{alignItems: 'center', gap: 12}}>
             <Icon name="warning" color={Colors.textYellow()} />
-            <Subheading>Warnings</Subheading>
+            <Subtitle>Warnings</Subtitle>
           </Box>
           <span>{alerts.length > 1 ? `${alerts.length} warnings` : `1 warning`}</span>
         </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
@@ -5,7 +5,7 @@ import {
   Icon,
   Popover,
   Spinner,
-  Subtitle2,
+  Subtitle,
   Tag,
   useViewport,
 } from '@dagster-io/ui-components';
@@ -121,7 +121,7 @@ export const RecentUpdatesTimeline = ({
   if (loading) {
     return (
       <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
-        <Subtitle2>Recent updates</Subtitle2>
+        <Subtitle>Recent updates</Subtitle>
         <Spinner purpose="body-text" />
       </Box>
     );
@@ -130,7 +130,7 @@ export const RecentUpdatesTimeline = ({
   if (!materializations?.length) {
     return (
       <Box flex={{direction: 'column', gap: 8}}>
-        <Subtitle2>Recent updates</Subtitle2>
+        <Subtitle>Recent updates</Subtitle>
         <Caption color={Colors.textLight()}>No materialization events found</Caption>
       </Box>
     );
@@ -139,7 +139,7 @@ export const RecentUpdatesTimeline = ({
   return (
     <Box flex={{direction: 'column', gap: 4}}>
       <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
-        <Subtitle2>Recent updates</Subtitle2>
+        <Subtitle>Recent updates</Subtitle>
         <Caption color={Colors.textLighter()}>
           {materializations.length === 100
             ? 'Last 100 updates'
@@ -181,7 +181,7 @@ export const RecentUpdatesTimeline = ({
                     content={
                       <Box flex={{direction: 'column', gap: 8}}>
                         <Box padding={8} border="bottom">
-                          <Subtitle2>Updates</Subtitle2>
+                          <Subtitle>Updates</Subtitle>
                         </Box>
                         <div style={{maxHeight: 'min(80vh, 300px)', overflow: 'scroll'}}>
                           {bucket.materializations

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
@@ -4,11 +4,11 @@ import {
   Box,
   ButtonLink,
   Caption,
-  CaptionSubtitle,
   Colors,
   Icon,
   Popover,
-  Subtitle2,
+  Subtitle,
+  SubtitleSmall,
   Tag,
   ifPlural,
 } from '@dagster-io/ui-components';
@@ -203,10 +203,10 @@ const StaleCausesPopoverSummary = ({
   return (
     <Box flex={{direction: 'column'}} style={{maxHeight: 300, overflowY: 'auto'}}>
       <Box padding={{horizontal: 12, vertical: 8}} border="bottom">
-        <Subtitle2>
+        <Subtitle>
           {numberFormatter.format(totalCauses)} {ifPlural(totalCauses, 'change', 'changes')} since
           last materialization
-        </Subtitle2>
+        </Subtitle>
       </Box>
       {Object.entries(grouped).map(([label, causes], idx) => {
         const isSelf = isEqual(assetKey.path, causes[0]!.key.path);
@@ -216,9 +216,9 @@ const StaleCausesPopoverSummary = ({
               padding={{horizontal: 12, vertical: 8}}
               border={idx === 0 ? 'bottom' : 'top-and-bottom'}
             >
-              <CaptionSubtitle>
+              <SubtitleSmall>
                 {getCollapsedHeaderLabel(isSelf, causes[0]!.category, causes.length)}
-              </CaptionSubtitle>
+              </SubtitleSmall>
             </Box>
             {causes.map((cause, idx) => (
               <Box

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckDetailModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckDetailModal.tsx
@@ -1,6 +1,6 @@
 import {gql} from '@apollo/client';
 import {
-  Body2,
+  Body,
   Box,
   Button,
   Colors,
@@ -100,10 +100,10 @@ export function MigrationRequired() {
         title="Migration required"
         description={
           <Box flex={{direction: 'column'}}>
-            <Body2 color={Colors.textLight()} style={{padding: '6px 0'}}>
+            <Body color={Colors.textLight()} style={{padding: '6px 0'}}>
               A database schema migration is required to use asset checks. Run{' '}
               <Mono>dagster instance migrate</Mono>.
-            </Body2>
+            </Body>
           </Box>
         }
       />
@@ -119,10 +119,10 @@ export function AgentUpgradeRequired() {
         title="Agent upgrade required"
         description={
           <Box flex={{direction: 'column'}}>
-            <Body2 color={Colors.textLight()} style={{padding: '6px 0'}}>
+            <Body color={Colors.textLight()} style={{padding: '6px 0'}}>
               Checks require Dagster Cloud Agent version 1.5 or higher. Upgrade your agent(s) to use
               checks.
-            </Body2>
+            </Body>
           </Box>
         }
       />
@@ -138,10 +138,10 @@ export function NeedsUserCodeUpgrade() {
         title="Upgrade required"
         description={
           <Box flex={{direction: 'column'}}>
-            <Body2 color={Colors.textLight()} style={{padding: '6px 0'}}>
+            <Body color={Colors.textLight()} style={{padding: '6px 0'}}>
               Checks aren&apos;t supported with dagster versions before 1.5. Upgrade the dagster
               library in this code location to use them.
-            </Body2>
+            </Body>
           </Box>
         }
       />
@@ -157,10 +157,10 @@ export function NoChecks() {
         title="No checks found for this asset"
         description={
           <Box flex={{direction: 'column'}}>
-            <Body2 color={Colors.textLight()} style={{padding: '6px 0'}}>
+            <Body color={Colors.textLight()} style={{padding: '6px 0'}}>
               Asset Checks run after a materialization and can verify a particular property of a
               data asset. Checks can help ensure that the contents of each data asset is correct.
-            </Body2>
+            </Body>
             {/* <Box
               as="a"
               href="https://docs.dagster.io/concepts/assets/asset-checks"

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -1,6 +1,6 @@
 import {gql, useQuery} from '@apollo/client';
 import {
-  Body2,
+  Body,
   Box,
   Caption,
   CollapsibleSection,
@@ -9,8 +9,8 @@ import {
   Icon,
   NonIdealState,
   Spinner,
-  Subtitle1,
-  Subtitle2,
+  Subtitle,
+  SubtitleLarge,
   Table,
   TextInput,
   useViewport,
@@ -140,10 +140,10 @@ export const AssetChecks = ({
           icon="asset_check"
           description={
             <Box flex={{direction: 'column', gap: 6}}>
-              <Body2>
+              <Body>
                 Asset checks can verify properties of a data asset, e.g. that there are no null
                 values in a particular column.
-              </Body2>
+              </Body>
               <a href="https://docs.dagster.io/concepts/assets/asset-checks">
                 Learn more about asset checks
               </a>
@@ -167,9 +167,9 @@ export const AssetChecks = ({
             flex={{justifyContent: 'space-between', alignItems: 'center'}}
             padding={{left: 24, vertical: 12, right: 12}}
           >
-            <Subtitle1>
+            <SubtitleLarge>
               Checks {checks.length ? <>({numberFormatter.format(checks.length)})</> : null}
-            </Subtitle1>
+            </SubtitleLarge>
             <ExecuteChecksButton assetNode={assetNode} checks={checks} />
           </Box>
           <Box
@@ -208,7 +208,7 @@ export const AssetChecks = ({
                             >
                               {getCheckIcon(check)}
                             </Box>
-                            <Body2>{check.name}</Body2>
+                            <Body>{check.name}</Body>
                           </Box>
                           <Box padding={{horizontal: 24}}>
                             <Caption
@@ -236,7 +236,7 @@ export const AssetChecks = ({
           >
             <Box flex={{direction: 'row', gap: 6, alignItems: 'center'}}>
               <Icon name="asset_check" />
-              <Subtitle1>{selectedCheck.name}</Subtitle1>
+              <SubtitleLarge>{selectedCheck.name}</SubtitleLarge>
             </Box>
             <ExecuteChecksButton assetNode={assetNode} checks={[selectedCheck]} label="Execute" />
           </Box>
@@ -245,16 +245,16 @@ export const AssetChecks = ({
             padding={{horizontal: 24, vertical: 12}}
           >
             <CollapsibleSection
-              header={<Subtitle2>About</Subtitle2>}
+              header={<Subtitle>About</Subtitle>}
               headerWrapperProps={headerWrapperProps}
               arrowSide="right"
             >
               <Box padding={{top: 12}} flex={{gap: 12, direction: 'column'}}>
-                <Body2>
+                <Body>
                   {selectedCheck.description ?? (
                     <Caption color={Colors.textLight()}>No description provided</Caption>
                   )}
-                </Body2>
+                </Body>
                 {/* {selectedCheck.dependencies?.length ? (
                   <Box flex={{direction: 'row', gap: 6}}>
                     {assetNode.dependencies.map((dep) => {
@@ -272,7 +272,7 @@ export const AssetChecks = ({
               </Box>
             </CollapsibleSection>
             <CollapsibleSection
-              header={<Subtitle2>Latest execution</Subtitle2>}
+              header={<Subtitle>Latest execution</Subtitle>}
               headerWrapperProps={headerWrapperProps}
               arrowSide="right"
             >
@@ -284,7 +284,7 @@ export const AssetChecks = ({
               <Box padding={{top: 12}} flex={{direction: 'column', gap: 12}}>
                 <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 24}}>
                   <Box flex={{direction: 'column', gap: 6}}>
-                    <Subtitle2>Evaluation result</Subtitle2>
+                    <Subtitle>Evaluation result</Subtitle>
                     <div>
                       <AssetCheckStatusTag
                         execution={selectedCheck.executionForLatestMaterialization}
@@ -293,7 +293,7 @@ export const AssetChecks = ({
                   </Box>
                   {lastExecution ? (
                     <Box flex={{direction: 'column', gap: 6}}>
-                      <Subtitle2>Timestamp</Subtitle2>
+                      <Subtitle>Timestamp</Subtitle>
                       <Link
                         to={linkToRunEvent(
                           {id: lastExecution.runId},
@@ -306,7 +306,7 @@ export const AssetChecks = ({
                   ) : null}
                   {targetMaterialization ? (
                     <Box flex={{direction: 'column', gap: 6}}>
-                      <Subtitle2>Target materialization</Subtitle2>
+                      <Subtitle>Target materialization</Subtitle>
                       <Link to={`/runs/${targetMaterialization.runId}`}>
                         <Timestamp timestamp={{unix: targetMaterialization.timestamp}} />
                       </Link>
@@ -315,14 +315,14 @@ export const AssetChecks = ({
                 </div>
                 {lastExecution?.evaluation?.metadataEntries.length ? (
                   <Box flex={{direction: 'column', gap: 6}}>
-                    <Subtitle2>Metadata</Subtitle2>
+                    <Subtitle>Metadata</Subtitle>
                     <MetadataEntries entries={lastExecution.evaluation.metadataEntries} />
                   </Box>
                 ) : null}
               </Box>
             </CollapsibleSection>
             <CollapsibleSection
-              header={<Subtitle2>Execution history</Subtitle2>}
+              header={<Subtitle>Execution history</Subtitle>}
               headerWrapperProps={headerWrapperProps}
               arrowSide="right"
             >

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecksStatusSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecksStatusSummary.tsx
@@ -4,7 +4,7 @@ import {
   Icon,
   Popover,
   Spinner,
-  Subtitle2,
+  Subtitle,
   Tag,
   TagIntent,
 } from '@dagster-io/ui-components';
@@ -94,7 +94,7 @@ const ChecksSummaryPopover = ({
   return (
     <Box flex={{direction: 'column'}} style={{maxHeight: 300, overflowY: 'auto'}}>
       <Box padding={{horizontal: 12, vertical: 8}} border="bottom">
-        <Subtitle2>{`${titlePerCheckType(type)} checks`}</Subtitle2>
+        <Subtitle>{`${titlePerCheckType(type)} checks`}</Subtitle>
       </Box>
       {assetChecks.map((check) => (
         <CheckStatusRow key={check.name} assetCheck={check} assetKey={assetKey} />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
@@ -1,5 +1,5 @@
 import {gql} from '@apollo/client';
-import {Body2, Box, Caption, Colors} from '@dagster-io/ui-components';
+import {Body, Box, Caption, Colors} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import {useRef} from 'react';
 import {Link} from 'react-router-dom';
@@ -79,7 +79,7 @@ export const VirtualizedAssetCheckRow = ({assetNode, height, start, row}: AssetC
             <Link
               to={assetDetailsPathForAssetCheck({assetKey: assetNode.assetKey, name: row.name})}
             >
-              <Body2>{row.name}</Body2>
+              <Body>{row.name}</Body>
             </Link>
             <CaptionEllipsed>{row.description}</CaptionEllipsed>
           </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationEvaluationHistoryTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationEvaluationHistoryTable.tsx
@@ -1,5 +1,5 @@
 import {
-  Body2,
+  Body,
   Box,
   ButtonGroup,
   ButtonLink,
@@ -122,9 +122,9 @@ export const AutomaterializationEvaluationHistoryTable = ({
                         setSelectedTick(tick);
                       }}
                     >
-                      <Body2>
+                      <Body>
                         {tick.requestedAssetMaterializationCount} materializations requested
-                      </Body2>
+                      </Body>
                     </ButtonLink>
                   ) : (
                     ' - '

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationTickDetailDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationTickDetailDialog.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Box, Caption, Colors, Icon, Spinner, Subtitle2} from '@dagster-io/ui-components';
+import {Box, Caption, Colors, Icon, Spinner, Subtitle} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import {memo, useMemo, useRef, useState} from 'react';
 import {Link} from 'react-router-dom';
@@ -167,7 +167,7 @@ export const AutomaterializationTickDetailDialog = memo(
                   padding={{vertical: 12, horizontal: 24}}
                   border={filteredAssetKeys.length > 0 ? undefined : 'bottom'}
                 >
-                  <Subtitle2>Materializations requested</Subtitle2>
+                  <Subtitle>Materializations requested</Subtitle>
                 </Box>
                 {content}
               </>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/GlobalAutomaterializationContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/GlobalAutomaterializationContent.tsx
@@ -1,5 +1,5 @@
 import {useLazyQuery} from '@apollo/client';
-import {Alert, Box, Checkbox, Colors, Spinner, Subtitle2, Table} from '@dagster-io/ui-components';
+import {Alert, Box, Checkbox, Colors, Spinner, Subtitle, Table} from '@dagster-io/ui-components';
 import {useCallback, useMemo, useState} from 'react';
 
 import {ASSET_DAEMON_TICKS_QUERY} from './AssetDaemonTicksQuery';
@@ -174,7 +174,7 @@ export const GlobalAutomaterializationContent = () => {
         </tbody>
       </Table>
       <Box padding={{vertical: 12, horizontal: 24}} border="bottom">
-        <Subtitle2>Evaluation timeline</Subtitle2>
+        <Subtitle>Evaluation timeline</Subtitle>
       </Box>
       {!data ? (
         <Box

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsModal.tsx
@@ -1,6 +1,6 @@
 import {gql, useMutation} from '@apollo/client';
 import {
-  Body2,
+  Body,
   Box,
   Button,
   Caption,
@@ -8,7 +8,7 @@ import {
   DialogFooter,
   DialogHeader,
   Icon,
-  Subheading,
+  Subtitle,
   TextInput,
   Tooltip,
 } from '@dagster-io/ui-components';
@@ -182,11 +182,11 @@ const ReportEventDialogBody = ({
         padding={{horizontal: 20, top: 16, bottom: 24}}
         border={asset.isPartitioned ? {side: 'bottom'} : undefined}
       >
-        <Body2>
+        <Body>
           Let Dagster know about a materialization that happened outside of Dagster. Typically used
           for testing or for manually fixing incorrect information in the asset catalog, not for
           normal operations.
-        </Body2>
+        </Body>
       </Box>
 
       {asset.isPartitioned ? (
@@ -194,7 +194,7 @@ const ReportEventDialogBody = ({
           isInitiallyOpen={true}
           title={
             <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
-              <Subheading>Partition selection</Subheading>
+              <Subtitle>Partition selection</Subtitle>
               <span>{partitionCountString(keyCountInSelections(selections))}</span>
             </Box>
           }
@@ -205,7 +205,7 @@ const ReportEventDialogBody = ({
               border="bottom"
               padding={{vertical: 12, horizontal: 20}}
             >
-              <Box as={Subheading} flex={{alignItems: 'center', gap: 8}}>
+              <Box as={Subtitle} flex={{alignItems: 'center', gap: 8}}>
                 <Icon name="partition" />
                 {range.dimension.name}
               </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/CodeLocationsPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/CodeLocationsPage.tsx
@@ -1,4 +1,4 @@
-import {Box, Heading, PageHeader, Subheading, TextInput} from '@dagster-io/ui-components';
+import {Box, Heading, PageHeader, Subtitle, TextInput} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {InstancePageContext} from './InstancePageContext';
@@ -32,7 +32,7 @@ export const CodeLocationsPageContent = () => {
   const entryCount = flattened.length;
   const showSearch = entryCount > SEARCH_THRESHOLD;
 
-  const subheadingText = () => {
+  const SubtitleText = () => {
     if (loading || !entryCount) {
       return 'Code locations';
     }
@@ -56,7 +56,7 @@ export const CodeLocationsPageContent = () => {
             style={{width: '400px'}}
           />
         ) : (
-          <Subheading id="repository-locations">{subheadingText()}</Subheading>
+          <Subtitle id="repository-locations">{SubtitleText()}</Subtitle>
         )}
         <Box flex={{direction: 'row', gap: 12, alignItems: 'center'}}>
           {showSearch ? <div>{`${entryCount} code locations`}</div> : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
@@ -19,7 +19,7 @@ import {
   Popover,
   Spinner,
   StyledRawCodeMirror,
-  Subheading,
+  Subtitle,
   Table,
   Tag,
   TextInput,
@@ -165,7 +165,7 @@ export const RunConcurrencyContent = ({
           border="bottom"
           flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
         >
-          <Subheading>Run concurrency</Subheading>
+          <Subtitle>Run concurrency</Subtitle>
           {refreshState ? <QueryRefreshCountdown refreshState={refreshState} /> : null}
         </Box>
         <div>
@@ -244,7 +244,7 @@ const RunConcurrencyLimitHeader = ({
     padding={{vertical: 16, horizontal: 24}}
     border="bottom"
   >
-    <Subheading>Run concurrency</Subheading>
+    <Subtitle>Run concurrency</Subtitle>
     <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
       {refreshState ? <QueryRefreshCountdown refreshState={refreshState} /> : null}
       {onEdit ? (
@@ -396,7 +396,7 @@ const ConcurrencyLimitHeader = ({onAdd}: {onAdd?: () => void}) => (
     border="top-and-bottom"
   >
     <Box flex={{alignItems: 'center', direction: 'row', gap: 8}}>
-      <Subheading>Global op/asset concurrency</Subheading>
+      <Subtitle>Global op/asset concurrency</Subtitle>
       <Tag>Experimental</Tag>
     </Box>
     {onAdd ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConfig.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConfig.tsx
@@ -9,7 +9,7 @@ import {
   PageHeader,
   Spinner,
   StyledRawCodeMirror,
-  Subheading,
+  Subtitle,
 } from '@dagster-io/ui-components';
 import CodeMirror from 'codemirror';
 import {memo, useContext, useMemo} from 'react';
@@ -87,9 +87,9 @@ export const InstanceConfigContent = memo(() => {
         border="bottom"
         flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
       >
-        <Subheading>
+        <Subtitle>
           Dagster version: <Code style={{fontSize: '16px'}}>{data.version}</Code>
-        </Subheading>
+        </Subtitle>
         <QueryRefreshCountdown refreshState={refreshState} />
       </Box>
       {/* Div wrapper on CodeMirror to allow entire page to scroll */}

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceHealthPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceHealthPage.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Box, Colors, Heading, PageHeader, Subheading} from '@dagster-io/ui-components';
+import {Box, Colors, Heading, PageHeader, Subtitle} from '@dagster-io/ui-components';
 import {useContext} from 'react';
 
 import {DaemonList} from './DaemonList';
@@ -47,7 +47,7 @@ export const InstanceHealthPageContent = () => {
         padding={{vertical: 16, horizontal: 24}}
         flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
       >
-        <Subheading>Daemon statuses</Subheading>
+        <Subtitle>Daemon statuses</Subtitle>
         <div>
           <QueryRefreshCountdown refreshState={refreshState} />
         </div>

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
@@ -9,7 +9,7 @@ import {
   DialogHeader,
   MiddleTruncate,
   Spinner,
-  Subtitle2,
+  Subtitle,
   Tab,
   Table,
   Tabs,
@@ -124,7 +124,7 @@ const TickDetailsDialogImpl = ({tickId, instigationSelector}: InnerProps) => {
           {tick.runIds.length || tick.originRunIds.length ? (
             <>
               <Box padding={{vertical: 12, horizontal: 24}} border="bottom">
-                <Subtitle2>Requested</Subtitle2>
+                <Subtitle>Requested</Subtitle>
               </Box>
               {tick.runIds.length ? (
                 <RunList runIds={tick.runIds} />
@@ -136,7 +136,7 @@ const TickDetailsDialogImpl = ({tickId, instigationSelector}: InnerProps) => {
           {addedPartitionRequests?.length ? (
             <>
               <Box padding={{vertical: 12, horizontal: 24}} border="bottom">
-                <Subtitle2>Added partitions</Subtitle2>
+                <Subtitle>Added partitions</Subtitle>
               </Box>
               <PartitionsTable partitions={addedPartitionRequests} />
             </>
@@ -144,7 +144,7 @@ const TickDetailsDialogImpl = ({tickId, instigationSelector}: InnerProps) => {
           {deletedPartitionRequests?.length ? (
             <>
               <Box padding={{vertical: 12, horizontal: 24}} border="bottom">
-                <Subtitle2>Deleted partitions</Subtitle2>
+                <Subtitle>Deleted partitions</Subtitle>
               </Box>
               <PartitionsTable partitions={deletedPartitionRequests} />
             </>
@@ -187,7 +187,7 @@ export function TickDetailSummary({tick}: {tick: HistoryTickFragment | AssetDaem
     <>
       <div style={{display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 12}}>
         <Box flex={{direction: 'column', gap: 4}}>
-          <Subtitle2>Status</Subtitle2>
+          <Subtitle>Status</Subtitle>
           <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
             <Tag intent={intent}>
               {tick.status === InstigationTickStatus.STARTED ? (
@@ -216,7 +216,7 @@ export function TickDetailSummary({tick}: {tick: HistoryTickFragment | AssetDaem
           </Box>
         </Box>
         <Box flex={{direction: 'column', gap: 4}}>
-          <Subtitle2>Timestamp</Subtitle2>
+          <Subtitle>Timestamp</Subtitle>
           <div>
             {tick ? (
               <Timestamp timestamp={{unix: tick.timestamp}} timeFormat={{showTimezone: true}} />
@@ -226,7 +226,7 @@ export function TickDetailSummary({tick}: {tick: HistoryTickFragment | AssetDaem
           </div>
         </Box>
         <Box flex={{direction: 'column', gap: 4}}>
-          <Subtitle2>Duration</Subtitle2>
+          <Subtitle>Duration</Subtitle>
           <div>
             {tick?.endTimestamp
               ? formatElapsedTimeWithoutMsec(tick.endTimestamp * 1000 - tick.timestamp * 1000)

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -13,7 +13,7 @@ import {
   IconWrapper,
   NonIdealState,
   Spinner,
-  Subheading,
+  Subtitle,
   Table,
   ifPlural,
 } from '@dagster-io/ui-components';
@@ -323,7 +323,7 @@ export const TickHistoryTimeline = ({
     return (
       <>
         <Box padding={{top: 16, horizontal: 24}} border="bottom">
-          <Subheading>Recent ticks</Subheading>
+          <Subtitle>Recent ticks</Subtitle>
         </Box>
         <Box padding={{vertical: 64}}>
           <Spinner purpose="section" />
@@ -365,7 +365,7 @@ export const TickHistoryTimeline = ({
         onClose={() => onTickClick(undefined)}
       />
       <Box padding={{vertical: 16, horizontal: 24}}>
-        <Subheading>Recent ticks</Subheading>
+        <Subtitle>Recent ticks</Subtitle>
       </Box>
       <Box border="top">
         <LiveTickTimeline

--- a/js_modules/dagster-ui/packages/ui-core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/metadata/MetadataEntry.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Button,
-  CaptionMono,
   Colors,
   Dialog,
   DialogBody,
@@ -9,6 +8,7 @@ import {
   FontFamily,
   Group,
   Icon,
+  MonoSmall,
   Table,
   Tooltip,
   tryPrettyPrintJSON,
@@ -374,9 +374,7 @@ export const TableMetadataEntryComponent = ({entry}: {entry: TableMetadataEntry}
                     content={<div style={{maxWidth: '400px'}}>{record}</div>}
                     placement="top"
                   >
-                    <CaptionMono>
-                      {record.length > 20 ? `${record.slice(0, 20)}…` : record}
-                    </CaptionMono>
+                    <MonoSmall>{record.length > 20 ? `${record.slice(0, 20)}…` : record}</MonoSmall>
                   </Tooltip>
                 </div>
               </td>

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/ScheduleAndSensorDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/ScheduleAndSensorDialog.tsx
@@ -1,4 +1,4 @@
-import {Box, Button, Dialog, DialogFooter, Subheading, Table} from '@dagster-io/ui-components';
+import {Box, Button, Dialog, DialogFooter, Subtitle, Table} from '@dagster-io/ui-components';
 import {Link} from 'react-router-dom';
 
 import {ScheduleSwitch} from '../schedules/ScheduleSwitch';
@@ -50,7 +50,7 @@ export const ScheduleAndSensorDialog = ({
           <>
             {sensorCount ? (
               <Box padding={{vertical: 16, horizontal: 24}}>
-                <Subheading>Schedules ({scheduleCount})</Subheading>
+                <Subtitle>Schedules ({scheduleCount})</Subtitle>
               </Box>
             ) : null}
             <Table>
@@ -89,7 +89,7 @@ export const ScheduleAndSensorDialog = ({
           <>
             {scheduleCount ? (
               <Box padding={{vertical: 16, horizontal: 24}}>
-                <Subheading>Sensors ({sensorCount})</Subheading>
+                <Subtitle>Sensors ({sensorCount})</Subtitle>
               </Box>
             ) : null}
             <Table>

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/AssetJobPartitionsView.tsx
@@ -1,4 +1,4 @@
-import {Box, Button, Subheading, useViewport} from '@dagster-io/ui-components';
+import {Box, Button, Subtitle, useViewport} from '@dagster-io/ui-components';
 import {useEffect, useMemo, useState} from 'react';
 
 import {JobBackfillsTable} from './JobBackfillsTable';
@@ -96,7 +96,7 @@ export const AssetJobPartitionsView = ({
         border="bottom"
         padding={{vertical: 16, horizontal: 24}}
       >
-        <Subheading>Status</Subheading>
+        <Subtitle>Status</Subtitle>
         <Box flex={{gap: 8}}>
           <Button onClick={() => setShowAssets(!showAssets)}>
             {showAssets ? 'Hide per-asset status' : 'Show per-asset status'}
@@ -164,7 +164,7 @@ export const AssetJobPartitionsView = ({
         border="top-and-bottom"
         style={{marginBottom: -1}}
       >
-        <Subheading>Backfill history</Subheading>
+        <Subtitle>Backfill history</Subtitle>
       </Box>
       <Box margin={{bottom: 20}}>
         <JobBackfillsTable
@@ -218,7 +218,7 @@ const AssetJobPartitionGraphs = ({
   return (
     <>
       <Box padding={{horizontal: 24, vertical: 16}} border="top-and-bottom">
-        <Subheading>Run duration</Subheading>
+        <Subtitle>Run duration</Subtitle>
       </Box>
 
       <Box margin={24}>
@@ -231,7 +231,7 @@ const AssetJobPartitionGraphs = ({
         />
       </Box>
       <Box padding={{horizontal: 24, vertical: 16}} border="top-and-bottom">
-        <Subheading>Step durations</Subheading>
+        <Subtitle>Step durations</Subtitle>
       </Box>
       <Box margin={24}>
         <PartitionGraph

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
@@ -9,7 +9,7 @@ import {
   Icon,
   NonIdealState,
   Spinner,
-  Subheading,
+  Subtitle,
   Tooltip,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
@@ -478,7 +478,7 @@ const Section = ({
   children: React.ReactNode;
 }) => (
   <Box flex={{direction: 'column', gap: 4}}>
-    <Subheading>{title}</Subheading>
+    <Subtitle>{title}</Subtitle>
     <Box flex={{direction: 'column', gap: 8}} padding={{top: 16}} border="top">
       {children}
     </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/OpJobPartitionsView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/OpJobPartitionsView.tsx
@@ -6,7 +6,7 @@ import {
   Icon,
   NonIdealState,
   Spinner,
-  Subheading,
+  Subtitle,
   Tooltip,
   useViewport,
 } from '@dagster-io/ui-components';
@@ -255,7 +255,7 @@ export const OpJobPartitionsViewContent = ({
         border="bottom"
         padding={{vertical: 16, horizontal: 24}}
       >
-        <Subheading>Status</Subheading>
+        <Subtitle>Status</Subtitle>
         <Box flex={{gap: 8}}>
           <Button onClick={() => setShowSteps(!showSteps)} active={showBackfillSetup}>
             {showSteps ? 'Hide per-step status' : 'Show per-step status'}
@@ -329,7 +329,7 @@ export const OpJobPartitionsViewContent = ({
         ) : null}
       </Box>
       <Box padding={{horizontal: 24, vertical: 16}} border="top-and-bottom">
-        <Subheading>Run duration</Subheading>
+        <Subtitle>Run duration</Subtitle>
       </Box>
       <Box margin={24}>
         <PartitionGraph
@@ -343,7 +343,7 @@ export const OpJobPartitionsViewContent = ({
       {showSteps ? (
         <>
           <Box padding={{horizontal: 24, vertical: 16}}>
-            <Subheading>Step duration</Subheading>
+            <Subtitle>Step duration</Subtitle>
           </Box>
           <Box margin={24}>
             <PartitionGraph
@@ -361,7 +361,7 @@ export const OpJobPartitionsViewContent = ({
         border="top-and-bottom"
         style={{marginBottom: -1}}
       >
-        <Subheading>Backfill history</Subheading>
+        <Subtitle>Backfill history</Subtitle>
       </Box>
       <Box margin={{bottom: 20}}>
         <JobBackfillsTable

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelinePathUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelinePathUtils.tsx
@@ -1,4 +1,4 @@
-import {CaptionMono, Mono} from '@dagster-io/ui-components';
+import {Mono, MonoSmall} from '@dagster-io/ui-components';
 import {useEffect} from 'react';
 import {Link, useHistory} from 'react-router-dom';
 
@@ -83,5 +83,5 @@ export const PipelineSnapshotLink = (props: {
 }) => {
   const snapshotLink = getPipelineSnapshotLink(props.pipelineName, props.snapshotId);
   const linkElem = <Link to={snapshotLink}>{props.snapshotId.slice(0, 8)}</Link>;
-  return props.size === 'small' ? <CaptionMono>{linkElem}</CaptionMono> : <Mono>{linkElem}</Mono>;
+  return props.size === 'small' ? <MonoSmall>{linkElem}</MonoSmall> : <Mono>{linkElem}</Mono>;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
@@ -3,18 +3,18 @@ import {
   Alert,
   Box,
   ButtonLink,
-  CaptionMono,
   Colors,
   Group,
   Heading,
   Icon,
   MiddleTruncate,
   Mono,
+  MonoSmall,
   NonIdealState,
   Page,
   PageHeader,
   SplitPanelContainer,
-  Subheading,
+  Subtitle,
   Table,
   Tag,
   Tooltip,
@@ -246,7 +246,7 @@ const ResourceConfig = (props: {
       {nestedResources.length > 0 && (
         <Box>
           <SectionHeader>
-            <Subheading>Resource dependencies</Subheading>
+            <Subtitle>Resource dependencies</Subtitle>
           </SectionHeader>
           <Table>
             <thead>
@@ -284,7 +284,7 @@ const ResourceConfig = (props: {
       )}
       <Box>
         <SectionHeader>
-          <Subheading>Configuration</Subheading>
+          <Subtitle>Configuration</Subtitle>
         </SectionHeader>
         <Table>
           <thead>
@@ -377,7 +377,7 @@ const ResourceUses = (props: {
       {parentResources.length > 0 && (
         <Box>
           <SectionHeader>
-            <Subheading>Parent resources</Subheading>
+            <Subtitle>Parent resources</Subtitle>
           </SectionHeader>
           <Table>
             <thead>
@@ -408,7 +408,7 @@ const ResourceUses = (props: {
       {resourceDetails.assetKeysUsing.length > 0 && (
         <Box>
           <SectionHeader>
-            <Subheading>Assets</Subheading>
+            <Subtitle>Assets</Subtitle>
           </SectionHeader>
           <Table>
             <thead>
@@ -433,7 +433,7 @@ const ResourceUses = (props: {
       {resourceDetails.jobsOpsUsing.length > 0 && (
         <Box>
           <SectionHeader>
-            <Subheading>Jobs</Subheading>
+            <Subtitle>Jobs</Subtitle>
           </SectionHeader>
           <Table>
             <thead>
@@ -523,7 +523,7 @@ const ResourceUses = (props: {
         .map(({name, objects, icon}) => (
           <div key={name}>
             <SectionHeader>
-              <Subheading>{name}</Subheading>
+              <Subtitle>{name}</Subtitle>
             </SectionHeader>
             <Table>
               <thead>
@@ -585,7 +585,7 @@ const ResourceEntry = (props: {name: string; url?: string; description?: string}
           )}
         </div>
       </Box>
-      <CaptionMono>{description}</CaptionMono>
+      <MonoSmall>{description}</MonoSmall>
     </Box>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunConfigDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunConfigDialog.tsx
@@ -4,7 +4,7 @@ import {
   Dialog,
   DialogFooter,
   StyledRawCodeMirror,
-  Subheading,
+  Subtitle,
 } from '@dagster-io/ui-components';
 import styled from 'styled-components';
 
@@ -47,7 +47,7 @@ export const RunConfigDialog = (props: Props) => {
         <Box flex={{direction: 'column', gap: 20}} style={{flex: 1, overflow: 'hidden'}}>
           {hasTags ? (
             <Box flex={{direction: 'column', gap: 12}} padding={{top: 16, horizontal: 24}}>
-              <Subheading>Tags</Subheading>
+              <Subtitle>Tags</Subtitle>
               <div>
                 <RunTags tags={tags} mode={isJob ? null : mode} />
               </div>
@@ -56,7 +56,7 @@ export const RunConfigDialog = (props: Props) => {
           <Box flex={{direction: 'column'}} style={{flex: 1, overflow: 'hidden'}}>
             {hasTags ? (
               <Box border="bottom" padding={{left: 24, bottom: 16}}>
-                <Subheading>Config</Subheading>
+                <Subtitle>Config</Subtitle>
               </Box>
             ) : null}
             <CodeMirrorContainer>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusPez.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusPez.tsx
@@ -1,4 +1,4 @@
-import {Box, CaptionMono, Colors, FontFamily, Popover} from '@dagster-io/ui-components';
+import {Box, Colors, FontFamily, MonoSmall, Popover} from '@dagster-io/ui-components';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -77,7 +77,7 @@ export const RunStatusOverlay = ({name, run}: OverlayProps) => {
         <Box flex={{alignItems: 'center', direction: 'row', gap: 8}}>
           <RunStatusIndicator status={run.status} />
           <Link to={`/runs/${run.id}`}>
-            <CaptionMono>{titleForRun(run)}</CaptionMono>
+            <MonoSmall>{titleForRun(run)}</MonoSmall>
           </Link>
         </Box>
         <Box flex={{direction: 'column', gap: 4}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusTag.tsx
@@ -1,4 +1,4 @@
-import {Box, CaptionMono, Colors, Popover, Tag} from '@dagster-io/ui-components';
+import {Box, Colors, MonoSmall, Popover, Tag} from '@dagster-io/ui-components';
 
 import {RunStats} from './RunStats';
 import {RunStatusIndicator} from './RunStatusDots';
@@ -105,7 +105,7 @@ export const RunStatusTagWithID = ({runId, status}: {runId: string; status: RunS
     <Tag intent={statusToIntent(status)}>
       <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
         <RunStatusIndicator status={status} size={10} />
-        <CaptionMono>{runId.slice(0, 8)}</CaptionMono>
+        <MonoSmall>{runId.slice(0, 8)}</MonoSmall>
       </Box>
     </Tag>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/SchedulesNextTicks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/SchedulesNextTicks.tsx
@@ -16,7 +16,7 @@ import {
   Popover,
   Spinner,
   StyledRawCodeMirror,
-  Subheading,
+  Subtitle,
   Table,
 } from '@dagster-io/ui-components';
 import qs from 'qs';
@@ -367,14 +367,14 @@ const NextTickDialog = ({
     body = (
       <Box flex={{direction: 'column', gap: 20}}>
         <Box flex={{direction: 'column', gap: 12}} padding={{top: 16, horizontal: 24}}>
-          <Subheading>Tags</Subheading>
+          <Subtitle>Tags</Subtitle>
           {selectedRunRequest.tags.length ? (
             <RunTags tags={selectedRunRequest.tags} mode={isJob ? null : schedule.mode} />
           ) : null}
         </Box>
         <div>
           <Box border="bottom" padding={{left: 24, bottom: 16}}>
-            <Subheading>Config</Subheading>
+            <Subtitle>Config</Subtitle>
           </Box>
           <StyledRawCodeMirror
             value={selectedRunRequest.runConfigYaml}

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
@@ -1,11 +1,11 @@
 import {
   Box,
   Caption,
-  CaptionBolded,
   Colors,
   Icon,
   IconName,
   StyledTag,
+  SubtitleSmall,
 } from '@dagster-io/ui-components';
 import Fuse from 'fuse.js';
 import * as React from 'react';
@@ -106,7 +106,7 @@ function buildSearchLabel(result: Fuse.FuseResult<SearchResult>): JSX.Element[] 
     parsedString += stringBeforeMatch;
 
     const match = result.item.label.slice(longestMatch[0], longestMatch[1] + 1);
-    labelComponents.push(<CaptionBolded>{match}</CaptionBolded>);
+    labelComponents.push(<SubtitleSmall>{match}</SubtitleSmall>);
     parsedString += match;
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
@@ -1,5 +1,5 @@
 import {useLazyQuery} from '@apollo/client';
-import {Alert, Box, Colors, Spinner, Subtitle2} from '@dagster-io/ui-components';
+import {Alert, Box, Colors, Spinner, Subtitle} from '@dagster-io/ui-components';
 import {useCallback, useMemo, useState} from 'react';
 
 import {ASSET_SENSOR_TICKS_QUERY} from './AssetSensorTicksQuery';
@@ -172,7 +172,7 @@ export const SensorPageAutomaterialize = (props: Props) => {
       </Box>
       <SensorInfo assetDaemonHealth={daemonStatus} padding={{vertical: 16, horizontal: 24}} />
       <Box padding={{vertical: 12, horizontal: 24}} border="bottom">
-        <Subtitle2>Evaluation timeline</Subtitle2>
+        <Subtitle>Evaluation timeline</Subtitle>
       </Box>
       {!sensor && loading ? (
         <Box

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorTargetList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorTargetList.tsx
@@ -9,7 +9,7 @@ import {
   DialogFooter,
   DisclosureTriangleButton,
   MiddleTruncate,
-  Subtitle2,
+  Subtitle,
 } from '@dagster-io/ui-components';
 import React from 'react';
 import {Link} from 'react-router-dom';
@@ -197,9 +197,9 @@ const Section = ({
             }}
           >
             <DisclosureTriangleButton onToggle={() => {}} isOpen={isOpen} />
-            <Subtitle2>
+            <Subtitle>
               {title} ({numberFormatter.format(assets.length)})
-            </Subtitle2>
+            </Subtitle>
           </Box>
         </Box>
       ) : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/DynamicPartitionRequests.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/DynamicPartitionRequests.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Icon, Subheading, Table, Tag} from '@dagster-io/ui-components';
+import {Box, Colors, Icon, Subtitle, Table, Tag} from '@dagster-io/ui-components';
 import {useMemo} from 'react';
 
 import {DynamicPartitionRequestFragment} from './types/SensorDryRunDialog.types';
@@ -37,7 +37,7 @@ export function DynamicPartitionRequests({
       {includeTitle ? (
         <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
           <Icon name="partition" />
-          <Subheading>Dynamic Partition Requests</Subheading>
+          <Subtitle>Dynamic Partition Requests</Subtitle>
         </Box>
       ) : null}
       <Table style={{borderRight: `1px solid ${Colors.keylineDefault()}`}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateScheduleDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateScheduleDialog.tsx
@@ -13,7 +13,7 @@ import {
   NonIdealState,
   Popover,
   Spinner,
-  Subheading,
+  Subtitle,
   Tag,
   useViewport,
 } from '@dagster-io/ui-components';
@@ -299,7 +299,7 @@ const EvaluateScheduleContent = ({
     if (!evaluationResult.runRequests?.length) {
       return (
         <div>
-          <Subheading>Skip Reason</Subheading>
+          <Subtitle>Skip Reason</Subtitle>
           <div>{evaluationResult?.skipReason || 'No skip reason was output'}</div>
         </div>
       );
@@ -324,7 +324,7 @@ const EvaluateScheduleContent = ({
       <Box>
         <Grid>
           <div>
-            <Subheading>Result</Subheading>
+            <Subtitle>Result</Subtitle>
             <Box flex={{grow: 1, alignItems: 'center'}}>
               <div>
                 {error ? (
@@ -338,7 +338,7 @@ const EvaluateScheduleContent = ({
             </Box>
           </div>
           <div>
-            <Subheading>Tick</Subheading>
+            <Subtitle>Tick</Subtitle>
             <Box flex={{grow: 1, alignItems: 'center'}}>
               <Mono>
                 {timestampToString({
@@ -397,7 +397,7 @@ const Grid = styled.div`
   padding-bottom: 12px;
   border-bottom: 1px solid ${Colors.keylineDefault()};
   margin-bottom: 12px;
-  ${Subheading} {
+  ${Subtitle} {
     padding-bottom: 4px;
     display: block;
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/SensorDryRunDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/SensorDryRunDialog.tsx
@@ -11,7 +11,7 @@ import {
   Icon,
   NonIdealState,
   Spinner,
-  Subheading,
+  Subtitle,
   Tag,
   TextInput,
 } from '@dagster-io/ui-components';
@@ -219,7 +219,7 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
           <Box>
             <Grid>
               <div>
-                <Subheading>Result</Subheading>
+                <Subtitle>Result</Subtitle>
                 <Box flex={{grow: 1, alignItems: 'center'}}>
                   <div>
                     {error ? (
@@ -233,11 +233,11 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
                 </Box>
               </div>
               <div>
-                <Subheading>Used cursor value</Subheading>
+                <Subtitle>Used cursor value</Subtitle>
                 <pre>{cursor?.length ? cursor : 'None'}</pre>
               </div>
               <div>
-                <Subheading>Computed cursor value</Subheading>
+                <Subtitle>Computed cursor value</Subtitle>
                 <pre>
                   {sensorExecutionData?.evaluationResult?.cursor?.length
                     ? sensorExecutionData?.evaluationResult.cursor
@@ -276,7 +276,7 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
             ) : null}
             {didSkip ? (
               <div>
-                <Subheading>Skip reason</Subheading>
+                <Subtitle>Skip reason</Subtitle>
                 <div>
                   {sensorExecutionData?.evaluationResult?.skipReason || 'No skip reason was output'}
                 </div>
@@ -398,7 +398,7 @@ const Grid = styled.div`
   padding-bottom: 12px;
   border-bottom: 1px solid ${Colors.keylineDefault()};
   margin-bottom: 12px;
-  ${Subheading} {
+  ${Subtitle} {
     padding-bottom: 4px;
     display: block;
   }


### PR DESCRIPTION
## Summary & Motivation
This PR aims to clean up all of our text styles, and introduces a new simplified naming convention that matches the style names within Figma.

The old text style naming convention of `body`, `body1`, and `body2` was difficult to grok, ie: is body2 bigger or smaller than body1? When should I `CaptionBold` or `SubtitleCaption`? 

**Now we now have just 3 main text styles `Subtitle`, `Body`, and `Mono`.**
- Each of these comes in a large and small variant, ie: `SubtitleLarge`| `Subtitle` | `SubtitleSmall`
- There are 3 other less utilized styles `title`, `heading`, and `code`.

The full set of styles now looks like this, and IMO is much easier to reason about. 
![image](https://github.com/dagster-io/dagster/assets/2798333/dcc79be7-aa03-45a5-9d9b-81a57d6aae73)


## Legacy styles
I've renamed or removed all the previous styles except for `caption` which is used in a lot of places. `caption` is the exact same style as the new `bodySmall` style.

## In Figma
This has all been updated in Figma as well. In Dev mode, selecting any text will now show it's corresponding style name in code.
![image](https://github.com/dagster-io/dagster/assets/2798333/4d34a002-1046-43be-a7f6-d08725e94e05)

## How I Tested These Changes
Loaded up the UI and clicked around.
