### PR TITLE
feat(looker): represent looker explores as assets

### DIFF
--- a/pyright/alt-1/requirements-pinned.txt
+++ b/pyright/alt-1/requirements-pinned.txt
@@ -61,7 +61,7 @@ cycler==0.12.1
 -e python_modules/libraries/dagster-spark
 -e python_modules/dagster-webserver
 db-dtypes==1.2.0
-dbt-core==1.7.13
+dbt-core==1.7.14
 dbt-duckdb==1.7.4
 dbt-extractor==0.5.1
 dbt-semantic-interfaces==0.4.4
@@ -125,7 +125,7 @@ jaraco-classes==3.4.0
 jedi==0.19.1
 jinja2==3.1.3
 jmespath==1.0.1
-joblib==1.4.0
+joblib==1.4.2
 json5==0.9.25
 jsonpointer==2.4
 jsonschema==4.22.0
@@ -175,7 +175,7 @@ oauth2client==4.1.3
 oauthlib==3.2.2
 objgraph==3.6.1
 ordered-set==4.1.0
-orjson==3.10.2
+orjson==3.10.3
 overrides==7.7.0
 packaging==24.0
 pandas==2.0.3
@@ -231,8 +231,8 @@ pytimeparse==1.1.8
 pytz==2024.1
 pyyaml==6.0.1
 pyzmq==26.0.3
-rapidfuzz==3.8.1
-referencing==0.35.0
+rapidfuzz==3.9.0
+referencing==0.35.1
 requests==2.31.0
 requests-oauthlib==2.0.0
 requests-toolbelt==1.0.0
@@ -277,7 +277,7 @@ tomlkit==0.12.4
 toposort==1.10
 tornado==6.4
 tox==3.25.0
-tqdm==4.66.2
+tqdm==4.66.4
 traitlets==5.14.3
 typeguard==4.2.1
 typer==0.12.3

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -59,8 +59,8 @@ bitmath==1.3.3.1
 bleach==6.1.0
 blinker==1.8.1
 bokeh==3.4.1
-boto3==1.34.95
-botocore==1.34.95
+boto3==1.34.97
+botocore==1.34.97
 buildkite-test-collector==0.1.7
 cachecontrol==0.14.0
 cached-property==1.5.2
@@ -72,7 +72,7 @@ cattrs==23.2.3
 celery==5.4.0
 certifi==2024.2.2
 cffi==1.16.0
-cfn-lint==0.87.0
+cfn-lint==0.87.1
 chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
@@ -131,6 +131,7 @@ cycler==0.12.1
 -e helm/dagster/schema
 -e python_modules/libraries/dagster-k8s
 -e integration_tests/python_modules/dagster-k8s-test-infra
+-e python_modules/libraries/dagster-looker
 -e python_modules/libraries/dagster-managed-elements
 -e python_modules/libraries/dagster-mlflow
 -e python_modules/libraries/dagster-msteams
@@ -171,7 +172,7 @@ dataclasses-json==0.6.5
 datadog==0.49.1
 dataproperty==1.0.1
 db-dtypes==1.2.0
-dbt-core==1.7.13
+dbt-core==1.7.14
 dbt-duckdb==1.7.4
 dbt-extractor==0.5.1
 dbt-semantic-interfaces==0.4.4
@@ -281,7 +282,7 @@ itsdangerous==2.2.0
 jedi==0.19.1
 jinja2==3.1.3
 jmespath==1.0.1
-joblib==1.4.0
+joblib==1.4.2
 jschema-to-python==1.2.3
 json5==0.9.25
 jsondiff==2.0.0
@@ -312,14 +313,15 @@ kubernetes==29.0.0
 kubernetes-asyncio==29.0.0
 langchain==0.1.11
 langchain-community==0.0.34
-langchain-core==0.1.48
+langchain-core==0.1.50
 langchain-openai==0.1.3
 langchain-text-splitters==0.0.1
-langsmith==0.1.52
+langsmith==0.1.53
 lazy-object-proxy==1.10.0
 leather==0.4.0
 limits==3.11.0
 linkify-it-py==2.0.3
+lkml==1.3.4
 locket==1.0.0
 lockfile==0.12.2
 logbook==1.5.3
@@ -328,7 +330,7 @@ mako==1.3.3
 markdown==3.6
 markdown-it-py==3.0.0
 markupsafe==2.1.5
-marshmallow==3.21.1
+marshmallow==3.21.2
 marshmallow-oneofschema==3.1.1
 marshmallow-sqlalchemy==0.26.1
 mashumaro==3.13
@@ -362,7 +364,7 @@ nest-asyncio==1.6.0
 networkx==3.3
 nh3==0.2.17
 nodeenv==1.8.0
-noteable-origami==1.1.5
+noteable-origami==0.0.35
 notebook==7.1.3
 notebook-shim==0.2.4
 numpy==1.26.4
