### PR TITLE
[perf] AssetKey.__eq__ tweaks

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_key.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_key.py
@@ -57,14 +57,10 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
         return hash(tuple(self.path))
 
     def __eq__(self, other):
-        if not isinstance(other, AssetKey):
+        if other.__class__ is not self.__class__:
             return False
-        if len(self.path) != len(other.path):
-            return False
-        for i in range(0, len(self.path)):
-            if self.path[i] != other.path[i]:
-                return False
-        return True
+
+        return self.path == other.path
 
     def to_string(self) -> str:
         """E.g. '["first_component", "second_component"]'."""


### PR DESCRIPTION
Noticed `AssetKey.__eq__` stand out in some profiling so took a pass at tightening it up. 

## How I Tested These Changes

using this script https://gist.github.com/alangenfeld/526e0d33af8b70ad2dff438258b0d574

before
```
(py311) ~/dagster:master$  python /tmp/key.py
1000
         5171004 function calls in 0.829 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2000    0.000    0.000    0.001    0.000 <frozen abc>:117(__instancecheck__)
     2000    0.000    0.000    0.001    0.000 <string>:1(<lambda>)
     2000    0.001    0.000    0.003    0.000 __init__.py:1100(sequence_param)
     2000    0.001    0.000    0.001    0.000 __init__.py:1736(_check_iterable_items)
     2000    0.002    0.000    0.005    0.000 asset_key.py:42(__new__)
  1000000    0.601    0.000    0.709    0.000 asset_key.py:59(__eq__)
        1    0.000    0.000    0.000    0.000 cProfile.py:118(__exit__)
        1    0.090    0.090    0.829    0.829 key.py:16(test)
     2000    0.003    0.000    0.024    0.000 key.py:7(random_key)
     6000    0.003    0.000    0.021    0.000 random.py:480(choices)
     6000    0.012    0.000    0.017    0.000 random.py:493(<listcomp>)
     2000    0.000    0.000    0.000    0.000 {built-in method __new__ of type object at 0x1013a7ca8}
     2000    0.000    0.000    0.000    0.000 {built-in method _abc._abc_instancecheck}
  1010000    0.025    0.000    0.026    0.000 {built-in method builtins.isinstance}
  3006000    0.084    0.000    0.084    0.000 {built-in method builtins.len}
        1    0.000    0.000    0.000    0.000 {built-in method builtins.print}
    60000    0.002    0.000    0.002    0.000 {built-in method math.floor}
     1000    0.000    0.000    0.000    0.000 {method 'append' of 'list' objects}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
     6000    0.001    0.000    0.001    0.000 {method 'join' of 'str' objects}
    60000    0.002    0.000    0.002    0.000 {method 'random' of '_random.Random' objects}

```

after
```
(py311) ~/dagster:al/05-01-_perf_assetkey.__eq___tweaks$  python /tmp/key.py
1000
         1171004 function calls in 0.361 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2000    0.000    0.000    0.001    0.000 <frozen abc>:117(__instancecheck__)
     2000    0.000    0.000    0.001    0.000 <string>:1(<lambda>)
     2000    0.001    0.000    0.005    0.000 __init__.py:1100(sequence_param)
     2000    0.001    0.000    0.002    0.000 __init__.py:1736(_check_iterable_items)
     2000    0.002    0.000    0.008    0.000 asset_key.py:42(__new__)
  1000000    0.203    0.000    0.203    0.000 asset_key.py:59(__eq__)
        1    0.000    0.000    0.000    0.000 cProfile.py:118(__exit__)
        1    0.118    0.118    0.361    0.361 key.py:16(test)
     2000    0.004    0.000    0.031    0.000 key.py:7(random_key)
     6000    0.006    0.000    0.027    0.000 random.py:480(choices)
     6000    0.015    0.000    0.020    0.000 random.py:493(<listcomp>)
     2000    0.000    0.000    0.000    0.000 {built-in method __new__ of type object at 0x102de3ca8}
     2000    0.001    0.000    0.001    0.000 {built-in method _abc._abc_instancecheck}
    10000    0.001    0.000    0.002    0.000 {built-in method builtins.isinstance}
     6000    0.001    0.000    0.001    0.000 {built-in method builtins.len}
        1    0.000    0.000    0.000    0.000 {built-in method builtins.print}
    60000    0.003    0.000    0.003    0.000 {built-in method math.floor}
     1000    0.000    0.000    0.000    0.000 {method 'append' of 'list' objects}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
     6000    0.001    0.000    0.001    0.000 {method 'join' of 'str' objects}
    60000    0.003    0.000    0.003    0.000 {method 'random' of '_random.Random' objects}
    ```
