### PR TITLE
[DS][5/n] Use AssetSlice in AssetConditionResult

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/asset_condition.py
@@ -18,6 +18,7 @@ from typing import (
 import pendulum
 
 from dagster._annotations import experimental
+from dagster._core.asset_graph_view.asset_graph_view import AssetSlice
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataMapping, MetadataValue
 from dagster._core.definitions.partition import AllPartitionsSubset
@@ -512,17 +513,21 @@ class AssetConditionResult:
     start_timestamp: float
     end_timestamp: float
 
-    true_subset: AssetSubset
+    true_slice: AssetSlice
     candidate_subset: AssetSubset
     subsets_with_metadata: Sequence[AssetSubsetWithMetadata]
 
     extra_state: PackableValue
     child_results: Sequence["AssetConditionResult"]
 
+    @property
+    def true_subset(self) -> AssetSubset:
+        return self.true_slice.convert_to_valid_asset_subset()
+
     @staticmethod
     def create_from_children(
         context: "SchedulingConditionEvaluationContext",
-        true_subset: AssetSubset,
+        true_subset: ValidAssetSubset,
         child_results: Sequence["AssetConditionResult"],
     ) -> "AssetConditionResult":
         """Returns a new AssetConditionEvaluation from the given child results."""
@@ -531,7 +536,7 @@ class AssetConditionResult:
             condition_unique_id=context.condition_unique_id,
             start_timestamp=context.start_timestamp,
             end_timestamp=pendulum.now("UTC").timestamp(),
-            true_subset=true_subset,
+            true_slice=context.asset_graph_view.get_asset_slice_from_subset(true_subset),
             candidate_subset=context.candidate_subset,
             subsets_with_metadata=[],
             child_results=child_results,
@@ -541,7 +546,7 @@ class AssetConditionResult:
     @staticmethod
     def create(
         context: "SchedulingConditionEvaluationContext",
-        true_subset: AssetSubset,
+        true_subset: ValidAssetSubset,
         subsets_with_metadata: Sequence[AssetSubsetWithMetadata] = [],
         extra_state: PackableValue = None,
     ) -> "AssetConditionResult":
@@ -551,7 +556,7 @@ class AssetConditionResult:
             condition_unique_id=context.condition_unique_id,
             start_timestamp=context.start_timestamp,
             end_timestamp=pendulum.now("UTC").timestamp(),
-            true_subset=true_subset,
+            true_slice=context.asset_graph_view.get_asset_slice_from_subset(true_subset),
             candidate_subset=context.candidate_subset,
             subsets_with_metadata=subsets_with_metadata,
             child_results=[],

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -11,7 +11,7 @@
 import datetime
 from typing import TYPE_CHECKING, AbstractSet, Optional, Sequence, Tuple
 
-from dagster._core.definitions.asset_subset import AssetSubset
+from dagster._core.definitions.asset_subset import AssetSubset, ValidAssetSubset
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._seven.compat.pendulum import (
@@ -159,7 +159,7 @@ def get_expected_data_time_for_asset_key(
 
 def freshness_evaluation_results_for_asset_key(
     context: "AssetConditionEvaluationContext",
-) -> Tuple[AssetSubset, Sequence["AssetSubsetWithMetadata"]]:
+) -> Tuple[ValidAssetSubset, Sequence["AssetSubsetWithMetadata"]]:
     """Returns a set of AssetKeyPartitionKeys to materialize in order to abide by the given
     FreshnessPolicies.
 


### PR DESCRIPTION
## Summary & Motivation
Use an AssetSlice object in the internals of this class. Doesn't make a big difference for now, but gives functions that operate over these objects the option to use the AssetSlice API instead of AssetSubset.

Future PRs will change the input type to the create() functions, but that requires larger changes.

## How I Tested These Changes
