### PR TITLE
[backfill daemon] logging when an asset gets removed from consideration 

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1369,12 +1369,12 @@ def can_run_with_parent(
     )
     if parent_node.backfill_policy != candidate_node.backfill_policy:
         logger.info(
-            "Excluding {candidate_node.asset_key} from request list. Reason: parent {parent_node.asset_key} and {candidate_node.asset_key} have different backfill policies."
+            f"Excluding {candidate} from request list. Reason: parent {parent_node.key} and {candidate_node.key} have different backfill policies."
         )
         return False
     if parent_node.priority_repository_handle is not candidate_node.priority_repository_handle:
         logger.info(
-            "Excluding {candidate_node.asset_key} from request list. Reason: parent {parent_node.asset_key} and {candidate_node.asset_key} are in different code locations."
+            f"Excluding {candidate} from request list. Reason: parent {parent_node.key} and {candidate_node.key} are in different code locations."
         )
         return False
     if (
@@ -1382,7 +1382,7 @@ def can_run_with_parent(
         and parent not in candidates_unit
     ):
         logger.info(
-            f"Excluding {candidate_node.asset_key} from request list. Reason: parent asset {parent.asset_key} with partition key {parent.partition_key} is not requested in this iteration."
+            f"Excluding {candidate} from request list. Reason: parent asset {parent.asset_key} with partition key {parent.partition_key} is not requested in this iteration."
         )
         return False
     if (
@@ -1410,12 +1410,12 @@ def can_run_with_parent(
         return True
     else:
         logger.log(
-            f"Excluding {candidate_node.asset_key} from request list. Reason: partition "
-            f"mapping between {parent_node.asset_key} and {candidate_node.asset_key} is not simple and "
-            f"{parent_node.asset_key} does not meet requirements of: targeting the same partitions as "
-            f"{candidate_node.asset_key}, have all of its partitions requested in this iteration, having "
+            f"Excluding {candidate} from request list. Reason: partition "
+            f"mapping between {parent_node.key} and {candidate_node.key} is not simple and "
+            f"{parent_node.key} does not meet requirements of: targeting the same partitions as "
+            f"{candidate_node.key}, have all of its partitions requested in this iteration, having "
             "a backfill policy, and that backfill policy size limit is not exceeded by adding "
-            f"{candidate_node.asset_key} to the run."
+            f"{candidate_node.key} to the run."
         )
         return False
 

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1409,7 +1409,7 @@ def can_run_with_parent(
     ):
         return True
     else:
-        logger.log(
+        logger.info(
             f"Excluding {candidate} from request list. Reason: partition "
             f"mapping between {parent_node.key} and {candidate_node.key} is not simple and "
             f"{parent_node.key} does not meet requirements of: targeting the same partitions as "

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1437,21 +1437,25 @@ def should_backfill_atomic_asset_partitions_unit(
         materialized.
     """
     for candidate in candidates_unit:
-        if (
-            candidate not in target_subset
-            or candidate in failed_and_downstream_subset
-            or candidate in materialized_subset
-            or candidate in requested_subset
-        ):
-            if candidate not in target_subset:
-                reason = "not targeted by backfill"
-            elif candidate in failed_and_downstream_subset:
-                reason = "in failed and downstream subset"
-            elif candidate in materialized_subset:
-                reason = "already materialized by backfill"
-            else:  # candidate in requested_subset
-                reason = "already requested by backfill"
-            logger.info(f"Excluding {candidate} from request list. Reason: {reason}")
+        if candidate not in target_subset:
+            logger.info(
+                f"Excluding {candidate} from request list. Reason: not targeted by backfill."
+            )
+            return False
+        elif candidate in failed_and_downstream_subset:
+            logger.info(
+                f"Excluding {candidate} from request list. Reason: in failed and downstream subset."
+            )
+            return False
+        elif candidate in materialized_subset:
+            logger.info(
+                f"Excluding {candidate} from request list. Reason: already materialized by backfill."
+            )
+            return False
+        elif candidate in requested_subset:
+            logger.info(
+                f"Excluding {candidate} from request list. Reason: already requested by backfill."
+            )
             return False
 
         parent_partitions_result = asset_graph.get_parents_partitions(

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1284,12 +1284,13 @@ def execute_asset_backfill_iteration_inner(
         f"After BFS-should-backfill filter, asset partitions to request: {asset_partitions_to_request}"
     )
     not_requested_str = (
-        "\n".join([f"{keys} - Reason: {reason}." for keys, reason in not_requested_and_reasons])
+        "\n"
+        + "\n".join([f"{keys} - Reason: {reason}." for keys, reason in not_requested_and_reasons])
         if len(not_requested_and_reasons) > 0
         else "None"
     )
     logger.info(
-        f"The following assets were considered for materialization but not requested:\n {not_requested_str}"
+        f"The following assets were considered for materialization but not requested:  {not_requested_str}"
     )
 
     # check if all assets have backfill policies if any of them do, otherwise, raise error

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1283,8 +1283,10 @@ def execute_asset_backfill_iteration_inner(
     logger.info(
         f"After BFS-should-backfill filter, asset partitions to request: {asset_partitions_to_request}"
     )
-    not_requested_str = "\n".join(
-        [f"{keys} - Reason: {reason}." for keys, reason in not_requested_and_reasons]
+    not_requested_str = (
+        "\n".join([f"{keys} - Reason: {reason}." for keys, reason in not_requested_and_reasons])
+        if len(not_requested_and_reasons) > 0
+        else "None"
     )
     logger.info(
         f"The following assets were considered for materialization but not requested:\n {not_requested_str}"
@@ -1386,6 +1388,11 @@ def can_run_with_parent(
         return (
             False,
             f"parent {parent_node.key} and {candidate_node.key} are in different code locations",
+        )
+    if parent_node.partitions_def != candidate_node.partitions_def:
+        return (
+            False,
+            f"parent {parent_node.key} and {candidate_node.key} have different partitions definitions",
         )
     if (
         parent.partition_key not in asset_partitions_to_request_map[parent.asset_key]

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -40,16 +40,23 @@ def execute_backfill_jobs(
 ) -> Iterable[Optional[SerializableErrorInfo]]:
     instance = workspace_process_context.instance
 
+    # TODO remove
+    fh = logging.FileHandler("backfill_logs.log")
+    fh.setLevel(logging.DEBUG)
+    logger.addHandler(fh)
+
     for backfill_job in backfill_jobs:
         backfill_id = backfill_job.backfill_id
 
         # refetch, in case the backfill was updated in the meantime
         backfill = cast(PartitionBackfill, instance.get_backfill(backfill_id))
         # create a logger that will always include the backfill_id as an `extra`
+
         backfill_logger = cast(
             logging.Logger,
             logging.LoggerAdapter(logger, extra={"backfill_id": backfill.backfill_id}),
         )
+
         try:
             if backfill.is_asset_backfill:
                 yield from execute_asset_backfill_iteration(

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -40,11 +40,6 @@ def execute_backfill_jobs(
 ) -> Iterable[Optional[SerializableErrorInfo]]:
     instance = workspace_process_context.instance
 
-    # TODO remove
-    fh = logging.FileHandler("backfill_logs.log")
-    fh.setLevel(logging.DEBUG)
-    logger.addHandler(fh)
-
     for backfill_job in backfill_jobs:
         backfill_id = backfill_job.backfill_id
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -485,7 +485,7 @@ def make_random_subset(
                 root_asset_partitions.add(AssetKeyPartitionKey(root_asset_key, None))
 
     target_asset_partitions = asset_graph.bfs_filter_asset_partitions(
-        instance, lambda _a, _b: True, root_asset_partitions, evaluation_time=evaluation_time
+        instance, lambda _a, _b: (True, ""), root_asset_partitions, evaluation_time=evaluation_time
     )
 
     return AssetGraphSubset.from_asset_partition_set(target_asset_partitions, asset_graph)
@@ -508,7 +508,7 @@ def make_subset_from_partition_keys(
             root_asset_partitions.add(AssetKeyPartitionKey(root_asset_key, None))
 
     target_asset_partitions = asset_graph.bfs_filter_asset_partitions(
-        instance, lambda _a, _b: True, root_asset_partitions, evaluation_time=evaluation_time
+        instance, lambda _a, _b: (True, ""), root_asset_partitions, evaluation_time=evaluation_time
     )
 
     return AssetGraphSubset.from_asset_partition_set(target_asset_partitions, asset_graph)
@@ -580,7 +580,7 @@ def run_backfill_to_completion(
 
     fail_and_downstream_asset_partitions = asset_graph.bfs_filter_asset_partitions(
         instance,
-        lambda _a, _b: True,
+        lambda _a, _b: (True, ""),
         fail_asset_partitions,
         evaluation_time=backfill_data.backfill_start_time,
     )

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -484,7 +484,7 @@ def make_random_subset(
             if i % 2 == 0:
                 root_asset_partitions.add(AssetKeyPartitionKey(root_asset_key, None))
 
-    target_asset_partitions = asset_graph.bfs_filter_asset_partitions(
+    target_asset_partitions, _ = asset_graph.bfs_filter_asset_partitions(
         instance, lambda _a, _b: (True, ""), root_asset_partitions, evaluation_time=evaluation_time
     )
 
@@ -507,7 +507,7 @@ def make_subset_from_partition_keys(
         else:
             root_asset_partitions.add(AssetKeyPartitionKey(root_asset_key, None))
 
-    target_asset_partitions = asset_graph.bfs_filter_asset_partitions(
+    target_asset_partitions, _ = asset_graph.bfs_filter_asset_partitions(
         instance, lambda _a, _b: (True, ""), root_asset_partitions, evaluation_time=evaluation_time
     )
 
@@ -578,7 +578,7 @@ def run_backfill_to_completion(
     # assert each asset partition only targeted once
     requested_asset_partitions: Set[AssetKeyPartitionKey] = set()
 
-    fail_and_downstream_asset_partitions = asset_graph.bfs_filter_asset_partitions(
+    fail_and_downstream_asset_partitions, _ = asset_graph.bfs_filter_asset_partitions(
         instance,
         lambda _a, _b: (True, ""),
         fail_asset_partitions,


### PR DESCRIPTION
## Summary & Motivation
In the backfill daemon, we create a list of candidates to request, then run a bfs search over those candidates and their children. assets are added and removed from the list of assets to request based on a variety of factors. This logging PR adds logs whenever an asset is removed from the list. This should make it easier to answer the question "'i expected asset A to get requested, why didn't it?" without needing to run a dry-run shadow script and see where in the code the asset gets removed from consideration. 

## How I Tested These Changes
The log messages from this PR look like this 
```
The following assets were considered for materialization but not requested:
[AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_1']), partition_key='2024-04-21'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_2']), partition_key='2024-04-21')] - Reason: parent AssetKey(['the_daily_asset']) and AssetKey(['weekly_asset_1']) have different partitions definitions.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-21')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-21') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_1']), partition_key='2024-04-21'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_2']), partition_key='2024-04-21')] - Reason: parent AssetKey(['the_daily_asset']) and AssetKey(['weekly_asset_1']) have different partitions definitions.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-20')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-20') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-19')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-19') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-18')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-18') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-17')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-17') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-16')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-16') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-15')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-15') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_1']), partition_key='2024-04-14'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_2']), partition_key='2024-04-14')] - Reason: parent AssetKey(['the_daily_asset']) and AssetKey(['weekly_asset_1']) have different partitions definitions.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-14')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-14') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_1']), partition_key='2024-04-14'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_2']), partition_key='2024-04-14')] - Reason: parent AssetKey(['the_daily_asset']) and AssetKey(['weekly_asset_1']) have different partitions definitions.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-13')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-13') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-12')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-12') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-11')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-11') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-10')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-10') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-09')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-09') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-08')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-08') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_1']), partition_key='2024-04-07'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_2']), partition_key='2024-04-07')] - Reason: parent AssetKey(['the_daily_asset']) and AssetKey(['weekly_asset_1']) have different partitions definitions.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-07')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-07') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_1']), partition_key='2024-04-07'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_2']), partition_key='2024-04-07')] - Reason: parent AssetKey(['the_daily_asset']) and AssetKey(['weekly_asset_1']) have different partitions definitions.

```

full sample output 
```
Evaluating asset backfill utgnwxxt
Targets for asset backfill utgnwxxt are valid. Continuing execution with current status: BulkActionStatus.REQUESTED.
Not all root assets have been requested, finding root assets.
Root assets that have not yet been requested: {AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-12'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-20'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-18'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-08'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-17'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-13'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-14'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-19'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-09'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-15'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-11'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-10'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-07'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-21'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-16')}
After BFS-should-backfill filter, asset partitions to request: {AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-12'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-20'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-18'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-08'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-17'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-13'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-14'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-09'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-15'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-07'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-11'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-10'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-19'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-21'), AssetKeyPartitionKey(asset_key=AssetKey(['the_daily_asset']), partition_key='2024-04-16')}
The following assets were considered for materialization but not requested:
[AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_1']), partition_key='2024-04-21'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_2']), partition_key='2024-04-21')] - Reason: parent AssetKey(['the_daily_asset']) and AssetKey(['weekly_asset_1']) have different partitions definitions.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-21')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-21') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_1']), partition_key='2024-04-21'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_2']), partition_key='2024-04-21')] - Reason: parent AssetKey(['the_daily_asset']) and AssetKey(['weekly_asset_1']) have different partitions definitions.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-20')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-20') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-19')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-19') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-18')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-18') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-17')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-17') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-16')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-16') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-15')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-15') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_1']), partition_key='2024-04-14'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_2']), partition_key='2024-04-14')] - Reason: parent AssetKey(['the_daily_asset']) and AssetKey(['weekly_asset_1']) have different partitions definitions.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-14')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-14') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_1']), partition_key='2024-04-14'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_2']), partition_key='2024-04-14')] - Reason: parent AssetKey(['the_daily_asset']) and AssetKey(['weekly_asset_1']) have different partitions definitions.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-13')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-13') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-12')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-12') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-11')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-11') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-10')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-10') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-09')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-09') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-08')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-08') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_1']), partition_key='2024-04-07'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_2']), partition_key='2024-04-07')] - Reason: parent AssetKey(['the_daily_asset']) and AssetKey(['weekly_asset_1']) have different partitions definitions.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-07')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_daily_asset']), partition_key='2024-04-07') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_1']), partition_key='2024-04-07'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_2']), partition_key='2024-04-07')] - Reason: parent AssetKey(['the_daily_asset']) and AssetKey(['weekly_asset_1']) have different partitions definitions.
Submitted run bf9f65bd-4726-4700-91fe-afaf29959e60 for assets the_daily_asset with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-07'}
Submitted run 22a09de1-1780-4e09-84c8-bf0a422a2b8e for assets the_daily_asset with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-08'}
Submitted run 27a069ec-7167-4ad7-8a8b-c267c91cf8d9 for assets the_daily_asset with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-09'}
Submitted run 5f5dfb18-010f-4da4-a4f1-f5a4a08a08bb for assets the_daily_asset with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-10'}
Submitted run 775fe96f-4ddd-4ac1-9078-9a0518c18707 for assets the_daily_asset with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-11'}
Submitted run 3e86e717-d84b-4d43-8cbc-effbb692f9d9 for assets the_daily_asset with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-12'}
Submitted run 017ac3ea-7aeb-45ca-9635-5eccf458eb9d for assets the_daily_asset with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-13'}
Submitted run bbf051e8-f339-4e4b-beea-069240e85b40 for assets the_daily_asset with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-14'}
Submitted run d9d47ce3-e6e8-4399-9cdc-c4ffb24c361e for assets the_daily_asset with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-15'}
Submitted run 90a90aca-6c2f-4ddd-b431-9c8f2f58c757 for assets the_daily_asset with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-16'}
Submitted run 0b6c3307-5f62-47cf-9628-31132f2c09bb for assets the_daily_asset with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-17'}
Submitted run a0ceffe7-a9ed-4315-b994-99bcb964ef77 for assets the_daily_asset with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-18'}
Submitted run 5b43fa3d-14c8-47e2-b439-e8de872eb03f for assets the_daily_asset with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-19'}
Submitted run 67436b1b-959c-4e6a-bd7e-dff0ab1d4a65 for assets the_daily_asset with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-20'}
Submitted run 844daeee-6a65-4b7d-a2a8-061af16485ee for assets the_daily_asset with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-21'}
Asset backfill utgnwxxt completed iteration with status BulkActionStatus.REQUESTED.
Updated asset backfill data for utgnwxxt: AssetBackfillData(target_subset=AssetGraphSubset(non_partitioned_asset_keys=set(), partitions_subsets_by_asset_key={AssetKey(['weekly_asset_2']): TimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')]), AssetKey(['the_daily_asset']): TimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')]), AssetKey(['weekly_asset_1']): TimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')])}), requested_runs_for_target_roots=True, latest_storage_id=8629, materialized_subset=AssetGraphSubset(non_partitioned_asset_keys=set(), partitions_subsets_by_asset_key={}), requested_subset=AssetGraphSubset(non_partitioned_asset_keys=set(), partitions_subsets_by_asset_key={AssetKey(['the_daily_asset']): PartitionKeysTimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')])}), failed_and_downstream_subset=AssetGraphSubset(non_partitioned_asset_keys=set(), partitions_subsets_by_asset_key={}), backfill_start_time=DateTime(2024, 5, 9, 14, 20, 37, 363453, tzinfo=Timezone('UTC')))
Evaluating asset backfill utgnwxxt
Targets for asset backfill utgnwxxt are valid. Continuing execution with current status: BulkActionStatus.REQUESTED.
Assets materialized since last tick AssetGraphSubset(non_partitioned_asset_keys=set(), partitions_subsets_by_asset_key={AssetKey(['the_daily_asset']): PartitionKeysTimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')])})
After BFS-should-backfill filter, asset partitions to request: {AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_1']), partition_key='2024-04-07'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_1']), partition_key='2024-04-21'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_1']), partition_key='2024-04-14'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_2']), partition_key='2024-04-14'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_2']), partition_key='2024-04-07'), AssetKeyPartitionKey(asset_key=AssetKey(['weekly_asset_2']), partition_key='2024-04-21')}
The following assets were considered for materialization but not requested:
[AssetKeyPartitionKey(asset_key=AssetKey(['another_weekly']), partition_key='2024-04-21')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_weekly']), partition_key='2024-04-21') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_weekly']), partition_key='2024-04-14')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_weekly']), partition_key='2024-04-14') not targeted by backfill.
[AssetKeyPartitionKey(asset_key=AssetKey(['another_weekly']), partition_key='2024-04-07')] - Reason: AssetKeyPartitionKey(asset_key=AssetKey(['another_weekly']), partition_key='2024-04-07') not targeted by backfill.
Submitted run 31bab3cb-bf1a-43a7-b1f3-c92e84566ccb for assets weekly_asset_1, weekly_asset_2 with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-07'}
Submitted run 72f4d14b-bb6c-4123-b361-6a9c8bd522ef for assets weekly_asset_1, weekly_asset_2 with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-14'}
Submitted run 36b884d9-74a9-4c5a-acc0-f8addd67a910 for assets weekly_asset_1, weekly_asset_2 with tags {'dagster/backfill': 'utgnwxxt', 'dagster/partition': '2024-04-21'}
Asset backfill utgnwxxt completed iteration with status BulkActionStatus.REQUESTED.
Updated asset backfill data for utgnwxxt: AssetBackfillData(target_subset=AssetGraphSubset(non_partitioned_asset_keys=set(), partitions_subsets_by_asset_key={AssetKey(['weekly_asset_2']): TimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')]), AssetKey(['the_daily_asset']): TimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')]), AssetKey(['weekly_asset_1']): TimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')])}), requested_runs_for_target_roots=True, latest_storage_id=8704, materialized_subset=AssetGraphSubset(non_partitioned_asset_keys=set(), partitions_subsets_by_asset_key={AssetKey(['the_daily_asset']): PartitionKeysTimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')])}), requested_subset=AssetGraphSubset(non_partitioned_asset_keys=set(), partitions_subsets_by_asset_key={AssetKey(['the_daily_asset']): TimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')]), AssetKey(['weekly_asset_1']): PartitionKeysTimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')]), AssetKey(['weekly_asset_2']): PartitionKeysTimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')])}), failed_and_downstream_subset=AssetGraphSubset(non_partitioned_asset_keys=set(), partitions_subsets_by_asset_key={}), backfill_start_time=DateTime(2024, 5, 9, 14, 20, 37, 363453, tzinfo=Timezone('UTC')))
Evaluating asset backfill utgnwxxt
Targets for asset backfill utgnwxxt are valid. Continuing execution with current status: BulkActionStatus.REQUESTED.
Assets materialized since last tick AssetGraphSubset(non_partitioned_asset_keys=set(), partitions_subsets_by_asset_key={AssetKey(['the_daily_asset']): TimeWindowPartitionsSubset([]), AssetKey(['weekly_asset_1']): PartitionKeysTimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')]), AssetKey(['weekly_asset_2']): PartitionKeysTimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')])})
After BFS-should-backfill filter, asset partitions to request: set()
The following assets were considered for materialization but not requested:  None
Asset backfill utgnwxxt completed iteration with status BulkActionStatus.COMPLETED.
Updated asset backfill data for utgnwxxt: AssetBackfillData(target_subset=AssetGraphSubset(non_partitioned_asset_keys=set(), partitions_subsets_by_asset_key={AssetKey(['weekly_asset_2']): TimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')]), AssetKey(['the_daily_asset']): TimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')]), AssetKey(['weekly_asset_1']): TimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')])}), requested_runs_for_target_roots=True, latest_storage_id=8725, materialized_subset=AssetGraphSubset(non_partitioned_asset_keys=set(), partitions_subsets_by_asset_key={AssetKey(['the_daily_asset']): TimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')]), AssetKey(['weekly_asset_1']): PartitionKeysTimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')]), AssetKey(['weekly_asset_2']): PartitionKeysTimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')])}), requested_subset=AssetGraphSubset(non_partitioned_asset_keys=set(), partitions_subsets_by_asset_key={AssetKey(['the_daily_asset']): TimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')]), AssetKey(['weekly_asset_1']): TimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')]), AssetKey(['weekly_asset_2']): TimeWindowPartitionsSubset([PartitionKeyRange(start='2024-04-07', end='2024-04-21')])}), failed_and_downstream_subset=AssetGraphSubset(non_partitioned_asset_keys=set(), partitions_subsets_by_asset_key={}), backfill_start_time=DateTime(2024, 5, 9, 14, 20, 37, 363453, tzinfo=Timezone('UTC')))

```