### PR TITLE
[mysql] use 8.3 image in docker compose

### DIFF
--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/docker-compose.yml
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # This is the standard MySQL test instance, running the latest version of MySQL. We use this for
   # all of our storage tests.
   test-mysql-db:
-    image: mysql:8
+    image: mysql:8.3
     command: mysqld --default-authentication-plugin=mysql_native_password
     container_name: test-mysql-db
     ports:


### PR DESCRIPTION
something is wrong with the 8.4 images that were published yesterday  https://hub.docker.com/layers/library/mysql/8.4.0/images/sha256-53a71a83be1fcbb1489c0fe23d377297f55b77a6c6ce816ca8fa30225adfe2df?context=explore

https://buildkite.com/dagster/dagster-dagster/builds/81667#018f34ad-7455-48a9-acfd-af4ad2ab3c09

## How I Tested These Changes
bk