### PR TITLE
feat: pass more options to dagster-aws Resources

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/cloudwatch/loggers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/cloudwatch/loggers.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from typing import Optional
 
 import boto3
 from dagster import (
@@ -34,14 +35,22 @@ class CloudwatchLogsHandler(logging.Handler):
         log_group_name,
         log_stream_name,
         aws_region=None,
-        aws_secret_access_key=None,
-        aws_access_key_id=None,
+        aws_access_key_id: Optional[str] = None,
+        aws_secret_access_key: Optional[str] = None,
+        endpoint_url: Optional[str] = None,
+        use_ssl: bool = True,
+        aws_session_token: Optional[str] = None,
+        verify=None,
     ):
         self.client = boto3.client(
             "logs",
             region_name=aws_region,
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
+            endpoint_url=endpoint_url,
+            use_ssl=use_ssl,
+            aws_session_token=aws_session_token,
+            verify=verify,
         )
         self.log_group_name = check.str_param(log_group_name, "log_group_name")
         # Maybe we should make this optional, and default to the run_id

--- a/python_modules/libraries/dagster-aws/dagster_aws/cloudwatch/loggers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/cloudwatch/loggers.py
@@ -40,7 +40,7 @@ class CloudwatchLogsHandler(logging.Handler):
         endpoint_url: Optional[str] = None,
         use_ssl: bool = True,
         aws_session_token: Optional[str] = None,
