### PR TITLE
in dagstermill test, don't dump entire dagster event to json

### DIFF
--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_logging.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_logging.py
@@ -31,13 +31,7 @@ class LogTestFileHandler(logging.Handler):
     def emit(self, record):
         with open(self.file_path, "a", encoding="utf8") as fd:
             fd.write(
-                seven.json.dumps(
-                    {
-                        "dagster_meta": {
-                            "orig_message": record.__dict__["dagster_meta"]["orig_message"]
-                        }
-                    }
-                )
+                seven.json.dumps({"the_message": record.__dict__["dagster_meta"]["orig_message"]})
                 + "\n"
             )
 
@@ -132,10 +126,10 @@ def test_logging(hello_logging_job_type) -> None:
                         if line
                     ]
 
-    messages = [x["dagster_meta"]["orig_message"] for x in records]
+    messages = [x["the_message"] for x in records]
 
     assert "Hello, there!" in messages
 
-    critical_messages = [x["dagster_meta"]["orig_message"] for x in critical_records]
+    critical_messages = [x["the_message"] for x in critical_records]
 
     assert "Hello, there!" not in critical_messages

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_logging.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_logging.py
@@ -30,7 +30,16 @@ class LogTestFileHandler(logging.Handler):
 
     def emit(self, record):
         with open(self.file_path, "a", encoding="utf8") as fd:
-            fd.write(seven.json.dumps(record.__dict__) + "\n")
+            fd.write(
+                seven.json.dumps(
+                    {
+                        "dagster_meta": {
+                            "orig_message": record.__dict__["dagster_meta"]["orig_message"]
+                        }
+                    }
+                )
+                + "\n"
+            )
 
 
 @logger(config_schema={"name": String, "log_level": String, "file_path": String})


### PR DESCRIPTION
## Summary & Motivation

In general, DagsterEvents are not always json-dumpable (e.g. they contain enums), but this test assumes they are. This causes problems when moving from `NamedTuple` (which are json-dumpable) to `DagsterModel` (which are not json-dumpable) for classes within `DagsterEvent`s.

## How I Tested These Changes
