### PR TITLE
adjust event log storage tests to avoid deprecated behavior

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -160,7 +160,11 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
             limit (Optional[int]): Max number of records to return.
         """
         if isinstance(cursor, int):
-            deprecation_warning("Integer cursor values in `get_logs_for_run`", "1.8.0")
+            deprecation_warning(
+                "Integer cursor values in `get_logs_for_run`",
+                "1.8.0",
+                "You can instead construct a storage_id-based string cursor e.g. `cursor = EventLogCursor.from_storage_id(storage_id).to_string()`",
+            )
             cursor = EventLogCursor.from_offset(cursor + 1).to_string()
         records = self.get_records_for_run(
             run_id, cursor, of_type, limit, ascending=ascending

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -36,6 +36,7 @@ from dagster._core.storage.dagster_run import DagsterRunStatsSnapshot
 from dagster._core.storage.sql import AlembicVersion
 from dagster._utils import PrintFn
 from dagster._utils.concurrency import ConcurrencyClaimStatus, ConcurrencyKeyInfo
+from dagster._utils.warnings import deprecation_warning
 
 if TYPE_CHECKING:
     from dagster._core.events.log import EventLogEntry
@@ -159,6 +160,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
             limit (Optional[int]): Max number of records to return.
         """
         if isinstance(cursor, int):
+            deprecation_warning("Integer cursor values in `get_logs_for_run`", "1.8.0")
             cursor = EventLogCursor.from_offset(cursor + 1).to_string()
         records = self.get_records_for_run(
             run_id, cursor, of_type, limit, ascending=ascending

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -52,7 +52,6 @@ from dagster._core.events import (
     ASSET_EVENTS,
     EVENT_TYPE_TO_PIPELINE_RUN_STATUS,
     MARKER_EVENTS,
-    PIPELINE_EVENTS,
     DagsterEventType,
 )
 from dagster._core.events.log import EventLogEntry
@@ -954,8 +953,6 @@ class SqlEventLogStorage(EventLogStorage):
         limit: Optional[int] = None,
         ascending: bool = False,
     ) -> Sequence[EventLogRecord]:
-        if event_records_filter.event_type not in ASSET_EVENTS.union(PIPELINE_EVENTS):
-            deprecation_warning(f"Querying by {event_records_filter.event_type.value}", "1.8.0")
         return self._get_event_records(
             event_records_filter=event_records_filter, limit=limit, ascending=ascending
         )
@@ -1131,7 +1128,9 @@ class SqlEventLogStorage(EventLogStorage):
 
         if isinstance(dagster_event_type, set) and len(dagster_event_type) > 1:
             deprecation_warning(
-                "Support for multiple event types to get_logs_for_all_runs_by_log_id", "1.8.0"
+                "Support for multiple event types to get_logs_for_all_runs_by_log_id",
+                "1.8.0",
+                "You should break up your query into multiple calls, one for each event type.",
             )
 
         dagster_event_types = (


### PR DESCRIPTION
## Summary & Motivation
This PR adjusts event log storage tests to avoid deprecated behavior:
* We want to avoid offset-based cursoring, preferring storage_id based string cursors
* We want to avoid passing in multiple event types to `get_logs_for_all_runs_by_log_id`
* We want to avoid fetching by event types that are not an asset event or a run status event

## How I Tested These Changes
BK