### PR TITLE
[ui] Reduce highlight intensity in global search

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Text.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Text.tsx
@@ -85,7 +85,7 @@ export const CaptionSubtitle = styled(Text)`
 export const CaptionBolded = styled(Text)`
   font-family: ${FontFamily.default};
   font-size: 12px;
-  font-weight: 900;
+  font-weight: 700;
 `;
 
 export const Code = styled(Text)`


### PR DESCRIPTION
## Summary & Motivation

Worlds smallest nit here, but the highlighting in global search is now STRONG with the new font, made it less so. This is the only place this text component is used.

Before:
<img width="805" alt="Screenshot 2024-05-03 at 3 40 34 PM" src="https://github.com/dagster-io/dagster/assets/1037212/07c8337a-a29c-4ae9-ac2f-350f3086b0a3">

After:
<img width="711" alt="Screenshot 2024-05-03 at 3 40 26 PM" src="https://github.com/dagster-io/dagster/assets/1037212/9b5370e3-7a1f-4994-aac7-9e811c8fec24">
