### PR TITLE
feat(looker): represent looker views dependencies from derived tables

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker/asset_decorator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/asset_decorator.py
@@ -1,10 +1,15 @@
 import itertools
+import logging
 from pathlib import Path
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Callable, Iterator, Mapping, Sequence, cast
 
 import lkml
 import yaml
 from dagster import AssetKey, AssetsDefinition, AssetSpec, multi_asset
+from sqlglot import exp, parse_one, to_table
+from sqlglot.optimizer import Scope, build_scope, optimize
+
+logger = logging.getLogger("dagster_looker")
 
 
 def build_looker_explore_specs(project_dir: Path) -> Sequence[AssetSpec]:
@@ -36,17 +41,70 @@ def build_looker_explore_specs(project_dir: Path) -> Sequence[AssetSpec]:
 
 def build_looker_view_specs(project_dir: Path) -> Sequence[AssetSpec]:
     looker_view_specs = []
+    sql_dialect = "bigquery"
 
     # https://cloud.google.com/looker/docs/reference/param-view
     for view_path in project_dir.rglob("*.view.lkml"):
         for view in lkml.load(view_path.read_text()).get("views", []):
-            upstream_table = view.get("sql_table_name") or view["name"]
-            upstream_table_asset_key = AssetKey(upstream_table.replace("`", "").split("."))
+            upstream_tables: Sequence[exp.Table] = [to_table(view["name"], dialect=sql_dialect)]
+
+            # https://cloud.google.com/looker/docs/derived-tables
+            derived_table_sql = view.get("derived_table", {}).get("sql")
+
+            if derived_table_sql and "$" in derived_table_sql:
+                logger.warn(
+                    f"Failed to parse the derived table SQL for view `{view['name']}`"
+                    f" in file {view_path.name}, because the SQL in this view contains the"
+                    " LookML substitution operator, `$`."
+                    " The upstream dependencies for the view will be omitted."
+                )
+
+                upstream_tables = []
+            elif (
+                derived_table_sql
+                # We need to handle the Looker substitution operator ($) properly since the lkml
+                # compatible SQL may not be parsable yet by sqlglot.
+                #
+                # https://cloud.google.com/looker/docs/sql-and-referring-to-lookml#substitution_operator_
+                and "$" not in derived_table_sql
+            ):
+                try:
+                    optimized_derived_table_ast = optimize(
+                        parse_one(sql=derived_table_sql, dialect=sql_dialect),
+                        dialect=sql_dialect,
+                        validate_qualify_columns=False,
+                    )
+                    root_scope = build_scope(optimized_derived_table_ast)
+
+                    upstream_tables = [
+                        source
+                        for scope in cast(
+                            Iterator[Scope], root_scope.traverse() if root_scope else []
+                        )
+                        for (_, source) in scope.selected_sources.values()
+                        if isinstance(source, exp.Table)
+                    ]
+                except Exception as e:
+                    logger.warn(
+                        f"Failed to optimize derived table SQL for view `{view['name']}`"
+                        f" in file {view_path.name}."
+                        " The upstream dependencies for the view will be omitted.\n\n"
+                        f"Exception: {e}"
+                    )
+
+                    upstream_tables = []
+
+            # https://cloud.google.com/looker/docs/reference/param-view-sql-table-name
+            elif sql_table_name := view.get("sql_table_name"):
+                upstream_tables = [to_table(sql_table_name.replace("`", ""), dialect=sql_dialect)]
 
             looker_view_specs.append(
                 AssetSpec(
                     key=AssetKey(["view", view["name"]]),
-                    deps={upstream_table_asset_key},
+                    deps={
+                        AssetKey([part.name.replace("*", "_star") for part in table.parts])
+                        for table in upstream_tables
+                    },
                 )
             )
 

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/test_asset_decorator.py
@@ -99,84 +99,61 @@ def test_asset_deps() -> None:
         AssetKey(["view", "customer_clustering_model"]): {
             AssetKey(["customer_clustering_model"]),
         },
