### PR TITLE
[DS][1/n] Create SchedulingConditionEvaluationContext

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -328,6 +328,9 @@ class AssetGraphView:
             ),
         )
 
+    def get_asset_slice_from_subset(self, subset: ValidAssetSubset) -> "AssetSlice":
+        return _slice_from_subset(self, subset)
+
     def compute_parent_asset_slice(
         self, parent_asset_key: AssetKey, asset_slice: AssetSlice
     ) -> AssetSlice:

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/scheduling_condition_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/scheduling_condition_evaluation_context.py
@@ -1,0 +1,114 @@
+import dataclasses
+import datetime
+import functools
+import logging
+from dataclasses import dataclass
+from typing import AbstractSet, Mapping, Optional, Tuple
+
+import pendulum
+
+from dagster._core.asset_graph_view.asset_graph_view import (
+    AssetGraphView,
+    AssetSlice,
+)
+from dagster._core.definitions.asset_condition.asset_condition import (
+    AssetCondition,
+    AssetConditionEvaluation,
+    AssetConditionEvaluationState,
+)
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_subset import ValidAssetSubset
+from dagster._core.definitions.events import AssetKeyPartitionKey
+
+from .asset_condition_evaluation_context import AssetConditionEvaluationContext
+
+
+@dataclass(frozen=True)
+class SchedulingConditionEvaluationContext:
+    # the AssetKey of the currently-evaluated asset
+    asset_key: AssetKey
+
+    # the condition that is being evaluated
+    condition: AssetCondition
+    # the subset of AssetPartitions for this Asset which must be evaluated. at the root of the
+    # condition evaluation tree, this is the AllPartitionsSubset, but this may shrink as conditions
+    # are applied and we can be certain that certain partitions will not be true for the overall
+    # expression
+    candidate_subset: ValidAssetSubset
+
+    # a view of the AssetGraph that will be used to help compute properties of the asset during
+    # computation
+    asset_graph_view: AssetGraphView
+
+    # the serialized information calculated during the previous evaluation of this condition
+    # note that this refers to the evaluation of this specific node in the condition tree, not the
+    # evaluation of the root of the tree
+    # used to avoid recomputing information that we know has not changed since the previous tick
+    previous_evaluation: Optional[AssetConditionEvaluation]
+
+    # contains information about the previous evaluation of all assets within this asset's automation
+    # policy sensor. this provides a pointer to the top-level condition in the evaluation tree, as
+    # well as a few extra fields, such as the previous evaluation timestamp, and the max event id
+    # at the time of that computation. this information is again used to avoid recomputing information
+    # as well as detecting if anything has changed since the previous time this condition was evaluated
+    previous_evaluation_state_by_key: Mapping[AssetKey, AssetConditionEvaluationState]
+    # this is the same as the above, but for information that has been calculated during this tick.
+    # it will be used to determine if a parent will be materialized on this tick
+    current_evaluation_state_by_key: Mapping[AssetKey, AssetConditionEvaluationState]
+
+    # the time at which this context object was created, allowing us to time the duration of an
+    # evaluation for display in the UI
+    create_time: datetime.datetime
+    logger: logging.Logger
+
+    # we need to continue supporting the current implementations of AutoMaterializeRules,
+    # which rely on the legact context object. however, this object contains many fields
+    # which are not relevant to the scheduling condition evaluation, and so keeping it
+    # as a reference here makes it easy to remove it in the future.
+    _legacy_context: AssetConditionEvaluationContext
+
+    @functools.cached_property
+    def candidate_slice(self) -> AssetSlice:
+        return self.asset_graph_view.get_asset_slice_from_subset(self.candidate_subset)
+
+    @property
+    def legacy_context(self) -> AssetConditionEvaluationContext:
+        return self._legacy_context
+
+    @property
+    def start_timestamp(self) -> float:
+        return self.create_time.timestamp()
+
+    @property
+    def previous_evaluation_state(self) -> Optional[AssetConditionEvaluationState]:
+        return self.previous_evaluation_state_by_key.get(self.asset_key)
+
+    @property
+    def new_max_storage_id(self) -> Optional[int]:
+        # TODO: this should be pulled from the asset graph view
+        return self._get_updated_parents_and_storage_id()[1]
+
+    def _get_updated_parents_and_storage_id(
+        self,
+    ) -> Tuple[AbstractSet[AssetKeyPartitionKey], Optional[int]]:
+        return self.asset_graph_view._queryer.asset_partitions_with_newly_updated_parents_and_new_cursor(  # noqa
+            latest_storage_id=self.previous_evaluation_state.max_storage_id
+            if self.previous_evaluation_state
+            else None,
+            child_asset_key=self.asset_key,
+            map_old_time_partitions=False,
+        )
+
+    def for_child_condition(
+        self, child_condition: AssetCondition, candidate_subset: ValidAssetSubset
+    ):
+        return dataclasses.replace(
+            self,
+            condition=child_condition,
+            candidate_subset=candidate_subset,
+            previous_evaluation=self.previous_evaluation.for_child(child_condition)
+            if self.previous_evaluation
+            else None,
+            create_time=pendulum.now("UTC"),
+            _legacy_context=self._legacy_context.for_child(child_condition, candidate_subset),
+        )

