### PR TITLE
[serdes] iterative serialization

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -185,13 +185,13 @@ class ReconstructableJobSerializer(NamedTupleSerializer):
             unpacked_dict["op_selection"] = solids_to_execute
         return unpacked_dict
 
-    def after_pack(self, **packed_dict: Any) -> Dict[str, Any]:
-        if packed_dict["op_selection"]:
-            packed_dict["solid_selection_str"] = json.dumps(packed_dict["op_selection"]["__set__"])
-        else:
-            packed_dict["solid_selection_str"] = None
-        del packed_dict["op_selection"]
-        return packed_dict
+    def pack_items(self, *args, **kwargs):
+        for k, v in super().pack_items(*args, **kwargs):
+            if k == "op_selection":
+                new_v = json.dumps(v["__set__"]) if v else None
+                yield "solid_selection_str", new_v
+            else:
+                yield k, v
 
 
 @whitelist_for_serdes(

--- a/python_modules/dagster/dagster/_serdes/config_class.py
+++ b/python_modules/dagster/dagster/_serdes/config_class.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     Mapping,
     NamedTuple,
     Optional,
@@ -36,9 +35,12 @@ T_ConfigurableClass = TypeVar("T_ConfigurableClass")
 
 
 class ConfigurableClassDataSerializer(NamedTupleSerializer["ConfigurableClassData"]):
-    def after_pack(self, **packed: Any) -> Dict[str, Any]:
-        packed["module_name"] = convert_dagster_submodule_name(packed["module_name"], "public")
-        return packed
+    def pack_items(self, *args, **kwargs):
+        for k, v in super().pack_items(*args, **kwargs):
+            if k == "module_name":
+                yield k, convert_dagster_submodule_name(v, "public")
+            else:
+                yield k, v
 
 
 @whitelist_for_serdes(serializer=ConfigurableClassDataSerializer)

--- a/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
@@ -634,10 +634,12 @@ def test_named_tuple_custom_serializer():
     test_map = WhitelistMap.create()
 
     class FooSerializer(NamedTupleSerializer):
-        def after_pack(self, **storage_dict: Dict[str, Any]):
-            storage_dict["colour"] = storage_dict["color"]
-            del storage_dict["color"]
-            return storage_dict
+        def pack_items(self, *args, **kwargs):
+            for k, v in super().pack_items(*args, **kwargs):
+                if k == "color":
+                    yield "colour", v
+                else:
+                    yield k, v
 
         def before_unpack(self, context, unpacked_dict: Dict[str, Any]):
             unpacked_dict["color"] = unpacked_dict["colour"]


### PR DESCRIPTION
Change how we drive serialization from the two step "pack" (turn whole tree in to primitives) then serialize to one where we wrap object types in a fake dict and iteratively process them as json iterencode walks the tree. 

original prototype https://github.com/dagster-io/dagster/pull/21595

## How I Tested These Changes

these raw results https://gist.github.com/alangenfeld/6673e4a8718ccea2dc4b287f811939eb fed through an llm to make this table

Target | Size | serialize_value (mean) | pack_value (mean) | serialize_value (% change) | pack_value (% change)
-- | -- | -- | -- | -- | --
0 | 68.7KiB | 1.679 (master) / 1.569 (al) | 1.100 (master) / 1.020 (al) | -6.5% | -7.8%
1 | 9.7MiB | 688.566 (master) / 398.689 (al) | 631.490 (master) / 424.501 (al) | -42.4% | -33.4%
2 | 25.8MiB | 2366.767 (master) / 1855.869 (al) | 2082.907 (master) / 1898.141 (al) | -21.6% | -10.3%
3 | 9.1MiB | 282.533 (master) / 234.455 (al) | 212.199 (master) / 228.063 (al) | -17.2% | +6.9%
4 | 2.5MiB | 50.936 (master) / 49.849 (al) | 33.145 (master) / 34.069 (al) | -1.7% | +2.7%
5 | 635.7KiB | 14.285 (master) / 14.051 (al) | 9.332 (master) / 9.861 (al) | -1.7% | +5.3%
6 | 42.6KiB | 0.934 (master) / 0.997 (al) | 0.604 (master) / 0.649 (al) | +6.3% | +7.0%
7 | 40.6MiB | 1305.244 (master) / 927.526 (al) | 990.155 (master) / 1045.181 (al) | -28.7% | +5.3%

we see the most improvement on large payloads

memory profiling `Target 3`:  ` 173.451MB` -> `85.128MB` ~50% reduction 
https://gist.github.com/alangenfeld/8c67ec41729f99fe78c73d70bfe8d080