-        AssetKey(["view", "customer_clustering_prediction"]): {
-            AssetKey(["customer_clustering_prediction"])
-        },
-        AssetKey(["view", "customer_clustering_prediction_aggregates"]): {
-            AssetKey(["customer_clustering_prediction_aggregates"])
-        },
-        AssetKey(["view", "customer_clustering_prediction_base"]): {
-            AssetKey(["customer_clustering_prediction_base"])
-        },
-        AssetKey(["view", "customer_clustering_prediction_centroid_ranks"]): {
-            AssetKey(["customer_clustering_prediction_centroid_ranks"])
-        },
+        AssetKey(["view", "customer_clustering_prediction"]): set(),
+        AssetKey(["view", "customer_clustering_prediction_aggregates"]): set(),
+        AssetKey(["view", "customer_clustering_prediction_base"]): set(),
+        AssetKey(["view", "customer_clustering_prediction_centroid_ranks"]): set(),
         AssetKey(["view", "customer_event_fact"]): {
             AssetKey(["customer_event_fact"]),
         },
-        AssetKey(["view", "customer_facts"]): {
-            AssetKey(["customer_facts"]),
-        },
+        AssetKey(["view", "customer_facts"]): set(),
         AssetKey(["view", "customer_support_fact"]): {
             AssetKey(["customer_support_fact"]),
         },
         AssetKey(["view", "customer_transaction_fact"]): {
             AssetKey(["customer_transaction_fact"]),
         },
-        AssetKey(["view", "customer_transaction_sequence"]): {
-            AssetKey(["customer_transaction_sequence"]),
-        },
+        AssetKey(["view", "customer_transaction_sequence"]): set(),
         AssetKey(["view", "customers"]): {
             AssetKey(["looker-private-demo", "retail", "customers"]),
         },
         AssetKey(["view", "date_comparison"]): {
             AssetKey(["date_comparison"]),
         },
-        AssetKey(["view", "distances"]): {
-            AssetKey(["distances"]),
-        },
+        AssetKey(["view", "distances"]): set(),
         AssetKey(["view", "events"]): {
             AssetKey(["looker-private-demo", "retail", "events"]),
         },
         AssetKey(["view", "omni_channel_events"]): {
-            AssetKey(["omni_channel_events"]),
+            AssetKey(["looker-private-demo", "ecomm", "events"])
         },
         AssetKey(["view", "omni_channel_support_calls"]): {
-            AssetKey(["omni_channel_support_calls"])
+            AssetKey(["looker-private-demo", "call_center", "transcript_with_messages"])
         },
         AssetKey(["view", "omni_channel_support_calls__messages"]): {
             AssetKey(["omni_channel_support_calls__messages"])
         },
         AssetKey(["view", "omni_channel_transactions"]): {
-            AssetKey(["omni_channel_transactions"]),
+            AssetKey(["looker-private-demo", "ecomm", "inventory_items"]),
+            AssetKey(["looker-private-demo", "ecomm", "order_items"]),
+            AssetKey(["looker-private-demo", "ecomm", "products"]),
+            AssetKey(["looker-private-demo", "ecomm", "users"]),
+            AssetKey(["looker-private-demo", "retail", "channels"]),
+            AssetKey(["looker-private-demo", "retail", "products"]),
+            AssetKey(["looker-private-demo", "retail", "transaction_detail"]),
+            AssetKey(["looker-private-demo", "retail", "us_stores"]),
         },
         AssetKey(["view", "omni_channel_transactions__transaction_details"]): {
             AssetKey(["omni_channel_transactions__transaction_details"])
         },
-        AssetKey(["view", "order_items"]): {
-            AssetKey(["order_items"]),
-        },
-        AssetKey(["view", "order_items_base"]): {
-            AssetKey(["order_items_base"]),
-        },
-        AssetKey(["view", "order_metrics"]): {
-            AssetKey(["order_metrics"]),
-        },
-        AssetKey(["view", "order_product"]): {
-            AssetKey(["order_product"]),
-        },
-        AssetKey(["view", "order_purchase_affinity"]): {
-            AssetKey(["order_purchase_affinity"]),
-        },
-        AssetKey(["view", "orders"]): {
-            AssetKey(["orders"]),
-        },
-        AssetKey(["view", "orders_by_product_loyal_users"]): {
-            AssetKey(["orders_by_product_loyal_users"])
-        },
-        AssetKey(["view", "product_loyal_users"]): {
-            AssetKey(["product_loyal_users"]),
-        },
+        AssetKey(["view", "order_items"]): set(),
+        AssetKey(["view", "order_items_base"]): set(),
+        AssetKey(["view", "order_metrics"]): set(),
+        AssetKey(["view", "order_product"]): set(),
+        AssetKey(["view", "order_purchase_affinity"]): set(),
+        AssetKey(["view", "orders"]): set(),
+        AssetKey(["view", "orders_by_product_loyal_users"]): set(),
+        AssetKey(["view", "product_loyal_users"]): set(),
         AssetKey(["view", "products"]): {
             AssetKey(["looker-private-demo", "retail", "products"]),
         },
