### PR TITLE
user-settable materialization & observation tags

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_out.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_out.py
@@ -15,7 +15,7 @@ from dagster._core.definitions.output import Out
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster._core.types.dagster_type import DagsterType, resolve_dagster_type
 
-from .utils import validate_definition_tags
+from .utils import validate_tags_strict
 
 
 @experimental_param(param="owners")
@@ -123,7 +123,7 @@ class AssetOut(
                 backfill_policy, "backfill_policy", BackfillPolicy
             ),
             owners=check.opt_sequence_param(owners, "owners", of_type=str),
-            tags=validate_definition_tags(tags),
+            tags=validate_tags_strict(tags),
         )
 
     def to_out(self) -> Out:

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -11,7 +11,7 @@ from .events import (
     CoercibleToAssetKey,
 )
 from .freshness_policy import FreshnessPolicy
-from .utils import validate_definition_tags
+from .utils import validate_tags_strict
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_dep import AssetDep, CoercibleToAssetDep
@@ -143,5 +143,5 @@ class AssetSpec(
                 AutoMaterializePolicy,
             ),
             owners=check.opt_sequence_param(owners, "owners", of_type=str),
-            tags=validate_definition_tags(tags),
+            tags=validate_tags_strict(tags),
         )

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -71,7 +71,7 @@ from .partition_mapping import (
 )
 from .resource_definition import ResourceDefinition
 from .source_asset import SourceAsset
-from .utils import DEFAULT_GROUP_NAME, validate_tags_strict, validate_group_name
+from .utils import DEFAULT_GROUP_NAME, validate_group_name, validate_tags_strict
 
 if TYPE_CHECKING:
     from .base_asset_graph import AssetKeyOrCheckKey

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -71,7 +71,7 @@ from .partition_mapping import (
 )
 from .resource_definition import ResourceDefinition
 from .source_asset import SourceAsset
-from .utils import DEFAULT_GROUP_NAME, validate_definition_tags, validate_group_name
+from .utils import DEFAULT_GROUP_NAME, validate_tags_strict, validate_group_name
 
 if TYPE_CHECKING:
     from .base_asset_graph import AssetKeyOrCheckKey
@@ -271,7 +271,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         )
 
         for tags in (tags_by_key or {}).values():
-            validate_definition_tags(tags)
+            validate_tags_strict(tags)
         self._tags_by_key = tags_by_key or {}
 
         self._descriptions_by_key = dict(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -55,7 +55,7 @@ from ..utils import (
     DEFAULT_IO_MANAGER_KEY,
     DEFAULT_OUTPUT,
     NoValueSentinel,
-    validate_definition_tags,
+    validate_tags_strict,
 )
 
 
@@ -236,7 +236,7 @@ def asset(
             ins=ins,
             deps=upstream_asset_deps,
             metadata=metadata,
-            tags=validate_definition_tags(tags),
+            tags=validate_tags_strict(tags),
             description=description,
             config_schema=config_schema,
             required_resource_keys=required_resource_keys,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -24,7 +24,7 @@ from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.source_asset import SourceAsset, SourceAssetObserveFunction
-from dagster._core.definitions.utils import validate_definition_tags
+from dagster._core.definitions.utils import validate_tags_strict
 
 
 @overload
@@ -131,7 +131,7 @@ def observable_source_asset(
         auto_observe_interval_minutes,
         freshness_policy,
         op_tags,
-        tags=validate_definition_tags(tags),
+        tags=validate_tags_strict(tags),
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/result.py
+++ b/python_modules/dagster/dagster/_core/definitions/result.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Optional, Sequence
+from typing import Mapping, NamedTuple, Optional, Sequence
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, experimental
@@ -20,6 +20,7 @@ class AssetResult(
             ("metadata", PublicAttr[Optional[RawMetadataMapping]]),
             ("check_results", PublicAttr[Sequence[AssetCheckResult]]),
             ("data_version", PublicAttr[Optional[DataVersion]]),
+            ("tags", PublicAttr[Optional[Mapping[str, str]]]),
         ],
     )
 ):
@@ -32,6 +33,7 @@ class AssetResult(
         metadata: Optional[RawMetadataMapping] = None,
         check_results: Optional[Sequence[AssetCheckResult]] = None,
         data_version: Optional[DataVersion] = None,
+        tags: Optional[Mapping[str, str]] = None,
     ):
         asset_key = AssetKey.from_coercible(asset_key) if asset_key else None
 
@@ -47,6 +49,7 @@ class AssetResult(
                 check_results, "check_results", of_type=AssetCheckResult
             ),
             data_version=check.opt_inst_param(data_version, "data_version", DataVersion),
+            tags=validate_asset_event_tags(tags),
         )
 
     def check_result_named(self, check_name: str) -> AssetCheckResult:

