### PR TITLE
"System tags" -> "Tags" in UI

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
@@ -156,7 +156,7 @@ export const AssetEventDetail = ({
       )}
 
       <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
-        <Subheading>System tags</Subheading>
+        <Subheading>Tags</Subheading>
         <AssetEventSystemTags event={event} collapsible />
       </Box>
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
@@ -377,7 +377,7 @@ export const AssetPartitionDetail = ({
         <AssetMaterializationUpstreamData timestamp={latest?.timestamp} assetKey={assetKey} />
       </Box>
       <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
-        <Subheading>System tags</Subheading>
+        <Subheading>Tags</Subheading>
         <AssetEventSystemTags event={latest} collapsible />
       </Box>
     </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -117,7 +117,7 @@ export const AssetSidebarActivitySummary = ({
             )}
           </SidebarSection>
           <SidebarSection
-            title={!isSourceAsset ? 'Materialization system tags' : 'Observation system tags'}
+            title={!isSourceAsset ? 'Materialization tags' : 'Observation tags'}
             collapsedByDefault
           >
             {displayedEvent ? (


### PR DESCRIPTION
## Summary & Motivation

This PR allows users to set their own materialization and observation tags: https://github.com/dagster-io/dagster/pull/21452. In light of that, it no longer makes sense to just label tags as "system tags".

## How I Tested These Changes
