### PR TITLE
[DS][23/n] Update SchedulingContext object

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
@@ -1,6 +1,14 @@
 from .legacy.asset_condition import AssetCondition as AssetCondition
-from .operators.dep_operators import (
+from .operands import (
+    InLatestTimeWindowCondition as InLatestTimeWindowCondition,
+    InProgressSchedulingCondition as InProgressSchedulingCondition,
+    MissingSchedulingCondition as MissingSchedulingCondition,
+)
+from .operators import (
     AllDepsCondition as AllDepsCondition,
+    AndAssetCondition as AndAssetCondition,
     AnyDepsCondition as AnyDepsCondition,
+    NotAssetCondition as NotAssetCondition,
+    OrAssetCondition as OrAssetCondition,
 )
 from .scheduling_condition import SchedulingCondition as SchedulingCondition

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
@@ -3,6 +3,7 @@ from abc import abstractmethod
 from typing import Optional
 
 from dagster._core.asset_graph_view.asset_graph_view import AssetSlice
+from dagster._serdes.serdes import whitelist_for_serdes
 
 from ..legacy.asset_condition import AssetCondition
 from ..scheduling_condition import SchedulingResult
@@ -25,6 +26,7 @@ class SliceSchedulingCondition(AssetCondition):
         return SchedulingResult.create(context, true_slice.convert_to_valid_asset_subset())
 
 
+@whitelist_for_serdes
 class MissingSchedulingCondition(SliceSchedulingCondition):
     @property
     def description(self) -> str:
@@ -36,6 +38,7 @@ class MissingSchedulingCondition(SliceSchedulingCondition):
         )
 
 
+@whitelist_for_serdes
 class InProgressSchedulingCondition(SliceSchedulingCondition):
     @property
     def description(self) -> str:
@@ -45,6 +48,7 @@ class InProgressSchedulingCondition(SliceSchedulingCondition):
         return context.asset_graph_view.compute_in_progress_asset_slice(context.asset_key)
 
 
+@whitelist_for_serdes
 class InLatestTimeWindowCondition(SliceSchedulingCondition):
     lookback_seconds: Optional[float] = None
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/dep_operators.py
@@ -25,7 +25,6 @@ class DepConditionWrapperCondition(SchedulingCondition):
             self.dep_key
         ).convert_to_valid_asset_subset()
         dep_context = context.for_child_condition(
-            asset_key=self.dep_key,
             child_condition=self.operand,
             candidate_subset=dep_candidate_subset,
         )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
