### PR TITLE
[DS][10/n] Create UpdatedSinceCronCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -92,7 +92,7 @@ class AssetSubset(DagsterModel):
             return False
         return self.size == 0
 
-    def _is_compatible_with_partitions_def(
+    def is_compatible_with_partitions_def(
         self, partitions_def: Optional[PartitionsDefinition]
     ) -> bool:
         if self.is_partitioned:
@@ -107,7 +107,7 @@ class AssetSubset(DagsterModel):
 
     def _is_compatible_with_subset(self, other: "AssetSubset") -> bool:
         if isinstance(other.value, (BaseTimeWindowPartitionsSubset, AllPartitionsSubset)):
-            return self._is_compatible_with_partitions_def(other.value.partitions_def)
+            return self.is_compatible_with_partitions_def(other.value.partitions_def)
         else:
             return self.is_partitioned == other.is_partitioned
 
@@ -115,7 +115,7 @@ class AssetSubset(DagsterModel):
         """Converts this AssetSubset to a ValidAssetSubset by returning a copy of this AssetSubset
         if it is compatible with the given PartitionsDefinition, otherwise returns an empty subset.
         """
-        if self._is_compatible_with_partitions_def(partitions_def):
+        if self.is_compatible_with_partitions_def(partitions_def):
             return ValidAssetSubset(asset_key=self.asset_key, value=self.value)
         else:
             return ValidAssetSubset.empty(self.asset_key, partitions_def)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition_evaluation_context.py
@@ -3,7 +3,7 @@ import datetime
 import functools
 import logging
 from dataclasses import dataclass
-from typing import AbstractSet, Mapping, Optional, Tuple
+from typing import TYPE_CHECKING, AbstractSet, Mapping, Optional, Tuple
 
 import pendulum
 
@@ -17,11 +17,15 @@ from dagster._core.definitions.declarative_scheduling.asset_condition import (
     AssetCondition,
     AssetConditionEvaluation,
     AssetConditionEvaluationState,
+    get_serializable_candidate_subset,
 )
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.partition import PartitionsDefinition
 
 from .asset_condition_evaluation_context import AssetConditionEvaluationContext
+
+if TYPE_CHECKING:
+    from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 
 @dataclass(frozen=True)
@@ -76,6 +80,10 @@ class SchedulingConditionEvaluationContext:
         return self.asset_graph_view.get_asset_slice_from_subset(self.candidate_subset)
 
     @property
+    def partitions_def(self) -> Optional[PartitionsDefinition]:
+        return self.asset_graph_view.asset_graph.get(self.asset_key).partitions_def
+
+    @property
     def legacy_context(self) -> AssetConditionEvaluationContext:
         return self._legacy_context
 
@@ -92,24 +100,48 @@ class SchedulingConditionEvaluationContext:
         return self.previous_evaluation_state_by_key.get(self.asset_key)
 
     @property
+    def previous_evaluation_timestamp(self) -> Optional[float]:
+        state = self.previous_evaluation_state
+        return state.previous_tick_evaluation_timestamp if state else None
+
+    @property
     def new_max_storage_id(self) -> Optional[int]:
         # TODO: this should be pulled from the asset graph view
         return self._get_updated_parents_and_storage_id()[1]
 
     @property
-    def partitions_def(self) -> Optional[PartitionsDefinition]:
-        return self.asset_graph_view.asset_graph.get(self.asset_key).partitions_def
+    def _queryer(self) -> "CachingInstanceQueryer":
+        return self.asset_graph_view._queryer  # noqa
 
     def _get_updated_parents_and_storage_id(
         self,
     ) -> Tuple[AbstractSet[AssetKeyPartitionKey], Optional[int]]:
-        return self.asset_graph_view._queryer.asset_partitions_with_newly_updated_parents_and_new_cursor(  # noqa
+        return self._queryer.asset_partitions_with_newly_updated_parents_and_new_cursor(
             latest_storage_id=self.previous_evaluation_state.max_storage_id
             if self.previous_evaluation_state
             else None,
             child_asset_key=self.asset_key,
             map_old_time_partitions=False,
         )
+
+    def target_asset_updated_since_previous_evaluation(self) -> bool:
+        """Returns True if the target asset has been updated since the previous evaluation."""
+        return self._queryer.asset_partition_has_materialization_or_observation(
+            asset_partition=AssetKeyPartitionKey(self.asset_key),
+            after_cursor=self.previous_evaluation_state.max_storage_id
+            if self.previous_evaluation_state
+            else None,
+        )
+
+    def has_new_candidate_subset(self) -> bool:
+        """Returns if the current tick's candidate subset is different from the previous tick's."""
+        if self.previous_evaluation is None:
+            return True
+        # convert to seriliazable form to compare in-memory object with object that passed through
+        # a serdes round trip
+        return get_serializable_candidate_subset(
+            self.candidate_subset
+        ) != get_serializable_candidate_subset(self.previous_evaluation.candidate_subset)
 
     def for_child_condition(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/updated_since_cron_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/updated_since_cron_condition.py
@@ -1,0 +1,55 @@
+import datetime
+
+from dagster._utils.schedules import reverse_cron_string_iterator
+
+from .asset_condition import AssetCondition, AssetConditionResult
+from .scheduling_condition_evaluation_context import SchedulingConditionEvaluationContext
+
+
+class UpdatedSinceCronCondition(AssetCondition):
+    cron_schedule: str
+    cron_timezone: str
+
+    @property
+    def condition_description(self) -> str:
+        return f"Updated since latest tick of {self.cron_schedule} ({self.cron_timezone})"
+
+    def _get_previous_cron_tick(
+        self, context: SchedulingConditionEvaluationContext
+    ) -> datetime.datetime:
+        previous_ticks = reverse_cron_string_iterator(
+            end_timestamp=context.effective_dt.timestamp(),
+            cron_string=self.cron_schedule,
+            execution_timezone=self.cron_timezone,
+        )
+        return next(previous_ticks)
+
+    def evaluate(self, context: SchedulingConditionEvaluationContext) -> AssetConditionResult:
+        previous_cron_tick = self._get_previous_cron_tick(context)
+
+        if (
+            # never evaluated
+            context.previous_evaluation is None
+            # partitions def has changed
+            or not context.previous_evaluation.true_subset.is_compatible_with_partitions_def(
+                context.partitions_def
+            )
+            # not evaluated since latest schedule tick
+            or (context.previous_evaluation_timestamp or 0) < previous_cron_tick.timestamp()
+            # has new set of candidates
+            or context.has_new_candidate_subset()
+            # asset updated since latest evaluation
+            or context.target_asset_updated_since_previous_evaluation()
+        ):
+            # do a full recomputation
+            true_subset = (
+                context.candidate_subset
+                & context._queryer.get_asset_subset_updated_after_time(  # noqa
+                    asset_key=context.asset_key,
+                    after_time=previous_cron_tick,
+                )
+            )
+        else:
+            true_subset = context.previous_evaluation.true_subset.as_valid(context.partitions_def)
+
+        return AssetConditionResult.create(context, true_subset)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_updated_since_cron_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_updated_since_cron_condition.py
@@ -1,0 +1,114 @@
+import datetime
+
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.declarative_scheduling.asset_condition import (
+    AssetCondition,
+)
+from dagster._core.definitions.events import AssetKeyPartitionKey
+
+from ..scenario_specs import (
+    daily_partitions_def,
+    one_asset,
+    time_partitions_start_datetime,
+    two_partitions_def,
+)
+from .asset_condition_scenario import AssetConditionScenarioState
+
+
+def test_in_latest_time_window_unpartitioned() -> None:
+    state = AssetConditionScenarioState(
+        one_asset, asset_condition=AssetCondition.in_latest_time_window()
+    )
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+
+def test_in_latest_time_window_unpartitioned_lookback() -> None:
+    state = AssetConditionScenarioState(
+        one_asset,
+        asset_condition=AssetCondition.in_latest_time_window(
+            lookback_delta=datetime.timedelta(days=3)
+        ),
+    )
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+
+def test_in_latest_time_window_static_partitioned() -> None:
+    state = AssetConditionScenarioState(
+        one_asset, asset_condition=AssetCondition.in_latest_time_window()
+    ).with_asset_properties(partitions_def=two_partitions_def)
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 2
+
+
+def test_in_latest_time_window_static_partitioned_lookback() -> None:
+    state = AssetConditionScenarioState(
+        one_asset,
+        asset_condition=AssetCondition.in_latest_time_window(
+            lookback_delta=datetime.timedelta(days=3)
+        ),
+    ).with_asset_properties(partitions_def=two_partitions_def)
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 2
+
+
+def test_in_latest_time_window_time_partitioned() -> None:
+    state = AssetConditionScenarioState(
+        one_asset, asset_condition=AssetCondition.in_latest_time_window()
+    ).with_asset_properties(partitions_def=daily_partitions_def)
+
+    # no partitions exist yet
+    state = state.with_current_time(time_partitions_start_datetime)
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 0
+
+    state = state.with_current_time("2020-02-02T01:00:00")
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+    assert result.true_subset.asset_partitions == {
+        AssetKeyPartitionKey(AssetKey("A"), "2020-02-01")
+    }
+
+    state = state.with_current_time_advanced(days=5)
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+    assert result.true_subset.asset_partitions == {
+        AssetKeyPartitionKey(AssetKey("A"), "2020-02-06")
+    }
+
+
+def test_in_latest_time_window_time_partitioned_lookback() -> None:
+    state = AssetConditionScenarioState(
+        one_asset,
+        asset_condition=AssetCondition.in_latest_time_window(
+            lookback_delta=datetime.timedelta(days=3)
+        ),
+    ).with_asset_properties(partitions_def=daily_partitions_def)
+
+    # no partitions exist yet
+    state = state.with_current_time(time_partitions_start_datetime)
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 0
+
+    state = state.with_current_time("2020-02-07T01:00:00")
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 3
+    assert result.true_subset.asset_partitions == {
+        AssetKeyPartitionKey(AssetKey("A"), "2020-02-06"),
+        AssetKeyPartitionKey(AssetKey("A"), "2020-02-05"),
+        AssetKeyPartitionKey(AssetKey("A"), "2020-02-04"),
+    }
+
+    state = state.with_current_time_advanced(days=5)
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 3
+    assert result.true_subset.asset_partitions == {
+        AssetKeyPartitionKey(AssetKey("A"), "2020-02-11"),
+        AssetKeyPartitionKey(AssetKey("A"), "2020-02-10"),
+        AssetKeyPartitionKey(AssetKey("A"), "2020-02-09"),
+    }


### PR DESCRIPTION
## Summary & Motivation

Creates an UpdatedSinceCronCondition, to find the subset of an asset which has been updated since the latest cron schedule tick.

If you compare this to the existing prior art, you'll notice that this is vastly simpler:

- materialize_on_cron: https://sourcegraph.com/github.com/dagster-io/dagster@9bc32ed40580aaf5923904cb75353faf8ac58b38/-/blob/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py?L87:7-87:28

- skip_on_not_all_parents_updated_since_cron: https://sourcegraph.com/github.com/dagster-io/dagster@9bc32ed40580aaf5923904cb75353faf8ac58b38/-/blob/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py?L712

Previous implementations were complicated for a few reasons, but the main one was that, due to the lack of composability in the AutoMaterializeRule system, if you had a rule that blanket said "return all partitions which have not been materialized since the latest cron schedule tick", this would have bad results for time-window partitions, as you'd end up materializing ALL time partitions every (e..g.) hour, which is essentially never what the user would want.

Now, users can compose this rule with `SchedulingCondition.in_latest_time_window` to get more sensible behavior.

Because computing this is a bit more expensive than other conditions that have been implemented thus far, I put a bit of extra effort in to ensure that we're not recomputing the value for this rule unless we need to.

## How I Tested These Changes

Still need to add tests
