### PR TITLE
More cleanly handle the case where a k8s job can't be found during health checks

### DIFF
--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -339,6 +339,11 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             return CheckRunHealthResult(
                 WorkerStatus.UNKNOWN, str(serializable_error_info_from_exc_info(sys.exc_info()))
             )
+
+        if not status:
+            return CheckRunHealthResult(
+                WorkerStatus.UNKNOWN, f"K8s job {job_name} could not be found"
+            )
         if status.failed:
             return CheckRunHealthResult(WorkerStatus.FAILED, "K8s job failed")
         return CheckRunHealthResult(WorkerStatus.RUNNING)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -317,6 +317,10 @@ class K8sStepHandler(StepHandler):
             namespace=container_context.namespace,
             job_name=job_name,
         )
+        if not status:
+            return CheckStepHealthResult.unhealthy(
+                reason=f"Kubernetes job {job_name} for step {step_key} could not be found."
+            )
         if status.failed:
             return CheckStepHealthResult.unhealthy(
                 reason=f"Discovered failed Kubernetes job {job_name} for step {step_key}.",

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -429,6 +429,9 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
                 WorkerStatus.UNKNOWN, str(serializable_error_info_from_exc_info(sys.exc_info()))
             )
 
+        if not status:
+            return CheckRunHealthResult(WorkerStatus.UNKNOWN, f"Job {job_name} could not be found")
+
         inactive_job_with_finished_pods = bool(
             (not status.active) and (status.failed or status.succeeded)
         )


### PR DESCRIPTION
Summary:
Return None instead of raising an unsightly exception when the k8s job doesn't exist at all

## Summary & Motivation

## How I Tested These Changes
