### PR TITLE
[DS][29/n] Create ParentNewerCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -11,7 +11,7 @@ from typing import (
 
 from dagster import _check as check
 from dagster._core.definitions.asset_subset import AssetSubset, ValidAssetSubset
-from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.multi_dimensional_partitions import (
     MultiPartitionKey,
     MultiPartitionsDefinition,
@@ -126,6 +126,11 @@ class AssetSlice:
             check.not_none(akpk.partition_key, "No None partition keys")
             for akpk in self._compatible_subset.asset_partitions
         }
+
+    def expensively_compute_asset_partitions(self) -> AbstractSet[AssetKeyPartitionKey]:
+        # this method requires computing all partition keys of the definition, which
+        # may be expensive
+        return self._compatible_subset.asset_partitions
 
     @property
     def asset_key(self) -> AssetKey:
@@ -346,6 +351,21 @@ class AssetGraphView:
     def get_asset_slice_from_valid_subset(self, subset: ValidAssetSubset) -> "AssetSlice":
         return _slice_from_subset(self, subset)
 
+    def get_asset_slice_from_asset_partitions(
+        self, asset_partitions: AbstractSet[AssetKeyPartitionKey]
+    ) -> "AssetSlice":
+        asset_keys = {akpk.asset_key for akpk in asset_partitions}
+        check.invariant(len(asset_keys) == 1, "Must have exactly one asset key")
+        asset_key = asset_keys.pop()
+        return _slice_from_subset(
+            self,
+            ValidAssetSubset.from_asset_partitions_set(
+                asset_key=asset_key,
+                partitions_def=self._get_partitions_def(asset_key),
+                asset_partitions_set=asset_partitions,
+            ),
+        )
+
     def compute_missing_subslice(
         self, asset_key: "AssetKey", from_slice: "AssetSlice"
     ) -> "AssetSlice":
@@ -469,6 +489,28 @@ class AssetGraphView:
             )
         else:
             check.failed(f"Unsupported partitions_def: {partitions_def}")
