### PR TITLE
[DS][26/n] Update internal representation of InLatestTimeWindow

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
@@ -129,9 +129,7 @@ class SchedulingCondition(ABC, DagsterModel):
         """
         from .operands import InLatestTimeWindowCondition
 
-        return InLatestTimeWindowCondition(
-            lookback_seconds=lookback_delta.total_seconds() if lookback_delta else None
-        )
+        return InLatestTimeWindowCondition.from_lookback_delta(lookback_delta)
 
 
 class SchedulingResult(DagsterModel):


### PR DESCRIPTION
## Summary & Motivation

Updates the internal representation to better match the timedelta class. The painful thing here is that you can't really set a constructor when using pydantic models.

Not a huge fan of representing "no timedelta at all" as "all the things are 0"

## How I Tested These Changes
