### PR TITLE
rename get_input_asset_version_info to maybe_fetch_and_get_input_asset_version_info

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
@@ -145,7 +145,9 @@ class AssetCheckResult(
 
         check_key = self.resolve_target_check_key(check_names_by_asset_key)
 
-        input_asset_info = step_context.get_input_asset_version_info(check_key.asset_key)
+        input_asset_info = step_context.maybe_fetch_and_get_input_asset_version_info(
+            check_key.asset_key
+        )
         from dagster._core.events import DagsterEventType
 
         if (

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -995,7 +995,9 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
     def is_external_input_asset_version_info_loaded(self) -> bool:
         return self._is_external_input_asset_version_info_loaded
 
-    def get_input_asset_version_info(self, key: AssetKey) -> Optional["InputAssetVersionInfo"]:
+    def maybe_fetch_and_get_input_asset_version_info(
+        self, key: AssetKey
+    ) -> Optional["InputAssetVersionInfo"]:
         if key not in self._input_asset_version_info:
             self._fetch_input_asset_version_info(key)
         return self._input_asset_version_info[key]

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -713,7 +713,7 @@ def _get_input_provenance_data(
         # the most recent materialization record (it will retrieve a cached record if it's already
         # been asked for). For this to be correct, the output materializations for the step must be
         # generated in topological order -- we assume this.
-        version_info = step_context.get_input_asset_version_info(key)
+        version_info = step_context.maybe_fetch_and_get_input_asset_version_info(key)
 
         # This can only happen for source assets that have never been observed.
         if version_info is None:


### PR DESCRIPTION
## Summary & Motivation

Rename `get_input_asset_version_info` to `maybe_fetch_and_get_input_asset_version_info` to accurately indicate that this *might* do a fetch which in the case of cloud can be very expensive (GraphQL query)

## How I Tested These Changes

BK
