### PR TITLE
get_latest_materialization_or_observation_record -> get_latest_persistence_record

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -198,10 +198,8 @@ class CachingDataTimeResolver:
                 before_cursor = None
 
             if before_cursor is not None:
-                parent_record = (
-                    self._instance_queryer.get_latest_materialization_or_observation_record(
-                        AssetKeyPartitionKey(parent_key), before_cursor=before_cursor
-                    )
+                parent_record = self._instance_queryer.get_latest_asset_partition_record(
+                    AssetKeyPartitionKey(parent_key), before_cursor=before_cursor
                 )
                 if parent_record is not None:
                     upstream_records[parent_key] = parent_record
@@ -495,7 +493,7 @@ class CachingDataTimeResolver:
     def get_current_data_time(
         self, asset_key: AssetKey, current_time: datetime.datetime
     ) -> Optional[datetime.datetime]:
-        latest_record = self.instance_queryer.get_latest_materialization_or_observation_record(
+        latest_record = self.instance_queryer.get_latest_asset_partition_record(
             AssetKeyPartitionKey(asset_key)
         )
         if latest_record is None:
@@ -511,7 +509,7 @@ class CachingDataTimeResolver:
     def _get_source_data_time(
         self, asset_key: AssetKey, current_time: datetime.datetime
     ) -> Optional[datetime.datetime]:
-        latest_record = self.instance_queryer.get_latest_materialization_or_observation_record(
+        latest_record = self.instance_queryer.get_latest_asset_partition_record(
             AssetKeyPartitionKey(asset_key)
         )
         if latest_record is None:
@@ -520,7 +518,7 @@ class CachingDataTimeResolver:
         if observation is None:
             check.failed(
                 "when invoked on a source asset, "
-                "get_latest_materialization_or_observation_record should always return an "
+                "get_latest_asset_partition_record should always return an "
                 "observation"
             )
 

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -198,7 +198,7 @@ class CachingDataTimeResolver:
                 before_cursor = None
 
             if before_cursor is not None:
-                parent_record = self._instance_queryer.get_latest_asset_partition_record(
+                parent_record = self._instance_queryer.get_latest_persistence_record(
                     AssetKeyPartitionKey(parent_key), before_cursor=before_cursor
                 )
                 if parent_record is not None:
@@ -493,7 +493,7 @@ class CachingDataTimeResolver:
     def get_current_data_time(
         self, asset_key: AssetKey, current_time: datetime.datetime
     ) -> Optional[datetime.datetime]:
-        latest_record = self.instance_queryer.get_latest_asset_partition_record(
+        latest_record = self.instance_queryer.get_latest_persistence_record(
             AssetKeyPartitionKey(asset_key)
         )
         if latest_record is None:
@@ -509,7 +509,7 @@ class CachingDataTimeResolver:
     def _get_source_data_time(
         self, asset_key: AssetKey, current_time: datetime.datetime
     ) -> Optional[datetime.datetime]:
-        latest_record = self.instance_queryer.get_latest_asset_partition_record(
+        latest_record = self.instance_queryer.get_latest_persistence_record(
             AssetKeyPartitionKey(asset_key)
         )
         if latest_record is None:
@@ -518,7 +518,7 @@ class CachingDataTimeResolver:
         if observation is None:
             check.failed(
                 "when invoked on a source asset, "
-                "get_latest_asset_partition_record should always return an "
+                "get_latest_persistence_record should always return an "
                 "observation"
             )
 

--- a/python_modules/dagster/dagster/_core/definitions/data_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_version.py
@@ -691,7 +691,7 @@ class CachingStaleStatusResolver:
         ):
             ancestors = self.asset_graph.get_ancestor_asset_keys(key.asset_key, include_self=True)
             self.instance_queryer.prefetch_asset_records(ancestors)
-        return self.instance_queryer.get_latest_asset_partition_record(asset_partition=key)
+        return self.instance_queryer.get_latest_persistence_record(asset_partition=key)
 
     # If a partition has greater than or equal to SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD
     # of dependencies, or is downstream of a time window partition with an AllPartitionsMapping,

--- a/python_modules/dagster/dagster/_core/definitions/data_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_version.py
@@ -691,9 +691,7 @@ class CachingStaleStatusResolver:
         ):
             ancestors = self.asset_graph.get_ancestor_asset_keys(key.asset_key, include_self=True)
             self.instance_queryer.prefetch_asset_records(ancestors)
-        return self.instance_queryer.get_latest_materialization_or_observation_record(
-            asset_partition=key
-        )
+        return self.instance_queryer.get_latest_asset_partition_record(asset_partition=key)
 
     # If a partition has greater than or equal to SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD
     # of dependencies, or is downstream of a time window partition with an AllPartitionsMapping,

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -211,7 +211,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             return DagsterEventType.ASSET_MATERIALIZATION
 
     @cached_method
-    def _get_latest_materialization_or_observation_record(
+    def _get_latest_asset_partition_record(
         self, *, asset_partition: AssetKeyPartitionKey, before_cursor: Optional[int] = None
     ) -> Optional["EventLogRecord"]:
         """Returns the latest event log record for the given asset partition of an asset. For
@@ -257,9 +257,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         present in the mapping, representing the latest storage id for the asset as a whole.
         """
         asset_partition = AssetKeyPartitionKey(asset_key)
-        latest_record = self._get_latest_materialization_or_observation_record(
-            asset_partition=asset_partition
-        )
+        latest_record = self._get_latest_asset_partition_record(asset_partition=asset_partition)
         latest_storage_ids = {
             asset_partition: latest_record.storage_id if latest_record is not None else None
         }
@@ -284,9 +282,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             asset_partition (AssetKeyPartitionKey): The asset partition to query.
         """
         if asset_partition.partition_key is None:
-            record = self._get_latest_materialization_or_observation_record(
-                asset_partition=asset_partition
-            )
+            record = self._get_latest_asset_partition_record(asset_partition=asset_partition)
             return record.storage_id if record else None
         return self._get_latest_materialization_or_observation_storage_ids_by_asset_partition(
             asset_key=asset_partition.asset_key
@@ -322,7 +318,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             after_cursor or 0
         )
 
-    def get_latest_materialization_or_observation_record(
+    def get_latest_asset_partition_record(
         self,
         asset_partition: AssetKeyPartitionKey,
         after_cursor: Optional[int] = None,
@@ -353,11 +349,9 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         elif (before_cursor or 0) > (
             self.get_latest_materialization_or_observation_storage_id(asset_partition) or 0
         ):
-            return self._get_latest_materialization_or_observation_record(
-                asset_partition=asset_partition
-            )
+            return self._get_latest_asset_partition_record(asset_partition=asset_partition)
         # otherwise, do the explicit query
-        return self._get_latest_materialization_or_observation_record(
+        return self._get_latest_asset_partition_record(
             asset_partition=asset_partition, before_cursor=before_cursor
         )
 
@@ -600,7 +594,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             ).partitions_def
             if parent_partitions_def is None:
                 latest_parent_record = check.not_none(
-                    self.get_latest_materialization_or_observation_record(
+                    self.get_latest_asset_partition_record(
                         AssetKeyPartitionKey(parent_asset_key), after_cursor=latest_storage_id
                     )
                 )
@@ -693,7 +687,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
                         # manually query to see if this asset partition was intended to be
                         # executed in the same run as its parent
                         latest_partition_record = check.not_none(
-                            self.get_latest_materialization_or_observation_record(
+                            self.get_latest_asset_partition_record(
                                 AssetKeyPartitionKey(parent_asset_key, child_partition),
                                 after_cursor=latest_storage_id,
                             )
@@ -723,7 +717,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
     ) -> Mapping[AssetKeyPartitionKey, Optional[DataVersion]]:
         if not self.asset_graph.get(asset_key).is_partitioned:
             asset_partition = AssetKeyPartitionKey(asset_key)
-            latest_record = self.get_latest_materialization_or_observation_record(
+            latest_record = self.get_latest_asset_partition_record(
                 asset_partition, after_cursor=after_cursor, before_cursor=before_cursor
             )
             return (

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -318,6 +318,17 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             after_cursor or 0
         )
 
+    # for internal compat. Will remove in followup -- schrockn 2024-04-27
+    def get_latest_materialization_or_observation_record(
+        self,
+        asset_partition: AssetKeyPartitionKey,
+        after_cursor: Optional[int] = None,
+        before_cursor: Optional[int] = None,
+    ) -> Optional["EventLogRecord"]:
+        return self.get_latest_asset_partition_record(
+            asset_partition=asset_partition, after_cursor=after_cursor, before_cursor=before_cursor
+        )
+
     def get_latest_asset_partition_record(
         self,
         asset_partition: AssetKeyPartitionKey,

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -139,8 +139,10 @@ def test_calculate_data_time_unpartitioned(ignore_asset_tags, runs_to_expected_d
 
             for asset_keys, expected_data_times in expected_index_mapping.items():
                 for ak in asset_keys:
-                    latest_asset_record = data_time_queryer.instance_queryer.get_latest_materialization_or_observation_record(
-                        AssetKeyPartitionKey(AssetKey(ak))
+                    latest_asset_record = (
+                        data_time_queryer.instance_queryer.get_latest_asset_partition_record(
+                            AssetKeyPartitionKey(AssetKey(ak))
+                        )
                     )
                     if ignore_asset_tags:
                         # simulate an environment where materialization tags were not populated

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -140,7 +140,7 @@ def test_calculate_data_time_unpartitioned(ignore_asset_tags, runs_to_expected_d
             for asset_keys, expected_data_times in expected_index_mapping.items():
                 for ak in asset_keys:
                     latest_asset_record = (
-                        data_time_queryer.instance_queryer.get_latest_asset_partition_record(
+                        data_time_queryer.instance_queryer.get_latest_persistence_record(
                             AssetKeyPartitionKey(AssetKey(ak))
                         )
                     )


### PR DESCRIPTION
## Summary & Motivation

We have a naming pattern of `materialization_or_observation` in various contexts across the codebase. I think this is gross and bad. Instead I propose we should standardize around language of "asset partition persistence record" where it is understood that "materialization" and "observation" both indicate that the underlying persisted asset partition corresponding to the definition does in fact exist.

If we agree that this is a good idea I'll rename all the other instances of this pattern in the codebase.

## How I Tested These Changes

BK
