### PR TITLE
fix backfill stalling if first tick does not successfully submit runs

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1197,8 +1197,8 @@ def execute_asset_backfill_iteration_inner(
     request_roots = not asset_backfill_data.requested_runs_for_target_roots
     if request_roots:
         target_roots = asset_backfill_data.get_target_root_asset_partitions(instance_queryer)
-        # check if any roots have already been requested, this make the bfs search more efficent
-        # later in the iteration
+        # Because the code server may have failed while requesting roots, some roots may have
+        # already been requested. Checking here will reduce the amount of BFS work later in the iteration.
         not_yet_requested = [
             root for root in target_roots if root not in asset_backfill_data.requested_subset
         ]


### PR DESCRIPTION
## Summary & Motivation

If the first tick of the backfill daemon is unable to request runs (for example, the user code server is unavailable) the backfill will stall since it has marked the roots as requested, but when evaluating if any children can be materialized, it repeatedly sees that no parents have completed materializations so requests no additional runs.

This PR resolves this by making the following changes:
* on the first tick, do not update `AssetBackfillData.requested_runs_for_target_roots` to True
* on the next tick, do an additional check to see that all of the backfill roots are included in `AssetBackfillData.requested_subset`. if some roots are not, this means the run request was not successfully submitted and we will try to submit the missing roots again. if all roots are in `requested_subset` then we set `AssetBackfillData.requested_runs_for_target_roots` to True. 
* the above step will repeat until all roots have been successfully requested. then the following ticks will proceed as usual.


This change means there is an iteration over the root assets to see if they are in the requested runs. i looked through how we determine if an `AssetKeyPartitionKey` is in an `AssetGraphSubset` and didn't see anything that would be computationally expensive, but i definitely want some second eyes on this because i'm not as familiar with this part of the code base and all its nuances yet.


## How I Tested These Changes