--- a/python_modules/dagster/dagster/_core/definitions/data_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_version.py
@@ -381,11 +381,12 @@ class CachingStaleStatusResolver:
         self,
         instance: "DagsterInstance",
         asset_graph: Union["BaseAssetGraph", Callable[[], "BaseAssetGraph"]],
+        instance_queryer: Optional["CachingInstanceQueryer"] = None,
     ):
         from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 
         self._instance = instance
-        self._instance_queryer = None
+        self._instance_queryer = instance_queryer
         if isinstance(asset_graph, BaseAssetGraph):
             self._asset_graph = asset_graph
             self._asset_graph_load_fn = None

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
@@ -13,6 +13,9 @@ from dagster._core.definitions.asset_condition.asset_condition import (
 from dagster._core.definitions.asset_condition.asset_condition_evaluation_context import (
     AssetConditionEvaluationContext,
 )
+from dagster._core.definitions.asset_condition.scheduling_condition_evaluation_context import (
+    SchedulingConditionEvaluationContext,
+)
 from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.data_time import CachingDataTimeResolver
@@ -30,8 +33,13 @@ class FalseAssetCondition(AssetCondition):
     def description(self) -> str:
         return ""
 
-    def evaluate(self, context: AssetConditionEvaluationContext) -> AssetConditionResult:
-        return AssetConditionResult.create(context, true_subset=context.empty_subset())
+    def evaluate(self, context: SchedulingConditionEvaluationContext) -> AssetConditionResult:
+        return AssetConditionResult.create(
+            context,
+            true_subset=context.asset_graph_view.create_empty_slice(
+                context.asset_key
+            ).convert_to_valid_asset_subset(),
+        )
 
 
 @dataclass(frozen=True)
@@ -53,7 +61,20 @@ class AssetConditionScenarioState(ScenarioState):
             instance_queryer = CachingInstanceQueryer(
                 instance=self.instance, asset_graph=self.asset_graph
             )
-            context = AssetConditionEvaluationContext.create(
+            daemon_context = AssetDaemonContext(
+                evaluation_id=1,
+                instance=self.instance,
+                asset_graph=self.asset_graph,
+                cursor=AssetDaemonCursor.empty(),
+                materialize_run_tags={},
+                observe_run_tags={},
+                auto_observe_asset_keys=None,
+                auto_materialize_asset_keys=None,
+                respect_materialization_data_versions=False,
+                logger=self.logger,
+                evaluation_time=self.current_time,
+            )
+            legacy_context = AssetConditionEvaluationContext.create(
                 asset_key=asset_key,
                 condition=asset_condition,
                 previous_evaluation_state=self.previous_evaluation_state,
@@ -61,19 +82,25 @@ class AssetConditionScenarioState(ScenarioState):
                 data_time_resolver=CachingDataTimeResolver(instance_queryer),
                 evaluation_state_by_key={},
                 expected_data_time_mapping={},
-                daemon_context=AssetDaemonContext(
-                    evaluation_id=1,
-                    instance=self.instance,
-                    asset_graph=self.asset_graph,
-                    cursor=AssetDaemonCursor.empty(),
-                    materialize_run_tags={},
-                    observe_run_tags={},
-                    auto_observe_asset_keys=None,
-                    auto_materialize_asset_keys=None,
-                    respect_materialization_data_versions=False,
-                    logger=self.logger,
-                    evaluation_time=self.current_time,
-                ),
+                daemon_context=daemon_context,
+            )
+            context = SchedulingConditionEvaluationContext(
+                asset_key=asset_key,
+                condition=asset_condition,
+                candidate_subset=daemon_context.asset_graph_view.get_asset_slice(
+                    asset_key
+                ).convert_to_valid_asset_subset(),
+                asset_graph_view=daemon_context.asset_graph_view,
+                previous_evaluation=self.previous_evaluation_state.previous_evaluation
+                if self.previous_evaluation_state
+                else None,
+                previous_evaluation_state_by_key={asset_key: self.previous_evaluation_state}
+                if self.previous_evaluation_state
+                else {},
+                current_evaluation_state_by_key={},
+                create_time=self.current_time,
+                logger=self.logger,
+                _legacy_context=legacy_context,
             )
 
             full_result = asset_condition.evaluate(context)


### PR DESCRIPTION
## Summary & Motivation

Creates a new SchedulingConditionEvaluationContext. This is essentially a "fresh start" for rebuilding the context object, to make it easier to refactor / delete the current state of the AssetConditionEvaluationContext in the future. It has a greatly reduced set of properties and methods, which can be incrementally built up as needed.

It does keep around a reference to the legacy AssetConditionEvaluationContext, for the sole purpose of letting us keep the existing AutoMaterializeRule implementations untouched. In the eventual future where these are deleted, we can very easily sever the entire legacy context from our new context object.

Note that the weird Union[Scheduling...Context, Asset...Context] thing will go away upstack, so don't worry about that bit.

## How I Tested These Changes
