### PR TITLE
RFC: AssetsDefinition.single

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_dep.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_dep.py
@@ -1,10 +1,9 @@
-from typing import Iterable, NamedTuple, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Iterable, NamedTuple, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._annotations import PublicAttr
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
@@ -14,8 +13,11 @@ from .events import (
     CoercibleToAssetKey,
 )
 
+if TYPE_CHECKING:
+    from dagster._core.definitions.assets import AssetsDefinition
+
 CoercibleToAssetDep = Union[
-    CoercibleToAssetKey, AssetSpec, AssetsDefinition, SourceAsset, "AssetDep"
+    CoercibleToAssetKey, AssetSpec, "AssetsDefinition", SourceAsset, "AssetDep"
 ]
 
 
@@ -54,10 +56,12 @@ class AssetDep(
 
     def __new__(
         cls,
-        asset: Union[CoercibleToAssetKey, AssetSpec, AssetsDefinition, SourceAsset],
+        asset: Union[CoercibleToAssetKey, AssetSpec, "AssetsDefinition", SourceAsset],
         *,
         partition_mapping: Optional[PartitionMapping] = None,
     ):
+        from dagster._core.definitions.assets import AssetsDefinition
+
         if isinstance(asset, list):
             check.list_param(asset, "asset", of_type=str)
         else:
@@ -92,6 +96,8 @@ class AssetDep(
 
 
 def _get_asset_key(arg: "CoercibleToAssetDep") -> AssetKey:
+    from dagster._core.definitions.assets import AssetsDefinition
+
     if isinstance(arg, (AssetsDefinition, SourceAsset, AssetSpec)):
         return arg.key
     elif isinstance(arg, AssetDep):

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -212,7 +212,8 @@ def asset(
             execute in the decorated function after materializing the asset.
         non_argument_deps (Optional[Union[Set[AssetKey], Set[str]]]): Deprecated, use deps instead.
             Set of asset keys that are upstream dependencies, but do not pass an input to the asset.
-        key (Optional[CoeercibleToAssetKey]): The key for this asset. If provided, cannot specify key_prefix or name.
+        key ((Optional[Union[AssetKey, str, Sequence[str]]])): The key for this asset. If provided,
+            cannot specify key_prefix or name.
         owners (Optional[Sequence[str]]): A list of strings representing owners of the asset. Each
             string can be a user's email address, or a team name prefixed with `team:`,
             e.g. `team:finops`.


### PR DESCRIPTION
## Summary & Motivation

This PR explores adding a static instantiator to `AssetsDefinition`, which makes it easy to construct an `AssetsDefinition` with a single asset with no associated materialization or observation function.

We would recommend using this in places where `SourceAsset` is currently used.

To get a sense of what the docs look like with this change, take a look at https://github.com/dagster-io/dagster/pulls?q=is%3Apr+is%3Aopen+%22eliminate-source-assets%22

#### Why replace `SourceAsset` with `AssetsDefinition` instead of `AssetSpec` or `AssetNode`?

The main advantage is that it represents asset definitions with a single type. This makes it much simpler to write and use functions that operate on sets of asset definitions. Examples of such functions:
- Functions that accept a list of asset definitions and return a list of asset definitions that include some metadata or attributes: e.g. `with_resources`, `with_source_code_links`. Some of these are Dagster-defined, but it's also useful for users to be able to define their own.
- `materialize`
- Check factories
- Asset factories

### Assuming we replace `SourceAsset` with `AssetsDefinition`, what other options should we consider for constructing one?

- `AssetsDefinition.from_spec`. Explored here: https://github.com/dagster-io/dagster/pull/21592. This seems like a bit of an awkward middle ground though.
- `AssetsDefinition.non_executable`
- `asset(...).no_function()`
- `asset(...)(None)`
- `asset(...)` - discussed here: https://github.com/dagster-io/internal/discussions/9371#discussioncomment-9169336

## How I Tested These Changes
