### PR TITLE
software-defined asset -> asset definition in docs

### DIFF
--- a/docs/content/_apidocs.mdx
+++ b/docs/content/_apidocs.mdx
@@ -35,14 +35,11 @@ APIs from the core `dagster` package, divided roughly by topic:
   <tbody>
     <tr>
       <td>
-        <a href="/_apidocs/assets">Software-defined Assets</a>
+        <a href="/_apidocs/assets">Asset definitions</a>
       </td>
       <td>
-        APIs to define data asset's using Dagster's{" "}
-        <a href="/concepts/assets/software-defined-assets">
-          Software-defined Assets
-        </a>
-        .
+        APIs to define data
+        <a href="/concepts/assets/software-defined-assets">assets</a>.
       </td>
     </tr>
     <tr>

--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -8,17 +8,17 @@ Learn about Dagster's core concepts and how to use them in your data platform.
 
 ---
 
-## Software-defined Assets
+## Asset definition
 
-An asset is an object in persistent storage, such as a table, file, or persisted machine learning model. A Software-defined Asset is a Dagster object that couples an asset to the function and upstream assets used to produce its contents.
+An asset is an object in persistent storage, such as a table, file, or persisted machine learning model. An asset definition is a Dagster object that couples an asset to the function and upstream assets used to produce its contents.
 
 <ArticleList>
   <ArticleListItem
-    title="Software-defined Assets"
+    title="Asset definitions"
     href="/concepts/assets/software-defined-assets"
   ></ArticleListItem>
   <ArticleListItem
-    title="Graph-backed Assets"
+    title="Graph-backed asset definitions"
     href="/concepts/assets/graph-backed-assets"
   ></ArticleListItem>
   <ArticleListItem
@@ -80,7 +80,7 @@ Dagster offers several ways to run data pipelines without manual intervention, i
 
 ## Partitions and backfills
 
-A software-defined asset or job can represent a collection of _partitions_ that can be tracked and executed independently.
+An asset defininition or job can represent a collection of _partitions_ that can be tracked and executed independently.
 
 <ArticleList>
   <ArticleListItem

--- a/docs/content/concepts/assets/asset-checks.mdx
+++ b/docs/content/concepts/assets/asset-checks.mdx
@@ -5,7 +5,7 @@ description: Asset checks are a way to define expectations about the quality of 
 
 # Asset checks
 
-Dagster allows you to define and execute data quality checks on your [Software-defined Assets](/concepts/assets/software-defined-assets). Each asset check verifies some property of a data asset, e.g. that there are no null values in a particular column.
+Dagster allows you to define and execute data quality checks on your [data assets](/concepts/assets/software-defined-assets). Each asset check verifies some property of a data asset, e.g. that there are no null values in a particular column.
 
 When viewing an asset in Dagster’s UI, you can see all of its checks, and whether they’ve passed, failed, or haven’t run.
 

--- a/docs/content/concepts/assets/asset-checks/checking-for-data-freshness.mdx
+++ b/docs/content/concepts/assets/asset-checks/checking-for-data-freshness.mdx
@@ -376,7 +376,7 @@ height={1944}
     href="/concepts/assets/asset-checks"
   ></ArticleListItem>
   <ArticleListItem
-    title="Software-defined Assets"
+    title="Asset definitions"
     href="/concepts/assets/software-defined-assets"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/concepts/assets/asset-checks/define-execute-asset-checks.mdx
+++ b/docs/content/concepts/assets/asset-checks/define-execute-asset-checks.mdx
@@ -5,7 +5,7 @@ description: Asset checks are a way to define expectations about the quality of 
 
 # Defining and executing asset checks
 
-After creating some [Software-defined Assets](/concepts/assets/software-defined-assets), you may want to automate checks on the assets that test for data quality.
+After creating some [asset definitions](/concepts/assets/software-defined-assets), you may want to automate checks on the assets that test for data quality.
 
 In this guide, we'll show you a few approaches to defining asset checks, how to use check results to include helpful information, and how to execute checks.
 
