### PR TITLE
convert dagster tests to deprecate get_event_records calls

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
+++ b/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
@@ -6,7 +6,7 @@ import time
 
 import requests
 import yaml
-from dagster import DagsterEventType, DagsterInstance, EventRecordsFilter
+from dagster import DagsterEventType, DagsterInstance
 from dagster._core.test_utils import environ, new_cwd
 from dagster._grpc.client import DagsterGrpcClient
 from dagster._grpc.server import wait_for_grpc_server
@@ -154,11 +154,9 @@ def test_dagster_dev_command_no_dagster_home():
                             if (
                                 len(instance.get_runs()) > 0
                                 and len(
-                                    instance.get_event_records(
-                                        event_records_filter=EventRecordsFilter(
-                                            event_type=DagsterEventType.PIPELINE_ENQUEUED
-                                        )
-                                    )
+                                    instance.fetch_run_status_changes(
+                                        DagsterEventType.PIPELINE_ENQUEUED, limit=1
+                                    ).records
                                 )
                                 > 0
                             ):

--- a/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_asset_events.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_asset_events.py
@@ -10,8 +10,6 @@ from dagster._core.definitions.data_version import (
     DATA_VERSION_TAG,
 )
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
-from dagster._core.event_api import EventRecordsFilter
-from dagster._core.events import DagsterEventType
 from dagster._seven import json
 from dagster_pipes import PipesContext
 from dagster_webserver.external_assets import (
@@ -270,13 +268,7 @@ def test_report_asset_check_evaluation_apis_consistent(
 
 
 def _assert_stored_obs(instance: DagsterInstance, asset_key: str):
-    records = instance.get_event_records(
-        EventRecordsFilter(
-            event_type=DagsterEventType.ASSET_OBSERVATION,
-            asset_key=AssetKey(asset_key),
-        ),
-        limit=1,
-    )
+    records = instance.fetch_observations(AssetKey(asset_key), limit=1).records
     assert records
     evt = records[0]
     assert evt.event_log_entry.dagster_event

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -8,7 +8,6 @@ from dagster import (
     AssetSelection,
     DagsterEventType,
     DailyPartitionsDefinition,
-    EventRecordsFilter,
     HourlyPartitionsDefinition,
     IOManager,
     Out,
@@ -370,9 +369,10 @@ def test_define_selection_job(job_selection, expected_assets, use_multi, prefixe
         result = job.execute_in_process(instance=instance)
         planned_asset_keys = {
             record.event_log_entry.dagster_event.event_specific_data.asset_key
-            for record in instance.get_event_records(
-                EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION_PLANNED)
-            )
+            for record in instance.get_records_for_run(
+                run_id=result.run_id,
+                of_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+            ).records
         }
 
     expected_asset_keys = set(

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
@@ -17,8 +17,6 @@ from dagster import (
 )
 from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.errors import DagsterBackfillFailedError
-from dagster._core.event_api import EventRecordsFilter
-from dagster._core.events import DagsterEventType
 from dagster._core.execution.asset_backfill import AssetBackfillData, AssetBackfillStatus
 from dagster._core.instance_for_test import instance_for_test
 from dagster._core.storage.tags import (
@@ -1060,12 +1058,7 @@ def test_single_run_backfill_full_execution(
                 [],
                 instance,
             )
-            events = instance.get_event_records(
-                EventRecordsFilter(
-                    asset_key=partitioned_asset.key,
-                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                )
-            )
+            events = instance.fetch_materializations(partitioned_asset.key, limit=5000).records
             assert len(events) == 4
 
             if batch_size > 0 and throw_store_event_batch_error:

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -31,8 +31,6 @@ from dagster._core.errors import (
     DagsterInvalidConfigError,
     DagsterInvariantViolationError,
 )
-from dagster._core.event_api import EventRecordsFilter
-from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.instance.config import DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
@@ -757,13 +755,7 @@ def test_report_runless_asset_event():
         assert mats[my_asset_key]
 
         instance.report_runless_asset_event(AssetObservation(my_asset_key))
-        records = instance.get_event_records(
-            EventRecordsFilter(
-                event_type=DagsterEventType.ASSET_OBSERVATION,
-                asset_key=my_asset_key,
-            ),
-            limit=1,
-        )
+        records = instance.fetch_observations(my_asset_key, limit=1).records
         assert len(records) == 1
 
         my_check = "my_check"

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -25,7 +25,6 @@ from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.materialize import materialize_to_memory
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition
-from dagster._core.event_api import EventRecordsFilter
 from dagster._core.test_utils import create_test_asset_job
 from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_freeze_time
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
@@ -194,14 +193,9 @@ def _get_record(instance):
     assert result.success
     return next(
         iter(
-            instance.get_event_records(
-                EventRecordsFilter(
-                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                    asset_key=AssetKey("unpartitioned_asset"),
-                ),
-                ascending=False,
-                limit=1,
-            )
+            instance.fetch_materializations(
+                AssetKey("unpartitioned_asset"), ascending=False, limit=1
+            ).records
         )
     )
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -22,7 +22,6 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR
 from dagster._core.remote_representation import CodeLocation, ExternalRepository
 from dagster._core.scheduler.instigation import SensorInstigatorData, TickStatus
-from dagster._core.storage.event_log.base import EventRecordsFilter
 from dagster._core.test_utils import (
     create_test_daemon_workspace_context,
     environ,
@@ -792,9 +791,9 @@ def test_run_failure_sensor_empty_run_records(
                 )
                 runs = instance.get_runs()
                 assert len(runs) == 0
-                failure_events = instance.get_event_records(
-                    EventRecordsFilter(event_type=DagsterEventType.PIPELINE_FAILURE)
-                )
+                failure_events = instance.fetch_run_status_changes(
+                    DagsterEventType.PIPELINE_FAILURE, limit=5000
+                ).records
                 assert len(failure_events) == 1
                 freeze_datetime = freeze_datetime.add(seconds=60)
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
@@ -6,9 +6,7 @@ from dagster import (
     AssetCheckSpec,
     AssetKey,
     AssetOut,
-    DagsterEventType,
     DagsterInstance,
-    EventRecordsFilter,
     In,
     MetadataValue,
     Output,
@@ -53,9 +51,7 @@ def test_asset_check_same_op():
 
     assert check_eval.target_materialization_data is not None
     assert check_eval.target_materialization_data.run_id == result.run_id
-    materialization_record = instance.get_event_records(
-        EventRecordsFilter(event_type=DagsterEventType.ASSET_MATERIALIZATION)
-    )[0]
+    materialization_record = instance.fetch_materializations(asset1.key, limit=1).records[0]
     assert check_eval.target_materialization_data.storage_id == materialization_record.storage_id
     assert check_eval.target_materialization_data.timestamp == materialization_record.timestamp
 
@@ -84,9 +80,7 @@ def test_asset_check_same_op_with_key_prefix():
 
     assert check_eval.target_materialization_data is not None
     assert check_eval.target_materialization_data.run_id == result.run_id
-    materialization_record = instance.get_event_records(
-        EventRecordsFilter(event_type=DagsterEventType.ASSET_MATERIALIZATION)
-    )[0]
+    materialization_record = instance.fetch_materializations(asset1.key, limit=1).records[0]
     assert check_eval.target_materialization_data.storage_id == materialization_record.storage_id
     assert check_eval.target_materialization_data.timestamp == materialization_record.timestamp
 
@@ -441,9 +435,7 @@ def test_asset_check_doesnt_store_output():
 
     assert check_eval.target_materialization_data is not None
     assert check_eval.target_materialization_data.run_id == result.run_id
-    materialization_record = instance.get_event_records(
-        EventRecordsFilter(event_type=DagsterEventType.ASSET_MATERIALIZATION)
-    )[0]
+    materialization_record = instance.fetch_materializations(asset1.key, limit=1).records[0]
     assert check_eval.target_materialization_data.storage_id == materialization_record.storage_id
     assert check_eval.target_materialization_data.timestamp == materialization_record.timestamp
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -5,11 +5,9 @@ import pytest
 from dagster import (
     AssetExecutionContext,
     AssetIn,
-    DagsterEventType,
     DailyPartitionsDefinition,
     DimensionPartitionMapping,
     DynamicPartitionsDefinition,
-    EventRecordsFilter,
     IdentityPartitionMapping,
     IOManager,
     MultiPartitionKey,
@@ -121,8 +119,10 @@ def test_tags_multi_dimensional_partitions():
         assert result.dagster_run.tags[get_multidimensional_partition_tag("abc")] == "a"
         assert result.dagster_run.tags[get_multidimensional_partition_tag("date")] == "2021-06-01"
 
+        asset1_records = instance.fetch_materializations(asset1.key, limit=1000).records
+        asset2_records = instance.fetch_materializations(asset2.key, limit=1000).records
         materializations = sorted(
-            instance.get_event_records(EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION)),
+            [*asset1_records, *asset2_records],
             key=lambda x: x.event_log_entry.dagster_event.asset_key,
         )
         assert len(materializations) == 2

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
@@ -14,7 +14,6 @@ from dagster import (
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.reconstruct import reconstructable
-from dagster._core.event_api import EventRecordsFilter
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import execute_job, execute_run_iterator
 from dagster._core.instance import DagsterInstance
@@ -336,12 +335,9 @@ def test_multi_run_concurrency(instance, workspace, two_tier_job_def):
     assert run_one.status == DagsterRunStatus.SUCCESS
     assert run_two.status == DagsterRunStatus.SUCCESS
 
-    records = instance.get_event_records(
-        EventRecordsFilter(
-            event_type=DagsterEventType.ASSET_MATERIALIZATION, asset_key=AssetKey(["foo_slot"])
-        ),
-        ascending=True,
-    )
+    records = [
+        *instance.fetch_materializations(AssetKey(["foo_slot"]), ascending=True, limit=5000).records
+    ]
     max_active = 0
     for record in records:
         num_active = record.asset_materialization.metadata["active"].value

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/test_branching_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/test_branching_io_manager.py
@@ -82,7 +82,9 @@ def test_write_staging_label():
     ) as staging_runner:
         assert staging_runner.materialize_all_assets().success
 
-        all_mat_log_records = staging_runner.get_all_asset_materialization_event_records("now_time")
+        all_mat_log_records = staging_runner.get_last_5000_asset_materialization_event_records(
+            "now_time"
+        )
         assert all_mat_log_records
 
         assert len(all_mat_log_records) == 1
@@ -114,7 +116,9 @@ def test_setup_teardown() -> None:
             "teardown_after_execution parent",
         ]
 
-        all_mat_log_records = staging_runner.get_all_asset_materialization_event_records("now_time")
+        all_mat_log_records = staging_runner.get_last_5000_asset_materialization_event_records(
+            "now_time"
+        )
         assert all_mat_log_records
 
         assert len(all_mat_log_records) == 1
@@ -139,7 +143,9 @@ def test_write_alternative_branch_metadata_key():
     ) as staging_runner:
         assert staging_runner.materialize_all_assets()
 
-        all_mat_log_records = staging_runner.get_all_asset_materialization_event_records("now_time")
+        all_mat_log_records = staging_runner.get_last_5000_asset_materialization_event_records(
+            "now_time"
+        )
         assert all_mat_log_records
 
         assert len(all_mat_log_records) == 1
@@ -197,7 +203,7 @@ def test_basic_workflow():
 
         assert dev_t0_runner.materialize_asset("now_time_plus_N").success
 
-        all_mat_event_log_records = dev_t0_runner.get_all_asset_materialization_event_records(
+        all_mat_event_log_records = dev_t0_runner.get_last_5000_asset_materialization_event_records(
             "now_time_plus_N"
         )
 
@@ -210,7 +216,7 @@ def test_basic_workflow():
         assert dev_t0_runner.load_asset_value("now_time_plus_N") == now_time_prod_value_1 + 10
 
         # we have done this with *no* materializations of the root asset in staging
-        assert not dev_t0_runner.get_all_asset_materialization_event_records("now_time")
+        assert not dev_t0_runner.get_last_5000_asset_materialization_event_records("now_time")
 
         dev_t1_runner = DefinitionsRunner(
             Definitions(
@@ -238,7 +244,7 @@ def test_basic_workflow():
         )
 
         # we were able to do this without having an materializations in staging of the root asset
-        assert not dev_t1_runner.get_all_asset_materialization_event_records("now_time")
+        assert not dev_t1_runner.get_last_5000_asset_materialization_event_records("now_time")
 
         dev_t1_runner.materialize_asset("now_time_plus_20_after_plus_N")
 

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
@@ -12,8 +12,7 @@ from dagster import (
 )
 from dagster._config.pythonic_config.io_manager import ConfigurableIOManager
 from dagster._core.definitions.events import CoercibleToAssetKey
-from dagster._core.event_api import EventLogRecord, EventRecordsFilter
-from dagster._core.events import DagsterEventType
+from dagster._core.event_api import EventLogRecord
 from dagster._core.execution.context.init import InitResourceContext
 from pydantic import PrivateAttr
 
@@ -63,16 +62,13 @@ class DefinitionsRunner:
             asset_key=asset_key, instance=self.instance, partition_key=partition_key
         )
 
-    def get_all_asset_materialization_event_records(
+    def get_last_5000_asset_materialization_event_records(
         self, asset_key: CoercibleToAssetKey
     ) -> List[EventLogRecord]:
         return [
-            *self.instance.get_event_records(
-                EventRecordsFilter(
-                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                    asset_key=AssetKey.from_coercible(asset_key),
-                )
-            )
+            *self.instance.fetch_materializations(
+                AssetKey.from_coercible(asset_key), limit=5000
+            ).records
         ]
 
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_events.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_events.py
@@ -12,7 +12,6 @@ from dagster import (
 )
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetLineageInfo
-from dagster._core.event_api import EventRecordsFilter
 from dagster._core.events import DagsterEventType
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.batch_asset_record_loader import BatchAssetRecordLoader
@@ -171,9 +170,8 @@ def test_asset_materialization_accessors():
 
         # test when it is not a materilization event
         records = [
-            *instance.get_event_records(EventRecordsFilter(event_type=DagsterEventType.STEP_OUTPUT))
+            *instance.fetch_run_status_changes(DagsterEventType.RUN_SUCCESS, limit=1).records
         ]
-
         assert len(records) == 1
         assert records[0].event_log_entry
         assert records[0].event_log_entry.asset_materialization is None

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/partition_status_cache.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/partition_status_cache.py
@@ -8,7 +8,6 @@ from dagster import (
     DailyPartitionsDefinition,
     DynamicPartitionsDefinition,
     EventLogEntry,
-    EventRecordsFilter,
     MultiPartitionKey,
     MultiPartitionsDefinition,
     StaticPartitionsDefinition,
@@ -72,15 +71,7 @@ class TestPartitionStatusCache:
         assert (
             cached_status.latest_storage_id
             == next(
-                iter(
-                    instance.get_event_records(
-                        EventRecordsFilter(
-                            asset_key=AssetKey("asset1"),
-                            event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                        ),
-                        limit=1,
-                    )
-                )
+                iter(instance.fetch_materializations(AssetKey("asset1"), limit=1).records)
             ).storage_id
         )
         assert cached_status.partitions_def_id is None


### PR DESCRIPTION
## Summary & Motivation
Marching along to deprecate `get_event_records`.

We want to more clearly define sanctioned APIs around making either 
1) Run-scoped event queries
2) Make single specific event-type queries (e.g. `fetch_materializations`, `fetch_observations`, `fetch_run_status_changes`)

This is so that we have the right tools to optimize storage / queries amongst our most critical paths.

Some of the tests that are switching to run-scoped queries just need to supply the run id of the test run they are executing.

## How I Tested These Changes
BK