### PR TITLE
[Datadog RUM] Give asset tabs their own view names

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -3,7 +3,8 @@ import {gql, useQuery} from '@apollo/client';
 import {BreadcrumbProps} from '@blueprintjs/core';
 import {Alert, Box, ErrorBoundary, NonIdealState, Spinner, Tag} from '@dagster-io/ui-components';
 import {useContext, useEffect, useMemo} from 'react';
-import {Link, Redirect, useLocation} from 'react-router-dom';
+import {Link, Redirect, useLocation, useRouteMatch} from 'react-router-dom';
+import {useSetRecoilState} from 'recoil';
 
 import {AssetEvents} from './AssetEvents';
 import {AssetFeatureContext} from './AssetFeatureContext';
@@ -38,6 +39,7 @@ import {
 import {healthRefreshHintFromLiveData} from './usePartitionHealthData';
 import {useReportEventsModal} from './useReportEventsModal';
 import {useFeatureFlags} from '../app/Flags';
+import {currentPageAtom} from '../app/analytics';
 import {Timestamp} from '../app/time/Timestamp';
 import {AssetLiveDataRefreshButton, useAssetLiveData} from '../asset-data/AssetLiveDataProvider';
 import {
@@ -264,6 +266,12 @@ export const AssetView = ({assetKey, trace, headerBreadcrumbs}: Props) => {
         });
     }
   };
+
+  const setCurrentPage = useSetRecoilState(currentPageAtom);
+  const {path} = useRouteMatch();
+  useEffect(() => {
+    setCurrentPage(({specificPath}) => ({specificPath, path: `${path}?view=${selectedTab}`}));
+  }, [path, selectedTab, setCurrentPage]);
 
   const reportEvents = useReportEventsModal(
     definition


### PR DESCRIPTION
## Summary & Motivation

Currently all of the asset tabs share the same view name of `/assets(/?.*)`. This pr gives them their own view name in datadog.

## How I Tested These Changes
<img width="865" alt="Screenshot 2024-05-06 at 10 36 33 PM" src="https://github.com/dagster-io/dagster/assets/2286579/dfee3e14-3621-4e5d-8670-0919bce88199">