@@ -373,7 +373,7 @@ Refer to the [Asset checks section](/concepts/testing#testing-asset-checks) of t
     href="/concepts/assets/asset-checks"
   ></ArticleListItem>
   <ArticleListItem
-    title="Software-defined Assets"
+    title="Asset definitions"
     href="/concepts/assets/software-defined-assets"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/concepts/assets/asset-jobs.mdx
+++ b/docs/content/concepts/assets/asset-jobs.mdx
@@ -1,18 +1,18 @@
 ---
 title: Asset jobs | Dagster
-description: Asset jobs are the main unit for materializing and monitoring Software-defined assets in Dagster.
+description: Asset jobs are the main unit for materializing and monitoring asset definitions in Dagster.
 ---
 
 # Asset jobs
 
 <Note>
   Looking to execute a <a href="/concepts/ops-jobs-graphs/graphs">graph</a> of{" "}
-  <a href="/concepts/ops-jobs-graphs/ops">ops</a>, which aren't tied to
-  Software-defined Assets? Check out the{" "}
+  <a href="/concepts/ops-jobs-graphs/ops">ops</a>, which aren't tied to asset
+  definitions? Check out the{" "}
   <a href="/concepts/ops-jobs-graphs/op-jobs">Op jobs</a> documentation.
 </Note>
 
-[Jobs](/concepts/ops-jobs-graphs/jobs) are the main unit for executing and monitoring Software-defined assets in Dagster. An asset job is a type of \[job]\(/concepts/ops-jobs-graphs/jobs] that targets a selection of [Software-defined Assets](/concepts/assets/software-defined-assets) and can be launched:
+[Jobs](/concepts/ops-jobs-graphs/jobs) are the main unit for executing and monitoring [asset definitions](/concepts/assets/software-defined-assets) in Dagster. An asset job is a type of \[job]\(/concepts/ops-jobs-graphs/jobs] that targets a selection of assets and can be launched:
 
 - Manually from the Dagster UI
 - At fixed intervals, by [schedules](/concepts/partitions-schedules-sensors/schedules)

--- a/docs/content/concepts/assets/asset-selection-syntax.mdx
+++ b/docs/content/concepts/assets/asset-selection-syntax.mdx
@@ -547,7 +547,7 @@ height={1508}
 
 <ArticleList>
   <ArticleListItem
-    title="Software-defined Assets"
+    title="Asset definitions"
     href="/concepts/assets/software-defined-assets"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/concepts/assets/external-assets.mdx
+++ b/docs/content/concepts/assets/external-assets.mdx
@@ -363,7 +363,7 @@ defs = Definitions(
 
 <ArticleList>
   <ArticleListItem
-    title="Software-defined Assets"
+    title="Asset definitions"
     href="/concepts/assets-software-defined-assets"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/concepts/assets/graph-backed-assets.mdx
+++ b/docs/content/concepts/assets/graph-backed-assets.mdx
@@ -1,11 +1,11 @@
 ---
 title: Graph-Backed Assets | Dagster
-description: Defining a software-defined asset with multiple discrete computations combined in an op graph.
+description: An asset definition with multiple discrete computations combined in an op graph.
 ---
 
 # Graph-Backed Assets
 
-[Basic software-defined assets](/concepts/assets/software-defined-assets#a-basic-software-defined-asset) are computed using a single op. If generating an asset involves multiple discrete computations, you can use graph-backed assets by separating each computation into an op and assembling them into an op graph to combine your computations. This allows you to launch re-executions of runs at the op boundaries, but doesn't require you to link each intermediate value to an asset in persistent storage.
+[Basic assets](/concepts/assets/software-defined-assets#basic-asset-definitions) are computed using a single op. If generating an asset involves multiple discrete computations, you can use graph-backed assets by separating each computation into an op and assembling them into an op graph to combine your computations. This allows you to launch re-executions of runs at the op boundaries, but doesn't require you to link each intermediate value to an asset in persistent storage.
 
 ---
 
@@ -59,7 +59,7 @@ def slack_files_table():
 
 ### Defining managed-loading dependencies for graph-backed assets
 
-Similar to software-defined assets, Dagster infers the upstream assets from the names of the arguments to the decorated function. Dagster will then delegate loading the data to an [I/O manager](/concepts/io-management/io-managers).
+Similar to single-op asset definitions, Dagster infers the upstream assets from the names of the arguments to the decorated function. Dagster will then delegate loading the data to an [I/O manager](/concepts/io-management/io-managers).
 
 The example below includes an asset named `middle_asset`. `middle_asset` depends on `upstream_asset`, and `downstream_asset` depends on `middle_asset`:
 

--- a/docs/content/concepts/assets/multi-assets.mdx
+++ b/docs/content/concepts/assets/multi-assets.mdx
@@ -5,7 +5,7 @@ description: A multi-asset represents a set of assets that are all updated by th
 
 # Multi-Assets
 
-A multi-asset represents a set of software-defined assets that are all updated by the same [op](/concepts/ops-jobs-graphs/ops) or [graph](/concepts/ops-jobs-graphs/graphs).
+A multi-asset represents a set of asset definitions that are all updated by the same [op](/concepts/ops-jobs-graphs/ops) or [graph](/concepts/ops-jobs-graphs/graphs).
 
 ## Relevant APIs
 
@@ -15,7 +15,7 @@ A multi-asset represents a set of software-defined assets that are all updated b
 
 ## Overview
 
-When working with [software-defined assets](/concepts/assets/software-defined-assets), it's sometimes inconvenient or impossible to map each persisted asset to a unique [op](/concepts/ops-jobs-graphs/ops) or [graph](/concepts/ops-jobs-graphs/graphs). A multi-asset is a way to define a single op or graph that will produce the contents of multiple data assets at once.
+When working with [asset definitions](/concepts/assets/software-defined-assets), it's sometimes inconvenient or impossible to map each persisted asset to a unique [op](/concepts/ops-jobs-graphs/ops) or [graph](/concepts/ops-jobs-graphs/graphs). A multi-asset is a way to define a single op or graph that will produce the contents of multiple data assets at once.
 
 Multi-assets may be useful in the following scenarios:
 
@@ -24,7 +24,7 @@ Multi-assets may be useful in the following scenarios:
 
 ## Defining multi-assets
 
-The function responsible for computing the contents of any software-defined asset is an [op](/concepts/ops-jobs-graphs/ops). Multi-assets are responsible for updating multiple assets, so the underlying op will have multiple outputs -- one for each associated asset.
+The function responsible for computing the contents of any asset is an [op](/concepts/ops-jobs-graphs/ops). Multi-assets are responsible for updating multiple assets, so the underlying op will have multiple outputs -- one for each associated asset.
 
 ### A basic multi-asset
 

--- a/docs/content/concepts/assets/software-defined-assets.mdx
+++ b/docs/content/concepts/assets/software-defined-assets.mdx
@@ -1,9 +1,9 @@
 ---
-title: Software-defined assets | Dagster
-description: A software-defined asset is a description of how to compute the contents of a particular data asset.
+title: Asset definitions | Dagster
+description: An asset definition is a description of how to compute the contents of a particular data asset.
 ---
 
-# Software-defined assets
+# Asset definitions
 
 <Note>
   Prefer videos? Check out our{" "}
@@ -14,20 +14,20 @@ description: A software-defined asset is a description of how to compute the con
   <a href="https://www.youtube.com/watch?v=lRwpcyd6w8k" target="new">
     demo
   </a>{" "}
-  videos to get a quick look at Software-defined assets.
+  videos to get a quick look at asset definitions.
 </Note>
 
-An **asset** is an object in persistent storage, such as a table, file, or persisted machine learning model. A **software-defined asset** is a description, in code, of an asset that should exist and how to produce and update that asset.
+An **asset** is an object in persistent storage, such as a table, file, or persisted machine learning model. A **asset definition** is a description, in code, of an asset that should exist and how to produce and update that asset.
 
-Software-defined assets enable a declarative approach to data management, in which code is the source of truth on what data assets should exist and how those assets are computed.
+Asset definitions enable a declarative approach to data management, in which code is the source of truth on what data assets should exist and how those assets are computed.
 
-A software-defined asset includes the following:
+An asset definition includes the following:
 
 - An <PyObject object="AssetKey" />, which is a handle for referring to the asset.
-- A set of upstream asset keys, which refer to assets that the contents of the software-defined asset are derived from.
+- A set of upstream asset keys, which refer to assets that the contents of the asset definition are derived from.
 - A Python function, which is responsible for computing the contents of the asset from its upstream dependencies and storing the results.
 
-  **Note**: Behind-the-scenes, the Python function is an [op](/concepts/ops-jobs-graphs/ops). Ops are an advanced topic that isn't required to get started with Dagster. A crucial distinction between Software-defined Assets and ops is that Software-defined Assets know about their dependencies, while ops do not. Ops aren't connected to dependencies until they're placed inside a [graph](/concepts/ops-jobs-graphs/graphs).
+  **Note**: Behind-the-scenes, the Python function is an [op](/concepts/ops-jobs-graphs/ops). Ops are an advanced topic that isn't required to get started with Dagster. A crucial distinction between asset definitions and ops is that asset definitions know about their dependencies, while ops do not. Ops aren't connected to dependencies until they're placed inside a [graph](/concepts/ops-jobs-graphs/graphs).
 
 **Materializing** an asset is the act of running its function and saving the results to persistent storage. You can initiate materializations from [the Dagster UI](/concepts/webserver/ui) or by invoking Python APIs.
 
@@ -44,15 +44,15 @@ A software-defined asset includes the following:
 
 ## Defining assets
 
-- [Basic software-defined assets](#a-basic-software-defined-asset)
+- [Basic asset definitions](#basic-asset-definitions)
 - [Assets with dependencies](#assets-with-dependencies)
 - [Graph-backed assets and multi-assets](#graph-backed-assets-and-multi-assets)
 - [Accessing asset context](#asset-context)
 - [Configuring assets](#asset-configuration)
 
-### A basic software-defined asset
+### Basic asset definitions
 
-The easiest way to create a software-defined asset is with the <PyObject object="asset" decorator /> decorator.
+The easiest way to create an asset definitions is with the <PyObject object="asset" decorator /> decorator.
 
 ```python file=/concepts/assets/basic_asset_definition.py
 import json
@@ -72,7 +72,7 @@ By default, the name of the decorated function, `my_asset`, is used as the asset
 
 ### Assets with dependencies
 
-Software-defined assets can depend on other software-defined assets. In this section, we'll show you how to define:
+Asset definitions can depend on other asset definitions. In this section, we'll show you how to define:
 
 - [Basic asset dependencies](#defining-basic-dependencies)
 - [Asset dependencies across code locations](#defining-asset-dependencies-across-code-locations)
@@ -142,9 +142,9 @@ defs = Definitions(assets=[code_location_2_asset])
 
 ### Graph-backed assets and multi-assets
 
-If you'd like to define more complex assets, Dagster offers augmented software-defined asset abstractions:
+If you'd like to define more complex assets, Dagster offers augmented asset definition abstractions:
 
-- [Multi-assets](/concepts/assets/multi-assets): A set of software-defined assets that are all updated by the same [op](/concepts/ops-jobs-graphs/ops) or [graph](/concepts/ops-jobs-graphs/graphs).
+- [Multi-assets](/concepts/assets/multi-assets): A set of asset definitions that are all updated by the same [op](/concepts/ops-jobs-graphs/ops) or [graph](/concepts/ops-jobs-graphs/graphs).
 - [Graph-backed assets](/concepts/assets/graph-backed-assets): An asset whose computations are separated into multiple [ops](/concepts/ops-jobs-graphs/ops) that are combined to build a [graph](/concepts/ops-jobs-graphs/graphs). If the graph outputs multiple assets, the graph-backed asset is a [multi-asset](/concepts/assets/multi-assets).
 
 ### Asset configuration
@@ -510,7 +510,7 @@ def downstream_asset(upstream_asset):
 
 ## See it in action
 
-For more examples of software-defined assets, check out these examples:
+For more examples of asset definitions, check out these examples:
 
 - In the [Fully Featured Project example](https://github.com/dagster-io/dagster/tree/master/examples/project_fully_featured):
 

--- a/docs/content/concepts/automation.mdx
+++ b/docs/content/concepts/automation.mdx
@@ -17,7 +17,7 @@ In this guide, we'll cover the available automation methods Dagser provides and 
 
 Before continuing, you should be familiar with:
 
-- [Software-defined Assets][assets]
+- [Asset definitions][assets]
 - [Jobs][jobs] (_optional_)
 - [Ops][ops] (_optional; advanced_)
 

--- a/docs/content/concepts/automation/schedules/automating-assets-schedules-jobs.mdx
+++ b/docs/content/concepts/automation/schedules/automating-assets-schedules-jobs.mdx
@@ -5,7 +5,7 @@ description: "Learn how to automate asset materialization using schedules and jo
 
 # Automating assets using schedules and jobs
 
-After creating some [Software-defined Assets](/concepts/assets/software-defined-assets), you may want to automate their materialization.
+After creating some [asset definitions](/concepts/assets/software-defined-assets), you may want to automate their materialization.
 
 In this guide, we'll show you one method of accomplishing this by using schedules and jobs. To do this for ops, refer to the [Automating ops using schedules guide](/concepts/automation/schedules/automating-ops-schedules-jobs).
 
@@ -24,7 +24,7 @@ To follow this guide, you'll need:
 
 - **To install Dagster and the Dagster UI.** Refer to the [Installation guide](/getting-started/install) for more info and instructions.
 - **Familiarity with**:
-  - [Software-defined Assets](/concepts/assets/software-defined-assets)
+  - [Asset definitions](/concepts/assets/software-defined-assets)
   - [Jobs](/concepts/ops-jobs-graphs/jobs)
   - [Code locations](/concepts/code-locations) (<PyObject object="Definitions" />)
 

--- a/docs/content/concepts/automation/schedules/automating-ops-schedules-jobs.mdx
+++ b/docs/content/concepts/automation/schedules/automating-ops-schedules-jobs.mdx
@@ -5,7 +5,7 @@ description: "Learn how to automate op execution using schedules and jobs."
 
 # Automating ops using schedules and jobs
 
-In this guide, we'll walk you through running ops on a schedule. To do this for Software-defined Assets, refer to the [Automating assets using schedules guide](/concepts/automation/schedules/automating-assets-schedules-jobs).
+In this guide, we'll walk you through running ops on a schedule. To do this for asset definitions, refer to the [Automating assets using schedules guide](/concepts/automation/schedules/automating-assets-schedules-jobs).
 
 By the end of this guide, you'll be able to:
 

--- a/docs/content/concepts/configuration/config-schema-legacy.mdx
+++ b/docs/content/concepts/configuration/config-schema-legacy.mdx
@@ -18,7 +18,7 @@ description: Job run configuration allows providing parameters to jobs at the ti
 
 Run configuration allows providing parameters to jobs at the time they're executed.
 
-It's often useful to provide user-chosen values to Dagster jobs or software-defined assets at runtime. For example, you might want to choose what dataset an op runs against, or provide a connection URL for a database resource. Dagster exposes this functionality through a configuration API.
+It's often useful to provide user-chosen values to Dagster jobs or asset definitions at runtime. For example, you might want to choose what dataset an op runs against, or provide a connection URL for a database resource. Dagster exposes this functionality through a configuration API.
 
 Various Dagster entities (ops, assets, resources) can be individually configured. When launching a job that executes (ops), materializes (assets), or instantiates (resources) a configurable entity, you can provide _run configuration_ for each entity. Within the function that defines the entity, you can access the passed-in configuration off of the `context`. Typically, the provided run configuration values correspond to a _configuration schema_ attached to the op/asset/resource definition. Dagster validates the run configuration against the schema and proceeds only if validation is successful.
 

--- a/docs/content/concepts/configuration/config-schema.mdx
+++ b/docs/content/concepts/configuration/config-schema.mdx
@@ -18,7 +18,7 @@ description: Job run configuration allows providing parameters to jobs at the ti
 
 Run configuration allows providing parameters to jobs at the time they're executed.
 
-It's often useful to provide user-chosen values to Dagster jobs or Software-defined Assets at runtime. For example, you might want to provide a connection URL for a database resource. Dagster exposes this functionality through a configuration API.
+It's often useful to provide user-chosen values to Dagster jobs or asset definitions at runtime. For example, you might want to provide a connection URL for a database resource. Dagster exposes this functionality through a configuration API.
 
 Various Dagster entities (assets, ops, resources) can be individually configured. When launching a job that materializes (assets), executes (ops), or instantiates (resources) a configurable entity, you can provide _run configuration_ for each entity. Within the function that defines the entity, you can access the passed-in configuration through the `config` parameter. Typically, the provided run configuration values correspond to a _configuration schema_ attached to the asset/op/resource definition. Dagster validates the run configuration against the schema and proceeds only if validation is successful.
 
@@ -35,7 +35,7 @@ During execution, the specified config is accessed within the body of the op or 
 <TabGroup persistentKey="assetsorops">
 <TabItem name="Using software-defined-assets">
 
-#### Using Software-defined Assets
+#### Using asset definitions
 
 Here, we define a subclass of <PyObject object="Config"/> holding a single string value representing the name of a user. We can access the config through the `config` parameter in the asset body.
 

--- a/docs/content/concepts/io-management/io-managers-legacy.mdx
+++ b/docs/content/concepts/io-management/io-managers-legacy.mdx
@@ -40,7 +40,7 @@ IO Managers are user-provided objects that store asset and op outputs and load t
 
 Functions decorated by <PyObject object="asset" decorator/>, <PyObject object="multi_asset" decorator/>, and <PyObject object="op" decorator/> can have parameters and return values that are loaded from and written to persistent storage. <PyObject module="dagster" object="IOManager" pluralize /> let the user control how this data is stored and how it's loaded in downstream ops and assets. For `@asset` and `@multi_asset`, the IO manager effectively determines where the physical asset lives.
 
-The IO manager APIs make it easy to separate code that's responsible for logical data transformation from code that's responsible for reading and writing the results. Software-defined assets and ops can focus on business logic, while IO managers handle I/O. This separation makes it easier to test the business logic and run it in different environments.
+The IO manager APIs make it easy to separate code that's responsible for logical data transformation from code that's responsible for reading and writing the results. Asset definitions and ops can focus on business logic, while IO managers handle I/O. This separation makes it easier to test the business logic and run it in different environments.
 
 For non-asset jobs with inputs that aren't connected to upstream outputs, see the [Unconnected Inputs](/concepts/io-management/unconnected-inputs) overview.
 
@@ -51,7 +51,7 @@ that are responsible for storing the output of an asset or op and loading it as 
 to downstream assets or ops. For example, an IO manager might store and load objects
 from files on a filesystem.
 
-Each software-defined asset can have its own IO manager. In the [multi-asset](/concepts/assets/multi-assets) case where multiple assets are outputted, each outputted asset can be handled with a different IO manager:
+Each asset definition can have its own IO manager. In the [multi-asset](/concepts/assets/multi-assets) case where multiple assets are outputted, each outputted asset can be handled with a different IO manager:
 
 <center>
   <Image
@@ -83,7 +83,7 @@ IO managers are [resources](/concepts/resources), which means users can supply d
 
 ---
 
-## Using IO managers with software-defined assets
+## Using IO managers with asset definitions
 
 ### Applying IO managers to assets
 
@@ -821,7 +821,7 @@ class DataframeTableIOManagerWithMetadata(IOManager):
 
 Any entries yielded this way will be attached to the `Handled Output` event for this output.
 
-Additionally, if the handled output is part of a software-defined asset, these metadata entries will also be attached to the materialization event created for that asset and show up on the Asset Details page for the asset.
+Additionally, if the handled output is part of an asset definition, these metadata entries will also be attached to the materialization event created for that asset and show up on the Asset Details page for the asset.
 
 ## See it in action
 

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -29,7 +29,7 @@ Functions decorated by <PyObject object="asset" decorator/>, <PyObject object="m
   />
 </center>
 
-The I/O manager APIs make it easy to separate code that's responsible for logical data transformation from code that's responsible for reading and writing the results. Software-defined Assets and ops can focus on business logic, while I/O managers handle I/O. This separation makes it easier to test the business logic and run it in different environments.
+The I/O manager APIs make it easy to separate code that's responsible for logical data transformation from code that's responsible for reading and writing the results. Asset definitions and ops can focus on business logic, while I/O managers handle I/O. This separation makes it easier to test the business logic and run it in different environments.
 
 For non-asset jobs with inputs that aren't connected to upstream outputs, see the [Unconnected Inputs](/concepts/io-management/unconnected-inputs) overview.
 
@@ -79,7 +79,7 @@ that are responsible for storing the output of an asset or op and loading it as 
 to downstream assets or ops. For example, an I/O manager might store and load objects
 from files on a filesystem.
 
-Each software-defined asset can have its own I/O manager. In the [multi-asset](/concepts/assets/multi-assets) case where multiple assets are outputted, each outputted asset can be handled with a different I/O manager:
+Each asset definition can have its own I/O manager. In the [multi-asset](/concepts/assets/multi-assets) case where multiple assets are outputted, each outputted asset can be handled with a different I/O manager:
 
 <center>
   <Image
@@ -116,7 +116,7 @@ I/O managers are provided through the [resources](/concepts/resources) system, w
 
 ---
 
-## Using I/O managers with Software-defined Assets
+## Using I/O managers with asset definitions
 
 ### Applying I/O managers to assets
 
@@ -240,7 +240,7 @@ defs = Definitions(
 
 ### Using I/O managers to load source data
 
-Software-defined assets often depend on data assets that are generated outside of Dagster, or in a different code location within Dagster, and it's often useful to use I/O managers to load the data from these assets. To represent one of these assets, you can create an asset definition that includes an I/O manager, but no materialization function. Your other assets can then depend on it and load data from it, just as they would with a materializable asset.
+Asset definitions often depend on data assets that are generated outside of Dagster, or in a different code location within Dagster, and it's often useful to use I/O managers to load the data from these assets. To represent one of these assets, you can create an asset definition that includes an I/O manager, but no materialization function. Your other assets can then depend on it and load data from it, just as they would with a materializable asset.
 
 For example:
 
@@ -885,7 +885,7 @@ class DataframeTableIOManagerWithMetadata(ConfigurableIOManager):
 
 Any entries yielded this way will be attached to the `Handled Output` event for this output.
 
-Additionally, if the handled output is part of a software-defined asset, these metadata entries will also be attached to the materialization event created for that asset and show up on the Asset Details page for the asset.
+Additionally, if the handled output is part of an asset definition, these metadata entries will also be attached to the materialization event created for that asset and show up on the Asset Details page for the asset.
 
 ---
 

--- a/docs/content/concepts/metadata-tags/asset-metadata.mdx
+++ b/docs/content/concepts/metadata-tags/asset-metadata.mdx
@@ -308,7 +308,7 @@ Refer to the [Integrating asset metadata into Dagster+ Insights](/dagster-plus/i
 
 <ArticleList>
   <ArticleListItem
-    title="Software-defined Assets"
+    title="Asset definitions"
     href="/concepts/assets/software-defined-assets"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/concepts/metadata-tags/asset-metadata/column-level-lineage.mdx
+++ b/docs/content/concepts/metadata-tags/asset-metadata/column-level-lineage.mdx
@@ -143,7 +143,7 @@ To view another column's lineage, click the **Column** dropdown and select anoth
     href="/concepts/metadata-tags"
   ></ArticleListItem>
   <ArticleListItem
-    title="Software-defined Assets"
+    title="Asset definitions"
     href="/concepts/assets/software-defined-assets"
   ></ArticleListItem>
 </ArticleList>

--- a/docs/content/concepts/metadata-tags/tags.mdx
+++ b/docs/content/concepts/metadata-tags/tags.mdx
@@ -164,7 +164,7 @@ height={1406}
 
 <ArticleList>
   <ArticleListItem
-    title="Software-defined Assets"
+    title="Asset definitions"
     href="/concepts/assets/software-defined-assets"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/concepts/ops-jobs-graphs/graphs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/graphs.mdx
@@ -9,7 +9,7 @@ A graph is a set of interconnected [ops](/concepts/ops-jobs-graphs/ops) or sub-g
 
 Graphs can be used in three different ways:
 
-- [**To back assets**](/concepts/assets/graph-backed-assets) - Basic software-defined assets are computed using a single op, but if computing one of your assets requires multiple discrete steps, you can compute it using a graph instead.
+- [**To back assets**](/concepts/assets/graph-backed-assets) - Basic assets are computed using a single op, but if computing one of your assets requires multiple discrete steps, you can compute it using a graph instead.
 - [**Directly inside a job**](/concepts/ops-jobs-graphs/op-jobs) - Each op job contains a graph.
 - [**Inside other graphs**](/concepts/ops-jobs-graphs/nesting-graphs) - You can build complex graphs out of simpler graphs.
 
@@ -401,9 +401,9 @@ def define_dep_dsl_graph() -> GraphDefinition:
 
 ### Inside assets
 
-Op graphs can be used to create [software-defined assets](/concepts/assets/software-defined-assets). Graph-backed assets are useful if you have an existing op graph that produces and consumes assets.
+Op graphs can be used to create [asset definitions](/concepts/assets/software-defined-assets). Graph-backed assets are useful if you have an existing op graph that produces and consumes assets.
 
-Wrapping your graph inside a software-defined asset gives you all the benefits of software-defined assets — like cross-job lineage — without requiring you to change the code inside your graph. Refer to the [graph-backed assets documentation](/concepts/assets/graph-backed-assets) for more info and examples.
+Wrapping your graph inside an asset definition gives you all the benefits of software-defined assets — like cross-job lineage — without requiring you to change the code inside your graph. Refer to the [graph-backed assets documentation](/concepts/assets/graph-backed-assets) for more info and examples.
 
 ### Directly inside op jobs
 

--- a/docs/content/concepts/ops-jobs-graphs/jobs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/jobs.mdx
@@ -5,7 +5,7 @@ description: Jobs are the main unit of execution and monitoring in Dagster.
 
 # Jobs
 
-Jobs are the main unit of execution and monitoring in Dagster. They allow you to execute a portion of a graph of [Software-defined Assets](/concepts/assets/software-defined-assets) or [ops](/concepts/ops-jobs-graphs/ops) based on a schedule or an external trigger.
+Jobs are the main unit of execution and monitoring in Dagster. They allow you to execute a portion of a graph of [asset definitions](/concepts/assets/software-defined-assets) or [ops](/concepts/ops-jobs-graphs/ops) based on a schedule or an external trigger.
 
 When a job begins, it kicks off a _run_. A run is a single execution of a job in Dagster. Runs can be launched and viewed in the Dagster UI.
 
@@ -23,14 +23,14 @@ Using jobs provides the following benefits:
 
 ## Uses
 
-Jobs are supported for both Software-defined Assets and ops, but the usage for each concept is unique. Refer to the following documentation for more info:
+Jobs are supported for both asset definitions and ops, but the usage for each concept is unique. Refer to the following documentation for more info:
 
 - [Asset jobs](/concepts/assets/asset-jobs)
 - [Op jobs](/concepts/ops-jobs-graphs/op-jobs)
 
 With jobs, you can:
 
-- Automate the execution of [Software-defined Assets](/concepts/assets/software-defined-assets) and [ops](/concepts/ops-jobs-graphs/ops)
+- Automate the execution of [asset definitions](/concepts/assets/software-defined-assets) and [ops](/concepts/ops-jobs-graphs/ops)
 - Materialize a selection of assets based on a schedule or external trigger (sensor)
 - Attach information using [metadata](/concepts/metadata-tags) and [tags](/concepts/metadata-tags/tags)
 - View and launch runs of jobs in the [Dagster UI](/concepts/webserver/ui)

--- a/docs/content/concepts/ops-jobs-graphs/op-events.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/op-events.mdx
@@ -126,7 +126,7 @@ to keep track of can be considered an asset.
 
 Generally, you'd want to send this event directly after you persist the asset to your external system. All <PyObject object="AssetMaterialization" /> events must define an `asset_key`, which is a unique identifier to describe the asset you are persisting. They can optionally include a `partition` if they're persisting a particular [partition](/concepts/partitions-schedules-sensors/partitions) of an asset.
 
-If you're using [Software-defined Assets](/concepts/assets/software-defined-assets), you don't need to record these events explicitly – the framework handles it for you.
+If you're using [asset definitions](/concepts/assets/software-defined-assets), you don't need to record these events explicitly – the framework handles it for you.
 
 ```python file=/concepts/ops_jobs_graphs/op_events.py startafter=start_asset_op endbefore=end_asset_op
 from dagster import AssetMaterialization, op, OpExecutionContext

--- a/docs/content/concepts/ops-jobs-graphs/op-jobs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/op-jobs.mdx
@@ -7,7 +7,7 @@ description: An op job
 
 <Note>
   Looking to materialize{" "}
-  <a href="/concepts/assets/software-defined-assets">Software-defined Assets</a>{" "}
+  <a href="/concepts/assets/software-defined-assets">asset definitions</a>{" "}
   instead of ops? Check out the{" "}
   <a href="/concepts/assets/asset-jobs">Asset jobs</a> documentation.
 </Note>

--- a/docs/content/concepts/ops-jobs-graphs/ops.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/ops.mdx
@@ -15,7 +15,7 @@ An individual op should perform relatively simple tasks, such as:
 - Querying an API and storing the result in a data warehouse
 - Sending an email or Slack message
 
-The computational core of a [software-defined asset](/concepts/assets/software-defined-assets) is an op. Collections of ops can also be assembled to create a [graph](/concepts/ops-jobs-graphs/graphs).
+The computational core of an [asset definition](/concepts/assets/software-defined-assets) is an op. Collections of ops can also be assembled to create a [graph](/concepts/ops-jobs-graphs/graphs).
 
 <Image alt="ops" src="/images/ops.png" width={3200} height={1040} />
 

--- a/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitioning-assets.mdx
@@ -6,15 +6,15 @@ description: Partitioned assets and jobs enable launching backfills, where each 
 # Partitioning assets
 
 <Note>
-  This page is specific to <strong>Software-defined Assets (SDAs)</strong>.
-  Looking for ops? Refer to the{" "}
+  This page is specific to <strong>asset definitions</strong>. Looking for ops?
+  Refer to the{" "}
   <a href="/concepts/partitions-schedules-sensors/partitioning-ops">
     Partitioned ops
   </a>{" "}
   documentation.
 </Note>
 
-A [Software-defined Asset](/concepts/assets/software-defined-assets) (SDA) can represent a collection of _partitions_ that can be tracked and materialized independently. In many ways, each partition functions like its own mini-asset, but they all share a common materialization function and dependencies. Typically, each partition will correspond to a separate file or a slice of a table in a database.
+A [asset definition](/concepts/assets/software-defined-assets) can represent a collection of _partitions_ that can be tracked and materialized independently. In many ways, each partition functions like its own mini-asset, but they all share a common materialization function and dependencies. Typically, each partition will correspond to a separate file or a slice of a table in a database.
 
 A common use is for each partition to represent all the records in a data set that fall within a particular time window, e.g. hourly, daily or monthly. Alternatively, each partition can represent a region, a customer, an experiment - any dimension along which you want to be able to materialize and monitor independently. An asset can also be partitioned along multiple dimensions, e.g. by region and by hour.
 
@@ -28,14 +28,14 @@ Once an asset has a set of partitions, you can launch materializations of indivi
 
 Before continuing, you should be familiar with:
 
-- [Software-defined Assets](/concepts/assets/software-defined-assets)
+- [Asset definitions](/concepts/assets/software-defined-assets)
 - [Jobs](/concepts/ops-jobs-graphs/jobs)
 
 ---
 
 ## Defining partitioned assets
 
-A Software-defined Asset can be assigned a <PyObject object="PartitionsDefinition" />, which determines the set of partitions that compose it. If the asset is stored in a filesystem or an object store, then each partition will typically correspond to a file or object. If the asset is stored in a database, then each partition will typically correspond to a range of values in a table that fall within a particular window.
+An asset definitions can be assigned a <PyObject object="PartitionsDefinition" />, which determines the set of partitions that compose it. If the asset is stored in a filesystem or an object store, then each partition will typically correspond to a file or object. If the asset is stored in a database, then each partition will typically correspond to a range of values in a table that fall within a particular window.
 
 The following example demonstrates creating an asset that has a partition for each day since October 1st, 2023. Materializing partition `2023-11-13` of this asset would result in fetching data from the URL `https://api.nasa.gov/planetary/apod?date=2023-11-13` and storing it at the path `nasa/2023-11-13.csv`. Note that `api_key=DEMO_KEY` is used but has a limited number of calls:
 
@@ -428,6 +428,6 @@ If using the default I/O manager, materializing partition `2022-07-23` of this a
   ></ArticleListItem>
   <ArticleListItem
     href="/concepts/assets/software-defined-assets"
-    title="Software-defined Assets"
+    title="Asset definitions"
   ></ArticleListItem>
 </ArticleList>

--- a/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
@@ -5,7 +5,7 @@ description: Partitions break data into smaller chunks, allowing you to compute 
 
 # Partitions
 
-A Software-defined Asset can represent a collection of _partitions_ that can be tracked and materialized independently. In many ways, each partition functions like its own mini-asset, but they all share a common materialization function and dependencies. Typically, each partition will correspond to a separate file, or a slice of a table in a database.
+A asset definition can represent a collection of _partitions_ that can be tracked and materialized independently. In many ways, each partition functions like its own mini-asset, but they all share a common materialization function and dependencies. Typically, each partition will correspond to a separate file, or a slice of a table in a database.
 
 Consider an online store's order data. In a database, the order data might be stored as a single `orders` table, which contains multiple days' worth of orders. However, if the data were ingested into Amazon Web Services (AWS) S3 as parquet files, you could create a new parquet file per day or partition.
 
@@ -25,7 +25,7 @@ Using partitions provides the following benefits:
 
 ## Uses
 
-Partitions are supported for both Software-defined Assets and ops, but how each concept is used is unique. Refer to the following documentation for more info:
+Partitions are supported for both asset definitions and ops, but how each concept is used is unique. Refer to the following documentation for more info:
 
 - [Partitioned assets](/concepts/partitions-schedules-sensors/partitioning-assets)
 - [Partitioned ops](/concepts/partitions-schedules-sensors/partitioning-ops) (Advanced)

--- a/docs/content/concepts/partitions-schedules-sensors/testing-partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/testing-partitions.mdx
@@ -7,8 +7,8 @@ description: Test your partition configuration and jobs.
 
 <Note>
   This guide is applicable to both{" "}
-  <a href="/concepts/assets/software-defined-assets">Software-defined Assets</a>{" "}
-  and <a href="/concepts/ops-jobs-graphs/ops">ops</a>.{" "}
+  <a href="/concepts/assets/software-defined-assets">asset definitions</a> and{" "}
+  <a href="/concepts/ops-jobs-graphs/ops">ops</a>.{" "}
 </Note>
 
 In this guide, we'll cover a few ways to test your partitioned config and jobs.
@@ -143,6 +143,6 @@ def test_do_stuff_partitioned():
   ></ArticleListItem>
   <ArticleListItem
     href="/concepts/assets/software-defined-assets"
-    title="Software-defined Assets"
+    title="Asset definitions"
   ></ArticleListItem>
 </ArticleList>

--- a/docs/content/concepts/repositories-workspaces/repositories.mdx
+++ b/docs/content/concepts/repositories-workspaces/repositories.mdx
@@ -13,11 +13,11 @@ description: A repository is a collection of jobs, schedules, and sensor definit
   info.
 </Note>
 
-A repository is a collection of software-defined assets, jobs, schedules, and sensors. Repositories are loaded as a unit by the Dagster CLI, Dagster webserver, and the Dagster daemon.
+A repository is a collection of asset definitions, jobs, schedules, and sensors. Repositories are loaded as a unit by the Dagster CLI, Dagster webserver, and the Dagster daemon.
 
 A convenient way to organize your job and other definitions, each repository:
 
-- Includes various definitions: [Software-defined assets](/concepts/assets/software-defined-assets), [Jobs](/concepts/ops-jobs-graphs/jobs), [Schedules](/concepts/partitions-schedules-sensors/schedules), and [Sensors](/concepts/partitions-schedules-sensors/sensors).
+- Includes various definitions: [Asset definitions](/concepts/assets/software-defined-assets), [Jobs](/concepts/ops-jobs-graphs/jobs), [Schedules](/concepts/partitions-schedules-sensors/schedules), and [Sensors](/concepts/partitions-schedules-sensors/sensors).
 - Is loaded in a different process than Dagster system processes like the webserver. Any communication between the Dagster system and repository code occurs over an RPC mechanism, ensuring that problems in repository code can't affect Dagster or other repositories.
 - Can be loaded in its own Python environment, so you can manage your dependencies (or even your own Python versions) separately.
 

--- a/docs/content/concepts/resources-legacy.mdx
+++ b/docs/content/concepts/resources-legacy.mdx
@@ -16,7 +16,7 @@ description: Resources enable you to separate graph logic from environment, and 
   guide.
 </Note>
 
-Resources are objects that are shared across the implementations of multiple [software-defined assets](/concepts/assets/software-defined-assets) and [ops](/concepts/ops-jobs-graphs/ops) and that can be plugged in after defining those ops and assets.
+Resources are objects that are shared across the implementations of multiple [asset definitions](/concepts/assets/software-defined-assets) and [ops](/concepts/ops-jobs-graphs/ops) and that can be plugged in after defining those ops and assets.
 
 Resources typically model external components that assets and ops interact with. For example, a resource might be a connection to a data warehouse like Snowflake or a service like Slack.
 
@@ -37,7 +37,7 @@ So, why use resources?
 | <PyObject object="InitResourceContext"/>         | The context object provided to a resource during initialization. This object contains required resource, config, and other run information.                                                                                 |
 | <PyObject object="build_init_resource_context"/> | Function for building an <PyObject object="InitResourceContext"/> outside of execution, intended to be used when testing a resource.                                                                                        |
 | <PyObject object="build_resources"/>             | Function for initializing a set of resources outside of the context of a job's execution.                                                                                                                                   |
-| <PyObject object="with_resources"/>              | Function for providing resources to software-defined assets and source assets.                                                                                                                                              |
+| <PyObject object="with_resources"/>              | Function for providing resources to asset definitions.                                                                                                                                                                      |
 
 ---
 
@@ -63,17 +63,17 @@ def cereal_fetcher(init_context):
 
 ## Using resources
 
-- [With software-defined assets](#using-resources-with-software-defined-assets)
+- [With asset definitions](#using-resources-with-asset-definitions)
 - [With ops](#using-resources-with-ops)
 
-### Using resources with software-defined assets
+### Using resources with asset definitions
 
-- [Accessing resources](#accessing-resources-in-software-defined-assets)
-- [Providing resources](#providing-resources-to-software-defined-assets)
+- [Accessing resources](#accessing-resources-in-asset-definitions)
+- [Providing resources](#providing-resources-to-asset-definitions)
 
-#### Accessing resources in software-defined assets
+#### Accessing resources in asset definitions
 
-Software-defined assets use resource keys to access resources:
+Asset definitions use resource keys to access resources:
 
 ```python file=/concepts/resources/resources.py startafter=start_asset_use_resource endbefore=end_asset_use_resource
 from dagster import asset, AssetExecutionContext
@@ -84,14 +84,14 @@ def asset_requires_resource(context: AssetExecutionContext):
     do_something_with_resource(context.resources.foo)
 ```
 
-#### Providing resources to software-defined assets
+#### Providing resources to asset definitions
 
 How resources are provided to assets depends on how you're organizing your code definitions in Dagster.
 
 <TabGroup>
 <TabItem name="Using Definitions (recommended)">
 
-Resources can be provided to software-defined assets by passing them to a <PyObject object="Definitions" /> object. The resources provided to <PyObject object="Definitions" /> are automatically bound to the assets.
+Resources can be provided to asset definitions by passing them to a <PyObject object="Definitions" /> object. The resources provided to <PyObject object="Definitions" /> are automatically bound to the assets.
 
 ```python file=/concepts/resources/resources.py startafter=start_asset_provide_resource endbefore=end_asset_provide_resource
 from dagster import Definitions
@@ -138,7 +138,7 @@ def repo():
 
 #### Accessing resources in ops
 
-Like software-defined assets, ops use resource keys to access resources:
+Like asset definitions, ops use resource keys to access resources:
 
 ```python file=/concepts/resources/resources.py startafter=start_op_with_resources_example endbefore=end_op_with_resources_example
 from dagster import op

--- a/docs/content/concepts/resources.mdx
+++ b/docs/content/concepts/resources.mdx
@@ -23,7 +23,7 @@ In data engineering, resources are the external services, tools, and storage you
 - The Snowflake/Databricks/BigQuery account the data is ingested into
 - The BI tool the dashboard was made in
 
-Using Dagster resources, you can standardize connections and integrations to these tools across Dagster definitions like [Software-defined Assets](/concepts/assets/software-defined-assets), [schedules](/concepts/partitions-schedules-sensors/schedules), [sensors](/concepts/partitions-schedules-sensors/sensors), [ops](/concepts/ops-jobs-graphs/ops), and [jobs](/concepts/ops-jobs-graphs/jobs).
+Using Dagster resources, you can standardize connections and integrations to these tools across Dagster definitions like [asset definitions](/concepts/assets/software-defined-assets), [schedules](/concepts/partitions-schedules-sensors/schedules), [sensors](/concepts/partitions-schedules-sensors/sensors), [ops](/concepts/ops-jobs-graphs/ops), and [jobs](/concepts/ops-jobs-graphs/jobs).
 
 So, why use resources?
 
@@ -44,7 +44,7 @@ So, why use resources?
 | <PyObject object="InitResourceContext"/>         | The context object provided to a resource during initialization. This object contains required resources, config, and other run information.                                                                                            |
 | <PyObject object="build_init_resource_context"/> | Function for building an <PyObject object="InitResourceContext"/> outside of execution, intended to be used when testing a resource.                                                                                                    |
 | <PyObject object="build_resources"/>             | Function for initializing a set of resources outside of the context of a job's execution.                                                                                                                                               |
-| <PyObject object="with_resources"/>              | Advanced API for providing resources to a specific set of Software-defined Assets and source assets, overriding those provided to <PyObject object="Definitions"/>.                                                                     |
+| <PyObject object="with_resources"/>              | Advanced API for providing resources to a specific set of asset definitions, overriding those provided to <PyObject object="Definitions"/>.                                                                                             |
 
 ---
 
@@ -58,7 +58,7 @@ The configuration system has a few advantages over plain Python parameter passin
 2. Displayed in the Dagster UI
 3. Set dynamically using environment variables, resolved at runtime
 
-### With Software-defined Assets
+### With asset definitions
 
 The following example demonstrates defining a subclass of <PyObject object="ConfigurableResource"/> that represents a connection to an external service. The resource can be configured by constructing it in the <PyObject object="Definitions" /> call.
 

--- a/docs/content/concepts/testing.mdx
+++ b/docs/content/concepts/testing.mdx
@@ -126,7 +126,7 @@ For more information, refer to the [Resources](/concepts/resources) documentatio
 
 ---
 
-## Testing Software-defined Assets
+## Testing asset definitions
 
 <PyObject object="asset" decorator />
 -decorated functions can be directly invoked, which will invoke the underlying op
@@ -558,7 +558,7 @@ def test_event_stream():
 
 <ArticleList>
   <ArticleListItem
-    title="Software-defined Assets"
+    title="Asset definitions"
     href="/concepts/assets/software-defined-assets"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/concepts/types.mdx
+++ b/docs/content/concepts/types.mdx
@@ -5,7 +5,7 @@ description: The Dagster type system helps you describe what kind of values your
 
 # Dagster Types
 
-The Dagster type system helps you describe what kind of values your software-defined assets and ops accept and produce.
+The Dagster type system helps you describe what kind of values your asset definitions and ops accept and produce.
 
 ## Relevant APIs
 

--- a/docs/content/dagster-plus/insights/asset-metadata.mdx
+++ b/docs/content/dagster-plus/insights/asset-metadata.mdx
@@ -64,7 +64,7 @@ In the dialog that appears, check or uncheck metrics to use them in Insights. Se
     href="/dagster-plus/insights"
   ></ArticleListItem>
   <ArticleListItem
-    title="Software-defined Assets"
+    title="Asset definitions"
     href="/concepts/assets/software-defined-assets"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/guides.mdx
+++ b/docs/content/guides.mdx
@@ -22,15 +22,15 @@ Learn to apply [Dagster concepts](/concepts) to your work, explore experimental 
 
 ## Working with data assets
 
-- [Understanding how assets relate to ops and graphs](/guides/dagster/how-assets-relate-to-ops-and-graphs) - Learn how software-defined assets relate to ops and graphs, and when to use one over the other
+- [Understanding how assets relate to ops and graphs](/guides/dagster/how-assets-relate-to-ops-and-graphs) - Learn how asset definitions relate to ops and graphs, and when to use one over the other
 
-- [Moving to Software-defined Assets](/guides/dagster/enriching-with-software-defined-assets) - Already using ops and graphs, but not Software-defined Assets? Learn why and how to use Software-defined Assets
+- [Moving to asset definitions](/guides/dagster/enriching-with-software-defined-assets) - Already using ops and graphs, but not asset definitions? Learn why and how to use asset definitions
 
 - [Using asset checks to check data freshness](/concepts/assets/asset-checks/checking-for-data-freshness) - Use freshness checks, a type of [asset check](/concepts/assets/asset-checks) to identify the data assets that are overdue for an update
 
-- [Using Software-defined assets with Pandas and PySpark](/guides/dagster/software-defined-assets) - A quick introduction to Software-defined Assets, featuring Pandas and PySpark
+- [Using asset definitions with Pandas and PySpark](/guides/dagster/software-defined-assets) - A quick introduction to asset definitions, featuring Pandas and PySpark
 
-- [Testing assets](/guides/dagster/testing-assets) - Learn to test your Software-defined Assets
+- [Testing assets](/guides/dagster/testing-assets) - Learn to test your asset definitions
 
 - [Migrating to Pythonic resources and config](/guides/dagster/migrating-to-pythonic-resources-and-config) - Incrementally migrate existing Dagster codebases to Pythonic resources and config
 

--- a/docs/content/guides/dagster/asset-versioning-and-caching.mdx
+++ b/docs/content/guides/dagster/asset-versioning-and-caching.mdx
@@ -35,7 +35,7 @@ In computationally expensive data pipelining, this approach can yield tremendous
 
 ## Step one: Understanding data versions
 
-By default, Dagster automatically computes a data version for each materialization of a software-defined asset. It does this by hashing a code version together with the data versions of any input assets.
+By default, Dagster automatically computes a data version for each materialization of an asset. It does this by hashing a code version together with the data versions of any input assets.
 
 Let's start with a trivial asset that returns a hardcoded number:
 

--- a/docs/content/guides/dagster/enriching-with-software-defined-assets.mdx
+++ b/docs/content/guides/dagster/enriching-with-software-defined-assets.mdx
@@ -1,26 +1,26 @@
 ---
-title: Upgrading to Software-defined Assets | Dagster Docs
-description: Understand when, why, and how to use Software-defined Assets (SDAs) in Dagster, as well as how SDAs work with other core Dagster concepts.
+title: Upgrading to asset definitions | Dagster Docs
+description: Understand when, why, and how to use asset definitions in Dagster, as well as how they work with other core Dagster concepts.
 ---
 
-# Upgrading to Software-defined Assets
+# Upgrading to asset definitions
 
-Familiar with ops and graphs? Want to understand when, why, and how to use Software-defined Assets in Dagster? If so, this guide is for you. We'll also demonstrate what some common Dagster jobs look like before and after using Software-defined Assets.
+Familiar with ops and graphs? Want to understand when, why, and how to use asset definitions in Dagster? If so, this guide is for you. We'll also demonstrate what some common Dagster jobs look like before and after using asset definitions.
 
 Before we jump in, here's a quick refresher:
 
 - An **asset** is a persistent object in storage, such as a table, machine learning (ML) model, or file.
 - An [**op**](/concepts/ops-jobs-graphs/ops) is the core unit of computation in Dagster. For example, an op might accept tabular data as its input and produce transformed tabular data as its output.
 - A [**graph**](/concepts/ops-jobs-graphs/graphs) is a directed acyclic graph of ops or other graphs, which execute in order and pass data to each other.
-- A [**Software-defined Asset**](/concepts/assets/software-defined-assets) is a declaration of an asset that should exist and a description of how to compute it: the op or graph that needs to run and the upstream assets that it should run on.
+- Am [**asset definition**](/concepts/assets/software-defined-assets) is a declaration of an asset that should exist and a description of how to compute it: the op or graph that needs to run and the upstream assets that it should run on.
 
-**Software-defined assets aren't a replacement for Dagster's core computational concepts** - ops are, in fact, the core unit of computation that occurs **within an asset**. Think of them as a top layer that links ops, graphs, and jobs to the long-lived objects they interact with.
+**Asset definitions aren't a replacement for Dagster's core computational concepts** - ops are, in fact, the core unit of computation that occurs **within an asset**. Think of them as a top layer that links ops, graphs, and jobs to the long-lived objects they interact with.
 
 ---
 
-## Why use Software-defined Assets?
+## Why use asset definitions?
 
-Using Software-defined Assets means building Dagster jobs in a way that declares _ahead of time_ the assets they produce and consume. This is different than using the <PyObject object="AssetMaterialization" /> API, which only informs Dagster at runtime about the assets a job interacted with.
+Using asset definitions means building Dagster jobs in a way that declares _ahead of time_ the assets they produce and consume. This is different than using the <PyObject object="AssetMaterialization" /> API, which only informs Dagster at runtime about the assets a job interacted with.
 
 Preemptively declaring assets offers distinct advantages, including:
 
@@ -30,13 +30,13 @@ Preemptively declaring assets offers distinct advantages, including:
 
 ### Lineage
 
-As Software-defined Assets know what other assets they depend on, an asset's lineage can be [viewed easily in the Dagster UI](/concepts/assets/software-defined-assets#viewing-assets-in-the-ui).
+As asset definitions know what other assets they depend on, an asset's lineage can be [viewed easily in the Dagster UI](/concepts/assets/software-defined-assets#viewing-assets-in-the-ui).
 
 Assets help track and define cross-job dependencies. For example, when viewing a job that materializes assets, you can navigate to the jobs that produce the assets that it depends on. Additionally, when an upstream asset has been updated more recently than a downstream asset, Dagster will indicate that the downstream asset might be out of date.
 
 ### Direct operation
 
-Using Software-defined Assets enables you to directly operate them in the UI. On the [Asset's Details page](/concepts/webserver/ui#asset-details), you can:
+Using asset definitions enables you to directly operate your assets in the UI. On the [Asset's Details page](/concepts/webserver/ui#asset-details), you can:
 
 - View the materialization history of the asset
 - Check when the next materialization will occur
@@ -45,13 +45,13 @@ Using Software-defined Assets enables you to directly operate them in the UI. On
 
 ### Improved code ergonomics
 
-Software-defined assets provide sizeable improvements when it comes to code ergonomics:
+Asset definitions provide sizeable improvements when it comes to code ergonomics:
 
-- **You'll usually write less code**. Specifying the inputs to a Software-defined Asset defines the assets it depends on. This means you don't need to use <PyObject object="graph" decorator /> and <PyObject object="job" decorator /> to wire dependencies between ops.
+- **You'll usually write less code**. Specifying the inputs to an asset definition defines the assets it depends on. This means you don't need to use <PyObject object="graph" decorator /> and <PyObject object="job" decorator /> to wire dependencies between ops.
 
   This approach improves scalability by reducing the number of times an asset's name appears in your codebase by half. Refer to the [I/O manager-based example](#materialize-two-interdependent-tables-without-an-io-manager) below to see this in action.
 
-- **You no longer have to choose between easy dependency tracking and manageable organization.** Without Software-defined Assets, you're often forced to:
+- **You no longer have to choose between easy dependency tracking and manageable organization.** Without asset definitions, you're often forced to:
 
   - Contain everything in a single mega-job, which allows for easy dependency tracking but creates maintenance difficulties, OR
   - Split your pipeline into smaller jobs, which allows for easy maintenance but makes dependency tracking difficult
@@ -60,14 +60,14 @@ Software-defined assets provide sizeable improvements when it comes to code ergo
 
 ---
 
-## When should I use Software-defined Assets?
+## When should I use asset definitions?
 
-You should use Software-defined Assets when:
+You should use asset definitions when:
 
 - You’re using Dagster to produce or maintain assets, AND
 - You know what those assets will be before you launch any runs.
 
-Note that using Software-defined Assets in one job doesn’t mean they need to be used in all your jobs. If your use case doesn't meet these criteria, you can still use graphs and ops.
+Note that using asset definitions in one job doesn’t mean they need to be used in all your jobs. If your use case doesn't meet these criteria, you can still use graphs and ops.
 
 Still not sure? Check out these examples to see what's a good fit and what isn't:
 
@@ -145,11 +145,11 @@ Still not sure? Check out these examples to see what's a good fit and what isn't
 
 ---
 
-## How do I upgrade jobs to use Software-defined Assets?
+## How do I upgrade jobs to use asset definitions?
 
-Let's say you've written jobs that you want to enrich using Software-defined Assets. Assuming assets are known and being updated, what would upgrading look like?
+Let's say you've written jobs that you want to enrich using asset definitions. Assuming assets are known and being updated, what would upgrading look like?
 
-Generally, every op output in a job that corresponds to a long-lived object in storage should have a Software-defined Asset. The following examples demonstrate some realistic Dagster jobs, both with and without Software-defined Assets:
+Generally, every op output in a job that corresponds to a long-lived object in storage should have an asset definition. The following examples demonstrate some realistic Dagster jobs, both with and without asset definitions:
 
 - [A job that materializes two interdependent tables](#materialize-two-interdependent-tables)
 - [A job that materializes two interdependent tables without an I/O manager](#materialize-two-interdependent-tables-without-an-io-manager)
@@ -157,8 +157,8 @@ Generally, every op output in a job that corresponds to a long-lived object in s
 
 <Note>
   This isn't an exhaustive list! We're adding the ability to define jobs that
-  materialize Software-defined Assets and then run arbitrary ops. Interested?
-  We'd love to hear from you in{" "}
+  materialize assets and then run arbitrary ops. Interested? We'd love to hear
+  from you in{" "}
   <a href="https://dagster.io/slack" target="new">
     Slack
   </a>{" "}
@@ -172,11 +172,11 @@ Generally, every op output in a job that corresponds to a long-lived object in s
 ### Materialize two interdependent tables
 
 <TabGroup>
-<TabItem name="Without Software-defined Assets">
+<TabItem name="Without asset definitions">
 
 This example is a vanilla, op-based job that follows the idiomatic practice of delegating all I/O to I/O managers and input managers.
 
-The goal of each op in the job is to produce an asset. However, because the job doesn't use the Software-defined Asset APIs, Dagster is unaware of this:
+The goal of each op in the job is to produce an asset. However, because the job doesn't use the asset definition APIs, Dagster is unaware of this:
 
 ```python file=/guides/dagster/enriching_with_software_defined_assets/vanilla_io_manager.py
 from pandas import DataFrame
@@ -212,9 +212,9 @@ defs = Definitions(
 ```
 
 </TabItem>
-<TabItem name="With Software-defined Assets">
+<TabItem name="With asset definitions">
 
-Here's what an equivalent job looks like using Software-defined Assets:
+Here's what an equivalent job looks like using asset definitions:
 
 ```python file=/guides/dagster/enriching_with_software_defined_assets/sda_io_manager.py
 from pandas import DataFrame
@@ -257,7 +257,7 @@ defs = Definitions(
 ### Materialize two interdependent tables without an I/O manager
 
 <TabGroup>
-<TabItem name="Without Software-defined Assets">
+<TabItem name="Without asset definitions">
 
 This example does the same things as the [previous example](#materialize-two-interdependent-tables), with one difference. This job performs I/O inside of the ops instead of delegating it to I/O managers and input managers:
 
@@ -294,9 +294,9 @@ defs = Definitions(
 ```
 
 </TabItem>
-<TabItem name="With Software-defined Assets">
+<TabItem name="With asset definitions">
 
-Here's an example of an equivalent job that uses Software-defined Assets:
+Here's an example of an equivalent job that uses asset definitions:
 
 ```python file=/guides/dagster/enriching_with_software_defined_assets/sda_nothing.py
 from pandas import read_sql
@@ -337,7 +337,7 @@ defs = Definitions(
 ### Not all ops produce assets
 
 <TabGroup>
-<TabItem name="Without Software-defined Assets">
+<TabItem name="Without asset definitions">
 
 This example demonstrates a job where some of the ops (`extract_products` and `get_categories`) don't produce assets of their own. Instead, they produce transient data that downstream ops will use to produce assets:
 
@@ -382,11 +382,11 @@ defs = Definitions(
 ```
 
 </TabItem>
-<TabItem name="With Software-defined Assets">
+<TabItem name="With asset definitions">
 
-Here's an equivalent job using Software-defined Assets.
+Here's an equivalent job using asset definitions.
 
-**Note:** Because some ops don't correspond to assets, this job uses <PyObject object="op" decorator /> and <PyObject object="graph" decorator /> APIs and <PyObject object="AssetsDefinition" method="from_graph" /> to wrap a graph in a Software-defined Asset:
+**Note:** Because some ops don't correspond to assets, this job uses <PyObject object="op" decorator /> and <PyObject object="graph" decorator /> APIs and <PyObject object="AssetsDefinition" method="from_graph" /> to wrap a graph in an asset definitions:
 
 ```python file=/guides/dagster/enriching_with_software_defined_assets/sda_graph.py
 from pandas import DataFrame
@@ -440,23 +440,23 @@ defs = Definitions(
 
 ---
 
-## How do Software-defined Assets work with other Dagster concepts?
+## How do asset definitions work with other Dagster concepts?
 
-Still not sure how Software-defined Assets fit into your current Dagster usage? In this section, we'll touch on how Software-defined Assets work with some of Dagster's core concepts.
+Still not sure how asset definitions fit into your current Dagster usage? In this section, we'll touch on how asset definitions work with some of Dagster's core concepts.
 
 <TabGroup>
 <TabItem name="Ops and graphs">
 
 ### Ops and graphs
 
-| Without Software-defined Assets                                                                           | With Software-defined Assets                                                                                                |
+| Without asset definitions                                                                                 | With asset definitions                                                                                                      |
 | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| An [op](/concepts/ops-jobs-graphs/ops) is the basic unit of computation                                   | Every Software-defined Asset includes a graph or an op                                                                      |
-| A [graph](/concepts/ops-jobs-graphs/graphs) is a composite unit of computation that connects multiple ops | Every Software-defined Asset includes a graph or an op                                                                      |
+| An [op](/concepts/ops-jobs-graphs/ops) is the basic unit of computation                                   | Every asset definitions includes a graph or an op                                                                           |
+| A [graph](/concepts/ops-jobs-graphs/graphs) is a composite unit of computation that connects multiple ops | Every asset definitions includes a graph or an op                                                                           |
 | Ops can have multiple outputs                                                                             | Multiple assets can be produced by a single op when defined using the <PyObject object="multi_asset" decorator /> decorator |
 | Ops can use [config](/concepts/ops-jobs-graphs/ops#op-configuration)                                      | Assets can use [config](/concepts/assets/software-defined-assets)                                                           |
 | Ops can access <PyObject object="OpExecutionContext" />                                                   | Assets can access <PyObject object="OpExecutionContext" />                                                                  |
-| Ops can require [resources](/concepts/resources)                                                          | Software-defined Assets can require [resources](/concepts/resources)                                                        |
+| Ops can require [resources](/concepts/resources)                                                          | Asset definitions can require [resources](/concepts/resources)                                                              |
 | Ops can be tested by directly invoking them                                                               | Assets can be tested by directly invoking them                                                                              |
 
 </TabItem>
@@ -464,9 +464,9 @@ Still not sure how Software-defined Assets fit into your current Dagster usage? 
 
 ### Jobs
 
-| Without Software-defined Assets                                                                                                               | With Software-defined Assets                                                                                                                        |
+| Without asset definitions                                                                                                                     | With asset definitions                                                                                                                              |
 | --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| A job targets a graph of ops                                                                                                                  | An asset job targets a selection of Software-defined Assets                                                                                         |
+| A job targets a graph of ops                                                                                                                  | An asset job targets a selection of asset definitions                                                                                               |
 | Jobs can be [partitioned](/concepts/partitions-schedules-sensors/partitions)                                                                  | Assets can be [partitioned](/concepts/partitions-schedules-sensors/partitions)                                                                      |
 | Jobs can be put on [schedules](/concepts/partitions-schedules-sensors/schedules) or [sensors](/concepts/partitions-schedules-sensors/sensors) | Asset jobs can be put on [schedules](/concepts/partitions-schedules-sensors/schedules) or [sensors](/concepts/partitions-schedules-sensors/sensors) |
 
@@ -475,9 +475,9 @@ Still not sure how Software-defined Assets fit into your current Dagster usage? 
 
 ### Dagster types
 
-| Without Software-defined Assets                                                                                                           | With Software-defined Assets                                                                                                                                                                                                            |
+| Without asset definitions                                                                                                                 | With asset definitions                                                                                                                                                                                                                  |
 | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Op outputs and inputs can have [Dagster types](/concepts/types)                                                                           | Software-defined assets can have [Dagster types](/concepts/types)                                                                                                                                                                       |
+| Op outputs and inputs can have [Dagster types](/concepts/types)                                                                           | Asset definitions can have [Dagster types](/concepts/types)                                                                                                                                                                             |
 | The `Nothing` Dagster type enables declaring that Dagster doesn't need to store or load the object corresponding to an op output or input | The [`deps`](/concepts/assets/software-defined-assets#defining-basic-dependencies) argument when defining an asset enables specifying dependencies without relying on Dagster to store or load objects corresponding to that dependency |
 
 </TabItem>
@@ -485,7 +485,7 @@ Still not sure how Software-defined Assets fit into your current Dagster usage? 
 
 ### Code locations
 
-| Without Software-defined Assets                                                             | With Software-defined Assets                                          |
+| Without asset definitions                                                                   | With asset definitions                                                |
 | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
 | Code locations (<PyObject object="Definitions" />) can contain jobs, schedules, and sensors | Code locations (<PyObject object="Definitions" />) can contain assets |
 
@@ -494,7 +494,7 @@ Still not sure how Software-defined Assets fit into your current Dagster usage? 
 
 ### I/O managers
 
-| Without Software-defined Assets                                                                                 | With Software-defined Assets                                                                     |
+| Without asset definitions                                                                                       | With asset definitions                                                                           |
 | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | [I/O managers](/concepts/io-management/io-managers) can control how op inputs and outputs are loaded and stored | [I/O managers](/concepts/io-management/io-managers) can control how assets are loaded and stored |
 

--- a/docs/content/guides/dagster/example_project.mdx
+++ b/docs/content/guides/dagster/example_project.mdx
@@ -46,7 +46,7 @@ This example shows useful patterns for many Dagster concepts, including:
 
 ### Organizing your assets in groups
 
-[Software-defined assets](/concepts/assets/software-defined-assets) - An asset is a software object that models a data asset. The prototypical example is a table in a database or a file in cloud storage.
+[Asset definitions](/concepts/assets/software-defined-assets) - An asset is a software object that models a data asset. The prototypical example is a table in a database or a file in cloud storage.
 
 This example contains [three asset groups](https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/project_fully_featured/assets/\__init\_\_.py):
 

--- a/docs/content/guides/dagster/how-assets-relate-to-ops-and-graphs.mdx
+++ b/docs/content/guides/dagster/how-assets-relate-to-ops-and-graphs.mdx
@@ -1,11 +1,11 @@
 ---
-title: Understanding how software-defined assets relate to ops and graphs | Dagster Docs
-description: Dagster’s main abstraction for building data pipelines is the software-defined asset. However, Dagster also has ops and graphs. How do these relate? When should you use one over the other?
+title: Understanding how asset definitions relate to ops and graphs | Dagster Docs
+description: Dagster’s main abstraction for building data pipelines is the asset definition. However, Dagster also has ops and graphs. How do these relate? When should you use one over the other?
 ---
 
-# Understanding how software-defined assets relate to ops and graphs
+# Understanding how asset definitions relate to ops and graphs
 
-Dagster’s main abstraction for building data pipelines is the _software-defined asset_. However, Dagster also has abstractions called _ops_ and _graphs_.
+Dagster’s main abstraction for building data pipelines is the _asset definition_. However, Dagster also has abstractions called _ops_ and _graphs_.
 
 If you're not sure which one to use, this guide is for you. In this guide, we'll cover:
 
@@ -16,7 +16,7 @@ If you're not sure which one to use, this guide is for you. In this guide, we'll
 
 ## When should I use assets or ops and graphs?
 
-Dagster is mainly used to build data pipelines, and most data pipelines can be expressed in Dagster as sets of [software-defined assets](/concepts/assets/software-defined-assets). If you’re a new Dagster user **and** your goal is to build a data pipeline, we recommend starting with software-defined assets and not worrying about ops or graphs. This is because most of the code you’ll be writing will directly relate to producing data assets.
+Dagster is mainly used to build data pipelines, and most data pipelines can be expressed in Dagster as sets of [asset definitions](/concepts/assets/software-defined-assets). If you’re a new Dagster user **and** your goal is to build a data pipeline, we recommend starting with asset definitions and not worrying about ops or graphs. This is because most of the code you’ll be writing will directly relate to producing data assets.
 
 However, there are some situations where you want to run code without thinking about data assets that the code is producing. In these cases, it’s appropriate to use [ops](/concepts/ops-jobs-graphs/ops) and [graphs](/concepts/ops-jobs-graphs/graphs). For example:
 
@@ -32,9 +32,9 @@ You want to schedule a workflow where the goal is **not** to keep a set of data 
 - Scan a data warehouse for tables that haven't been used in months and delete them
 - Record metadata about a set of data assets
 
-In these cases, you should define your workflow in terms ops and graphs, not software-defined assets. The [Intro to ops and jobs guide](/guides/dagster/intro-to-ops-jobs) is a good place to start learning how to do this.
+In these cases, you should define your workflow in terms ops and graphs, not asset definitions. The [Intro to ops and jobs guide](/guides/dagster/intro-to-ops-jobs) is a good place to start learning how to do this.
 
-Additionally, note that a single Dagster deployment can contain software-defined assets and op/graph-based jobs side-by-side, which means that you’re not bound to one particular choice. If your workflow reads from software-defined assets, you can model that explicitly in Dagster, which is discussed in a [a later section](#op-graphs-that-read-from-an-asset).
+Additionally, note that a single Dagster deployment can contain asset definitions and op/graph-based jobs side-by-side, which means that you’re not bound to one particular choice. If your workflow reads from asset definitions, you can model that explicitly in Dagster, which is discussed in a [a later section](#op-graphs-that-read-from-an-asset).
 
 ### Situation 2: You want to break an asset into multiple steps
 
@@ -44,60 +44,60 @@ If you're in a situation like the following:
 - Some of the steps don't produce assets of their own
 - You need to be able to re-execute individual steps
 
-In this case, you might want to use a [graph-backed asset](/concepts/assets/graph-backed-assets). This is discussed more [later in this guide](#graph-backed-assets).
+In this case, you might want to use a [graph-backed asset](/concepts/assets/graph-backed-assets). This is discussed more [later in this guide](#graph-backed-asset-definitions).
 
 ### Situation 3: You’re anchored in task-based workflows
 
-Task-based workflows have been a popular way of defining data pipelines for a long time. While we believe that software-defined assets provide a superior way of writing and operating data pipelines, we acknowledge that teams often have existing codebases or mindsets that are heavily anchored in task-based workflows.
+Task-based workflows have been a popular way of defining data pipelines for a long time. While we believe that asset definitions provide a superior way of writing and operating data pipelines, we acknowledge that teams often have existing codebases or mindsets that are heavily anchored in task-based workflows.
 
-Op-based graphs resemble task-based workflows very closely, so they’re a natural choice for data pipelines that want to stick to that paradigm, either permanently or temporarily, while migrating to software-defined assets.
+Op-based graphs resemble task-based workflows very closely, so they’re a natural choice for data pipelines that want to stick to that paradigm, either permanently or temporarily, while migrating to asset definitions.
 
 ---
 
 ## How do assets relate to ops and graphs?
 
-Next, we'll discuss how assets relate to ops and graphs. By the end of this section, you should understand how each type of software-defined asset relates to ops and graphs.
+Next, we'll discuss how assets relate to ops and graphs. By the end of this section, you should understand how each type of asset definition relates to ops and graphs.
 
-- [Software-defined assets](#software-defined-assets)
-- [Multi-assets](#multi-assets)
-- [Graph-backed assets](#graph-backed-assets)
+- [Basic asset definitions](#basic-asset-definitions)
+- [Multi-asset definitions](#multi-asset-definitions)
+- [Graph-backed asset definitions](#graph-backed-asset-definitions)
 - [Op graphs that read from an asset](#op-graphs-that-read-from-an-asset)
 
-### Software-defined assets
+### Basic asset definitions
 
-A software-defined asset is a description of how to compute the contents of a particular data asset.
+An asset definitions is a description of how to compute the contents of a particular data asset.
 
-Under the hood, every software-defined asset contains an op (or graph of ops), which is the function that’s invoked to compute its contents. In most cases, the underlying op is invisible to the user.
+Under the hood, every asset definition contains an op (or graph of ops), which is the function that’s invoked to compute its contents. In most cases, the underlying op is invisible to the user.
 
-<!-- ![Op and software-defined asset](/images/guides/assets-relate-to-ops/op-software-defined-asset.png) -->
+<!-- ![Op and basic asset definition](/images/guides/assets-relate-to-ops/op-software-defined-asset.png) -->
 
 <center>
   <Image
-    alt="Op and software-defined asset"
+    alt="Op and basic asset definition"
     src="/images/guides/assets-relate-to-ops/op-software-defined-asset.png"
     width={714}
     height={516}
   />
 </center>
 
-### Multi-assets
+### Multi-asset definitions
 
 When you use the <PyObject object="multi_asset" decorator /> decorator, you’re defining a single op that produces multiple assets:
 
-<!-- ![Multi- software-defined asset](/images/guides/assets-relate-to-ops/multi-software-defined-asset.png) -->
+<!-- ![Multi- asset definition](/images/guides/assets-relate-to-ops/multi-software-defined-asset.png) -->
 
 <center>
   <Image
-    alt="Multi- software-defined asset"
+    alt="Multi- asset definition"
     src="/images/guides/assets-relate-to-ops/multi-software-defined-asset.png"
     width={715}
     height={286}
   />
 </center>
 
-### Graph-backed assets
+### Graph-backed asset definitions
 
-Dagster supports composing a set of ops into an op graph, usually by using the <PyObject object="graph" decorator /> decorator. A software-defined asset can be backed by an **op graph**, instead of an op.
+Dagster supports composing a set of ops into an op graph, usually by using the <PyObject object="graph" decorator /> decorator. An asset definition can be backed by an **op graph**, instead of an op.
 
 <!-- ![Op graph and graph-backed asset](/images/guides/assets-relate-to-ops/op-graph-graph-backed-asset.png) -->
 

--- a/docs/content/guides/dagster/ml-pipeline.mdx
+++ b/docs/content/guides/dagster/ml-pipeline.mdx
@@ -13,7 +13,7 @@ We will work through building a machine learning pipeline, including using asset
 
 ## Before you begin
 
-This guide assumes you have familiarity with machine learning concepts and several Dagster concepts, including [software-defined assets](/concepts/assets/software-defined-assets) and [jobs](/concepts/ops-jobs-graphs/jobs).
+This guide assumes you have familiarity with machine learning concepts and several Dagster concepts, including [asset definitions](/concepts/assets/software-defined-assets) and [jobs](/concepts/ops-jobs-graphs/jobs).
 
 ---
 

--- a/docs/content/guides/dagster/software-defined-assets.mdx
+++ b/docs/content/guides/dagster/software-defined-assets.mdx
@@ -1,17 +1,17 @@
 ---
-title: Software-Defined Assets with Pandas and PySpark | Dagster
-description: The "software-defined asset" APIs sit atop of the graph/job/op APIs and enable a novel approach to orchestration that puts assets at the forefront.
+title: Asset definitions with Pandas and PySpark | Dagster
+description: The asset definition APIs sit atop of the graph/job/op APIs and enable a novel approach to orchestration that puts assets at the forefront.
 ---
 
-# Software-Defined Assets with Pandas and PySpark
+# Asset definitions with Pandas and PySpark
 
 <CodeReferenceLink filePath="examples/assets_pandas_pyspark" />
 
-The software-defined asset APIs sit atop of the graph/job/op APIs and enable a novel approach to orchestration that puts assets at the forefront.
+The asset definition APIs sit atop of the graph/job/op APIs and enable a novel approach to orchestration that puts assets at the forefront.
 
 In Dagster, an "asset" is a data product, an object produced by a data pipeline. Some examples are tables, machine learning models, or reports.
 
-Conceptually, software-defined assets invert the typical relationship between assets and computation. Instead of defining a graph of ops and recording which assets those ops end up materializing, you define a set of assets. Each asset knows how to compute its contents from upstream assets.
+Conceptually, asset definitions invert the typical relationship between assets and computation. Instead of defining a graph of ops and recording which assets those ops end up materializing, you define a set of assets. Each asset knows how to compute its contents from upstream assets.
 
 Taking a software-defined asset approach has a few main benefits:
 

--- a/docs/content/guides/general.mdx
+++ b/docs/content/guides/general.mdx
@@ -20,15 +20,15 @@ title: General Dagster Guides | Dagster Docs
 
 ## Working with data assets
 
-- [Understanding how assets relate to ops and graphs](/guides/dagster/how-assets-relate-to-ops-and-graphs) - Learn how software-defined assets relate to ops and graphs, and when to use one over the other
+- [Understanding how assets relate to ops and graphs](/guides/dagster/how-assets-relate-to-ops-and-graphs) - Learn how asset definitions relate to ops and graphs, and when to use one over the other
 
-- [Moving to Software-defined Assets](/guides/dagster/enriching-with-software-defined-assets) - Already using ops and graphs, but not Software-defined Assets? Learn why and how to use Software-defined Assets
+- [Moving to asset definitions](/guides/dagster/enriching-with-software-defined-assets) - Already using ops and graphs, but not asset definitions? Learn why and how to use asset definitions
 
 - [Using asset checks to check data freshness](/concepts/assets/asset-checks/checking-for-data-freshness) - Use freshness checks, a type of [asset check](/concepts/assets/asset-checks) to identify the data assets that are overdue for an update
 
-- [Using Software-defined assets with Pandas and PySpark](/guides/dagster/software-defined-assets) - A quick introduction to Software-defined Assets, featuring Pandas and PySpark
+- [Using asset definitions with Pandas and PySpark](/guides/dagster/software-defined-assets) - A quick introduction to asset definitions, featuring Pandas and PySpark
 
-- [Testing assets](/guides/dagster/testing-assets) - Learn to test your Software-defined Assets
+- [Testing assets](/guides/dagster/testing-assets) - Learn to test your asset definitions
 
 - [Migrating to Pythonic resources and config](/guides/dagster/migrating-to-pythonic-resources-and-config) - Incrementally migrate existing Dagster codebases to Pythonic resources and config
 

--- a/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
+++ b/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
@@ -55,14 +55,14 @@ Concurrency is the ability of a system to execute multiple processes in parallel
       <td>
         <strong>
           <a href="/concepts/assets/software-defined-assets">
-            Software-defined asset
+            Asset definition
           </a>
         </strong>
       </td>
       <td>
-        A Software-defined asset is a Dagster object that couples an asset to
-        the function and upstream assets used to produce its contents. An asset
-        is an object in persistent storage, such as a table, file, or persisted
+        An asset definition is a Dagster object that couples an asset to the
+        function and upstream assets used to produce its contents. An asset is
+        an object in persistent storage, such as a table, file, or persisted
         machine learning model.
       </td>
     </tr>

--- a/docs/content/guides/understanding-dagster-project-files.mdx
+++ b/docs/content/guides/understanding-dagster-project-files.mdx
@@ -93,7 +93,7 @@ Let's take a look at what each of these files and directories does:
       <td>assets.py</td>
       <td>
         A Python module that contains {" "}
-        <a href="/concepts/assets/software-defined-assets">software-defined assets</a>.
+        <a href="/concepts/assets/software-defined-assets">asset definitions</a>.
         <br />
         <br />
         <strong>Note:</strong> As your project grows, we recommend organizing assets in sub-modules.

--- a/docs/content/integrations/airbyte-cloud.mdx
+++ b/docs/content/integrations/airbyte-cloud.mdx
@@ -27,9 +27,9 @@ This guide focuses on how to work with Airbyte Cloud connections using Dagster's
 
 ---
 
-## Airbyte Cloud connections and Dagster software-defined assets
+## Airbyte Cloud connections and Dagster assets
 
-An [Airbyte Cloud connection](https://docs.airbyte.com/understanding-airbyte/connections/) defines a series of data streams which are synced between a source and a destination. During a sync, a replica of the data from each data stream is written to the destination, typically as one or more tables. Dagster represents each of the replicas generated in the destination as a software-defined asset. This enables you to easily:
+An [Airbyte Cloud connection](https://docs.airbyte.com/understanding-airbyte/connections/) defines a series of data streams which are synced between a source and a destination. During a sync, a replica of the data from each data stream is written to the destination, typically as one or more tables. Dagster represents each of the replicas generated in the destination as an asset. This enables you to easily:
 
 - Visualize the streams involved in an Airbyte Cloud connection and execute a sync from Dagster
 - Define downstream computations which depend on replicas produced by Airbyte
@@ -68,7 +68,7 @@ Here, the API key is provided using an <PyObject object="EnvVar" />. For more in
 
 ## Step 2: Building Airbyte Cloud assets using Dagster
 
-In order to create software-defined assets for your Airbyte Cloud connections, you will first need to determine the connection IDs for each of the connections you would like to build assets for. The connection ID can be seen in the URL of the connection page when viewing the Airbyte Cloud UI, located between `/connections/` and `/status`.
+In order to create asset definitions for your Airbyte Cloud connections, you will first need to determine the connection IDs for each of the connections you would like to build assets for. The connection ID can be seen in the URL of the connection page when viewing the Airbyte Cloud UI, located between `/connections/` and `/status`.
 
 For example, the connection ID for the URL `https://cloud.airbyte.com/workspaces/11f3741b-0b54-45f8-9886-937f96f2ba88/connections/43908042-8399-4a58-82f1-71a45099fff7/status` is `43908042-8399-4a58-82f1-71a45099fff7`.
 
@@ -81,7 +81,7 @@ For example, the connection ID for the URL `https://cloud.airbyte.com/workspaces
   />
 </center>
 
-Then, supply the connection ID and the list of tables which the connection creates in the destination to `build_airbyte_assets`. This utility will generate a set of software-defined assets corresponding to the tables which Airbyte creates in the destination.
+Then, supply the connection ID and the list of tables which the connection creates in the destination to `build_airbyte_assets`. This utility will generate a set of f corresponding to the tables which Airbyte creates in the destination.
 
 ```python startafter=start_manually_define_airbyte_assets_cloud endbefore=end_manually_define_airbyte_assets_cloud file=/integrations/airbyte/airbyte.py dedent=4
 from dagster_airbyte import build_airbyte_assets
@@ -319,7 +319,7 @@ If you have questions on using Airbyte with Dagster, we'd love to hear from you:
   ></ArticleListItem>
   <ArticleListItem
     href="/concepts/assets/software-defined-assets"
-    title="Software-defined assets"
+    title="Asset definitions"
   ></ArticleListItem>
   <ArticleListItem
     href="/concepts/resources"

--- a/docs/content/integrations/airbyte.mdx
+++ b/docs/content/integrations/airbyte.mdx
@@ -25,9 +25,9 @@ This guide focuses on how to work with Airbyte connections using Dagster's [soft
 
 ---
 
-## Airbyte connections and Dagster software-defined assets
+## Airbyte connections and Dagster assets
 
-An [Airbyte connection](https://docs.airbyte.com/understanding-airbyte/connections/) defines a series of data streams which are synced between a source and a destination. During a sync, a replica of the data from each data stream is written to the destination, typically as one or more tables. Dagster represents each of the replicas generated in the destination as a software-defined asset. This enables you to easily:
+An [Airbyte connection](https://docs.airbyte.com/understanding-airbyte/connections/) defines a series of data streams which are synced between a source and a destination. During a sync, a replica of the data from each data stream is written to the destination, typically as one or more tables. Dagster represents each of the replicas generated in the destination as an asset. This enables you to easily:
 
 - Visualize the streams involved in an Airbyte connection and execute a sync from Dagster
 - Define downstream computations which depend on replicas produced by Airbyte
@@ -95,7 +95,7 @@ from dagster_airbyte import load_assets_from_airbyte_instance
 airbyte_assets = load_assets_from_airbyte_instance(airbyte_instance)
 ```
 
-The `load_assets_from_airbyte_instance` function retrieves all of the connections you have defined in the Airbyte interface, creating software-defined assets for each data stream. Each connection has an associated [op](https://docs.dagster.io/concepts/ops-jobs-graphs/ops#ops) which triggers a sync of that connection.
+The `load_assets_from_airbyte_instance` function retrieves all of the connections you have defined in the Airbyte interface, creating asset definitions for each data stream. Each connection has an associated [op](https://docs.dagster.io/concepts/ops-jobs-graphs/ops#ops) which triggers a sync of that connection.
 
 </TabItem>
 
@@ -113,7 +113,7 @@ airbyte_assets = load_assets_from_airbyte_project(
 )
 ```
 
-The `load_assets_from_airbyte_project` function parses the YAML metadata, generating a set of software-defined assets which reflect each of the data streams synced by your connections. Each connection has an associated [op](https://docs.dagster.io/concepts/ops-jobs-graphs/ops#ops) which triggers a sync of that connection.
+The `load_assets_from_airbyte_project` function parses the YAML metadata, generating a set of asset definitions which reflect each of the data streams synced by your connections. Each connection has an associated [op](https://docs.dagster.io/concepts/ops-jobs-graphs/ops#ops) which triggers a sync of that connection.
 
 #### Adding a resource
 
@@ -379,7 +379,7 @@ If you have questions on using Airbyte with Dagster, we'd love to hear from you:
   ></ArticleListItem>
   <ArticleListItem
     href="/concepts/assets/software-defined-assets"
-    title="Software-defined assets"
+    title="Asset definitions"
   ></ArticleListItem>
   <ArticleListItem
     href="/concepts/resources"

--- a/docs/content/integrations/airflow.mdx
+++ b/docs/content/integrations/airflow.mdx
@@ -70,13 +70,11 @@ While Airflow and Dagster have some significant differences, there are many conc
     <tr>
       <td>Datasets</td>
       <td>
-        <a href="/concepts/assets/software-defined-assets">
-          Software-defined Assets (SDAs)
-        </a>
+        <a href="/concepts/assets/software-defined-assets">Assets</a>
       </td>
       <td>
-        SDAs are more powerful and mature than datasets and include support for
-        things like{" "}
+        Dagster assets are more powerful and mature than datasets and include
+        support for things like{" "}
         <a href="/concepts/partitions-schedules-sensors/partitioning-assets">
           partitioning
         </a>

--- a/docs/content/integrations/bigquery.mdx
+++ b/docs/content/integrations/bigquery.mdx
@@ -5,7 +5,7 @@ description: Store your Dagster assets in BigQuery
 
 # Google BigQuery & Dagster
 
-Using Dagster's [software-defined assets](/concepts/assets/software-defined-assets) and BigQuery I/O manager, you can easily interact with BigQuery tables alongside other Dagster assets.
+Using Dagster's [asset definitions](/concepts/assets/software-defined-assets) and BigQuery I/O manager, you can easily interact with BigQuery tables alongside other Dagster assets.
 
 Managing your BigQuery tables with Dagster enables you to:
 
@@ -18,7 +18,7 @@ Managing your BigQuery tables with Dagster enables you to:
 
 ## BigQuery and Dagster tutorial
 
-In this tutorial, you'll learn how to store and load Dagster's [software-defined asset](/concepts/assets/software-defined-assets) in BigQuery. [Click here to get started](/integrations/bigquery/using-bigquery-with-dagster).
+In this tutorial, you'll learn how to store and load Dagster's [asset definitions](/concepts/assets/software-defined-assets) in BigQuery. [Click here to get started](/integrations/bigquery/using-bigquery-with-dagster).
 
 By the end of the tutorial, you will have a connection to your BigQuery instance and a handful of assets that create tables in BigQuery or read existing tables from BigQuery.
 

--- a/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
+++ b/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
@@ -5,7 +5,7 @@ description: Store your Dagster assets in BigQuery
 
 # Using Dagster with Google BigQuery
 
-This tutorial focuses on creating and interacting with BigQuery tables using Dagster's [software-defined assets (SDAs)](/concepts/assets/software-defined-assets).
+This tutorial focuses on creating and interacting with BigQuery tables using Dagster's [asset definitions](/concepts/assets/software-defined-assets).
 
 The `dagster-gcp` library provides two ways to interact with BigQuery tables:
 
@@ -398,6 +398,6 @@ defs = Definitions(
 
 For more BigQuery features, refer to the [BigQuery reference](/integrations/bigquery/reference).
 
-For more information on software-defined assets, refer to the [tutorial](/tutorial) or the [Assets concept documentation](/concepts/assets/software-defined-assets).
+For more information on asset definitions, refer to the [tutorial](/tutorial) or the [Assets concept documentation](/concepts/assets/software-defined-assets).
 
 For more information on I/O managers, refer to the [I/O manager concept documentation](/concepts/io-management/io-managers).

--- a/docs/content/integrations/databricks.mdx
+++ b/docs/content/integrations/databricks.mdx
@@ -50,7 +50,7 @@ databricks_client_instance = databricks_client.configured(
 
 ## Step 2: Create an op/asset that connects to Databricks
 
-In this step, we'll demonstrate several ways to model a Databricks API call as either a Dagster [op](/concepts/ops-jobs-graphs/ops) or the computation backing a [Software-defined asset](/concepts/assets/software-defined-assets). You can either:
+In this step, we'll demonstrate several ways to model a Databricks API call as either a Dagster [op](/concepts/ops-jobs-graphs/ops) or the computation backing an [asset definition](/concepts/assets/software-defined-assets). You can either:
 
 - Use the `dagster-databricks` op factories, which create ops that invoke the Databricks Jobs' [Run Now](https://docs.databricks.com/api-explorer/workspace/jobs/runnow) ([`create_databricks_run_now_op`](/\_apidocs/libraries/dagster-databricks)) or [Submit Run](https://docs.databricks.com/api-explorer/workspace/jobs/submit) ([`create_databricks_submit_run_op`](/\_apidocs/libraries/dagster-databricks)) APIs, or
 - Manually create a Dagster op or asset that connects to Databricks using the configured Databricks resource.
@@ -171,5 +171,5 @@ By now, you should have a working Databricks and Dagster integration!
 
 What's next? From here, you can:
 
-- Learn more about [software-defined assets](/concepts/assets/software-defined-assets)
+- Learn more about [asset definitions](/concepts/assets/software-defined-assets)
 - Check out the [`dagster-databricks` API docs](/\_apidocs/libraries/dagster-databricks)

--- a/docs/content/integrations/dbt-cloud.mdx
+++ b/docs/content/integrations/dbt-cloud.mdx
@@ -13,7 +13,7 @@ description: Dagster can orchestrate dbt Cloud alongside other technologies.
   !
 </Note>
 
-Dagster allows you to run dbt Cloud alongside other technologies like Spark, Python, etc., and has built-in support for loading dbt Cloud models, seeds, and snapshots as [Software-defined Assets](/concepts/assets/software-defined-assets).
+Dagster allows you to run dbt Cloud alongside other technologies like Spark, Python, etc., and has built-in support for loading dbt Cloud models, seeds, and snapshots as [asset definitions](/concepts/assets/software-defined-assets).
 
 ---
 
@@ -64,7 +64,7 @@ In this example, <PyObject object="EnvVar" /> is used to pass in dbt Cloud crede
 
 ## Step 2: Loading dbt Cloud models as assets
 
-In this step, you'll load the dbt Cloud models managed by a dbt Cloud job into Dagster as [Software-defined Assets](/concepts/assets/software-defined-assets).
+In this step, you'll load the dbt Cloud models managed by a dbt Cloud job into Dagster as [asset definitions](/concepts/assets/software-defined-assets).
 
 For context, a dbt Cloud job defines set of commands to run for a dbt Cloud project. The dbt Cloud models managed by a dbt Cloud job are the models that are run by the job after filtering options are respected.
 
@@ -93,7 +93,7 @@ When invoked, the function:
 
 1. Invokes your dbt Cloud job with command overrides to compile your dbt project,
 2. Parses the metadata provided by dbt Cloud, and
-3. Generates a set of Software-defined Assets reflecting the models in the project managed by the dbt Cloud job. Materializing these assets will run the dbt Cloud job that is represented by the loaded assets.
+3. Generates a set of asset definitions reflecting the models in the project managed by the dbt Cloud job. Materializing these assets will run the dbt Cloud job that is represented by the loaded assets.
 
 ---
 
@@ -203,5 +203,5 @@ By now, you should have a working dbt Cloud and Dagster integration and a handfu
 
 What's next? From here, you can:
 
-- Learn more about [Software-defined Assets](/concepts/assets/software-defined-assets)
+- Learn more about [asset definitions](/concepts/assets/software-defined-assets)
 - Check out the [`dagster-dbt` API docs](/\_apidocs/libraries/dagster-dbt)

--- a/docs/content/integrations/dbt.mdx
+++ b/docs/content/integrations/dbt.mdx
@@ -17,7 +17,7 @@ description: Dagster can orchestrate dbt alongside other technologies.
 
 Dagster orchestrates dbt alongside other technologies, so you can schedule dbt with Spark, Python, etc. in a single data pipeline.
 
-Dagster's [Software-defined Asset](/concepts/assets/software-defined-assets) approach allows Dagster to understand dbt at the level of individual dbt models. This means that you can:
+Dagster's [asset definition](/concepts/assets/software-defined-assets) approach allows Dagster to understand dbt at the level of individual dbt models. This means that you can:
 
 - Use Dagster's UI or APIs to run subsets of your dbt models, seeds, and snapshots.
 - Track failures, logs, and run history for individual dbt models, seeds, and snapshots.
@@ -78,7 +78,7 @@ There are a few ways to get started with Dagster and dbt:
 
 ---
 
-## Understanding how dbt models relate to Dagster Software-defined assets
+## Understanding how dbt models relate to Dagster asset definitions
 
 <DbtModelAssetExplanation />
 

--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -12,7 +12,7 @@ description: Dagster can orchestrate dbt alongside other technologies.
 
 This reference provides a high-level look at working with dbt models through Dagster's [software-defined assets](/concepts/assets/software-defined-assets) framework using the [`dagster-dbt` integration library](/\_apidocs/libraries/dagster-dbt).
 
-For a step-by-step implementation walkthrough, refer to the [Using dbt with Dagster software-defined assets tutorial](/integrations/dbt/using-dbt-with-dagster).
+For a step-by-step implementation walkthrough, refer to the [Using dbt with Dagster asset definitions tutorial](/integrations/dbt/using-dbt-with-dagster).
 
 ---
 
@@ -37,7 +37,7 @@ For a step-by-step implementation walkthrough, refer to the [Using dbt with Dags
 
 ---
 
-## dbt models and Dagster software-defined assets
+## dbt models and Dagster asset definitions
 
 <DbtModelAssetExplanation />
 
@@ -217,7 +217,7 @@ Refer to the [Schedule documentation](/concepts/partitions-schedules-sensors/sch
 
 ## Understanding asset definition attributes
 
-In Dagster, each asset definition has attributes. Dagster automatically generates these attributes for each software-defined asset loaded from the dbt project. These attributes can optionally be overridden by the user.
+In Dagster, each asset definition has attributes. Dagster automatically generates these attributes for each asset definition loaded from the dbt project. These attributes can optionally be overridden by the user.
 
 - [Customizing asset keys](#customizing-asset-keys)
 - [Customizing group names](#customizing-group-names)
@@ -536,7 +536,7 @@ def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
 
 ## dbt models, code versions, and "Unsynced"
 
-Note that Dagster allows the optional specification of a [`code_version`](/concepts/assets/software-defined-assets#asset-code-versions) for each software-defined asset, which are used to track changes. The `code_version` for an asset arising from a dbt model is defined automatically as the hash of the SQL defining the DBT model. This allows the asset graph in the UI to use the "Unsynced" status to indicate which dbt models have new SQL since they were last materialized.
+Note that Dagster allows the optional specification of a [`code_version`](/concepts/assets/software-defined-assets#asset-code-versions) for each asset definition, which are used to track changes. The `code_version` for an asset arising from a dbt model is defined automatically as the hash of the SQL defining the DBT model. This allows the asset graph in the UI to use the "Unsynced" status to indicate which dbt models have new SQL since they were last materialized.
 
 ---
 
@@ -861,7 +861,7 @@ where order_date >= '{{ var('min_date') }}' and order_date <= '{{ var('max_date'
 
 <ArticleList>
   <ArticleListItem
-    title="Using dbt with Dagster software-defined assets"
+    title="Using dbt with Dagster asset definitions"
     href="/integrations/dbt/using-dbt-with-dagster"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/integrations/dbt/using-dbt-with-dagster.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster.mdx
@@ -12,7 +12,7 @@ description: Dagster can orchestrate dbt alongside other technologies.
 
 In this tutorial, we'll walk you through integrating dbt with Dagster using a smaller version of dbt's example [jaffle shop project](https://github.com/dbt-labs/jaffle_shop), the [dagster-dbt library](/\_apidocs/libraries/dagster-dbt), and a data warehouse, such as [DuckDB](https://duckdb.org/).
 
-By the end of this tutorial, you'll have your dbt models represented in Dagster along with other [Dagster Software-defined Assets](/integrations/dbt/reference#dbt-models-and-dagster-software-defined-assets) upstream and downstream of them:
+By the end of this tutorial, you'll have your dbt models represented in Dagster along with other [Dagster asset definitions](/integrations/dbt/reference#dbt-models-and-dagster-asset-definitions) upstream and downstream of them:
 
 <!--
 ![Asset group with dbt models and Python asset](/images/integrations/dbt/using-dbt-with-dagster/downstream-assets/asset-graph-materialized.png)

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/downstream-assets.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/downstream-assets.mdx
@@ -8,7 +8,7 @@ description: Dagster can orchestrate dbt alongside other technologies.
 <Note>
   This is part four of the{" "}
   <a href="/integrations/dbt/using-dbt-with-dagster">
-    Using dbt with Dagster software-defined assets
+    Using dbt with Dagster assets
   </a>{" "}
   tutorial.
 </Note>
@@ -151,7 +151,7 @@ That's the end of this tutorial - congratulations! By now, you should have a wor
 
 What's next? From here, you can:
 
-- Learn more about [software-defined assets](/concepts/assets/software-defined-assets)
+- Learn more about [asset definitions](/concepts/assets/software-defined-assets)
 - Learn how to [build jobs that materialize dbt assets](/integrations/dbt/reference#scheduling-dbt-jobs)
 - Get a [deeper understanding of Dagster's dbt integration](/integrations/dbt/reference)
 - Check out the [`dagster-dbt` API docs](/\_apidocs/libraries/dagster-dbt)

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/load-dbt-models.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/load-dbt-models.mdx
@@ -8,7 +8,7 @@ description: Dagster can orchestrate dbt alongside other technologies.
 <Note>
   This is part two of the{" "}
   <a href="/integrations/dbt/using-dbt-with-dagster">
-    Using dbt with Dagster software-defined assets
+    Using dbt with Dagster assets
   </a>{" "}
   tutorial.
 </Note>

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/upstream-assets.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/upstream-assets.mdx
@@ -8,7 +8,7 @@ description: Dagster can orchestrate dbt alongside other technologies.
 <Note>
   This is part three of the{" "}
   <a href="/integrations/dbt/using-dbt-with-dagster">
-    Using dbt with Dagster software-defined assets
+    Using dbt with Dagster assets
   </a>{" "}
   tutorial.
 </Note>
@@ -17,7 +17,7 @@ By this point, you've [set up a dbt project](/integrations/dbt/using-dbt-with-da
 
 However, the tables at the root of the pipeline are static: they're [dbt seeds](https://docs.getdbt.com/docs/build/seeds), CSVs that are hardcoded into the dbt project. In a more realistic data pipeline, these tables would typically be ingested from some external data source, for example by using a tool like Airbyte or Fivetran, or by Python code.
 
-These ingestion steps in the pipeline often don't make sense to define inside dbt, but they often still do make sense to define as Dagster software-defined assets. You can think of a Dagster software-defined asset as a more general version of a dbt model. A dbt model is one kind of asset, but another kind is one that's defined in Python, using Dagster's Python API. The dbt integration reference page includes a [section](/integrations/dbt/reference#dbt-models-and-dagster-software-defined-assets) that outlines the parallels between dbt models and Dagster Software-defined Assets.
+These ingestion steps in the pipeline often don't make sense to define inside dbt, but they often still do make sense to define as Dagster assets. You can think of a Dagster asset definition as a more general version of a dbt model. A dbt model is one kind of asset, but another kind is one that's defined in Python, using Dagster's Python API. The dbt integration reference page includes a [section](/integrations/dbt/reference#dbt-models-and-dagster-asset-definitions) that outlines the parallels between dbt models and Dagster asset definitions.
 
 In this section, you'll replace the `raw_customers` dbt seed with a Dagster asset that represents it. You'll write Python code that populates this table by fetching data from the web. This will allow you to launch runs that first execute Python code to populate the `raw_customers` table and then invoke dbt to populate the downstream tables.
 

--- a/docs/content/integrations/deltalake.mdx
+++ b/docs/content/integrations/deltalake.mdx
@@ -5,7 +5,7 @@ description: Store your Dagster assets in a Delta Lake
 
 # Delta Lake & Dagster
 
-Using Dagster's [Software-defined Assets](/concepts/assets/software-defined-assets) and Delta Lake I/O manager, you can easily interact with Delta Lake tables alongside other Dagster assets.
+Using Dagster's [asset definitions](/concepts/assets/software-defined-assets) and Delta Lake I/O manager, you can easily interact with Delta Lake tables alongside other Dagster assets.
 
 Managing your Delta tables with Dagster enables you to:
 
@@ -18,7 +18,7 @@ Managing your Delta tables with Dagster enables you to:
 
 ## Delta Lake and Dagster tutorial
 
-In this tutorial, you'll learn how to store and load Dagster's [Software-defined Assets](/concepts/assets/software-defined-assets) in a Delta Lake. [Click here to get started](/integrations/deltalake/using-deltalake-with-dagster).
+In this tutorial, you'll learn how to store and load Dagster's [asset definitions](/concepts/assets/software-defined-assets) in a Delta Lake. [Click here to get started](/integrations/deltalake/using-deltalake-with-dagster).
 
 By the end of the tutorial, you will have a connection to your Delta Lake and a handful of assets that create tables in a Deltalake or read existing tables from Deltalake.
 

--- a/docs/content/integrations/deltalake/reference.mdx
+++ b/docs/content/integrations/deltalake/reference.mdx
@@ -234,7 +234,7 @@ If you want all of your assets to be stored in the same schema, you can specify 
 If you want to store assets in different schemas, you can specify the schema as part of the asset's asset key:
 
 - **For `SourceAsset`**, use the `key` parameter. The schema should be the second-to-last value in the parameter. In the following example, this would be `daffodil`.
-- **For Software-defined Assets**, use the `key_prefix` parameter. This value will be prepended to the asset name to create the full asset key. In the following example, this would be `iris`.
+- **For asset definitions**, use the `key_prefix` parameter. This value will be prepended to the asset name to create the full asset key. In the following example, this would be `iris`.
 
 ```python file=/integrations/deltalake/schema.py startafter=start_asset_key endbefore=end_asset_key
 import pandas as pd

--- a/docs/content/integrations/deltalake/using-deltalake-with-dagster.mdx
+++ b/docs/content/integrations/deltalake/using-deltalake-with-dagster.mdx
@@ -5,7 +5,7 @@ description: Store your Dagster assets in a Delta Lake
 
 # Using Dagster with Delta Lake
 
-This tutorial focuses on how to store and load Dagster's [Software-defined Assets (SDAs)](/concepts/assets/software-defined-assets) in a Delta Lake.
+This tutorial focuses on how to store and load Dagster [asset definitions](/concepts/assets/software-defined-assets) in a Delta Lake.
 
 By the end of the tutorial, you will:
 
@@ -191,6 +191,6 @@ defs = Definitions(
 
 For more Delta Lake features, refer to the [Delta Lake reference](/integrations/deltalake/reference).
 
-For more information on Software-defined Assets, refer to the [Dagster tutorial](/tutorial) or the [Assets documentation](/concepts/assets/software-defined-assets).
+For more information on asset definitions, refer to the [Dagster tutorial](/tutorial) or the [Assets documentation](/concepts/assets/software-defined-assets).
 
 For more information on I/O managers, refer to the [I/O manager documentation](/concepts/io-management/io-managers).

--- a/docs/content/integrations/duckdb.mdx
+++ b/docs/content/integrations/duckdb.mdx
@@ -5,7 +5,7 @@ description: Store your Dagster assets in DuckDB
 
 # DuckDB & Dagster
 
-Using Dagster's [Software-defined Assets](/concepts/assets/software-defined-assets) and DuckDB I/O manager, you can easily interact with DuckDB tables alongside other Dagster assets.
+Using Dagster's [asset definitions](/concepts/assets/software-defined-assets) and DuckDB I/O manager, you can easily interact with DuckDB tables alongside other Dagster assets.
 
 Managing your DuckDB tables with Dagster enables you to:
 
@@ -20,7 +20,7 @@ Additionally, since DuckDB is a local database, you can use the DuckDB I/O manag
 
 ## DuckDB and Dagster tutorial
 
-In this tutorial, you'll learn how to store and load Dagster's [Software-defined Assets](/concepts/assets/software-defined-assets) in DuckDB. [Click here to get started](/integrations/duckdb/using-duckdb-with-dagster).
+In this tutorial, you'll learn how to store and load Dagster's [asset definitions](/concepts/assets/software-defined-assets) in DuckDB. [Click here to get started](/integrations/duckdb/using-duckdb-with-dagster).
 
 By the end of the tutorial, you will have a connection to your DuckDB instance and a handful of assets that create tables in DuckDB or read existing tables from DuckDB.
 

--- a/docs/content/integrations/duckdb/reference.mdx
+++ b/docs/content/integrations/duckdb/reference.mdx
@@ -295,7 +295,7 @@ def iris_dataset() -> pd.DataFrame:
 You can also specify the schema as part of the asset's asset key:
 
 - **For `SourceAsset`**, use the `key` parameter. The schema should be the second-to-last value in the parameter. In the following example, this would be `daffodil`.
-- **For Software-defined Assets**, use the `key_prefix` parameter. This value will be prepended to the asset name to create the full asset key. In the following example, this would be `iris`.
+- **For asset definitions**, use the `key_prefix` parameter. This value will be prepended to the asset name to create the full asset key. In the following example, this would be `iris`.
 
 ```python file=/integrations/duckdb/reference/schema.py startafter=start_asset_key endbefore=end_asset_key dedent=4
 daffodil_dataset = SourceAsset(key=["daffodil", "daffodil_dataset"])

--- a/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
+++ b/docs/content/integrations/duckdb/using-duckdb-with-dagster.mdx
@@ -5,7 +5,7 @@ description: Store your Dagster assets in DuckDB
 
 # Using Dagster with DuckDB
 
-This tutorial focuses on creating and interacting with DuckDB tables using Dagster's [Software-defined Assets (SDAs)](/concepts/assets/software-defined-assets).
+This tutorial focuses on creating and interacting with DuckDB tables using Dagster's [asset definitions](/concepts/assets/software-defined-assets).
 
 The `dagster-duckdb` library provides two ways to interact with DuckDB tables:
 
@@ -355,6 +355,6 @@ defs = Definitions(
 
 For more DuckDB features, refer to the [DuckDB reference](/integrations/duckdb/reference).
 
-For more information on Software-defined Assets, refer to the [tutorial](/tutorial) or the [Assets documentation](/concepts/assets/software-defined-assets).
+For more information on asset definitions, refer to the [tutorial](/tutorial) or the [Assets documentation](/concepts/assets/software-defined-assets).
 
 For more information on I/O managers, refer to the [I/O manager documentation](/concepts/io-management/io-managers).

--- a/docs/content/integrations/fivetran.mdx
+++ b/docs/content/integrations/fivetran.mdx
@@ -22,9 +22,9 @@ This guide focuses on how to work with Fivetran connectors using Dagster's [soft
 
 ---
 
-## Fivetran connectors and Dagster Software-defined Assets
+## Fivetran connectors and Dagster assets
 
-A [Fivetran connector](https://fivetran.com/docs/getting-started/core-concepts) defines a series of schemas and tables which are synced between a source and a destination. During a sync, data is retrieved from the source and written to the destination as one or more tables. Dagster represents each of the replicas generated in the destination as a Software-Defined Asset. This enables you to easily:
+A [Fivetran connector](https://fivetran.com/docs/getting-started/core-concepts) defines a series of schemas and tables which are synced between a source and a destination. During a sync, data is retrieved from the source and written to the destination as one or more tables. Dagster represents each of the replicas generated in the destination as an asset. This enables you to easily:
 
 - Visualize the schemas and tables involved in a Fivetran connector and execute a sync from Dagster
 - Define downstream computations which depend on replicas produced by Fivetran
@@ -274,7 +274,7 @@ If you find a bug or want to add a feature to the `dagster-fivetran` library, we
 ### Related
 
 - [`dagster-fivetran` API reference](/\_apidocs/libraries/dagster-fivetran)
-- [Software-defined Assets](/concepts/assets/software-defined-assets)
+- [Asset definitions](/concepts/assets/software-defined-assets)
 - [Resources](/concepts/resources)
 - [Using environment variables and secrets](/guides/dagster/using-environment-variables-and-secrets)
 - [Scheduling Dagster jobs](/concepts/partitions-schedules-sensors/schedules#running-the-scheduler)

--- a/docs/content/integrations/openai.mdx
+++ b/docs/content/integrations/openai.mdx
@@ -13,7 +13,7 @@ The `dagster-openai` library allows you to build OpenAI pipelines with Dagster a
 
 Using this library's <PyObject module="dagster_openai" object="OpenAIResource" />, you can easily interact with the [OpenAI REST API](https://platform.openai.com/docs/introduction) via the [OpenAI Python API](https://github.com/openai/openai-python).
 
-When used with Dagster's [Software-defined Assets](/concepts/assets/software-defined-assets), the resource automatically logs OpenAI usage metadata in asset metadata. See the [Relevant APIs](#relevant-apis) section for more information.
+When used with Dagster's [asset definitions](/concepts/assets/software-defined-assets), the resource automatically logs OpenAI usage metadata in asset metadata. See the [Relevant APIs](#relevant-apis) section for more information.
 
 ---
 

--- a/docs/content/integrations/snowflake.mdx
+++ b/docs/content/integrations/snowflake.mdx
@@ -5,7 +5,7 @@ description: Store your Dagster assets in Snowflake
 
 # Snowflake & Dagster
 
-Using Dagster's [Software-defined Assets](/concepts/assets/software-defined-assets) and a Snowflake [resource](/concepts/resources) or [I/O manager](/concepts/io-management/io-managers), you can easily interact with Snowflake tables alongside other Dagster assets.
+Using Dagster's [asset definitions](/concepts/assets/software-defined-assets) and a Snowflake [resource](/concepts/resources) or [I/O manager](/concepts/io-management/io-managers), you can easily interact with Snowflake tables alongside other Dagster assets.
 
 Managing your Snowflake tables with Dagster enables you to:
 

--- a/docs/content/integrations/snowflake/using-snowflake-with-dagster-io-managers.mdx
+++ b/docs/content/integrations/snowflake/using-snowflake-with-dagster-io-managers.mdx
@@ -5,7 +5,7 @@ description: "Learn to integrate Snowflake with Dagster using a Snowflake I/O ma
 
 # Integrating Snowflake with Dagster using I/O managers
 
-This tutorial focuses on how to store and load Dagster's [Software-defined Assets (SDAs)](/concepts/assets/software-defined-assets) in Snowflake by using a Snowflake I/O manager. An [**I/O manager**](/concepts/io-management/io-managers) transfers the responsibility of storing and loading DataFrames as Snowflake tables to Dagster.
+This tutorial focuses on how to store and load Dagster's [asset definitions](/concepts/assets/software-defined-assets) in Snowflake by using a Snowflake I/O manager. An [**I/O manager**](/concepts/io-management/io-managers) transfers the responsibility of storing and loading DataFrames as Snowflake tables to Dagster.
 
 By the end of the tutorial, you will:
 
@@ -234,7 +234,7 @@ defs = Definitions(
     href="/integrations/snowflake/reference"
   ></ArticleListItem>
   <ArticleListItem
-    title="Software-defined Assets"
+    title="Asset definitions"
     href="/concepts/assets/software-defined-assets"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/integrations/snowflake/using-snowflake-with-dagster.mdx
+++ b/docs/content/integrations/snowflake/using-snowflake-with-dagster.mdx
@@ -5,7 +5,7 @@ description: "Learn to integrate Snowflake with Dagster using a Snowflake resour
 
 # Integrating Snowflake with Dagster using resources
 
-This tutorial focuses on how to store and load Dagster's [Software-defined Assets (SDAs)](/concepts/assets/software-defined-assets) in Snowflake by using Dagster's <PyObject object="SnowflakeResource" module="dagster_snowflake" />. A [**resource**](/concepts/resources) allows you to directly run SQL queries against tables within an asset's compute function.
+This tutorial focuses on how to store and load Dagster's [asset definitions](/concepts/assets/software-defined-assets) in Snowflake by using Dagster's <PyObject object="SnowflakeResource" module="dagster_snowflake" />. A [**resource**](/concepts/resources) allows you to directly run SQL queries against tables within an asset's compute function.
 
 By the end of the tutorial, you will:
 
@@ -284,7 +284,7 @@ defs = Definitions(
     href="/integrations/snowflake/reference"
   ></ArticleListItem>
   <ArticleListItem
-    title="Software-defined Assets"
+    title="Asset definitions"
     href="/concepts/assets/software-defined-assets"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/tutorial.mdx
+++ b/docs/content/tutorial.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Building your first pipeline using Software-defined Assets | Dagster Docs"
+title: "Building your first pipeline using asset definitions | Dagster Docs"
 description: Getting familiar with Dagster's feature set and tooling through a hands-on tutorial.
 ---
 
-# Building a pipeline using Software-defined Assets
+# Building a pipeline using asset definitions
 
 <Note>
   <strong>New to Dagster?</strong> Start here!

--- a/docs/content/tutorial/building-an-asset-graph.mdx
+++ b/docs/content/tutorial/building-an-asset-graph.mdx
@@ -5,7 +5,7 @@ description: Learn how to build graphs of assets in Dagster
 
 # Tutorial, part four: Building an asset graph
 
-In the previous portion of the tutorial, you wrote your first Software-defined asset (SDA), looked at Dagster's UI, and manually materialized your asset.
+In the previous portion of the tutorial, you wrote your first asset definition, looked at Dagster's UI, and manually materialized your asset.
 
 Continuing from there, you will:
 
@@ -138,7 +138,7 @@ def most_frequent_words() -> None:
 
 Up until now, you've annotated your asset functions with `None`, meaning the asset doesn't return anything. In this section, you'll learn about the <PyObject object="MaterializeResult" /> object, which lets you record metadata about your asset.
 
-Software-defined Assets can be enriched with different types of metadata. Anything can be used as metadata for an asset. Common details to add are:
+Asset definitions can be enriched with different types of metadata. Anything can be used as metadata for an asset. Common details to add are:
 
 - Statistics about the data, such as row counts or other data profiling
 - Test results or assertions about the data

--- a/docs/content/tutorial/introduction.mdx
+++ b/docs/content/tutorial/introduction.mdx
@@ -1,6 +1,6 @@
 ---
-title: Introduction to Dagster and Software-defined Assets Tutorial | Dagster Docs
-description: Software-defined assets are the building blocks of Dagster
+title: Introduction to Dagster and Asset Definitions Tutorial | Dagster Docs
+description: Asset definitions are the building blocks of Dagster
 ---
 
 # Tutorial, part one: Intro to Dagster
@@ -11,9 +11,9 @@ In this tutorial, you'll analyze activity on the popular news aggregation websit
 
 ---
 
-## Introduction to Software-defined assets
+## Introduction to asset definitions
 
-Before building a Dagster project, you'll first learn about Dagster's core concept: the Software-defined asset (SDA).
+Before building a Dagster project, you'll first learn about Dagster's core concept: the asset definition.
 
 An asset is an object in persistent storage that captures some understanding of the world. Assets can be any type of object, such as:
 
@@ -23,7 +23,7 @@ An asset is an object in persistent storage that captures some understanding of 
 
 If you have an existing data pipeline, you likely already have assets.
 
-_Software-defined assets_ are a Dagster concept that allows you to write data pipelines in terms of the assets that they produce. How they work: you write code that describes an asset that you want to exist, along with any other assets that the asset is derived from, and a function that can be run to compute the contents of the asset.
+_Asset definitions_ are a Dagster concept that allows you to write data pipelines in terms of the assets that they produce. How they work: you write code that describes an asset that you want to exist, along with any other assets that the asset is derived from, and a function that can be run to compute the contents of the asset.
 
 Here's an example. The asset is a dataset called `topstories`, and it depends on another asset called `topstory_ids`. `topstories` gets the IDs computed in `topstory_ids`, then fetches data for each of those IDs.
 
@@ -70,7 +70,7 @@ height={405}
   and Graphs, refer to{" "}
   <a href="/guides/dagster/intro-to-ops-jobs">their tutorial</a> and a guide on{" "}
   <a href="/guides/dagster/how-assets-relate-to-ops-and-graphs">
-    how SDAs relate to ops and graphs
+    how asset definitions relate to ops and graphs
   </a>
   .
 </Note>
@@ -79,10 +79,10 @@ height={405}
 
 ## Next steps
 
-In this section, you learned how Software-defined assets are the building blocks of Dagster and also about the benefits of asset-based pipelines.
+In this section, you learned how asset definitions are the building blocks of Dagster and also about the benefits of asset-based pipelines.
 
 Within your current data pipelines, you likely have many assets. Or if you are earlier in your data journey, you might have an understanding of what data your stakeholders need.
 
-When going through this tutorial, think about what benefits you'll be receiving by treating your data as Software-defined assets in Dagster.
+When going through this tutorial, think about what benefits you'll be receiving by defining your data assets in Dagster.
 
 In [the next section](/tutorial/setup), you'll install Dagster on your computer and start a new project.

--- a/docs/content/tutorial/next-steps.mdx
+++ b/docs/content/tutorial/next-steps.mdx
@@ -5,7 +5,7 @@ description: What if you want to do more after completing the asset tutorial?
 
 # Tutorial: Next steps
 
-🎉 Congratulations! Having reached this far, you now have a working set of software-defined assets.
+🎉 Congratulations! Having reached this far, you now have a working data pipeline.
 
 What if you want to do more?
 

--- a/docs/content/tutorial/writing-your-first-asset.mdx
+++ b/docs/content/tutorial/writing-your-first-asset.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Tutorial, part three: Writing your first asset | Dagster Docs"
-description: Software-defined assets can depend on other software-defined assets
+description: Asset definitions can depend on other asset definitions
 ---
 
 # Tutorial, part three: Writing your first asset
@@ -46,7 +46,7 @@ with open("data/topstory_ids.json", "w") as f:
 
 This code creates a list of integers representing the IDs for the current top stories on Hacker News and stores them in a file called `data/topstory_ids.json`.
 
-Next, you will work towards making this code into a software-defined asset. The first step is turning it into a function:
+Next, you will work towards making this code into an asset definition. The first step is turning it into a function:
 
 ```python
 import json
@@ -114,7 +114,7 @@ Observe that Dagster has detected your `topstory_ids` asset, but it says that th
 
 ## Step 2: Materialize your asset
 
-To **materialize** a Software-defined asset means to create or update it. Dagster materializes assets by executing the asset's function or triggering an integration.
+To **materialize** an asset means to create or update it. Dagster materializes assets by executing the asset's function or triggering an integration.
 
 To manually materialize an asset in the UI, click the **Materialize** button in the upper right corner of the screen. This will create a Dagster run that will materialize your assets.
 

--- a/docs/next/components/mdx/includes/dagster/integrations/DbtModelAssetExplanation.mdx
+++ b/docs/next/components/mdx/includes/dagster/integrations/DbtModelAssetExplanation.mdx
@@ -1,10 +1,10 @@
-Dagster’s [software-defined assets](/concepts/assets/software-defined-assets) (SDAs) bear several similarities to dbt models. A software-defined asset contains an asset key, a set of upstream asset keys, and an operation that is responsible for computing the asset from its upstream dependencies. Models defined in a dbt project can be interpreted as Dagster SDAs:
+Dagster’s [asset definitions](/concepts/assets/software-defined-assets) bear several similarities to dbt models. An asset definition contains an asset key, a set of upstream asset keys, and an operation that is responsible for computing the asset from its upstream dependencies. Models defined in a dbt project can be interpreted as Dagster asset definitions:
 
 - The asset key for a dbt model is (by default) the name of the model.
 - The upstream dependencies of a dbt model are defined with `ref` or `source` calls within the model's definition.
 - The computation required to compute the asset from its upstream dependencies is the SQL within the model's definition.
 
-These similarities make it natural to interact with dbt models as SDAs. Let’s take a look at a dbt model and an SDA, in code:
+These similarities make it natural to interact with dbt models as asset definitions. Let’s take a look at a dbt model and an asset definition, in code:
 
 <Image
 alt="Comparison of a dbt model and Dagster asset in code"


### PR DESCRIPTION
## Summary & Motivation

This proposes using the term "asset definition" instead of "software-defined asset" in docs. We would continue to use the word "software-defined asset" in thought-leader-y content, to refer to the idea of managing data assets using software.

Reasoning:
- All Dagster definitions come from software. Calling it out in this particular case is inconsistent.
- "Software-defined asset" is a mouthful. This will matter even more in a world where we treat what we now call "external assets" as a kind of software-defined asset. Terms like "external software-defined asset" or "materializable software-defined asset" are unnecessarily long and difficult to work with.

## How I Tested These Changes
