### PR TITLE
[DS][24/n] Remove all AssetSubset references from the context and result objects

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -164,6 +164,16 @@ class AssetSlice:
             self._asset_graph_view, self._compatible_subset - other.convert_to_valid_asset_subset()
         )
 
+    def compute_union(self, other: "AssetSlice") -> "AssetSlice":
+        return _slice_from_subset(
+            self._asset_graph_view, self._compatible_subset | other.convert_to_valid_asset_subset()
+        )
+
+    def compute_intersection(self, other: "AssetSlice") -> "AssetSlice":
+        return _slice_from_subset(
+            self._asset_graph_view, self._compatible_subset & other.convert_to_valid_asset_subset()
+        )
+
     def compute_intersection_with_partition_keys(
         self, partition_keys: AbstractSet[str]
     ) -> "AssetSlice":
@@ -327,7 +337,7 @@ class AssetGraphView:
             ),
         )
 
-    def get_asset_slice_from_subset(self, subset: ValidAssetSubset) -> "AssetSlice":
+    def get_asset_slice_from_subset(self, subset: AssetSubset) -> "AssetSlice":
         return _slice_from_subset(self, subset)
 
     def compute_missing_subslice(

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -80,7 +80,8 @@ class MaterializeOnRequiredForFreshnessRule(
         true_subset, subsets_with_metadata = freshness_evaluation_results_for_asset_key(
             context.legacy_context.root_context
         )
-        return SchedulingResult.create(context, true_subset, subsets_with_metadata)
+        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
 @whitelist_for_serdes
@@ -216,7 +217,8 @@ class MaterializeOnCronRule(
             - context.legacy_context.materialized_requested_or_discarded_since_previous_tick_subset
         )
 
-        return SchedulingResult.create(context, true_subset=asset_subset_to_request)
+        true_slice = context.asset_graph_view.get_asset_slice_from_subset(asset_subset_to_request)
+        return SchedulingResult.create(context, true_slice=true_slice)
 
 
 @whitelist_for_serdes
@@ -433,7 +435,8 @@ class MaterializeOnParentUpdatedRule(
                 ignore_subset=context.legacy_context.materialized_requested_or_discarded_since_previous_tick_subset,
             )
         )
-        return SchedulingResult.create(context, true_subset, subsets_with_metadata)
+        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
 @whitelist_for_serdes
@@ -531,7 +534,7 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
 
         return SchedulingResult.create(
             context,
-            true_subset=unhandled_candidates,
+            true_slice=context.asset_graph_view.get_asset_slice_from_subset(unhandled_candidates),
             # we keep track of the handled subset instead of the unhandled subset because new
             # partitions may spontaneously jump into existence at any time
             extra_state=handled_subset,
@@ -585,7 +588,8 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
                 asset_partitions_by_evaluation_data, ignore_subset=subset_to_evaluate
             )
         )
-        return SchedulingResult.create(context, true_subset, subsets_with_metadata)
+        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
 @whitelist_for_serdes
@@ -641,7 +645,8 @@ class SkipOnParentMissingRule(AutoMaterializeRule, NamedTuple("_SkipOnParentMiss
                 asset_partitions_by_evaluation_data, ignore_subset=subset_to_evaluate
             )
         )
-        return SchedulingResult.create(context, true_subset, subsets_with_metadata)
+        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
 @whitelist_for_serdes
@@ -734,7 +739,8 @@ class SkipOnNotAllParentsUpdatedRule(
                 asset_partitions_by_evaluation_data, ignore_subset=subset_to_evaluate
             )
         )
-        return SchedulingResult.create(context, true_subset, subsets_with_metadata)
+        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
 @whitelist_for_serdes
@@ -959,7 +965,9 @@ class SkipOnNotAllParentsUpdatedSinceCronRule(
 
         return SchedulingResult.create(
             context,
-            true_subset=context.legacy_context.candidate_subset - all_parents_updated_subset,
+            true_slice=context.asset_graph_view.get_asset_slice_from_subset(
+                context.legacy_context.candidate_subset - all_parents_updated_subset
+            ),
             extra_state=list(updated_subsets_by_key.values()),
         )
 
@@ -1008,7 +1016,8 @@ class SkipOnRequiredButNonexistentParentsRule(
                 asset_partitions_by_evaluation_data, ignore_subset=subset_to_evaluate
             )
         )
-        return SchedulingResult.create(context, true_subset, subsets_with_metadata)
+        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
 @whitelist_for_serdes
