### PR TITLE
[ui] Fix broken AssetNode storybook, one test is for data-loading state

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
@@ -35,8 +35,11 @@ export const LiveStates = () => {
     const dimensions = getAssetNodeDimensions(definitionCopy);
 
     function SetCacheEntry() {
-      const entry = {[tokenForAssetKey(definitionCopy.assetKey)]: scenario.liveData!};
-      const {staleStatus, staleCauses} = scenario.liveData!;
+      if (!scenario.liveData) {
+        return null;
+      }
+      const entry = {[tokenForAssetKey(definitionCopy.assetKey)]: scenario.liveData};
+      const {staleStatus, staleCauses} = scenario.liveData;
       const staleEntry = {
         [tokenForAssetKey(definitionCopy.assetKey)]: buildAssetNode({
           assetKey: definitionCopy.assetKey,


### PR DESCRIPTION
<img width="1840" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/3df4aedc-2c83-41d7-926c-48f5f8d675a9">