### PR TITLE
s/AssetRecord/LatestAssetInfo

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
@@ -16,7 +16,7 @@ from dagster._core.storage.asset_check_execution_record import (
     AssetCheckExecutionResolvedStatus,
     AssetCheckInstanceSupport,
 )
-from dagster._core.storage.event_log.base import AssetRecord
+from dagster._core.storage.event_log.base import LatestAssetInfo
 from dagster._core.workspace.context import WorkspaceRequestContext
 from packaging import version
 
@@ -178,7 +178,7 @@ class AssetChecksLoader:
 
 def _execution_targets_latest_materialization(
     instance: DagsterInstance,
-    asset_record: Optional[AssetRecord],
+    asset_record: Optional[LatestAssetInfo],
     execution: AssetCheckExecutionRecord,
     resolved_status: AssetCheckExecutionResolvedStatus,
 ) -> bool:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -42,7 +42,7 @@ from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.remote_representation.code_location import CodeLocation
 from dagster._core.remote_representation.external import ExternalRepository
 from dagster._core.remote_representation.external_data import ExternalAssetNode
-from dagster._core.storage.event_log.base import AssetRecord
+from dagster._core.storage.event_log.base import LatestAssetInfo
 from dagster._core.storage.event_log.sql_event_log import get_max_event_records_limit
 from dagster._core.storage.partition_status_cache import (
     build_failed_and_in_progress_partition_subset,
@@ -414,7 +414,7 @@ def get_partition_subsets(
     instance: DagsterInstance,
     asset_key: AssetKey,
     dynamic_partitions_loader: DynamicPartitionsStore,
-    asset_record: Optional[AssetRecord],
+    asset_record: Optional[LatestAssetInfo],
     partitions_def: Optional[PartitionsDefinition] = None,
 ) -> Tuple[Optional[PartitionsSubset], Optional[PartitionsSubset], Optional[PartitionsSubset]]:
     """Returns a tuple of PartitionSubset objects: the first is the materialized partitions,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2212,6 +2212,20 @@ class DagsterInstance(DynamicPartitionsStore):
             return status_by_partition
 
     @public
+    def get_latest_asset_infos(
+        self, asset_keys: Optional[Sequence[AssetKey]] = None
+    ) -> Sequence["LatestAssetInfo"]:
+        """Return the latest materialization status for the given asset keys.
+
+        Args:
+            asset_keys (Optional[Sequence[AssetKey]]): List of asset keys to retrieve status for.
+
+        Returns:
+            Sequence[LatestAssetInfo]: List of asset status.
+        """
+        return self._event_storage.get_latest_asset_infos(asset_keys)
+
+    @public
     @traced
     def get_asset_records(
         self, asset_keys: Optional[Sequence[AssetKey]] = None

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -164,11 +164,11 @@ if TYPE_CHECKING:
     from dagster._core.storage.daemon_cursor import DaemonCursorStorage
     from dagster._core.storage.event_log import EventLogStorage
     from dagster._core.storage.event_log.base import (
-        AssetRecord,
         EventLogConnection,
         EventLogRecord,
         EventRecordsFilter,
         EventRecordsResult,
+        LatestAssetInfo,
         PlannedMaterializationInfo,
     )
     from dagster._core.storage.partition_status_cache import (
@@ -2215,7 +2215,7 @@ class DagsterInstance(DynamicPartitionsStore):
     @traced
     def get_asset_records(
         self, asset_keys: Optional[Sequence[AssetKey]] = None
-    ) -> Sequence["AssetRecord"]:
+    ) -> Sequence["LatestAssetInfo"]:
         """Return an `AssetRecord` for each of the given asset keys.
 
         Args:

--- a/python_modules/dagster/dagster/_core/storage/event_log/__init__.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/__init__.py
@@ -1,7 +1,7 @@
 from .base import (
-    AssetRecord as AssetRecord,
     EventLogRecord as EventLogRecord,
     EventLogStorage as EventLogStorage,
+    LatestAssetInfo as LatestAssetInfo,
 )
 from .in_memory import InMemoryEventLogStorage as InMemoryEventLogStorage
 from .polling_event_watcher import SqlPollingEventWatcher as SqlPollingEventWatcher

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -292,6 +292,11 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     ) -> Sequence[LatestAssetInfo]:
         pass
 