-        verify: Optional[bool] =None,
+        verify: Optional[bool] = None,
     ):
         self.client = boto3.client(
             "logs",

--- a/python_modules/libraries/dagster-aws/dagster_aws/cloudwatch/loggers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/cloudwatch/loggers.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from typing import Optional
+from typing import Optional, Union
 
 import boto3
 from dagster import (
@@ -40,7 +40,7 @@ class CloudwatchLogsHandler(logging.Handler):
         endpoint_url: Optional[str] = None,
         use_ssl: bool = True,
         aws_session_token: Optional[str] = None,
-        verify=None,
+        verify: Optional[Union[str, bool]] =None,
     ):
         self.client = boto3.client(
             "logs",

--- a/python_modules/libraries/dagster-aws/dagster_aws/cloudwatch/loggers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/cloudwatch/loggers.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from typing import Optional, Union
+from typing import Optional
 
 import boto3
 from dagster import (
@@ -40,7 +40,7 @@ class CloudwatchLogsHandler(logging.Handler):
         endpoint_url: Optional[str] = None,
         use_ssl: bool = True,
         aws_session_token: Optional[str] = None,
-        verify: Optional[Union[str, bool]] =None,
+        verify: Optional[bool] =None,
     ):
         self.client = boto3.client(
             "logs",

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Optional
 
 import boto3
 from botocore.stub import Stubber
@@ -7,8 +8,26 @@ from dagster._core.definitions.resource_definition import dagster_maintained_res
 
 
 class ECRPublicClient:
-    def __init__(self):
-        self.client = boto3.client("ecr-public")
+    def __init__(
+        self,
+        region_name: Optional[str] = None,
+        endpoint_url: Optional[str] = None,
+        use_ssl: bool = True,
+        aws_access_key_id: Optional[str] = None,
+        aws_secret_access_key: Optional[str] = None,
+        aws_session_token: Optional[str] = None,
+        verify=None,
+    ):
+        self.client = boto3.client(
+            "ecr-public",
+            region_name=region_name,
+            use_ssl=use_ssl,
+            verify=verify,
+            endpoint_url=endpoint_url,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
+        )
 
     def get_login_password(self):
         return self.client.get_authorization_token()["authorizationData"]["authorizationToken"]

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Optional
+from typing import Optional, Union
 
 import boto3
 from botocore.stub import Stubber
@@ -16,7 +16,7 @@ class ECRPublicClient:
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_session_token: Optional[str] = None,
-        verify=None,
+        verify: Optional[Union[str, bool]] =None,
     ):
         self.client = boto3.client(
             "ecr-public",

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecr/resources.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Optional, Union
+from typing import Optional
 
 import boto3
 from botocore.stub import Stubber
@@ -16,7 +16,7 @@ class ECRPublicClient:
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_session_token: Optional[str] = None,
-        verify: Optional[Union[str, bool]] =None,
+        verify: Optional[bool] = None,
     ):
         self.client = boto3.client(
             "ecr-public",

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, TypeVar
+from typing import Any, Optional, TypeVar, Union
 
 from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
@@ -33,12 +33,10 @@ class ResourceWithS3Configuration(ConfigurableResource):
     use_ssl: bool = Field(
         default=True, description="Whether or not to use SSL. By default, SSL is used."
     )
-    verify: Optional[str] = Field(
+    verify: Optional[bool] = Field(
         default=None,
         description=(
             "Whether or not to verify SSL certificates. By default SSL certificates are verified."
-            " You can also specify this argument if you want to use a different CA cert bundle than"
-            " the one used by botocore."
         ),
     )
     aws_access_key_id: Optional[str] = Field(

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, TypeVar, Union
+from typing import Any, Optional, TypeVar
 
 from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
 from dagster._core.definitions.resource_definition import dagster_maintained_resource

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
@@ -1,3 +1,5 @@
+from typing import Optional, Union
+
 import boto3
 import dagster._check as check
 from botocore.handlers import disable_signing
@@ -23,16 +25,17 @@ class S3Callback:
 
 
 def construct_s3_client(
-    max_attempts,
-    region_name=None,
-    endpoint_url=None,
-    use_unsigned_session=False,
-    profile_name=None,
-    use_ssl=True,
-    verify=None,
-    aws_access_key_id=None,
-    aws_secret_access_key=None,
-    aws_session_token=None,
+    max_attempts: int,
+    region_name: Optional[str] = None,
+    endpoint_url: Optional[str] = None,
+    use_unsigned_session: bool=False,
+    profile_name: Optional[str] = None,
+    use_ssl: bool = True,
+    verify: Optional[Union[str, bool]] = None,
+    aws_access_key_id: Optional[str] = None,
+    aws_secret_access_key: Optional[str] = None,
+    aws_session_token: Optional[str] = None,
+    
 ):
     check.int_param(max_attempts, "max_attempts")
     check.opt_str_param(region_name, "region_name")
@@ -40,7 +43,6 @@ def construct_s3_client(
     check.bool_param(use_unsigned_session, "use_unsigned_session")
     check.opt_str_param(profile_name, "profile_name")
     check.bool_param(use_ssl, "use_ssl")
-    check.opt_str_param(verify, "verify")
     check.opt_str_param(profile_name, "aws_access_key_id")
     check.opt_str_param(profile_name, "aws_secret_access_key")
     check.opt_str_param(profile_name, "aws_session_token")

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
@@ -35,7 +35,6 @@ def construct_s3_client(
     aws_access_key_id: Optional[str] = None,
     aws_secret_access_key: Optional[str] = None,
     aws_session_token: Optional[str] = None,
-    
 ):
     check.int_param(max_attempts, "max_attempts")
     check.opt_str_param(region_name, "region_name")

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
@@ -28,7 +28,7 @@ def construct_s3_client(
     max_attempts: int,
     region_name: Optional[str] = None,
     endpoint_url: Optional[str] = None,
-    use_unsigned_session: bool=False,
+    use_unsigned_session: bool = False,
     profile_name: Optional[str] = None,
     use_ssl: bool = True,
     verify: Optional[Union[str, bool]] = None,

--- a/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/resources.py
@@ -61,6 +61,12 @@ class SecretsManagerResource(ResourceWithBoto3Configuration):
             max_attempts=self.max_attempts,
             region_name=self.region_name,
             profile_name=self.profile_name,
+            endpoint_url=self.endpoint_url,
+            use_ssl=self.use_ssl,
+            verify=self.verify,
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+            aws_session_token=self.aws_session_token,
         )
 
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/secrets.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/secrets.py
@@ -7,16 +7,36 @@ from ..utils import construct_boto_client_retry_config
 
 
 def construct_secretsmanager_client(
-    max_attempts: int, region_name: Optional[str] = None, profile_name: Optional[str] = None
+    max_attempts: int,
+    region_name: Optional[str] = None,
+    profile_name: Optional[str] = None,
+    endpoint_url: Optional[str] = None,
+    use_ssl: bool = True,
+    aws_access_key_id: Optional[str] = None,
+    aws_secret_access_key: Optional[str] = None,
+    aws_session_token: Optional[str] = None,
+    verify=None,
 ):
     check.int_param(max_attempts, "max_attempts")
     check.opt_str_param(region_name, "region_name")
     check.opt_str_param(profile_name, "profile_name")
+    check.opt_str_param(endpoint_url, "endpoint_url")
+    check.bool_param(use_ssl, "use_ssl")
+    check.opt_str_param(verify, "verify")
+    check.opt_str_param(aws_access_key_id, "aws_access_key_id")
+    check.opt_str_param(aws_secret_access_key, "aws_secret_access_key")
+    check.opt_str_param(aws_session_token, "aws_session_token")
 
     client_session = boto3.session.Session(profile_name=profile_name)
     secrets_manager = client_session.client(
         "secretsmanager",
         region_name=region_name,
+        use_ssl=use_ssl,
+        verify=verify,
+        endpoint_url=endpoint_url,
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+        aws_session_token=aws_session_token,
         config=construct_boto_client_retry_config(max_attempts),
     )
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/secrets.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/secrets.py
@@ -15,7 +15,7 @@ def construct_secretsmanager_client(
     aws_access_key_id: Optional[str] = None,
     aws_secret_access_key: Optional[str] = None,
     aws_session_token: Optional[str] = None,
-    verify: Optional[bool]=None,
+    verify: Optional[bool] = None,
 ):
     check.int_param(max_attempts, "max_attempts")
     check.opt_str_param(region_name, "region_name")

--- a/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/secrets.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/secrets.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional, Sequence, Union
+from typing import Mapping, Optional, Sequence
 
 import boto3.session
 import dagster._check as check
@@ -15,14 +15,14 @@ def construct_secretsmanager_client(
     aws_access_key_id: Optional[str] = None,
     aws_secret_access_key: Optional[str] = None,
     aws_session_token: Optional[str] = None,
-    verify: Optional[Union[str, bool]]=None,
+    verify: Optional[bool]=None,
 ):
     check.int_param(max_attempts, "max_attempts")
     check.opt_str_param(region_name, "region_name")
     check.opt_str_param(profile_name, "profile_name")
     check.opt_str_param(endpoint_url, "endpoint_url")
     check.bool_param(use_ssl, "use_ssl")
-    check.opt_str_param(verify, "verify")
+    check.opt_bool_param(verify, "verify")
     check.opt_str_param(aws_access_key_id, "aws_access_key_id")
     check.opt_str_param(aws_secret_access_key, "aws_secret_access_key")
     check.opt_str_param(aws_session_token, "aws_session_token")

--- a/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/secrets.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/secretsmanager/secrets.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional, Sequence
+from typing import Mapping, Optional, Sequence, Union
 
 import boto3.session
 import dagster._check as check
@@ -15,7 +15,7 @@ def construct_secretsmanager_client(
     aws_access_key_id: Optional[str] = None,
     aws_secret_access_key: Optional[str] = None,
     aws_session_token: Optional[str] = None,
-    verify=None,
+    verify: Optional[Union[str, bool]]=None,
 ):
     check.int_param(max_attempts, "max_attempts")
     check.opt_str_param(region_name, "region_name")

--- a/python_modules/libraries/dagster-aws/dagster_aws/ssm/parameters.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ssm/parameters.py
@@ -7,16 +7,36 @@ from dagster_aws.utils import construct_boto_client_retry_config
 
 
 def construct_ssm_client(
-    max_attempts: int, region_name: Optional[str] = None, profile_name: Optional[str] = None
+    max_attempts: int,
+    region_name: Optional[str] = None,
+    profile_name: Optional[str] = None,
+    endpoint_url: Optional[str] = None,
+    use_ssl: bool = True,
+    aws_access_key_id: Optional[str] = None,
+    aws_secret_access_key: Optional[str] = None,
+    aws_session_token: Optional[str] = None,
+    verify=None,
 ):
     check.int_param(max_attempts, "max_attempts")
     check.opt_str_param(region_name, "region_name")
     check.opt_str_param(profile_name, "profile_name")
+    check.opt_str_param(endpoint_url, "endpoint_url")
+    check.bool_param(use_ssl, "use_ssl")
+    check.opt_str_param(verify, "verify")
+    check.opt_str_param(aws_access_key_id, "aws_access_key_id")
+    check.opt_str_param(aws_secret_access_key, "aws_secret_access_key")
+    check.opt_str_param(aws_session_token, "aws_session_token")
 
     client_session = boto3.session.Session(profile_name=profile_name)
     ssm_client = client_session.client(
         "ssm",
         region_name=region_name,
+        use_ssl=use_ssl,
+        verify=verify,
+        endpoint_url=endpoint_url,
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+        aws_session_token=aws_session_token,
         config=construct_boto_client_retry_config(max_attempts),
     )
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/ssm/parameters.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ssm/parameters.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence
 
 import boto3.session
 import dagster._check as check
@@ -15,14 +15,14 @@ def construct_ssm_client(
     aws_access_key_id: Optional[str] = None,
     aws_secret_access_key: Optional[str] = None,
     aws_session_token: Optional[str] = None,
-    verify: Optional[Union[str, bool]] = None,
+    verify: Optional[bool] = None,
 ):
     check.int_param(max_attempts, "max_attempts")
     check.opt_str_param(region_name, "region_name")
     check.opt_str_param(profile_name, "profile_name")
     check.opt_str_param(endpoint_url, "endpoint_url")
     check.bool_param(use_ssl, "use_ssl")
-    check.opt_str_param(verify, "verify")
+    check.opt_bool_param(verify, "verify")
     check.opt_str_param(aws_access_key_id, "aws_access_key_id")
     check.opt_str_param(aws_secret_access_key, "aws_secret_access_key")
     check.opt_str_param(aws_session_token, "aws_session_token")

--- a/python_modules/libraries/dagster-aws/dagster_aws/ssm/parameters.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ssm/parameters.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import boto3.session
 import dagster._check as check
@@ -15,7 +15,7 @@ def construct_ssm_client(
     aws_access_key_id: Optional[str] = None,
     aws_secret_access_key: Optional[str] = None,
     aws_session_token: Optional[str] = None,
-    verify=None,
+    verify: Optional[Union[str, bool]] = None,
 ):
     check.int_param(max_attempts, "max_attempts")
     check.opt_str_param(region_name, "region_name")

--- a/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ssm/resources.py
@@ -68,6 +68,12 @@ class SSMResource(ResourceWithBoto3Configuration):
             max_attempts=self.max_attempts,
             region_name=self.region_name,
             profile_name=self.profile_name,
+            endpoint_url=self.endpoint_url,
+            use_ssl=self.use_ssl,
+            verify=self.verify,
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+            aws_session_token=self.aws_session_token,
         )
 
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/utils/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/utils/__init__.py
@@ -40,6 +40,29 @@ class ResourceWithBoto3Configuration(ConfigurableResource):
     profile_name: Optional[str] = Field(
         default=None, description="Specifies a profile to connect that session"
     )
+    use_ssl: bool = Field(
+        default=True, description="Whether or not to use SSL. By default, SSL is used."
+    )
+    endpoint_url: Optional[str] = Field(
+        default=None, description="Specifies a custom endpoint for the Boto3 session."
+    )
+    verify: Optional[str] = Field(
+        default=None,
+        description=(
+            "Whether or not to verify SSL certificates. By default SSL certificates are verified."
+            " You can also specify this argument if you want to use a different CA cert bundle than"
+            " the one used by botocore."
+        ),
+    )
+    aws_access_key_id: Optional[str] = Field(
+        default=None, description="AWS access key ID to use when creating the boto3 session."
+    )
+    aws_secret_access_key: Optional[str] = Field(
+        default=None, description="AWS secret access key to use when creating the boto3 session."
+    )
+    aws_session_token: Optional[str] = Field(
+        default=None, description="AWS session token to use when creating the boto3 session."
+    )
 
 
 def ensure_dagster_aws_tests_import() -> None:

--- a/python_modules/libraries/dagster-aws/dagster_aws/utils/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/utils/__init__.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from typing import Optional, TypeVar, Union
+from typing import Optional, TypeVar
 
 import dagster._check as check
 from botocore import __version__ as botocore_version
@@ -46,12 +46,10 @@ class ResourceWithBoto3Configuration(ConfigurableResource):
     endpoint_url: Optional[str] = Field(
         default=None, description="Specifies a custom endpoint for the Boto3 session."
     )
-    verify: Optional[Union[str, bool]] = Field(
-        default=None,
+    verify: Optional[bool] = Field(
+        default=True,
         description=(
             "Whether or not to verify SSL certificates. By default SSL certificates are verified."
-            " You can pass the following values to this parameter: True, False, or a path to a"
-            " CA_BUNDLE file."
         ),
     )
     aws_access_key_id: Optional[str] = Field(

--- a/python_modules/libraries/dagster-aws/dagster_aws/utils/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/utils/__init__.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from typing import Optional, TypeVar
+from typing import Optional, TypeVar, Union
 
 import dagster._check as check
 from botocore import __version__ as botocore_version
@@ -46,12 +46,12 @@ class ResourceWithBoto3Configuration(ConfigurableResource):
     endpoint_url: Optional[str] = Field(
         default=None, description="Specifies a custom endpoint for the Boto3 session."
     )
-    verify: Optional[str] = Field(
+    verify: Optional[Union[str, bool]] = Field(
         default=None,
         description=(
             "Whether or not to verify SSL certificates. By default SSL certificates are verified."
-            " You can also specify this argument if you want to use a different CA cert bundle than"
-            " the one used by botocore."
+            " You can pass the following values to this parameter: True, False, or a path to a"
+            " CA_BUNDLE file."
         ),
     )
     aws_access_key_id: Optional[str] = Field(

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/conftest.py
@@ -8,6 +8,7 @@ from moto import mock_s3, mock_secretsmanager, mock_ssm
 def fake_aws_credentials(monkeypatch):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary & Motivation

I am using dagster with localstack for dev testing, and I am unable to pass `endpoint_url` variable to the `SSMResource` as with the `S3Resource`. This PR will allow for more configuration options to be passed to resources that support it.

- `CloudwatchLogsHandler`
- `ECRPublicClient`
- `SecretsManagerResource`
- `SSMResource`


## How I Tested These Changes

The unit tests for the library passed. As the resources that are being changed, all call `boto3.session.Session.client()` verified that the options are in the [documentation for boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client).