### PR TITLE
[DS][27/n] Make candidate_slice and true_slice Optional

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -80,7 +80,7 @@ class MaterializeOnRequiredForFreshnessRule(
         true_subset, subsets_with_metadata = freshness_evaluation_results_for_asset_key(
             context.legacy_context.root_context
         )
-        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
         return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
@@ -217,7 +217,9 @@ class MaterializeOnCronRule(
             - context.legacy_context.materialized_requested_or_discarded_since_previous_tick_subset
         )
 
-        true_slice = context.asset_graph_view.get_asset_slice_from_subset(asset_subset_to_request)
+        true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(
+            asset_subset_to_request
+        )
         return SchedulingResult.create(context, true_slice=true_slice)
 
 
@@ -435,7 +437,7 @@ class MaterializeOnParentUpdatedRule(
                 ignore_subset=context.legacy_context.materialized_requested_or_discarded_since_previous_tick_subset,
             )
         )
-        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
         return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
@@ -534,7 +536,9 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
 
         return SchedulingResult.create(
             context,
-            true_slice=context.asset_graph_view.get_asset_slice_from_subset(unhandled_candidates),
+            true_slice=context.asset_graph_view.get_asset_slice_from_valid_subset(
+                unhandled_candidates
+            ),
             # we keep track of the handled subset instead of the unhandled subset because new
             # partitions may spontaneously jump into existence at any time
             extra_state=handled_subset,
@@ -588,7 +592,7 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
                 asset_partitions_by_evaluation_data, ignore_subset=subset_to_evaluate
             )
         )
-        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
         return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
@@ -645,7 +649,7 @@ class SkipOnParentMissingRule(AutoMaterializeRule, NamedTuple("_SkipOnParentMiss
                 asset_partitions_by_evaluation_data, ignore_subset=subset_to_evaluate
             )
         )
-        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
         return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
@@ -739,7 +743,7 @@ class SkipOnNotAllParentsUpdatedRule(
                 asset_partitions_by_evaluation_data, ignore_subset=subset_to_evaluate
             )
         )
-        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
         return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
