### PR TITLE
[prototype] new serdes serialization approach

### DIFF
--- a/python_modules/dagster/dagster/_serdes/utils.py
+++ b/python_modules/dagster/dagster/_serdes/utils.py
@@ -1,7 +1,10 @@
 import hashlib
 from typing import NamedTuple, Optional
 
-from .serdes import WhitelistMap, serialize_value
+from .serdes import (
+    WhitelistMap,
+    serialize_value,
+)
 
 
 def create_snapshot_id(snapshot: NamedTuple, whitelist_map: Optional[WhitelistMap] = None) -> str:


### PR DESCRIPTION
move from creating a full copy of the object tree then serializing it to iteratively converting during iterencode via `items` on a wrapper object that subclasses `dict` 


speed improvements (new approach is `experi serialize`):
```
Target 0 size 68.7KiB:
deserialize_value (5 samples): mean 0.942, stdev 0.104, min 0.886
serialize_value   (5 samples): mean 1.543, stdev 0.050, min 1.502
experi serialize  (5 samples): mean 1.344, stdev 0.038, min 1.320

Target 1 size 9.7MiB:
deserialize_value (5 samples): mean 595.023, stdev 81.653, min 449.857
serialize_value   (5 samples): mean 495.601, stdev 4.152, min 492.365
experi serialize  (5 samples): mean 358.226, stdev 3.743, min 354.215

Target 2 size 9.1MiB:
deserialize_value (5 samples): mean 200.348, stdev 43.165, min 180.442
serialize_value   (5 samples): mean 272.024, stdev 2.205, min 270.294
experi serialize  (5 samples): mean 187.590, stdev 1.025, min 186.035

Target 3 size 2.5MiB:
deserialize_value (5 samples): mean 27.922, stdev 1.413, min 27.196
serialize_value   (5 samples): mean 49.156, stdev 0.695, min 48.694
experi serialize  (5 samples): mean 41.489, stdev 0.579, min 41.098

Target 4 size 635.7KiB:
deserialize_value (5 samples): mean 7.090, stdev 0.339, min 6.885
serialize_value   (5 samples): mean 13.912, stdev 0.127, min 13.821
experi serialize  (5 samples): mean 11.379, stdev 0.052, min 11.318

Target 5 size 42.6KiB:
deserialize_value (5 samples): mean 0.723, stdev 0.293, min 0.567
serialize_value   (5 samples): mean 0.967, stdev 0.084, min 0.899
experi serialize  (5 samples): mean 0.792, stdev 0.008, min 0.784

Target 6 size 40.6MiB:
deserialize_value (5 samples): mean 774.462, stdev 118.834, min 583.603
serialize_value   (5 samples): mean 1245.506, stdev 18.143, min 1228.168
experi serialize  (5 samples): mean 711.982, stdev 3.918, min 705.361
```

memory imrovements:
```

(py311) ~/dagster:al/05-02-_prototype_serdes_serialization$ memray summary /tmp/serialize_value_mem.bin
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃                                                                                      ┃                  ┃                 ┃                 ┃                 ┃      Allocation ┃
┃ Location                                                                             ┃   <Total Memory> ┃  Total Memory % ┃      Own Memory ┃    Own Memory % ┃           Count ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│ serialize_value at                                                                   │        167.232MB │          98.11% │          0.000B │           0.00% │            1331 │
│ /Users/alangenfeld/dagster/python_modules/dagster/dagster/_serdes/serdes.py          │                  │                 │                 │                 │                 │
│ <module> at /tmp/compare.py                                                          │        167.232MB │          98.11% │          0.000B │           0.00% │            1331 │
│ dumps at /Users/alangenfeld/.pyenv/versions/3.11.7/lib/python3.11/json/__init__.py   │         84.126MB │          49.35% │          0.000B │           0.00% │              60 │
│ _pack_value at                                                                       │         83.106MB │          48.76% │          0.000B │           0.00% │            1271 │
│ /Users/alangenfeld/dagster/python_modules/dagster/dagster/_serdes/serdes.py          │                  │                 │                 │                 │                 │
│ pack_value at                                                                        │         83.106MB │          48.76% │          0.000B │           0.00% │            1271 │
│ /Users/alangenfeld/dagster/python_modules/dagster/dagster/_serdes/serdes.py          │                  │                 │                 │                 │                 │
│ iterencode at                                                                        │         43.564MB │          25.56% │        43.564MB │          25.56% │              59 │
│ /Users/alangenfeld/.pyenv/versions/3.11.7/lib/python3.11/json/encoder.py             │                  │                 │                 │                 │                 │
│ encode at /Users/alangenfeld/.pyenv/versions/3.11.7/lib/python3.11/json/encoder.py   │         40.562MB │          23.80% │        40.562MB │          23.80% │               1 │
│ pack at /Users/alangenfeld/dagster/python_modules/dagster/dagster/_serdes/serdes.py  │         38.106MB │          22.36% │         2.000MB │           1.17% │            1226 │
│ <listcomp> at                                                                        │         12.939MB │           7.59% │       114.031KB │           0.07% │            1196 │
│ /Users/alangenfeld/dagster/python_modules/dagster/dagster/_serdes/serdes.py          │                  │                 │                 │                 │                 │
│ <dictcomp> at                                                                        │         12.827MB │           7.53% │        12.827MB │           7.53% │            1091 │
│ /Users/alangenfeld/dagster/python_modules/dagster/dagster/_serdes/serdes.py          │                  │                 │                 │                 │                 │
└──────────────────────────────────────────────────────────────────────────────────────┴──────────────────┴─────────────────┴─────────────────┴─────────────────┴─────────────────┘


(py311) ~/dagster:al/05-02-_prototype_serdes_serialization$ memray summary /tmp/exp_serialize_value_mem.bin
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃                                                                                      ┃                  ┃                 ┃                 ┃                 ┃      Allocation ┃
┃ Location                                                                             ┃   <Total Memory> ┃  Total Memory % ┃      Own Memory ┃    Own Memory % ┃           Count ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│ experimental_serialize_value at                                                      │         81.127MB │         100.00% │         1.617KB │           0.00% │              58 │
│ /Users/alangenfeld/dagster/python_modules/dagster/dagster/_serdes/serdes.py          │                  │                 │                 │                 │                 │
│ <module> at /tmp/compare.py                                                          │         81.127MB │         100.00% │          0.000B │           0.00% │              58 │
│ dumps at /Users/alangenfeld/.pyenv/versions/3.11.7/lib/python3.11/json/__init__.py   │         81.126MB │         100.00% │          0.000B │           0.00% │              57 │
│ iterencode at                                                                        │         40.564MB │          50.00% │        40.564MB │          50.00% │              56 │
│ /Users/alangenfeld/.pyenv/versions/3.11.7/lib/python3.11/json/encoder.py             │                  │                 │                 │                 │                 │
│ encode at /Users/alangenfeld/.pyenv/versions/3.11.7/lib/python3.11/json/encoder.py   │         40.562MB │          50.00% │        40.562MB │          50.00% │               1 │
└──────────────────────────────────────────────────────────────────────────────────────┴──────────────────┴─────────────────┴─────────────────┴─────────────────┴─────────────────┘
```

