### PR TITLE
Misc fixes for run status sensor UI

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/InstigationTick.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/InstigationTick.tsx
@@ -53,7 +53,7 @@ export const RunList = ({runIds}: {runIds: string[]}) => {
   );
 };
 
-export const FailedRunList = ({originRunIds}: {originRunIds?: string[]}) => {
+export const TargetedRunList = ({originRunIds}: {originRunIds?: string[]}) => {
   if (!originRunIds || !originRunIds.length) {
     return null;
   }
@@ -61,12 +61,11 @@ export const FailedRunList = ({originRunIds}: {originRunIds?: string[]}) => {
     <Group direction="column" spacing={16}>
       <Box padding={12} border={{side: 'bottom', color: Colors.textLighter()}}>
         <Body>
-          Failed Runs
-          <Tooltip content="Failed runs this tick reacted on and reported back to.">
+          Targeted Runs
+          <Tooltip content="Runs this tick reacted on and reported back to.">
             <Icon name="info" color={Colors.textLight()} />
           </Tooltip>
         </Body>
-
         <RunList runIds={originRunIds} />
       </Box>
       <Box padding={12} margin={{bottom: 8}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
@@ -17,7 +17,7 @@ import {
 } from '@dagster-io/ui-components';
 import {useMemo, useState} from 'react';
 
-import {FailedRunList, RunList} from './InstigationTick';
+import {RunList, TargetedRunList} from './InstigationTick';
 import {HISTORY_TICK_FRAGMENT} from './InstigationUtils';
 import {HistoryTickFragment} from './types/InstigationUtils.types';
 import {SelectedTickQuery, SelectedTickQueryVariables} from './types/TickDetailsDialog.types';
@@ -121,17 +121,15 @@ const TickDetailsDialogImpl = ({tickId, instigationSelector}: InnerProps) => {
       </Box>
       {activeTab === 'result' ? (
         <div style={{height: '500px', overflowY: 'auto'}}>
-          {tick.runIds.length || tick.originRunIds.length ? (
+          {tick.runIds.length ? (
             <>
               <Box padding={{vertical: 12, horizontal: 24}} border="bottom">
-                <Subtitle2>Requested</Subtitle2>
+                <Subtitle2>Requested Runs</Subtitle2>
               </Box>
-              {tick.runIds.length ? (
-                <RunList runIds={tick.runIds} />
-              ) : (
-                <FailedRunList originRunIds={tick.originRunIds} />
-              )}
+              <RunList runIds={tick.runIds} />
             </>
+          ) : tick.originRunIds.length ? (
+            <TargetedRunList originRunIds={tick.originRunIds} />
           ) : null}
           {addedPartitionRequests?.length ? (
             <>


### PR DESCRIPTION
Summary:
- Instead of Failed Runs, say Targeted Runs - so it applies to run success sensors / run started sensors / etc.
- Don't show "Requested" in the case where there are targeted runs, there is a separate "Requested Runs" section below for that case

Test Plan:
View dialog for a regular sensor that launched runs, and a run status sensor that reacted to runs

## Summary & Motivation

## How I Tested These Changes
