### PR TITLE
[DS][9/n] Add lookback_timedelta to InLatestTimeWindow condition

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
@@ -20,14 +20,12 @@ from dagster._core.definitions.multi_dimensional_partitions import (
 from dagster._core.definitions.partition import (
     AllPartitionsSubset,
     DefaultPartitionsSubset,
-    DynamicPartitionsDefinition,
-    StaticPartitionsDefinition,
 )
 from dagster._core.definitions.time_window_partitions import (
-    PartitionKeysTimeWindowPartitionsSubset,
+    BaseTimeWindowPartitionsSubset,
     TimeWindow,
     TimeWindowPartitionsDefinition,
-    TimeWindowPartitionsSubset,
+    get_time_partitions_def,
 )
 from dagster._utils.cached_method import cached_method
 
@@ -179,7 +177,7 @@ class AssetSlice:
             self._time_window_partitions_def_in_context(), "Must be time windowed."
         )
 
-        if isinstance(self._compatible_subset.subset_value, TimeWindowPartitionsSubset):
+        if isinstance(self._compatible_subset.subset_value, BaseTimeWindowPartitionsSubset):
             return self._compatible_subset.subset_value.included_time_windows
         elif isinstance(self._compatible_subset.subset_value, AllPartitionsSubset):
             last_tw = tw_partitions_def.get_last_partition_window(
@@ -203,13 +201,9 @@ class AssetSlice:
 
             subset_from_tw = tw_partitions_def.subset_with_partition_keys(tw_partition_keys)
             check.inst(
-                subset_from_tw,
-                (TimeWindowPartitionsSubset, PartitionKeysTimeWindowPartitionsSubset),
-                "Must be time window subset.",
+                subset_from_tw, BaseTimeWindowPartitionsSubset, "Must be time window subset."
             )
-            if isinstance(subset_from_tw, TimeWindowPartitionsSubset):
-                return subset_from_tw.included_time_windows
-            elif isinstance(subset_from_tw, PartitionKeysTimeWindowPartitionsSubset):
+            if isinstance(subset_from_tw, BaseTimeWindowPartitionsSubset):
                 return subset_from_tw.included_time_windows
             else:
                 check.failed(
@@ -414,60 +408,46 @@ class AssetGraphView:
             ),
         )
 
