### PR TITLE
[DS][28/n] Create WillBeRequestedCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
@@ -4,6 +4,7 @@ from .operands import (
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,
     InProgressSchedulingCondition as InProgressSchedulingCondition,
     MissingSchedulingCondition as MissingSchedulingCondition,
+    RequestedThisTickCondition as RequestedThisTickCondition,
 )
 from .operators import (
     AllDepsCondition as AllDepsCondition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/__init__.py
@@ -2,5 +2,6 @@ from .slice_conditions import (
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,
     InProgressSchedulingCondition as InProgressSchedulingCondition,
     MissingSchedulingCondition as MissingSchedulingCondition,
+    RequestedThisTickCondition as RequestedThisTickCondition,
 )
 from .updated_since_cron_condition import UpdatedSinceCronCondition as UpdatedSinceCronCondition

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
@@ -49,6 +49,31 @@ class InProgressSchedulingCondition(SliceSchedulingCondition):
 
 
 @whitelist_for_serdes
+class RequestedThisTickCondition(SliceSchedulingCondition):
+    @property
+    def description(self) -> str:
+        return "Will be requested this tick"
+
+    def _executable_with_root_context_key(self, context: SchedulingContext) -> bool:
+        # TODO: once we can launch backfills via the asset daemon, this can be removed
+        root_key = context.root_context.asset_key
+        return context.legacy_context.materializable_in_same_run(
+            child_key=root_key, parent_key=context.asset_key
+        )
+
+    def compute_slice(self, context: SchedulingContext) -> AssetSlice:
+        current_info = context.current_tick_evaluation_info_by_key.get(context.asset_key)
+        if (
+            current_info
+            and current_info.requested_slice
+            and self._executable_with_root_context_key(context)
+        ):
+            return current_info.requested_slice
+        else:
+            return context.asset_graph_view.create_empty_slice(context.asset_key)
+
+
+@whitelist_for_serdes
 class InLatestTimeWindowCondition(SliceSchedulingCondition):
     # This is a serializable representation of the lookback timedelta object
     lookback_days_second_microseconds: Optional[Tuple[int, int, int]] = None

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/dep_operators.py
@@ -1,7 +1,6 @@
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._serdes.serdes import whitelist_for_serdes
 
-from ..legacy.asset_condition import AssetCondition
 from ..scheduling_condition import SchedulingCondition, SchedulingResult
 from ..scheduling_context import SchedulingContext
 
@@ -36,10 +35,12 @@ class DepConditionWrapperCondition(SchedulingCondition):
         )
 
 
-@whitelist_for_serdes
-class AnyDepsCondition(AssetCondition):
+class DepCondition(SchedulingCondition):
     operand: SchedulingCondition
 
+
+@whitelist_for_serdes
+class AnyDepsCondition(DepCondition):
     @property
     def description(self) -> str:
         return "Any deps"
@@ -66,9 +67,7 @@ class AnyDepsCondition(AssetCondition):
 
 
 @whitelist_for_serdes
-class AllDepsCondition(SchedulingCondition):
-    operand: SchedulingCondition
-
+class AllDepsCondition(DepCondition):
     @property
     def description(self) -> str:
         return "All deps"

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
         InLatestTimeWindowCondition,
         InProgressSchedulingCondition,
         MissingSchedulingCondition,
