### PR TITLE
[DS][6/n] Create Any/AllDepsMatchSchedulingConditions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/README.md
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/README.md
@@ -23,11 +23,9 @@ These conditions may be combined in a variety of ways. All conditions support th
 - `a & b`: Both `a` and `b`
 - `~a`: Not `a`
 
-[to be implemented]
-
 Conditions can also be applied to dependencies:
 
-- `SchedulingCondition.any_dep_matches(a)`: Any asset partition of any dep matches condition `a`
+- `SchedulingCondition.any_deps_match(a)`: Any asset partition of any deps match condition `a`
 - `SchedulingCondition.all_deps_match(a)`: Any asset partition of all deps match condition `a`
 
 ## Examples

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
@@ -1,1 +1,7 @@
 from .asset_condition import AssetCondition as AssetCondition
+
+# for whitelist_for_serdes
+from .dep_condition import (
+    AllDepsCondition as AllDepsCondition,
+    AnyDepsCondition as AnyDepsCondition,
+)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/asset_condition.py
@@ -393,6 +393,24 @@ class AssetCondition(ABC, DagsterModel):
             )
         )
 
+    @staticmethod
+    def any_deps_match(condition: "AssetCondition") -> "AssetCondition":
+        """Returns an AssetCondition that is true for an asset partition if at least one partition
+        of any of its dependencies evaluate to True for the given condition.
+        """
+        from .dep_condition import AnyDepsCondition
+
+        return AnyDepsCondition(operand=condition)
+
+    @staticmethod
+    def all_deps_match(condition: "AssetCondition") -> "AssetCondition":
+        """Returns an AssetCondition that is true for an asset partition if at least one partition
+        of all of its dependencies evaluate to True for the given condition.
+        """
+        from .dep_condition import AllDepsCondition
+
+        return AllDepsCondition(operand=condition)
+
 
 @experimental
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/dep_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/dep_condition.py
@@ -1,0 +1,101 @@
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._serdes.serdes import whitelist_for_serdes
+
+from .asset_condition import AssetCondition, AssetConditionResult
+from .scheduling_condition_evaluation_context import SchedulingConditionEvaluationContext
+
+
+class DepConditionWrapperCondition(AssetCondition):
+    """Wrapper object which evaluates a condition against a dependency and returns a subset
+    representing the subset of downstream asset which has at least one parent which evaluated to
+    True.
+    """
+
+    dep_key: AssetKey
+    operand: AssetCondition
+
+    @property
+    def description(self) -> str:
+        return f"{self.dep_key.to_user_string()}"
+
+    def evaluate(self, context: SchedulingConditionEvaluationContext) -> AssetConditionResult:
+        # only evaluate parents of the current candidate subset
+        dep_candidate_subset = context.candidate_slice.compute_parent_slice(
+            self.dep_key
+        ).convert_to_valid_asset_subset()
+        dep_context = context.for_child_condition(
+            asset_key=self.dep_key,
+            child_condition=self.operand,
+            candidate_subset=dep_candidate_subset,
+        )
+
+        # evaluate condition against the dependency
+        dep_result = self.operand.evaluate(dep_context)
+
+        # find all children of the true dep slice
+        true_subset = dep_result.true_slice.compute_child_slice(
+            context.asset_key
+        ).convert_to_valid_asset_subset()
+        return AssetConditionResult.create_from_children(
+            context=context,
+            true_subset=true_subset,
+            child_results=[dep_result],
+        )
+
+
+@whitelist_for_serdes
+class AnyDepsCondition(AssetCondition):
+    operand: AssetCondition
+
+    @property
+    def description(self) -> str:
+        return "Any deps"
+
+    def evaluate(self, context: SchedulingConditionEvaluationContext) -> AssetConditionResult:
+        dep_results = []
+        true_subset = context.asset_graph_view.create_empty_slice(
+            context.asset_key
+        ).convert_to_valid_asset_subset()
+
+        dep_keys = context.asset_graph_view.asset_graph.get(context.asset_key).parent_keys
+        for dep_key in dep_keys:
+            dep_condition = DepConditionWrapperCondition(dep_key=dep_key, operand=self.operand)
+            dep_result = dep_condition.evaluate(
+                context.for_child_condition(
+                    child_condition=dep_condition, candidate_subset=context.candidate_subset
+                )
+            )
+            dep_results.append(dep_result)
+            true_subset |= dep_result.true_subset
+
+        return AssetConditionResult.create_from_children(
+            context, true_subset=context.candidate_subset & true_subset, child_results=dep_results
+        )
+
+
+@whitelist_for_serdes
+class AllDepsCondition(AssetCondition):
+    operand: AssetCondition
+
+    @property
+    def description(self) -> str:
+        return "All deps"
+
+    def evaluate(self, context: SchedulingConditionEvaluationContext) -> AssetConditionResult:
+        dep_results = []
+        true_subset = context.candidate_subset
+
+        dep_keys = context.asset_graph_view.asset_graph.get(context.asset_key).parent_keys
+        for dep_key in dep_keys:
+            dep_condition = DepConditionWrapperCondition(dep_key=dep_key, operand=self.operand)
+            dep_result = dep_condition.evaluate(
+                context.for_child_condition(
+                    child_condition=dep_condition, candidate_subset=context.candidate_subset
+                )
+            )
+            dep_results.append(dep_result)
+            true_subset &= dep_result.true_subset
+
+        return AssetConditionResult.create_from_children(
+            context, true_subset=true_subset, child_results=dep_results
+        )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition_evaluation_context.py
@@ -103,11 +103,15 @@ class SchedulingConditionEvaluationContext:
         )
 
     def for_child_condition(
-        self, child_condition: AssetCondition, candidate_subset: ValidAssetSubset
+        self,
+        child_condition: AssetCondition,
+        candidate_subset: ValidAssetSubset,
+        asset_key: Optional[AssetKey] = None,
     ):
         child_unique_id = child_condition.get_unique_id(parent_unique_id=self.condition_unique_id)
         return dataclasses.replace(
             self,
+            asset_key=asset_key or self.asset_key,
             condition=child_condition,
             condition_unique_id=child_unique_id,
             candidate_subset=candidate_subset,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
@@ -1,0 +1,120 @@
+import pytest
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_subset import AssetSubset
+from dagster._core.definitions.declarative_scheduling.asset_condition import (
+    AssetCondition,
+    AssetConditionResult,
+)
+from dagster._core.definitions.declarative_scheduling.scheduling_condition_evaluation_context import (
+    SchedulingConditionEvaluationContext,
+)
+from dagster._core.definitions.events import AssetKeyPartitionKey
+
+from ..scenario_specs import one_asset_depends_on_two, two_partitions_def
+from .asset_condition_scenario import AssetConditionScenarioState
+
+
+def get_hardcoded_condition():
+    true_set = set()
+
+    class HardcodedCondition(AssetCondition):
+        @property
+        def description(self) -> str:
+            return "..."
+
+        def evaluate(self, context: SchedulingConditionEvaluationContext) -> AssetConditionResult:
+            true_candidates = {
+                candidate
+                for candidate in context.candidate_subset.asset_partitions
+                if candidate in true_set
+            }
+            partitions_def = context.asset_graph_view.asset_graph.get(
+                context.asset_key
+            ).partitions_def
+            return AssetConditionResult.create(
+                context,
+                true_subset=AssetSubset.from_asset_partitions_set(
+                    context.asset_key, partitions_def, true_candidates
+                ),
+            )
+
+    return HardcodedCondition(), true_set
+
+
+@pytest.mark.parametrize("is_any", [True, False])
+def test_dep_missing_unpartitioned(is_any: bool) -> None:
+    inner_condition, true_set = get_hardcoded_condition()
+    condition = (
+        AssetCondition.any_deps_match(inner_condition)
+        if is_any
+        else AssetCondition.all_deps_match(inner_condition)
+    )
+    state = AssetConditionScenarioState(one_asset_depends_on_two, asset_condition=condition)
+
+    # neither parent is true
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 0
+
+    # one parent true, still one false
+    true_set.add(AssetKeyPartitionKey(AssetKey("A")))
+    state, result = state.evaluate("C")
+    if is_any:
+        assert result.true_subset.size == 1
+    else:
+        assert result.true_subset.size == 0
+
+    # both parents true
+    true_set.add(AssetKeyPartitionKey(AssetKey("B")))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+
+@pytest.mark.parametrize("is_any", [True, False])
+def test_dep_missing_partitioned(is_any: bool) -> None:
+    inner_condition, true_set = get_hardcoded_condition()
+    condition = (
+        AssetCondition.any_deps_match(inner_condition)
+        if is_any
+        else AssetCondition.all_deps_match(inner_condition)
+    )
+    state = AssetConditionScenarioState(
+        one_asset_depends_on_two, asset_condition=condition
+    ).with_asset_properties(partitions_def=two_partitions_def)
+
+    # no parents true
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 0
+
+    true_set.add(AssetKeyPartitionKey(AssetKey("A"), "1"))
+    state, result = state.evaluate("C")
+    if is_any:
+        # one parent is true for partition 1
+        assert result.true_subset.size == 1
+    else:
+        # neither 1 nor 2 have all parents true
+        assert result.true_subset.size == 0
+
+    true_set.add(AssetKeyPartitionKey(AssetKey("A"), "2"))
+    state, result = state.evaluate("C")
+    if is_any:
+        # both partitions 1 and 2 have at least one true parent
+        assert result.true_subset.size == 2
+    else:
+        # neither 1 nor 2 have all parents true
+        assert result.true_subset.size == 0
+
+    true_set.add(AssetKeyPartitionKey(AssetKey("B"), "1"))
+    state, result = state.evaluate("C")
+    if is_any:
+        assert result.true_subset.size == 2
+    else:
+        # now partition 1 has all parents true
+        assert result.true_subset.size == 1
+
+    true_set.add(AssetKeyPartitionKey(AssetKey("B"), "2"))
+    state, result = state.evaluate("C")
+    if is_any:
+        assert result.true_subset.size == 2
+    else:
+        # now partition 2 has all parents true
+        assert result.true_subset.size == 2


### PR DESCRIPTION
## Summary & Motivation

This introduces a new composable operator into the declarative scheduling system. These conditions allow you to take an arbitrary `SchedulingCondition`, apply it to all dependencies, and then select the subset of the asset which is downstream of any/all dependencies which are true. For example, "materialize an asset if it's never been materialized and none of its parents are currently missing or in progress" becomes:

```python

~SchedulingCondition.materialized() & ~SchedulingCondition.any_deps_match(SchedulingCondition.in_progress() | ~SchedulingCondition.materialized())

```

Note that this does a lot of stuff "for free" that prior solutions struggled with, such as visualizing the parents which match a condition, limiting the search to "only the newest parent partitions", expressing all combinations of any partition of any parent, all partitions of any parent, any partition of all parents, etc.

Also note that this will cause issues in the UI if any of the deps are partitioned differently than their children. We'll need to figure out a way to handle that nicely in the future, but for now this problem is ignored.

## How I Tested These Changes
