### PR TITLE
(RFC) New AssetGraphStep API for factories

### DIFF
--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py
@@ -5,9 +5,9 @@ from typing import Any, Dict, List, Optional
 import yaml
 from dagster import AssetsDefinition
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.definitions.factory.executable import (
-    AssetGraphExecutable,
+from dagster._core.definitions.factory.step import (
     AssetGraphExecutionContext,
+    AssetGraphStep,
 )
 from dagster._utils import file_relative_path
 
@@ -26,7 +26,7 @@ def load_yaml(relative_path) -> Dict[str, Any]:
         return yaml.load(ff, Loader=Loader)
 
 
-class PureDSLAsset(AssetGraphExecutable):
+class PureDSLAsset(AssetGraphStep):
     def __init__(self, asset_entry: dict, sql: str, group_name: Optional[str]):
         self.sql = sql
         super().__init__(

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py
@@ -1,10 +1,14 @@
 import os
 import shutil
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import yaml
 from dagster import AssetsDefinition
-from dagster._core.execution.context.compute import AssetExecutionContext
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.factory.executable import (
+    AssetGraphExecutable,
+    AssetGraphExecutionContext,
+)
 from dagster._utils import file_relative_path
 
 try:
@@ -12,7 +16,7 @@ try:
 except ImportError:
     from yaml import Loader
 
-from dagster import AssetKey, asset
+from dagster import AssetKey
 from dagster._core.pipes.subprocess import PipesSubprocessClient
 
 
@@ -22,37 +26,44 @@ def load_yaml(relative_path) -> Dict[str, Any]:
         return yaml.load(ff, Loader=Loader)
 
 
-def from_asset_entries(asset_entries: Dict[str, Any]) -> List[AssetsDefinition]:
-    assets_defs = []
+class PureDSLAsset(AssetGraphExecutable):
+    def __init__(self, asset_entry: dict, sql: str, group_name: Optional[str]):
+        self.sql = sql
+        super().__init__(
+            specs=[
+                AssetSpec(
+                    group_name=group_name,
+                    key=AssetKey.from_user_string(asset_entry["asset_key"]),
+                    description=asset_entry.get("description"),
+                    deps=[
+                        AssetKey.from_user_string(dep_entry)
+                        for dep_entry in asset_entry.get("deps", [])
+                    ],
+                )
+            ],
+            compute_kind="python",
+        )
 
-    group_name = asset_entries.get("group_name")
+    def execute(
+        self, context: AssetGraphExecutionContext, pipes_subprocess_client: PipesSubprocessClient
+    ):
+        python_executable = shutil.which("python")
+        assert python_executable is not None
+        return pipes_subprocess_client.run(
+            command=[python_executable, file_relative_path(__file__, "sql_script.py"), self.sql],
+            context=context.to_op_execution_context(),
+        ).get_results()
 
-    for asset_entry in asset_entries["assets"]:
-        asset_key_str = asset_entry["asset_key"]
-        dep_entries = asset_entry.get("deps", [])
-        description = asset_entry.get("description")
-        asset_key = AssetKey.from_user_string(asset_key_str)
-        deps = [AssetKey.from_user_string(dep_entry) for dep_entry in dep_entries]
 
-        sql = asset_entry["sql"]  # this is required
-
-        @asset(key=asset_key, deps=deps, description=description, group_name=group_name)
-        def _assets_def(
-            context: AssetExecutionContext,
-            pipes_subprocess_client: PipesSubprocessClient,
-        ):
-            # instead of querying a dummy client, do your real data processing here
-
-            python_executable = shutil.which("python")
-            assert python_executable is not None
-            pipes_subprocess_client.run(
-                command=[python_executable, file_relative_path(__file__, "sql_script.py"), sql],
-                context=context,
-            ).get_results()
-
-        assets_defs.append(_assets_def)
-
-    return assets_defs
+def from_asset_entries(asset_entries: dict) -> List[AssetsDefinition]:
+    return [
+        PureDSLAsset(
+            asset_entry=asset_entry,
+            sql=asset_entry["sql"],
+            group_name=asset_entries.get("group_name"),
+        ).to_assets_def()
+        for asset_entry in asset_entries["assets"]
+    ]
 
 
 def get_asset_dsl_example_defs() -> List[AssetsDefinition]:

--- a/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_assets_dsl.py
+++ b/examples/experimental/assets_yaml_dsl/assets_yaml_dsl_tests/test_assets_dsl.py
@@ -77,7 +77,9 @@ assets:
     assert assets_defs
     assert len(assets_defs) == 1
     assets_def = assets_defs[0]
-    assets_def(context=build_asset_context(), pipes_subprocess_client=PipesSubprocessClient())
+    assets_def(
+        context=build_asset_context(resources=dict(pipes_subprocess_client=PipesSubprocessClient()))
+    )
 
 
 def test_basic_group() -> None:

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -31,6 +31,9 @@ class AssetCheckSeverity(Enum):
     ERROR = "ERROR"
 
 
+from dagster import _seven as seven
+
+
 @whitelist_for_serdes(old_storage_names={"AssetCheckHandle"})
 class AssetCheckKey(NamedTuple):
     """Check names are expected to be unique per-asset. Thus, this combination of asset key and
@@ -49,6 +52,9 @@ class AssetCheckKey(NamedTuple):
 
     def with_asset_key_prefix(self, prefix: CoercibleToAssetKeyPrefix) -> "AssetCheckKey":
         return self._replace(asset_key=self.asset_key.with_prefix(prefix))
+
+    def to_string(self) -> str:
+        return seven.json.dumps({"name": self.name, "asset_key": self.asset_key.to_string()})
 
     def to_user_string(self) -> str:
         return f"{self.asset_key.to_user_string()}:{self.name}"

--- a/python_modules/dagster/dagster/_core/definitions/factory/executable.py
+++ b/python_modules/dagster/dagster/_core/definitions/factory/executable.py
@@ -1,0 +1,174 @@
+import inspect
+from abc import ABC, abstractmethod
+from functools import cached_property
+from typing import (
+    Iterable,
+    Optional,
+    Sequence,
+    Set,
+    Union,
+)
+
+from dagster import _check as check
+from dagster._core.definitions.asset_check_result import AssetCheckResult
+from dagster._core.definitions.asset_check_spec import AssetCheckSpec
+from dagster._core.definitions.asset_checks import AssetChecksDefinition
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.base_asset_graph import AssetKeyOrCheckKey
+from dagster._core.definitions.decorators.asset_check_decorator import multi_asset_check
+from dagster._core.definitions.decorators.asset_decorator import multi_asset
+from dagster._core.definitions.partition import PartitionsDefinition
+from dagster._core.definitions.result import MaterializeResult, ObserveResult
+from dagster._core.execution.context.compute import (
+    AssetCheckExecutionContext,
+    AssetExecutionContext,
+    OpExecutionContext,
+)
+from dagster._utils.security import non_secure_md5_hash_str
+
+
+def unique_id_from_key(keys: Sequence[AssetKeyOrCheckKey]) -> str:
+    """Generate a unique ID from the provided keys.
+
+    This is necessary to disambiguate between different ops underlying sections without
+    forcing the user to provide a name for the underlying op.
+    """
+    sorted_keys = sorted(keys, key=lambda key: key.to_string())
+    return non_secure_md5_hash_str(",".join([str(key) for key in sorted_keys]).encode())[:8]
+
+
+AssetGraphExecutionResult = Iterable[Union[MaterializeResult, AssetCheckResult, ObserveResult]]
+
+
+# This is a placeholder for now. I think this is an opportunity to unify all of
+# our contexts with final, canonical object that works for any execution
+# happening in the context of the asset graph.
+class AssetGraphExecutionContext:
+    __slots__ = ["_context"]
+
+    def __init__(self, context: Union[AssetExecutionContext, AssetCheckExecutionContext]):
+        self._context = context
+
+    def to_op_execution_context(self) -> OpExecutionContext:
+        return self._context.op_execution_context
+
+
+# Here are some example alternatives:
+#   - ExecutableSubgraph
+#   - ExecutableAssetGraphFragment
+#   - ExecutableDefinitionSet
+#   - AssetGraphExecutable
+#   - ExecutableDefinitionGroup
+class AssetGraphExecutable(ABC):
+    def __init__(
+        self,
+        specs: Sequence[Union[AssetSpec, AssetCheckSpec]],
+        compute_kind: Optional[str] = None,
+        subsettable: bool = False,
+        tags: Optional[dict] = None,
+        friendly_name: Optional[str] = None,
+        partitions_def: Optional[PartitionsDefinition] = None,
+        # TODO implement these
+        # backfill_policy: Optional[BackfillPolicy] = None,
+        # retry_policy: Optional[RetryPolicy] = None,
+        # config_schema: Optional[UserConfigSchema] = None,
+    ):
+        self.specs = specs
+        self._compute_kind = compute_kind
+        self._subsettable = subsettable
+        self._tags = tags or {}
+        self._friendly_name = friendly_name or unique_id_from_key([spec.key for spec in self.specs])
+        self._partitions_def = partitions_def
+
+    @property
+    def required_resource_keys(self) -> Set[str]:
+        # calling inner property to cache property while
+        # still allowing a user to override this
+        return self._cached_required_resource_keys
+
+    @cached_property
+    def _cached_required_resource_keys(self) -> Set[str]:
+        execute_method = getattr(self, "execute")
+        parameters = inspect.signature(execute_method).parameters
+        return {param for param in parameters if param != "context"}
+
+    @property
+    def asset_specs(self) -> Sequence[AssetSpec]:
+        return [spec for spec in self.specs if isinstance(spec, AssetSpec)]
+
+    @property
+    def asset_check_specs(self) -> Sequence[AssetCheckSpec]:
+        return [spec for spec in self.specs if isinstance(spec, AssetCheckSpec)]
+
+    @property
+    def op_name(self) -> str:
+        return self._friendly_name
+
+    @property
+    def tags(self) -> Optional[dict]:
+        return self._tags
+
+    @property
+    def subsettable(self) -> bool:
+        return self._subsettable
+
+    @property
+    def compute_kind(self) -> Optional[str]:
+        return self._compute_kind
+
+    def _only_required_resources(self, original_resource_dict: dict):
+        return {k: v for k, v in original_resource_dict.items() if k in self.required_resource_keys}
+
+    def to_assets_def(self) -> AssetsDefinition:
+        if self.asset_specs:
+
+            @multi_asset(
+                specs=self.asset_specs,
+                check_specs=self.asset_check_specs,
+                name=self.op_name,
+                op_tags=self.tags,
+                required_resource_keys=self.required_resource_keys,
+                compute_kind=self.compute_kind,
+                can_subset=self.subsettable,
+                partitions_def=self._partitions_def,
+            )
+            def _nope_multi_asset(context: AssetExecutionContext):
+                return self.execute(
+                    context=AssetGraphExecutionContext(context),
+                    **self._only_required_resources(context.resources.original_resource_dict),
+                )
+
+            return _nope_multi_asset
+        else:
+            return self.to_asset_checks_def()
+
+    def to_asset_checks_def(self) -> AssetChecksDefinition:
+        check.invariant(
+            not self._partitions_def,
+            f"PartitionsDefinition not supported for check-only {type(self)}",
+        )
+
+        @multi_asset_check(
+            specs=self.asset_check_specs,
+            name=self.op_name,
+            op_tags=self.tags,
+            required_resource_keys=self.required_resource_keys,
+            compute_kind=self.compute_kind,
+            can_subset=self.subsettable,
+        )
+        def _nope_multi_asset_check(context: AssetCheckExecutionContext):
+            return self.execute(
+                context=AssetGraphExecutionContext(context),
+                **self._only_required_resources(context.resources.original_resource_dict),
+            )
+
+        return _nope_multi_asset_check
+
+    # Resources as kwargs. Must match set in required_resource_keys.
+    # If the user has only specified asset checks, they can override typed as AssetCheckExecutionContext
+    # instead. It would be preferable to have a unified context.
+    @abstractmethod
+    def execute(
+        self, context: AssetGraphExecutionContext, **kwargs
+    ) -> AssetGraphExecutionResult: ...

--- a/python_modules/dagster/dagster/_core/definitions/factory/step.py
+++ b/python_modules/dagster/dagster/_core/definitions/factory/step.py
@@ -54,13 +54,7 @@ class AssetGraphExecutionContext:
         return self._context.op_execution_context
 
 
-# Here are some example alternatives:
-#   - ExecutableSubgraph
-#   - ExecutableAssetGraphFragment
-#   - ExecutableDefinitionSet
-#   - AssetGraphExecutable
-#   - ExecutableDefinitionGroup
-class AssetGraphExecutable(ABC):
+class AssetGraphStep(ABC):
     def __init__(
         self,
         specs: Sequence[Union[AssetSpec, AssetCheckSpec]],


### PR DESCRIPTION
### New pattern for factories: the `AssetGraphStep`

Writing asset and asset check factories is important to a lot of Dagster users and to the Dagster core team. 

Unfortunately it's not a great experience right now. There's a number of problems. A few of them:

1) It relies on dynamically creating decorated functions, which is an awkward pattern. Higher order functions are not that normative in Python. The best we have done is the `dbt_assets` pattern that composes a decorator itself.
2) However even in the best case there are composability. If you want to change the function signature provided to the use, it is very challenging, as you lose introspection-based features (e.g. inferring required resource keys from parameters) that Dagster users expect.
3) Decorated functions have unclear typing in Python. And our `multi_asset` is particularly challenging here. You cannot reliably type it, so typically it is left untyped, and it allows a huge set of return values, which is effectively undocumented.

This proposes a new class-based API for building executable definitions in Dagster, designed for the factory use case. Class-based APIs are more natural for pluggability for Python.

Let's just walk through the example of the example YAML DSL in examples/experimental/assets_yaml_dsl/assets_yaml_dsl/pure_assets_dsl/assets_dsl.py

The before code is:

```python
def from_asset_entries(asset_entries: Dict[str, Any]) -> List[AssetsDefinition]:
    assets_defs = []

    group_name = asset_entries.get("group_name")

    for asset_entry in asset_entries["assets"]:
        asset_key_str = asset_entry["asset_key"]
        dep_entries = asset_entry.get("deps", [])
        description = asset_entry.get("description")
        asset_key = AssetKey.from_user_string(asset_key_str)
        deps = [AssetKey.from_user_string(dep_entry) for dep_entry in dep_entries]

        sql = asset_entry["sql"]  # this is required

        @asset(key=asset_key, deps=deps, description=description, group_name=group_name)
        def _assets_def(
            context: AssetExecutionContext,
            pipes_subprocess_client: PipesSubprocessClient,
        ):
            # instead of querying a dummy client, do your real data processing here

            python_executable = shutil.which("python")
            assert python_executable is not None
            pipes_subprocess_client.run(
                command=[python_executable, file_relative_path(__file__, "sql_script.py"), sql],
                context=context,
            ).get_results()

        assets_defs.append(_assets_def)

    return assets_defs

def get_asset_dsl_example_defs() -> List[AssetsDefinition]:
    asset_entries = load_yaml("assets.yaml")
    return from_asset_entries(asset_entries)
```

We consume a dictionary loaded from a yaml file and create an `AssetsDefinition` object by dynamically creating a function decorated with `@asset` within the function and return it.

Here is the implementation using `AssetGraphStep`:

```python
class PureDSLAsset(AssetGraphStep):
    def __init__(self, asset_entry: dict, sql: str, group_name: Optional[str]):
        self.sql = sql
        super().__init__(
            specs=[
                AssetSpec(
                    group_name=group_name,
                    key=AssetKey.from_user_string(asset_entry["asset_key"]),
                    description=asset_entry.get("description"),
                    deps=[
                        AssetKey.from_user_string(dep_entry)
                        for dep_entry in asset_entry.get("deps", [])
                    ],
                )
            ],
            compute_kind="python",
        )

    def execute(
        self, context: AssetGraphExecutionContext, pipes_subprocess_client: PipesSubprocessClient
    )-> EntitySetExecuteResult:
        python_executable = shutil.which("python")
        assert python_executable is not None
        return pipes_subprocess_client.run(
            command=[python_executable, file_relative_path(__file__, "sql_script.py"), self.sql],
            context=context,
        ).get_results()


def from_asset_entries(asset_entries: dict) -> List[AssetsDefinition]:
    return [
        PureDSLAsset(
            asset_entry=asset_entry,
            sql=asset_entry["sql"],
            group_name=asset_entries.get("group_name"),
        ).to_assets_def() # we would probably eventually alter Definitions to take these eliminating the need for this directl call
        for asset_entry in asset_entries["assets"]
    ]


def get_asset_dsl_example_defs() -> List[AssetsDefinition]:
    asset_entries = load_yaml("assets.yaml")
    return from_asset_entries(asset_entries)
```

* Direct invocation is obvious and requires no magic. `execute` is a directly invokable Python function
* The function signature of `execute` is more obvious and overridable. There is one return type.
    * _Note: We could also eliminate resource parameter magic completely if we wanted here, and instead have an inner class called `Resources` that defines the required resources and their types._
* The class has a much simpler interface than `AssetsDefinition` or even `multi_asset`.

Here is the base class `__init__` that subclasses would call:

```python
class AssetGraphStep(ABC):
    def __init__(
        self,
        specs: Sequence[Union[AssetSpec, AssetCheckSpec]],
        compute_kind: Optional[str] = None,
        subsettable: bool = False,
        tags: Optional[dict] = None,
        friendly_name: Optional[str] = None,
        partitions_def: Optional[PartitionsDefinition] = None,
        # below are TODOs in PR
        backfill_policy: Optional[BackfillPolicy] = None,
        retry_policy: Optional[RetryPolicy] = None,
        config_schema: Optional[UserConfigSchema] = None,    
    ): ...
```

Compare to `multi_asset`:

```python
def multi_asset(
    *,
    outs: Optional[Mapping[str, AssetOut]] = None,
    name: Optional[str] = None,
    ins: Optional[Mapping[str, AssetIn]] = None,
    deps: Optional[Iterable[CoercibleToAssetDep]] = None,
    description: Optional[str] = None,
    config_schema: Optional[UserConfigSchema] = None,
    required_resource_keys: Optional[Set[str]] = None,
    compute_kind: Optional[str] = None,
    internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
    partitions_def: Optional[PartitionsDefinition] = None,
    backfill_policy: Optional[BackfillPolicy] = None,
    op_tags: Optional[Mapping[str, Any]] = None,
    can_subset: bool = False,
    resource_defs: Optional[Mapping[str, object]] = None,
    group_name: Optional[str] = None,
    retry_policy: Optional[RetryPolicy] = None,
    code_version: Optional[str] = None,
    specs: Optional[Sequence[AssetSpec]] = None,
    check_specs: Optional[Sequence[AssetCheckSpec]] = None,
    # deprecated
    non_argument_deps: Optional[Union[Set[AssetKey], Set[str]]] = None,
) -> Callable[[Callable[..., Any]], AssetsDefinition]: ...
```

or `AssetDefinition`

```python
    def __init__(
        self,
        *,
        keys_by_input_name: Mapping[str, AssetKey],
        keys_by_output_name: Mapping[str, AssetKey],
        node_def: NodeDefinition,
        partitions_def: Optional[PartitionsDefinition] = None,
        partition_mappings: Optional[Mapping[AssetKey, PartitionMapping]] = None,
        asset_deps: Optional[Mapping[AssetKey, AbstractSet[AssetKey]]] = None,
        selected_asset_keys: Optional[AbstractSet[AssetKey]] = None,
        can_subset: bool = False,
        resource_defs: Optional[Mapping[str, object]] = None,
        group_names_by_key: Optional[Mapping[AssetKey, str]] = None,
        metadata_by_key: Optional[Mapping[AssetKey, ArbitraryMetadataMapping]] = None,
        tags_by_key: Optional[Mapping[AssetKey, Mapping[str, str]]] = None,
        freshness_policies_by_key: Optional[Mapping[AssetKey, FreshnessPolicy]] = None,
        auto_materialize_policies_by_key: Optional[Mapping[AssetKey, AutoMaterializePolicy]] = None,
        backfill_policy: Optional[BackfillPolicy] = None,
        descriptions_by_key: Optional[Mapping[AssetKey, str]] = None,
        check_specs_by_output_name: Optional[Mapping[str, AssetCheckSpec]] = None,
        selected_asset_check_keys: Optional[AbstractSet[AssetCheckKey]] = None,
        is_subset: bool = False,
        owners_by_key: Optional[Mapping[AssetKey, Sequence[Union[str, AssetOwner]]]] = None,
        # if adding new fields, make sure to handle them in the with_attributes, from_graph,
        # from_op, and get_attributes_dict methods
    ): ...
```

Any class can be used as a resource, with or without `ResourceParam`.

This would be framed to the user base as a more convenient API for building factories. However I do think the natural end state is to replace `AssetsDefinition` as the core primitive.

In the next stack in this PR I will apply this pattern to a more realistic example which we just added, the freshness checks.
