### PR TITLE
stop trying to directly serialize dagster events in json console logger

### DIFF
--- a/python_modules/dagster/dagster/_loggers/__init__.py
+++ b/python_modules/dagster/dagster/_loggers/__init__.py
@@ -6,7 +6,11 @@ import coloredlogs
 from dagster import _seven
 from dagster._config import Field
 from dagster._core.definitions.logger_definition import LoggerDefinition, logger
-from dagster._core.log_manager import LOG_RECORD_EVENT_ATTR
+from dagster._core.log_manager import (
+    LOG_RECORD_EVENT_ATTR,
+    LOG_RECORD_METADATA_ATTR,
+    DagsterLogRecordMetadata,
+)
 from dagster._core.utils import coerce_valid_log_level
 from dagster._serdes import pack_value
 from dagster._utils.log import create_console_logger
@@ -95,12 +99,20 @@ def json_console_logger(init_context: "InitLoggerContext") -> logging.Logger:
 
     class JsonFormatter(logging.Formatter):
         def format(self, record):
-            # Events objects are not always JSON-serializable, so handle need to pack them first
-            dict_to_dump = record.__dict__
-            if LOG_RECORD_EVENT_ATTR in dict_to_dump:
-                packed_event = pack_value(dict_to_dump[LOG_RECORD_EVENT_ATTR])
-                dict_to_dump = {**dict_to_dump, LOG_RECORD_EVENT_ATTR: packed_event}
-            breakpoint()
+            dict_to_dump = {}
+            for k, v in record.__dict__.items():
+                if k == LOG_RECORD_EVENT_ATTR:
+                    # Redundant with the "dagster_event" field under "dagster_meta"
+                    continue
+                elif k == LOG_RECORD_METADATA_ATTR:
+                    # Events objects are not always JSON-serializable, so need to pack them first
+                    json_serializable_event = pack_value(v[LOG_RECORD_EVENT_ATTR])
+                    json_serializable_dagster_meta = DagsterLogRecordMetadata(
+                        **{**v, "dagster_event": json_serializable_event}
+                    )
+                    dict_to_dump[LOG_RECORD_METADATA_ATTR] = json_serializable_dagster_meta
+                else:
+                    dict_to_dump[k] = v
 
             return _seven.json.dumps(dict_to_dump)
 

--- a/python_modules/dagster/dagster_tests/logging_tests/test_logging.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_logging.py
@@ -308,13 +308,14 @@ def test_json_console_logger(capsys):
     for line in captured.err.split("\n"):
         if line:
             parsed = json.loads(line)
+            assert "dagster_event" not in parsed
             if parsed[LOG_RECORD_METADATA_ATTR]["orig_message"] == "Hello, world!":
                 found_msg = True
 
     assert found_msg
 
 
-def test_json_console_run_failure(capsys):
+def test_json_console_logger_run_failure(capsys):
     @op
     def failing_op(context):
         context.log.info("Hello, world!")
@@ -333,6 +334,7 @@ def test_json_console_run_failure(capsys):
     for line in captured.err.split("\n"):
         if line:
             parsed = json.loads(line)
+            assert "dagster_event" not in parsed
             if parsed[LOG_RECORD_METADATA_ATTR]["orig_message"] == "Hello, world!":
                 found_msg = True
 

--- a/python_modules/dagster/dagster_tests/logging_tests/test_logging.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_logging.py
@@ -314,6 +314,31 @@ def test_json_console_logger(capsys):
     assert found_msg
 
 
+def test_json_console_run_failure(capsys):
+    @op
+    def failing_op(context):
+        context.log.info("Hello, world!")
+        assert False
+
+    wrap_op_in_graph_and_execute(
+        failing_op,
+        logger_defs={"json": json_console_logger},
+        run_config={"loggers": {"json": {"config": {}}}},
+        raise_on_error=False,
+    )
+
+    captured = capsys.readouterr()
+
+    found_msg = False
+    for line in captured.err.split("\n"):
+        if line:
+            parsed = json.loads(line)
+            if parsed[LOG_RECORD_METADATA_ATTR]["orig_message"] == "Hello, world!":
+                found_msg = True
+
+    assert found_msg
+
+
 def test_job_logging(capsys):
     @op
     def foo(context):


### PR DESCRIPTION
## Summary & Motivation

Something I encountered while trying to move classes from `NamedTuple` to Pydantic: the `json_console_logger` tries to invoke `json.dumps` on dictionaries with values that are `DagsterEvent`s.

This works ...sometimes, because it treats the events as tuples. However, if those events happen to include include objects that are not `json.dump`-able types, then it fails. For example, run failure events include a `RunFailureReason` enum which is not `json.dump`-able.

In the process of working on this, I also noticed that `DagsterEvent`s get included twice on lines logged by the `json_console_logger`:
- Once because they're the value for the "dagster_event" key on the top-level record dict.
- Once because they're the value for the "dagster_event" key inside the value for the "dagster_meta" key in the top-level record dict.

