### PR TITLE
Remove pins for pandas<2.1 for dagster-duckdb libraries

### DIFF
--- a/pyright/alt-1/requirements-pinned.txt
+++ b/pyright/alt-1/requirements-pinned.txt
@@ -19,7 +19,7 @@ asttokens==2.4.1
 async-lru==2.0.4
 async-timeout==4.0.3
 attrs==23.2.0
-babel==2.14.0
+babel==2.15.0
 backoff==2.2.1
 beautifulsoup4==4.12.3
 bleach==6.1.0
@@ -36,9 +36,9 @@ colorama==0.4.6
 coloredlogs==14.0
 comm==0.2.2
 contourpy==1.2.1
-coverage==7.5.0
+coverage==7.5.1
 croniter==2.0.5
-cryptography==42.0.5
+cryptography==42.0.7
 cycler==0.12.1
 -e python_modules/dagster
 -e python_modules/libraries/dagster-aws
@@ -92,7 +92,7 @@ google-api-python-client==2.127.0
 google-auth==2.29.0
 google-auth-httplib2==0.2.0
 google-auth-oauthlib==1.2.0
-google-cloud-bigquery==3.21.0
+google-cloud-bigquery==3.22.0
 google-cloud-core==2.4.1
 google-cloud-storage==2.16.0
 google-crc32c==1.5.0
@@ -112,7 +112,7 @@ httplib2==0.22.0
 httptools==0.6.1
 httpx==0.27.0
 humanfriendly==10.0
-hypothesis==6.100.2
+hypothesis==6.100.4
 idna==3.7
 importlib-metadata==6.11.0
 iniconfig==2.0.0
@@ -123,7 +123,7 @@ isoduration==20.11.0
 isort==5.13.2
 jaraco-classes==3.4.0
 jedi==0.19.1
-jinja2==3.1.3
+jinja2==3.1.4
 jmespath==1.0.1
 joblib==1.4.2
 json5==0.9.25
@@ -136,7 +136,7 @@ jupyter-events==0.10.0
 jupyter-lsp==2.2.5
 jupyter-server==2.14.0
 jupyter-server-terminals==0.5.3
-jupyterlab==4.1.8
+jupyterlab==4.2.0
 jupyterlab-pygments==0.3.0
 jupyterlab-server==2.27.1
 keyring==24.3.1
@@ -178,9 +178,9 @@ ordered-set==4.1.0
 orjson==3.10.3
 overrides==7.7.0
 packaging==24.0
-pandas==2.0.3
+pandas==2.2.2
 pandas-stubs==2.2.1.240316
-pandera==0.18.3
+pandera==0.19.0
 pandocfilters==1.5.1
 parsedatetime==2.6
 parso==0.8.4
@@ -210,7 +210,7 @@ pyasn1-modules==0.4.0
 pycparser==2.22
 pydantic==2.7.1
 pydantic-core==2.18.2
-pygments==2.17.2
+pygments==2.18.0
 pyjwt==2.8.0
 pylint==3.1.0
 pyopenssl==24.1.0
@@ -240,7 +240,7 @@ responses==0.23.1
 rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rich==13.7.1
-rpds-py==0.18.0
+rpds-py==0.18.1
 rsa==4.9
 s3fs==2024.3.1
 s3transfer==0.10.1
@@ -258,7 +258,7 @@ snowflake-sqlalchemy==1.5.1
 sortedcontainers==2.4.0
 soupsieve==2.5
 sqlalchemy==1.4.52
-sqlglot==23.12.2
+sqlglot==23.13.7
 sqlglotrs==0.2.0
 sqlparse==0.5.0
 stack-data==0.6.3

--- a/python_modules/libraries/dagster-duckdb-pandas/setup.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/setup.py
@@ -37,9 +37,7 @@ setup(
     install_requires=[
         f"dagster{pin}",
         f"dagster-duckdb{pin}",
-        # Pinned pending duckdb removal of broken pandas import. Pin can be
-        # removed as soon as it produces a working build.
-        "pandas<2.1",
+        "pandas",
     ],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-duckdb-pyspark/setup.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/setup.py
@@ -37,9 +37,7 @@ setup(
         f"dagster{pin}",
         f"dagster-duckdb{pin}",
         "pyspark>=3",
-        # Pinned pending duckdb removal of broken pandas import. Pin can be
-        # removed as soon as it produces a working build.
-        "pandas<2.1",
+        "pandas",
         "pyarrow",
     ],
     zip_safe=False,

--- a/python_modules/libraries/dagster-duckdb/setup.py
+++ b/python_modules/libraries/dagster-duckdb/setup.py
@@ -39,9 +39,7 @@ setup(
     ],
     extras_require={
         "pandas": [
-            # Pinned pending duckdb removal of broken pandas import. Pin can be
-            # removed as soon as it produces a working build.
-            "pandas<2.1",
+            "pandas",
         ],
         "pyspark": ["pyspark>=3"],
     },


### PR DESCRIPTION
## Summary & Motivation

Originally pinned [here](https://github.com/dagster-io/dagster/pull/16203), fixed on DuckDB's side [here](https://github.com/duckdb/duckdb/pull/8738).

## How I Tested These Changes

```
make rebuild_pyright_pins
make pyrights
```
