### PR TITLE
[DS][3/n] Update unique_id creation logic

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition/asset_condition_evaluation_context.py
@@ -22,19 +22,20 @@ import pendulum
 from dagster._core.definitions.asset_condition.asset_condition import (
     HistoricalAllPartitionsSubsetSentinel,
 )
-from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.partition_mapping import IdentityPartitionMapping
 from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
-from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from ..asset_subset import AssetSubset, ValidAssetSubset
-from ..base_asset_graph import BaseAssetGraph
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.data_time import CachingDataTimeResolver
+    from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
+
     from ..asset_daemon_context import AssetDaemonContext
+    from ..base_asset_graph import BaseAssetGraph
     from .asset_condition import (
         AssetCondition,
         AssetConditionEvaluation,
@@ -68,8 +69,8 @@ class AssetConditionEvaluationContext:
     previous_evaluation: Optional["AssetConditionEvaluation"]
     candidate_subset: ValidAssetSubset
 
-    instance_queryer: CachingInstanceQueryer
-    data_time_resolver: CachingDataTimeResolver
+    instance_queryer: "CachingInstanceQueryer"
+    data_time_resolver: "CachingDataTimeResolver"
     daemon_context: "AssetDaemonContext"
 
     evaluation_state_by_key: Mapping[AssetKey, "AssetConditionEvaluationState"]
@@ -83,8 +84,8 @@ class AssetConditionEvaluationContext:
         asset_key: AssetKey,
         condition: "AssetCondition",
         previous_evaluation_state: Optional["AssetConditionEvaluationState"],
-        instance_queryer: CachingInstanceQueryer,
-        data_time_resolver: CachingDataTimeResolver,
+        instance_queryer: "CachingInstanceQueryer",
+        data_time_resolver: "CachingDataTimeResolver",
         daemon_context: "AssetDaemonContext",
         evaluation_state_by_key: Mapping[AssetKey, "AssetConditionEvaluationState"],
         expected_data_time_mapping: Mapping[AssetKey, Optional[datetime.datetime]],
@@ -113,12 +114,12 @@ class AssetConditionEvaluationContext:
         )
 
     def for_child(
-        self, condition: "AssetCondition", candidate_subset: AssetSubset
+        self, child_condition: "AssetCondition", child_unique_id: str, candidate_subset: AssetSubset
     ) -> "AssetConditionEvaluationContext":
         return dataclasses.replace(
             self,
-            condition=condition,
-            previous_evaluation=self.previous_evaluation.for_child(condition)
+            condition=child_condition,
+            previous_evaluation=self.previous_evaluation.for_child(child_unique_id)
             if self.previous_evaluation
             else None,
             candidate_subset=candidate_subset,
@@ -132,7 +133,7 @@ class AssetConditionEvaluationContext:
         return self.root_ref or self
 
     @property
-    def asset_graph(self) -> BaseAssetGraph:
+    def asset_graph(self) -> "BaseAssetGraph":
         return self.instance_queryer.asset_graph
 
     @property
@@ -361,7 +362,7 @@ class AssetConditionEvaluationContext:
             FrozenSet[Tuple[str, MetadataValue]], AbstractSet[AssetKeyPartitionKey]
         ],
         ignore_subset: AssetSubset,
-    ) -> Tuple[AssetSubset, Sequence["AssetSubsetWithMetadata"]]:
+    ) -> Tuple[ValidAssetSubset, Sequence["AssetSubsetWithMetadata"]]:
         """Combines information calculated on this tick with information from the previous tick,
         returning a tuple of the combined true subset and the combined subsets with metadata.
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -230,6 +230,7 @@ class AssetDaemonContext:
         context = SchedulingConditionEvaluationContext(
             asset_key=asset_key,
             condition=asset_condition,
+            condition_unique_id=asset_condition.get_unique_id(parent_unique_id=None),
             candidate_subset=self.asset_graph_view.get_asset_slice(
                 asset_key
             ).convert_to_valid_asset_subset(),

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -160,7 +160,7 @@ def get_backcompat_asset_condition_evaluation_state(
         max_storage_id=latest_storage_id,
         # the only information we need to preserve from the previous cursor is the handled subset
         extra_state_by_unique_id={
-            RuleCondition(rule=MaterializeOnMissingRule()).unique_id: handled_root_subset,
+            RuleCondition(rule=MaterializeOnMissingRule()).get_unique_id(None): handled_root_subset,
         }
         if handled_root_subset and handled_root_subset.size > 0
         else {},

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -460,7 +460,7 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
         """
         previous_handled_subset = (
             context.legacy_context.previous_evaluation_state.get_extra_state(
-                context.legacy_context.condition, AssetSubset
+                context.condition_unique_id, AssetSubset
             )
             if context.legacy_context.previous_evaluation_state
             else None
@@ -815,7 +815,7 @@ class SkipOnNotAllParentsUpdatedSinceCronRule(
             # previous state still valid
             previous_parent_subsets = (
                 context.legacy_context.previous_evaluation_state.get_extra_state(
-                    context.legacy_context.condition, list
+                    context.condition_unique_id, list
                 )
                 or []
             )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
@@ -87,6 +87,7 @@ class AssetConditionScenarioState(ScenarioState):
             context = SchedulingConditionEvaluationContext(
                 asset_key=asset_key,
                 condition=asset_condition,
+                condition_unique_id=asset_condition.get_unique_id(parent_unique_id=None),
                 candidate_subset=daemon_context.asset_graph_view.get_asset_slice(
                     asset_key
                 ).convert_to_valid_asset_subset(),


### PR DESCRIPTION
## Summary & Motivation

We need a way to uniquely identify a node in a AssetCondition tree. The main use case here is to be able to associate an in-memory AssetCondition with information about it that was serialized on the previous tick. In order to do this, we need to be able to have a shared unique id.

The previous scheme worked bottom-up, meaning that a condition's unique id was based on a hash of its properties and the properties of all of its children. This has an obvious problem, in that if you have two leaf nodes with identical properties, then they will have the same "unique" id.

This wasn't really a big deal in the previous world as it'd be very silly in most cases to have multiple leaf nodes with the same properties, but it's more realistic now, as if you do something like `~materialized & ~any_deps_match(~materialized), then you'll have two leaf nodes which are just "materialized".

So, the simple fix is to just make this a top-down process, where the parent unique id is an input into your unique id.

Note that this breaks a bit of backcompat logic, which could in theory (potentially) be fixed with a fair amount of effort. However, this backcompat logic is only used on the first tick of AMP after upgrading from dagster<1.5 to dagster>=1.5. Considering this transition happened months ago, and the consequences are fairly minimal (asset partitions which were requested, but failed, will be attempted again), I think this is a reasonable sacrifice. In fact, we can probably remove most of this backcompat stuff entirely in the near future.

## How I Tested These Changes
