### PR TITLE
feat(looker): represent looker views as assets

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/test_asset_decorator.py
@@ -83,4 +83,155 @@ def test_asset_deps() -> None:
             AssetKey(["view", "transactions"]),
             AssetKey(["view", "transactions__line_items"]),
         },
+        # Views
+        AssetKey(["view", "c360"]): {
+            AssetKey(["c360"]),
+        },
+        AssetKey(["view", "category_lookup"]): {
+            AssetKey(["looker-private-demo", "retail", "category_lookup"])
+        },
+        AssetKey(["view", "channels"]): {
+            AssetKey(["looker-private-demo", "retail", "channels"]),
+        },
+        AssetKey(["view", "customer_clustering_input"]): {
+            AssetKey(["customer_clustering_input"]),
+        },
+        AssetKey(["view", "customer_clustering_model"]): {
+            AssetKey(["customer_clustering_model"]),
+        },
+        AssetKey(["view", "customer_clustering_prediction"]): {
+            AssetKey(["customer_clustering_prediction"])
+        },
+        AssetKey(["view", "customer_clustering_prediction_aggregates"]): {
+            AssetKey(["customer_clustering_prediction_aggregates"])
+        },
+        AssetKey(["view", "customer_clustering_prediction_base"]): {
+            AssetKey(["customer_clustering_prediction_base"])
+        },
+        AssetKey(["view", "customer_clustering_prediction_centroid_ranks"]): {
+            AssetKey(["customer_clustering_prediction_centroid_ranks"])
+        },
+        AssetKey(["view", "customer_event_fact"]): {
+            AssetKey(["customer_event_fact"]),
+        },
+        AssetKey(["view", "customer_facts"]): {
+            AssetKey(["customer_facts"]),
+        },
+        AssetKey(["view", "customer_support_fact"]): {
+            AssetKey(["customer_support_fact"]),
+        },
+        AssetKey(["view", "customer_transaction_fact"]): {
+            AssetKey(["customer_transaction_fact"]),
+        },
+        AssetKey(["view", "customer_transaction_sequence"]): {
+            AssetKey(["customer_transaction_sequence"]),
+        },
+        AssetKey(["view", "customers"]): {
+            AssetKey(["looker-private-demo", "retail", "customers"]),
+        },
+        AssetKey(["view", "date_comparison"]): {
+            AssetKey(["date_comparison"]),
+        },
+        AssetKey(["view", "distances"]): {
+            AssetKey(["distances"]),
+        },
+        AssetKey(["view", "events"]): {
+            AssetKey(["looker-private-demo", "retail", "events"]),
+        },
+        AssetKey(["view", "omni_channel_events"]): {
+            AssetKey(["omni_channel_events"]),
+        },
+        AssetKey(["view", "omni_channel_support_calls"]): {
+            AssetKey(["omni_channel_support_calls"])
+        },
+        AssetKey(["view", "omni_channel_support_calls__messages"]): {
+            AssetKey(["omni_channel_support_calls__messages"])
+        },
+        AssetKey(["view", "omni_channel_transactions"]): {
+            AssetKey(["omni_channel_transactions"]),
+        },
+        AssetKey(["view", "omni_channel_transactions__transaction_details"]): {
+            AssetKey(["omni_channel_transactions__transaction_details"])
+        },
+        AssetKey(["view", "order_items"]): {
+            AssetKey(["order_items"]),
+        },
+        AssetKey(["view", "order_items_base"]): {
+            AssetKey(["order_items_base"]),
+        },
+        AssetKey(["view", "order_metrics"]): {
+            AssetKey(["order_metrics"]),
+        },
+        AssetKey(["view", "order_product"]): {
+            AssetKey(["order_product"]),
+        },
+        AssetKey(["view", "order_purchase_affinity"]): {
+            AssetKey(["order_purchase_affinity"]),
+        },
+        AssetKey(["view", "orders"]): {
+            AssetKey(["orders"]),
+        },
+        AssetKey(["view", "orders_by_product_loyal_users"]): {
+            AssetKey(["orders_by_product_loyal_users"])
+        },
+        AssetKey(["view", "product_loyal_users"]): {
+            AssetKey(["product_loyal_users"]),
+        },
+        AssetKey(["view", "products"]): {
+            AssetKey(["looker-private-demo", "retail", "products"]),
+        },
+        AssetKey(["view", "retail_clv_predict"]): {
+            AssetKey(["retail_ltv", "lpd_retail_clv_predict_tbl"])
+        },
+        AssetKey(["view", "stock_forecasting_category_week_facts_prior_year"]): {
+            AssetKey(["stock_forecasting_category_week_facts_prior_year"])
+        },
+        AssetKey(["view", "stock_forecasting_explore_base"]): {
+            AssetKey(["stock_forecasting_explore_base"])
+        },
+        AssetKey(["view", "stock_forecasting_input"]): {
+            AssetKey(["stock_forecasting_input"]),
+        },
+        AssetKey(["view", "stock_forecasting_prediction"]): {
+            AssetKey(["stock_forecasting_prediction"])
+        },
+        AssetKey(["view", "stock_forecasting_product_store_week_facts"]): {
+            AssetKey(["stock_forecasting_product_store_week_facts"])
+        },
+        AssetKey(["view", "stock_forecasting_product_store_week_facts_prior_year"]): {
+            AssetKey(["stock_forecasting_product_store_week_facts_prior_year"])
+        },
+        AssetKey(["view", "stock_forecasting_regression"]): {
+            AssetKey(["stock_forecasting_regression"])
+        },
+        AssetKey(["view", "stock_forecasting_store_week_facts_prior_year"]): {
+            AssetKey(["stock_forecasting_store_week_facts_prior_year"])
+        },
+        AssetKey(["view", "store_weather"]): {
+            AssetKey(["store_weather"]),
+        },
+        AssetKey(["view", "stores"]): {
+            AssetKey(["stores"]),
+        },
+        AssetKey(["view", "total_order_product"]): {
+            AssetKey(["total_order_product"]),
+        },
+        AssetKey(["view", "total_orders"]): {
+            AssetKey(["total_orders"]),
+        },
+        AssetKey(["view", "transaction_detail"]): {
+            AssetKey(["transaction_detail"]),
+        },
+        AssetKey(["view", "transactions"]): {
+            AssetKey(["looker-private-demo", "retail", "transaction_detail"])
+        },
+        AssetKey(["view", "transactions__line_items"]): {
+            AssetKey(["transactions__line_items"]),
+        },
+        AssetKey(["view", "weather_pivoted"]): {
+            AssetKey(["weather_pivoted"]),
+        },
+        AssetKey(["view", "weather_raw"]): {
+            AssetKey(["weather_raw"]),
+        },
     }


### PR DESCRIPTION
## Summary & Motivation
Model the basic Looker view, where a view is queried off of an existing sql table.

In this case, we can determine the Looker view's upstream dependency using [`sql_table_name`](https://cloud.google.com/looker/docs/reference/param-view-sql-table-name). In the case that `sql_table_name` is not defined, then use the name of the Looker view as the upstream dependency.

In a downstream PR, we'll determine the dependency of Looker views that rely on sql specified in [`derived_table`](https://cloud.google.com/looker/docs/reference/param-view-derived-table).

## How I Tested These Changes
pytest