### PR TITLE
fix asset status updated by runless materializations

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1972,6 +1972,7 @@ class SqlEventLogStorage(EventLogStorage):
                 latest_events_subquery.c.dagster_event_type,
                 latest_events_subquery.c.partition,
                 latest_events_subquery.c.run_id,
+                latest_events_subquery.c.id,
             ]
         ).where(
             latest_events_subquery.c.dagster_event_type
@@ -1983,16 +1984,17 @@ class SqlEventLogStorage(EventLogStorage):
             materialization_rows = db_fetch_mappings(conn, materialization_events)
 
         materialization_planned_rows_by_partition = {
-            cast(str, row["partition"]): (cast(str, row["run_id"]), cast(int, row["id"]))
-            for row in materialization_planned_rows
+            row["partition"]: (row["run_id"], row["id"]) for row in materialization_planned_rows
         }
-        for row in materialization_rows:
-            if (
-                row["partition"] in materialization_planned_rows_by_partition
-                and materialization_planned_rows_by_partition[cast(str, row["partition"])][0]
-                == row["run_id"]
-            ):
-                materialization_planned_rows_by_partition.pop(cast(str, row["partition"]))
+        for mat_row in materialization_rows:
+            mat_partition = mat_row["partition"]
+            mat_event_id = mat_row["id"]
+            if mat_partition not in materialization_planned_rows_by_partition:
+                continue
+            _, planned_event_id = materialization_planned_rows_by_partition[mat_partition]
+            if planned_event_id < mat_event_id:
+                # this planned materialization event was followed by a materialization event
+                materialization_planned_rows_by_partition.pop(mat_partition)
 
         return materialization_planned_rows_by_partition
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -3048,16 +3048,18 @@ class TestEventLogStorage:
                     },
                 )
 
+                # simulate an external asset materialization for the partition... this should also make the planned
+                # materialization go away
                 storage.store_event(
                     EventLogEntry(
                         error_info=None,
                         level="debug",
                         user_message="",
-                        run_id=run_id_4,
+                        run_id=RUNLESS_RUN_ID,
                         timestamp=time.time(),
                         dagster_event=DagsterEvent(
                             DagsterEventType.ASSET_MATERIALIZATION.value,
-                            "nonce",
+                            RUNLESS_JOB_NAME,
                             event_specific_data=StepMaterializationData(
                                 AssetMaterialization(asset_key=a, partition="bar")
                             ),

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -3048,18 +3048,16 @@ class TestEventLogStorage:
                     },
                 )
 
-                # simulate an external asset materialization for the partition... this should also make the planned
-                # materialization go away
                 storage.store_event(
                     EventLogEntry(
                         error_info=None,
                         level="debug",
                         user_message="",
-                        run_id=RUNLESS_RUN_ID,
+                        run_id=run_id_4,
                         timestamp=time.time(),
                         dagster_event=DagsterEvent(
                             DagsterEventType.ASSET_MATERIALIZATION.value,
-                            RUNLESS_JOB_NAME,
+                            "nonce",
                             event_specific_data=StepMaterializationData(
                                 AssetMaterialization(asset_key=a, partition="bar")
                             ),
@@ -3074,6 +3072,61 @@ class TestEventLogStorage:
                     ),
                     {},
                 )
+
+    def test_get_latest_asset_partition_materialization_attempts_without_materializations_external_asset(
+        self, storage, instance
+    ):
+        a = AssetKey(["a"])
+
+        def _planned_unmaterialized_runs_by_partition(asset_key):
+            result = storage.get_latest_asset_partition_materialization_attempts_without_materializations(
+                asset_key
+            )
+            return {partition: run_id for partition, (run_id, _event_id) in result.items()}
+
+        run_id = make_new_run_id()
+        with create_and_delete_test_runs(instance, [run_id]):
+            # no events
+            assert _planned_unmaterialized_runs_by_partition(a) == {}
+
+            storage.store_event(
+                EventLogEntry(
+                    error_info=None,
+                    level="debug",
+                    user_message="",
+                    run_id=run_id,
+                    timestamp=time.time(),
+                    dagster_event=DagsterEvent(
+                        DagsterEventType.ASSET_MATERIALIZATION_PLANNED.value,
+                        "nonce",
+                        event_specific_data=AssetMaterializationPlannedData(a, "foo"),
+                    ),
+                )
+            )
+
+            # new materialization planned appears
+            assert _planned_unmaterialized_runs_by_partition(a) == {"foo": run_id}
+
+            # materialize external asset
+            storage.store_event(
+                EventLogEntry(
+                    error_info=None,
+                    level="debug",
+                    user_message="",
+                    run_id=RUNLESS_RUN_ID,
+                    timestamp=time.time(),
+                    dagster_event=DagsterEvent(
+                        DagsterEventType.ASSET_MATERIALIZATION.value,
+                        RUNLESS_JOB_NAME,
+                        event_specific_data=StepMaterializationData(
+                            AssetMaterialization(asset_key=a, partition="foo")
+                        ),
+                    ),
+                )
+            )
+
+            # no events
+            assert _planned_unmaterialized_runs_by_partition(a) == {}
 
     def test_store_asset_materialization_planned_event_with_invalid_partitions_subset(
         self, storage, instance


### PR DESCRIPTION
## Summary & Motivation
We're not handling asset status correctly for planned materializations that were later materialized by a runless (external) asset materialization.

## How I Tested These Changes
BK