### PR TITLE
remove further reading section from sda concept page

### DIFF
--- a/docs/content/concepts/assets/software-defined-assets.mdx
+++ b/docs/content/concepts/assets/software-defined-assets.mdx
@@ -508,12 +508,6 @@ def downstream_asset(upstream_asset):
 
 ---
 
-## Further reading
-
-Interested in learning more about software-defined assets and working through a more complex example? Check out our [guide on software-defined assets](/guides/dagster/software-defined-assets) and our [example project](https://github.com/dagster-io/dagster/tree/master/examples/assets_modern_data_stack) that integrates software-defined assets with other Modern Data Stack tools.
-
----
-
 ## See it in action
 
 For more examples of software-defined assets, check out these examples:


### PR DESCRIPTION
## Summary & Motivation

- The first link in this section points to a guide that is no longer a definitive guide on SDAs, and is more of a how-to for SDAs + IO managers in a particular setting
- The second link is redundant with the section below

## How I Tested These Changes
