### PR TITLE
test(dbt): use `dbt parse` to create manifest

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
@@ -60,7 +60,7 @@ def _create_dbt_invocation(project_dir: Path, build_project: bool = False) -> Db
     if not project_dir.joinpath("dbt_packages").exists():
         dbt.cli(["deps"], raise_on_error=False).wait()
 
-    dbt_invocation = dbt.cli(["compile"]).wait()
+    dbt_invocation = dbt.cli(["parse"]).wait()
 
     if build_project:
         dbt.cli(["build", "--exclude", "resource_type:test"], raise_on_error=False).wait()


### PR DESCRIPTION
## Summary & Motivation
Addresses the following issues:

- https://buildkite.com/dagster/dagster-dagster/builds/81546#018f2f91-5d39-4e9a-abfe-840e458c730e/502-974
- https://buildkite.com/dagster/dagster-dagster/builds/81633#018f314f-daf3-43f3-b328-619f8abe6cba/503-975

Instead of creating the manifest using `dbt compile`, which creates a connection to the database, use `dbt parse`, which doesn't need a connection. This way, the local duckdb file will never be locked on fixture creation.

I'm not sure why this error is happening in the first place. This is a session-scoped fixture, meaning it should only be instantiated once per worker, at session start. This error makes it seem like that invariant is not being followed. Fix it anyways.

## How I Tested These Changes
bk