-    def create_from_time_window(self, asset_key: AssetKey, time_window: TimeWindow) -> AssetSlice:
-        return _slice_from_subset(
-            self,
-            AssetSubset(
-                asset_key=asset_key,
-                value=TimeWindowPartitionsSubset(
-                    partitions_def=_required_tw_partitions_def(self._get_partitions_def(asset_key)),
-                    num_partitions=None,
-                    included_time_windows=[time_window],
-                ),
-            ),
-        )
-
-    def create_latest_time_window_slice(self, asset_key: AssetKey) -> AssetSlice:
-        """If the underlying asset is time-window partitioned, this will return the latest complete
-        time window relative to the effective date. For example if it is daily partitioned starting
-        at midnight every day.  If the effective date is before the start of the partition definition, this will
-        return the empty time window (where both start and end are datetime.max).
-
-        If the underlying asset is unpartitioned or static partitioned and it is not empty,
-        this will return a time window from the beginning of time to the effective date. If
-        it is empty it will return the empty time window.
-
-        TODO: add language for multi-dimensional partitioning when we support it
-        TODO: add language for dynamic partitioning when we support it
+    def compute_latest_time_window_slice(
+        self, asset_key: AssetKey, lookback_delta: Optional[timedelta] = None
+    ) -> AssetSlice:
+        """Compute the slice of the asset which exists within the latest time partition window. If
+        the asset has no time dimension, this will always return the full slice. If
+        lookback_delta is provided, all partitions that are up to that timedelta before the
+        end of the latest time partition window will be included.
         """
         partitions_def = self._get_partitions_def(asset_key)
-        if partitions_def is None or isinstance(
-            partitions_def, (DynamicPartitionsDefinition, StaticPartitionsDefinition)
-        ):
+        time_partitions_def = get_time_partitions_def(partitions_def)
+        if time_partitions_def is None:
+            # if the asset has no time dimension, then return a full slice
             return self.get_asset_slice(asset_key)
 
+        latest_time_window = time_partitions_def.get_last_partition_window(self.effective_dt)
+        if latest_time_window is None:
+            return self.create_empty_slice(asset_key)
+
+        # the time window in which to look for partitions
+        time_window = (
+            TimeWindow(
+                start=max(
+                    # do not look before the start of the definition
+                    time_partitions_def.start,
+                    latest_time_window.end - lookback_delta,
+                ),
+                end=latest_time_window.end,
+            )
+            if lookback_delta
+            else latest_time_window
+        )
+
         if isinstance(partitions_def, TimeWindowPartitionsDefinition):
-            time_window = partitions_def.get_last_partition_window(self.effective_dt)
-            return (
-                self.create_from_time_window(asset_key, time_window)
-                if time_window
-                else self.create_empty_slice(asset_key)
+            return self._build_time_partition_slice(asset_key, partitions_def, time_window)
+        elif isinstance(partitions_def, MultiPartitionsDefinition):
+            return self._build_multi_partition_slice(
+                asset_key, self._get_multi_dim_info(asset_key), time_window
             )
-
-        if isinstance(partitions_def, MultiPartitionsDefinition):
-            if not partitions_def.has_time_window_dimension:
-                return self.get_asset_slice(asset_key)
-
-            multi_dim_info = self._get_multi_dim_info(asset_key)
-            last_tw = multi_dim_info.tw_partition_def.get_last_partition_window(self.effective_dt)
-            return (
-                self._build_multi_partition_slice(asset_key, multi_dim_info, last_tw)
-                if last_tw
-                else self.create_empty_slice(asset_key)
-            )
-
-        # Need to handle dynamic partitioning
-        check.failed(f"Unsupported partitions_def: {partitions_def}")
+        else:
+            check.failed(f"Unsupported partitions_def: {partitions_def}")
 
     def create_empty_slice(self, asset_key: AssetKey) -> AssetSlice:
         return _slice_from_subset(
@@ -500,8 +480,18 @@ class AssetGraphView:
             secondary_dim=partitions_def.secondary_dimension,
         )
 
+    def _build_time_partition_slice(
+        self,
+        asset_key: AssetKey,
+        partitions_def: TimeWindowPartitionsDefinition,
+        time_window: TimeWindow,
+    ) -> "AssetSlice":
+        return self.get_asset_slice(asset_key).compute_intersection_with_partition_keys(
+            set(partitions_def.get_partition_keys_in_time_window(time_window))
+        )
+
     def _build_multi_partition_slice(
-        self, asset_key: AssetKey, multi_dim_info: MultiDimInfo, last_tw: TimeWindow
+        self, asset_key: AssetKey, multi_dim_info: MultiDimInfo, time_window: TimeWindow
     ) -> "AssetSlice":
         # Note: Potential perf improvement here. There is no way to encode a cartesian product
         # in the underlying PartitionsSet. We could add a specialized PartitionsSubset
@@ -516,7 +506,7 @@ class AssetGraphView:
                     }
                 )
                 for tw_pk in multi_dim_info.tw_partition_def.get_partition_keys_in_time_window(
-                    last_tw
+                    time_window
                 )
                 for secondary_pk in multi_dim_info.secondary_partition_def.get_partition_keys(
                     current_time=self.effective_dt,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/asset_condition.py
@@ -1,3 +1,4 @@
+import datetime
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import (
@@ -419,13 +420,23 @@ class AssetCondition(ABC, DagsterModel):
         return MissingSchedulingCondition()
 
     @staticmethod
-    def in_latest_time_window() -> "AssetCondition":
+    def in_latest_time_window(
+        lookback_delta: Optional[datetime.timedelta] = None,
+    ) -> "AssetCondition":
         """Returns an AssetCondition that is true for an asset partition when it is within the latest
         time window.