@@ -372,7 +374,7 @@ objgraph==3.6.1
 onnx==1.16.0
 onnxconverter-common==1.13.0
 onnxruntime==1.17.3
-openai==1.25.0
+openai==1.25.1
 openapi-schema-validator==0.6.2
 openapi-spec-validator==0.7.1
 opentelemetry-api==1.24.0
@@ -384,7 +386,7 @@ opentelemetry-proto==1.24.0
 opentelemetry-sdk==1.24.0
 opentelemetry-semantic-conventions==0.45b0
 ordered-set==4.1.0
-orjson==3.10.2
+orjson==3.10.3
 outcome==1.3.0.post0
 overrides==7.7.0
 packaging==23.2
@@ -394,7 +396,7 @@ pandas-stubs==2.2.1.240316
 pandera==0.18.3
 pandocfilters==1.5.1
 papermill==2.6.0
-papermill-origami==0.0.29
+papermill-origami==0.0.30
 paramiko==3.4.0
 parsedatetime==2.6
 parso==0.8.4
@@ -468,7 +470,7 @@ pytzdata==2020.1
 pyyaml==6.0.1
 pyzmq==26.0.3
 querystring-parser==1.2.4
-rapidfuzz==3.8.1
+rapidfuzz==3.9.0
 readme-renderer==43.0
 referencing==0.31.1
 regex==2024.4.28
@@ -536,7 +538,7 @@ sshpubkeys==3.3.1
 sshtunnel==0.4.0
 stack-data==0.6.3
 starlette==0.37.2
-structlog==24.1.0
+structlog==22.3.0
 sympy==1.12
 syrupy==4.6.1
 tabledata==1.3.3
@@ -558,7 +560,7 @@ torch==2.3.0
 torchvision==0.18.0
 tornado==6.4
 tox==3.25.0
-tqdm==4.66.2
+tqdm==4.66.4
 traitlets==5.14.3
 trio==0.25.0
 trio-websocket==0.11.1

--- a/python_modules/libraries/dagster-looker/dagster_looker/asset_decorator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/asset_decorator.py
@@ -1,16 +1,44 @@
 import itertools
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Mapping, Sequence
 
+import lkml
 import yaml
 from dagster import AssetKey, AssetsDefinition, AssetSpec, multi_asset
