### PR TITLE
[deprecate-source-assets] storage integration docs

### DIFF
--- a/docs/content/integrations/bigquery/reference.mdx
+++ b/docs/content/integrations/bigquery/reference.mdx
@@ -273,7 +273,7 @@ You can specify the default dataset where data will be stored as configuration t
 If you want to store assets in different datasets, you can specify the dataset as metadata:
 
 ```python file=/integrations/bigquery/reference/dataset.py startafter=start_metadata endbefore=end_metadata dedent=4
-daffodil_data = SourceAsset(key=["daffodil_data"], metadata={"schema": "daffodil"})
+daffodil_data = AssetSpec(key=["daffodil_data"], metadata={"schema": "daffodil"})
 
 @asset(metadata={"schema": "iris"})
 def iris_data() -> pd.DataFrame:
@@ -292,7 +292,7 @@ def iris_data() -> pd.DataFrame:
 You can also specify the dataset as part of the asset's asset key:
 
 ```python file=/integrations/bigquery/reference/dataset.py startafter=start_asset_key endbefore=end_asset_key dedent=4
-daffodil_data = SourceAsset(key=["gcp", "bigquery", "daffodil", "daffodil_data"])
+daffodil_data = AssetSpec(key=["gcp", "bigquery", "daffodil", "daffodil_data"])
 
 @asset(key_prefix=["gcp", "bigquery", "iris"])
 def iris_data() -> pd.DataFrame:

--- a/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
+++ b/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
@@ -129,15 +129,15 @@ Now you can run `dagster dev` and materialize the `iris_data` asset from the Dag
 
 #### Making Dagster aware of existing tables
 
