### PR TITLE
Display error message from cli asset materialize if partitioned asset has no --partition

### DIFF
--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -73,6 +73,11 @@ def execute_materialize_command(instance: DagsterInstance, kwargs: Mapping[str, 
 
         tags = partitions_def.get_tags_for_partition_key(partition)
     else:
+        if any(
+            implicit_job_def.asset_layer.get(asset_key).partitions_def is not None
+            for asset_key in asset_keys
+        ):
+            check.failed("Asset has partitions, but no '--partition' option was provided")
         tags = {}
 
     result = execute_job(

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_materialize_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_materialize_command.py
@@ -94,6 +94,14 @@ def test_partition_option_with_non_partitioned_asset():
         )
 
 
+def test_no_partition_option_with_partitioned_asset():
+    with instance_for_test():
+        result = invoke_materialize("partitioned_asset")
+        assert "Asset has partitions, but no '--partition' option was provided" in str(
+            result.exception
+        )
+
+
 def test_asset_key_missing():
     with instance_for_test():
         result = invoke_materialize("nonexistent_asset")


### PR DESCRIPTION
## Summary & Motivation

- Provides more clear messaging when trying to materialize partitioned asset with no `--partition` flag.

## How I Tested These Changes

- Added unit test
- Some manual invocation:

```
# ~/src/playground/gh-partitions.py

from dagster import asset, StaticPartitionsDefinition, Definitions

color_partitions = StaticPartitionsDefinition(["red", "yellow", "blue"])


@asset(partitions_def=color_partitions)
def color_asset(context):
    color = context.partition_key
    context.log.info(f"Processing color: {color}")
    return f"Data for color {color}"


@asset()
def another_one():
    print('o/')

defs = Definitions(assets=[color_asset, another_one])
```

```
$ dagster asset materialize -f ~/src/playground/gh-partitions.py --select another_one
$ dagster asset materialize -f ~/src/playground/gh-partitions.py --select another_one --partition red
 
$ dagster asset materialize -f ~/src/playground/gh-partitions.py --select color_asset
$ dagster asset materialize -f ~/src/playground/gh-partitions.py --select color_asset --partition red
```

Closes https://github.com/dagster-io/dagster/issues/21559