### PR TITLE
add title and description to PartitionBackfill

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2262,6 +2262,8 @@ input LaunchBackfillParams {
   allPartitions: Boolean
   tags: [ExecutionTag!]
   forceSynchronousSubmission: Boolean
+  title: String
+  description: String
 }
 
 input PartitionSetSelector {
@@ -2779,6 +2781,8 @@ type PartitionBackfill {
   hasResumePermission: Boolean!
   user: String
   tags: [PipelineTag!]!
+  title: String
+  description: String
 }
 
 enum BulkActionStatus {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2149,6 +2149,7 @@ export type LaunchBackfillMutation = {
 export type LaunchBackfillParams = {
   allPartitions?: InputMaybe<Scalars['Boolean']['input']>;
   assetSelection?: InputMaybe<Array<AssetKeyInput>>;
+  description?: InputMaybe<Scalars['String']['input']>;
   forceSynchronousSubmission?: InputMaybe<Scalars['Boolean']['input']>;
   fromFailure?: InputMaybe<Scalars['Boolean']['input']>;
   partitionNames?: InputMaybe<Array<Scalars['String']['input']>>;
@@ -2156,6 +2157,7 @@ export type LaunchBackfillParams = {
   reexecutionSteps?: InputMaybe<Array<Scalars['String']['input']>>;
   selector?: InputMaybe<PartitionSetSelector>;
   tags?: InputMaybe<Array<ExecutionTag>>;
+  title?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type LaunchBackfillResult =
@@ -3036,6 +3038,7 @@ export type PartitionBackfill = {
   __typename: 'PartitionBackfill';
   assetBackfillData: Maybe<AssetBackfillData>;
   assetSelection: Maybe<Array<AssetKey>>;
+  description: Maybe<Scalars['String']['output']>;
   endTimestamp: Maybe<Scalars['Float']['output']>;
   error: Maybe<PythonError>;
   fromFailure: Scalars['Boolean']['output'];
@@ -3057,6 +3060,7 @@ export type PartitionBackfill = {
   status: BulkActionStatus;
   tags: Array<PipelineTag>;
   timestamp: Scalars['Float']['output'];
+  title: Maybe<Scalars['String']['output']>;
   unfinishedRuns: Array<Run>;
   user: Maybe<Scalars['String']['output']>;
 };
@@ -9145,6 +9149,8 @@ export const buildLaunchBackfillParams = (
       overrides && overrides.hasOwnProperty('allPartitions') ? overrides.allPartitions! : false,
     assetSelection:
       overrides && overrides.hasOwnProperty('assetSelection') ? overrides.assetSelection! : [],
+    description:
+      overrides && overrides.hasOwnProperty('description') ? overrides.description! : 'expedita',
     forceSynchronousSubmission:
       overrides && overrides.hasOwnProperty('forceSynchronousSubmission')
         ? overrides.forceSynchronousSubmission!
@@ -9166,6 +9172,7 @@ export const buildLaunchBackfillParams = (
         ? ({} as PartitionSetSelector)
         : buildPartitionSetSelector({}, relationshipsToOmit),
     tags: overrides && overrides.hasOwnProperty('tags') ? overrides.tags! : [],
+    title: overrides && overrides.hasOwnProperty('title') ? overrides.title! : 'soluta',
   };
 };
 
@@ -10568,6 +10575,10 @@ export const buildPartitionBackfill = (
         : buildAssetBackfillData({}, relationshipsToOmit),
     assetSelection:
       overrides && overrides.hasOwnProperty('assetSelection') ? overrides.assetSelection! : [],
+    description:
+      overrides && overrides.hasOwnProperty('description')
+        ? overrides.description!
+        : 'reprehenderit',
     endTimestamp:
       overrides && overrides.hasOwnProperty('endTimestamp') ? overrides.endTimestamp! : 0.33,
     error:
@@ -10634,6 +10645,7 @@ export const buildPartitionBackfill = (
         : BulkActionStatus.CANCELED,
     tags: overrides && overrides.hasOwnProperty('tags') ? overrides.tags! : [],
     timestamp: overrides && overrides.hasOwnProperty('timestamp') ? overrides.timestamp! : 8.28,
+    title: overrides && overrides.hasOwnProperty('title') ? overrides.title! : 'veritatis',
     unfinishedRuns:
       overrides && overrides.hasOwnProperty('unfinishedRuns') ? overrides.unfinishedRuns! : [],
     user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : 'eius',

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -163,6 +163,8 @@ def create_and_launch_partition_backfill(
             tags=tags,
             backfill_timestamp=backfill_timestamp,
             asset_selection=asset_selection,
+            title=backfill_params.get("title"),
+            description=backfill_params.get("description"),
         )
 
         if backfill_params.get("forceSynchronousSubmission"):
@@ -214,6 +216,8 @@ def create_and_launch_partition_backfill(
                 utc_datetime_from_timestamp(backfill_timestamp),
             ),
             all_partitions=backfill_params.get("allPartitions", False),
+            title=backfill_params.get("title"),
+            description=backfill_params.get("description"),
         )
     elif partitions_by_assets is not None:
         if backfill_params.get("forceSynchronousSubmission"):
@@ -242,6 +246,8 @@ def create_and_launch_partition_backfill(
                 PartitionsByAssetSelector.from_graphql_input(partitions_by_asset_selector)
                 for partitions_by_asset_selector in partitions_by_assets
             ],
+            title=backfill_params.get("title"),
+            description=backfill_params.get("description"),
         )
     else:
         raise DagsterError(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, List, Sequence, Union, cast
 import dagster._check as check
 import pendulum
 from dagster._core.definitions.selector import PartitionsByAssetSelector, RepositorySelector
-from dagster._core.definitions.utils import check_valid_title
+from dagster._core.definitions.utils import is_valid_title_and_reason
 from dagster._core.errors import (
     DagsterError,
     DagsterInvariantViolationError,
@@ -154,6 +154,10 @@ def create_and_launch_partition_backfill(
                 "arguments"
             )
 
+        is_valid_title, reason = is_valid_title_and_reason(backfill_params.get("title"))
+        if not is_valid_title:
+            raise DagsterInvariantViolationError(reason)
+
         backfill = PartitionBackfill(
             backfill_id=backfill_id,
             partition_set_origin=external_partition_set.get_external_origin(),
@@ -164,7 +168,7 @@ def create_and_launch_partition_backfill(
             tags=tags,
             backfill_timestamp=backfill_timestamp,
             asset_selection=asset_selection,
-            title=check_valid_title(backfill_params.get("title")),
+            title=backfill_params.get("title"),
             description=backfill_params.get("description"),
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, List, Sequence, Union, cast
 import dagster._check as check
 import pendulum
 from dagster._core.definitions.selector import PartitionsByAssetSelector, RepositorySelector
+from dagster._core.definitions.utils import check_valid_title
 from dagster._core.errors import (
     DagsterError,
     DagsterInvariantViolationError,
@@ -163,7 +164,7 @@ def create_and_launch_partition_backfill(
             tags=tags,
             backfill_timestamp=backfill_timestamp,
             asset_selection=asset_selection,
-            title=backfill_params.get("title"),
+            title=check_valid_title(backfill_params.get("title")),
             description=backfill_params.get("description"),
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -286,6 +286,8 @@ class GraphenePartitionBackfill(graphene.ObjectType):
     hasResumePermission = graphene.NonNull(graphene.Boolean)
     user = graphene.Field(graphene.String)
     tags = non_null_list("dagster_graphql.schema.tags.GraphenePipelineTag")
+    title = graphene.Field(graphene.String)
+    description = graphene.Field(graphene.String)
 
     def __init__(self, backfill_job: PartitionBackfill):
         self._backfill_job = check.inst_param(backfill_job, "backfill_job", PartitionBackfill)
@@ -523,6 +525,12 @@ class GraphenePartitionBackfill(graphene.ObjectType):
 
     def resolve_user(self, _graphene_info: ResolveInfo) -> Optional[str]:
         return self._backfill_job.user
+
+    def resolve_title(self, _graphene_info: ResolveInfo) -> Optional[str]:
+        return self._backfill_job.title
+
+    def resolve_description(self, _graphene_info: ResolveInfo) -> Optional[str]:
+        return self._backfill_job.description
 
 
 class GrapheneBackfillNotFoundError(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -199,6 +199,8 @@ class GrapheneLaunchBackfillParams(graphene.InputObjectType):
     allPartitions = graphene.Boolean()
     tags = graphene.List(graphene.NonNull(GrapheneExecutionTag))
     forceSynchronousSubmission = graphene.Boolean()
+    title = graphene.String()
+    description = graphene.String()
 
     class Meta:
         name = "LaunchBackfillParams"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -1185,6 +1185,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
             },
         )
 
+        assert result.errors
         assert result.data
         assert result.data["launchPartitionBackfill"]["__typename"] == "PythonError"
         assert (

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -1185,7 +1185,6 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
             },
         )
 
-        assert result.errors
         assert result.data
         assert result.data["launchPartitionBackfill"]["__typename"] == "PythonError"
         assert (

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -74,6 +74,8 @@ PARTITION_PROGRESS_QUERY = """
         hasCancelPermission
         hasResumePermission
         user
+        title
+        description
       }
       ... on PythonError {
         message
@@ -1124,6 +1126,44 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data["partitionBackfillOrError"]["__typename"] == "PartitionBackfill"
         assert result.data["partitionBackfillOrError"]["id"] == backfill_id
         assert result.data["partitionBackfillOrError"]["user"] == user_email
+
+    def test_set_title_and_description_for_backfill(self, graphql_context):
+        title = "Test backfill"
+        description = "This is a test backfill"
+        repository_selector = infer_repository_selector(graphql_context)
+        result = execute_dagster_graphql(
+            graphql_context,
+            LAUNCH_PARTITION_BACKFILL_MUTATION,
+            variables={
+                "backfillParams": {
+                    "selector": {
+                        "repositorySelector": repository_selector,
+                        "partitionSetName": "integers_partition_set",
+                    },
+                    "partitionNames": ["2", "3"],
+                    "title": title,
+                    "description": description,
+                }
+            },
+        )
+
+        assert not result.errors
+        assert result.data
+        assert result.data["launchPartitionBackfill"]["__typename"] == "LaunchBackfillSuccess"
+        backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            PARTITION_PROGRESS_QUERY,
+            variables={"backfillId": backfill_id},
+        )
+
+        assert not result.errors
+        assert result.data
+        assert result.data["partitionBackfillOrError"]["__typename"] == "PartitionBackfill"
+        assert result.data["partitionBackfillOrError"]["id"] == backfill_id
+        assert result.data["partitionBackfillOrError"]["title"] == title
+        assert result.data["partitionBackfillOrError"]["description"] == description
 
 
 class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -41,6 +41,10 @@ DISALLOWED_NAMES = set(
 VALID_NAME_REGEX_STR = r"^[A-Za-z0-9_]+$"
 VALID_NAME_REGEX = re.compile(VALID_NAME_REGEX_STR)
 
+INVALID_TITLE_CHARACTERS_REGEX_STR = r"[\%\*\"]"
+INVALID_TITLE_CHARACTERS_REGEX = re.compile(INVALID_TITLE_CHARACTERS_REGEX_STR)
+MAX_TITLE_LENGTH = 100
+
 
 class NoValueSentinel:
     """Sentinel value to distinguish unset from None."""
@@ -80,6 +84,34 @@ def is_valid_name(name: str) -> bool:
     check.str_param(name, "name")
 
     return name not in DISALLOWED_NAMES and has_valid_name_chars(name)
+
+
+def check_valid_title(title: Optional[str]) -> Optional[str]:
+    """A title is distinguished from a name in that the title is a descriptive string meant for display in the UI.
+    It is not used as an identifier for an object.
+    """
+    check.opt_str_param(title, "title")
+
+    if title is None:
+        return
+
+    if len(title) > MAX_TITLE_LENGTH:
+        raise DagsterInvariantViolationError(
+            f'"{title}" ({len(title)} characters) is not a valid title in Dagster. Titles must'
+            f" not be longer than {MAX_TITLE_LENGTH}."
+        )
+
+    if not is_valid_title_chars(title):
+        raise DagsterInvariantViolationError(
+            f'"{title}" is not a valid title in Dagster. Titles must not contain regex'
+            f" {INVALID_TITLE_CHARACTERS_REGEX_STR}."
+        )
+
+    return title
+
+
+def is_valid_title_chars(title: str):
+    return not bool(INVALID_TITLE_CHARACTERS_REGEX.search(title))
 
 
 def _kv_str(key: object, value: object) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -86,28 +86,40 @@ def is_valid_name(name: str) -> bool:
     return name not in DISALLOWED_NAMES and has_valid_name_chars(name)
 
 
+def is_valid_title_and_reason(title: Optional[str]) -> Tuple[bool, Optional[str]]:
+    check.opt_str_param(title, "title")
+
+    if title is None:
+        return True, None
+
+    if len(title) > MAX_TITLE_LENGTH:
+        return (
+            False,
+            f'"{title}" ({len(title)} characters) is not a valid title in Dagster. Titles must not be longer than {MAX_TITLE_LENGTH}.',
+        )
+
+    if not is_valid_title_chars(title):
+        return (
+            False,
+            f'"{title}" is not a valid title in Dagster. Titles must not contain regex {INVALID_TITLE_CHARACTERS_REGEX_STR}.',
+        )
+
+    return True, None
+
+
 def check_valid_title(title: Optional[str]) -> Optional[str]:
     """A title is distinguished from a name in that the title is a descriptive string meant for display in the UI.
     It is not used as an identifier for an object.
     """
-    check.opt_str_param(title, "title")
-
-    if title is None:
-        return
-
-    if len(title) > MAX_TITLE_LENGTH:
-        raise DagsterInvariantViolationError(
-            f'"{title}" ({len(title)} characters) is not a valid title in Dagster. Titles must'
-            f" not be longer than {MAX_TITLE_LENGTH}."
-        )
-
-    if not is_valid_title_chars(title):
-        raise DagsterInvariantViolationError(
-            f'"{title}" is not a valid title in Dagster. Titles must not contain regex'
-            f" {INVALID_TITLE_CHARACTERS_REGEX_STR}."
-        )
+    is_valid, reason = is_valid_title_and_reason(title)
+    if not is_valid:
+        raise DagsterInvariantViolationError(reason)
 
     return title
+
+
+def is_valid_title(title: Optional[str]) -> bool:
+    return is_valid_title_and_reason(title)[0]
 
 
 def is_valid_title_chars(title: str):

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -7,6 +7,7 @@ from dagster import _check as check
 from dagster._core.definitions import AssetKey
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.partition import PartitionsSubset
+from dagster._core.definitions.utils import check_valid_title
 from dagster._core.errors import DagsterDefinitionChangedDeserializationError
 from dagster._core.execution.bulk_actions import BulkActionType
 from dagster._core.instance import DynamicPartitionsStore
@@ -102,7 +103,7 @@ class PartitionBackfill(
             asset_selection=check.opt_nullable_sequence_param(
                 asset_selection, "asset_selection", of_type=AssetKey
             ),
-            title=check.opt_str_param(title, "title"),
+            title=check_valid_title(title),
             description=check.opt_str_param(description, "description"),
             partition_set_origin=check.opt_inst_param(
                 partition_set_origin, "partition_set_origin", RemotePartitionSetOrigin

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -791,6 +791,8 @@ def test_unloadable_backfill_retry(
             partition_names=partition_keys,
             dynamic_partitions_store=instance,
             all_partitions=False,
+            title=None,
+            description=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -923,6 +925,8 @@ def test_pure_asset_backfill_with_multiple_assets_selected(
             partition_names=partition_keys,
             dynamic_partitions_store=instance,
             all_partitions=False,
+            title=None,
+            description=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -986,6 +990,8 @@ def test_pure_asset_backfill(
             partition_names=partition_keys,
             dynamic_partitions_store=instance,
             all_partitions=False,
+            title=None,
+            description=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -1074,6 +1080,8 @@ def test_asset_backfill_cancellation(
             partition_names=partition_keys,
             dynamic_partitions_store=instance,
             all_partitions=False,
+            title=None,
+            description=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -1133,6 +1141,8 @@ def test_asset_backfill_submit_runs_in_chunks(
             partition_names=target_partitions,
             dynamic_partitions_store=instance,
             all_partitions=False,
+            title=None,
+            description=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -1171,6 +1181,8 @@ def test_asset_backfill_mid_iteration_cancel(
         partition_names=target_partitions,
         dynamic_partitions_store=instance,
         all_partitions=False,
+        title=None,
+        description=None,
     )
     instance.add_backfill(backfill)
     assert instance.get_runs_count() == 0
@@ -1237,6 +1249,8 @@ def test_asset_backfill_forcible_mark_as_canceled_during_canceling_iteration(
         partition_names=["2023-01-01"],
         dynamic_partitions_store=instance,
         all_partitions=False,
+        title=None,
+        description=None,
     ).with_status(BulkActionStatus.CANCELING)
     instance.add_backfill(
         # Add some partitions in a "requested" state to mock that certain partitions are hanging
@@ -1307,6 +1321,8 @@ def test_asset_backfill_mid_iteration_code_location_unreachable_error(
         partition_names=target_partitions,
         dynamic_partitions_store=instance,
         all_partitions=False,
+        title=None,
+        description=None,
     )
     instance.add_backfill(backfill)
     assert instance.get_runs_count() == 0
@@ -1418,6 +1434,8 @@ def test_asset_backfill_first_iteration_code_location_unreachable_error_no_runs_
         partition_names=target_partitions,
         dynamic_partitions_store=instance,
         all_partitions=False,
+        title=None,
+        description=None,
     )
     instance.add_backfill(backfill)
     assert instance.get_runs_count() == 0
@@ -1497,6 +1515,8 @@ def test_asset_backfill_first_iteration_code_location_unreachable_error_some_run
         partition_names=target_partitions,
         dynamic_partitions_store=instance,
         all_partitions=False,
+        title=None,
+        description=None,
     )
     instance.add_backfill(backfill)
     assert instance.get_runs_count() == 0
@@ -1584,6 +1604,8 @@ def test_fail_backfill_when_runs_completed_but_partitions_marked_as_in_progress(
         partition_names=target_partitions,
         dynamic_partitions_store=instance,
         all_partitions=False,
+        title=None,
+        description=None,
     )
     instance.add_backfill(backfill)
     assert instance.get_runs_count() == 0
@@ -1740,6 +1762,8 @@ def test_asset_backfill_with_single_run_backfill_policy(
                 PartitionsSelector(PartitionRangeSelector(partitions[0], partitions[-1])),
             )
         ],
+        title=None,
+        description=None,
     )
     instance.add_backfill(backfill)
 
@@ -1779,6 +1803,8 @@ def test_asset_backfill_with_multi_run_backfill_policy(
         partition_names=partitions,
         dynamic_partitions_store=instance,
         all_partitions=False,
+        title=None,
+        description=None,
     )
     instance.add_backfill(backfill)
 
@@ -1827,6 +1853,8 @@ def test_error_code_location(
             partition_names=partition_keys,
             dynamic_partitions_store=instance,
             all_partitions=False,
+            title=None,
+            description=None,
         )
     )
 
@@ -1869,6 +1897,8 @@ def test_raise_error_on_asset_backfill_partitions_defs_changes(
         partition_names=partition_keys,
         dynamic_partitions_store=instance,
         all_partitions=False,
+        title=None,
+        description=None,
     )
 
     if backcompat_serialization:
@@ -1919,6 +1949,8 @@ def test_raise_error_on_partitions_defs_removed(
         partition_names=partition_keys,
         dynamic_partitions_store=instance,
         all_partitions=False,
+        title=None,
+        description=None,
     )
 
     if backcompat_serialization:
@@ -1964,6 +1996,8 @@ def test_raise_error_on_target_static_partition_removed(
         partition_names=partition_keys,
         dynamic_partitions_store=instance,
         all_partitions=False,
+        title=None,
+        description=None,
     )
     instance.add_backfill(backfill)
     # When a static partitions def is changed, but all target partitions still exist,
@@ -1987,6 +2021,8 @@ def test_raise_error_on_target_static_partition_removed(
         partition_names=["c"],
         dynamic_partitions_store=instance,
         all_partitions=False,
+        title=None,
+        description=None,
     )
     instance.add_backfill(backfill)
     # When a static partitions def is changed, but any target partitions is removed,
@@ -2025,6 +2061,8 @@ def test_partitions_def_changed_backfill_retry_envvar_set(
         partition_names=partition_keys,
         dynamic_partitions_store=instance,
         all_partitions=False,
+        title=None,
+        description=None,
     )
 
     instance.add_backfill(backfill)
@@ -2060,6 +2098,8 @@ def test_asset_backfill_logging(caplog, instance, workspace_context):
             partition_names=partition_keys,
             dynamic_partitions_store=instance,
             all_partitions=False,
+            title=None,
+            description=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -2106,6 +2146,8 @@ def test_asset_backfill_asset_graph_out_of_sync_with_workspace(
         partition_names=["2023-01-01-00:00"],
         dynamic_partitions_store=instance,
         all_partitions=False,
+        title=None,
+        description=None,
     )
     instance.add_backfill(backfill)
 
@@ -2148,3 +2190,69 @@ def test_asset_backfill_asset_graph_out_of_sync_with_workspace(
     planned_event = planned_events[0]
     assert planned_event and planned_event.is_asset_materialization_planned
     assert planned_event.asset_key == AssetKey(["hourly_asset"])
+
+
+def test_backfill_with_title_and_description(
+    instance: DagsterInstance,
+    workspace_context: WorkspaceProcessContext,
+    external_repo: ExternalRepository,
+):
+    asset_selection = [
+        AssetKey("asset_a"),
+        AssetKey("asset_b"),
+    ]
+
+    partition_keys = partitions_a.get_partition_keys()
+
+    instance.add_backfill(
+        PartitionBackfill.from_asset_partitions(
+            asset_graph=workspace_context.create_request_context().asset_graph,
+            backfill_id="backfill_with_title",
+            tags={"custom_tag_key": "custom_tag_value"},
+            backfill_timestamp=pendulum.now().timestamp(),
+            asset_selection=asset_selection,
+            partition_names=partition_keys,
+            dynamic_partitions_store=instance,
+            all_partitions=False,
+            title="Custom title",
+            description="this backfill is fancy",
+        )
+    )
+    assert instance.get_runs_count() == 0
+    backfill = instance.get_backfill("backfill_with_title")
+    assert backfill
+    assert backfill.status == BulkActionStatus.REQUESTED
+    assert backfill.title == "Custom title"
+    assert backfill.description == "this backfill is fancy"
+
+    assert all(
+        not error
+        for error in list(
+            execute_backfill_iteration(
+                workspace_context, get_default_daemon_logger("BackfillDaemon")
+            )
+        )
+    )
+    assert instance.get_runs_count() == 1
+    wait_for_all_runs_to_start(instance, timeout=30)
+    wait_for_all_runs_to_finish(instance, timeout=30)
+    assert backfill.title == "Custom title"
+    assert backfill.description == "this backfill is fancy"
+
+    assert all(
+        not error
+        for error in list(
+            execute_backfill_iteration(
+                workspace_context, get_default_daemon_logger("BackfillDaemon")
+            )
+        )
+    )
+    assert instance.get_runs_count() == 2
+    wait_for_all_runs_to_start(instance, timeout=30)
+    wait_for_all_runs_to_finish(instance, timeout=30)
+    assert backfill.title == "Custom title"
+    assert backfill.description == "this backfill is fancy"
+
+    runs = instance.get_runs()
+
+    assert all([run.status == DagsterRunStatus.SUCCESS] for run in runs)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_utils.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_utils.py
@@ -1,7 +1,12 @@
+import pytest
 from dagster._core.definitions.utils import (
+    MAX_TITLE_LENGTH,
+    check_valid_title,
     is_valid_definition_tag_key,
     is_valid_definition_tag_value,
+    is_valid_title_chars,
 )
+from dagster._core.errors import DagsterInvariantViolationError
 
 
 def test_is_valid_definition_tag_key():
@@ -34,3 +39,18 @@ def test_is_valid_definition_tag_value():
     assert is_valid_definition_tag_value("a" * 64) is False
     assert is_valid_definition_tag_value("a" * 63 + "/" + "b" * 63) is False
     assert is_valid_definition_tag_value("a" * 64 + "/" + "b" * 63) is False
+
+
+def test_is_valid_title():
+    assert is_valid_title_chars("this is a valid title")
+    assert is_valid_title_chars("This is ALSO a valid title 12345")
+    assert not is_valid_title_chars("no astricks *")
+    assert not is_valid_title_chars("no precentage symbols %")
+    assert not is_valid_title_chars('no " quotes')
+    assert is_valid_title_chars("other symbols are ok @$#!?&|")
+
+    with pytest.raises(DagsterInvariantViolationError, match="Titles must not contain regex"):
+        check_valid_title("no astricks *")
+
+    with pytest.raises(DagsterInvariantViolationError, match="Titles must not be longer than"):
+        check_valid_title("a" * (MAX_TITLE_LENGTH + 1))

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_utils.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_utils.py
@@ -4,7 +4,7 @@ from dagster._core.definitions.utils import (
     check_valid_title,
     is_valid_definition_tag_key,
     is_valid_definition_tag_value,
-    is_valid_title_chars,
+    is_valid_title,
 )
 from dagster._core.errors import DagsterInvariantViolationError
 
@@ -42,12 +42,12 @@ def test_is_valid_definition_tag_value():
 
 
 def test_is_valid_title():
-    assert is_valid_title_chars("this is a valid title")
-    assert is_valid_title_chars("This is ALSO a valid title 12345")
-    assert not is_valid_title_chars("no astricks *")
-    assert not is_valid_title_chars("no precentage symbols %")
-    assert not is_valid_title_chars('no " quotes')
-    assert is_valid_title_chars("other symbols are ok @$#!?&|")
+    assert is_valid_title("this is a valid title")
+    assert is_valid_title("This is ALSO a valid title 12345")
+    assert not is_valid_title("no astricks *")
+    assert not is_valid_title("no precentage symbols %")
+    assert not is_valid_title('no " quotes')
+    assert is_valid_title("other symbols are ok @$#!?&|")
 
     with pytest.raises(DagsterInvariantViolationError, match="Titles must not contain regex"):
         check_valid_title("no astricks *")


### PR DESCRIPTION
## Summary & Motivation
Discussed in a UI meeting that it would be nice for users to set titles for their backfills. these would not be used as the unique identifier for the backfill (ie for db queries), but would make it easier to navigate the backfill table in the UI

## How I Tested These Changes
new unit tests