@@ -159,7 +159,7 @@ class SchedulingResult(DagsterModel):
         return SchedulingResult(
             condition=context.condition,
             condition_unique_id=context.condition_unique_id,
-            start_timestamp=context.start_timestamp,
+            start_timestamp=context.create_time.timestamp(),
             end_timestamp=pendulum.now("UTC").timestamp(),
             true_slice=context.asset_graph_view.get_asset_slice_from_subset(true_subset),
             candidate_subset=context.candidate_subset,
@@ -179,7 +179,7 @@ class SchedulingResult(DagsterModel):
         return SchedulingResult(
             condition=context.condition,
             condition_unique_id=context.condition_unique_id,
-            start_timestamp=context.start_timestamp,
+            start_timestamp=context.create_time.timestamp(),
             end_timestamp=pendulum.now("UTC").timestamp(),
             true_slice=context.asset_graph_view.get_asset_slice_from_subset(true_subset),
             candidate_subset=context.candidate_subset,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
@@ -1,10 +1,11 @@
 import datetime
 import functools
 import logging
-from typing import TYPE_CHECKING, AbstractSet, Any, Mapping, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Mapping, Optional
 
 import pendulum
 
+import dagster._check as check
 from dagster._core.asset_graph_view.asset_graph_view import (
     AssetGraphView,
     AssetSlice,
@@ -14,9 +15,11 @@ from dagster._core.definitions.asset_subset import ValidAssetSubset
 from dagster._core.definitions.declarative_scheduling.scheduling_condition import (
     SchedulingCondition,
 )
+from dagster._core.definitions.declarative_scheduling.scheduling_evaluation_info import (
+    SchedulingEvaluationInfo,
+    SchedulingEvaluationNode,
+)
 from dagster._core.definitions.declarative_scheduling.serialized_objects import (
-    AssetConditionEvaluation,
-    AssetConditionEvaluationState,
     get_serializable_candidate_subset,
 )
 from dagster._core.definitions.events import AssetKeyPartitionKey
@@ -30,82 +33,114 @@ if TYPE_CHECKING:
 
 
 class SchedulingContext(DagsterModel):
-    # the AssetKey of the currently-evaluated asset
-    asset_key: AssetKey
+    # the slice over which the condition is being evaluated
+    candidate_slice: AssetSlice
 
-    # the condition that is being evaluated
+    # the condition being evaluated
     condition: SchedulingCondition
-    # the unique identifier for this condition within the broader condition tree
+    # a unique identifier for the condition within the broader tree
     condition_unique_id: str
 
-    # the subset of AssetPartitions for this Asset which must be evaluated. at the root of the
-    # condition evaluation tree, this is the AllPartitionsSubset, but this may shrink as conditions
-    # are applied and we can be certain that certain partitions will not be true for the overall
-    # expression
-    candidate_subset: ValidAssetSubset
-
-    # a view of the AssetGraph that will be used to help compute properties of the asset during
-    # computation
     asset_graph_view: AssetGraphView
 
-    # the serialized information calculated during the previous evaluation of this condition
-    # note that this refers to the evaluation of this specific node in the condition tree, not the
-    # evaluation of the root of the tree
-    # used to avoid recomputing information that we know has not changed since the previous tick
-    previous_evaluation: Optional[AssetConditionEvaluation]
+    # the context object for the parent condition
+    parent_context: Optional["SchedulingContext"]
 
-    # contains information about the previous evaluation of all assets within this asset's automation
-    # policy sensor. this provides a pointer to the top-level condition in the evaluation tree, as
-    # well as a few extra fields, such as the previous evaluation timestamp, and the max event id
-    # at the time of that computation. this information is again used to avoid recomputing information
-    # as well as detecting if anything has changed since the previous time this condition was evaluated
-    previous_evaluation_state_by_key: Mapping[AssetKey, AssetConditionEvaluationState]
-    # this is the same as the above, but for information that has been calculated during this tick.
-    # it will be used to determine if a parent will be materialized on this tick
-    current_evaluation_state_by_key: Mapping[AssetKey, AssetConditionEvaluationState]
-
-    # the time at which this context object was created, allowing us to time the duration of an
-    # evaluation for display in the UI
+    # the time at which this context object was created
     create_time: datetime.datetime
     logger: logging.Logger
 
-    # we need to continue supporting the current implementations of AutoMaterializeRules,
-    # which rely on the legact context object. however, this object contains many fields
-    # which are not relevant to the scheduling condition evaluation, and so keeping it
-    # as a reference here makes it easy to remove it in the future.
-    #
-    # marked as Any to avoid circular imports in the pydantic validation logic
-    inner_legacy_context: Any  # AssetConditionEvaluationContext
+    # a SchedulingEvaluationInfo object representing information about the full evaluation tree
+    # from the previous tick, if this asset was evaluated on the previous tick
+    previous_evaluation_info: Optional[SchedulingEvaluationInfo]
+    # a mapping of information computed on the current tick for assets which are upstream of this
+    # asset
+    current_tick_evaluation_info_by_key: Mapping[AssetKey, SchedulingEvaluationInfo]
 
-    @functools.cached_property
-    def candidate_slice(self) -> AssetSlice:
-        return self.asset_graph_view.get_asset_slice_from_subset(self.candidate_subset)
+    # hack to avoid circular references during pydantic validation
+    inner_legacy_context: Any
+
+    @staticmethod
+    def create(
+        asset_key: AssetKey,
+        asset_graph_view: AssetGraphView,
+        logger: logging.Logger,
+        current_tick_evaluation_info_by_key: Mapping[AssetKey, SchedulingEvaluationInfo],
+        previous_evaluation_info: Optional[SchedulingEvaluationInfo],
+        legacy_context: "LegacyRuleEvaluationContext",
+    ) -> "SchedulingContext":
+        asset_graph = asset_graph_view.asset_graph
+        auto_materialize_policy = check.not_none(asset_graph.get(asset_key).auto_materialize_policy)
+        scheduling_condition = auto_materialize_policy.to_scheduling_condition()
+
+        return SchedulingContext(
+            candidate_slice=asset_graph_view.get_asset_slice(asset_key),
+            condition=scheduling_condition,
+            condition_unique_id=scheduling_condition.get_unique_id(None),
+            asset_graph_view=asset_graph_view,
+            parent_context=None,
+            create_time=pendulum.now("UTC"),
+            logger=logger,
+            previous_evaluation_info=previous_evaluation_info,
+            current_tick_evaluation_info_by_key=current_tick_evaluation_info_by_key,
+            inner_legacy_context=legacy_context,
+        )
+
+    def for_child_condition(
+        self, child_condition: SchedulingCondition, candidate_subset: ValidAssetSubset
+    ) -> "SchedulingContext":
+        return SchedulingContext(
+            candidate_slice=self.asset_graph_view.get_asset_slice_from_subset(candidate_subset),
+            condition=child_condition,
+            condition_unique_id=child_condition.get_unique_id(
+                parent_unique_id=self.condition_unique_id
+            ),
+            asset_graph_view=self.asset_graph_view,
+            parent_context=self,
+            create_time=pendulum.now("UTC"),
+            logger=self.logger,
+            previous_evaluation_info=self.previous_evaluation_info,
+            current_tick_evaluation_info_by_key=self.current_tick_evaluation_info_by_key,
+            inner_legacy_context=self.legacy_context.for_child(
+                child_condition,
+                child_condition.get_unique_id(self.condition_unique_id),
+                candidate_subset,
+            ),
+        )
+
+    @property
+    def asset_key(self) -> AssetKey:
+        """The asset key over which this condition is being evaluated."""
+        return self.candidate_subset.asset_key
 
     @property
     def partitions_def(self) -> Optional[PartitionsDefinition]:
+        """The partitions definition for the asset being evaluated, if it exists."""
         return self.asset_graph_view.asset_graph.get(self.asset_key).partitions_def
 
+    @functools.cached_property
+    def candidate_subset(self) -> ValidAssetSubset:
+        """The AssetSubset over which this condition is being evaluated."""
+        return self.candidate_slice.convert_to_valid_asset_subset()
+
     @property
-    def start_timestamp(self) -> float:
-        return self.create_time.timestamp()
+    def root_context(self) -> "SchedulingContext":
+        """Returns the context object at the root of the condition evaluation tree."""
+        return self.parent_context.root_context if self.parent_context is not None else self
+
+    @property
+    def previous_evaluation_node(self) -> Optional[SchedulingEvaluationNode]:
+        """Returns the evaluation node for this asset from the previous evaluation, if this node
+        was evaluated on the previous tick.
+        """
+        if self.previous_evaluation_info is None:
+            return None
+        else:
+            return self.previous_evaluation_info.get_evaluation_node(self.condition_unique_id)
 
     @property
     def effective_dt(self) -> datetime.datetime:
         return self.asset_graph_view.effective_dt
-
-    @property
-    def previous_evaluation_state(self) -> Optional[AssetConditionEvaluationState]:
-        return self.previous_evaluation_state_by_key.get(self.asset_key)
-
-    @property
-    def previous_evaluation_timestamp(self) -> Optional[float]:
-        state = self.previous_evaluation_state
-        return state.previous_tick_evaluation_timestamp if state else None
-
-    @property
-    def new_max_storage_id(self) -> Optional[int]:
-        # TODO: this should be pulled from the asset graph view
-        return self._get_updated_parents_and_storage_id()[1]
 
     @property
     def legacy_context(self) -> LegacyRuleEvaluationContext:
@@ -115,55 +150,29 @@ class SchedulingContext(DagsterModel):
     def _queryer(self) -> "CachingInstanceQueryer":
         return self.asset_graph_view._queryer  # noqa
 
-    def _get_updated_parents_and_storage_id(
-        self,
-    ) -> Tuple[AbstractSet[AssetKeyPartitionKey], Optional[int]]:
-        return self._queryer.asset_partitions_with_newly_updated_parents_and_new_cursor(
-            latest_storage_id=self.previous_evaluation_state.max_storage_id
-            if self.previous_evaluation_state
-            else None,
-            child_asset_key=self.asset_key,
-            map_old_time_partitions=False,
-        )
+    @property
+    def new_max_storage_id(self) -> Optional[int]:
+        # TODO: pull this from the AssetGraphView instead
+        return self.legacy_context.new_max_storage_id
 
-    def target_asset_updated_since_previous_evaluation(self) -> bool:
+    def asset_updated_since_previous_tick(self) -> bool:
         """Returns True if the target asset has been updated since the previous evaluation."""
+        cursor = (
+            self.previous_evaluation_info.temporal_context.last_event_id
+            if self.previous_evaluation_info
+            else None
+        )
         return self._queryer.asset_partition_has_materialization_or_observation(
             asset_partition=AssetKeyPartitionKey(self.asset_key),
-            after_cursor=self.previous_evaluation_state.max_storage_id
-            if self.previous_evaluation_state
-            else None,
+            after_cursor=cursor,
         )
 
     def has_new_candidate_subset(self) -> bool:
         """Returns if the current tick's candidate subset is different from the previous tick's."""
-        if self.previous_evaluation is None:
+        if self.previous_evaluation_node is None:
             return True
         # convert to seriliazable form to compare in-memory object with object that passed through
         # a serdes round trip
         return get_serializable_candidate_subset(
             self.candidate_subset
-        ) != get_serializable_candidate_subset(self.previous_evaluation.candidate_subset)
-
-    def for_child_condition(
-        self,
-        child_condition: SchedulingCondition,
-        candidate_subset: ValidAssetSubset,
-        asset_key: Optional[AssetKey] = None,
-    ):
-        child_unique_id = child_condition.get_unique_id(parent_unique_id=self.condition_unique_id)
-        return self.model_copy(
-            update={
-                "asset_key": asset_key or self.asset_key,
-                "condition": child_condition,
-                "condition_unique_id": child_unique_id,
-                "candidate_subset": candidate_subset,
-                "previous_evaluation": self.previous_evaluation.for_child(child_unique_id)
-                if self.previous_evaluation
-                else None,
-                "create_time": pendulum.now("UTC"),
-                "inner_legacy_context": self.legacy_context.for_child(
-                    child_condition, child_unique_id, candidate_subset
-                ),
-            }
-        )
+        ) != get_serializable_candidate_subset(self.previous_evaluation_node.candidate_subset)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
@@ -1,0 +1,84 @@
+import datetime
+import itertools
+from typing import Any, Optional, Sequence
+
+from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView, TemporalContext
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_subset import AssetSubset
+from dagster._core.definitions.declarative_scheduling.serialized_objects import (
+    AssetConditionEvaluation,
+    AssetConditionEvaluationState,
+    AssetSubsetWithMetadata,
+)
+from dagster._model import DagsterModel
+
+
+class SchedulingEvaluationNode(DagsterModel):
+    """Represents computed information for a single node in the evaluation tree."""
+
+    asset_key: AssetKey
+    condition_unique_id: str
+
+    true_subset: AssetSubset
+    candidate_subset: AssetSubset
+    subsets_with_metadata: Sequence[AssetSubsetWithMetadata]
+
+    extra_state: Any
+
+    @staticmethod
+    def nodes_for_evaluation(
+        asset_graph_view: AssetGraphView,
+        state: AssetConditionEvaluationState,
+        condition_evaluation: AssetConditionEvaluation,
+    ) -> Sequence["SchedulingEvaluationNode"]:
+        unique_id = condition_evaluation.condition_snapshot.unique_id
+        asset_key = condition_evaluation.asset_key
+        # we store AllPartitionsSubset as a sentinel value to avoid serializing the entire set of
+        # partitions on each tick. this logic handles converting that back to an AllPartitionsSubset
+        # at read time.
+        candidate_subset = (
+            condition_evaluation.candidate_subset
+            if isinstance(condition_evaluation.candidate_subset, AssetSubset)
+            else asset_graph_view.get_asset_slice(asset_key).convert_to_valid_asset_subset()
+        )
+        node = SchedulingEvaluationNode(
+            asset_key=asset_key,
+            condition_unique_id=unique_id,
+            true_subset=condition_evaluation.true_subset,
+            candidate_subset=candidate_subset,
+            subsets_with_metadata=condition_evaluation.subsets_with_metadata,
+            extra_state=state.extra_state_by_unique_id.get(unique_id),
+        )
+        child_nodes = [
+            SchedulingEvaluationNode.nodes_for_evaluation(asset_graph_view, state, child)
+            for child in condition_evaluation.child_evaluations
+        ]
+        return list(itertools.chain([node], *child_nodes))
+
+
+class SchedulingEvaluationInfo(DagsterModel):
+    """Represents computed information for the entire evaluation tree."""
+
+    temporal_context: TemporalContext
+    evaluation_nodes: Sequence[SchedulingEvaluationNode]
+
+    def get_evaluation_node(self, unique_id: str) -> Optional[SchedulingEvaluationNode]:
+        for node in self.evaluation_nodes:
+            if node.condition_unique_id == unique_id:
+                return node
+        return None
+
+    @staticmethod
+    def from_asset_condition_evaluation_state(
+        asset_graph_view: AssetGraphView, state: AssetConditionEvaluationState
+    ) -> "SchedulingEvaluationInfo":
+        temporal_context = TemporalContext(
+            effective_dt=datetime.datetime.fromtimestamp(
+                state.previous_tick_evaluation_timestamp or 0
+            ),
+            last_event_id=state.max_storage_id,
+        )
+        nodes = SchedulingEvaluationNode.nodes_for_evaluation(
+            asset_graph_view, state, state.previous_evaluation
+        )
+        return SchedulingEvaluationInfo(temporal_context=temporal_context, evaluation_nodes=nodes)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
@@ -6,6 +6,7 @@ import dagster._check as check
 from dagster import AssetKey
 from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
+from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.declarative_scheduling.legacy.legacy_context import (
     LegacyRuleEvaluationContext,
@@ -19,6 +20,9 @@ from dagster._core.definitions.declarative_scheduling.scheduling_condition impor
 )
 from dagster._core.definitions.declarative_scheduling.scheduling_context import (
     SchedulingContext,
+)
+from dagster._core.definitions.declarative_scheduling.scheduling_evaluation_info import (
+    SchedulingEvaluationInfo,
 )
 from dagster._core.definitions.declarative_scheduling.serialized_objects import (
     AssetConditionEvaluationState,
@@ -60,15 +64,19 @@ class AssetConditionScenarioState(ScenarioState):
         asset_condition = AndAssetCondition(
             operands=[check.not_none(self.asset_condition), FalseAssetCondition()]
         )
+        asset_graph = self.scenario_spec.with_asset_properties(
+            asset,
+            auto_materialize_policy=AutoMaterializePolicy.from_asset_condition(asset_condition),
+        ).asset_graph
 
         with pendulum_freeze_time(self.current_time):
             instance_queryer = CachingInstanceQueryer(
-                instance=self.instance, asset_graph=self.asset_graph
+                instance=self.instance, asset_graph=asset_graph
             )
             daemon_context = AssetDaemonContext(
                 evaluation_id=1,
                 instance=self.instance,
-                asset_graph=self.asset_graph,
+                asset_graph=asset_graph,
                 cursor=AssetDaemonCursor.empty(),
                 materialize_run_tags={},
                 observe_run_tags={},
@@ -88,24 +96,17 @@ class AssetConditionScenarioState(ScenarioState):
                 expected_data_time_mapping={},
                 daemon_context=daemon_context,
             )
-            context = SchedulingContext(
+            context = SchedulingContext.create(
                 asset_key=asset_key,
-                condition=asset_condition,
-                condition_unique_id=asset_condition.get_unique_id(parent_unique_id=None),
-                candidate_subset=daemon_context.asset_graph_view.get_asset_slice(
-                    asset_key
-                ).convert_to_valid_asset_subset(),
                 asset_graph_view=daemon_context.asset_graph_view,
-                previous_evaluation=self.previous_evaluation_state.previous_evaluation
+                logger=self.logger,
+                current_tick_evaluation_info_by_key={},
+                previous_evaluation_info=SchedulingEvaluationInfo.from_asset_condition_evaluation_state(
+                    daemon_context.asset_graph_view, self.previous_evaluation_state
+                )
                 if self.previous_evaluation_state
                 else None,
-                previous_evaluation_state_by_key={asset_key: self.previous_evaluation_state}
-                if self.previous_evaluation_state
-                else {},
-                current_evaluation_state_by_key={},
-                create_time=self.current_time,
-                logger=self.logger,
-                inner_legacy_context=legacy_context,
+                legacy_context=legacy_context,
             )
 
             full_result = asset_condition.evaluate(context)


### PR DESCRIPTION
## Summary & Motivation

This makes a range of changes inspired by comments on https://github.com/dagster-io/dagster/pull/21499.

It hides away any references to AssetConditionX, and simplifies the set of properties available on the context object.

It also adds in a sort of "breadcrumb" thing, where each context object stores a reference to its parent context object. No existing rules currently take advantage of this, but the soon-to-be-created "NewerThanChild" condition (name pending) will be a rule that gets applied against dependencies, but needs to know which child it is comparing itself to. i.e. you would have something like:

SchedulingCondition.any_dep_matches(SchedulingCondition.newer_than_child())

## How I Tested These Changes