+
+
+def build_looker_explore_specs(project_dir: Path) -> Sequence[AssetSpec]:
+    looker_explore_specs = []
+
+    # https://cloud.google.com/looker/docs/reference/param-explore
+    for model_path in project_dir.rglob("*.model.lkml"):
+        for explore in lkml.load(model_path.read_text()).get("explores", []):
+            explore_asset_key = AssetKey(["explore", explore["name"]])
+
+            # https://cloud.google.com/looker/docs/reference/param-explore-from
+            explore_base_view = [{"name": explore.get("from") or explore["name"]}]
+
+            # https://cloud.google.com/looker/docs/reference/param-explore-join
+            explore_join_views: Sequence[Mapping[str, Any]] = explore.get("joins", [])
+
+            looker_explore_specs.append(
+                AssetSpec(
+                    key=explore_asset_key,
+                    deps={
+                        AssetKey(["view", view["name"]])
+                        for view in itertools.chain(explore_base_view, explore_join_views)
+                    },
+                )
+            )
+
+    return looker_explore_specs
 
 
 def looker_assets(*, project_dir: Path) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     lookml_dashboard_specs = [
         AssetSpec(
-            key=AssetKey(lookml_dashboard["dashboard"]),
-            deps={AssetKey(dashboard_element["explore"])},
+            key=AssetKey(["dashboard", lookml_dashboard["dashboard"]]),
+            deps={AssetKey(["explore", dashboard_element["explore"]])},
         )
         for dashboard_path in project_dir.rglob("*.dashboard.lookml")
         # Each dashboard file can contain multiple dashboards.
@@ -27,5 +55,6 @@ def looker_assets(*, project_dir: Path) -> Callable[[Callable[..., Any]], Assets
         compute_kind="looker",
         specs=[
             *lookml_dashboard_specs,
+            *build_looker_explore_specs(project_dir),
         ],
     )

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/test_asset_decorator.py
@@ -9,12 +9,78 @@ def test_asset_deps() -> None:
     def my_looker_assets(): ...
 
     assert my_looker_assets.asset_deps == {
-        AssetKey(["address_deepdive"]): {AssetKey(["transactions"])},
-        AssetKey(["campaign_activation"]): {AssetKey(["omni_channel_transactions"])},
-        AssetKey(["customer_360"]): {AssetKey(["omni_channel_transactions"])},
-        AssetKey(["customer_deep_dive"]): {AssetKey(["customer_transaction_fact"])},
-        AssetKey(["customer_segment_deepdive"]): {AssetKey(["transactions"])},
-        AssetKey(["group_overview"]): {AssetKey(["transactions"])},
-        AssetKey(["item_affinity_analysis"]): {AssetKey(["order_purchase_affinity"])},
-        AssetKey(["store_deepdive"]): {AssetKey(["transactions"])},
+        # Dashboards
+        AssetKey(["dashboard", "address_deepdive"]): {
+            AssetKey(["explore", "transactions"]),
+        },
+        AssetKey(["dashboard", "campaign_activation"]): {
+            AssetKey(["explore", "omni_channel_transactions"])
+        },
+        AssetKey(["dashboard", "customer_360"]): {
+            AssetKey(["explore", "omni_channel_transactions"])
+        },
+        AssetKey(["dashboard", "customer_deep_dive"]): {
+            AssetKey(["explore", "customer_transaction_fact"])
+        },
+        AssetKey(["dashboard", "customer_segment_deepdive"]): {
+            AssetKey(["explore", "transactions"])
+        },
+        AssetKey(["dashboard", "group_overview"]): {
+            AssetKey(["explore", "transactions"]),
+        },
+        AssetKey(["dashboard", "item_affinity_analysis"]): {
+            AssetKey(["explore", "order_purchase_affinity"])
+        },
+        AssetKey(["dashboard", "store_deepdive"]): {
+            AssetKey(["explore", "transactions"]),
+        },
+        # Explores
+        AssetKey(["explore", "customer_clustering_prediction"]): {
+            AssetKey(["view", "customer_clustering_prediction"]),
+            AssetKey(["view", "transactions"]),
+        },
+        AssetKey(["explore", "customer_event_fact"]): {AssetKey(["view", "customer_event_fact"])},
+        AssetKey(["explore", "customer_transaction_fact"]): {
+            AssetKey(["view", "customer_event_fact"]),
+            AssetKey(["view", "customer_support_fact"]),
+            AssetKey(["view", "customer_transaction_fact"]),
+        },
+        AssetKey(["explore", "omni_channel_events"]): {
+            AssetKey(["view", "c360"]),
+            AssetKey(["view", "omni_channel_events"]),
+            AssetKey(["view", "omni_channel_transactions"]),
+            AssetKey(["view", "omni_channel_transactions__transaction_details"]),
+            AssetKey(["view", "retail_clv_predict"]),
+        },
+        AssetKey(["explore", "omni_channel_support_calls"]): {
+            AssetKey(["view", "omni_channel_support_calls"]),
+        },
+        AssetKey(["explore", "omni_channel_transactions"]): {
+            AssetKey(["view", "c360"]),
+            AssetKey(["view", "customers"]),
+            AssetKey(["view", "omni_channel_transactions"]),
+            AssetKey(["view", "omni_channel_transactions__transaction_details"]),
+            AssetKey(["view", "retail_clv_predict"]),
+        },
+        AssetKey(["explore", "order_purchase_affinity"]): {
+            AssetKey(["view", "order_items_base"]),
+            AssetKey(["view", "order_purchase_affinity"]),
+            AssetKey(["view", "total_orders"]),
+        },
+        AssetKey(["explore", "stock_forecasting_explore_base"]): {
+            AssetKey(["view", "stock_forecasting_explore_base"]),
+            AssetKey(["view", "stock_forecasting_prediction"]),
+        },
+        AssetKey(["explore", "transactions"]): {
+            AssetKey(["view", "channels"]),
+            AssetKey(["view", "customer_clustering_prediction"]),
+            AssetKey(["view", "customer_facts"]),
+            AssetKey(["view", "customer_transaction_sequence"]),
+            AssetKey(["view", "customers"]),
+            AssetKey(["view", "products"]),
+            AssetKey(["view", "store_weather"]),
+            AssetKey(["view", "stores"]),
+            AssetKey(["view", "transactions"]),
+            AssetKey(["view", "transactions__line_items"]),
+        },
     }

--- a/python_modules/libraries/dagster-looker/setup.py
+++ b/python_modules/libraries/dagster-looker/setup.py
@@ -31,6 +31,7 @@ setup(
     packages=find_packages(exclude=["dagster_looker_tests*"]),
     install_requires=[
         f"dagster{pin}",
+        "lkml",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
## Summary & Motivation
Model the basic Looker explore where an explore is joined off of existing Looker views.

To parse the Looker specifications, we use [`lkml`](https://lkml.readthedocs.io/en/latest/simple.html).

A Looker explore will always be based on an existing sql table. By default, this is the `explore_name`, but it can be overridden with the [`from`](https://cloud.google.com/looker/docs/reference/param-explore-from) attribute.

Joins on this table are specified using [`join`](https://cloud.google.com/looker/docs/reference/param-explore-join).

The combination of these two lists will give the upstream dependencies for the Looker view.



## How I Tested These Changes
pytest