### PR TITLE
unify metadata replacement api across event types

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
@@ -13,6 +13,7 @@ from dagster._core.definitions.asset_check_spec import (
 from dagster._core.definitions.events import (
     AssetKey,
     CoercibleToAssetKey,
+    EventWithMetadata,
     MetadataValue,
     RawMetadataValue,
     normalize_metadata,
@@ -34,7 +35,8 @@ class AssetCheckResult(
             ("severity", PublicAttr[AssetCheckSeverity]),
             ("description", PublicAttr[Optional[str]]),
         ],
-    )
+    ),
+    EventWithMetadata,
 ):
     """The result of an asset check.
 
@@ -168,6 +170,16 @@ class AssetCheckResult(
             passed=self.passed,
             metadata=self.metadata,
             target_materialization_data=target_materialization_data,
+            severity=self.severity,
+            description=self.description,
+        )
+
+    def with_metadata(self, metadata: Mapping[str, RawMetadataValue]) -> "AssetCheckResult":
+        return AssetCheckResult(
+            passed=self.passed,
+            asset_key=self.asset_key,
+            check_name=self.check_name,
+            metadata=metadata,
             severity=self.severity,
             description=self.description,
         )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_output_events.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_output_events.py
@@ -26,22 +26,6 @@ def test_output_object_equality():
     )
 
 
-def test_output_object_with_metadata() -> None:
-    def _get_output() -> Output:
-        return Output(5, output_name="foo", metadata={"foo": "bar"}, tags={"baz": "qux"})
-
-    assert _get_output() == _get_output()
-
-    assert _get_output().with_metadata({"new": "metadata"}) == Output(
-        5, output_name="foo", metadata={"new": "metadata"}, tags={"baz": "qux"}
-    )
-
-    out = _get_output()
-    assert out.with_metadata({**out.metadata, "new": "metadata"}) == Output(
-        5, output_name="foo", metadata={"foo": "bar", "new": "metadata"}, tags={"baz": "qux"}
-    )
-
-
 def test_dynamic_output_object_equality():
     def _get_output():
         return DynamicOutput(5, output_name="foo", mapping_key="bar", metadata={"foo": "bar"})

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_replace_event_metadata.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_replace_event_metadata.py
@@ -1,0 +1,119 @@
+from dagster import (
+    AssetCheckResult,
+    AssetCheckSeverity,
+    AssetKey,
+    AssetMaterialization,
+    AssetObservation,
+    Output,
+)
+
+
+def test_output_object_with_metadata() -> None:
+    def _get_output() -> Output:
+        return Output(5, output_name="foo", metadata={"foo": "bar"}, tags={"baz": "qux"})
+
+    assert _get_output() == _get_output()
+
+    assert _get_output().with_metadata({"new": "metadata"}) == Output(
+        5, output_name="foo", metadata={"new": "metadata"}, tags={"baz": "qux"}
+    )
+
+    out = _get_output()
+    assert out.with_metadata({**out.metadata, "new": "metadata"}) == Output(
+        5, output_name="foo", metadata={"foo": "bar", "new": "metadata"}, tags={"baz": "qux"}
+    )
+
+
+def test_asset_materialization_object_with_metadata() -> None:
+    def _get_materialization() -> AssetMaterialization:
+        return AssetMaterialization(
+            asset_key=AssetKey("my_key"),
+            description="foo",
+            metadata={"foo": "bar"},
+            tags={"baz": "qux"},
+            partition="my_partition",
+        )
+
+    assert _get_materialization() == _get_materialization()
+
+    assert _get_materialization().with_metadata({"new": "metadata"}) == AssetMaterialization(
+        asset_key=AssetKey("my_key"),
+        description="foo",
+        metadata={"new": "metadata"},
+        tags={"baz": "qux"},
+        partition="my_partition",
+    )
+
+    mat = _get_materialization()
+
+    assert mat.with_metadata({**mat.metadata, "new": "metadata"}) == AssetMaterialization(
+        asset_key=AssetKey("my_key"),
+        description="foo",
+        metadata={"foo": "bar", "new": "metadata"},
+        tags={"baz": "qux"},
+        partition="my_partition",
+    )
+
+
+def test_asset_observation_object_with_metadata() -> None:
+    def _get_observation() -> AssetObservation:
+        return AssetObservation(
+            asset_key=AssetKey("my_key"),
+            description="foo",
+            metadata={"foo": "bar"},
+            tags={"baz": "qux"},
+            partition="my_partition",
+        )
+
+    assert _get_observation() == _get_observation()
+
+    assert _get_observation().with_metadata({"new": "metadata"}) == AssetObservation(
+        asset_key=AssetKey("my_key"),
+        description="foo",
+        metadata={"new": "metadata"},
+        tags={"baz": "qux"},
+        partition="my_partition",
+    )
+
+    obs = _get_observation()
+
+    assert obs.with_metadata({**obs.metadata, "new": "metadata"}) == AssetObservation(
+        asset_key=AssetKey("my_key"),
+        description="foo",
+        metadata={"foo": "bar", "new": "metadata"},
+        tags={"baz": "qux"},
+        partition="my_partition",
+    )
+
+
+def test_asset_check_result_object_with_metadata() -> None:
+    def _get_check_result() -> AssetCheckResult:
+        return AssetCheckResult(
+            asset_key=AssetKey("my_key"),
+            metadata={"foo": "bar"},
+            passed=True,
+            severity=AssetCheckSeverity.WARN,
+            description="foo",
+            check_name="my_check",
+        )
+
+    assert _get_check_result() == _get_check_result()
+
+    assert _get_check_result().with_metadata({"new": "metadata"}) == AssetCheckResult(
+        asset_key=AssetKey("my_key"),
+        metadata={"new": "metadata"},
+        passed=True,
+        severity=AssetCheckSeverity.WARN,
+        description="foo",
+        check_name="my_check",
+    )
+
+    check = _get_check_result()
+    assert check.with_metadata({**check.metadata, "new": "metadata"}) == AssetCheckResult(
+        asset_key=AssetKey("my_key"),
+        metadata={"foo": "bar", "new": "metadata"},
+        passed=True,
+        severity=AssetCheckSeverity.WARN,
+        description="foo",
+        check_name="my_check",
+    )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -926,10 +926,7 @@ class DbtEventIterator(Generic[T], abc.Iterator):
             row_count = query_result[1][0]["row_count"]
             additional_metadata = {**TableMetadataSet(row_count=row_count)}
 
-            if isinstance(event, Output):
-                return event.with_metadata(metadata={**event.metadata, **additional_metadata})
-            else:
-                return event._replace(metadata={**event.metadata, **additional_metadata})
+            return event.with_metadata(metadata={**event.metadata, **additional_metadata})
         except Exception as e:
             logger.exception(
                 f"An error occurred while fetching row count for {unique_id}. Row count metadata"


### PR DESCRIPTION
## Summary

Stacks on #21666 to provide a shared abc/api for replacing metadata on event types which have it.

## Test Plan

Unit tests
