### PR TITLE
[DS][30/n] Create new unique ids for each child based off of index

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
@@ -6,6 +6,7 @@ from .operands import (
     MissingSchedulingCondition as MissingSchedulingCondition,
     ParentNewerCondition as ParentNewerCondition,
     RequestedThisTickCondition as RequestedThisTickCondition,
+    UpdatedSinceCronCondition as UpdatedSinceCronCondition,
 )
 from .operators import (
     AllDepsCondition as AllDepsCondition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/rule_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/rule_condition.py
@@ -17,7 +17,7 @@ class RuleCondition(AssetCondition):
 
     rule: AutoMaterializeRule
 
-    def get_unique_id(self, parent_unique_id: Optional[str]) -> str:
+    def get_unique_id(self, *, parent_unique_id: Optional[str], index: Optional[str]) -> str:
         # preserves old (bad) behavior of not including the parent_unique_id to avoid inavlidating
         # old serialized information
         parts = [self.rule.__class__.__name__, self.description]

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/boolean_operators.py
@@ -25,9 +25,9 @@ class AndAssetCondition(SchedulingCondition):
     def evaluate(self, context: SchedulingContext) -> SchedulingResult:
         child_results: List[SchedulingResult] = []
         true_slice = context.candidate_slice
-        for child in self.children:
+        for i, child in enumerate(self.children):
             child_context = context.for_child_condition(
-                child_condition=child, candidate_slice=true_slice
+                child_condition=child, child_index=i, candidate_slice=true_slice
             )
             child_result = child.evaluate(child_context)
             child_results.append(child_result)
@@ -53,9 +53,9 @@ class OrAssetCondition(SchedulingCondition):
     def evaluate(self, context: SchedulingContext) -> SchedulingResult:
         child_results: List[SchedulingResult] = []
         true_slice = context.asset_graph_view.create_empty_slice(context.asset_key)
-        for child in self.children:
+        for i, child in enumerate(self.children):
             child_context = context.for_child_condition(
-                child_condition=child, candidate_slice=context.candidate_slice
+                child_condition=child, child_index=i, candidate_slice=context.candidate_slice
             )
             child_result = child.evaluate(child_context)
             child_results.append(child_result)
@@ -81,7 +81,7 @@ class NotAssetCondition(SchedulingCondition):
 
     def evaluate(self, context: SchedulingContext) -> SchedulingResult:
         child_context = context.for_child_condition(
-            child_condition=self.operand, candidate_slice=context.candidate_slice
+            child_condition=self.operand, child_index=0, candidate_slice=context.candidate_slice
         )
         child_result = self.operand.evaluate(child_context)
         true_slice = context.candidate_slice.compute_difference(child_result.true_slice)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/dep_operators.py
@@ -22,7 +22,7 @@ class DepConditionWrapperCondition(SchedulingCondition):
         # only evaluate parents of the current candidates
         dep_candidate_slice = context.candidate_slice.compute_parent_slice(self.dep_key)
         dep_context = context.for_child_condition(
-            child_condition=self.operand, candidate_slice=dep_candidate_slice
+            child_condition=self.operand, child_index=0, candidate_slice=dep_candidate_slice
         )
 
         # evaluate condition against the dependency
@@ -50,11 +50,13 @@ class AnyDepsCondition(DepCondition):
         true_slice = context.asset_graph_view.create_empty_slice(context.asset_key)
 
         dep_keys = context.asset_graph_view.asset_graph.get(context.asset_key).parent_keys
-        for dep_key in dep_keys:
+        for i, dep_key in enumerate(sorted(dep_keys)):
             dep_condition = DepConditionWrapperCondition(dep_key=dep_key, operand=self.operand)
             dep_result = dep_condition.evaluate(
                 context.for_child_condition(
-                    child_condition=dep_condition, candidate_slice=context.candidate_slice
+                    child_condition=dep_condition,
+                    child_index=i,
+                    candidate_slice=context.candidate_slice,
                 )
             )
             dep_results.append(dep_result)
@@ -77,11 +79,13 @@ class AllDepsCondition(DepCondition):
         true_slice = context.candidate_slice
 
         dep_keys = context.asset_graph_view.asset_graph.get(context.asset_key).parent_keys
-        for dep_key in dep_keys:
+        for i, dep_key in enumerate(sorted(dep_keys)):
             dep_condition = DepConditionWrapperCondition(dep_key=dep_key, operand=self.operand)
             dep_result = dep_condition.evaluate(
                 context.for_child_condition(
-                    child_condition=dep_condition, candidate_slice=context.candidate_slice
+                    child_condition=dep_condition,
+                    child_index=i,
+                    candidate_slice=context.candidate_slice,
                 )
             )
             dep_results.append(dep_result)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
@@ -52,9 +52,9 @@ class SchedulingCondition(ABC, DagsterModel):
             unique_id=unique_id,
         )
 
-    def get_unique_id(self, parent_unique_id: Optional[str]) -> str:
+    def get_unique_id(self, *, parent_unique_id: Optional[str], index: Optional[int]) -> str:
         """Returns a unique identifier for this condition within the broader condition tree."""
-        parts = [str(parent_unique_id), self.__class__.__name__, self.description]
+        parts = [str(parent_unique_id), str(index), self.__class__.__name__, self.description]
         return non_secure_md5_hash_str("".join(parts).encode())
 
     @abstractmethod


### PR DESCRIPTION
## Summary & Motivation

This fixes an issue I noticed when experimenting with the PR above this (creating the eager condition).

If we base an evaluation node's id off of purely its description and its parent id, then we run into an issue if you have two children with the same description (but different sub-conditions).

This new scheme ensures that all nodes in the graph will have unique ids, as no two nodes can have the same parent id, description, AND index within that parent

## How I Tested These Changes
