### PR TITLE
Fix perf regression when checking asset records for many asset keys

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/batch_asset_record_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/batch_asset_record_loader.py
@@ -20,7 +20,7 @@ class BatchAssetRecordLoader:
         self._asset_records: Mapping[AssetKey, Optional["AssetRecord"]] = {}
 
     def add_asset_keys(self, asset_keys: Iterable[AssetKey]):
-        unfetched_asset_keys = set(asset_keys).difference(self._asset_records.keys())
+        unfetched_asset_keys = set(asset_keys).difference(self._asset_records)
         self._unfetched_asset_keys = self._unfetched_asset_keys.union(unfetched_asset_keys)
 
     def get_asset_record(self, asset_key: AssetKey) -> Optional["AssetRecord"]:


### PR DESCRIPTION
Summary:
Speedscope shows that we were spending a regression-worthy amount of time in add_asset_keys while getting asset records in CachingInstanceQueryer. Make a simpler version of add_asset_keys for a single key that has to do less expensive set math, and use it.

Test Plan: AMP perf tests back to normal

## Summary & Motivation

## How I Tested These Changes
