### PR TITLE
fix(looker): add `dagster-looker` to `automation`

### DIFF
--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -31,6 +31,7 @@ deps =
   -e ../libraries/dagster-github
   -e ../libraries/dagster-mlflow
   -e ../libraries/dagster-mysql
+  -e ../libraries/dagster-looker
   -e ../libraries/dagster-pagerduty
   -e ../libraries/dagster-pandas
   -e ../libraries/dagster-papertrail


### PR DESCRIPTION
## Summary & Motivation
The build is failing because `dagster-looker` is not installed in `automation`.

Need to also figure out how to make this test always run for changes. It didn't run in the initial PR.

## How I Tested These Changes
bk