--- a/python_modules/dagster/dagster/_core/definitions/result.py
+++ b/python_modules/dagster/dagster/_core/definitions/result.py
@@ -35,6 +35,8 @@ class AssetResult(
         data_version: Optional[DataVersion] = None,
         tags: Optional[Mapping[str, str]] = None,
     ):
+        from dagster._core.definitions.events import validate_asset_event_tags
+
         asset_key = AssetKey.from_coercible(asset_key) if asset_key else None
 
         return super().__new__(
@@ -71,6 +73,8 @@ class MaterializeResult(AssetResult):
         check_results (Optional[Sequence[AssetCheckResult]]): Check results to record with the
             corresponding AssetMaterialization event.
         data_version (Optional[DataVersion]): The data version of the asset that was observed.
+        tags (Optional[Mapping[str, str]]): Tags to record with the corresponding
+            AssetMaterialization event.
     """
 
 
@@ -86,4 +90,6 @@ class ObserveResult(AssetResult):
         check_results (Optional[Sequence[AssetCheckResult]]): Check results to record with the
             corresponding AssetObservation event.
         data_version (Optional[DataVersion]): The data version of the asset that was observed.
+        tags (Optional[Mapping[str, str]]): Tags to record with the corresponding AssetObservation
+            event.
     """

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -51,7 +51,7 @@ from dagster._core.errors import (
     DagsterInvalidObservationError,
 )
 
-from .utils import validate_definition_tags
+from .utils import validate_tags_strict
 
 if TYPE_CHECKING:
     from dagster._core.definitions.decorators.op_decorator import (
@@ -233,7 +233,7 @@ class SourceAsset(ResourceAddable):
         metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
         self.raw_metadata = metadata
         self.metadata = normalize_metadata(metadata, allow_invalid=True)
-        self.tags = validate_definition_tags(tags) or {}
+        self.tags = validate_tags_strict(tags) or {}
 
         resource_defs_dict = dict(check.opt_mapping_param(resource_defs, "resource_defs"))
         if io_manager_def:

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -183,24 +183,28 @@ def validate_tags_strict(tags: Optional[Mapping[str, str]]) -> Optional[Mapping[
         return tags
 
     for key, value in tags.items():
-        if not isinstance(key, str):
-            raise DagsterInvalidDefinitionError("Tag keys must be strings")
-
-        if not isinstance(value, str):
-            raise DagsterInvalidDefinitionError("Tag values must be strings")
-
-        if not is_valid_definition_tag_key(key):
-            raise DagsterInvalidDefinitionError(
-                f"Invalid tag key: {key}. {VALID_DEFINITION_TAG_KEY_EXPLANATION}"
-            )
-
-        if not is_valid_definition_tag_value(value):
-            raise DagsterInvalidDefinitionError(
-                f"Invalid tag value: {value}. Allowed characters: alpha-numeric, '_', '-', '.'. "
-                "Must have <= 63 characters."
-            )
+        validate_tag_strict(key, value)
 
     return tags
+
+
+def validate_tag_strict(key: str, value: str) -> None:
+    if not isinstance(key, str):
+        raise DagsterInvalidDefinitionError("Tag keys must be strings")
+
+    if not isinstance(value, str):
+        raise DagsterInvalidDefinitionError("Tag values must be strings")
+
+    if not is_valid_definition_tag_key(key):
+        raise DagsterInvalidDefinitionError(
+            f"Invalid tag key: {key}. {VALID_DEFINITION_TAG_KEY_EXPLANATION}"
+        )
+
+    if not is_valid_definition_tag_value(value):
+        raise DagsterInvalidDefinitionError(
+            f"Invalid tag value: {value}, for key: {key}. Allowed characters: alpha-numeric, '_', '-', '.'. "
+            "Must have <= 63 characters."
+        )
 
 
 def validate_group_name(group_name: Optional[str]) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -178,8 +178,7 @@ def is_valid_definition_tag_value(key: str) -> bool:
     return bool(VALID_DEFINITION_TAG_VALUE_REGEX.match(key))
 
 
-def validate_definition_tags(tags: Optional[Mapping[str, str]]) -> Optional[Mapping[str, str]]:
-    """More restrictive than validate_tags."""
+def validate_tags_strict(tags: Optional[Mapping[str, str]]) -> Optional[Mapping[str, str]]:
     if tags is None:
         return tags
 

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -356,6 +356,7 @@ def validate_and_coerce_op_result_to_iterator(
                         value=element.value,
                         metadata=element.metadata,
                         data_version=element.data_version,
+                        tags=element.tags,
                     )
             else:
                 # If annotation indicates a generic output annotation, and an

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -126,6 +126,7 @@ def _process_user_event(
             output_name=output_name,
             metadata=user_event.metadata,
             data_version=user_event.data_version,
+            tags=user_event.tags,
         )
     elif isinstance(user_event, AssetCheckResult):
         asset_check_evaluation = user_event.to_asset_check_evaluation(step_context)
@@ -276,6 +277,7 @@ def _step_output_error_checked_user_event_sequence(
                         **normalize_metadata(metadata or {}),
                     },
                     data_version=output.data_version,
+                    tags=output.tags,
                 )
         else:
             if not output_def.is_dynamic:
@@ -658,6 +660,8 @@ def _get_output_asset_events(
     else:
         tags = {}
 
+    all_tags = {**tags, **((output.tags if not isinstance(output, DynamicOutput) else None) or {})}
+
     backfill_id = step_context.get_tag(BACKFILL_ID_TAG)
     if backfill_id:
         tags[BACKFILL_ID_TAG] = backfill_id
@@ -673,7 +677,7 @@ def _get_output_asset_events(
     if asset_partitions:
         for partition in asset_partitions:
             with disable_dagster_warnings():
-                tags.update(
+                all_tags.update(
                     get_tags_from_multi_partition_key(partition)
                     if isinstance(partition, MultiPartitionKey)
                     else {}
@@ -683,11 +687,11 @@ def _get_output_asset_events(
                     asset_key=asset_key,
                     partition=partition,
                     metadata=all_metadata,
-                    tags=tags,
+                    tags=all_tags,
                 )
     else:
         with disable_dagster_warnings():
-            yield event_class(asset_key=asset_key, metadata=all_metadata, tags=tags)
+            yield event_class(asset_key=asset_key, metadata=all_metadata, tags=all_tags)
 
 
 def _get_code_version(asset_key: AssetKey, step_context: StepExecutionContext) -> str:

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_materialize_result.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_materialize_result.py
@@ -36,12 +36,14 @@ def test_materialize_result_asset():
     def ret_untyped(context: AssetExecutionContext):
         return MaterializeResult(
             metadata={"one": 1},
+            tags={"foo": "bar"},
         )
 
     mats = _exec_asset(ret_untyped)
     assert len(mats) == 1, mats
     assert "one" in mats[0].metadata
     assert mats[0].tags
+    assert mats[0].tags["foo"] == "bar"
 
     # key mismatch
     @asset

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observe_result.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observe_result.py
@@ -45,15 +45,14 @@ def _external_observable_asset(**kwargs) -> Callable[..., AssetsDefinition]:
 def test_observe_result_asset():
     @_external_observable_asset()
     def ret_untyped(context: AssetExecutionContext):
-        return ObserveResult(
-            metadata={"one": 1},
-        )
+        return ObserveResult(metadata={"one": 1}, tags={"foo": "bar"})
 
     result = observe([ret_untyped])
     assert result.success
     observations = result.asset_observations_for_node(ret_untyped.node_def.name)
     assert len(observations) == 1, observations
     assert "one" in observations[0].metadata
+    assert observations[0].tags["foo"] == "bar"
 
     # key mismatch
     @_external_observable_asset()

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_output_events.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_output_events.py
@@ -3,14 +3,23 @@ from dagster import DynamicOutput, Output
 
 def test_output_object_equality():
     def _get_output():
-        return Output(5, output_name="foo", metadata={"foo": "bar"})
+        return Output(5, output_name="foo", metadata={"foo": "bar"}, tags={"baz": "qux"})
 
     assert _get_output() == _get_output()
 
-    assert not _get_output() == Output(6, output_name="foo", metadata={"foo": "bar"})
-    assert not _get_output() == Output(5, output_name="diff", metadata={"foo": "bar"})
+    assert not _get_output() == Output(
+        6, output_name="foo", metadata={"foo": "bar"}, tags={"baz": "qux"}
+    )
+    assert not _get_output() == Output(
+        5, output_name="diff", metadata={"foo": "bar"}, tags={"baz": "qux"}
+    )
 
-    assert not _get_output() == Output(5, output_name="foo", metadata={"foo": "baz"})
+    assert not _get_output() == Output(
+        5, output_name="foo", metadata={"foo": "baz"}, tags={"baz": "qux"}
+    )
+    assert not _get_output() == Output(
+        5, output_name="foo", metadata={"foo": "bar"}, tags={"baz": "qub"}
+    )
 
     assert not _get_output() == DynamicOutput(
         5, output_name="foo", metadata={"foo": "bar"}, mapping_key="blah"


### PR DESCRIPTION
## Summary & Motivation

Currently, asset materializations and asset observation events have a `tags` field. However, users are not able/expected to set values on this field. This PR changes that.

A notable aspect of what's being proposed here: users can override the system tags, like those we set to track data provenance at the materialization level.

The direct catalyst for this PR was a conversation I had with an ML-focused user, who wanted to be able to customize data provenance tracking. More info here: https://github.com/dagster-io/dagster/issues/21436.

I'm not yet convinced this is the right way to handle that need. An alternative would be something like a `provenance` argument on `MaterializeResult` and `Output`. But this approach involves less surface area in the long term.

## How I Tested These Changes
