### PR TITLE
Experimental flag to attach row count metadata as part of `dagster-dbt` execution

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -785,6 +785,14 @@ class DbtCliInvocation:
                 def my_dbt_assets(context, dbt: DbtCliResource):
                     yield from dbt.cli(["run"], context=context).stream()
         """
+        has_any_parallel_tasks = self.should_fetch_row_count
+
+        if not has_any_parallel_tasks:
+            # If we're not enqueuing any parallel tasks, we can just stream the events in
+            # the main thread.
+            yield from self._stream_asset_events()
+            return
+
         if self.should_fetch_row_count:
             logger.info(
                 "Row counts will be fetched for non-view models once they are materialized."

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_row_count_postprocessing.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_row_count_postprocessing.py
@@ -34,7 +34,7 @@ def test_no_row_count(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
 def test_row_count(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
     @dbt_assets(manifest=test_jaffle_shop_manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        yield from dbt.cli(["build"], context=context).fetch_row_counts().stream()
+        yield from dbt.cli(["build"], context=context).enable_fetch_row_count().stream()
 
     result = materialize(
         [my_dbt_assets],

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_row_count_postprocessing.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_row_count_postprocessing.py
@@ -1,0 +1,64 @@
+import os
+from typing import Any, Dict, cast
+
+from dagster import (
+    AssetExecutionContext,
+    _check as check,
+    materialize,
+)
+from dagster._core.definitions.metadata import IntMetadataValue
+from dagster_dbt.asset_decorator import dbt_assets
+from dagster_dbt.core.resources_v2 import DbtCliResource
+
+from ...dbt_projects import test_jaffle_shop_path
+
+
+def test_no_row_count(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
+    @dbt_assets(manifest=test_jaffle_shop_manifest)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        yield from dbt.cli(["build"], context=context).stream()
+
+    result = materialize(
+        [my_dbt_assets],
+        resources={"dbt": DbtCliResource(project_dir=os.fspath(test_jaffle_shop_path))},
+    )
+
+    assert result.success
+
+    assert not any(
+        "dagster/row_count" in event.materialization.metadata
+        for event in result.get_asset_materialization_events()
+    )
+
+
+def test_row_count(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
+    @dbt_assets(manifest=test_jaffle_shop_manifest)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        yield from dbt.cli(["build"], context=context).fetch_row_counts().stream()
+
+    result = materialize(
+        [my_dbt_assets],
+        resources={"dbt": DbtCliResource(project_dir=os.fspath(test_jaffle_shop_path))},
+    )
+
+    assert result.success
+
+    # Validate that we have row counts for all models which are not views
+    assert all(
+        "dagster/row_count" not in event.materialization.metadata
+        for event in result.get_asset_materialization_events()
+        # staging tables are views, so we don't attempt to get row counts for them
+        if "stg" in check.not_none(event.asset_key).path[-1]
+    )
+    assert all(
+        "dagster/row_count" in event.materialization.metadata
+        for event in result.get_asset_materialization_events()
+        if "stg" not in check.not_none(event.asset_key).path[-1]
+    )
+
+    row_counts = [
+        cast(IntMetadataValue, event.materialization.metadata["dagster/row_count"]).value
+        for event in result.get_asset_materialization_events()
+        if "stg" not in check.not_none(event.asset_key).path[-1]
+    ]
+    assert all(row_count and row_count > 0 for row_count in row_counts), row_counts

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_row_count_postprocessing.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_row_count_postprocessing.py
@@ -10,7 +10,7 @@ from dagster._core.definitions.metadata import IntMetadataValue
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.core.resources_v2 import DbtCliResource
 
-from ...dbt_projects import test_jaffle_shop_path
+from ..dbt_projects import test_jaffle_shop_path
 
 
 def test_no_row_count(test_jaffle_shop_manifest: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary

Adds a new `fetch_table_metadata` experimental flag to `DbtCliResource.cli` which allows us to fetch `dagster/total_row_count` (introduced in #21524) to dbt-built tables:

```python
@dbt_assets(manifest=dbt_manifest)
def jaffle_shop_dbt_assets(
    context: AssetExecutionContext,
    dbt: DbtCliResource,
):
    yield from dbt.cli(
        ["build"],
        context=context,
        fetch_table_metadata=True,
    ).stream()
```

<img width="534" alt="Screenshot 2024-05-03 at 11 03 19 AM" src="https://github.com/dagster-io/dagster/assets/10215173/c3e64633-5fc3-44e4-99e3-601f0c7a0856">

Under the hood, this PR uses dbt's `dbt.adapters.base.impl.BaseAdapter` abstraction to let Dagster connect to the user's warehouse using the dbt-provided credentials. Right now, we just run a simple `select count(*)` on the tables specified in each `AssetMaterialization` and `Output`, but this lays some groundwork we could use for fetching other data as well.

There are a few caveats:
- When using duckdb, we wait for the dbt run to conclude, since duckdb does not allow simultaneous connections when a write connection is open (e.g. when dbt is running)
- We don't query row counts on views, since they may include non-trivial sql which could be expensive to query

## Test Plan

Tested locally w/ duckdb, bigquery, and snowflake. Introduced basic pytest test to test against duckdb.