### PR TITLE
[backfill daemon] add logging

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -220,6 +220,7 @@ def _execute_asset_backfill_iteration_no_side_effects(
             asset_graph=asset_graph,
             run_tags=backfill.tags,
             backfill_start_time=asset_backfill_data.backfill_start_time,
+            logger=logging.getLogger("fake_logger"),
         ):
             pass
 

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1198,6 +1198,7 @@ def execute_asset_backfill_iteration_inner(
     initial_candidates: Set[AssetKeyPartitionKey] = set()
     request_roots = not asset_backfill_data.requested_runs_for_target_roots
     if request_roots:
+        logger.info("Not all root assets have been requested, finding root assets.")
         target_roots = asset_backfill_data.get_target_root_asset_partitions(instance_queryer)
         # Because the code server may have failed while requesting roots, some roots may have
         # already been requested. Checking here will reduce the amount of BFS work later in the iteration.
@@ -1205,6 +1206,7 @@ def execute_asset_backfill_iteration_inner(
             root for root in target_roots if root not in asset_backfill_data.requested_subset
         ]
         initial_candidates.update(not_yet_requested)
+        logger.info(f"Root assets that have not yet been requested: {initial_candidates}")
 
         yield None
 

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1267,7 +1267,6 @@ def execute_asset_backfill_iteration_inner(
             failed_and_downstream_subset=failed_and_downstream_subset,
             dynamic_partitions_store=instance_queryer,
             current_time=backfill_start_time,
-            logger=logger,
         ),
         initial_asset_partitions=initial_candidates,
         evaluation_time=backfill_start_time,
@@ -1410,7 +1409,6 @@ def should_backfill_atomic_asset_partitions_unit(
     failed_and_downstream_subset: AssetGraphSubset,
     dynamic_partitions_store: DynamicPartitionsStore,
     current_time: datetime,
-    logger: logging.Logger,
 ) -> bool:
     """Args:
     candidates_unit: A set of asset partitions that must all be materialized if any is
@@ -1423,15 +1421,6 @@ def should_backfill_atomic_asset_partitions_unit(
             or candidate in materialized_subset
             or candidate in requested_subset
         ):
-            if candidate not in target_subset:
-                reason = "not targeted by backfill"
-            elif candidate in failed_and_downstream_subset:
-                reason = "in failed and downstream subset"
-            elif candidate in materialized_subset:
-                reason = "already materialized by backfill"
-            else:  # candidate in requested_subset
-                reason = "already requested by a previous iteration of the backfill"
-            logger.info(f"Excluding {candidate} from request list. Reason: {reason}.")
             return False
 
         parent_partitions_result = asset_graph.get_parents_partitions(

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -54,10 +54,10 @@ def execute_job_backfill_iteration(
     instance: DagsterInstance,
 ) -> Iterable[Optional[SerializableErrorInfo]]:
     if not backfill.last_submitted_partition_name:
-        logger.info(f"Starting backfill for {backfill.backfill_id}")
+        logger.info(f"Starting job backfill for {backfill.backfill_id}")
     else:
         logger.info(
-            f"Resuming backfill for {backfill.backfill_id} from"
+            f"Resuming job backfill for {backfill.backfill_id} from"
             f" {backfill.last_submitted_partition_name}"
         )
 

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -52,12 +52,10 @@ def execute_backfill_jobs(
         )
         try:
             if backfill.is_asset_backfill:
-                backfill_logger.info("Backfill is an asset backfill.")
                 yield from execute_asset_backfill_iteration(
                     backfill, backfill_logger, workspace_process_context, instance
                 )
             else:
-                backfill_logger.info("Backfill is a job backfill.")
                 yield from execute_job_backfill_iteration(
                     backfill,
                     backfill_logger,

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -52,10 +52,12 @@ def execute_backfill_jobs(
         )
         try:
             if backfill.is_asset_backfill:
+                backfill_logger.info("Backfill is an asset backfill.")
                 yield from execute_asset_backfill_iteration(
                     backfill, backfill_logger, workspace_process_context, instance
                 )
             else:
+                backfill_logger.info("Backfill is a job backfill.")
                 yield from execute_job_backfill_iteration(
                     backfill,
                     backfill_logger,

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from typing import (
     AbstractSet,
     Iterable,
@@ -554,6 +555,7 @@ def execute_asset_backfill_iteration_consume_generator(
             asset_graph=asset_graph,
             run_tags={},
             backfill_start_time=asset_backfill_data.backfill_start_time,
+            logger=logging.getLogger("fake_logger"),
         ):
             if isinstance(result, AssetBackfillIterationResult):
                 assert counter.counts().get("DagsterInstance.get_dynamic_partitions", 0) <= 1


### PR DESCRIPTION
## Summary & Motivation
Start of a stack of PRs to add logging to the backfill daemon. This PR adds a small amount of status logging, stacked PRs will dig into the more complex parts of the daemon

Adds a couple checkpoints that should give us an idea of where the backfill is in the iteration and modifies some of the log messages for job backfills to explicitly state "job backfill" so that we know they are job backfills at a glance

## How I Tested These Changes
