### PR TITLE
fix build_column_schema_change_checks

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/test_schema_change_checks.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_schema_change_checks.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Optional, Sequence
 
 from dagster import (
     AssetSelection,
@@ -13,6 +13,7 @@ from dagster import (
     materialize,
 )
 from dagster._core.definitions.metadata import TableMetadataSet
+from dagster._core.execution.context.compute import AssetExecutionContext
 
 
 def execute_checks(asset_checks, instance=None) -> ExecuteInProcessResult:
@@ -25,24 +26,26 @@ def execute_checks(asset_checks, instance=None) -> ExecuteInProcessResult:
 
 
 def assert_expected_schema_change(
-    old_schema: TableSchema,
-    new_schema: TableSchema,
+    old_schema: Optional[TableSchema],
+    new_schema: Optional[TableSchema],
     description_substrs: Sequence[str],
     passed: bool,
 ):
     @asset(name="asset1")
-    def old():
-        return MaterializeResult(metadata=dict(TableMetadataSet(column_schema=old_schema)))
-
-    @asset(name="asset1")
-    def new():
-        return MaterializeResult(metadata=dict(TableMetadataSet(column_schema=new_schema)))
+    def my_asset(context: AssetExecutionContext):
+        if context.has_tag("old"):
+            return MaterializeResult(
+                metadata=dict(TableMetadataSet(column_schema=old_schema)) if old_schema else None
+            )
+        return MaterializeResult(
+            metadata=dict(TableMetadataSet(column_schema=new_schema)) if new_schema else None
+        )
 
     instance = DagsterInstance.ephemeral()
-    materialize([old], instance=instance)
-    materialize([new], instance=instance)
+    materialize([my_asset], instance=instance, tags={"old": "true"})
+    materialize([my_asset], instance=instance)
 
-    checks = build_column_schema_change_checks(assets=[new])
+    checks = build_column_schema_change_checks(assets=[my_asset])
     result = execute_checks(checks, instance=instance)
     assert result.success
 
@@ -57,7 +60,28 @@ def assert_expected_schema_change(
         assert substr in description
 
 
-def test_build_column_schema_change_checks():
+def test_missing_schema():
+    assert_expected_schema_change(
+        None,
+        None,
+        ["Latest materialization has no column schema metadata"],
+        False,
+    )
+    assert_expected_schema_change(
+        TableSchema.from_name_type_dict({"foo": "str", "bar": "str"}),
+        None,
+        ["Latest materialization has no column schema metadata"],
+        False,
+    )
+    assert_expected_schema_change(
+        None,
+        TableSchema.from_name_type_dict({"foo": "str", "bar": "str"}),
+        ["Previous materialization has no column schema metadata"],
+        False,
+    )
+
+
+def test_no_change():
     assert_expected_schema_change(
         TableSchema.from_name_type_dict({"foo": "str", "bar": "str"}),
         TableSchema.from_name_type_dict({"foo": "str", "bar": "str"}),
@@ -65,6 +89,8 @@ def test_build_column_schema_change_checks():
         True,
     )
 
+
+def test_changed():
     assert_expected_schema_change(
         TableSchema.from_name_type_dict({"foo": "str", "bar": "str"}),
         TableSchema.from_name_type_dict({"foo": "str", "bar": "str", "baz": "str", "qux": "str"}),
@@ -97,5 +123,96 @@ def test_build_column_schema_change_checks():
             "bar: str -> int",
             "baz: int -> float",
         ],
+        False,
+    )
+
+
+def test_not_enough_materializations():
+    @asset(name="asset1")
+    def my_asset(context: AssetExecutionContext):
+        pass
+
+    checks = build_column_schema_change_checks(assets=[my_asset])
+    result = execute_checks(checks)
+    assert result.success
+
+    check_evals = result.get_asset_check_evaluations()
+    assert len(check_evals) == 1
+    check_eval = check_evals[0]
+
+    assert check_eval.passed
+    assert check_eval.description == "The asset has been materialized fewer than 2 times"
+
+
+def assert_expected_schema_change_two_assets(
+    old_schema_1: Optional[TableSchema],
+    new_schema_1: Optional[TableSchema],
+    old_schema_2: Optional[TableSchema],
+    new_schema_2: Optional[TableSchema],
+    description_1_substrs: Sequence[str],
+    passed_1: bool,
+    description_2_substrs: Sequence[str],
+    passed_2: bool,
+):
+    @asset()
+    def my_asset_1(context: AssetExecutionContext):
+        if context.has_tag("old"):
+            return MaterializeResult(
+                metadata=dict(TableMetadataSet(column_schema=old_schema_1))
+                if old_schema_1
+                else None
+            )
+        return MaterializeResult(
+            metadata=dict(TableMetadataSet(column_schema=new_schema_1)) if new_schema_1 else None
+        )
+
+    @asset()
+    def my_asset_2(context: AssetExecutionContext):
+        if context.has_tag("old"):
+            return MaterializeResult(
+                metadata=dict(TableMetadataSet(column_schema=old_schema_2))
+                if old_schema_2
+                else None
+            )
+        return MaterializeResult(
+            metadata=dict(TableMetadataSet(column_schema=new_schema_2)) if new_schema_2 else None
+        )
+
+    instance = DagsterInstance.ephemeral()
+    materialize([my_asset_1, my_asset_2], instance=instance, tags={"old": "true"})
+    materialize([my_asset_1, my_asset_2], instance=instance)
+
+    checks = build_column_schema_change_checks(assets=[my_asset_1, my_asset_2])
+    result = execute_checks(checks, instance=instance)
+    assert result.success
+
+    check_evals = result.get_asset_check_evaluations()
+    assert len(check_evals) == 2
+    check_evals_by_key = {check_eval.asset_key: check_eval for check_eval in check_evals}
+    check_eval_1 = check_evals_by_key[my_asset_1.key]
+    check_eval_2 = check_evals_by_key[my_asset_2.key]
+
+    assert check_eval_1.passed == passed_1
+    description = check_eval_1.description
+    assert description is not None
+    for substr in description_1_substrs:
+        assert substr in description
+
+    assert check_eval_2.passed == passed_2
+    description = check_eval_2.description
+    assert description is not None
+    for substr in description_2_substrs:
+        assert substr in description
+
+
+def test_multiple_assets():
+    assert_expected_schema_change_two_assets(
+        TableSchema.from_name_type_dict({"foo": "str", "bar": "str"}),
+        TableSchema.from_name_type_dict({"foo": "str", "bar": "str"}),
+        TableSchema.from_name_type_dict({"foo": "str", "bar": "str", "baz": "int"}),
+        TableSchema.from_name_type_dict({"foo": "str", "bar": "int", "baz": "float"}),
+        ["No changes to column schema between previous and latest materialization"],
+        True,
+        ["Column schema changed", "Column type changes:", "bar: str -> int", "baz: int -> float"],
         False,
     )


### PR DESCRIPTION
two bugs:
- if neither the old or new materialization had schema metadata, we'd yield two AssetCheckResults for one check spec (`Compute for op "_checks" returned an output "RAW_DATA__orders_column_schema_change" multiple times`)
- we weren't setting asset key or check name on AssetCheckResult, so it broke when multiple assets were passed in