+    def get_latest_asset_infos(
+        self, asset_keys: Optional[Sequence[AssetKey]] = None
+    ) -> Sequence[LatestAssetInfo]:
+        return self.get_asset_records(asset_keys)
+
     @abstractmethod
     def has_asset_key(self, asset_key: AssetKey) -> bool:
         pass

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -109,10 +109,9 @@ class AssetEntry(
         return self.last_materialization_record.storage_id
 
 
-class AssetRecord(NamedTuple):
-    """Internal representation of an asset record, as stored in a :py:class:`~dagster._core.storage.event_log.EventLogStorage`.
-
-    Users should not invoke this class directly.
+class LatestAssetInfo(NamedTuple):
+    """Representation of latest information about an asset key, as stored in a :py:class:`~dagster._core.storage.event_log.EventLogStorage`.
+    Backed by the asset_keys table.
     """
 
     storage_id: int
@@ -290,7 +289,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     @abstractmethod
     def get_asset_records(
         self, asset_keys: Optional[Sequence[AssetKey]] = None
-    ) -> Sequence[AssetRecord]:
+    ) -> Sequence[LatestAssetInfo]:
         pass
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -90,13 +90,13 @@ from dagster._utils.concurrency import (
 from ..dagster_run import DagsterRunStatsSnapshot
 from .base import (
     AssetEntry,
-    AssetRecord,
     AssetRecordsFilter,
     EventLogConnection,
     EventLogCursor,
     EventLogRecord,
     EventLogStorage,
     EventRecordsFilter,
+    LatestAssetInfo,
     PlannedMaterializationInfo,
 )
 from .migration import ASSET_DATA_MIGRATIONS, ASSET_KEY_INDEX_COLS, EVENT_LOG_DATA_MIGRATIONS
@@ -1174,12 +1174,12 @@ class SqlEventLogStorage(EventLogStorage):
         row,
         last_materialization_record: Optional[EventLogRecord],
         can_cache_asset_status_data: bool,
-    ) -> AssetRecord:
+    ) -> LatestAssetInfo:
         from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
         asset_key = AssetKey.from_db_string(row["asset_key"])
         if asset_key:
-            return AssetRecord(
+            return LatestAssetInfo(
                 storage_id=row["id"],
                 asset_entry=AssetEntry(
                     asset_key=asset_key,
@@ -1281,12 +1281,12 @@ class SqlEventLogStorage(EventLogStorage):
 
     def get_asset_records(
         self, asset_keys: Optional[Sequence[AssetKey]] = None
-    ) -> Sequence[AssetRecord]:
+    ) -> Sequence[LatestAssetInfo]:
         rows = self._fetch_asset_rows(asset_keys=asset_keys)
         latest_materialization_records = self._get_latest_materialization_records(rows)
         can_cache_asset_status_data = self.can_cache_asset_status_data()
 
-        asset_records: List[AssetRecord] = []
+        asset_records: List[LatestAssetInfo] = []
         for row in rows:
             asset_key = AssetKey.from_db_string(row["asset_key"])
             if asset_key:

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -27,12 +27,12 @@ from dagster._utils.concurrency import ConcurrencyClaimStatus, ConcurrencyKeyInf
 
 from .base_storage import DagsterStorage
 from .event_log.base import (
-    AssetRecord,
     EventLogConnection,
     EventLogRecord,
     EventLogStorage,
     EventRecordsFilter,
     EventRecordsResult,
+    LatestAssetInfo,
     PlannedMaterializationInfo,
 )
 from .runs.base import RunStorage
@@ -502,7 +502,7 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
 
     def get_asset_records(
         self, asset_keys: Optional[Sequence["AssetKey"]] = None
-    ) -> Iterable[AssetRecord]:
+    ) -> Iterable[LatestAssetInfo]:
         return self._storage.event_log_storage.get_asset_records(asset_keys)
 
     def has_asset_key(self, asset_key: "AssetKey") -> bool:

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -31,7 +31,7 @@ from dagster._serdes.errors import DeserializationError
 from dagster._serdes.serdes import deserialize_value
 
 if TYPE_CHECKING:
-    from dagster._core.storage.event_log.base import AssetRecord
+    from dagster._core.storage.event_log.base import LatestAssetInfo
 
 
 CACHEABLE_PARTITION_TYPES = (
@@ -399,7 +399,7 @@ def get_and_update_asset_status_cache_value(
     asset_key: AssetKey,
     partitions_def: Optional[PartitionsDefinition] = None,
     dynamic_partitions_loader: Optional[DynamicPartitionsStore] = None,
-    asset_record: Optional["AssetRecord"] = None,
+    asset_record: Optional["LatestAssetInfo"] = None,
 ) -> Optional[AssetStatusCacheValue]:
     asset_record = asset_record or next(
         iter(instance.get_asset_records(asset_keys=[asset_key])), None

--- a/python_modules/dagster/dagster/_core/workspace/batch_asset_record_loader.py
+++ b/python_modules/dagster/dagster/_core/workspace/batch_asset_record_loader.py
@@ -6,7 +6,7 @@ from dagster import (
 )
 from dagster._core.definitions.events import AssetKey
 from dagster._core.events.log import EventLogEntry
-from dagster._core.storage.event_log.base import AssetRecord
+from dagster._core.storage.event_log.base import LatestAssetInfo
 
 
 class BatchAssetRecordLoader:
@@ -17,13 +17,13 @@ class BatchAssetRecordLoader:
     def __init__(self, instance: DagsterInstance, asset_keys: Iterable[AssetKey]):
         self._instance = instance
         self._unfetched_asset_keys: Set[AssetKey] = set(asset_keys)
-        self._asset_records: Mapping[AssetKey, Optional[AssetRecord]] = {}
+        self._asset_records: Mapping[AssetKey, Optional[LatestAssetInfo]] = {}
 
     def add_asset_keys(self, asset_keys: Iterable[AssetKey]):
         unfetched_asset_keys = set(asset_keys).difference(self._asset_records.keys())
         self._unfetched_asset_keys = self._unfetched_asset_keys.union(unfetched_asset_keys)
 
-    def get_asset_record(self, asset_key: AssetKey) -> Optional[AssetRecord]:
+    def get_asset_record(self, asset_key: AssetKey) -> Optional[LatestAssetInfo]:
         if asset_key not in self._asset_records and asset_key not in self._unfetched_asset_keys:
             check.failed(
                 f"Asset key {asset_key} not recognized for this loader. Expected one of:"
@@ -40,7 +40,7 @@ class BatchAssetRecordLoader:
         self._unfetched_asset_keys = self._unfetched_asset_keys.union(self._asset_records.keys())
         self._asset_records = {}
 
-    def get_asset_records(self, asset_keys: Sequence[AssetKey]) -> Sequence[AssetRecord]:
+    def get_asset_records(self, asset_keys: Sequence[AssetKey]) -> Sequence[LatestAssetInfo]:
         records = [self.get_asset_record(asset_key) for asset_key in asset_keys]
         return [record for record in records if record]
 

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -52,7 +52,7 @@ from dagster._utils.cached_method import cached_method
 
 if TYPE_CHECKING:
     from dagster._core.storage.event_log import EventLogRecord
-    from dagster._core.storage.event_log.base import AssetRecord
+    from dagster._core.storage.event_log.base import LatestAssetInfo
     from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
 
@@ -76,7 +76,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         self._asset_graph = asset_graph
         self._logger = logger or logging.getLogger("dagster")
 
-        self._asset_record_cache: Dict[AssetKey, Optional[AssetRecord]] = {}
+        self._asset_record_cache: Dict[AssetKey, Optional[LatestAssetInfo]] = {}
         self._asset_partitions_cache: Dict[Optional[int], Dict[AssetKey, Set[str]]] = defaultdict(
             dict
         )
@@ -178,7 +178,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
     def has_cached_asset_record(self, asset_key: AssetKey) -> bool:
         return asset_key in self._asset_record_cache
 
-    def get_asset_record(self, asset_key: AssetKey) -> Optional["AssetRecord"]:
+    def get_asset_record(self, asset_key: AssetKey) -> Optional["LatestAssetInfo"]:
         if asset_key not in self._asset_record_cache:
             self._asset_record_cache[asset_key] = next(
                 iter(self.instance.get_asset_records([asset_key])), None


### PR DESCRIPTION
## Summary & Motivation

Rename AssetRecord to LatestAssetInfo per discussion here https://github.com/dagster-io/dagster/pull/21470#issuecomment-2083414711

Also add methods `get_latest_asset_infos` to replace `get_asset_records`.

As part of this we would also add properties at the top-level of `LatestAssetInfo` (next PR in stack) so that we don't have to deal
with `asset_entry` in product code. `AssetEntry` should probably just go away entirely.

## How I Tested These Changes

BK