+
+    @cached_method
+    def compute_updated_since_cursor_slice(
+        self, asset_key: AssetKey, cursor: Optional[int]
+    ) -> AssetSlice:
+        subset = self._queryer.get_asset_subset_updated_after_cursor(
+            asset_key=asset_key, after_cursor=cursor
+        )
+        return self.get_asset_slice_from_valid_subset(subset)
+
+    @cached_method
+    def compute_parent_updated_since_cursor_slice(
+        self, asset_key: AssetKey, cursor: Optional[int]
+    ) -> AssetSlice:
+        result_slice = self.create_empty_slice(asset_key)
+        for parent_key in self.asset_graph.get(asset_key).parent_keys:
+            result_slice = result_slice.compute_union(
+                self.compute_updated_since_cursor_slice(
+                    asset_key=parent_key, cursor=cursor
+                ).compute_child_slice(asset_key)
+            )
+        return result_slice
 
     def create_empty_slice(self, asset_key: AssetKey) -> AssetSlice:
         return _slice_from_subset(

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -368,8 +368,8 @@ class MaterializeOnParentUpdatedRule(
             ).parent_partitions
 
             updated_parent_asset_partitions = context.legacy_context.instance_queryer.get_parent_asset_partitions_updated_after_child(
-                asset_partition,
-                parent_asset_partitions,
+                asset_partition=asset_partition,
+                parent_asset_partitions=parent_asset_partitions,
                 # do a precise check for updated parents, factoring in data versions, as long as
                 # we're within reasonable limits on the number of partitions to check
                 respect_materialization_data_versions=context.legacy_context.daemon_context.respect_materialization_data_versions
@@ -706,9 +706,9 @@ class SkipOnNotAllParentsUpdatedRule(
 
             updated_parent_partitions = (
                 context.legacy_context.instance_queryer.get_parent_asset_partitions_updated_after_child(
-                    candidate,
-                    parent_partitions,
-                    context.legacy_context.daemon_context.respect_materialization_data_versions,
+                    asset_partition=candidate,
+                    parent_asset_partitions=parent_partitions,
+                    respect_materialization_data_versions=context.legacy_context.daemon_context.respect_materialization_data_versions,
                     ignored_parent_keys=set(),
                 )
                 | context.legacy_context.parent_will_update_subset.asset_partitions

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
@@ -4,6 +4,7 @@ from .operands import (
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,
     InProgressSchedulingCondition as InProgressSchedulingCondition,
     MissingSchedulingCondition as MissingSchedulingCondition,
+    ParentNewerCondition as ParentNewerCondition,
     RequestedThisTickCondition as RequestedThisTickCondition,
 )
 from .operators import (

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/__init__.py
@@ -1,3 +1,4 @@
+from .parent_newer_condition import ParentNewerCondition as ParentNewerCondition
 from .slice_conditions import (
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,
     InProgressSchedulingCondition as InProgressSchedulingCondition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/parent_newer_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/parent_newer_condition.py
@@ -1,0 +1,106 @@
+from typing import AbstractSet
+
+from dagster._core.asset_graph_view.asset_graph_view import AssetSlice
+from dagster._core.definitions.declarative_scheduling.scheduling_condition import (
+    SchedulingCondition,
+    SchedulingResult,
+)
+from dagster._core.definitions.declarative_scheduling.scheduling_context import SchedulingContext
+from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._serdes.serdes import whitelist_for_serdes
+
+
+@whitelist_for_serdes
+class ParentNewerCondition(SchedulingCondition):
+    @property
+    def description(self) -> str:
+        return "At least one parent has been updated more recently than the candidate."
+
+    def compute_newer_parents(
+        self, context: SchedulingContext, candidate: AssetKeyPartitionKey
+    ) -> AbstractSet[AssetKeyPartitionKey]:
+        """Returns the set of parent asset partitions that are newer than the candidate."""
+        # TODO: replace this implementation with one backed by the StaleStatusResolver
+        candidate_slice = context.asset_graph_view.get_asset_slice_from_asset_partitions(
+            {candidate}
+        )
+        parent_slices = candidate_slice.compute_parent_slices()
+        all_parent_asset_partitions = {
+            ap
+            for parent_slice in parent_slices.values()
+            for ap in parent_slice.expensively_compute_asset_partitions()
+        }
+        return (
+            context.legacy_context.instance_queryer.get_parent_asset_partitions_updated_after_child(
+                asset_partition=candidate,
+                parent_asset_partitions=all_parent_asset_partitions,
+                respect_materialization_data_versions=False,
+                ignored_parent_keys=set(),
+            )
+        )
+
+    def compute_parent_newer_slice(
+        self, context: SchedulingContext, from_slice: AssetSlice
+    ) -> AssetSlice:
+        """For a given slice, computes the slice for which at least one parent is newer than the
+        given asset partition.
+        """
+        asset_partitions_with_updated_parents = {
+            ap
+            for ap in from_slice.expensively_compute_asset_partitions()
+            if len(self.compute_newer_parents(context, ap)) > 0
+        }
+        return (
+            context.asset_graph_view.get_asset_slice_from_asset_partitions(
+                asset_partitions_with_updated_parents
+            )
+            if asset_partitions_with_updated_parents
+            else context.asset_graph_view.create_empty_slice(context.asset_key)
+        )
+
+    def compute_slice_to_evaluate(self, context: SchedulingContext) -> AssetSlice:
+        """Computes the slice of the target asset that must be fully evaluated this tick."""
+        if context.previous_evaluation_max_storage_id is None:
+            # on the first tick, evaluate all candidates, as you have no previous information
+            return context.candidate_slice
+        else:
+            # on subsequent ticks, only evaluate candidates if they were not evaluated on the
+            # previous tick, or have been updated since the previous tick, or have parents that
+            # have been updated since the previous tick
+            if context.previous_candidate_slice:
+                new_candidates = context.candidate_slice.compute_difference(
+                    context.previous_candidate_slice
+                )
+            else:
+                new_candidates = context.candidate_slice
+
+            # candidates that have updated since the previous tick
+            newly_updated_slice = context.asset_graph_view.compute_updated_since_cursor_slice(
+                asset_key=context.asset_key, cursor=context.previous_evaluation_max_storage_id
+            )
+            # candidates that have parents that have updated since the previous tick
+            parent_newly_updated_slice = (
+                context.asset_graph_view.compute_parent_updated_since_cursor_slice(
+                    asset_key=context.asset_key,
+                    cursor=context.previous_evaluation_max_storage_id,
+                )
+            )
+            updated_slice = newly_updated_slice.compute_union(parent_newly_updated_slice)
+
+            return new_candidates.compute_union(
+                context.candidate_slice.compute_intersection(updated_slice)
+            )
+
+    def evaluate(self, context: SchedulingContext):
+        slice_to_evaluate = self.compute_slice_to_evaluate(context)
+        new_parent_newer_slice = self.compute_parent_newer_slice(context, slice_to_evaluate)
+
+        if context.previous_evaluation_node and context.previous_evaluation_node.true_slice:
+            # combine new results calculated this tick with results from the previous tick
+            true_slice = context.previous_evaluation_node.true_slice.compute_difference(
+                slice_to_evaluate
+            ).compute_union(new_parent_newer_slice)
+        else:
+            true_slice = new_parent_newer_slice
+
+        return SchedulingResult.create(context, true_slice=true_slice)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
         InLatestTimeWindowCondition,
         InProgressSchedulingCondition,
         MissingSchedulingCondition,
+        ParentNewerCondition,
         RequestedThisTickCondition,
     )
     from .operators import (
@@ -138,6 +139,13 @@ class SchedulingCondition(ABC, DagsterModel):
         from .operands import RequestedThisTickCondition
 
         return RequestedThisTickCondition()
+
+    @staticmethod
+    def parent_newer() -> "ParentNewerCondition":
+        """Returns a SchedulingCondition that is true for an asset partition if at least one of its parents is newer."""
+        from .operands import ParentNewerCondition
+
+        return ParentNewerCondition()
 
 
 class SchedulingResult(DagsterModel):

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -911,6 +911,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
 
     def get_parent_asset_partitions_updated_after_child(
         self,
+        *,
         asset_partition: AssetKeyPartitionKey,
         parent_asset_partitions: AbstractSet[AssetKeyPartitionKey],
         respect_materialization_data_versions: bool,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_parent_newer_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_parent_newer_condition.py
@@ -1,0 +1,90 @@
+from dagster import SchedulingCondition
+
+from ..base_scenario import run_request
+from ..scenario_specs import one_asset_depends_on_two, two_partitions_def
+from .asset_condition_scenario import AssetConditionScenarioState
+
+
+def test_parent_newer_unpartitioned() -> None:
+    state = AssetConditionScenarioState(
+        one_asset_depends_on_two, asset_condition=SchedulingCondition.parent_newer()
+    )
+
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 0
+
+    state = state.with_runs(run_request("A"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+    # now C is refreshed, so no longer any newer parents
+    state = state.with_runs(run_request("C"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 0
+
+    # B and C updated -> C still newer
+    state = state.with_runs(run_request("B"))
+    state = state.with_runs(run_request("C"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 0
+
+    # C and B updated -> now B is newer
+    state = state.with_runs(run_request("C"))
+    state = state.with_runs(run_request("B"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+    # recalculate from scratch, B is still newer
+    state = state.without_previous_evaluation_state()
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+
+def test_parent_newer_partitioned() -> None:
+    state = AssetConditionScenarioState(
+        one_asset_depends_on_two, asset_condition=SchedulingCondition.parent_newer()
+    ).with_asset_properties(partitions_def=two_partitions_def)
+
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 0
+
+    state = state.with_runs(run_request("A", "1"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+    # same partition materialized again
+    state = state.with_runs(run_request("A", "1"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+    # different partition materialized, still upstream of C 1
+    state = state.with_runs(run_request("B", "1"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+    # C 2 upstream materialized
+    state = state.with_runs(run_request("B", "2"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 2
+
+    # C 1 materialized, only C 2 has a newer parent
+    state = state.with_runs(run_request("C", "1"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+    # B 1, C 1 materialized, only C 2 has a newer parent
+    state = state.with_runs(run_request("B", "1"))
+    state = state.with_runs(run_request("C", "1"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+    # C 1, B 1 materialized, both have newer parents
+    state = state.with_runs(run_request("C", "1"))
+    state = state.with_runs(run_request("B", "1"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 2
+
+    # recalculate from scratch, both still have newer parents
+    state = state.without_previous_evaluation_state()
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 2


### PR DESCRIPTION
## Summary & Motivation

Originally, this was conceived as a condition that would be used as part of an `any_deps_match()` sort of context. There are a few problems with this:

1. All other conditions are simply true or false for a given asset partition, regardless of which child_partition we consider to be the "downstream". e.g. an asset partition is unambiguously missing or not missing. However, if you have A -> B with A unpartitioned and B partitioned, then it's possible for A to be newer than some partitions of B but older than others. This means that if we wanted to evaluate something like: `any_deps_match(missing() | newer_than_child())`, then we would have to evaluate the inner expression of missing | newer_than_child on a per-child-partition basis, which is both expensive and extremely challenging to visualize
2. We want to eventually implement this via the StaleStatusResolver, which fits way better with the mental model of "a child partition can have the status (parent is newer)" rather than "a child partition can have the status (any parent has the status (newer than child partition))"

The downside is that this does not compose as nicely with other conditions, but I think this is actually ok. For example, we don't support "all parents newer" out of the box, but I think this is a good thing, as that sort of behavior is actually a bit of a footgun, which leads to weird synchronization issues if you (e.g.) materialize one of the two parents, then manually materialize the child. Now you're on a weird new cadence in which your child will _not_ materialize after the second parent updates.

For most cases in which you want to wait for more than one parent to update, you're either filling in time partitions as they come in (and so you can just wait for no parent partitions to be missing, rather than all parent partitions to update), or you want to materialize an unpartitioned asset regularly (in which you can wait for all parent partitions to be updated since a given cron tick, rather than waiting for them all to be updated more recently than you have updated).

## How I Tested These Changes