+        RequestedThisTickCondition,
     )
     from .operators import (
         AllDepsCondition,
@@ -130,6 +131,13 @@ class SchedulingCondition(ABC, DagsterModel):
         from .operands import InLatestTimeWindowCondition
 
         return InLatestTimeWindowCondition.from_lookback_delta(lookback_delta)
+
+    @staticmethod
+    def requested_this_tick() -> "RequestedThisTickCondition":
+        """Returns a SchedulingCondition that is true for an asset partition if it will be requested this tick."""
+        from .operands import RequestedThisTickCondition
+
+        return RequestedThisTickCondition()
 
 
 class SchedulingResult(DagsterModel):

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
@@ -67,6 +67,7 @@ class SchedulingEvaluationInfo(DagsterModel):
 
     temporal_context: TemporalContext
     evaluation_nodes: Sequence[SchedulingEvaluationResultNode]
+    requested_slice: Optional[AssetSlice]
 
     def get_evaluation_node(self, unique_id: str) -> Optional[SchedulingEvaluationResultNode]:
         for node in self.evaluation_nodes:
@@ -87,4 +88,9 @@ class SchedulingEvaluationInfo(DagsterModel):
         nodes = SchedulingEvaluationResultNode.nodes_for_evaluation(
             asset_graph_view, state, state.previous_evaluation
         )
-        return SchedulingEvaluationInfo(temporal_context=temporal_context, evaluation_nodes=nodes)
+        requested_slice = asset_graph_view.get_asset_slice_from_subset(state.true_subset)
+        return SchedulingEvaluationInfo(
+            temporal_context=temporal_context,
+            evaluation_nodes=nodes,
+            requested_slice=requested_slice,
+        )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_will_be_requested_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_will_be_requested_condition.py
@@ -1,0 +1,66 @@
+from dagster import AssetKey, SchedulingCondition
+from dagster._core.definitions.events import AssetKeyPartitionKey
+
+from ..scenario_specs import two_assets_in_sequence, two_partitions_def
+from .asset_condition_scenario import AssetConditionScenarioState
+
+
+def test_will_be_requested_unpartitioned() -> None:
+    condition = SchedulingCondition.any_deps_match(SchedulingCondition.requested_this_tick())
+    state = AssetConditionScenarioState(two_assets_in_sequence, asset_condition=condition)
+
+    # no requested parents
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # parent is requested
+    state = state.with_requested_asset_partitions([AssetKeyPartitionKey(AssetKey("A"))])
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 1
+
+
+def test_will_be_requested_static_partitioned() -> None:
+    condition = SchedulingCondition.any_deps_match(SchedulingCondition.requested_this_tick())
+    state = AssetConditionScenarioState(
+        two_assets_in_sequence, asset_condition=condition
+    ).with_asset_properties(partitions_def=two_partitions_def)
+
+    # no requested parents
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # one requested parent
+    state = state.with_requested_asset_partitions([AssetKeyPartitionKey(AssetKey("A"), "1")])
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 1
+    assert result.true_subset.asset_partitions == {AssetKeyPartitionKey(AssetKey("B"), "1")}
+
+    # two requested parents
+    state = state.with_requested_asset_partitions(
+        [AssetKeyPartitionKey(AssetKey("A"), "1"), AssetKeyPartitionKey(AssetKey("A"), "2")]
+    )
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 2
+
+
+def test_will_be_requested_different_partitions() -> None:
+    condition = SchedulingCondition.any_deps_match(SchedulingCondition.requested_this_tick())
+    state = AssetConditionScenarioState(
+        two_assets_in_sequence, asset_condition=condition
+    ).with_asset_properties("A", partitions_def=two_partitions_def)
+
+    # no requested parents
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # one requested parent, but can't execute in same run
+    state = state.with_requested_asset_partitions([AssetKeyPartitionKey(AssetKey("A"), "1")])
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # two requested parents, but can't execute in same run
+    state = state.with_requested_asset_partitions(
+        [AssetKeyPartitionKey(AssetKey("A"), "1"), AssetKeyPartitionKey(AssetKey("A"), "2")]
+    )
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0


### PR DESCRIPTION
## Summary & Motivation

Creates a WillBeRequestedCondition. Naming is somewhat sketch, but the basic idea is that in the past we've merged together this concept with existing rules.

I.e. in AMP-world, the "skip_on_parent_missing" rule is actually "skip on parent (missing and will not be requested this tick)".

This is obviously a bit confusing, and now that all of our dep conditions are composable, breaking this out into its own separate condition is desirable.

## How I Tested These Changes