This PR changes the `json_console_logger` to:
- Ignore the top-level "dagster_event" key (if I understand correctly from talking to Sean, it has been around less often than "dagster_meta").
- Within the "dagster_meta" value, use our serdes library to serialize the `DagsterEvent`.


Before:
```json
{"args": [], "created": 1714508485.1674728, "dagster_event": ["STEP_SUCCESS", "wraps_hello_world", [["hello_world", null], "hello_world"], ["hello_world", null], "COMPUTE", {"job_name": "wraps_hello_world", "op_name": "hello_world", "resource_fn_name": "None", "resource_name": "None", "run_id": "0c4a8273-bac9-4e12-88de-0f9bafca527c", "step_key": "hello_world"}, [2.6706659991759807], "Finished execution of step \"hello_world\" in 2.67ms.", 54168, "hello_world"], "dagster_event_batch_metadata": null, "dagster_meta": {"dagster_event": ["STEP_SUCCESS", "wraps_hello_world", [["hello_world", null], "hello_world"], ["hello_world", null], "COMPUTE", {"job_name": "wraps_hello_world", "op_name": "hello_world", "resource_fn_name": "None", "resource_name": "None", "run_id": "0c4a8273-bac9-4e12-88de-0f9bafca527c", "step_key": "hello_world"}, [2.6706659991759807], "Finished execution of step \"hello_world\" in 2.67ms.", 54168, "hello_world"], "dagster_event_batch_metadata": null, "job_name": "wraps_hello_world", "job_tags": {}, "log_message_id": "1a1701a4-dbc3-4b97-a5ab-49b5155863d3", "log_timestamp": "2024-04-30T20:21:25.166985", "op_name": "hello_world", "orig_message": "Finished execution of step \"hello_world\" in 2.67ms.", "resource_fn_name": null, "resource_name": null, "run_id": "0c4a8273-bac9-4e12-88de-0f9bafca527c", "step_key": "hello_world"}, "exc_info": null, "exc_text": null, "filename": "log_manager.py", "funcName": "emit", "levelname": "DEBUG", "levelno": 10, "lineno": 281, "module": "log_manager", "msecs": 167.47283935546875, "msg": "wraps_hello_world - 0c4a8273-bac9-4e12-88de-0f9bafca527c - 54168 - hello_world - STEP_SUCCESS - Finished execution of step \"hello_world\" in 2.67ms.", "name": "dagster", "pathname": "/Users/sryza/dagster/python_modules/dagster/dagster/_core/log_manager.py", "process": 54168, "processName": "MainProcess", "relativeCreated": 2159.540891647339, "stack_info": null, "thread": 8633771520, "threadName": "MainThread"}
```

After:
```json
{"args": [], "created": 1714508420.212634, "dagster_event_batch_metadata": null, "dagster_meta": {"dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepSuccessData", "duration_ms": 2.777916000923142}, "event_type_value": "STEP_SUCCESS", "logging_tags": {"job_name": "wraps_hello_world", "op_name": "hello_world", "resource_fn_name": "None", "resource_name": "None", "run_id": "568862ad-3497-4986-8583-72a5554070b0", "step_key": "hello_world"}, "message": "Finished execution of step \"hello_world\" in 2.78ms.", "pid": 53954, "pipeline_name": "wraps_hello_world", "solid_handle": {"__class__": "SolidHandle", "name": "hello_world", "parent": null}, "step_handle": {"__class__": "StepHandle", "key": "hello_world", "solid_handle": {"__class__": "SolidHandle", "name": "hello_world", "parent": null}}, "step_key": "hello_world", "step_kind_value": "COMPUTE"}, "dagster_event_batch_metadata": null, "job_name": "wraps_hello_world", "job_tags": {}, "log_message_id": "b194832b-201d-491b-a278-499700df8ffb", "log_timestamp": "2024-04-30T20:20:20.212144", "op_name": "hello_world", "orig_message": "Finished execution of step \"hello_world\" in 2.78ms.", "resource_fn_name": null, "resource_name": null, "run_id": "568862ad-3497-4986-8583-72a5554070b0", "step_key": "hello_world"}, "exc_info": null, "exc_text": null, "filename": "log_manager.py", "funcName": "emit", "levelname": "DEBUG", "levelno": 10, "lineno": 281, "module": "log_manager", "msecs": 212.63408660888672, "msg": "wraps_hello_world - 568862ad-3497-4986-8583-72a5554070b0 - 53954 - hello_world - STEP_SUCCESS - Finished execution of step \"hello_world\" in 2.78ms.", "name": "dagster", "pathname": "/Users/sryza/dagster/python_modules/dagster/dagster/_core/log_manager.py", "process": 53954, "processName": "MainProcess", "relativeCreated": 2150.8212089538574, "stack_info": null, "thread": 8671471104, "threadName": "MainThread"}
```

## How I Tested These Changes
