### PR TITLE
[DS][32/n] Update UpdatedSinceCronCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         MissingSchedulingCondition,
         ParentNewerCondition,
         RequestedThisTickCondition,
+        UpdatedSinceCronCondition,
     )
     from .operators import (
         AllDepsCondition,
@@ -115,6 +116,17 @@ class SchedulingCondition(ABC, DagsterModel):
         from .operands import InProgressSchedulingCondition
 
         return InProgressSchedulingCondition()
+
+    @staticmethod
+    def updated_since_cron(
+        cron_schedule: str, cron_timezone: str = "UTC"
+    ) -> "UpdatedSinceCronCondition":
+        """Returns a SchedulingCondition that is true for an asset partition if it has been updated
+        since the latest tick of the provided cron schedule.
+        """
+        from .operands import UpdatedSinceCronCondition
+
+        return UpdatedSinceCronCondition(cron_schedule=cron_schedule, cron_timezone=cron_timezone)
 
     @staticmethod
     def in_latest_time_window(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
@@ -17,7 +17,6 @@ from dagster._core.definitions.declarative_scheduling.scheduling_evaluation_info
     SchedulingEvaluationInfo,
     SchedulingEvaluationResultNode,
 )
-from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._model import DagsterModel
 
@@ -175,15 +174,3 @@ class SchedulingContext(DagsterModel):
     def new_max_storage_id(self) -> Optional[int]:
         # TODO: pull this from the AssetGraphView instead
         return self.legacy_context.new_max_storage_id
-
-    def asset_updated_since_previous_tick(self) -> bool:
-        """Returns True if the target asset has been updated since the previous evaluation."""
-        cursor = (
-            self.previous_evaluation_info.temporal_context.last_event_id
-            if self.previous_evaluation_info
-            else None
-        )
-        return self._queryer.asset_partition_has_materialization_or_observation(
-            asset_partition=AssetKeyPartitionKey(self.asset_key),
-            after_cursor=cursor,
-        )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
@@ -1,4 +1,3 @@
-import datetime
 import itertools
 from typing import Any, Optional, Sequence
 
@@ -15,6 +14,7 @@ from dagster._core.definitions.declarative_scheduling.serialized_objects import 
     AssetSubsetWithMetadata,
 )
 from dagster._model import DagsterModel
+from dagster._utils import utc_datetime_from_timestamp
 
 
 class SchedulingEvaluationResultNode(DagsterModel):
@@ -80,9 +80,7 @@ class SchedulingEvaluationInfo(DagsterModel):
         asset_graph_view: AssetGraphView, state: AssetConditionEvaluationState
     ) -> "SchedulingEvaluationInfo":
         temporal_context = TemporalContext(
-            effective_dt=datetime.datetime.fromtimestamp(
-                state.previous_tick_evaluation_timestamp or 0
-            ),
+            effective_dt=utc_datetime_from_timestamp(state.previous_tick_evaluation_timestamp or 0),
             last_event_id=state.max_storage_id,
         )
         nodes = SchedulingEvaluationResultNode.nodes_for_evaluation(


### PR DESCRIPTION
## Summary & Motivation

First, realized that this wasn't actually tested. Added real tests, and updated the implementation to be slightly more efficient. In particular, previously whenever any partition of a given asset was updated since the previous tick (not near a cron boundary), we'd end up doing a somewhat-inefficient db query to get all the materialization events since the previous cron tick. Instead, we can just use the (probably already-fetched) information about materializations since the previous tick and keep track of that. Not a game changer or anything, but a bit nicer.

## How I Tested These Changes
