### PR TITLE
Update asset-selection-syntax.mdx

### DIFF
--- a/docs/content/concepts/assets/asset-selection-syntax.mdx
+++ b/docs/content/concepts/assets/asset-selection-syntax.mdx
@@ -84,7 +84,7 @@ A query includes a list of clauses. Clauses are separated by commas, except in t
         <code>ASSET_KEY*</code>
       </td>
       <td>
-        An asterisk (<code>*</code>) preceding an asset key selects an asset and
+        An asterisk (<code>*</code>) following an asset key selects an asset and
         all of its downstream dependencies
       </td>
     </tr>


### PR DESCRIPTION
## Summary & Motivation
Currently, the docs incorrectly describe the " * " character as preceding  ASSET_KEY when selecting an asset and its downstream dependencies, when this character actually comes after ASSET_KEY. Here I have fixed this typo.

## How I Tested These Changes
N/A