### PR TITLE
[du][dbt] going for parity with directory name

### DIFF
--- a/docs/dagster-university/pages/dagster-dbt/lesson-2/1-requirements.md
+++ b/docs/dagster-university/pages/dagster-dbt/lesson-2/1-requirements.md
@@ -36,5 +36,5 @@ Even if you’ve already completed the Dagster Essentials course, you should sti
 Run the following to clone the project:
 
 ```bash
-dagster project from-example --name project-dagster-university --example project_du_dbt_starter
+dagster project from-example --name dagster-and-dbt --example project_du_dbt_starter
 ```


### PR DESCRIPTION
## Summary & Motivation

When users make the project, they name the directory `project-dagster-university`, but then we tell them to `cd` into a `dagster-and-dbt` directory which doesn't exist.

Changing the command to make the `dagster-and-dbt` directory instead.

## How I Tested These Changes
