### PR TITLE
[ui] Make table headers consistently sticky, place inside scroll container

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/BackfillPreviewModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/BackfillPreviewModal.tsx
@@ -18,7 +18,7 @@ import {
 import {tokenForAssetKey} from '../asset-graph/Utils';
 import {TargetPartitionsDisplay} from '../instance/backfill/TargetPartitionsDisplay';
 import {testId} from '../testing/testId';
-import {Container, HeaderCell, Inner, Row, RowCell} from '../ui/VirtualizedTable';
+import {Container, HeaderCell, HeaderRow, Inner, Row, RowCell} from '../ui/VirtualizedTable';
 
 interface BackfillPreviewModalProps {
   isOpen: boolean;
@@ -137,21 +137,12 @@ const RowGrid = styled(Box)`
 
 export const BackfillPreviewTableHeader = () => {
   return (
-    <Box
-      border="bottom"
-      style={{
-        display: 'grid',
-        gridTemplateColumns: TEMPLATE_COLUMNS,
-        height: '32px',
-        fontSize: '12px',
-        color: Colors.textLight(),
-      }}
-    >
+    <HeaderRow templateColumns={TEMPLATE_COLUMNS} sticky>
       <HeaderCell>Asset key</HeaderCell>
       <HeaderCell>Backfill policy</HeaderCell>
       <HeaderCell>Partition definition</HeaderCell>
       <HeaderCell>Partitions to launch</HeaderCell>
-    </Box>
+    </HeaderRow>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
@@ -1,5 +1,5 @@
 import {gql} from '@apollo/client';
-import {Body2, Box, Caption, Colors} from '@dagster-io/ui-components';
+import {Body2, Box, Caption} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import {useRef} from 'react';
 import {Link} from 'react-router-dom';
@@ -13,7 +13,7 @@ import {AssetCheckTableFragment} from './types/VirtualizedAssetCheckTable.types'
 import {linkToRunEvent} from '../../runs/RunUtils';
 import {TimestampDisplay} from '../../schedules/TimestampDisplay';
 import {testId} from '../../testing/testId';
-import {Container, HeaderCell, Inner, Row, RowCell} from '../../ui/VirtualizedTable';
+import {Container, HeaderCell, HeaderRow, Inner, Row, RowCell} from '../../ui/VirtualizedTable';
 import {assetDetailsPathForAssetCheck} from '../assetDetailsPathForKey';
 
 type Props = {
@@ -130,22 +130,13 @@ const CaptionEllipsed = styled(Caption)`
 
 export const VirtualizedAssetCheckHeader = () => {
   return (
-    <Box
-      border="top-and-bottom"
-      style={{
-        display: 'grid',
-        gridTemplateColumns: TEMPLATE_COLUMNS,
-        height: '32px',
-        fontSize: '12px',
-        color: Colors.textLight(),
-      }}
-    >
+    <HeaderRow templateColumns={TEMPLATE_COLUMNS} sticky>
       <HeaderCell>Check name</HeaderCell>
       <HeaderCell>Status</HeaderCell>
       <HeaderCell>Evaluation timestamp</HeaderCell>
       <HeaderCell>Evaluation metadata</HeaderCell>
       <HeaderCell>Actions</HeaderCell>
-    </Box>
+    </HeaderRow>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationTickDetailDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationTickDetailDialog.tsx
@@ -14,7 +14,7 @@ import {Timestamp} from '../../app/time/Timestamp';
 import {tokenForAssetKey} from '../../asset-graph/Utils';
 import {AssetKeyInput, InstigationTickStatus} from '../../graphql/types';
 import {TickDetailSummary} from '../../instigation/TickDetailsDialog';
-import {HeaderCell, Inner, Row, RowCell} from '../../ui/VirtualizedTable';
+import {HeaderCell, HeaderRow, Inner, Row, RowCell} from '../../ui/VirtualizedTable';
 import {buildRepoAddress} from '../../workspace/buildRepoAddress';
 import {workspacePathFromAddress} from '../../workspace/workspacePath';
 import {AssetLink} from '../AssetLink';
@@ -91,24 +91,11 @@ export const AutomaterializationTickDetailDialog = memo(
       }
       return (
         <div style={{overflow: 'scroll'}} ref={parentRef}>
-          <Box
-            border="top-and-bottom"
-            style={{
-              display: 'grid',
-              gridTemplateColumns: TEMPLATE_COLUMNS,
-              height: '32px',
-              fontSize: '12px',
-              color: Colors.textLight(),
-              position: 'sticky',
-              top: 0,
-              zIndex: 1,
-              background: Colors.backgroundDefault(),
-            }}
-          >
+          <HeaderRow templateColumns={TEMPLATE_COLUMNS} sticky>
             <HeaderCell>Asset</HeaderCell>
             <HeaderCell>Group</HeaderCell>
             <HeaderCell>Result</HeaderCell>
-          </Box>
+          </HeaderRow>
           <Inner $totalHeight={totalHeight}>
             {items.map(({index, key, size, start}) => {
               const assetKey = filteredAssetKeys[index]!;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
@@ -168,7 +168,7 @@ export const RunConcurrencyContent = ({
           <Subheading>Run concurrency</Subheading>
           {refreshState ? <QueryRefreshCountdown refreshState={refreshState} /> : null}
         </Box>
-        <div>
+        <Box padding={{vertical: 16, horizontal: 24}}>
           Run concurrency is not supported with this run coordinator. To enable run concurrency
           limits, configure your instance to use the <Mono>QueuedRunCoordinator</Mono> in your{' '}
           <Mono>dagster.yaml</Mono>. See the{' '}
@@ -180,7 +180,7 @@ export const RunConcurrencyContent = ({
             QueuedRunCoordinator documentation
           </a>{' '}
           for more information.
-        </div>
+        </Box>
       </>
     );
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/VirtualizedInstanceConcurrencyTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/VirtualizedInstanceConcurrencyTable.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   Button,
   ButtonLink,
-  Colors,
   Icon,
   Menu,
   MenuItem,
@@ -19,7 +18,7 @@ import {
   SingleConcurrencyKeyQueryVariables,
 } from './types/VirtualizedInstanceConcurrencyTable.types';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
-import {Container, HeaderCell, Inner, Row, RowCell} from '../ui/VirtualizedTable';
+import {Container, HeaderCell, HeaderRow, Inner, Row, RowCell} from '../ui/VirtualizedTable';
 import {LoadingOrNone, useDelayedRowQuery} from '../workspace/VirtualizedWorkspaceTable';
 
 const TEMPLATE_COLUMNS = '1fr 150px 150px 150px 150px 150px';
@@ -48,51 +47,40 @@ export const ConcurrencyTable = ({
   const items = rowVirtualizer.getVirtualItems();
 
   return (
-    <>
-      <ConcurrencyHeader />
-      <div style={{overflow: 'hidden'}}>
-        <Container ref={parentRef}>
-          <Inner $totalHeight={totalHeight}>
-            {items.map(({index, key, size, start}) => {
-              const concurrencyKey = concurrencyKeys[index]!;
-              return (
-                <ConcurrencyRow
-                  key={key}
-                  concurrencyKey={concurrencyKey}
-                  onEdit={onEdit}
-                  onDelete={onDelete}
-                  onSelect={onSelect}
-                  height={size}
-                  start={start}
-                />
-              );
-            })}
-          </Inner>
-        </Container>
-      </div>
-    </>
+    <div style={{overflow: 'hidden'}}>
+      <Container ref={parentRef}>
+        <ConcurrencyHeader />
+        <Inner $totalHeight={totalHeight}>
+          {items.map(({index, key, size, start}) => {
+            const concurrencyKey = concurrencyKeys[index]!;
+            return (
+              <ConcurrencyRow
+                key={key}
+                concurrencyKey={concurrencyKey}
+                onEdit={onEdit}
+                onDelete={onDelete}
+                onSelect={onSelect}
+                height={size}
+                start={start}
+              />
+            );
+          })}
+        </Inner>
+      </Container>
+    </div>
   );
 };
 
 const ConcurrencyHeader = () => {
   return (
-    <Box
-      border="top-and-bottom"
-      style={{
-        display: 'grid',
-        gridTemplateColumns: TEMPLATE_COLUMNS,
-        height: '32px',
-        fontSize: '12px',
-        color: Colors.textLight(),
-      }}
-    >
+    <HeaderRow templateColumns={TEMPLATE_COLUMNS} sticky>
       <HeaderCell>Concurrency key</HeaderCell>
       <HeaderCell>Total slots</HeaderCell>
       <HeaderCell>Assigned steps</HeaderCell>
       <HeaderCell>Pending steps</HeaderCell>
       <HeaderCell>All steps</HeaderCell>
       <HeaderCell></HeaderCell>
-    </Box>
+    </HeaderRow>
   );
 };
 const ConcurrencyRow = ({

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
@@ -31,7 +31,7 @@ import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {usePageLoadTrace} from '../performance';
-import {Container, HeaderCell, Inner, Row, RowCell} from '../ui/VirtualizedTable';
+import {Container, HeaderCell, HeaderRow, Inner, Row, RowCell} from '../ui/VirtualizedTable';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
@@ -207,30 +207,15 @@ function groupAssets(assets: Assets) {
 
 const TEMPLATE_COLUMNS = '5fr 1fr 1fr 1fr 1fr';
 
-function VirtualHeaderRow() {
-  return (
-    <Box
-      border="top-and-bottom"
-      style={{
-        display: 'grid',
-        gridTemplateColumns: TEMPLATE_COLUMNS,
-        height: '32px',
-        fontSize: '12px',
-        color: Colors.textLight(),
-        position: 'sticky',
-        top: 0,
-        zIndex: 1,
-        background: Colors.backgroundDefault(),
-      }}
-    >
-      <HeaderCell>Group name</HeaderCell>
-      <HeaderCell>Missing</HeaderCell>
-      <HeaderCell>Failed/Overdue</HeaderCell>
-      <HeaderCell>In progress</HeaderCell>
-      <HeaderCell>Materialized</HeaderCell>
-    </Box>
-  );
-}
+const VirtualHeaderRow = () => (
+  <HeaderRow templateColumns={TEMPLATE_COLUMNS} sticky>
+    <HeaderCell>Group name</HeaderCell>
+    <HeaderCell>Missing</HeaderCell>
+    <HeaderCell>Failed/Overdue</HeaderCell>
+    <HeaderCell>In progress</HeaderCell>
+    <HeaderCell>Materialized</HeaderCell>
+  </HeaderRow>
+);
 
 const UNGROUPED_ASSETS = 'Ungrouped Assets';
 type RowProps = {

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewJobsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewJobsTable.tsx
@@ -3,7 +3,7 @@ import {useVirtualizer} from '@tanstack/react-virtual';
 import {useMemo, useRef} from 'react';
 
 import {OVERVIEW_COLLAPSED_KEY} from './OverviewExpansionKey';
-import {Container, Inner} from '../ui/VirtualizedTable';
+import {Container, Inner, TABLE_HEADER_HEIGHT} from '../ui/VirtualizedTable';
 import {findDuplicateRepoNames} from '../ui/findDuplicateRepoNames';
 import {useRepoExpansionState} from '../ui/useRepoExpansionState';
 import {VirtualizedJobHeader, VirtualizedJobRow} from '../workspace/VirtualizedJobRow';
@@ -60,7 +60,7 @@ export const OverviewJobsTable = ({repos}: Props) => {
     getScrollElement: () => parentRef.current,
     estimateSize: (ii: number) => {
       const row = flattened[ii];
-      return row?.type === 'header' ? 32 : 64;
+      return row?.type === 'header' ? TABLE_HEADER_HEIGHT : 64;
     },
     overscan: 10,
   });
@@ -69,47 +69,45 @@ export const OverviewJobsTable = ({repos}: Props) => {
   const items = rowVirtualizer.getVirtualItems();
 
   return (
-    <>
-      <VirtualizedJobHeader />
-      <div style={{overflow: 'hidden'}}>
-        <Container ref={parentRef}>
-          <Inner $totalHeight={totalHeight}>
-            {items.map(({index, key, size, start}) => {
-              const row: RowType = flattened[index]!;
-              const type = row!.type;
-              return type === 'header' ? (
-                <RepoRow
-                  repoAddress={row.repoAddress}
-                  key={key}
-                  height={size}
-                  start={start}
-                  onToggle={onToggle}
-                  onToggleAll={onToggleAll}
-                  expanded={expandedKeys.includes(repoAddressAsHumanString(row.repoAddress))}
-                  showLocation={duplicateRepoNames.has(row.repoAddress.name)}
-                  rightElement={
-                    <Tooltip
-                      content={row.jobCount === 1 ? '1 job' : `${row.jobCount} jobs`}
-                      placement="top"
-                    >
-                      <Tag>{row.jobCount}</Tag>
-                    </Tooltip>
-                  }
-                />
-              ) : (
-                <VirtualizedJobRow
-                  key={key}
-                  name={row.name}
-                  isJob={row.isJob}
-                  repoAddress={row.repoAddress}
-                  height={size}
-                  start={start}
-                />
-              );
-            })}
-          </Inner>
-        </Container>
-      </div>
-    </>
+    <div style={{overflow: 'hidden'}}>
+      <Container ref={parentRef}>
+        <VirtualizedJobHeader />
+        <Inner $totalHeight={totalHeight}>
+          {items.map(({index, key, size, start}) => {
+            const row: RowType = flattened[index]!;
+            const type = row!.type;
+            return type === 'header' ? (
+              <RepoRow
+                repoAddress={row.repoAddress}
+                key={key}
+                height={size}
+                start={start}
+                onToggle={onToggle}
+                onToggleAll={onToggleAll}
+                expanded={expandedKeys.includes(repoAddressAsHumanString(row.repoAddress))}
+                showLocation={duplicateRepoNames.has(row.repoAddress.name)}
+                rightElement={
+                  <Tooltip
+                    content={row.jobCount === 1 ? '1 job' : `${row.jobCount} jobs`}
+                    placement="top"
+                  >
+                    <Tag>{row.jobCount}</Tag>
+                  </Tooltip>
+                }
+              />
+            ) : (
+              <VirtualizedJobRow
+                key={key}
+                name={row.name}
+                isJob={row.isJob}
+                repoAddress={row.repoAddress}
+                height={size}
+                start={start}
+              />
+            );
+          })}
+        </Inner>
+      </Container>
+    </div>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewResourcesTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewResourcesTable.tsx
@@ -73,42 +73,40 @@ export const OverviewResourcesTable = ({repos}: Props) => {
   const items = rowVirtualizer.getVirtualItems();
 
   return (
-    <>
-      <VirtualizedResourceHeader />
-      <div style={{overflow: 'hidden'}}>
-        <Container ref={parentRef}>
-          <Inner $totalHeight={totalHeight}>
-            {items.map(({index, key, size, start}) => {
-              const row: RowType = flattened[index]!;
-              const type = row!.type;
-              return type === 'header' ? (
-                <RepoRow
-                  repoAddress={row.repoAddress}
-                  key={key}
-                  height={size}
-                  start={start}
-                  onToggle={onToggle}
-                  onToggleAll={onToggleAll}
-                  expanded={expandedKeys.includes(repoAddressAsHumanString(row.repoAddress))}
-                  showLocation={duplicateRepoNames.has(row.repoAddress.name)}
-                  rightElement={
-                    <Tooltip
-                      content={
-                        row.resourceCount === 1 ? '1 resource' : `${row.resourceCount} resources`
-                      }
-                      placement="top"
-                    >
-                      <Tag>{row.resourceCount}</Tag>
-                    </Tooltip>
-                  }
-                />
-              ) : (
-                <VirtualizedResourceRow key={key} height={size} start={start} {...row} />
-              );
-            })}
-          </Inner>
-        </Container>
-      </div>
-    </>
+    <div style={{overflow: 'hidden'}}>
+      <Container ref={parentRef}>
+        <VirtualizedResourceHeader />
+        <Inner $totalHeight={totalHeight}>
+          {items.map(({index, key, size, start}) => {
+            const row: RowType = flattened[index]!;
+            const type = row!.type;
+            return type === 'header' ? (
+              <RepoRow
+                repoAddress={row.repoAddress}
+                key={key}
+                height={size}
+                start={start}
+                onToggle={onToggle}
+                onToggleAll={onToggleAll}
+                expanded={expandedKeys.includes(repoAddressAsHumanString(row.repoAddress))}
+                showLocation={duplicateRepoNames.has(row.repoAddress.name)}
+                rightElement={
+                  <Tooltip
+                    content={
+                      row.resourceCount === 1 ? '1 resource' : `${row.resourceCount} resources`
+                    }
+                    placement="top"
+                  >
+                    <Tag>{row.resourceCount}</Tag>
+                  </Tooltip>
+                }
+              />
+            ) : (
+              <VirtualizedResourceRow key={key} height={size} start={start} {...row} />
+            );
+          })}
+        </Inner>
+      </Container>
+    </div>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSchedulesTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSchedulesTable.tsx
@@ -82,9 +82,9 @@ export const OverviewScheduleTable = ({
 
   return (
     <>
-      <VirtualizedScheduleHeader checkbox={headerCheckbox} />
       <div style={{overflow: 'hidden'}}>
         <Container ref={parentRef}>
+          <VirtualizedScheduleHeader checkbox={headerCheckbox} />
           <Inner $totalHeight={totalHeight}>
             {items.map(({index, key, size, start}) => {
               const row: RowType = flattened[index]!;

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSensorsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSensorsTable.tsx
@@ -77,56 +77,54 @@ export const OverviewSensorTable = ({
   const items = rowVirtualizer.getVirtualItems();
 
   return (
-    <>
-      <VirtualizedSensorHeader checkbox={headerCheckbox} />
-      <div style={{overflow: 'hidden'}}>
-        <Container ref={parentRef}>
-          <Inner $totalHeight={totalHeight}>
-            {items.map(({index, key, size, start}) => {
-              const row: RowType = flattened[index]!;
-              const type = row!.type;
-              if (type === 'header') {
-                return (
-                  <RepoRow
-                    repoAddress={row.repoAddress}
-                    key={key}
-                    height={size}
-                    start={start}
-                    onToggle={onToggle}
-                    onToggleAll={onToggleAll}
-                    expanded={expandedKeys.includes(repoAddressAsHumanString(row.repoAddress))}
-                    showLocation={duplicateRepoNames.has(row.repoAddress.name)}
-                    rightElement={
-                      <Tooltip
-                        content={row.sensorCount === 1 ? '1 sensor' : `${row.sensorCount} sensors`}
-                        placement="top"
-                      >
-                        <Tag>{row.sensorCount}</Tag>
-                      </Tooltip>
-                    }
-                  />
-                );
-              }
-
-              const sensorKey = makeSensorKey(row.repoAddress, row.sensor.name);
-
+    <div style={{overflow: 'hidden'}}>
+      <Container ref={parentRef}>
+        <VirtualizedSensorHeader checkbox={headerCheckbox} />
+        <Inner $totalHeight={totalHeight}>
+          {items.map(({index, key, size, start}) => {
+            const row: RowType = flattened[index]!;
+            const type = row!.type;
+            if (type === 'header') {
               return (
-                <VirtualizedSensorRow
-                  key={key}
-                  name={row.sensor.name}
-                  sensorState={row.sensor.sensorState}
-                  showCheckboxColumn={!!headerCheckbox}
-                  checked={checkedKeys.has(sensorKey)}
-                  onToggleChecked={onToggleCheckFactory(sensorKey)}
+                <RepoRow
                   repoAddress={row.repoAddress}
+                  key={key}
                   height={size}
                   start={start}
+                  onToggle={onToggle}
+                  onToggleAll={onToggleAll}
+                  expanded={expandedKeys.includes(repoAddressAsHumanString(row.repoAddress))}
+                  showLocation={duplicateRepoNames.has(row.repoAddress.name)}
+                  rightElement={
+                    <Tooltip
+                      content={row.sensorCount === 1 ? '1 sensor' : `${row.sensorCount} sensors`}
+                      placement="top"
+                    >
+                      <Tag>{row.sensorCount}</Tag>
+                    </Tooltip>
+                  }
                 />
               );
-            })}
-          </Inner>
-        </Container>
-      </div>
-    </>
+            }
+
+            const sensorKey = makeSensorKey(row.repoAddress, row.sensor.name);
+
+            return (
+              <VirtualizedSensorRow
+                key={key}
+                name={row.sensor.name}
+                sensorState={row.sensor.sensorState}
+                showCheckboxColumn={!!headerCheckbox}
+                checked={checkedKeys.has(sensorKey)}
+                onToggleChecked={onToggleCheckFactory(sensorKey)}
+                repoAddress={row.repoAddress}
+                height={size}
+                start={start}
+              />
+            );
+          })}
+        </Inner>
+      </Container>
+    </div>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/resources/VirtualizedResourceRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/VirtualizedResourceRow.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import {succinctType} from './ResourceRoot';
 import {ResourceEntryFragment} from './types/WorkspaceResourcesRoot.types';
-import {HeaderCell, Row, RowCell} from '../ui/VirtualizedTable';
+import {HeaderCell, HeaderRow, Row, RowCell} from '../ui/VirtualizedTable';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
@@ -85,20 +85,11 @@ export const VirtualizedResourceRow = (props: ResourceRowProps) => {
 
 export const VirtualizedResourceHeader = () => {
   return (
-    <Box
-      border="top-and-bottom"
-      style={{
-        display: 'grid',
-        gridTemplateColumns: TEMPLATE_COLUMNS,
-        height: '32px',
-        fontSize: '12px',
-        color: Colors.textLight(),
-      }}
-    >
+    <HeaderRow templateColumns={TEMPLATE_COLUMNS} sticky>
       <HeaderCell>Name</HeaderCell>
       <HeaderCell>Type</HeaderCell>
       <HeaderCell>Uses</HeaderCell>
-    </Box>
+    </HeaderRow>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/resources/VirtualizedResourceTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/VirtualizedResourceTable.tsx
@@ -25,26 +25,24 @@ export const VirtualizedResourceTable = ({repoAddress, resources}: Props) => {
   const items = rowVirtualizer.getVirtualItems();
 
   return (
-    <>
-      <VirtualizedResourceHeader />
-      <div style={{overflow: 'hidden'}}>
-        <Container ref={parentRef}>
-          <Inner $totalHeight={totalHeight}>
-            {items.map(({index, key, size, start}) => {
-              const row: ResourceEntryFragment = resources[index]!;
-              return (
-                <VirtualizedResourceRow
-                  key={key}
-                  repoAddress={repoAddress}
-                  height={size}
-                  start={start}
-                  {...row}
-                />
-              );
-            })}
-          </Inner>
-        </Container>
-      </div>
-    </>
+    <div style={{overflow: 'hidden'}}>
+      <Container ref={parentRef}>
+        <VirtualizedResourceHeader />
+        <Inner $totalHeight={totalHeight}>
+          {items.map(({index, key, size, start}) => {
+            const row: ResourceEntryFragment = resources[index]!;
+            return (
+              <VirtualizedResourceRow
+                key={key}
+                repoAddress={repoAddress}
+                height={size}
+                start={start}
+                {...row}
+              />
+            );
+          })}
+        </Inner>
+      </Container>
+    </div>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
@@ -1,6 +1,39 @@
-import {Box} from '@dagster-io/ui-components';
+import {Box, Colors} from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled from 'styled-components';
+
+export const TABLE_HEADER_HEIGHT = 32;
+
+export const HeaderRow = ({
+  children,
+  templateColumns,
+  sticky = false,
+}: {
+  children: React.ReactNode;
+  templateColumns: string;
+  sticky?: boolean;
+}) => (
+  <Box
+    border="top-and-bottom"
+    style={{
+      display: 'grid',
+      gridTemplateColumns: templateColumns,
+      height: TABLE_HEADER_HEIGHT,
+      fontSize: '12px',
+      color: Colors.textLight(),
+      ...(sticky
+        ? {
+            position: 'sticky',
+            top: 0,
+            zIndex: 1,
+            background: Colors.backgroundDefault(),
+          }
+        : {}),
+    }}
+  >
+    {children}
+  </Box>
+);
 
 export const HeaderCell = ({
   children,
@@ -54,6 +87,7 @@ const CellBox = styled(Box)`
 
   :last-child {
     padding-right: 24px;
+    box-shadow: none;
   }
 `;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryLocationsList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryLocationsList.tsx
@@ -67,37 +67,35 @@ export const RepositoryLocationsList = ({loading, codeLocations, searchValue}: P
   }
 
   return (
-    <>
+    <Container ref={parentRef}>
       <VirtualizedCodeLocationHeader />
-      <Container ref={parentRef}>
-        <Inner $totalHeight={totalHeight}>
-          <DynamicRowContainer $start={items[0]?.start ?? 0}>
-            {items.map(({index, key}) => {
-              const row: CodeLocationRowType = codeLocations[index]!;
-              if (row.type === 'error') {
-                return (
-                  <VirtualizedCodeLocationErrorRow
-                    key={key}
-                    index={index}
-                    locationNode={row.node}
-                    ref={virtualizer.measureElement}
-                  />
-                );
-              }
-
+      <Inner $totalHeight={totalHeight}>
+        <DynamicRowContainer $start={items[0]?.start ?? 0}>
+          {items.map(({index, key}) => {
+            const row: CodeLocationRowType = codeLocations[index]!;
+            if (row.type === 'error') {
               return (
-                <VirtualizedCodeLocationRow
+                <VirtualizedCodeLocationErrorRow
                   key={key}
                   index={index}
-                  codeLocation={row.codeLocation}
-                  repository={row.repository}
+                  locationNode={row.node}
                   ref={virtualizer.measureElement}
                 />
               );
-            })}
-          </DynamicRowContainer>
-        </Inner>
-      </Container>
-    </>
+            }
+
+            return (
+              <VirtualizedCodeLocationRow
+                key={key}
+                index={index}
+                codeLocation={row.codeLocation}
+                repository={row.repository}
+                ref={virtualizer.measureElement}
+              />
+            );
+          })}
+        </DynamicRowContainer>
+      </Inner>
+    </Container>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -26,7 +26,7 @@ import {AssetKeyInput} from '../graphql/types';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {testId} from '../testing/testId';
-import {HeaderCell, Row, RowCell} from '../ui/VirtualizedTable';
+import {HeaderCell, HeaderRow, Row, RowCell} from '../ui/VirtualizedTable';
 
 const TEMPLATE_COLUMNS = '1.3fr 1fr 80px';
 const TEMPLATE_COLUMNS_FOR_CATALOG = '76px 1.3fr 1.3fr 1.3fr 80px';
@@ -210,45 +210,23 @@ export const VirtualizedAssetCatalogHeader = ({
   view: AssetViewType;
 }) => {
   return (
-    <Box
-      background={Colors.backgroundDefault()}
-      border="top-and-bottom"
-      style={{
-        display: 'grid',
-        gridTemplateColumns: TEMPLATE_COLUMNS_FOR_CATALOG,
-        height: '32px',
-        fontSize: '12px',
-        color: Colors.textLight(),
-        position: 'sticky',
-        top: 0,
-        zIndex: 1,
-      }}
-    >
+    <HeaderRow templateColumns={TEMPLATE_COLUMNS_FOR_CATALOG} sticky>
       <HeaderCell>{headerCheckbox}</HeaderCell>
       <HeaderCell>{view === 'flat' ? 'Asset name' : 'Asset key prefix'}</HeaderCell>
       <HeaderCell>Code location / Asset group</HeaderCell>
       <HeaderCell>Status</HeaderCell>
       <HeaderCell></HeaderCell>
-    </Box>
+    </HeaderRow>
   );
 };
 
 export const VirtualizedAssetHeader = ({nameLabel}: {nameLabel: React.ReactNode}) => {
   return (
-    <Box
-      border="top-and-bottom"
-      style={{
-        display: 'grid',
-        gridTemplateColumns: TEMPLATE_COLUMNS,
-        height: '32px',
-        fontSize: '12px',
-        color: Colors.textLight(),
-      }}
-    >
+    <HeaderRow templateColumns={TEMPLATE_COLUMNS} sticky>
       <HeaderCell>{nameLabel}</HeaderCell>
       <HeaderCell>Status</HeaderCell>
       <HeaderCell></HeaderCell>
-    </Box>
+    </HeaderRow>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedCodeLocationRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedCodeLocationRow.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, JoinedButtons, MiddleTruncate} from '@dagster-io/ui-components';
+import {Box, JoinedButtons, MiddleTruncate} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
@@ -15,7 +15,7 @@ import {
 } from './types/WorkspaceContext.types';
 import {workspacePathFromAddress} from './workspacePath';
 import {TimeFromNow} from '../ui/TimeFromNow';
-import {HeaderCell, RowCell} from '../ui/VirtualizedTable';
+import {HeaderCell, HeaderRow, RowCell} from '../ui/VirtualizedTable';
 
 export type CodeLocationRowType =
   | {
@@ -120,22 +120,13 @@ export const VirtualizedCodeLocationRow = React.forwardRef(
 
 export const VirtualizedCodeLocationHeader = () => {
   return (
-    <Box
-      border="top-and-bottom"
-      style={{
-        display: 'grid',
-        gridTemplateColumns: TEMPLATE_COLUMNS,
-        height: '32px',
-        fontSize: '12px',
-        color: Colors.textLight(),
-      }}
-    >
+    <HeaderRow templateColumns={TEMPLATE_COLUMNS} sticky>
       <HeaderCell>Name</HeaderCell>
       <HeaderCell>Status</HeaderCell>
       <HeaderCell>Updated</HeaderCell>
       <HeaderCell>Definitions</HeaderCell>
       <HeaderCell style={{textAlign: 'right'}}>Actions</HeaderCell>
-    </Box>
+    </HeaderRow>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedGraphTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedGraphTable.tsx
@@ -9,7 +9,7 @@ import {useDelayedRowQuery} from './VirtualizedWorkspaceTable';
 import {RepoAddress} from './types';
 import {SingleGraphQuery, SingleGraphQueryVariables} from './types/VirtualizedGraphTable.types';
 import {workspacePathFromAddress} from './workspacePath';
-import {Container, HeaderCell, Inner, Row, RowCell} from '../ui/VirtualizedTable';
+import {Container, HeaderCell, HeaderRow, Inner, Row, RowCell} from '../ui/VirtualizedTable';
 
 export type Graph = {name: string; path: string; description: string | null};
 
@@ -32,40 +32,29 @@ export const VirtualizedGraphTable = ({repoAddress, graphs}: Props) => {
   const items = rowVirtualizer.getVirtualItems();
 
   return (
-    <>
-      <Box
-        border="top-and-bottom"
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '100%',
-          height: '32px',
-          fontSize: '12px',
-          color: Colors.textLight(),
-        }}
-      >
-        <HeaderCell>Graph</HeaderCell>
-      </Box>
-      <div style={{overflow: 'hidden'}}>
-        <Container ref={parentRef}>
-          <Inner $totalHeight={totalHeight}>
-            {items.map(({index, key, size, start}) => {
-              const row: Graph = graphs[index]!;
-              return (
-                <GraphRow
-                  key={key}
-                  name={row.name}
-                  description={row.description}
-                  path={row.path}
-                  repoAddress={repoAddress}
-                  height={size}
-                  start={start}
-                />
-              );
-            })}
-          </Inner>
-        </Container>
-      </div>
-    </>
+    <div style={{overflow: 'hidden'}}>
+      <Container ref={parentRef}>
+        <HeaderRow templateColumns="100%" sticky>
+          <HeaderCell>Graph</HeaderCell>
+        </HeaderRow>
+        <Inner $totalHeight={totalHeight}>
+          {items.map(({index, key, size, start}) => {
+            const row: Graph = graphs[index]!;
+            return (
+              <GraphRow
+                key={key}
+                name={row.name}
+                description={row.description}
+                path={row.path}
+                repoAddress={repoAddress}
+                height={size}
+                start={start}
+              />
+            );
+          })}
+        </Inner>
+      </Container>
+    </div>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedJobRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedJobRow.tsx
@@ -1,5 +1,5 @@
 import {gql, useLazyQuery} from '@apollo/client';
-import {Box, Colors, MiddleTruncate} from '@dagster-io/ui-components';
+import {Box, MiddleTruncate} from '@dagster-io/ui-components';
 import {useMemo} from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
@@ -17,7 +17,7 @@ import {RunStatusPezList} from '../runs/RunStatusPez';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
 import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
-import {HeaderCell, Row, RowCell} from '../ui/VirtualizedTable';
+import {HeaderCell, HeaderRow, Row, RowCell} from '../ui/VirtualizedTable';
 
 const TEMPLATE_COLUMNS = '1.5fr 1fr 180px 96px 80px';
 
@@ -130,22 +130,13 @@ export const VirtualizedJobRow = (props: JobRowProps) => {
 
 export const VirtualizedJobHeader = () => {
   return (
-    <Box
-      border="top-and-bottom"
-      style={{
-        display: 'grid',
-        gridTemplateColumns: TEMPLATE_COLUMNS,
-        height: '32px',
-        fontSize: '12px',
-        color: Colors.textLight(),
-      }}
-    >
+    <HeaderRow templateColumns={TEMPLATE_COLUMNS} sticky>
       <HeaderCell>Name</HeaderCell>
       <HeaderCell>Schedules/sensors</HeaderCell>
       <HeaderCell>Latest run</HeaderCell>
       <HeaderCell>Run history</HeaderCell>
       <HeaderCell></HeaderCell>
-    </Box>
+    </HeaderRow>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedJobTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedJobTable.tsx
@@ -26,27 +26,25 @@ export const VirtualizedJobTable = ({repoAddress, jobs}: Props) => {
   const items = rowVirtualizer.getVirtualItems();
 
   return (
-    <>
-      <VirtualizedJobHeader />
-      <div style={{overflow: 'hidden'}}>
-        <Container ref={parentRef}>
-          <Inner $totalHeight={totalHeight}>
-            {items.map(({index, key, size, start}) => {
-              const row: Job = jobs[index]!;
-              return (
-                <VirtualizedJobRow
-                  key={key}
-                  name={row.name}
-                  isJob={row.isJob}
-                  repoAddress={repoAddress}
-                  height={size}
-                  start={start}
-                />
-              );
-            })}
-          </Inner>
-        </Container>
-      </div>
-    </>
+    <div style={{overflow: 'hidden'}}>
+      <Container ref={parentRef}>
+        <VirtualizedJobHeader />
+        <Inner $totalHeight={totalHeight}>
+          {items.map(({index, key, size, start}) => {
+            const row: Job = jobs[index]!;
+            return (
+              <VirtualizedJobRow
+                key={key}
+                name={row.name}
+                isJob={row.isJob}
+                repoAddress={repoAddress}
+                height={size}
+                start={start}
+              />
+            );
+          })}
+        </Inner>
+      </Container>
+    </div>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedRepoAssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedRepoAssetTable.tsx
@@ -72,46 +72,44 @@ export const VirtualizedRepoAssetTable = ({repoAddress, assets}: Props) => {
   const items = rowVirtualizer.getVirtualItems();
 
   return (
-    <>
-      <VirtualizedAssetHeader nameLabel="Asset name" />
-      <div style={{overflow: 'hidden'}}>
-        <Container ref={parentRef}>
-          <Inner $totalHeight={totalHeight}>
-            {items.map(({index, key, size, start}) => {
-              const row: RowType = flattened[index]!;
-              const type = row!.type;
-              return type === 'group' ? (
-                <GroupNameRow
-                  repoAddress={repoAddress}
-                  groupName={row.name}
-                  assetCount={row.assetCount}
-                  expanded={expandedKeys.includes(row.name)}
-                  key={key}
-                  height={size}
-                  start={start}
-                  onToggle={onToggle}
-                />
-              ) : (
-                <VirtualizedAssetRow
-                  showCheckboxColumn={false}
-                  definition={row.definition}
-                  path={row.definition.assetKey.path}
-                  key={key}
-                  type="asset"
-                  repoAddress={repoAddress}
-                  showRepoColumn={false}
-                  height={size}
-                  start={start}
-                  checked={false}
-                  onToggleChecked={() => {}}
-                  onWipe={() => {}}
-                />
-              );
-            })}
-          </Inner>
-        </Container>
-      </div>
-    </>
+    <div style={{overflow: 'hidden'}}>
+      <Container ref={parentRef}>
+        <VirtualizedAssetHeader nameLabel="Asset name" />
+        <Inner $totalHeight={totalHeight}>
+          {items.map(({index, key, size, start}) => {
+            const row: RowType = flattened[index]!;
+            const type = row!.type;
+            return type === 'group' ? (
+              <GroupNameRow
+                repoAddress={repoAddress}
+                groupName={row.name}
+                assetCount={row.assetCount}
+                expanded={expandedKeys.includes(row.name)}
+                key={key}
+                height={size}
+                start={start}
+                onToggle={onToggle}
+              />
+            ) : (
+              <VirtualizedAssetRow
+                showCheckboxColumn={false}
+                definition={row.definition}
+                path={row.definition.assetKey.path}
+                key={key}
+                type="asset"
+                repoAddress={repoAddress}
+                showRepoColumn={false}
+                height={size}
+                start={start}
+                checked={false}
+                onToggleChecked={() => {}}
+                onWipe={() => {}}
+              />
+            );
+          })}
+        </Inner>
+      </Container>
+    </div>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleRow.tsx
@@ -36,7 +36,7 @@ import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {humanCronString} from '../schedules/humanCronString';
 import {TickStatusTag} from '../ticks/TickStatusTag';
 import {MenuLink} from '../ui/MenuLink';
-import {HeaderCell, Row, RowCell} from '../ui/VirtualizedTable';
+import {HeaderCell, HeaderRow, Row, RowCell} from '../ui/VirtualizedTable';
 
 const TEMPLATE_COLUMNS_WITH_CHECKBOX = '60px 1fr 1fr 76px 148px 210px 92px';
 const TEMPLATE_COLUMNS = '1fr 1fr 76px 148px 210px 92px';
@@ -274,15 +274,9 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
 export const VirtualizedScheduleHeader = (props: {checkbox: React.ReactNode}) => {
   const {checkbox} = props;
   return (
-    <Box
-      border="top-and-bottom"
-      style={{
-        display: 'grid',
-        gridTemplateColumns: checkbox ? TEMPLATE_COLUMNS_WITH_CHECKBOX : TEMPLATE_COLUMNS,
-        height: '32px',
-        fontSize: '12px',
-        color: Colors.textLight(),
-      }}
+    <HeaderRow
+      templateColumns={checkbox ? TEMPLATE_COLUMNS_WITH_CHECKBOX : TEMPLATE_COLUMNS}
+      sticky
     >
       {checkbox ? (
         <HeaderCell>
@@ -295,7 +289,7 @@ export const VirtualizedScheduleHeader = (props: {checkbox: React.ReactNode}) =>
       <HeaderCell>Last tick</HeaderCell>
       <HeaderCell>Last run</HeaderCell>
       <HeaderCell>Actions</HeaderCell>
-    </Box>
+    </HeaderRow>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleTable.tsx
@@ -37,31 +37,29 @@ export const VirtualizedScheduleTable = ({
   const items = rowVirtualizer.getVirtualItems();
 
   return (
-    <>
-      <VirtualizedScheduleHeader checkbox={headerCheckbox} />
-      <div style={{overflow: 'hidden'}}>
-        <Container ref={parentRef}>
-          <Inner $totalHeight={totalHeight}>
-            {items.map(({index, key, size, start}) => {
-              const row: ScheduleInfo = schedules[index]!;
-              const scheduleKey = makeScheduleKey(repoAddress, row.name);
-              return (
-                <VirtualizedScheduleRow
-                  key={key}
-                  name={row.name}
-                  repoAddress={repoAddress}
-                  scheduleState={row.scheduleState}
-                  checked={checkedKeys.has(scheduleKey)}
-                  showCheckboxColumn={!!headerCheckbox}
-                  onToggleChecked={onToggleCheckFactory(scheduleKey)}
-                  height={size}
-                  start={start}
-                />
-              );
-            })}
-          </Inner>
-        </Container>
-      </div>
-    </>
+    <div style={{overflow: 'hidden'}}>
+      <Container ref={parentRef}>
+        <VirtualizedScheduleHeader checkbox={headerCheckbox} />
+        <Inner $totalHeight={totalHeight}>
+          {items.map(({index, key, size, start}) => {
+            const row: ScheduleInfo = schedules[index]!;
+            const scheduleKey = makeScheduleKey(repoAddress, row.name);
+            return (
+              <VirtualizedScheduleRow
+                key={key}
+                name={row.name}
+                repoAddress={repoAddress}
+                scheduleState={row.scheduleState}
+                checked={checkedKeys.has(scheduleKey)}
+                showCheckboxColumn={!!headerCheckbox}
+                onToggleChecked={onToggleCheckFactory(scheduleKey)}
+                height={size}
+                start={start}
+              />
+            );
+          })}
+        </Inner>
+      </Container>
+    </div>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedSensorRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedSensorRow.tsx
@@ -32,7 +32,7 @@ import {
   SensorAssetSelectionQueryVariables,
 } from '../sensors/types/SensorRoot.types';
 import {TickStatusTag} from '../ticks/TickStatusTag';
-import {HeaderCell, Row, RowCell} from '../ui/VirtualizedTable';
+import {HeaderCell, HeaderRow, Row, RowCell} from '../ui/VirtualizedTable';
 
 const TEMPLATE_COLUMNS = '1.5fr 150px 1fr 76px 120px 148px 180px';
 const TEMPLATE_COLUMNS_WITH_CHECKBOX = `60px ${TEMPLATE_COLUMNS}`;
@@ -239,18 +239,11 @@ export const VirtualizedSensorRow = (props: SensorRowProps) => {
   );
 };
 
-export const VirtualizedSensorHeader = (props: {checkbox: React.ReactNode}) => {
-  const {checkbox} = props;
+export const VirtualizedSensorHeader = ({checkbox}: {checkbox: React.ReactNode}) => {
   return (
-    <Box
-      border="top-and-bottom"
-      style={{
-        display: 'grid',
-        gridTemplateColumns: checkbox ? TEMPLATE_COLUMNS_WITH_CHECKBOX : TEMPLATE_COLUMNS,
-        height: '32px',
-        fontSize: '12px',
-        color: Colors.textLight(),
-      }}
+    <HeaderRow
+      templateColumns={checkbox ? TEMPLATE_COLUMNS_WITH_CHECKBOX : TEMPLATE_COLUMNS}
+      sticky
     >
       {checkbox ? (
         <HeaderCell>
@@ -264,7 +257,7 @@ export const VirtualizedSensorHeader = (props: {checkbox: React.ReactNode}) => {
       <HeaderCell>Frequency</HeaderCell>
       <HeaderCell>Last tick</HeaderCell>
       <HeaderCell>Last run</HeaderCell>
-    </Box>
+    </HeaderRow>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedSensorTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedSensorTable.tsx
@@ -37,31 +37,29 @@ export const VirtualizedSensorTable = ({
   const items = rowVirtualizer.getVirtualItems();
 
   return (
-    <>
-      <VirtualizedSensorHeader checkbox={headerCheckbox} />
-      <div style={{overflow: 'hidden'}}>
-        <Container ref={parentRef}>
-          <Inner $totalHeight={totalHeight}>
-            {items.map(({index, key, size, start}) => {
-              const row: SensorInfo = sensors[index]!;
-              const sensorKey = makeSensorKey(repoAddress, row.name);
-              return (
-                <VirtualizedSensorRow
-                  key={key}
-                  name={row.name}
-                  repoAddress={repoAddress}
-                  sensorState={row.sensorState}
-                  checked={checkedKeys.has(sensorKey)}
-                  showCheckboxColumn={!!headerCheckbox}
-                  onToggleChecked={onToggleCheckFactory(sensorKey)}
-                  height={size}
-                  start={start}
-                />
-              );
-            })}
-          </Inner>
-        </Container>
-      </div>
-    </>
+    <div style={{overflow: 'hidden'}}>
+      <Container ref={parentRef}>
+        <VirtualizedSensorHeader checkbox={headerCheckbox} />
+        <Inner $totalHeight={totalHeight}>
+          {items.map(({index, key, size, start}) => {
+            const row: SensorInfo = sensors[index]!;
+            const sensorKey = makeSensorKey(repoAddress, row.name);
+            return (
+              <VirtualizedSensorRow
+                key={key}
+                name={row.name}
+                repoAddress={repoAddress}
+                sensorState={row.sensorState}
+                checked={checkedKeys.has(sensorKey)}
+                showCheckboxColumn={!!headerCheckbox}
+                onToggleChecked={onToggleCheckFactory(sensorKey)}
+                height={size}
+                start={start}
+              />
+            );
+          })}
+        </Inner>
+      </Container>
+    </div>
   );
 };


### PR DESCRIPTION
This prevents the header and the table cells from falling out of vertical alignment when the table has a visible scrollbar. 

Thankfully we’ve been super consistent about our tables - this change is identical in each file in the PR. We already did it in one or two places, and I converted those to use the new `<TableRow />` component as well.

Before:
<img width="1728" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/9c3c0310-449b-40f5-95d2-57df06424919">


After:

<img width="1727" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/fcfbb31f-9cfc-4a6d-813f-a0e6b3bbea67">

## Summary & Motivation

## How I Tested These Changes
