### PR TITLE
test(dbt): ignore temporary `*.wal` files on copy

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/conftest.py
@@ -9,6 +9,13 @@ from ..dbt_projects import test_jaffle_shop_path
 @pytest.fixture(name="dbt_project_dir", scope="function")
 def dbt_project_dir_fixture(tmp_path: Path) -> Path:
     dbt_project_dir = tmp_path.joinpath("test_jaffle_shop")
-    shutil.copytree(src=test_jaffle_shop_path, dst=dbt_project_dir)
+    shutil.copytree(
+        src=test_jaffle_shop_path,
+        dst=dbt_project_dir,
+        # Ignore temporary files when copying the folder.
+        ignore=shutil.ignore_patterns(
+            "*.wal",
+        ),
+    )
 
     return dbt_project_dir


### PR DESCRIPTION
## Summary & Motivation
Hoping to squash errors like https://buildkite.com/dagster/dagster-dagster/builds/81581#018f2feb-35ad-408d-9fb4-966a7487adc6:

```
[2024-04-30T17:09:54Z] E           shutil.Error: [('/workdir/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/target/gw2_jaffle_shop.duckdb.wal', '/tmp/pytest-of-root/pytest-0/popen-gw1/test_prepare_for_deployment_wi1/test_jaffle_shop/target/gw2_jaffle_shop.duckdb.wal', "[Errno 2] No such file or directory: '/workdir/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/target/gw2_jaffle_shop.duckdb.wal'")]
```

These `*.wal` files are temporary, so don't copy them.

## How I Tested These Changes
bk
