### PR TITLE
[DS][15/n] Move operators to separate folder

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -8,8 +8,8 @@ from dagster._core.definitions.auto_materialize_rule_evaluation import (
 from dagster._core.definitions.declarative_scheduling.asset_condition import (
     AssetConditionEvaluation,
     AssetSubsetWithMetadata,
-    RuleCondition,
 )
+from dagster._core.definitions.declarative_scheduling.operators.rule_operator import RuleCondition
 from dagster._core.definitions.metadata import DagsterAssetMetadataValue
 from dagster._core.scheduler.instigation import AutoMaterializeAssetEvaluationRecord
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -151,6 +151,8 @@ def get_backcompat_asset_condition_evaluation_state(
     from dagster._core.definitions.auto_materialize_rule_impls import MaterializeOnMissingRule
     from dagster._core.definitions.declarative_scheduling.asset_condition import (
         AssetConditionEvaluationState,
+    )
+    from dagster._core.definitions.declarative_scheduling.operators.rule_operator import (
         RuleCondition,
     )
 

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -284,7 +284,7 @@ class AutoMaterializePolicy(
     def to_asset_condition(self) -> AssetCondition:
         """Converts a set of materialize / skip rules into a single binary expression."""
         from .auto_materialize_rule_impls import DiscardOnMaxMaterializationsExceededRule
-        from .declarative_scheduling.asset_condition import (
+        from .declarative_scheduling.operators.boolean_operators import (
             AndAssetCondition,
             NotAssetCondition,
             OrAssetCondition,

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -62,7 +62,7 @@ class AutoMaterializeRule(ABC):
 
     def to_asset_condition(self) -> "AssetCondition":
         """Converts this AutoMaterializeRule into an AssetCondition."""
-        from .declarative_scheduling.asset_condition import RuleCondition
+        from .declarative_scheduling.operators.rule_operator import RuleCondition
 
         return RuleCondition(rule=self)
 

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
@@ -213,7 +213,8 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(PydanticModelSerializer
     def _asset_condition_snapshot_from_rule_snapshot(
         self, rule_snapshot: AutoMaterializeRuleSnapshot
     ) -> "AssetConditionSnapshot":
-        from .declarative_scheduling.asset_condition import AssetConditionSnapshot, RuleCondition
+        from .declarative_scheduling.asset_condition import AssetConditionSnapshot
+        from .declarative_scheduling.operators.rule_operator import RuleCondition
 
         unique_id_parts = [rule_snapshot.class_name, rule_snapshot.description]
         unique_id = non_secure_md5_hash_str("".join(unique_id_parts).encode())
@@ -282,6 +283,8 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(PydanticModelSerializer
             AssetConditionEvaluation,
             AssetConditionSnapshot,
             HistoricalAllPartitionsSubsetSentinel,
+        )
+        from .declarative_scheduling.operators.boolean_operators import (
             NotAssetCondition,
             OrAssetCondition,
         )
@@ -372,11 +375,11 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(PydanticModelSerializer
         context: UnpackContext,
     ) -> "AssetConditionEvaluationWithRunIds":
         from .declarative_scheduling.asset_condition import (
-            AndAssetCondition,
             AssetConditionEvaluation,
             AssetConditionSnapshot,
             HistoricalAllPartitionsSubsetSentinel,
         )
+        from .declarative_scheduling.operators.boolean_operators import AndAssetCondition
 
         asset_key = cast(AssetKey, unpacked_dict.get("asset_key"))
         partition_subsets_by_condition = cast(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
@@ -1,7 +1,7 @@
 from .asset_condition import AssetCondition as AssetCondition
 
 # for whitelist_for_serdes
-from .dep_condition import (
+from .operators.dep_operators import (
     AllDepsCondition as AllDepsCondition,
     AnyDepsCondition as AnyDepsCondition,
 )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
@@ -4,8 +4,8 @@ from typing import Optional
 
 from dagster._core.asset_graph_view.asset_graph_view import AssetSlice
 
-from .asset_condition import AssetCondition, AssetConditionResult
-from .scheduling_context import SchedulingContext
+from ..asset_condition import AssetCondition, AssetConditionResult
+from ..scheduling_context import SchedulingContext
 
 
 class SliceSchedulingCondition(AssetCondition):

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/updated_since_cron_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/updated_since_cron_condition.py
@@ -2,8 +2,8 @@ import datetime
 
 from dagster._utils.schedules import reverse_cron_string_iterator
 
-from .asset_condition import AssetCondition, AssetConditionResult
-from .scheduling_context import SchedulingContext
+from ..asset_condition import AssetCondition, AssetConditionResult
+from ..scheduling_context import SchedulingContext
 
 
 class UpdatedSinceCronCondition(AssetCondition):

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/boolean_operators.py
@@ -1,0 +1,90 @@
+from typing import List, Sequence
+
+from dagster._annotations import experimental
+from dagster._serdes.serdes import whitelist_for_serdes
+
+from ..asset_condition import AssetCondition, AssetConditionResult
+from ..scheduling_context import SchedulingContext
+
+
+@experimental
+@whitelist_for_serdes
+class AndAssetCondition(AssetCondition):
+    """This class represents the condition that all of its children evaluate to true."""
+
+    operands: Sequence[AssetCondition]
+
+    @property
+    def children(self) -> Sequence[AssetCondition]:
+        return self.operands
+
+    @property
+    def description(self) -> str:
+        return "All of"
+
+    def evaluate(self, context: SchedulingContext) -> AssetConditionResult:
+        child_results: List[AssetConditionResult] = []
+        true_subset = context.candidate_subset
+        for child in self.children:
+            child_context = context.for_child_condition(
+                child_condition=child, candidate_subset=true_subset
+            )
+            child_result = child.evaluate(child_context)
+            child_results.append(child_result)
+            true_subset &= child_result.true_subset
+        return AssetConditionResult.create_from_children(context, true_subset, child_results)
+
+
+@experimental
+@whitelist_for_serdes
+class OrAssetCondition(AssetCondition):
+    """This class represents the condition that any of its children evaluate to true."""
+
+    operands: Sequence[AssetCondition]
+
+    @property
+    def children(self) -> Sequence[AssetCondition]:
+        return self.operands
+
+    @property
+    def description(self) -> str:
+        return "Any of"
+
+    def evaluate(self, context: SchedulingContext) -> AssetConditionResult:
+        child_results: List[AssetConditionResult] = []
+        true_subset = context.asset_graph_view.create_empty_slice(
+            context.asset_key
+        ).convert_to_valid_asset_subset()
+        for child in self.children:
+            child_context = context.for_child_condition(
+                child_condition=child, candidate_subset=context.candidate_subset
+            )
+            child_result = child.evaluate(child_context)
+            child_results.append(child_result)
+            true_subset |= child_result.true_subset
+        return AssetConditionResult.create_from_children(context, true_subset, child_results)
+
+
+@experimental
+@whitelist_for_serdes
+class NotAssetCondition(AssetCondition):
+    """This class represents the condition that none of its children evaluate to true."""
+
+    operand: AssetCondition
+
+    @property
+    def description(self) -> str:
+        return "Not"
+
+    @property
+    def children(self) -> Sequence[AssetCondition]:
+        return [self.operand]
+
+    def evaluate(self, context: SchedulingContext) -> AssetConditionResult:
+        child_context = context.for_child_condition(
+            child_condition=self.operand, candidate_subset=context.candidate_subset
+        )
+        child_result = self.operand.evaluate(child_context)
+        true_subset = context.candidate_subset - child_result.true_subset
+
+        return AssetConditionResult.create_from_children(context, true_subset, [child_result])

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/dep_operators.py
@@ -1,8 +1,8 @@
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._serdes.serdes import whitelist_for_serdes
 
-from .asset_condition import AssetCondition, AssetConditionResult
-from .scheduling_context import SchedulingContext
+from ..asset_condition import AssetCondition, AssetConditionResult
+from ..scheduling_context import SchedulingContext
 
 
 class DepConditionWrapperCondition(AssetCondition):

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/rule_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/rule_operator.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+from dagster._annotations import experimental
+from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
+from dagster._serdes.serdes import whitelist_for_serdes
+from dagster._utils.security import non_secure_md5_hash_str
+
+from ..asset_condition import AssetCondition, AssetConditionResult
+from ..scheduling_context import SchedulingContext
+
+
+@experimental
+@whitelist_for_serdes
+class RuleCondition(AssetCondition):
+    """This class represents the condition that a particular AutoMaterializeRule is satisfied."""
+
+    rule: AutoMaterializeRule
+
+    def get_unique_id(self, parent_unique_id: Optional[str]) -> str:
+        # preserves old (bad) behavior of not including the parent_unique_id to avoid inavlidating
+        # old serialized information
+        parts = [self.rule.__class__.__name__, self.description]
+        return non_secure_md5_hash_str("".join(parts).encode())
+
+    @property
+    def description(self) -> str:
+        return self.rule.description
+
+    def evaluate(self, context: SchedulingContext) -> AssetConditionResult:
+        context.legacy_context.root_context.daemon_context.logger.debug(
+            f"Evaluating rule: {self.rule.to_snapshot()}"
+        )
+        evaluation_result = self.rule.evaluate_for_asset(context)
+        context.legacy_context.root_context.daemon_context.logger.debug(
+            f"Rule returned {evaluation_result.true_subset.size} partitions "
+            f"({evaluation_result.end_timestamp - evaluation_result.start_timestamp:.2f} seconds)"
+        )
+        return evaluation_result

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
@@ -8,13 +8,15 @@ from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.declarative_scheduling.asset_condition import (
-    AndAssetCondition,
     AssetCondition,
     AssetConditionEvaluationState,
     AssetConditionResult,
 )
 from dagster._core.definitions.declarative_scheduling.asset_condition_evaluation_context import (
     AssetConditionEvaluationContext,
+)
+from dagster._core.definitions.declarative_scheduling.operators.boolean_operators import (
+    AndAssetCondition,
 )
 from dagster._core.definitions.declarative_scheduling.scheduling_context import (
     SchedulingContext,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/custom_condition_scenarios.py
@@ -1,15 +1,11 @@
 from dagster import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
-from dagster._core.definitions.declarative_scheduling.asset_condition import (
-    AssetCondition,
-    RuleCondition,
-)
+from dagster._core.definitions.declarative_scheduling.asset_condition import AssetCondition
+from dagster._core.definitions.declarative_scheduling.operators.rule_operator import RuleCondition
 
 from ..base_scenario import run_request
 from ..scenario_specs import one_asset, two_assets_in_sequence
-from .asset_daemon_scenario import (
-    AssetDaemonScenario,
-)
+from .asset_daemon_scenario import AssetDaemonScenario
 
 custom_condition_scenarios = [
     AssetDaemonScenario(


### PR DESCRIPTION
## Summary & Motivation

Just organizing stuff a bit more -- in the past it's been very painful to scroll through a huge volume of files (or very large files) when looking for a specific implementation. This separates out the "operators", which take in other conditions as parameters, into a separate subfolder. The next PR will move operands into their own subfolder.

Another option is to just merge operators / operands into a single "implementations" folder, which also seems fine.

## How I Tested These Changes
