### PR TITLE
[ui] Stop memoizing repoAddressAsString - can cause Map overflow

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/repoAddressAsString.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/repoAddressAsString.ts
@@ -1,17 +1,22 @@
-import memoize from 'lodash/memoize';
-
 import {buildRepoPathForHuman, buildRepoPathForURL} from './buildRepoAddress';
 import {RepoAddress} from './types';
 
-export const repoAddressAsHumanString = memoize((repoAddress: RepoAddress) => {
+// Note: These are not memoized because the result is a primitive value and
+// there are scenarios where the repoAddress argument is a temporary object,
+// so WeakMapping the input to the output can cause the WeakMap to become
+// huge before it's garbage collected. We could use memoize() with a cache-key
+// function, but the cache-key generator would essentially BE this method,
+// which would eat up any perf gains yielded by memoizing it.
+//
+export const repoAddressAsHumanString = (repoAddress: RepoAddress) => {
   return buildRepoPathForHuman(repoAddress.name, repoAddress.location);
-});
+};
 
-export const repoAddressAsURLString = memoize((repoAddress: RepoAddress) => {
+export const repoAddressAsURLString = (repoAddress: RepoAddress) => {
   return buildRepoPathForURL(repoAddress.name, repoAddress.location);
-});
+};
 
 // Unencoded, dunder repo visible.
-export const repoAddressAsTag = memoize((repoAddress: RepoAddress) => {
+export const repoAddressAsTag = (repoAddress: RepoAddress) => {
   return `${repoAddress.name}@${repoAddress.location}`;
-});
+};


### PR DESCRIPTION
## Summary & Motivation

Fixes FE-339

Added a bit of additional context in an inline comment!

[https://app.datadoghq.com/rum/error-tracking?query=%40application.id%3A7edc09bb-51d0-[…]ew=spans&from_ts=1713823797049&to_ts=1714428597049&live=true](https://app.datadoghq.com/rum/error-tracking?query=%40application.id%3A7edc09bb-51d0-4555-90cd-b19ca483d1fe&fromUser=true&issueId=832a59d8-94d2-11ee-bd10-da7ad0900002&view=spans&from_ts=1713823797049&to_ts=1714428597049&live=true)

## How I Tested These Changes

```
  for (let ii = 0; ii < 10000000; ii++) {
    console.log(repoAddressAsHumanString({...addressForPath}));
  }
```

Does bad things!