+
+        Args:
+            lookback_delta (Optional, datetime.timedelta): If provided, the condition will
+                return all partitions within the provided delta of the end of the latest time window.
+                For example, if you provide a delta of 48 hours for a daily-partitioned asset, this
+                will return the last two partitions.
         """
         from .slice_condition import InLatestTimeWindowCondition
 
-        return InLatestTimeWindowCondition()
+        return InLatestTimeWindowCondition(
+            lookback_seconds=lookback_delta.total_seconds() if lookback_delta else None
+        )
 
 
 @experimental

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition_evaluation_context.py
@@ -84,6 +84,10 @@ class SchedulingConditionEvaluationContext:
         return self.create_time.timestamp()
 
     @property
+    def effective_dt(self) -> datetime.datetime:
+        return self.asset_graph_view.effective_dt
+
+    @property
     def previous_evaluation_state(self) -> Optional[AssetConditionEvaluationState]:
         return self.previous_evaluation_state_by_key.get(self.asset_key)
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_latest_time_window.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_latest_time_window.py
@@ -52,16 +52,16 @@ def test_latest_time_slice_no_end() -> None:
         partition_key_list
     )
 
-    assert asset_graph_view_on_2_4.create_latest_time_window_slice(
+    assert asset_graph_view_on_2_4.compute_latest_time_window_slice(
         daily.key
     ).compute_partition_keys() == {"2020-02-03"}
 
     assert _tw(
-        asset_graph_view_on_2_4.create_latest_time_window_slice(daily.key)
+        asset_graph_view_on_2_4.compute_latest_time_window_slice(daily.key)
     ).start == pendulum.datetime(2020, 2, 3)
 
     assert _tw(
-        asset_graph_view_on_2_4.create_latest_time_window_slice(daily.key)
+        asset_graph_view_on_2_4.compute_latest_time_window_slice(daily.key)
     ).end == pendulum.datetime(2020, 2, 4)
 
     # effective date is 2020-2-5. Ensure one more date
@@ -74,7 +74,7 @@ def test_latest_time_slice_no_end() -> None:
         partition_key_list + ["2020-02-04"]
     )
 
-    assert asset_graph_view_on_2_5.create_latest_time_window_slice(
+    assert asset_graph_view_on_2_5.compute_latest_time_window_slice(
         daily.key
     ).compute_partition_keys() == {"2020-02-04"}
 
@@ -87,11 +87,11 @@ def test_latest_time_slice_no_end() -> None:
     assert asset_graph_view_on_1_1.get_asset_slice(daily.key).compute_partition_keys() == set()
 
     assert (
-        asset_graph_view_on_1_1.create_latest_time_window_slice(daily.key).compute_partition_keys()
+        asset_graph_view_on_1_1.compute_latest_time_window_slice(daily.key).compute_partition_keys()
         == set()
     )
 
-    assert asset_graph_view_on_1_1.create_latest_time_window_slice(daily.key).is_empty
+    assert asset_graph_view_on_1_1.compute_latest_time_window_slice(daily.key).is_empty
 
     # effective datetime is in the middle of 02-02, it means the latest
     # complete time window is 02-01 -> 02-02, so the partition key should be 02-01
@@ -125,7 +125,7 @@ def test_latest_time_slice_with_end() -> None:
         defs, instance, effective_dt=pendulum.datetime(2019, 12, 31)
     )
     assert (
-        asset_graph_view_before_start.create_latest_time_window_slice(
+        asset_graph_view_before_start.compute_latest_time_window_slice(
             daily.key
         ).compute_partition_keys()
         == set()
@@ -135,7 +135,7 @@ def test_latest_time_slice_with_end() -> None:
         defs, instance, effective_dt=pendulum.datetime(2020, 1, 1)
     )
     assert (
-        asset_graph_view_at_start.create_latest_time_window_slice(
+        asset_graph_view_at_start.compute_latest_time_window_slice(
             daily.key
         ).compute_partition_keys()
         == set()
@@ -144,14 +144,14 @@ def test_latest_time_slice_with_end() -> None:
     asset_graph_view_after_start_before_end = AssetGraphView.for_test(
         defs, instance, effective_dt=pendulum.datetime(2020, 1, 3)
     )
-    assert asset_graph_view_after_start_before_end.create_latest_time_window_slice(
+    assert asset_graph_view_after_start_before_end.compute_latest_time_window_slice(
         daily.key
     ).compute_partition_keys() == set(["2020-01-02"])
 
     asset_graph_view_after_end = AssetGraphView.for_test(
         defs, instance, effective_dt=pendulum.datetime(2020, 2, 5)
     )
-    assert asset_graph_view_after_end.create_latest_time_window_slice(
+    assert asset_graph_view_after_end.compute_latest_time_window_slice(
         daily.key
     ).compute_partition_keys() == set(["2020-01-31"])
 
@@ -165,7 +165,7 @@ def test_latest_time_slice_unpartitioned() -> None:
 
     asset_graph_view = AssetGraphView.for_test(defs, instance)
     assert not asset_graph_view.get_asset_slice(unpartitioned.key).is_empty
-    assert not asset_graph_view.create_latest_time_window_slice(unpartitioned.key).is_empty
+    assert not asset_graph_view.compute_latest_time_window_slice(unpartitioned.key).is_empty
 
 
 def test_latest_time_slice_static_partitioned() -> None:
@@ -179,7 +179,7 @@ def test_latest_time_slice_static_partitioned() -> None:
     instance = DagsterInstance.ephemeral()
 
     asset_graph_view = AssetGraphView.for_test(defs, instance)
-    latest_up_slice = asset_graph_view.create_latest_time_window_slice(up_numbers.key)
+    latest_up_slice = asset_graph_view.compute_latest_time_window_slice(up_numbers.key)
     assert latest_up_slice.compute_partition_keys() == number_keys
 
 
@@ -216,7 +216,7 @@ def test_multi_dimesional_with_time_partition_latest_time_window() -> None:
 
     md_slice = asset_graph_view_within_partition.get_asset_slice(multi_dimensional.key)
     assert md_slice.compute_partition_keys() == set(partition_keys)
-    last_tw_slice = asset_graph_view_within_partition.create_latest_time_window_slice(
+    last_tw_slice = asset_graph_view_within_partition.compute_latest_time_window_slice(
         multi_dimensional.key
     )
     assert last_tw_slice.compute_partition_keys() == set(jan_2_keys)
@@ -227,7 +227,7 @@ def test_multi_dimesional_with_time_partition_latest_time_window() -> None:
         defs, instance, effective_dt=pendulum.datetime(2019, 3, 3)
     )
 
-    md_slice_in_past = asset_graph_view_in_past.create_latest_time_window_slice(
+    md_slice_in_past = asset_graph_view_in_past.compute_latest_time_window_slice(
         multi_dimensional.key
     )
     assert md_slice_in_past.compute_partition_keys() == set()
@@ -255,7 +255,7 @@ def test_multi_dimesional_without_time_partition_latest_time_window() -> None:
     asset_graph_view = AssetGraphView.for_test(defs, instance)
     md_slice = asset_graph_view.get_asset_slice(multi_dimensional.key)
     assert md_slice.compute_partition_keys() == set(partition_keys)
-    assert asset_graph_view.create_latest_time_window_slice(
+    assert asset_graph_view.compute_latest_time_window_slice(
         multi_dimensional.key
     ).compute_partition_keys() == set(partition_keys)
 
@@ -287,7 +287,9 @@ def test_dynamic_partitioning_latest_time_window() -> None:
         == partition_keys
     )
     assert (
-        asset_graph_view.create_latest_time_window_slice(dynamic_asset.key).compute_partition_keys()
+        asset_graph_view.compute_latest_time_window_slice(
+            dynamic_asset.key
+        ).compute_partition_keys()
         == partition_keys
     )
 
@@ -305,14 +307,14 @@ def test_dynamic_partitioning_latest_time_window() -> None:
     assert asset_graph_view.get_asset_slice(
         dynamic_multi_dimensional.key
     ).compute_partition_keys() == set(partition_keys)
-    assert asset_graph_view.create_latest_time_window_slice(
+    assert asset_graph_view.compute_latest_time_window_slice(
         dynamic_multi_dimensional.key
     ).compute_partition_keys() == set(jan_2_keys)
 
     assert _tw(
-        asset_graph_view.create_latest_time_window_slice(dynamic_multi_dimensional.key)
+        asset_graph_view.compute_latest_time_window_slice(dynamic_multi_dimensional.key)
     ).start == pendulum.datetime(2020, 1, 2)
 
     assert _tw(
-        asset_graph_view.create_latest_time_window_slice(dynamic_multi_dimensional.key)
+        asset_graph_view.compute_latest_time_window_slice(dynamic_multi_dimensional.key)
     ).end == pendulum.datetime(2020, 1, 3)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_latest_time_window_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_latest_time_window_condition.py
@@ -1,3 +1,5 @@
+import datetime
+
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.declarative_scheduling.asset_condition import (
     AssetCondition,
@@ -22,9 +24,33 @@ def test_in_latest_time_window_unpartitioned() -> None:
     assert result.true_subset.size == 1
 
 
+def test_in_latest_time_window_unpartitioned_lookback() -> None:
+    state = AssetConditionScenarioState(
+        one_asset,
+        asset_condition=AssetCondition.in_latest_time_window(
+            lookback_delta=datetime.timedelta(days=3)
+        ),
+    )
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+
 def test_in_latest_time_window_static_partitioned() -> None:
     state = AssetConditionScenarioState(
         one_asset, asset_condition=AssetCondition.in_latest_time_window()
+    ).with_asset_properties(partitions_def=two_partitions_def)
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 2
+
+
+def test_in_latest_time_window_static_partitioned_lookback() -> None:
+    state = AssetConditionScenarioState(
+        one_asset,
+        asset_condition=AssetCondition.in_latest_time_window(
+            lookback_delta=datetime.timedelta(days=3)
+        ),
     ).with_asset_properties(partitions_def=two_partitions_def)
 
     state, result = state.evaluate("A")
@@ -53,4 +79,36 @@ def test_in_latest_time_window_time_partitioned() -> None:
     assert result.true_subset.size == 1
     assert result.true_subset.asset_partitions == {
         AssetKeyPartitionKey(AssetKey("A"), "2020-02-06")
+    }
+
+
+def test_in_latest_time_window_time_partitioned_lookback() -> None:
+    state = AssetConditionScenarioState(
+        one_asset,
+        asset_condition=AssetCondition.in_latest_time_window(
+            lookback_delta=datetime.timedelta(days=3)
+        ),
+    ).with_asset_properties(partitions_def=daily_partitions_def)
+
+    # no partitions exist yet
+    state = state.with_current_time(time_partitions_start_datetime)
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 0
+
+    state = state.with_current_time("2020-02-07T01:00:00")
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 3
+    assert result.true_subset.asset_partitions == {
+        AssetKeyPartitionKey(AssetKey("A"), "2020-02-06"),
+        AssetKeyPartitionKey(AssetKey("A"), "2020-02-05"),
+        AssetKeyPartitionKey(AssetKey("A"), "2020-02-04"),
+    }
+
+    state = state.with_current_time_advanced(days=5)
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 3
+    assert result.true_subset.asset_partitions == {
+        AssetKeyPartitionKey(AssetKey("A"), "2020-02-11"),
+        AssetKeyPartitionKey(AssetKey("A"), "2020-02-10"),
+        AssetKeyPartitionKey(AssetKey("A"), "2020-02-09"),
     }


### PR DESCRIPTION
## Summary & Motivation

This diverges slightly from past conversations we've had about separating out this functionality into two separate conditions.

That said, I think this definition actually ends up making more sense overall.

The most annoying bit with the originally-proposed definition is that if you define a "RecentPartitionsCondition" to mean "all partitions within the time window (current_time - 3 days, current_time)" you end up with the annoying result that this time range actually only contains 2 full daily partitions, as you are inevitably going to call this function at some time other than "exactly midnight", meaning that you have (partital_day, full_day, full_day, part of today) as your range, leaving you with only 2 partitions. I think this would be a persistant annoyance for users that would simply want to express "the last 3 daily partitions" in a natural way.

I think this formulation ends up being more intuitive, and has the added bonus of consolidating two very-similar concepts into a single condition.

This definition also handles partitions deifnitions with an end date nicely, which is nice.


## How I Tested These Changes