@@ -1047,7 +1056,8 @@ class SkipOnBackfillInProgressRule(
         else:
             true_subset = context.legacy_context.candidate_subset & backfilling_subset
 
-        return SchedulingResult.create(context, true_subset)
+        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        return SchedulingResult.create(context, true_slice)
 
 
 @whitelist_for_serdes
@@ -1075,10 +1085,12 @@ class DiscardOnMaxMaterializationsExceededRule(
 
         return SchedulingResult.create(
             context,
-            AssetSubset.from_asset_partitions_set(
-                context.legacy_context.asset_key,
-                context.legacy_context.partitions_def,
-                rate_limited_asset_partitions,
+            context.asset_graph_view.get_asset_slice_from_subset(
+                AssetSubset.from_asset_partitions_set(
+                    context.legacy_context.asset_key,
+                    context.legacy_context.partitions_def,
+                    rate_limited_asset_partitions,
+                )
             ),
         )
 
@@ -1109,5 +1121,15 @@ class SkipOnRunInProgressRule(AutoMaterializeRule, NamedTuple("_SkipOnRunInProgr
         if planned_materialization_info:
             dagster_run = instance.get_run_by_id(planned_materialization_info.run_id)
             if dagster_run and dagster_run.status in IN_PROGRESS_RUN_STATUSES:
-                return SchedulingResult.create(context, context.legacy_context.candidate_subset)
-        return SchedulingResult.create(context, context.legacy_context.empty_subset())
+                return SchedulingResult.create(
+                    context,
+                    context.asset_graph_view.get_asset_slice_from_subset(
+                        context.legacy_context.candidate_subset
+                    ),
+                )
+        return SchedulingResult.create(
+            context,
+            context.asset_graph_view.get_asset_slice_from_subset(
+                context.legacy_context.empty_subset()
+            ),
+        )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
@@ -23,7 +23,7 @@ class SliceSchedulingCondition(AssetCondition):
         else:
             true_slice = self.compute_slice(context)
 
-        return SchedulingResult.create(context, true_slice.convert_to_valid_asset_subset())
+        return SchedulingResult.create(context, true_slice)
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional, Sequence
 import pendulum
 
 from dagster._core.asset_graph_view.asset_graph_view import AssetSlice
-from dagster._core.definitions.asset_subset import AssetSubset, ValidAssetSubset
+from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.declarative_scheduling.serialized_objects import (
     AssetConditionSnapshot,
     AssetSubsetWithMetadata,
@@ -152,7 +152,7 @@ class SchedulingResult(DagsterModel):
     @staticmethod
     def create_from_children(
         context: "SchedulingContext",
-        true_subset: ValidAssetSubset,
+        true_slice: AssetSlice,
         child_results: Sequence["SchedulingResult"],
     ) -> "SchedulingResult":
         """Returns a new AssetConditionEvaluation from the given child results."""
@@ -161,8 +161,8 @@ class SchedulingResult(DagsterModel):
             condition_unique_id=context.condition_unique_id,
             start_timestamp=context.create_time.timestamp(),
             end_timestamp=pendulum.now("UTC").timestamp(),
-            true_slice=context.asset_graph_view.get_asset_slice_from_subset(true_subset),
-            candidate_subset=context.candidate_subset,
+            true_slice=true_slice,
+            candidate_subset=context.candidate_slice.convert_to_valid_asset_subset(),
             subsets_with_metadata=[],
             child_results=child_results,
             extra_state=None,
@@ -171,7 +171,7 @@ class SchedulingResult(DagsterModel):
     @staticmethod
     def create(
         context: "SchedulingContext",
-        true_subset: ValidAssetSubset,
+        true_slice: AssetSlice,
         subsets_with_metadata: Sequence[AssetSubsetWithMetadata] = [],
         extra_state: PackableValue = None,
     ) -> "SchedulingResult":
@@ -181,8 +181,8 @@ class SchedulingResult(DagsterModel):
             condition_unique_id=context.condition_unique_id,
             start_timestamp=context.create_time.timestamp(),
             end_timestamp=pendulum.now("UTC").timestamp(),
-            true_slice=context.asset_graph_view.get_asset_slice_from_subset(true_subset),
-            candidate_subset=context.candidate_subset,
+            true_slice=true_slice,
+            candidate_subset=context.candidate_slice.convert_to_valid_asset_subset(),
             subsets_with_metadata=subsets_with_metadata,
             child_results=[],
             extra_state=extra_state,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
@@ -2,7 +2,11 @@ import datetime
 import itertools
 from typing import Any, Optional, Sequence
 
-from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView, TemporalContext
+from dagster._core.asset_graph_view.asset_graph_view import (
+    AssetGraphView,
+    AssetSlice,
+    TemporalContext,
+)
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.declarative_scheduling.serialized_objects import (
@@ -13,14 +17,14 @@ from dagster._core.definitions.declarative_scheduling.serialized_objects import 
 from dagster._model import DagsterModel
 
 
-class SchedulingEvaluationNode(DagsterModel):
-    """Represents computed information for a single node in the evaluation tree."""
+class SchedulingEvaluationResultNode(DagsterModel):
+    """Represents the results of evaluating a single condition in the broader evaluation tree."""
 
     asset_key: AssetKey
     condition_unique_id: str
 
-    true_subset: AssetSubset
-    candidate_subset: AssetSubset
+    true_slice: AssetSlice
+    candidate_slice: AssetSlice
     subsets_with_metadata: Sequence[AssetSubsetWithMetadata]
 
     extra_state: Any
@@ -30,7 +34,7 @@ class SchedulingEvaluationNode(DagsterModel):
         asset_graph_view: AssetGraphView,
         state: AssetConditionEvaluationState,
         condition_evaluation: AssetConditionEvaluation,
-    ) -> Sequence["SchedulingEvaluationNode"]:
+    ) -> Sequence["SchedulingEvaluationResultNode"]:
         unique_id = condition_evaluation.condition_snapshot.unique_id
         asset_key = condition_evaluation.asset_key
         # we store AllPartitionsSubset as a sentinel value to avoid serializing the entire set of
@@ -41,16 +45,18 @@ class SchedulingEvaluationNode(DagsterModel):
             if isinstance(condition_evaluation.candidate_subset, AssetSubset)
             else asset_graph_view.get_asset_slice(asset_key).convert_to_valid_asset_subset()
         )
-        node = SchedulingEvaluationNode(
+        node = SchedulingEvaluationResultNode(
             asset_key=asset_key,
             condition_unique_id=unique_id,
-            true_subset=condition_evaluation.true_subset,
-            candidate_subset=candidate_subset,
+            true_slice=asset_graph_view.get_asset_slice_from_subset(
+                condition_evaluation.true_subset
+            ),
+            candidate_slice=asset_graph_view.get_asset_slice_from_subset(candidate_subset),
             subsets_with_metadata=condition_evaluation.subsets_with_metadata,
             extra_state=state.extra_state_by_unique_id.get(unique_id),
         )
         child_nodes = [
-            SchedulingEvaluationNode.nodes_for_evaluation(asset_graph_view, state, child)
+            SchedulingEvaluationResultNode.nodes_for_evaluation(asset_graph_view, state, child)
             for child in condition_evaluation.child_evaluations
         ]
         return list(itertools.chain([node], *child_nodes))
@@ -60,9 +66,9 @@ class SchedulingEvaluationInfo(DagsterModel):
     """Represents computed information for the entire evaluation tree."""
 
     temporal_context: TemporalContext
-    evaluation_nodes: Sequence[SchedulingEvaluationNode]
+    evaluation_nodes: Sequence[SchedulingEvaluationResultNode]
 
-    def get_evaluation_node(self, unique_id: str) -> Optional[SchedulingEvaluationNode]:
+    def get_evaluation_node(self, unique_id: str) -> Optional[SchedulingEvaluationResultNode]:
         for node in self.evaluation_nodes:
             if node.condition_unique_id == unique_id:
                 return node
@@ -78,7 +84,7 @@ class SchedulingEvaluationInfo(DagsterModel):
             ),
             last_event_id=state.max_storage_id,
         )
-        nodes = SchedulingEvaluationNode.nodes_for_evaluation(
+        nodes = SchedulingEvaluationResultNode.nodes_for_evaluation(
             asset_graph_view, state, state.previous_evaluation
         )
         return SchedulingEvaluationInfo(temporal_context=temporal_context, evaluation_nodes=nodes)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
@@ -44,9 +44,7 @@ class FalseAssetCondition(SchedulingCondition):
     def evaluate(self, context: SchedulingContext) -> SchedulingResult:
         return SchedulingResult.create(
             context,
-            true_subset=context.asset_graph_view.create_empty_slice(
-                context.asset_key
-            ).convert_to_valid_asset_subset(),
+            true_slice=context.asset_graph_view.create_empty_slice(context.asset_key),
         )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
@@ -27,7 +27,7 @@ def get_hardcoded_condition():
         def evaluate(self, context: SchedulingContext) -> SchedulingResult:
             true_candidates = {
                 candidate
-                for candidate in context.candidate_subset.asset_partitions
+                for candidate in context.candidate_slice.convert_to_valid_asset_subset().asset_partitions
                 if candidate in true_set
             }
             partitions_def = context.asset_graph_view.asset_graph.get(
@@ -35,8 +35,10 @@ def get_hardcoded_condition():
             ).partitions_def
             return SchedulingResult.create(
                 context,
-                true_subset=AssetSubset.from_asset_partitions_set(
-                    context.asset_key, partitions_def, true_candidates
+                true_slice=context.asset_graph_view.get_asset_slice_from_subset(
+                    AssetSubset.from_asset_partitions_set(
+                        context.asset_key, partitions_def, true_candidates
+                    )
                 ),
             )
 


### PR DESCRIPTION
## Summary & Motivation

As title -- for the new codepaths, helps avoid a lot of convert_to_valid_asset_subset() business.

I didn't bother updating the AutoMaterializeRule side of the world in a nicer way, as this code will eventually be removed anyway.

Had to add some new methods to replace the & / | / - operators, this time properly labeled with "compute_"

## How I Tested These Changes
