### PR TITLE
RFC: DataLoader in Dagster

### DIFF
--- a/async_run.py
+++ b/async_run.py
@@ -1,0 +1,32 @@
+import asyncio
+from typing import List
+
+from dagster._model import DagsterModel
+from dagster._utils.aiodataloader import DataLoader
+
+
+class Thing(DagsterModel):
+    key: str
+
+
+class ThingLoader(DataLoader[str, Thing]):
+    async def batch_load_fn(self, keys: List[str]):
+        print(f"Imagine: SELECT * from THINGS where keys in {keys}")
+        return [Thing(key=key + "_value") for key in keys]
+
+
+async def two_round_trips(loader: ThingLoader, key: str):
+    thing_one = await loader.load(key)
+    return await loader.load(thing_one.key)
+
+
+async def main() -> None:
+    loader = ThingLoader()
+    value1, value2 = await asyncio.gather(
+        two_round_trips(loader, "key"), two_round_trips(loader, "another_key")
+    )
+
+    print(f"Value 1: {value1}. Value 2: {value2}") # noqa: T201
+
+
+asyncio.run(main())

--- a/python_modules/dagster/dagster/_utils/aiodataloader.py
+++ b/python_modules/dagster/dagster/_utils/aiodataloader.py
@@ -1,0 +1,294 @@
+# Copied from https://github.com/syrusakbary/aiodataloader
+
+import sys
+from asyncio import (
+    AbstractEventLoop,
+    Future,
+    ensure_future,
+    gather,
+    get_event_loop,
+    iscoroutine,
+    iscoroutinefunction,
+)
+from collections import namedtuple
+from functools import partial
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Generic,
+    Iterable,
+    Iterator,
+    List,
+    MutableMapping,
+    Optional,
+    TypeVar,
+    Union,
+)
+
+if sys.version_info >= (3, 10):
+    from typing import TypeGuard
+else:
+    from typing_extensions import TypeGuard
+
+__version__ = "0.4.0"
+
+KeyT = TypeVar("KeyT")
+ReturnT = TypeVar("ReturnT")
+CacheKeyT = TypeVar("CacheKeyT")
+DataLoaderT = TypeVar("DataLoaderT", bound="DataLoader[Any, Any]")
+T = TypeVar("T")
+
+
+def iscoroutinefunctionorpartial(
+    fn: Union[Callable[..., ReturnT], "partial[ReturnT]"],
+) -> TypeGuard[Callable[..., Coroutine[Any, Any, ReturnT]]]:
+    return iscoroutinefunction(fn.func if isinstance(fn, partial) else fn)
+
+
+Loader = namedtuple("Loader", "key,future")
+
+
+class DataLoader(Generic[KeyT, ReturnT]):
+    batch: bool = True
+    max_batch_size: Optional[int] = None
+    cache: Optional[bool] = True
+
+    def __init__(
+        self,
+        batch_load_fn: Optional[Callable[[List[KeyT]], Coroutine[Any, Any, List[ReturnT]]]] = None,
+        batch: Optional[bool] = None,
+        max_batch_size: Optional[int] = None,
+        cache: Optional[bool] = None,
+        get_cache_key: Optional[Callable[[KeyT], Union[CacheKeyT, KeyT]]] = None,
+        cache_map: Optional[MutableMapping[Union[CacheKeyT, KeyT], "Future[ReturnT]"]] = None,
+        loop: Optional[AbstractEventLoop] = None,
+    ):
+        self.loop = loop or get_event_loop()
+
+        if batch_load_fn is not None:
+            self.batch_load_fn = batch_load_fn
+
+        assert iscoroutinefunctionorpartial(
+            self.batch_load_fn
+        ), f"batch_load_fn must be coroutine. Received: {self.batch_load_fn}"
+
+        if not callable(self.batch_load_fn):
+            raise TypeError(
+                (
+                    "DataLoader must have a batch_load_fn which accepts "
+                    f"Iterable<key> and returns Future<Iterable<value>>, but got: {batch_load_fn}."
+                )
+            )
+
+        if batch is not None:
+            self.batch = batch
+
+        if max_batch_size is not None:
+            self.max_batch_size = max_batch_size
+
+        if cache is not None:
+            self.cache = cache
+
+        if get_cache_key is not None:
+            self.get_cache_key = get_cache_key
+        if not hasattr(self, "get_cache_key"):
+            self.get_cache_key = lambda x: x
+
+        self._cache = cache_map if cache_map is not None else {}
+        self._queue: List[Loader] = []
+
+    def load(self, key: KeyT) -> "Future[ReturnT]":
+        """Loads a key, returning a `Future` for the value represented by that key."""
+        if key is None:
+            raise TypeError(
+                ("The loader.load() function must be called with a value, " f"but got: {key}.")
+            )
+
+        cache_key = self.get_cache_key(key)
+
+        # If caching and there is a cache-hit, return cached Future.
+        if self.cache:
+            cached_result = self._cache.get(cache_key)
+            if cached_result:
+                return cached_result
+
+        # Otherwise, produce a new Future for this value.
+        future = self.loop.create_future()
+        # If caching, cache this Future.
+        if self.cache:
+            self._cache[cache_key] = future
+
+        self.do_resolve_reject(key, future)
+        return future
+
+    def do_resolve_reject(self, key: KeyT, future: "Future[ReturnT]") -> None:
+        # Enqueue this Future to be dispatched.
+        self._queue.append(Loader(key=key, future=future))
+        # Determine if a dispatch of this queue should be scheduled.
+        # A single dispatch should be scheduled per queue at the time when the
+        # queue changes from "empty" to "full".
+        if len(self._queue) == 1:
+            if self.batch:
+                # If batching, schedule a task to dispatch the queue.
+                enqueue_post_future_job(self.loop, self)
+            else:
+                # Otherwise dispatch the (queue of one) immediately.
+                dispatch_queue(self)
+
+    def load_many(self, keys: Iterable[KeyT]) -> "Future[List[ReturnT]]":
+        """Loads multiple keys, returning a list of values.
+
+        >>> a, b = await my_loader.load_many([ 'a', 'b' ])
+
+        This is equivalent to the more verbose:
+
+        >>> a, b = await gather(
+        >>>    my_loader.load('a'),
+        >>>    my_loader.load('b')
+        >>> )
+        """
+        if not isinstance(keys, Iterable):
+            raise TypeError(
+                (
+                    "The loader.load_many() function must be called with Iterable<key> "
+                    f"but got: {keys}."
+                )
+            )
+
+        return gather(*[self.load(key) for key in keys])
+
+    def clear(self: DataLoaderT, key: KeyT) -> DataLoaderT:
+        """Clears the value at `key` from the cache, if it exists. Returns itself for
+        method chaining.
+        """
+        cache_key = self.get_cache_key(key)
+        self._cache.pop(cache_key, None)
+        return self
+
+    def clear_all(self: DataLoaderT) -> DataLoaderT:
+        """Clears the entire cache. To be used when some event results in unknown
+        invalidations across this particular `DataLoader`. Returns itself for
+        method chaining.
+        """
+        self._cache.clear()
+        return self
+
+    def prime(self: DataLoaderT, key: KeyT, value: ReturnT) -> DataLoaderT:
+        """Adds the provied key and value to the cache. If the key already exists, no
+        change is made. Returns itself for method chaining.
+        """
+        cache_key = self.get_cache_key(key)
+
+        # Only add the key if it does not already exist.
+        if cache_key not in self._cache:
+            # Cache a rejected future if the value is an Error, in order to match
+            # the behavior of load(key).
+            future = self.loop.create_future()
+            if isinstance(value, Exception):
+                future.set_exception(value)
+            else:
+                future.set_result(value)
+
+            self._cache[cache_key] = future
+
+        return self
+
+
+def enqueue_post_future_job(loop: AbstractEventLoop, loader: DataLoader[Any, Any]) -> None:
+    async def dispatch() -> None:
+        dispatch_queue(loader)
+
+    loop.call_soon(ensure_future, dispatch())
+
+
+def get_chunks(iterable_obj: List[T], chunk_size: int = 1) -> Iterator[List[T]]:
+    chunk_size = max(1, chunk_size)
+    return (iterable_obj[i : i + chunk_size] for i in range(0, len(iterable_obj), chunk_size))
+
+
+def dispatch_queue(loader: DataLoader[Any, Any]) -> None:
+    """Given the current state of a Loader instance, perform a batch load
+    from its current queue.
+    """
+    # Take the current loader queue, replacing it with an empty queue.
+    queue = loader._queue  # noqa: SLF001
+    loader._queue = []  # noqa: SLF001
+
+    # If a max_batch_size was provided and the queue is longer, then segment the
+    # queue into multiple batches, otherwise treat the queue as a single batch.
+    max_batch_size = loader.max_batch_size
+
+    if max_batch_size and max_batch_size < len(queue):
+        chunks = get_chunks(queue, max_batch_size)
+        for chunk in chunks:
+            # Note: the noqa here might mask a real bug and worthy of investigation
+            ensure_future(dispatch_queue_batch(loader, chunk))  # noqa: RUF006
+    else:
+        ensure_future(dispatch_queue_batch(loader, queue))  # noqa: RUF006
+
+
+async def dispatch_queue_batch(loader: DataLoader[Any, Any], queue: List[Loader]) -> None:
+    # Collect all keys to be loaded in this dispatch
+    keys = [ql.key for ql in queue]
+
+    # Call the provided batch_load_fn for this loader with the loader queue's keys.
+    batch_future = loader.batch_load_fn(keys)
+
+    # Assert the expected response from batch_load_fn
+    if not batch_future or not iscoroutine(batch_future):
+        return failed_dispatch(
+            loader,
+            queue,
+            TypeError(
+                (
+                    "DataLoader must be constructed with a function which accepts "
+                    "Iterable<key> and returns Future<Iterable<value>>, but the "
+                    f"function did not return a Coroutine: {batch_future}."
+                )
+            ),
+        )
+
+    try:
+        values = await batch_future
+        if not isinstance(values, Iterable):
+            raise TypeError(
+                (
+                    "DataLoader must be constructed with a function which accepts "
+                    "Iterable<key> and returns Future<Iterable<value>>, but the "
+                    f"function did not return a Future of a Iterable: {values}."
+                )
+            )
+
+        values = list(values)
+        if len(values) != len(keys):
+            raise TypeError(
+                (
+                    "DataLoader must be constructed with a function which accepts "
+                    "Iterable<key> and returns Future<Iterable<value>>, but the "
+                    "function did not return a Future of a Iterable with the same "
+                    "length as the Iterable of keys."
+                    f"\n\nKeys:\n{keys}"
+                    f"\n\nValues:\n{values}"
+                )
+            )
+
+        # Step through the values, resolving or rejecting each Future in the
+        # loaded queue.
+        for ql, value in zip(queue, values):
+            if isinstance(value, Exception):
+                ql.future.set_exception(value)
+            else:
+                ql.future.set_result(value)
+
+    except Exception as e:
+        return failed_dispatch(loader, queue, e)
+
+
+def failed_dispatch(loader: DataLoader[Any, Any], queue: List[Loader], error: Exception) -> None:
+    """Do not cache individual loads if the entire batch dispatch fails,
+    but still reject each request so they do not hang.
+    """
+    for ql in queue:
+        loader.clear(ql.key)
+        ql.future.set_exception(error)


