### PR TITLE
[perf] Instrument more pages

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphJobSidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphJobSidebar.tsx
@@ -6,6 +6,7 @@ import {
 } from './types/AssetGraphJobSidebar.types';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PipelineSelector} from '../graphql/types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {NonIdealPipelineQueryResult} from '../pipelines/NonIdealPipelineQueryResult';
 import {
   SIDEBAR_ROOT_CONTAINER_FRAGMENT,
@@ -25,6 +26,7 @@ export const AssetGraphJobSidebar = ({pipelineSelector}: Props) => {
       variables: {pipelineSelector},
     },
   );
+  useBlockTraceOnQueryResult(queryResult, 'AssetGraphSidebarQuery');
 
   const {repositoryName, repositoryLocationName} = pipelineSelector;
   const repoAddress = buildRepoAddress(repositoryName, repositoryLocationName);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -34,6 +34,7 @@ import {DagsterTypeSummary} from '../dagstertype/DagsterType';
 import {DagsterTypeFragment} from '../dagstertype/types/DagsterType.types';
 import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntryFragment';
 import {TableSchemaAssetContext} from '../metadata/TableSchema';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {Description} from '../pipelines/Description';
 import {SidebarSection, SidebarTitle} from '../pipelines/SidebarComponents';
 import {ResourceContainer, ResourceHeader} from '../pipelines/SidebarOpHelpers';
@@ -51,9 +52,11 @@ export const SidebarAssetInfo = ({graphNode}: {graphNode: GraphNode}) => {
     partitionHealthRefreshHint,
     'background',
   );
