### PR TITLE
Update assets and io managers in with_openai

### DIFF
--- a/examples/with_openai/setup.py
+++ b/examples/with_openai/setup.py
@@ -5,6 +5,7 @@ setup(
     packages=find_packages(exclude=["with_openai_tests"]),
     install_requires=[
         "dagster",
+        "dagster-aws",
         "dagster-openai",
         "faiss-cpu==1.8.0",
         "filelock",

--- a/examples/with_openai/setup.py
+++ b/examples/with_openai/setup.py
@@ -6,9 +6,9 @@ setup(
     install_requires=[
         "dagster",
         "dagster-aws",
-        "dagster-openai",
         # Commented to avoid version conflicts with Pyright in the Dagster repo, uncomment when using Dagster+
         # "dagster-cloud",
+        "dagster-openai",
         "faiss-cpu==1.8.0",
         "filelock",
         "langchain==0.1.11",

--- a/examples/with_openai/setup.py
+++ b/examples/with_openai/setup.py
@@ -7,7 +7,8 @@ setup(
         "dagster",
         "dagster-aws",
         "dagster-openai",
-        # "dagster-cloud", # Uncomment when using Dagster+
+        # Commented to avoid version conflicts with Pyright in the Dagster repo, uncomment when using Dagster+
+        # "dagster-cloud",
         "faiss-cpu==1.8.0",
         "filelock",
         "langchain==0.1.11",

--- a/examples/with_openai/setup.py
+++ b/examples/with_openai/setup.py
@@ -7,6 +7,7 @@ setup(
         "dagster",
         "dagster-aws",
         "dagster-openai",
+        # "dagster-cloud", # Uncomment when using Dagster+
         "faiss-cpu==1.8.0",
         "filelock",
         "langchain==0.1.11",

--- a/examples/with_openai/with_openai/assets.py
+++ b/examples/with_openai/with_openai/assets.py
@@ -1,24 +1,24 @@
 import os
-import pickle
+from typing import Any, Dict, List
 
 from dagster import (
+    AllPartitionMapping,
     AssetExecutionContext,
+    AssetIn,
     Config,
     StaticPartitionsDefinition,
     asset,
     define_asset_job,
 )
 from dagster_openai import OpenAIResource
-from filelock import FileLock
 from langchain.chains.qa_with_sources import stuff_prompt
-from langchain.chat_models.openai import ChatOpenAI
 from langchain.docstore.document import Document
-from langchain.embeddings.openai import OpenAIEmbeddings
 from langchain.schema.output_parser import StrOutputParser
 from langchain.text_splitter import CharacterTextSplitter
-from langchain.vectorstores.faiss import FAISS
+from langchain_community.vectorstores import FAISS
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
-from .constants import SEARCH_INDEX_FILE, SUMMARY_TEMPLATE
+from .constants import SUMMARY_TEMPLATE
 from .utils import get_github_docs
 
 docs_partitions_def = StaticPartitionsDefinition(
@@ -35,14 +35,19 @@ docs_partitions_def = StaticPartitionsDefinition(
     ]
 )
 
+if bool(os.getenv("DAGSTER_IS_DEV_CLI")):
+    io_manager_key = "io_manager"
+else:
+    io_manager_key = "s3_io_manager"
 
-@asset(compute_kind="GitHub", partitions_def=docs_partitions_def)
+
+@asset(compute_kind="GitHub", partitions_def=docs_partitions_def, io_manager_key=io_manager_key)
 def source_docs(context: AssetExecutionContext):
     return list(get_github_docs("dagster-io", "dagster", context.partition_key))
 
 
-@asset(compute_kind="OpenAI", partitions_def=docs_partitions_def)
-def search_index(context: AssetExecutionContext, openai: OpenAIResource, source_docs):
+@asset(compute_kind="OpenAI", partitions_def=docs_partitions_def, io_manager_key=io_manager_key)
+def search_index(context: AssetExecutionContext, openai: OpenAIResource, source_docs: List[Any]):
     source_chunks = []
     splitter = CharacterTextSplitter(separator=" ", chunk_size=1024, chunk_overlap=0)
     for source in source_docs:
@@ -55,17 +60,7 @@ def search_index(context: AssetExecutionContext, openai: OpenAIResource, source_
             source_chunks, OpenAIEmbeddings(client=client.embeddings)
         )
 
-    with FileLock(SEARCH_INDEX_FILE):
-        if os.path.getsize(SEARCH_INDEX_FILE) > 0:
-            with open(SEARCH_INDEX_FILE, "rb") as f:
-                serialized_search_index = pickle.load(f)
-            cached_search_index = FAISS.deserialize_from_bytes(
-                serialized_search_index, OpenAIEmbeddings()
-            )
-            search_index.merge_from(cached_search_index)
-
-        with open(SEARCH_INDEX_FILE, "wb") as f:
-            pickle.dump(search_index.serialize_to_bytes(), f)
+    return search_index.serialize_to_bytes()
 
 
 class OpenAIConfig(Config):
@@ -73,24 +68,36 @@ class OpenAIConfig(Config):
     question: str
 
 
-@asset(compute_kind="OpenAI", deps=[search_index])
+@asset(
+    compute_kind="OpenAI",
+    ins={
+        "search_index": AssetIn(partition_mapping=AllPartitionMapping()),
+    },
+    io_manager_key=io_manager_key,
+)
 def completion(
     context: AssetExecutionContext,
     openai: OpenAIResource,
     config: OpenAIConfig,
+    search_index: Dict[str, Any],
 ):
-    with open(SEARCH_INDEX_FILE, "rb") as f:
-        serialized_search_index = pickle.load(f)
-    search_index = FAISS.deserialize_from_bytes(serialized_search_index, OpenAIEmbeddings())
+    merged_index = None
+    for index in search_index.values():
+        curr = FAISS.deserialize_from_bytes(index, OpenAIEmbeddings())
+        if not merged_index:
+            merged_index = curr
+        else:
+            merged_index.merge_from(FAISS.deserialize_from_bytes(index, OpenAIEmbeddings()))
     with openai.get_client(context) as client:
         prompt = stuff_prompt.PROMPT
         model = ChatOpenAI(client=client.chat.completions, model=config.model, temperature=0)
         summaries = " ".join(
             [
                 SUMMARY_TEMPLATE.format(content=doc.page_content, source=doc.metadata["source"])
-                for doc in search_index.similarity_search(config.question, k=4)
+                for doc in merged_index.similarity_search(config.question, k=4)
             ]
         )
+        context.log.info(summaries)
         output_parser = StrOutputParser()
         chain = prompt | model | output_parser
         context.log.info(chain.invoke({"summaries": summaries, "question": config.question}))

--- a/examples/with_openai/with_openai/assets.py
+++ b/examples/with_openai/with_openai/assets.py
@@ -81,7 +81,7 @@ def completion(
     config: OpenAIConfig,
     search_index: Dict[str, Any],
 ):
-    merged_index = None
+    merged_index: Any = None
     for index in search_index.values():
         curr = FAISS.deserialize_from_bytes(index, OpenAIEmbeddings())
         if not merged_index:

--- a/examples/with_openai/with_openai/assets.py
+++ b/examples/with_openai/with_openai/assets.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any, Dict, List
 
 from dagster import (
@@ -35,18 +34,13 @@ docs_partitions_def = StaticPartitionsDefinition(
     ]
 )
 
-if bool(os.getenv("DAGSTER_IS_DEV_CLI")):
-    io_manager_key = "io_manager"
-else:
-    io_manager_key = "s3_io_manager"
 
-
-@asset(compute_kind="GitHub", partitions_def=docs_partitions_def, io_manager_key=io_manager_key)
+@asset(compute_kind="GitHub", partitions_def=docs_partitions_def)
 def source_docs(context: AssetExecutionContext):
     return list(get_github_docs("dagster-io", "dagster", context.partition_key))
 
 
-@asset(compute_kind="OpenAI", partitions_def=docs_partitions_def, io_manager_key=io_manager_key)
+@asset(compute_kind="OpenAI", partitions_def=docs_partitions_def)
 def search_index(context: AssetExecutionContext, openai: OpenAIResource, source_docs: List[Any]):
     source_chunks = []
     splitter = CharacterTextSplitter(separator=" ", chunk_size=1024, chunk_overlap=0)
@@ -73,7 +67,6 @@ class OpenAIConfig(Config):
     ins={
         "search_index": AssetIn(partition_mapping=AllPartitionMapping()),
     },
-    io_manager_key=io_manager_key,
 )
 def completion(
     context: AssetExecutionContext,

--- a/examples/with_openai/with_openai/definitions.py
+++ b/examples/with_openai/with_openai/definitions.py
@@ -49,16 +49,25 @@ all_assets = load_assets_from_modules([assets])
 all_jobs = [question_job, search_index_job]
 all_sensors = [question_sensor]
 
+# for handling passing data between assets in cloud env
+io_manager_resource_dict = (
+    {
+        "io_manager": S3PickleIOManager(
+            s3_resource=S3Resource(),
+            s3_bucket="with_openai",
+        )
+    }
+    if os.getenv("DAGSTER_CLOUD_DEPLOYMENT_NAME")
+    else {}
+)
+
 
 defs = Definitions(
     assets=all_assets,
     jobs=all_jobs,
     resources={
         "openai": OpenAIResource(api_key=EnvVar("OPENAI_API_KEY")),
-        "s3_io_manager": S3PickleIOManager(
-            s3_resource=S3Resource(),
-            s3_bucket="with_openai",
-        ),
+        **io_manager_resource_dict,
     },
     sensors=all_sensors,
 )

--- a/examples/with_openai/with_openai/definitions.py
+++ b/examples/with_openai/with_openai/definitions.py
@@ -9,6 +9,7 @@ from dagster import (
     load_assets_from_modules,
     sensor,
 )
+from dagster_aws.s3 import S3PickleIOManager, S3Resource
 from dagster_openai import OpenAIResource
 
 from . import assets
@@ -48,11 +49,16 @@ all_assets = load_assets_from_modules([assets])
 all_jobs = [question_job, search_index_job]
 all_sensors = [question_sensor]
 
+
 defs = Definitions(
     assets=all_assets,
     jobs=all_jobs,
     resources={
         "openai": OpenAIResource(api_key=EnvVar("OPENAI_API_KEY")),
+        "s3_io_manager": S3PickleIOManager(
+            s3_resource=S3Resource(),
+            s3_bucket="with_openai",
+        ),
     },
     sensors=all_sensors,
 )

--- a/pyright/alt-1/requirements-pinned.txt
+++ b/pyright/alt-1/requirements-pinned.txt
@@ -128,7 +128,7 @@ jmespath==1.0.1
 joblib==1.4.0
 json5==0.9.25
 jsonpointer==2.4
-jsonschema==4.21.1
+jsonschema==4.22.0
 jsonschema-specifications==2023.12.1
 jupyter-client==8.6.1
 jupyter-core==5.7.2
@@ -175,7 +175,7 @@ oauth2client==4.1.3
 oauthlib==3.2.2
 objgraph==3.6.1
 ordered-set==4.1.0
-orjson==3.10.1
+orjson==3.10.2
 overrides==7.7.0
 packaging==24.0
 pandas==2.0.3
@@ -230,7 +230,7 @@ python-slugify==8.0.4
 pytimeparse==1.1.8
 pytz==2024.1
 pyyaml==6.0.1
-pyzmq==26.0.2
+pyzmq==26.0.3
 rapidfuzz==3.8.1
 referencing==0.35.0
 requests==2.31.0

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -290,7 +290,7 @@ jsonpath-ng==1.6.1
 jsonpickle==3.0.4
 jsonpointer==2.4
 jsonref==1.1.0
-jsonschema==4.21.1
+jsonschema==4.22.0
 jsonschema-path==0.3.2
 jsonschema-specifications==2023.12.1
 junit-xml==1.9
@@ -312,7 +312,7 @@ kubernetes==29.0.0
 kubernetes-asyncio==29.0.0
 langchain==0.1.11
 langchain-community==0.0.34
-langchain-core==0.1.47
+langchain-core==0.1.48
 langchain-openai==0.1.3
 langchain-text-splitters==0.0.1
 langsmith==0.1.52
@@ -372,7 +372,7 @@ objgraph==3.6.1
 onnx==1.16.0
 onnxconverter-common==1.13.0
 onnxruntime==1.17.3
-openai==1.24.1
+openai==1.25.0
 openapi-schema-validator==0.6.2
 openapi-spec-validator==0.7.1
 opentelemetry-api==1.24.0
@@ -384,7 +384,7 @@ opentelemetry-proto==1.24.0
 opentelemetry-sdk==1.24.0
 opentelemetry-semantic-conventions==0.45b0
 ordered-set==4.1.0
-orjson==3.10.1
+orjson==3.10.2
 outcome==1.3.0.post0
 overrides==7.7.0
 packaging==23.2
@@ -410,7 +410,7 @@ pillow==10.3.0
 pip==24.0
 pkginfo==1.10.0
 platformdirs==4.2.1
-plotly==5.21.0
+plotly==5.22.0
 pluggy==1.5.0
 ply==3.11
 polars==0.20.23
@@ -466,7 +466,7 @@ pytimeparse==1.1.8
 pytz==2024.1
 pytzdata==2020.1
 pyyaml==6.0.1
-pyzmq==26.0.2
+pyzmq==26.0.3
 querystring-parser==1.2.4
 rapidfuzz==3.8.1
 readme-renderer==43.0


### PR DESCRIPTION
## Summary & Motivation

This PR updates the assets in the `with_openai`, to make it more user friendly in Dagster+.

Changes:
- completion now uses AllPartitionMapping to handle the search index partitions
- the IO manager is set to S3PickleIOManager in Dagster+
- merging the FAISS index objects is handled in completion, because it is needed to answer the prompt
- imports are updated to use the new LangChain libraries, because importing OpenAI and FAISS classes directly from `langchain` will soon be deprecated.

## How I Tested These Changes

dagster dev
BK