### PR TITLE
feat(dbt): remove support for `dbt-core==1.5.*`

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -452,7 +452,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         "python_modules/libraries/dagster-dbt",
         pytest_tox_factors=[
             f"{deps_factor}-{command_factor}"
-            for deps_factor in ["dbt15", "dbt16", "dbt17", "pydantic1"]
+            for deps_factor in ["dbt16", "dbt17", "pydantic1"]
             for command_factor in ["cloud", "core", "legacy"]
         ],
         unsupported_python_versions=[

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -41,8 +41,6 @@ from dagster._core.definitions.decorators.asset_decorator import (
 from dagster._core.definitions.metadata import TableMetadataSet
 from dagster._utils.merger import merge_dicts
 from dagster._utils.warnings import deprecation_warning
-from dbt.version import __version__ as dbt_version
-from packaging import version
 
 from .utils import ASSET_RESOURCE_TYPES, dagster_name_fn
 
@@ -869,7 +867,7 @@ def get_asset_check_key_for_test(
     )
 
     # Attempt to find the attached node from the ref.
-    if attached_node_ref and version.parse(dbt_version) >= version.parse("1.6.0"):
+    if attached_node_ref:
         ref_name, ref_package, ref_version = (
             attached_node_ref["name"],
             attached_node_ref.get("package"),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -377,11 +377,8 @@ class DbtCliEventMessage:
             Dict[str, Any]: The lineage metadata.
         """
         if (
-            # The dbt project name is only available from the manifest in `dbt-core>=1.6`.
-            version.parse(dbt_version) < version.parse("1.6.0")
             # Column lineage can only be built if initial metadata is provided.
-            or not self.has_column_lineage_metadata
-            or not target_path
+            not self.has_column_lineage_metadata or not target_path
         ):
             return {}
 
@@ -1075,9 +1072,9 @@ class DbtCliResource(ConfigurableResource):
     @compat_model_validator(mode="before")
     def validate_dbt_version(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Validate that the dbt version is supported."""
-        if version.parse(dbt_version) < version.parse("1.5.0"):
+        if version.parse(dbt_version) < version.parse("1.6.0"):
             raise ValueError(
-                "To use `dagster_dbt.DbtCliResource`, you must use `dbt-core>=1.5.0`. Currently,"
+                "To use `dagster_dbt.DbtCliResource`, you must use `dbt-core>=1.6.0`. Currently,"
                 f" you are using `dbt-core=={dbt_version}`. Please install a compatible dbt-core"
                 " version."
             )
@@ -1137,11 +1134,7 @@ class DbtCliResource(ConfigurableResource):
         if not (self.state_path and Path(self.state_path).joinpath("manifest.json").exists()):
             return []
 
-        state_flag = "--defer-state"
-        if version.parse(dbt_version) < version.parse("1.6.0"):
-            state_flag = "--state"
-
-        return ["--defer", state_flag, self.state_path]
+        return ["--defer", "--defer-state", self.state_path]
 
     def get_state_args(self) -> Sequence[str]:
         """Build the state arguments for the dbt CLI command, using the supplied state directory.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -17,8 +17,6 @@ from dagster import (
 from dagster._core.definitions.metadata import TableMetadataSet
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.core.resources_v2 import DbtCliResource
-from dbt.version import __version__ as dbt_version
-from packaging import version
 from pytest_mock import MockFixture
 from sqlglot import Dialect
 
@@ -102,10 +100,6 @@ def test_exception_column_schema(
     )
 
 
-@pytest.mark.skipif(
-    version.parse(dbt_version) < version.parse("1.6.0"),
-    reason="Retrieving the dbt project name from the manifest is only available in `dbt-core>=1.6`",
-)
 def test_no_column_lineage(test_metadata_manifest: Dict[str, Any]) -> None:
     @dbt_assets(manifest=test_metadata_manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
@@ -130,10 +124,6 @@ def test_no_column_lineage(test_metadata_manifest: Dict[str, Any]) -> None:
     )
 
 
-@pytest.mark.skipif(
-    version.parse(dbt_version) < version.parse("1.6.0"),
-    reason="Retrieving the dbt project name from the manifest is only available in `dbt-core>=1.6`",
-)
 def test_exception_column_lineage(
     mocker: MockFixture, test_metadata_manifest: Dict[str, Any]
 ) -> None:
@@ -158,10 +148,6 @@ def test_exception_column_lineage(
     )
 
 
-@pytest.mark.skipif(
-    version.parse(dbt_version) < version.parse("1.6.0"),
-    reason="Retrieving the dbt project name from the manifest is only available in `dbt-core>=1.6`",
-)
 @pytest.mark.parametrize(
     "asset_key_selection",
     [

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=[
         f"dagster{pin}",
         # Follow the version support constraints for dbt Core: https://docs.getdbt.com/docs/dbt-versions/core
-        "dbt-core>=1.5,<1.8",
+        "dbt-core>=1.6,<1.8",
         "Jinja2",
         "networkx",
         "orjson",

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -10,9 +10,6 @@ deps =
   -e ../../dagster-pipes
   -e ../dagster-duckdb
   -e ../dagster-duckdb-pandas
-  dbt15: dbt-core==1.5.*
-  dbt15: dbt-duckdb==1.5.*
-  dbt15: duckdb<0.10.0
   dbt16: dbt-core==1.6.*
   dbt16: dbt-duckdb==1.6.*
   dbt17: dbt-core==1.7.*


### PR DESCRIPTION
## Summary & Motivation
`dbt-core==1.5.*` has been EOL since April 27, 2024: https://docs.getdbt.com/docs/dbt-versions/core.

Also, enforce that dbt-core>=1.6 on installation.

Same rodeo as #19476.

## How I Tested These Changes
pytest