-  const {data} = useQuery<SidebarAssetQuery, SidebarAssetQueryVariables>(SIDEBAR_ASSET_QUERY, {
+  const queryResult = useQuery<SidebarAssetQuery, SidebarAssetQueryVariables>(SIDEBAR_ASSET_QUERY, {
     variables: {assetKey: {path: assetKey.path}},
   });
+  useBlockTraceOnQueryResult(queryResult, 'SidebarAssetQuery');
+  const {data} = queryResult;
 
   const {lastMaterialization} = liveData || {};
   const asset = data?.assetNodeOrError.__typename === 'AssetNode' ? data.assetNodeOrError : null;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetDefinedInMultipleReposNotice.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetDefinedInMultipleReposNotice.tsx
@@ -8,7 +8,6 @@ import {
 } from './types/AssetDefinedInMultipleReposNotice.types';
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
-import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
@@ -32,8 +31,6 @@ export const AssetDefinedInMultipleReposNotice = ({
     variables: {assetKeys: [{path: assetKey.path}]},
   });
   const {data} = queryResult;
-
-  useBlockTraceOnQueryResult(queryResult, 'AssetDefinitionCollisionQuery');
 
   const collision = data?.assetNodeDefinitionCollisions[0];
   if (!collision) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetDefinedInMultipleReposNotice.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetDefinedInMultipleReposNotice.tsx
@@ -8,6 +8,7 @@ import {
 } from './types/AssetDefinedInMultipleReposNotice.types';
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
@@ -24,12 +25,15 @@ export const AssetDefinedInMultipleReposNotice = ({
   loadedFromRepo: RepoAddress;
   padded?: boolean;
 }) => {
-  const {data} = useQuery<AssetDefinitionCollisionQuery, AssetDefinitionCollisionQueryVariables>(
-    ASSET_DEFINITION_COLLISION_QUERY,
-    {
-      variables: {assetKeys: [{path: assetKey.path}]},
-    },
-  );
+  const queryResult = useQuery<
+    AssetDefinitionCollisionQuery,
+    AssetDefinitionCollisionQueryVariables
+  >(ASSET_DEFINITION_COLLISION_QUERY, {
+    variables: {assetKeys: [{path: assetKey.path}]},
+  });
+  const {data} = queryResult;
+
+  useBlockTraceOnQueryResult(queryResult, 'AssetDefinitionCollisionQuery');
 
   const collision = data?.assetNodeDefinitionCollisions[0];
   if (!collision) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
@@ -20,6 +20,7 @@ import {AssetLocation} from '../asset-graph/useFindAssetLocation';
 import {AssetGroupSelector} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {RepositoryLink} from '../nav/RepositoryLink';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {
   ExplorerPath,
   explorerPathFromString,
@@ -164,10 +165,12 @@ export const AssetGroupTags = ({
   repoAddress: RepoAddress;
 }) => {
   const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
-  const {data} = useQuery<AssetGroupMetadataQuery, AssetGroupMetadataQueryVariables>(
+  const queryResult = useQuery<AssetGroupMetadataQuery, AssetGroupMetadataQueryVariables>(
     ASSET_GROUP_METADATA_QUERY,
     {variables: {selector: groupSelector}},
   );
+  useBlockTraceOnQueryResult(queryResult, 'AssetGroupMetadataQuery');
+  const {data} = queryResult;
 
   const sensorTag = () => {
     const assetNodes = data?.assetNodes;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMaterializationUpstreamData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMaterializationUpstreamData.tsx
@@ -16,6 +16,7 @@ import {
 import {Timestamp} from '../app/time/Timestamp';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {AssetKeyInput} from '../graphql/types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
 dayjs.extend(relativeTime);
 
@@ -146,13 +147,15 @@ export const AssetMaterializationUpstreamData = ({
   assetKey: AssetKeyInput;
   timestamp?: string;
 }) => {
+  const skip = !timestamp;
   const result = useQuery<
     AssetMaterializationUpstreamQuery,
     AssetMaterializationUpstreamQueryVariables
   >(ASSET_MATERIALIZATION_UPSTREAM_QUERY, {
     variables: {assetKey: {path: assetKey.path}, timestamp},
-    skip: !timestamp,
+    skip,
   });
+  useBlockTraceOnQueryResult(result, 'AssetMaterializationUpstreamQuery', {skip});
 
   if (!timestamp) {
     return <Caption color={Colors.textLight()}>None</Caption>;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverviewRoot.tsx
@@ -46,15 +46,15 @@ export const AssetsOverviewRoot = ({
   );
   const assetKey = useMemo(() => ({path: currentPath}), [currentPath]);
 
+  const skip = currentPath.length === 0;
   const queryResult = useQuery<AssetsOverviewRootQuery, AssetsOverviewRootQueryVariables>(
     ASSETS_OVERVIEW_ROOT_QUERY,
     {
-      skip: currentPath.length === 0,
+      skip,
       variables: {assetKey},
     },
   );
-
-  useBlockTraceOnQueryResult(queryResult, 'AssetsOverviewRootQuery');
+  useBlockTraceOnQueryResult(queryResult, 'AssetsOverviewRootQuery', {skip});
 
   useDocumentTitle(
     currentPath && currentPath.length

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
@@ -43,7 +43,7 @@ import {formatElapsedTimeWithMsec} from '../../app/Util';
 import {Timestamp} from '../../app/time/Timestamp';
 import {DimensionPartitionKeys, SensorType} from '../../graphql/types';
 import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
-import {useBlockTraceUntilTrue} from '../../performance/TraceContext';
+import {useBlockTraceOnQueryResult} from '../../performance/TraceContext';
 import {AnchorButton} from '../../ui/AnchorButton';
 import {buildRepoAddress} from '../../workspace/buildRepoAddress';
 import {workspacePathFromAddress} from '../../workspace/workspacePath';
@@ -73,12 +73,12 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
     queryKey: SELECTED_PARTITION_QUERY_STRING_KEY,
   });
 
-  const skipQuery = !!_selectedEvaluation || !!selectedPartition;
+  const skip = !!_selectedEvaluation || !!selectedPartition;
 
   // We receive the selected evaluation ID and retrieve it here because the middle panel
   // may be displaying an evaluation that was not retrieved at the page level for the
   // left panel, e.g. as we paginate away from it, we don't want to lose it.
-  const {data, loading, error} = useQuery<GetEvaluationsQuery, GetEvaluationsQueryVariables>(
+  const queryResult = useQuery<GetEvaluationsQuery, GetEvaluationsQueryVariables>(
     GET_EVALUATIONS_QUERY,
     {
       variables: {
@@ -86,11 +86,11 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
         cursor: selectedEvaluationId ? `${selectedEvaluationId + 1}` : undefined,
         limit: 2,
       },
-      skip: !!_selectedEvaluation || !!selectedPartition,
+      skip,
     },
   );
-
-  useBlockTraceUntilTrue('GetEvaluationsQuery<Single>', !!data || skipQuery);
+  const {data, loading, error} = queryResult;
+  useBlockTraceOnQueryResult(queryResult, 'GetEvaluationsQuery<Single>', {skip});
 
   const {data: specificPartitionData, previousData: previousSpecificPartitionData} = useQuery<
     GetEvaluationsSpecificPartitionQuery,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
@@ -92,7 +92,7 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
   const {data, loading, error} = queryResult;
   useBlockTraceOnQueryResult(queryResult, 'GetEvaluationsQuery<Single>', {skip});
 
-  const {data: specificPartitionData, previousData: previousSpecificPartitionData} = useQuery<
+  const queryResult2 = useQuery<
     GetEvaluationsSpecificPartitionQuery,
     GetEvaluationsSpecificPartitionQueryVariables
   >(GET_EVALUATIONS_SPECIFIC_PARTITION_QUERY, {
@@ -103,6 +103,10 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
     },
     skip: !selectedEvaluationId || !selectedPartition,
   });
+  useBlockTraceOnQueryResult(queryResult2, 'GetEvaluationsSpecificPartitionQuery', {
+    skip: !selectedEvaluationId || !selectedPartition,
+  });
+  const {data: specificPartitionData, previousData: previousSpecificPartitionData} = queryResult2;
 
   const sensorName = React.useMemo(
     () =>
@@ -293,7 +297,7 @@ export const AutomaterializeMiddlePanelWithData = ({
     selectedEvaluation?.numRequested,
   ]);
 
-  const {data} = useQuery<FullPartitionsQuery, FullPartitionsQueryVariables>(
+  const fullPartitionsQueryResult = useQuery<FullPartitionsQuery, FullPartitionsQueryVariables>(
     FULL_PARTITIONS_QUERY,
     {
       variables: definition
@@ -304,6 +308,11 @@ export const AutomaterializeMiddlePanelWithData = ({
       skip: !definition?.assetKey,
     },
   );
+  useBlockTraceOnQueryResult(fullPartitionsQueryResult, 'FullPartitionsQuery', {
+    skip: !definition?.assetKey,
+  });
+
+  const {data} = fullPartitionsQueryResult;
 
   let partitionKeys: DimensionPartitionKeys[] = emptyArray;
   if (data?.assetNodeOrError.__typename === 'AssetNode') {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRequestedPartitionsLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRequestedPartitionsLink.tsx
@@ -24,6 +24,7 @@ import {
 import {showCustomAlert} from '../../app/CustomAlertProvider';
 import {PYTHON_ERROR_FRAGMENT} from '../../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../../app/PythonErrorInfo';
+import {useBlockTraceOnQueryResult} from '../../performance/TraceContext';
 import {RunStatusTagWithID} from '../../runs/RunStatusTag';
 import {DagsterTag} from '../../runs/RunTag';
 import {Container, Inner, Row} from '../../ui/VirtualizedTable';
@@ -114,12 +115,14 @@ export const AutomaterializeRequestedPartitionsLink = ({runIds, partitionKeys, i
 type PartitionRunTuple = [string, RunStatusAndTagsFragment];
 
 const PartitionAndRunList = ({runIds, partitionKeys}: Props) => {
-  const {data, loading} = useQuery<
+  const queryResult = useQuery<
     RunStatusAndPartitionKeyQuery,
     RunStatusAndPartitionKeyQueryVariables
   >(RUN_STATUS_AND_PARTITION_KEY, {
     variables: {filter: {runIds}},
   });
+  useBlockTraceOnQueryResult(queryResult, 'RunStatusAndPartitionKeyQuery');
+  const {data, loading} = queryResult;
 
   const runs = data?.runsOrError;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRunsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRunsTable.tsx
@@ -24,6 +24,7 @@ export const AutomaterializeRunsTable = ({runIds}: {runIds: string[]}) => {
       skip: !runIds.length,
     },
   );
+  const {data, loading, error} = queryResult;
   useBlockTraceOnQueryResult(queryResult, 'AutomaterializeRunsQuery', {skip: !runIds.length});
 
   if (!runIds.length) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRunsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRunsTable.tsx
@@ -8,21 +8,23 @@ import {
 } from './types/AutomaterializeRunsTable.types';
 import {PYTHON_ERROR_FRAGMENT} from '../../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../../app/PythonErrorInfo';
+import {useBlockTraceOnQueryResult} from '../../performance/TraceContext';
 import {RunStatusTagWithStats} from '../../runs/RunStatusTag';
 import {RUN_TIME_FRAGMENT, RunStateSummary, RunTime, titleForRun} from '../../runs/RunUtils';
 
 export const AutomaterializeRunsTable = ({runIds}: {runIds: string[]}) => {
-  const {data, loading, error} = useQuery<
-    AutomaterializeRunsQuery,
-    AutomaterializeRunsQueryVariables
-  >(AUTOMATERIALIZE_RUNS_QUERY, {
-    variables: {
-      filter: {
-        runIds,
+  const queryResult = useQuery<AutomaterializeRunsQuery, AutomaterializeRunsQueryVariables>(
+    AUTOMATERIALIZE_RUNS_QUERY,
+    {
+      variables: {
+        filter: {
+          runIds,
+        },
       },
+      skip: !runIds.length,
     },
-    skip: !runIds.length,
-  });
+  );
+  useBlockTraceOnQueryResult(queryResult, 'AutomaterializeRunsQuery', {skip: !runIds.length});
 
   if (!runIds.length) {
     return (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializeSensorFlag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializeSensorFlag.tsx
@@ -4,13 +4,17 @@ import {
   AutoMaterializeSensorFlagQuery,
   AutoMaterializeSensorFlagQueryVariables,
 } from './types/AutoMaterializeSensorFlag.types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
 type FlagState = 'unknown' | 'has-sensor-amp' | 'has-global-amp';
 
 export const useAutoMaterializeSensorFlag = (): FlagState => {
-  const {data} = useQuery<AutoMaterializeSensorFlagQuery, AutoMaterializeSensorFlagQueryVariables>(
-    AUTO_MATERIALIZE_POLICY_SENSOR_FLAG_QUERY,
-  );
+  const queryResult = useQuery<
+    AutoMaterializeSensorFlagQuery,
+    AutoMaterializeSensorFlagQueryVariables
+  >(AUTO_MATERIALIZE_POLICY_SENSOR_FLAG_QUERY);
+  useBlockTraceOnQueryResult(queryResult, 'AutoMaterializeSensorFlagQuery');
+  const {data} = queryResult;
   if (!data) {
     return 'unknown';
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/BackfillPreviewModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/BackfillPreviewModal.tsx
@@ -58,7 +58,7 @@ export const BackfillPreviewModal = ({
       skip: !isOpen,
     },
   );
-  useBlockTraceOnQueryResult(queryResult, 'BackfillPreviewQuery');
+  useBlockTraceOnQueryResult(queryResult, 'BackfillPreviewQuery', {skip: !isOpen});
   const {data} = queryResult;
 
   const partitionsByAssetToken = useMemo(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/BackfillPreviewModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/BackfillPreviewModal.tsx
@@ -17,6 +17,7 @@ import {
 } from './types/LaunchAssetExecutionButton.types';
 import {tokenForAssetKey} from '../asset-graph/Utils';
 import {TargetPartitionsDisplay} from '../instance/backfill/TargetPartitionsDisplay';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {testId} from '../testing/testId';
 import {Container, HeaderCell, HeaderRow, Inner, Row, RowCell} from '../ui/VirtualizedTable';
 
@@ -50,13 +51,15 @@ export const BackfillPreviewModal = ({
   const totalHeight = rowVirtualizer.getTotalSize();
   const items = rowVirtualizer.getVirtualItems();
 
-  const {data} = useQuery<BackfillPreviewQuery, BackfillPreviewQueryVariables>(
+  const queryResult = useQuery<BackfillPreviewQuery, BackfillPreviewQueryVariables>(
     BACKFILL_PREVIEW_QUERY,
     {
       variables: {partitionNames: keysFiltered, assetKeys},
       skip: !isOpen,
     },
   );
+  useBlockTraceOnQueryResult(queryResult, 'BackfillPreviewQuery');
+  const {data} = queryResult;
 
   const partitionsByAssetToken = useMemo(() => {
     return Object.fromEntries(

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/RunningBackfillsNotice.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/RunningBackfillsNotice.tsx
@@ -6,11 +6,14 @@ import {
   RunningBackfillsNoticeQuery,
   RunningBackfillsNoticeQueryVariables,
 } from './types/RunningBackfillsNotice.types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
 export const RunningBackfillsNotice = ({partitionSetName}: {partitionSetName: string}) => {
-  const {data} = useQuery<RunningBackfillsNoticeQuery, RunningBackfillsNoticeQueryVariables>(
+  const queryResult = useQuery<RunningBackfillsNoticeQuery, RunningBackfillsNoticeQueryVariables>(
     RUNNING_BACKFILLS_NOTICE_QUERY,
   );
+  useBlockTraceOnQueryResult(queryResult, 'RunningBackfillsNoticeQuery');
+  const {data} = queryResult;
 
   const runningBackfills =
     data?.partitionBackfillsOrError.__typename === 'PartitionBackfills'

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -415,7 +415,7 @@ const useHistoricalCheckExecutions = (
     },
     pageSize: PAGE_SIZE,
   });
-  useBlockTraceOnQueryResult(queryResult, 'AssetCheckDetailsQuery');
+  useBlockTraceOnQueryResult(queryResult, 'AssetCheckDetailsQuery', {skip: !variables});
 
   // TODO - in a follow up PR we should have some kind of queryRefresh context that can merge all of the uses of queryRefresh.
   useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAutomaterializeDaemonStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAutomaterializeDaemonStatus.tsx
@@ -7,12 +7,15 @@ import {
   SetAutoMaterializePausedMutation,
   SetAutoMaterializePausedMutationVariables,
 } from './types/useAutomaterializeDaemonStatus.types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
 export function useAutomaterializeDaemonStatus() {
-  const {data, loading, refetch} = useQuery<
+  const queryResult = useQuery<
     GetAutoMaterializePausedQuery,
     GetAutoMaterializePausedQueryVariables
   >(AUTOMATERIALIZE_PAUSED_QUERY);
+  useBlockTraceOnQueryResult(queryResult, 'GetAutoMaterializePausedQuery');
+  const {data, loading, refetch} = queryResult;
 
   const [setAutoMaterializePaused] = useMutation<
     SetAutoMaterializePausedMutation,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useLatestPartitionEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useLatestPartitionEvents.tsx
@@ -25,6 +25,7 @@ export function useLatestPartitionEvents(
   >(ASSET_OVERVIEW_METADATA_EVENTS_QUERY, {
     variables: {assetKey: asAssetKeyInput(assetNode)},
   });
+  useBlockTraceOnQueryResult(queryResult, 'AssetOverviewMetadataEventsQuery');
 
   const {data, refetch} = queryResult;
 
@@ -38,8 +39,6 @@ export function useLatestPartitionEvents(
       : undefined;
   const observation =
     data?.assetOrError.__typename === 'Asset' ? data.assetOrError.assetObservations[0] : undefined;
-
-  useBlockTraceOnQueryResult(queryResult, 'AssetOverviewMetadataEventsQuery');
 
   return {materialization, observation, loading: !data};
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/usePartitionNameForPipeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/usePartitionNameForPipeline.tsx
@@ -22,7 +22,7 @@ export function usePartitionNameForPipeline(repoAddress: RepoAddress, pipelineNa
     },
   );
 
-  useBlockTraceOnQueryResult(queryResult, 'AssetJobPartitionSetsQuery');
+  useBlockTraceOnQueryResult(queryResult, 'AssetJobPartitionSetsQuery', {skip: !pipelineName});
   const {data: partitionSetsData} = queryResult;
 
   return useMemo(

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
@@ -65,7 +65,7 @@ export function useRecentAssetEvents(
         },
   });
   const {data, loading, refetch} = queryResult;
-  useBlockTraceOnQueryResult(queryResult, 'AssetEventsQuery');
+  useBlockTraceOnQueryResult(queryResult, 'AssetEventsQuery', {skip: !assetKey});
 
   const value = useMemo(() => {
     const asset = data?.assetOrError.__typename === 'Asset' ? data?.assetOrError : null;

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -181,7 +181,9 @@ export function useOpLayout(ops: ILayoutOp[], parentOp?: ILayoutOp) {
   const loading = state.loading || !state.layout || state.cacheKey !== cacheKey;
 
   // Add a UID to create a new dependency whenever the layout inputs change
-  useBlockTraceUntilTrue('useAssetLayout', !loading && !!state.layout, uid.current);
+  useBlockTraceUntilTrue('useAssetLayout', !loading && !!state.layout, {
+    uid: uid.current.toString(),
+  });
 
   return {
     loading: state.loading || !state.layout || state.cacheKey !== cacheKey,
@@ -232,7 +234,9 @@ export function useAssetLayout(
   const loading = state.loading || !state.layout || state.cacheKey !== cacheKey;
 
   // Add a UID to create a new dependency whenever the layout inputs change
-  useBlockTraceUntilTrue('useAssetLayout', !loading && !!state.layout, uid.current);
+  useBlockTraceUntilTrue('useAssetLayout', !loading && !!state.layout, {
+    uid: uid.current.toString(),
+  });
 
   return {
     loading,

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
@@ -60,6 +60,7 @@ import {useTrackPageView} from '../app/analytics';
 import {RunStatus} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {RunStatusDot} from '../runs/RunStatusDots';
 import {failedStatuses} from '../runs/RunStatuses';
 import {titleForRun} from '../runs/RunUtils';
@@ -719,6 +720,7 @@ const ConcurrencyStepsDialog = ({
       skip: !concurrencyKey,
     },
   );
+  useBlockTraceOnQueryResult(queryResult, 'ConcurrencyKeyDetailsQuery', {skip: !concurrencyKey});
   useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
   const {data} = queryResult;
   const refetch = React.useCallback(() => {
@@ -773,6 +775,9 @@ const PendingStepsTable = ({
       skip: !keyInfo.pendingSteps.length,
     },
   );
+  useBlockTraceOnQueryResult(queryResult, 'RunsForConcurrencyKeyQuery', {
+    skip: !keyInfo.pendingSteps.length,
+  });
   const statusByRunId: {[id: string]: RunStatus} = {};
   const runs =
     queryResult.data?.pipelineRunsOrError.__typename === 'Runs'

--- a/js_modules/dagster-ui/packages/ui-core/src/performance/__tests__/TraceContext.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/performance/__tests__/TraceContext.test.tsx
@@ -119,7 +119,7 @@ describe('useBlockTraceUntilTrue', () => {
     );
 
     const {rerender, unmount} = renderHook(
-      ({name, isSuccessful}: any) => useBlockTraceUntilTrue(name, isSuccessful, 'uid123'),
+      ({name, isSuccessful}: any) => useBlockTraceUntilTrue(name, isSuccessful, {uid: 'uid123'}),
       {
         initialProps: {name: 'testDep', isSuccessful: false},
         wrapper,

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarOp.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarOp.tsx
@@ -13,6 +13,7 @@ import {
   SidebarPipelineOpQueryVariables,
 } from './types/SidebarOp.types';
 import {OpNameOrPath} from '../ops/OpNameOrPath';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {LoadingSpinner} from '../ui/Loading';
 import {RepoAddress} from '../workspace/types';
 
@@ -48,6 +49,7 @@ const useSidebarOpQuery = (
       skip: isGraph,
     },
   );
+  useBlockTraceOnQueryResult(pipelineResult, 'SidebarPipelineOpQuery', {skip: isGraph});
 
   const graphResult = useQuery<SidebarGraphOpQuery, SidebarGraphOpQueryVariables>(
     SIDEBAR_GRAPH_OP_QUERY,
@@ -63,6 +65,8 @@ const useSidebarOpQuery = (
       skip: !isGraph,
     },
   );
+
+  useBlockTraceOnQueryResult(graphResult, 'SidebarPipelineOpQuery', {skip: !isGraph});
 
   if (isGraph) {
     const {error, data, loading} = graphResult;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunAssetTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunAssetTags.tsx
@@ -4,13 +4,17 @@ import {AssetKeyTagCollection} from './AssetTagCollections';
 import {RunAssetsQuery, RunAssetsQueryVariables} from './types/RunAssetTags.types';
 import {RunFragment} from './types/RunFragments.types';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
 export const RunAssetTags = (props: {run: RunFragment}) => {
   const {run} = props;
-  const {data, loading} = useQuery<RunAssetsQuery, RunAssetsQueryVariables>(RUN_ASSETS_QUERY, {
+  const skip = isHiddenAssetGroupJob(run.pipelineName);
+  const queryResult = useQuery<RunAssetsQuery, RunAssetsQueryVariables>(RUN_ASSETS_QUERY, {
     variables: {runId: run.id},
-    skip: isHiddenAssetGroupJob(run.pipelineName),
+    skip,
   });
+  const {data, loading} = queryResult;
+  useBlockTraceOnQueryResult(queryResult, 'RunAssetsQuery', {skip});
 
   if (loading || !data || data.pipelineRunOrError.__typename !== 'Run') {
     return null;

--- a/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/TypeListContainer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/TypeListContainer.tsx
@@ -7,6 +7,7 @@ import {
   TypeListContainerQuery,
   TypeListContainerQueryVariables,
 } from './types/TypeListContainer.types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {ExplorerPath} from '../pipelines/PipelinePathUtils';
 import {Loading} from '../ui/Loading';
 import {
@@ -43,6 +44,7 @@ export const TypeListContainer = ({explorerPath, repoAddress}: ITypeListContaine
       skip: !pipelineSelector,
     },
   );
+  useBlockTraceOnQueryResult(queryResult, 'TypeListContainerQuery', {skip: !pipelineSelector});
 
   if (!pipelineSelector) {
     return (

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -24,7 +24,7 @@ import {AssetViewType} from '../assets/useAssetView';
 import {AssetComputeKindTag} from '../graph/OpTags';
 import {AssetKeyInput} from '../graphql/types';
 import {RepositoryLink} from '../nav/RepositoryLink';
-import {useBlockTraceUntilTrue} from '../performance/TraceContext';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {testId} from '../testing/testId';
 import {HeaderCell, HeaderRow, Row, RowCell} from '../ui/VirtualizedTable';
@@ -258,15 +258,15 @@ export function useLiveDataOrLatestMaterializationDebounced(
   const {liveDataByNode} = useAssetsLiveData(type === 'asset' ? debouncedKeys : []);
 
   const skip = type !== 'asset_non_sda' || !debouncedKey;
-  const {data: nonSDAData} = useQuery<SingleNonSdaAssetQuery, SingleNonSdaAssetQueryVariables>(
+  const queryResult = useQuery<SingleNonSdaAssetQuery, SingleNonSdaAssetQueryVariables>(
     SINGLE_NON_SDA_ASSET_QUERY,
     {
       skip,
       variables: {input: debouncedKey},
     },
   );
-
-  useBlockTraceUntilTrue('SingleNonSdaAssetQuery', !!nonSDAData || skip);
+  const {data: nonSDAData} = queryResult;
+  useBlockTraceOnQueryResult(queryResult, 'SingleNonSdaAssetQuery', {skip});
 
   React.useEffect(() => {
     if (type === 'folder') {


### PR DESCRIPTION
## Summary & Motivation

Grep for useQuery and add useBlockTraceOnQueryResult for queries that are part of a page (I left out some that were part of dialogs).

Also added a "skip" option to trace context. Tested it works correctly on the billing page: https://app.datadoghq.com/rum/sessions?query=%40type%3Aview%20%40application.id%3A6d12cca2-0263-463b-a90e-cc6c524e14bd%20%40usr.email%3Amarco%40dagsterlabs.com&agg_m=count&agg_m_source=base&agg_t=count&cols=&event=AgAAAY9TO_hG3Vy2nQAAAAAAAAAYAAAAAEFZOVRPX2hHQUFBTFhXRnNSQlVKTjhVcAAAACQAAAAAMDE4ZjUzM2MtOTBkZi00ZmJjLWFiNWMtZjAwYmU1Y2NhN2Zm&fromUser=false&viz=stream&from_ts=1715002192162&to_ts=1715088592162&live=true

## How I Tested These Changes
Visited each of these pages and looked at the views. 