### PR DESCRIPTION
## Summary & Motivation

This is an RFC for an approach to add a formalized loader pattern leveraging https://github.com/syrusakbary/aiodataloader (which is a port of https://github.com/graphql/dataloader [which is a port from EntLoader in Hack]). 

For the uninitiated here, the goal here is to allow for product engineers to write code in terms of individual objects while writing backends in batch. We do this manually right now with all of our hand-crafted "Loader" classes but they are a pain to write and to use. They are difficult/impossible to compose with eachother. There are a lot of problems.

Instead of having to manually new up and manage loaders as a product engineer, they would plug into the `AssetGraphView` layer more elegantly, which I can prototype further if we think would be of interest.

It is a *non-goal* to actually execute the underlying I/O asynchronously. While this leaves some performace on the table it has a number of advantages:

1) It enables us to introduce this much more incrementally without having to rewrite any of our lower level storage code.
2) We do not rely on underlying async implementation of SQL, grpc, or whatever, which I frankly I do not trust. This reduces a lot of implementation risk much less.

By vendoring aiodataloader we completely control our own destiny and confine async code to lightweight orchestration layer under our control. Product engineers in the webserver can think in single objects, and it stacks very nicely with the way that the graphql layer pushes you to write your code.

## How I Tested These Changes

```python
import asyncio
from typing import List

from dagster._model import DagsterModel
from dagster._utils.aiodataloader import DataLoader


class Thing(DagsterModel):
    key: str


class ThingLoader(DataLoader[str, Thing]):
    async def batch_load_fn(self, keys: List[str]):
        print(f"Imagine: SELECT * from THINGS where keys in {keys}")
        return [Thing(key=key + "_value") for key in keys]


async def two_round_trips(loader: ThingLoader, key: str):
    thing_one = await loader.load(key)
    return await loader.load(thing_one.key)


async def main() -> None:
    loader = ThingLoader()
    value1, value2 = await asyncio.gather(
        two_round_trips(loader, "key"), two_round_trips(loader, "another_key")
    )

    print(f"Value 1: {value1}. Value 2: {value2}") # noqa: T201


asyncio.run(main())
```

```
(dagster-internal.3.11.5-2024-04-26) ➜  dagster git:(vendor-aiodataloader) ✗ python async_run.py
Imagine: SELECT * from THINGS where keys in ['key', 'another_key']
Imagine: SELECT * from THINGS where keys in ['key_value', 'another_key_value']
Value 1: key='key_value_value'. Value 2: key='another_key_value_value'
```