@@ -192,9 +169,7 @@ def test_asset_deps() -> None:
         AssetKey(["view", "stock_forecasting_input"]): {
             AssetKey(["stock_forecasting_input"]),
         },
-        AssetKey(["view", "stock_forecasting_prediction"]): {
-            AssetKey(["stock_forecasting_prediction"])
-        },
+        AssetKey(["view", "stock_forecasting_prediction"]): set(),
         AssetKey(["view", "stock_forecasting_product_store_week_facts"]): {
             AssetKey(["stock_forecasting_product_store_week_facts"])
         },
@@ -207,18 +182,10 @@ def test_asset_deps() -> None:
         AssetKey(["view", "stock_forecasting_store_week_facts_prior_year"]): {
             AssetKey(["stock_forecasting_store_week_facts_prior_year"])
         },
-        AssetKey(["view", "store_weather"]): {
-            AssetKey(["store_weather"]),
-        },
-        AssetKey(["view", "stores"]): {
-            AssetKey(["stores"]),
-        },
-        AssetKey(["view", "total_order_product"]): {
-            AssetKey(["total_order_product"]),
-        },
-        AssetKey(["view", "total_orders"]): {
-            AssetKey(["total_orders"]),
-        },
+        AssetKey(["view", "store_weather"]): set(),
+        AssetKey(["view", "stores"]): set(),
+        AssetKey(["view", "total_order_product"]): set(),
+        AssetKey(["view", "total_orders"]): set(),
         AssetKey(["view", "transaction_detail"]): {
             AssetKey(["transaction_detail"]),
         },
@@ -228,10 +195,12 @@ def test_asset_deps() -> None:
         AssetKey(["view", "transactions__line_items"]): {
             AssetKey(["transactions__line_items"]),
         },
-        AssetKey(["view", "weather_pivoted"]): {
-            AssetKey(["weather_pivoted"]),
-        },
+        AssetKey(["view", "weather_pivoted"]): set(),
         AssetKey(["view", "weather_raw"]): {
-            AssetKey(["weather_raw"]),
+            AssetKey(["bigquery-public-data", "ghcn_d", "ghcnd_2016"]),
+            AssetKey(["bigquery-public-data", "ghcn_d", "ghcnd_2017"]),
+            AssetKey(["bigquery-public-data", "ghcn_d", "ghcnd_2018"]),
+            AssetKey(["bigquery-public-data", "ghcn_d", "ghcnd_2019"]),
+            AssetKey(["bigquery-public-data", "ghcn_d", "ghcnd_202_star"]),
         },
     }

--- a/python_modules/libraries/dagster-looker/setup.py
+++ b/python_modules/libraries/dagster-looker/setup.py
@@ -32,6 +32,7 @@ setup(
     install_requires=[
         f"dagster{pin}",
         "lkml",
+        "sqlglot",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
## Summary & Motivation

Introduce `sqlglot` to parse Looker views that are defined with a `derived_table`.

The annoying part here is that the SQL here is potentially templated: https://cloud.google.com/looker/docs/sql-and-referring-to-lookml#substitution_operator_. In this case, don't give it upstream dependencies.

In a future PR, we can potentially look at a way to use regex to template the names into file, using a context dictionary assembled from the total aggregate of `*.view.lkml` files.

## How I Tested These Changes
pytest

- SQL with the `$` operator will have an empty set of upstream dependencies
- SQL without the `$` operator but cannot be parsed by `sqlglot` will have an empty set of upstream dependencies