### PR TITLE
Refactor "invalid asset selection" handling in asset backfills and AMP

### DIFF
--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -9,6 +9,9 @@ from dagster._core.remote_representation import (
     ExternalRepository,
     InProcessCodeLocationOrigin,
 )
+from dagster._core.remote_representation.origin import (
+    ManagedGrpcPythonEnvCodeLocationOrigin,
+)
 from dagster._core.test_utils import (
     InProcessTestWorkspaceLoadTarget,
     create_test_daemon_workspace_context,
@@ -154,7 +157,7 @@ def partitions_defs_changes_location_2_fixture(
 
 def base_job_name_changes_workspace_1_load_target(attribute=None):
     return InProcessTestWorkspaceLoadTarget(
-        InProcessCodeLocationOrigin(
+        ManagedGrpcPythonEnvCodeLocationOrigin(
             loadable_target_origin=LoadableTargetOrigin(
                 executable_path=sys.executable,
                 module_name="dagster_tests.daemon_tests.test_locations.base_job_name_changes_locations.location_1",
@@ -179,7 +182,7 @@ def base_job_name_changes_location_1_fixture(
 
 def base_job_name_changes_workspace_2_load_target(attribute=None):
     return InProcessTestWorkspaceLoadTarget(
-        InProcessCodeLocationOrigin(
+        ManagedGrpcPythonEnvCodeLocationOrigin(
             loadable_target_origin=LoadableTargetOrigin(
                 executable_path=sys.executable,
                 module_name="dagster_tests.daemon_tests.test_locations.base_job_name_changes_locations.location_2",

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -2008,7 +2008,10 @@ def test_asset_backfill_asset_graph_out_of_sync_with_workspace(
         )
 
     logs = caplog.text
-    assert "Execution plan is out of sync with the workspace" in logs
+    assert (
+        "Error while generating the execution plan, possibly because the code server is out of sync with the daemon"
+        in logs
+    )
 
     assert instance.get_runs_count() == 1
     assert (


### PR DESCRIPTION
Summary:
We were missing a case where a race condition causes the job to be out of sync with user code (a UserCodeProcessError). Also just tweak the logic a bit here so that we actually log the exception when it happens, and more clearly deliniate between the different cases where we might retry.

## Summary & Motivation

## How I Tested These Changes
