### PR TITLE
[ui] Workaround issues with react-router-dom auto-decoding path

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelinePathUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelinePathUtils.tsx
@@ -26,6 +26,21 @@ export function explorerPathToString(path: ExplorerPath) {
   return `${root}/${path.opNames.map(encodeURIComponent).join('/')}`;
 }
 
+/** react-router-dom helpfully auto-decodes the location.path, but does not auto-encode it.
+ * We still need explorerPathToString to encode the path, since the value could be passed
+ * to window.open, etc., and we need explorerPathFromString to reverse explorerPathToString.
+ *
+ * Our best option is to try decoding the path, and if it fails, assume that react-router-dom
+ * has already done it for us.
+ */
+function tryDecodeURIComponent(str: string) {
+  try {
+    return decodeURIComponent(str);
+  } catch (err) {
+    return str;
+  }
+}
+
 export function explorerPathFromString(path: string): ExplorerPath {
   const rootAndOps = path.split('/');
   const root = rootAndOps[0]!;
@@ -43,9 +58,9 @@ export function explorerPathFromString(path: string): ExplorerPath {
   return {
     pipelineName,
     snapshotId,
-    opsQuery: decodeURIComponent(opsQuery || ''),
+    opsQuery: tryDecodeURIComponent(opsQuery || ''),
     explodeComposites: explodeComposites === '!',
-    opNames: opNames.map(decodeURIComponent),
+    opNames: opNames.map(tryDecodeURIComponent),
   };
 }
 


### PR DESCRIPTION
Related: https://dagsterlabs.slack.com/archives/C058CBEL230/p1715004497479149

Test Plan:

Verified the scenario (typing “%” in the asset query box) now works

Verified that other text fields / search boxes in the app can succesfully save the value % to the URL
