### PR TITLE
whitelist the asset tags we store in the asset tags table (to query by)

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -14,6 +14,7 @@ from typing import (
 import dagster._check as check
 from dagster._core.assets import AssetDetails
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
+from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.definitions.events import AssetKey
 from dagster._core.event_api import (
     AssetRecordsFilter,
@@ -34,6 +35,7 @@ from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
 from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecord
 from dagster._core.storage.dagster_run import DagsterRunStatsSnapshot
 from dagster._core.storage.sql import AlembicVersion
+from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX
 from dagster._utils import PrintFn
 from dagster._utils.concurrency import ConcurrencyClaimStatus, ConcurrencyKeyInfo
 from dagster._utils.warnings import deprecation_warning
@@ -377,6 +379,13 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         filter_event_id: Optional[int] = None,
     ) -> Sequence[Mapping[str, str]]:
         pass
+
+    def get_asset_tags_to_index(self, tag_keys: Set[str]) -> Set[str]:
+        return {
+            key
+            for key in tag_keys
+            if key == DATA_VERSION_TAG or key.startswith(MULTIDIMENSIONAL_PARTITION_PREFIX)
+        }
 
     @abstractmethod
     def wipe_asset(self, asset_key: AssetKey) -> None:

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -23,6 +23,7 @@ from dagster import (
     op,
 )
 from dagster._cli.debug import DebugRunPayload
+from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.definitions.dependency import NodeHandle
 from dagster._core.definitions.events import UNDEFINED_ASSET_KEY_PATH, AssetLineageInfo
 from dagster._core.definitions.metadata import MetadataValue
@@ -1021,7 +1022,7 @@ def test_add_kvs_table():
 def test_add_asset_event_tags_table():
     @op
     def yields_materialization_w_tags(_):
-        yield AssetMaterialization(asset_key=AssetKey(["a"]), tags={"dagster/foo": "bar"})
+        yield AssetMaterialization(asset_key=AssetKey(["a"]), tags={DATA_VERSION_TAG: "bar"})
         yield Output(1)
 
     @job
@@ -1050,7 +1051,7 @@ def test_add_asset_event_tags_table():
 
             asset_job.execute_in_process(instance=instance)
             assert instance._event_storage.get_event_tags_for_asset(asset_key=AssetKey(["a"])) == [
-                {"dagster/foo": "bar"}
+                {DATA_VERSION_TAG: "bar"}
             ]
 
             indexes = get_sqlite3_indexes(db_path, "asset_event_tags")

--- a/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
@@ -159,6 +159,10 @@ class TestLegacyStorage(TestEventLogStorage):
     def is_sqlite(self, storage):
         return True
 
+    @pytest.mark.parametrize("dagster_event_type", ["dummy"])
+    def test_get_latest_tags_by_partition(self, storage, instance, dagster_event_type):
+        pytest.skip("skip this since legacy storage is harder to mock.patch")
+
 
 def _insert_slots(conn: Connection, concurrency_key: str, num: int, delete_num: int = 0):
     rows = [

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -45,6 +45,7 @@ from dagster._core.definitions.asset_check_evaluation import (
     AssetCheckEvaluationTargetMaterializationData,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSeverity
+from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.dependency import NodeHandle
 from dagster._core.definitions.job_base import InMemoryJob
@@ -2750,7 +2751,10 @@ class TestEventLogStorage:
                 ascending=False,
             )[0].storage_id
 
-        with create_and_delete_test_runs(instance, [run_id]):
+        passthrough_all_tags = lambda tags: tags
+        with mock.patch.object(
+            storage, "get_asset_tags_to_index", passthrough_all_tags
+        ), create_and_delete_test_runs(instance, [run_id]):
             # no events
             assert (
                 storage.get_latest_tags_by_partition(
@@ -2859,6 +2863,146 @@ class TestEventLogStorage:
                     a, dagster_event_type, tag_keys=["dagster/a", "dagster/b"]
                 ) == {
                     "p1": {"dagster/a": "3", "dagster/b": "3"},
+                }
+
+    @pytest.mark.parametrize(
+        "dagster_event_type",
+        [DagsterEventType.ASSET_OBSERVATION, DagsterEventType.ASSET_MATERIALIZATION],
+    )
+    def test_get_latest_data_version_by_partition(self, storage, instance, dagster_event_type):
+        """Test that queries latest data version (same as above test, but without needing to mock the indexed tags)."""
+        a = AssetKey(["a"])
+        b = AssetKey(["b"])
+        run_id = make_new_run_id()
+
+        def _store_partition_event(asset_key, partition, tags) -> int:
+            if dagster_event_type == DagsterEventType.ASSET_MATERIALIZATION:
+                dagster_event = DagsterEvent(
+                    dagster_event_type.value,
+                    "nonce",
+                    event_specific_data=StepMaterializationData(
+                        AssetMaterialization(asset_key=asset_key, partition=partition, tags=tags)
+                    ),
+                )
+            else:
+                dagster_event = DagsterEvent(
+                    dagster_event_type.value,
+                    "nonce",
+                    event_specific_data=AssetObservationData(
+                        AssetObservation(asset_key=asset_key, partition=partition, tags=tags)
+                    ),
+                )
+
+            storage.store_event(
+                EventLogEntry(
+                    error_info=None,
+                    level="debug",
+                    user_message="",
+                    run_id=run_id,
+                    timestamp=time.time(),
+                    dagster_event=dagster_event,
+                )
+            )
+            # get the storage id of the materialization we just stored
+            return storage.get_event_records(
+                EventRecordsFilter(dagster_event_type),
+                limit=1,
+                ascending=False,
+            )[0].storage_id
+
+        with create_and_delete_test_runs(instance, [run_id]):
+            # no events
+            assert (
+                storage.get_latest_tags_by_partition(
+                    a, dagster_event_type, tag_keys=[DATA_VERSION_TAG]
+                )
+                == {}
+            )
+
+            # p1 materialized
+            _store_partition_event(a, "p1", tags={DATA_VERSION_TAG: "1"})
+
+            # p2 materialized
+            _store_partition_event(a, "p2", tags={DATA_VERSION_TAG: "1"})
+
+            # unrelated asset materialized
+            t1 = _store_partition_event(b, "p1", tags={DATA_VERSION_TAG: "..."})
+            _store_partition_event(b, "p2", tags={DATA_VERSION_TAG: "..."})
+
+            # p1 re materialized
+            _store_partition_event(a, "p1", tags={DATA_VERSION_TAG: "2"})
+
+            # p3 materialized
+            _store_partition_event(a, "p3", tags={DATA_VERSION_TAG: "1"})
+
+            # subset of existing tag keys
+            assert storage.get_latest_tags_by_partition(
+                a, dagster_event_type, tag_keys=[DATA_VERSION_TAG]
+            ) == {
+                "p1": {DATA_VERSION_TAG: "2"},
+                "p2": {DATA_VERSION_TAG: "1"},
+                "p3": {DATA_VERSION_TAG: "1"},
+            }
+
+            # subset of existing partition keys
+            assert storage.get_latest_tags_by_partition(
+                a,
+                dagster_event_type,
+                tag_keys=[DATA_VERSION_TAG],
+                asset_partitions=["p1"],
+            ) == {
+                "p1": {DATA_VERSION_TAG: "2"},
+            }
+
+            # superset of existing partition keys
+            assert storage.get_latest_tags_by_partition(
+                a,
+                dagster_event_type,
+                tag_keys=[DATA_VERSION_TAG],
+                asset_partitions=["p1", "p2", "p3", "p4"],
+            ) == {
+                "p1": {DATA_VERSION_TAG: "2"},
+                "p2": {DATA_VERSION_TAG: "1"},
+                "p3": {DATA_VERSION_TAG: "1"},
+            }
+
+            # before p1 rematerialized and p3 existed
+            assert storage.get_latest_tags_by_partition(
+                a,
+                dagster_event_type,
+                tag_keys=[DATA_VERSION_TAG],
+                before_cursor=t1,
+            ) == {
+                "p1": {DATA_VERSION_TAG: "1"},
+                "p2": {DATA_VERSION_TAG: "1"},
+            }
+
+            # shouldn't include p2's materialization
+            assert storage.get_latest_tags_by_partition(
+                a,
+                dagster_event_type,
+                tag_keys=[DATA_VERSION_TAG],
+                after_cursor=t1,
+            ) == {
+                "p1": {DATA_VERSION_TAG: "2"},
+                "p3": {DATA_VERSION_TAG: "1"},
+            }
+
+            if self.can_wipe():
+                storage.wipe_asset(a)
+                assert (
+                    storage.get_latest_tags_by_partition(
+                        a,
+                        dagster_event_type,
+                        tag_keys=[DATA_VERSION_TAG],
+                    )
+                    == {}
+                )
+                _store_partition_event(a, "p1", tags={DATA_VERSION_TAG: "3"})
+                assert storage.get_latest_tags_by_partition(
+                    a, dagster_event_type, tag_keys=[DATA_VERSION_TAG]
+                ) == {
+                    "p1": {DATA_VERSION_TAG: "3"},
                 }
 
     def test_get_latest_asset_partition_materialization_attempts_without_materializations(

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -15,6 +15,7 @@ from dagster import (
     job,
     op,
 )
+from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
@@ -256,7 +257,7 @@ def test_add_kvs_table(conn_string):
 def test_add_asset_event_tags_table(conn_string):
     @op
     def yields_materialization_w_tags(_):
-        yield AssetMaterialization(asset_key=AssetKey(["a"]), tags={"dagster/foo": "bar"})
+        yield AssetMaterialization(asset_key=AssetKey(["a"]), tags={DATA_VERSION_TAG: "bar"})
         yield Output(1)
 
     @job
@@ -289,7 +290,7 @@ def test_add_asset_event_tags_table(conn_string):
             assert "asset_event_tags" in get_tables(instance)
             asset_job.execute_in_process(instance=instance)
             assert instance._event_storage.get_event_tags_for_asset(asset_key=AssetKey(["a"])) == [
-                {"dagster/foo": "bar"}
+                {DATA_VERSION_TAG: "bar"}
             ]
 
             indexes = get_indexes(instance, "asset_event_tags")

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -1,5 +1,4 @@
 # ruff: noqa: SLF001
-
 import datetime
 import os
 import re
@@ -17,6 +16,7 @@ from dagster import (
     op,
     reconstructable,
 )
+from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.execution.api import execute_job
 from dagster._core.instance import DagsterInstance
@@ -658,7 +658,7 @@ def test_add_asset_event_tags_table(hostname, conn_string):
     @op
     def yields_materialization_w_tags():
         yield AssetMaterialization(asset_key=AssetKey(["a"]))
-        yield AssetMaterialization(asset_key=AssetKey(["a"]), tags={"dagster/foo": "bar"})
+        yield AssetMaterialization(asset_key=AssetKey(["a"]), tags={DATA_VERSION_TAG: "bar"})
         yield Output(1)
 
     @job
@@ -696,7 +696,7 @@ def test_add_asset_event_tags_table(hostname, conn_string):
             assert "asset_event_tags" in get_tables(instance)
             asset_job.execute_in_process(instance=instance)
             assert instance._event_storage.get_event_tags_for_asset(asset_key=AssetKey(["a"])) == [
-                {"dagster/foo": "bar"}
+                {DATA_VERSION_TAG: "bar"}
             ]
 
             indexes = get_indexes(instance, "asset_event_tags")


### PR DESCRIPTION
## Summary & Motivation
We have been storing a sizeable number of tags on asset events to track all sorts of things, including:
1) multidimensional partitions
2) data version
3) code version
4) input lineage

Most of these tags are only used by reading them out of the materialization event body.

All of them are currently getting stored within `store_event` to the `asset_event_tags` table.  This is unnecessary for most of these tags.  

The `asset_event_tags` table is queried in two places:
1) For a multi-dimensional partitioned asset, find all dimensions that have ever been materialized (`get_event_tags_for_asset`)
2) For a given asset, find the last data version by partition (`get_latest_tags_by_partition`).

This PR changes the store_event logic so that it only persists asset tag rows that match one of these two cases.  This should save about 75% of the rows that we are currently writing for storing materializations/observations.

It's a little awkward, since we've provided a very generic API to service a very narrow set of queries, and we have to provide backwards compatibility for that API.  This change should be pretty safe, though, since it is a private API (note that the signature has not changed at all).

Adding narrower APIs (e.g. `get_latest_data_version_by_partition`, `get_materialized_partition_dimensions`) was considered, but ultimately moved to be in a future diff, since we may need to workshop the exact names / signature.

Background context of this tag data in Cloud: https://www.notion.so/dagster/Migrating-asset-event-tags-in-Cloud-83508e282b2f4b508cbe78d5348414eb

## How I Tested These Changes
BK