### PR TITLE
Revert "Revert "MetadataValue subclasses to DagsterModel (#21324)" (#…

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
@@ -1,4 +1,21 @@
-from dagster import GraphDefinition, NodeInvocation, op
+from dagster import (
+    AssetKey,
+    GraphDefinition,
+    IntMetadataValue,
+    JsonMetadataValue,
+    MetadataValue,
+    NodeInvocation,
+    TableColumn,
+    TableColumnDep,
+    TableColumnLineage,
+    TableMetadataValue,
+    TableRecord,
+    TableSchema,
+    TableSchemaMetadataValue,
+    UrlMetadataValue,
+    op,
+)
+from dagster._serdes.serdes import deserialize_value, serialize_value
 
 
 def test_op_instance_tags():
@@ -25,3 +42,66 @@ def test_op_instance_tags():
 
     assert result.success
     assert called["yup"]
+
+
+def test_table_schema_from_name_type_dict():
+    assert TableSchema.from_name_type_dict({"foo": "customtype", "bar": "string"}) == TableSchema(
+        columns=[
+            TableColumn(name="foo", type="customtype"),
+            TableColumn(name="bar", type="string"),
+        ],
+    )
+
+
+def test_table_serialization():
+    table_metadata = MetadataValue.table(
+        records=[
+            TableRecord(dict(foo=1, bar=2)),
+        ],
+    )
+    serialized = serialize_value(table_metadata)
+    assert deserialize_value(serialized, TableMetadataValue) == table_metadata
+
+
+def test_metadata_value_column_lineage() -> None:
+    expected_column_lineage = TableColumnLineage(
+        {"foo": [TableColumnDep(asset_key=AssetKey("bar"), column_name="baz")]}
+    )
+    column_lineage_metadata_value = MetadataValue.column_lineage(expected_column_lineage)
+
+    assert column_lineage_metadata_value.value == expected_column_lineage
+
+
+def test_int_metadata_value():
+    assert IntMetadataValue(5).value == 5
+    assert IntMetadataValue(value=5).value == 5
+
+
+def test_url_metadata_value():
+    url = "http://dagster.io"
+    assert UrlMetadataValue(url).value == url
+    assert UrlMetadataValue(url).url == url
+    assert UrlMetadataValue(url=url).value == url
+
+
+def test_table_metadata_value():
+    records = [TableRecord(dict(foo=1, bar=2))]
+    schema = TableSchema(
+        columns=[TableColumn(name="foo", type="int"), TableColumn(name="bar", type="int")]
+    )
+    metadata_val = TableMetadataValue(records, schema=schema)
+
+    assert metadata_val.records == records
+    assert metadata_val.schema == schema
+
+
+def test_table_schema_metadata_value():
+    schema = TableSchema(
+        columns=[TableColumn(name="foo", type="int"), TableColumn(name="bar", type="int")]
+    )
+    assert TableSchemaMetadataValue(schema).schema == schema
+
+
+def test_json_metadata_value():
+    assert JsonMetadataValue({"a": "b"}).data == {"a": "b"}
+    assert JsonMetadataValue({"a": "b"}).value == {"a": "b"}

--- a/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
@@ -29,7 +29,6 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.metadata import (
     DagsterInvalidMetadata,
     TableColumnLineageMetadataValue,
-    TableMetadataValue,
     normalize_metadata,
 )
 from dagster._core.definitions.metadata.table import (
@@ -43,7 +42,6 @@ from dagster._core.definitions.metadata.table import (
 )
 from dagster._core.execution.execution_result import ExecutionResult
 from dagster._core.snap.node import build_node_defs_snapshot
-from dagster._serdes.serdes import deserialize_value, serialize_value
 
 
 def step_events_of_type(result: ExecutionResult, node_name: str, event_type: DagsterEventType):
@@ -368,34 +366,6 @@ def test_complex_table_schema():
         ),
         TableSchema,
     )
-
-
-def test_table_schema_from_name_type_dict():
-    assert TableSchema.from_name_type_dict({"foo": "customtype", "bar": "string"}) == TableSchema(
-        columns=[
-            TableColumn(name="foo", type="customtype"),
-            TableColumn(name="bar", type="string"),
-        ],
-    )
-
-
-def test_table_serialization():
-    table_metadata = MetadataValue.table(
-        records=[
-            TableRecord(dict(foo=1, bar=2)),
-        ],
-    )
-    serialized = serialize_value(table_metadata)
-    assert deserialize_value(serialized, TableMetadataValue) == table_metadata
-
-
-def test_metadata_value_column_lineage() -> None:
-    expected_column_lineage = TableColumnLineage(
-        {"foo": [TableColumnDep(asset_key=AssetKey("bar"), column_name="baz")]}
-    )
-    column_lineage_metadata_value = MetadataValue.column_lineage(expected_column_lineage)
-
-    assert column_lineage_metadata_value.value == expected_column_lineage
 
 
 def test_bool_metadata_value():


### PR DESCRIPTION
…21462)"

This reverts commit 7b103db9438bb4e5018c7ae67e845982a9a376ac.

## Summary & Motivation

This moves `MetadataValue` subclasses to also be subclasses of `DagsterModel`, instead of `NamedTuple`s.

This was originally reverted because it caused a test failure. This PR fixed the test failure: https://github.com/dagster-io/dagster/pull/21463. This PR further reduced the risk: https://github.com/dagster-io/dagster/pull/21531.

Original PR: https://github.com/dagster-io/dagster/pull/21324

## How I Tested These Changes
