### PR TITLE
RFC [graphql] change id scheme for job, schedule, & sensor

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -892,7 +892,7 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
         self._external_job = check.inst_param(external_job, "external_job", ExternalJob)
 
     def resolve_id(self, _graphene_info: ResolveInfo):
-        return self._external_job.get_external_origin_id()
+        return self._external_job.handle.to_string()
 
     def get_represented_job(self) -> RepresentedJob:
         return self._external_job

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -91,7 +91,8 @@ class GrapheneSchedule(graphene.ObjectType):
         )
 
     def resolve_id(self, _graphene_info: ResolveInfo):
-        return self._external_schedule.get_external_origin_id()
+        # use semantic selector string for identifier
+        return self._external_schedule.selector.string
 
     def resolve_defaultStatus(self, _graphene_info: ResolveInfo):
         default_schedule_status = self._external_schedule.default_status

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -127,8 +127,9 @@ class GrapheneSensor(graphene.ObjectType):
             else None,
         )
 
-    def resolve_id(self, _):
-        return self._external_sensor.get_external_origin_id()
+    def resolve_id(self, _) -> str:
+        # use semantic selector string for identifier
+        return self._external_sensor.selector.string
 
     def resolve_defaultStatus(self, _graphene_info: ResolveInfo):
         default_sensor_status = self._external_sensor.default_status

--- a/python_modules/dagster/dagster/_core/definitions/selector.py
+++ b/python_modules/dagster/dagster/_core/definitions/selector.py
@@ -272,6 +272,10 @@ class InstigatorSelector(
     def get_id(self) -> str:
         return create_snapshot_id(self)
 
+    @property
+    def string(self) -> str:
+        return f"{self.location_name}.{self.repository_name}.{self.name}"
+
 
 class GraphSelector(
     NamedTuple(

--- a/python_modules/dagster/dagster/_core/remote_representation/handle.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/handle.py
@@ -59,7 +59,7 @@ class JobHandle(
             check.inst_param(repository_handle, "repository_handle", RepositoryHandle),
         )
 
-    def to_string(self):
+    def to_string(self) -> str:
         return f"{self.location_name}.{self.repository_name}.{self.job_name}"
 
     @property


### PR DESCRIPTION
Instead of using the opaque identifier from hashing the serialized `ExternalOrigin` , use the semantic identifier `<location_name>.<repository_name>.<object_name>`

## How I Tested These Changes

existing coverage
click around dagit