@@ -965,7 +969,7 @@ class SkipOnNotAllParentsUpdatedSinceCronRule(
 
         return SchedulingResult.create(
             context,
-            true_slice=context.asset_graph_view.get_asset_slice_from_subset(
+            true_slice=context.asset_graph_view.get_asset_slice_from_valid_subset(
                 context.legacy_context.candidate_subset - all_parents_updated_subset
             ),
             extra_state=list(updated_subsets_by_key.values()),
@@ -1016,7 +1020,7 @@ class SkipOnRequiredButNonexistentParentsRule(
                 asset_partitions_by_evaluation_data, ignore_subset=subset_to_evaluate
             )
         )
-        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
         return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
@@ -1056,7 +1060,7 @@ class SkipOnBackfillInProgressRule(
         else:
             true_subset = context.legacy_context.candidate_subset & backfilling_subset
 
-        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
         return SchedulingResult.create(context, true_slice)
 
 
@@ -1085,7 +1089,7 @@ class DiscardOnMaxMaterializationsExceededRule(
 
         return SchedulingResult.create(
             context,
-            context.asset_graph_view.get_asset_slice_from_subset(
+            context.asset_graph_view.get_asset_slice_from_valid_subset(
                 AssetSubset.from_asset_partitions_set(
                     context.legacy_context.asset_key,
                     context.legacy_context.partitions_def,
@@ -1123,13 +1127,13 @@ class SkipOnRunInProgressRule(AutoMaterializeRule, NamedTuple("_SkipOnRunInProgr
             if dagster_run and dagster_run.status in IN_PROGRESS_RUN_STATUSES:
                 return SchedulingResult.create(
                     context,
-                    context.asset_graph_view.get_asset_slice_from_subset(
+                    context.asset_graph_view.get_asset_slice_from_valid_subset(
                         context.legacy_context.candidate_subset
                     ),
                 )
         return SchedulingResult.create(
             context,
-            context.asset_graph_view.get_asset_slice_from_subset(
+            context.asset_graph_view.get_asset_slice_from_valid_subset(
                 context.legacy_context.empty_subset()
             ),
         )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/updated_since_cron_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/updated_since_cron_condition.py
@@ -27,9 +27,10 @@ class UpdatedSinceCronCondition(AssetCondition):
         previous_cron_tick = self._get_previous_cron_tick(context)
 
         if (
-            # never evaluated
+            # never evaluated or evaluation info is no longer valid
             context.previous_evaluation_info is None
             or context.previous_evaluation_node is None
+            or context.previous_evaluation_node.true_slice is None
             # not evaluated since latest schedule tick
             or context.previous_evaluation_info.temporal_context.effective_dt < previous_cron_tick
             # has new set of candidates
@@ -46,7 +47,7 @@ class UpdatedSinceCronCondition(AssetCondition):
             )
             # TODO: implement this on the AssetGraphView
             true_slice = context.candidate_slice.compute_intersection(
-                context.asset_graph_view.get_asset_slice_from_subset(updated_subset)
+                context.asset_graph_view.get_asset_slice_from_valid_subset(updated_subset)
             )
         else:
             true_slice = context.previous_evaluation_node.true_slice

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
@@ -23,8 +23,8 @@ class SchedulingEvaluationResultNode(DagsterModel):
     asset_key: AssetKey
     condition_unique_id: str
 
-    true_slice: AssetSlice
-    candidate_slice: AssetSlice
+    true_slice: Optional[AssetSlice]
+    candidate_slice: Optional[AssetSlice]
     subsets_with_metadata: Sequence[AssetSubsetWithMetadata]
 
     extra_state: Any

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
@@ -1,3 +1,4 @@
+import dagster._check as check
 import pytest
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_subset import AssetSubset
@@ -35,9 +36,11 @@ def get_hardcoded_condition():
             ).partitions_def
             return SchedulingResult.create(
                 context,
-                true_slice=context.asset_graph_view.get_asset_slice_from_subset(
-                    AssetSubset.from_asset_partitions_set(
-                        context.asset_key, partitions_def, true_candidates
+                true_slice=check.not_none(
+                    context.asset_graph_view.get_asset_slice_from_subset(
+                        AssetSubset.from_asset_partitions_set(
+                            context.asset_key, partitions_def, true_candidates
+                        )
                     )
                 ),
             )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
@@ -1,0 +1,103 @@
+import datetime
+
+from dagster import AutoMaterializePolicy, Definitions, asset
+from dagster._core.definitions.declarative_scheduling.legacy.asset_condition import (
+    AssetCondition,
+)
+from dagster._core.definitions.declarative_scheduling.serialized_objects import (
+    AssetConditionEvaluation,
+)
+from dagster._core.remote_representation.external_data import external_repository_data_from_def
+from dagster._serdes import serialize_value
+from dagster._serdes.serdes import deserialize_value
+
+from ..base_scenario import run_request
+from ..scenario_specs import (
+    daily_partitions_def,
+    day_partition_key,
+    one_asset,
+    time_partitions_start_datetime,
+)
+from .asset_condition_scenario import AssetConditionScenarioState
+
+
+def test_missing_unpartitioned() -> None:
+    state = AssetConditionScenarioState(one_asset, asset_condition=AssetCondition.missing())
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+    evaluation1 = deserialize_value(
+        serialize_value(AssetConditionEvaluation.from_result(result)), AssetConditionEvaluation
+    )
+
+    # still true
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+    evaluation2 = AssetConditionEvaluation.from_result(result)
+
+    assert evaluation2.equivalent_to_stored_evaluation(evaluation1)
+
+    # after a run of A it's now False
+    state, result = state.with_runs(run_request("A")).evaluate("A")
+    assert result.true_subset.size == 0
+
+    # if we evaluate from scratch, it's also False
+    _, result = state.without_previous_evaluation_state().evaluate("A")
+    assert result.true_subset.size == 0
+
+
+def test_missing_time_partitioned() -> None:
+    state = (
+        AssetConditionScenarioState(one_asset, asset_condition=AssetCondition.missing())
+        .with_asset_properties(partitions_def=daily_partitions_def)
+        .with_current_time(time_partitions_start_datetime)
+        .with_current_time_advanced(days=6, minutes=1)
+    )
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 6
+
+    # still true
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 6
+
+    # after two runs of A those partitions are now False
+    state, result = state.with_runs(
+        run_request("A", day_partition_key(time_partitions_start_datetime, 2)),
+        run_request("A", day_partition_key(time_partitions_start_datetime, 3)),
+    ).evaluate("A")
+    assert result.true_subset.size == 4
+
+    # result is stable
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 4
+
+    # if the partitions definition changes, then we have 1 fewer missing partition
+    state = state.with_asset_properties(
+        partitions_def=daily_partitions_def._replace(
+            start=time_partitions_start_datetime + datetime.timedelta(days=1)
+        )
+    )
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 3
+
+    # if we evaluate from scratch, get the same answer
+    _, result = state.without_previous_evaluation_state().evaluate("A")
+    assert result.true_subset.size == 3
+
+
+def test_serialize_definitions_with_asset_condition():
+    amp = AutoMaterializePolicy.from_asset_condition(
+        AssetCondition.parent_newer() & ~AssetCondition.updated_since_cron("0 * * * *")
+    )
+
+    @asset(auto_materialize_policy=amp)
+    def my_asset():
+        return 0
+
+    result = serialize_value(
+        external_repository_data_from_def(Definitions(assets=[my_asset]).get_repository_def())
+    )
+    assert isinstance(result, str)


### PR DESCRIPTION
## Summary & Motivation

This helps avoid a class of errors using the type system. We have these concepts of "AssetSubsets" vs. "ValidAssetSubsets", where valid asset subsets are known to have been created with the asset's current-tick PartitionsDefinition, and AssetSubsets have gone through a serdes layer and therefore may have a differen partitions definition than they did at serialization time.

This means that care needs to be taken when using a bare AssetSubset.

Previously, we had these fancy operators which would treat AssetSubsets which had invalid partitions_definitions as the empty subset, but that is not actually always accurate. i.e. you may have been keeping track of all the materialized partitions of an asset using a subset, then you update the partitions definition. The correct thing to do here is to recompute the materialized partitions from scratch, NOT assume that this susbet is equivalent to the empty subset.

By explicitly creating a None value for candidate_slice / true_slice in these cases, we force authors of conditions to handle these cases through the type system. This already uncovered a potential bug in the new UpdatedSinceCron condition, in which it would return an empty set in the case that a partition was updated since the latest cron tick, but then the partitions definition was updated.

## How I Tested These Changes