-If you already have existing tables in BigQuery and other assets defined in Dagster depend on those tables, you may want Dagster to be aware of those upstream dependencies. Making Dagster aware of these tables will allow you to track the full data lineage in Dagster. You can accomplish this by creating [source assets](/concepts/io-management/io-managers#using-io-managers-to-load-source-data) for these tables.
+If you already have existing tables in BigQuery and other assets defined in Dagster depend on those tables, you may want Dagster to be aware of those upstream dependencies. Making Dagster aware of these tables will allow you to track the full data lineage in Dagster. You can accomplish this by defining [external assets](/concepts/assets/external-assets) for these tables.
 
 ```python file=/integrations/bigquery/tutorial/resource/source_asset.py
-from dagster import SourceAsset
+from dagster import AssetSpec
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 ```
 
-In this example, you're creating a <PyObject object="SourceAsset" /> for a pre-existing table called `iris_harvest_data`.
+In this example, you're creating an <PyObject object="AssetSpec" /> for a pre-existing table called `iris_harvest_data`.
 
 </TabItem>
 
@@ -176,9 +176,9 @@ import pandas as pd
 from dagster_gcp import BigQueryResource
 from google.cloud import bigquery as bq
 
-from dagster import Definitions, SourceAsset, asset
+from dagster import AssetSpec, Definitions, asset
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 
 
 @asset
@@ -311,17 +311,17 @@ When Dagster materializes the `iris_data` asset using the configuration from [St
 
 #### Making Dagster aware of existing tables
 
-If you already have existing tables in BigQuery and other assets defined in Dagster depend on those tables, you may want Dagster to be aware of those upstream dependencies. Making Dagster aware of these tables will allow you to track the full data lineage in Dagster. You can create [source assets](/concepts/io-management/io-managers#using-io-managers-to-load-source-data) for these tables. When using an I/O manager, creating a source asset for an existing table also allows you to tell Dagster how to find the table so it can be fetched for downstream assets.
+If you already have existing tables in BigQuery and other assets defined in Dagster depend on those tables, you may want Dagster to be aware of those upstream dependencies. Making Dagster aware of these tables will allow you to track the full data lineage in Dagster. You can define [external assets](/concepts/assets/external-assets) for these tables. When using an I/O manager, defining an external asset for an existing table also allows you to tell Dagster how to find the table so it can be fetched for downstream assets.
 
 ```python file=/integrations/bigquery/tutorial/io_manager/source_asset.py
-from dagster import SourceAsset
+from dagster import AssetSpec
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 ```
 
-In this example, you're creating a <PyObject object="SourceAsset" /> for a pre-existing table - perhaps created by an external data ingestion tool - that contains data about iris harvests. To make the data available to other Dagster assets, you need to tell the BigQuery I/O manager how to find the data, so that the I/O manager can load the data into memory.
+In this example, you're creating a <PyObject object="AssetSpec" /> for a pre-existing table - perhaps created by an external data ingestion tool - that contains data about iris harvests. To make the data available to other Dagster assets, you need to tell the BigQuery I/O manager how to find the data, so that the I/O manager can load the data into memory.
 
-Because you already supplied the project and dataset in the I/O manager configuration in [Step 1: Configure the BigQuery I/O manager](#step-1-configure-the-bigquery-io-manager), you only need to provide the table name. This is done with the `key` parameter in `SourceAsset`. When the I/O manager needs to load the `iris_harvest_data` in a downstream asset, it will select the data in the `IRIS.IRIS_HARVEST_DATA` table as a Pandas DataFrame and provide it to the downstream asset.
+Because you already supplied the project and dataset in the I/O manager configuration in [Step 1: Configure the BigQuery I/O manager](#step-1-configure-the-bigquery-io-manager), you only need to provide the table name. This is done with the `key` parameter in `AssetSpec`. When the I/O manager needs to load the `iris_harvest_data` in a downstream asset, it will select the data in the `IRIS.IRIS_HARVEST_DATA` table as a Pandas DataFrame and provide it to the downstream asset.
 
 </TabItem>
 </TabGroup>
@@ -355,9 +355,9 @@ When finished, your code should look like the following:
 import pandas as pd
 from dagster_gcp_pandas import BigQueryPandasIOManager
 
-from dagster import Definitions, SourceAsset, asset
+from dagster import AssetSpec, Definitions, asset
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 
 
 @asset

--- a/docs/content/integrations/deltalake/reference.mdx
+++ b/docs/content/integrations/deltalake/reference.mdx
@@ -231,17 +231,14 @@ You may want to have different assets stored in different Delta Lake schemas. Th
 
 If you want all of your assets to be stored in the same schema, you can specify the schema as configuration to the I/O manager, as we did in [Step 1](/integrations/deltalake/using-deltalake-with-dagster#step-1-configure-the-delta-lake-io-manager) of the [Using Dagster with Delta Lake tutorial](/integrations/deltalake/using-deltalake-with-dagster).
 
-If you want to store assets in different schemas, you can specify the schema as part of the asset's asset key:
-
-- **For `SourceAsset`**, use the `key` parameter. The schema should be the second-to-last value in the parameter. In the following example, this would be `daffodil`.
-- **For asset definitions**, use the `key_prefix` parameter. This value will be prepended to the asset name to create the full asset key. In the following example, this would be `iris`.
+If you want to store assets in different schemas, you can specify the schema as part of the asset's key:
 
 ```python file=/integrations/deltalake/schema.py startafter=start_asset_key endbefore=end_asset_key
 import pandas as pd
 
-from dagster import SourceAsset, asset
+from dagster import AssetSpec, asset
 
-daffodil_dataset = SourceAsset(key=["daffodil", "daffodil_dataset"])
+daffodil_dataset = AssetSpec(key=["daffodil", "daffodil_dataset"])
 
 
 @asset(key_prefix=["iris"])

--- a/docs/content/integrations/deltalake/using-deltalake-with-dagster.mdx
+++ b/docs/content/integrations/deltalake/using-deltalake-with-dagster.mdx
@@ -98,17 +98,17 @@ When Dagster materializes the `iris_dataset` asset using the configuration from 
 
 ### Make an existing table available in Dagster
 
-If you already have tables in your Delta Lake, you may want to make them available to other Dagster assets. You can accomplish this by using [source assets](/concepts/io-management/io-managers#using-io-managers-to-load-source-data) for these tables. By creating a source asset for the existing table, you tell Dagster how to find the table so it can be fetched for downstream assets.
+If you already have tables in your Delta Lake, you may want to make them available to other Dagster assets. You can accomplish this by defining [external assets](/concepts/assets/external-assets) for these tables. By creating an external asset for the existing table, you tell Dagster how to find the table so it can be fetched for downstream assets.
 
 ```python file=/integrations/deltalake/source_asset.py
-from dagster import SourceAsset
+from dagster import AssetSpec
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 ```
 
-In this example, we create a <PyObject object="SourceAsset" /> for an existing table containing iris harvest data. To make the data available to other Dagster assets, we need to tell the Delta Lake I/O manager how to find the data.
+In this example, we create a <PyObject object="AssetSpec" /> for an existing table containing iris harvest data. To make the data available to other Dagster assets, we need to tell the Delta Lake I/O manager how to find the data.
 
-Because we already supplied the database and schema in the I/O manager configuration in [Step 1](#step-1-configure-the-delta-lake-io-manager), we only need to provide the table name. We do this with the `key` parameter in `SourceAsset`. When the I/O manager needs to load the `iris_harvest_data` in a downstream asset, it will select the data in the `iris/iris_harvest_data` folder as a Pandas DataFrame and provide it to the downstream asset.
+Because we already supplied the database and schema in the I/O manager configuration in [Step 1](#step-1-configure-the-delta-lake-io-manager), we only need to provide the table name. We do this with the `key` parameter in `AssetSpec`. When the I/O manager needs to load the `iris_harvest_data` in a downstream asset, it will select the data in the `iris/iris_harvest_data` folder as a Pandas DataFrame and provide it to the downstream asset.
 
 </TabItem>
 </TabGroup>
@@ -117,7 +117,7 @@ Because we already supplied the database and schema in the I/O manager configura
 
 ## Step 3: Load Delta Lake tables in downstream assets
 
-Once you've created an asset or source asset that represents a table in your Delta Lake, you will likely want to create additional assets that work with the data. Dagster and the Delta Lake I/O manager allow you to load the data stored in Delta tables into downstream assets.
+Once you've created an asset that represents a table in your Delta Lake, you will likely want to create additional assets that work with the data. Dagster and the Delta Lake I/O manager allow you to load the data stored in Delta tables into downstream assets.
 
 ```python file=/integrations/deltalake/load_downstream.py startafter=start_example endbefore=end_example
 import pandas as pd
@@ -149,9 +149,9 @@ import pandas as pd
 from dagster_deltalake import LocalConfig
 from dagster_deltalake_pandas import DeltaLakePandasIOManager
 
-from dagster import Definitions, SourceAsset, asset
+from dagster import AssetSpec, Definitions, asset
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 
 
 @asset

--- a/docs/content/integrations/duckdb/reference.mdx
+++ b/docs/content/integrations/duckdb/reference.mdx
@@ -274,7 +274,7 @@ You can specify the default schema where data will be stored as configuration to
 If you want to store assets in different schemas, you can specify the schema as metadata:
 
 ```python file=/integrations/duckdb/reference/schema.py startafter=start_metadata endbefore=end_metadata dedent=4
-daffodil_dataset = SourceAsset(
+daffodil_dataset = AssetSpec(
     key=["daffodil_dataset"], metadata={"schema": "daffodil"}
 )
 
@@ -292,13 +292,10 @@ def iris_dataset() -> pd.DataFrame:
     )
 ```
 
-You can also specify the schema as part of the asset's asset key:
-
-- **For `SourceAsset`**, use the `key` parameter. The schema should be the second-to-last value in the parameter. In the following example, this would be `daffodil`.
-- **For asset definitions**, use the `key_prefix` parameter. This value will be prepended to the asset name to create the full asset key. In the following example, this would be `iris`.
+You can also specify the schema as part of the asset's key:
 
 ```python file=/integrations/duckdb/reference/schema.py startafter=start_asset_key endbefore=end_asset_key dedent=4
-daffodil_dataset = SourceAsset(key=["daffodil", "daffodil_dataset"])
+daffodil_dataset = AssetSpec(key=["daffodil", "daffodil_dataset"])
 
 @asset(key_prefix=["iris"])
 def iris_dataset() -> pd.DataFrame:

--- a/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
+++ b/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
@@ -111,15 +111,15 @@ In this example, you're defining an asset that fetches the Iris dataset as a Pan
 
 #### Making Dagster aware of existing tables
 
-If you already have existing tables in DuckDB and other assets defined in Dagster depend on those tables, you may want Dagster to be aware of those upstream dependencies. Making Dagster aware of these tables will allow you to track the full data lineage in Dagster. You can accomplish this by creating [source assets](/concepts/io-management/io-managers#using-io-managers-to-load-source-data) for these tables.
+If you already have existing tables in DuckDB and other assets defined in Dagster depend on those tables, you may want Dagster to be aware of those upstream dependencies. Making Dagster aware of these tables will allow you to track the full data lineage in Dagster. You can accomplish this by defining [external assets](/concepts/assets/external-assets) for these tables.
 
 ```python file=/integrations/duckdb/tutorial/io_manager/source_asset.py
-from dagster import SourceAsset
+from dagster import AssetSpec
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 ```
 
-In this example, you're creating a <PyObject object="SourceAsset" /> for a pre-existing table called `iris_harvest_data`.
+In this example, you're creating a <PyObject object="AssetSpec" /> for a pre-existing table called `iris_harvest_data`.
 
 </TabItem>
 
@@ -156,9 +156,9 @@ When finished, your code should look like the following:
 import pandas as pd
 from dagster_duckdb import DuckDBResource
 
-from dagster import Definitions, SourceAsset, asset
+from dagster import AssetSpec, Definitions, asset
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 
 
 @asset
@@ -272,17 +272,17 @@ When Dagster materializes the `iris_dataset` asset using the configuration from 
 
 #### Make an existing table available in Dagster
 
-If you already have existing tables in DuckDB and other assets defined in Dagster depend on those tables, you may want Dagster to be aware of those upstream dependencies. Making Dagster aware of these tables will allow you to track the full data lineage in Dagster. You can accomplish this by creating [source assets](/concepts/io-management/io-managers#using-io-managers-to-load-source-data) for these tables.
+If you already have existing tables in DuckDB and other assets defined in Dagster depend on those tables, you may want Dagster to be aware of those upstream dependencies. Making Dagster aware of these tables will allow you to track the full data lineage in Dagster. You can accomplish this by defining [external assets](/concepts/assets/external-assets) for these tables.
 
 ```python file=/integrations/duckdb/tutorial/io_manager/source_asset.py
-from dagster import SourceAsset
+from dagster import AssetSpec
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 ```
 
-In this example, you're creating a <PyObject object="SourceAsset" /> for a pre-existing table containing iris harvests data. To make the data available to other Dagster assets, you need to tell the DuckDB I/O manager how to find the data.
+In this example, you're creating a <PyObject object="AssetSpec" /> for a pre-existing table containing iris harvests data. To make the data available to other Dagster assets, you need to tell the DuckDB I/O manager how to find the data.
 
-Because you already supplied the database and schema in the I/O manager configuration in [Step 1: Configure the DuckDB I/O manager](#step-1-configure-the-duckdb-io-manager), you only need to provide the table name. This is done with the `key` parameter in `SourceAsset`. When the I/O manager needs to load the `iris_harvest_data` in a downstream asset, it will select the data in the `IRIS.IRIS_HARVEST_DATA` table as a Pandas DataFrame and provide it to the downstream asset.
+Because you already supplied the database and schema in the I/O manager configuration in [Step 1: Configure the DuckDB I/O manager](#step-1-configure-the-duckdb-io-manager), you only need to provide the table name. This is done with the `key` parameter in `AssetSpec`. When the I/O manager needs to load the `iris_harvest_data` in a downstream asset, it will select the data in the `IRIS.IRIS_HARVEST_DATA` table as a Pandas DataFrame and provide it to the downstream asset.
 
 </TabItem>
 </TabGroup>
@@ -314,9 +314,9 @@ When finished, your code should look like the following:
 import pandas as pd
 from dagster_duckdb_pandas import DuckDBPandasIOManager
 
-from dagster import Definitions, SourceAsset, asset
+from dagster import AssetSpec, Definitions, asset
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 
 
 @asset

--- a/docs/content/integrations/snowflake/reference.mdx
+++ b/docs/content/integrations/snowflake/reference.mdx
@@ -386,7 +386,7 @@ You can specify the default schema where data will be stored as configuration to
 To store assets in different schemas, specify the schema as metadata:
 
 ```python file=/integrations/snowflake/schema.py startafter=start_metadata endbefore=end_metadata dedent=4
-daffodil_dataset = SourceAsset(
+daffodil_dataset = AssetSpec(
     key=["daffodil_dataset"], metadata={"schema": "daffodil"}
 )
 
@@ -407,7 +407,7 @@ def iris_dataset() -> pd.DataFrame:
 You can also specify the schema as part of the asset's asset key:
 
 ```python file=/integrations/snowflake/schema.py startafter=start_asset_key endbefore=end_asset_key dedent=4
-daffodil_dataset = SourceAsset(key=["daffodil", "daffodil_dataset"])
+daffodil_dataset = AssetSpec(key=["daffodil", "daffodil_dataset"])
 
 @asset(key_prefix=["iris"])
 def iris_dataset() -> pd.DataFrame:

--- a/docs/content/integrations/snowflake/using-snowflake-with-dagster-io-managers.mdx
+++ b/docs/content/integrations/snowflake/using-snowflake-with-dagster-io-managers.mdx
@@ -132,17 +132,17 @@ When Dagster materializes the `iris_dataset` asset using the configuration from 
 
 ### Make an existing table available in Dagster
 
-You may already have tables in Snowflake that you want to make available to other Dagster assets. You can create [source assets](/concepts/io-management/io-managers#using-io-managers-to-load-source-data) for these tables. By creating a source asset for the existing table, you tell Dagster how to find the table so it can be fetched for downstream assets.
+You may already have tables in Snowflake that you want to make available to other Dagster assets. You can define [external assets](/concepts/assets/external-assets) for these tables. By defining an external asset for the existing table, you tell Dagster how to find the table so it can be fetched for downstream assets.
 
 ```python file=/integrations/snowflake/source_asset.py
-from dagster import SourceAsset
+from dagster import AssetSpec
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 ```
 
-In this example, we create a <PyObject object="SourceAsset" /> for a pre-existing table - perhaps created by an external data ingestion tool - that contains data about iris harvests. To make the data available to other Dagster assets, we need to tell the Snowflake I/O manager how to find the data.
+In this example, we create a <PyObject object="AssetSpec" /> for a pre-existing table - perhaps created by an external data ingestion tool - that contains data about iris harvests. To make the data available to other Dagster assets, we need to tell the Snowflake I/O manager how to find the data.
 
-Since we supply the database and the schema in the I/O manager configuration in [Step 1: Configure the Snowflake I/O manager](#step-1-configure-the-snowflake-io-manager), we only need to provide the table name. We do this with the `key` parameter in `SourceAsset`. When the I/O manager needs to load the `iris_harvest_data` in a downstream asset, it will select the data in the `FLOWERS.IRIS.IRIS_HARVEST_DATA` table as a Pandas DataFrame and provide it to the downstream asset.
+Since we supply the database and the schema in the I/O manager configuration in [Step 1: Configure the Snowflake I/O manager](#step-1-configure-the-snowflake-io-manager), we only need to provide the table name. We do this with the `key` parameter in `AssetSpec`. When the I/O manager needs to load the `iris_harvest_data` in a downstream asset, it will select the data in the `FLOWERS.IRIS.IRIS_HARVEST_DATA` table as a Pandas DataFrame and provide it to the downstream asset.
 
 </TabItem>
 </TabGroup>
@@ -151,7 +151,7 @@ Since we supply the database and the schema in the I/O manager configuration in 
 
 ## Step 3: Load Snowflake tables in downstream assets
 
-Once you have created an asset or source asset that represents a table in Snowflake, you will likely want to create additional assets that work with the data. Dagster and the Snowflake I/O manager allow you to load the data stored in Snowflake tables into downstream assets.
+Once you have created an asset that represents a table in Snowflake, you will likely want to create additional assets that work with the data. Dagster and the Snowflake I/O manager allow you to load the data stored in Snowflake tables into downstream assets.
 
 ```python file=/integrations/snowflake/io_manager_tutorial/downstream.py startafter=start_example endbefore=end_example
 import pandas as pd
@@ -180,9 +180,9 @@ When finished, your code should look like the following:
 import pandas as pd
 from dagster_snowflake_pandas import SnowflakePandasIOManager
 
-from dagster import Definitions, EnvVar, SourceAsset, asset
+from dagster import AssetSpec, Definitions, EnvVar, asset
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 
 
 @asset

--- a/docs/content/integrations/snowflake/using-snowflake-with-dagster.mdx
+++ b/docs/content/integrations/snowflake/using-snowflake-with-dagster.mdx
@@ -139,17 +139,17 @@ In this example, we've defined an asset that fetches the Iris dataset as a Panda
 
 If you have existing tables in Snowflake and other assets defined in Dagster depend on those tables, you may want Dagster to be aware of those upstream dependencies.
 
-Making Dagster aware of these tables allows you to track the full data lineage in Dagster. You can accomplish this by creating [source assets](/concepts/io-management/io-managers#using-io-managers-to-load-source-data) for these tables. For example:
+Making Dagster aware of these tables allows you to track the full data lineage in Dagster. You can accomplish this by defining [external assets](/concepts/assets/external-assets) for these tables. For example:
 
 ```python file=/integrations/snowflake/source_asset.py
-from dagster import SourceAsset
+from dagster import AssetSpec
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 ```
 
-In this example, we created a <PyObject object="SourceAsset" /> for a pre-existing table called `iris_harvest_data`.
+In this example, we created a <PyObject object="AssetSpec" /> for a pre-existing table called `iris_harvest_data`.
 
-Since we supplied the database and the schema in the resource configuration in [Step 1](#step-1-configure-the-snowflake-resource), we only need to provide the table name. We did this by using the `key` parameter in our <PyObject object="SourceAsset" />. When the `iris_harvest_data` asset needs to be loaded in a downstream asset, the data in the `FLOWERS.IRIS.IRIS_HARVEST_DATA` table will be selected and provided to the asset.
+Since we supplied the database and the schema in the resource configuration in [Step 1](#step-1-configure-the-snowflake-resource), we only need to provide the table name. We did this by using the `key` parameter in our <PyObject object="AssetSpec" />. When the `iris_harvest_data` asset needs to be loaded in a downstream asset, the data in the `FLOWERS.IRIS.IRIS_HARVEST_DATA` table will be selected and provided to the asset.
 
 </TabItem>
 </TabGroup>

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/dataset.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/dataset.py
@@ -1,11 +1,11 @@
 import pandas as pd
 
-from dagster import SourceAsset, asset
+from dagster import AssetSpec, asset
 
 
 def scppe_asset_key():
     # start_asset_key
-    daffodil_data = SourceAsset(key=["gcp", "bigquery", "daffodil", "daffodil_data"])
+    daffodil_data = AssetSpec(key=["gcp", "bigquery", "daffodil", "daffodil_data"])
 
     @asset(key_prefix=["gcp", "bigquery", "iris"])
     def iris_data() -> pd.DataFrame:
@@ -25,7 +25,7 @@ def scppe_asset_key():
 
 def scope_metadata():
     # start_metadata
-    daffodil_data = SourceAsset(key=["daffodil_data"], metadata={"schema": "daffodil"})
+    daffodil_data = AssetSpec(key=["daffodil_data"], metadata={"schema": "daffodil"})
 
     @asset(metadata={"schema": "iris"})
     def iris_data() -> pd.DataFrame:

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/io_manager/full_example.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/io_manager/full_example.py
@@ -1,9 +1,9 @@
 import pandas as pd
 from dagster_gcp_pandas import BigQueryPandasIOManager
 
-from dagster import Definitions, SourceAsset, asset
+from dagster import AssetSpec, Definitions, asset
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 
 
 @asset

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/io_manager/source_asset.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/io_manager/source_asset.py
@@ -1,3 +1,3 @@
-from dagster import SourceAsset
+from dagster import AssetSpec
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/resource/full_example.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/resource/full_example.py
@@ -2,9 +2,9 @@ import pandas as pd
 from dagster_gcp import BigQueryResource
 from google.cloud import bigquery as bq
 
-from dagster import Definitions, SourceAsset, asset
+from dagster import AssetSpec, Definitions, asset
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 
 
 @asset

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/resource/source_asset.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/tutorial/resource/source_asset.py
@@ -1,3 +1,3 @@
-from dagster import SourceAsset
+from dagster import AssetSpec
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")

--- a/examples/docs_snippets/docs_snippets/integrations/deltalake/full_example.py
+++ b/examples/docs_snippets/docs_snippets/integrations/deltalake/full_example.py
@@ -2,9 +2,9 @@ import pandas as pd
 from dagster_deltalake import LocalConfig
 from dagster_deltalake_pandas import DeltaLakePandasIOManager
 
-from dagster import Definitions, SourceAsset, asset
+from dagster import AssetSpec, Definitions, asset
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 
 
 @asset

--- a/examples/docs_snippets/docs_snippets/integrations/deltalake/schema.py
+++ b/examples/docs_snippets/docs_snippets/integrations/deltalake/schema.py
@@ -2,9 +2,9 @@
 
 import pandas as pd
 
-from dagster import SourceAsset, asset
+from dagster import AssetSpec, asset
 
-daffodil_dataset = SourceAsset(key=["daffodil", "daffodil_dataset"])
+daffodil_dataset = AssetSpec(key=["daffodil", "daffodil_dataset"])
 
 
 @asset(key_prefix=["iris"])

--- a/examples/docs_snippets/docs_snippets/integrations/deltalake/source_asset.py
+++ b/examples/docs_snippets/docs_snippets/integrations/deltalake/source_asset.py
@@ -1,3 +1,3 @@
-from dagster import SourceAsset
+from dagster import AssetSpec
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/schema.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/schema.py
@@ -1,11 +1,11 @@
 import pandas as pd
 
-from dagster import SourceAsset, asset
+from dagster import AssetSpec, asset
 
 
 def scope_asset_key():
     # start_asset_key
-    daffodil_dataset = SourceAsset(key=["daffodil", "daffodil_dataset"])
+    daffodil_dataset = AssetSpec(key=["daffodil", "daffodil_dataset"])
 
     @asset(key_prefix=["iris"])
     def iris_dataset() -> pd.DataFrame:
@@ -26,7 +26,7 @@ def scope_asset_key():
 def scope_metadata():
     # start_metadata
 
-    daffodil_dataset = SourceAsset(
+    daffodil_dataset = AssetSpec(
         key=["daffodil_dataset"], metadata={"schema": "daffodil"}
     )
 

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/io_manager/full_example.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/io_manager/full_example.py
@@ -1,9 +1,9 @@
 import pandas as pd
 from dagster_duckdb_pandas import DuckDBPandasIOManager
 
-from dagster import Definitions, SourceAsset, asset
+from dagster import AssetSpec, Definitions, asset
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 
 
 @asset

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/io_manager/source_asset.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/io_manager/source_asset.py
@@ -1,3 +1,3 @@
-from dagster import SourceAsset
+from dagster import AssetSpec
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/resource/full_example.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/tutorial/resource/full_example.py
@@ -1,9 +1,9 @@
 import pandas as pd
 from dagster_duckdb import DuckDBResource
 
-from dagster import Definitions, SourceAsset, asset
+from dagster import AssetSpec, Definitions, asset
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 
 
 @asset

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/io_manager_tutorial/full_example.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/io_manager_tutorial/full_example.py
@@ -1,9 +1,9 @@
 import pandas as pd
 from dagster_snowflake_pandas import SnowflakePandasIOManager
 
-from dagster import Definitions, EnvVar, SourceAsset, asset
+from dagster import AssetSpec, Definitions, EnvVar, asset
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")
 
 
 @asset

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/schema.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/schema.py
@@ -1,11 +1,11 @@
 import pandas as pd
 
-from dagster import SourceAsset, asset
+from dagster import AssetSpec, asset
 
 
 def scope_asset_key():
     # start_asset_key
-    daffodil_dataset = SourceAsset(key=["daffodil", "daffodil_dataset"])
+    daffodil_dataset = AssetSpec(key=["daffodil", "daffodil_dataset"])
 
     @asset(key_prefix=["iris"])
     def iris_dataset() -> pd.DataFrame:
@@ -25,7 +25,7 @@ def scope_asset_key():
 
 def scope_metadata():
     # start_metadata
-    daffodil_dataset = SourceAsset(
+    daffodil_dataset = AssetSpec(
         key=["daffodil_dataset"], metadata={"schema": "daffodil"}
     )
 

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/source_asset.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/source_asset.py
@@ -1,3 +1,3 @@
-from dagster import SourceAsset
+from dagster import AssetSpec
 
-iris_harvest_data = SourceAsset(key="iris_harvest_data")
+iris_harvest_data = AssetSpec(key="iris_harvest_data")


### PR DESCRIPTION
 ## Summary & Motivation

`SourceAsset` is a deprecated concept, but our docs on warehouse integrations still mention them. This PR switches mentions to `AssetSpec` and "external asset".

## How I Tested These Changes
