### PR TITLE
[1/n][perf monitoring] Wrap React.lazy so that it blocks traces

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
@@ -1,9 +1,10 @@
 import {ErrorBoundary, MainContent} from '@dagster-io/ui-components';
-import {Suspense, lazy, memo, useEffect, useRef} from 'react';
+import {memo, useEffect, useRef} from 'react';
 import {Route, Switch, useLocation} from 'react-router-dom';
 
 import {AssetFeatureProvider} from '../assets/AssetFeatureContext';
 import {AssetsOverview} from '../assets/AssetsOverview';
+import {lazy} from '../util/lazy';
 
 const WorkspaceRoot = lazy(() => import('../workspace/WorkspaceRoot'));
 const OverviewRoot = lazy(() => import('../overview/OverviewRoot'));
@@ -35,94 +36,60 @@ export const ContentRoot = memo(() => {
       <ErrorBoundary region="page" resetErrorOnChange={[pathname]}>
         <Switch>
           <Route path="/asset-groups(/?.*)">
-            <Suspense fallback={<div />}>
-              <AssetsGroupsGlobalGraphRoot />
-            </Suspense>
+            <AssetsGroupsGlobalGraphRoot />
           </Route>
           <Route path="/assets(/?.*)">
-            <Suspense fallback={<div />}>
-              <AssetFeatureProvider>
-                <AssetsOverview
-                  headerBreadcrumbs={[{text: 'Assets', href: '/assets'}]}
-                  documentTitlePrefix="Assets"
-                />
-              </AssetFeatureProvider>
-            </Suspense>
+            <AssetFeatureProvider>
+              <AssetsOverview
+                headerBreadcrumbs={[{text: 'Assets', href: '/assets'}]}
+                documentTitlePrefix="Assets"
+              />
+            </AssetFeatureProvider>
           </Route>
           <Route path="/runs" exact>
-            <Suspense fallback={<div />}>
-              <RunsRoot />
-            </Suspense>
+            <RunsRoot />
           </Route>
           <Route path="/runs/scheduled" exact>
-            <Suspense fallback={<div />}>
-              <ScheduledRunListRoot />
-            </Suspense>
+            <ScheduledRunListRoot />
           </Route>
           <Route path="/runs/:runId" exact>
-            <Suspense fallback={<div />}>
-              <RunRoot />
-            </Suspense>
+            <RunRoot />
           </Route>
           <Route path="/snapshots/:pipelinePath/:tab?">
-            <Suspense fallback={<div />}>
-              <SnapshotRoot />
-            </Suspense>
+            <SnapshotRoot />
           </Route>
           <Route path="/health">
-            <Suspense fallback={<div />}>
-              <InstanceHealthPage />
-            </Suspense>
+            <InstanceHealthPage />
           </Route>
           <Route path="/concurrency">
-            <Suspense fallback={<div />}>
-              <InstanceConcurrencyPage />
-            </Suspense>
+            <InstanceConcurrencyPage />
           </Route>
           <Route path="/config">
-            <Suspense fallback={<div />}>
-              <InstanceConfig />
-            </Suspense>
+            <InstanceConfig />
           </Route>
           <Route path="/locations" exact>
-            <Suspense fallback={<div />}>
-              <CodeLocationsPage />
-            </Suspense>
+            <CodeLocationsPage />
           </Route>
           <Route path="/locations">
-            <Suspense fallback={<div />}>
-              <WorkspaceRoot />
-            </Suspense>
+            <WorkspaceRoot />
           </Route>
           <Route path="/guess/:jobPath">
-            <Suspense fallback={<div />}>
-              <GuessJobLocationRoot />
-            </Suspense>
+            <GuessJobLocationRoot />
           </Route>
           <Route path="/overview">
-            <Suspense fallback={<div />}>
-              <OverviewRoot />
-            </Suspense>
+            <OverviewRoot />
           </Route>
           <Route path="/jobs">
-            <Suspense fallback={<div />}>
-              <JobsRoot />
-            </Suspense>
+            <JobsRoot />
           </Route>
           <Route path="/automation">
-            <Suspense fallback={<div />}>
-              <AutomationRoot />
-            </Suspense>
+            <AutomationRoot />
           </Route>
           <Route path="/settings">
-            <Suspense fallback={<div />}>
-              <SettingsRoot />
-            </Suspense>
+            <SettingsRoot />
           </Route>
           <Route path="*">
-            <Suspense fallback={<div />}>
-              <FallthroughRoot />
-            </Suspense>
+            <FallthroughRoot />
           </Route>
         </Switch>
       </ErrorBoundary>

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadAllowedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadAllowedRoot.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Suspense, lazy, useEffect, useMemo} from 'react';
+import {useEffect, useMemo} from 'react';
 import * as yaml from 'yaml';
 
 import {
@@ -18,6 +18,7 @@ import {usePageLoadTrace} from '../performance';
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {explorerPathFromString, useStripSnapshotFromPath} from '../pipelines/PipelinePathUtils';
 import {useJobTitle} from '../pipelines/useJobTitle';
+import {lazy} from '../util/lazy';
 import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
 
@@ -159,19 +160,17 @@ export const LaunchpadAllowedRoot = (props: Props) => {
   } else {
     // job
     return (
-      <Suspense fallback={<div />}>
-        <LaunchpadStoredSessionsContainer
-          launchpadType={launchpadType}
-          pipeline={pipelineOrError}
-          partitionSets={partitionSetsOrError}
-          repoAddress={repoAddress}
-          rootDefaultYaml={
-            result.data?.runConfigSchemaOrError.__typename === 'RunConfigSchema'
-              ? result.data.runConfigSchemaOrError.rootDefaultYaml
-              : undefined
-          }
-        />
-      </Suspense>
+      <LaunchpadStoredSessionsContainer
+        launchpadType={launchpadType}
+        pipeline={pipelineOrError}
+        partitionSets={partitionSetsOrError}
+        repoAddress={repoAddress}
+        rootDefaultYaml={
+          result.data?.runConfigSchemaOrError.__typename === 'RunConfigSchema'
+            ? result.data.runConfigSchemaOrError.rootDefaultYaml
+            : undefined
+        }
+      />
     );
   }
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/__tests__/useTimeRangeFilter.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/__tests__/useTimeRangeFilter.test.tsx
@@ -82,9 +82,7 @@ describe('CustomTimeRangeFilterDialog', () => {
     const {result} = renderHook(() => useTimeRangeFilter(mockFilterProps));
     const filter = result.current;
 
-    const {getByText} = render(
-      <CustomTimeRangeFilterDialog filter={filter} closeRef={{current: () => {}}} />,
-    );
+    const {getByText} = render(<CustomTimeRangeFilterDialog filter={filter} close={() => {}} />);
 
     expect(getByText('Select a date range')).toBeInTheDocument();
   });
@@ -93,18 +91,20 @@ describe('CustomTimeRangeFilterDialog', () => {
     const {result} = renderHook(() => useTimeRangeFilter(mockFilterProps));
     let filter = result.current;
 
-    const {getByText} = render(
-      <CustomTimeRangeFilterDialog filter={filter} closeRef={{current: () => {}}} />,
+    const {getByText} = await act(async () =>
+      render(<CustomTimeRangeFilterDialog filter={filter} close={() => {}} />),
     );
 
     // Mock selecting start and end dates
     const startDate = moment().startOf('day').subtract(10, 'days');
     const endDate = moment().endOf('day').subtract(5, 'days');
 
-    act(() => {
-      ((mockReactDates.mock.calls[0] as any)[0] as any).onDatesChange({
-        startDate,
-        endDate,
+    await waitFor(() => {
+      act(() => {
+        ((mockReactDates.mock.calls[0] as any)[0] as any).onDatesChange({
+          startDate,
+          endDate,
+        });
       });
     });
 
@@ -116,13 +116,11 @@ describe('CustomTimeRangeFilterDialog', () => {
   });
 
   it('should close dialog on cancel', async () => {
-    const closeRefMock = jest.fn();
-    const {result} = renderHook(() => useTimeRangeFilter(mockFilterProps));
+    const closeMock = jest.fn();
+    const {result} = await act(async () => renderHook(() => useTimeRangeFilter(mockFilterProps)));
     let filter = result.current;
 
-    const {getByText} = render(
-      <CustomTimeRangeFilterDialog filter={filter} closeRef={{current: closeRefMock}} />,
-    );
+    const {getByText} = render(<CustomTimeRangeFilterDialog filter={filter} close={closeMock} />);
 
     // Click cancel button
     await userEvent.click(getByText('Cancel'));
@@ -130,7 +128,7 @@ describe('CustomTimeRangeFilterDialog', () => {
 
     await waitFor(() => {
       // wait for blueprint animation
-      expect(closeRefMock).toHaveBeenCalled();
+      expect(closeMock).toHaveBeenCalled();
     });
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useTimeRangeFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useTimeRangeFilter.tsx
@@ -150,11 +150,13 @@ export function useTimeRangeFilter({
         createPortal: (element: JSX.Element) => () => void;
       }) => {
         if (value === 'CUSTOM') {
-          const closeRef = {
-            current: () => {},
-          };
-          closeRef.current = createPortal(
-            <CustomTimeRangeFilterDialog filter={filterObjRef.current} closeRef={closeRef} />,
+          const closeFn = createPortal(
+            <CustomTimeRangeFilterDialog
+              filter={filterObjRef.current}
+              close={() => {
+                closeFn();
+              }}
+            />,
           );
         } else {
           const nextState = timeRanges[value].range;
@@ -284,10 +286,10 @@ export function ActiveFilterState({
 
 export function CustomTimeRangeFilterDialog({
   filter,
-  closeRef,
+  close,
 }: {
   filter: TimeRangeFilter;
-  closeRef: {current: () => void};
+  close: () => void;
 }) {
   const [startDate, setStartDate] = useState<moment.Moment | null>(null);
   const [endDate, setEndDate] = useState<moment.Moment | null>(null);
@@ -296,15 +298,7 @@ export function CustomTimeRangeFilterDialog({
   const [isOpen, setIsOpen] = useState(true);
 
   return (
-    <Dialog
-      isOpen={isOpen}
-      title="Select a date range"
-      onClosed={() => {
-        // close the portal after the animation is done
-        closeRef.current();
-      }}
-      style={{width: '652px'}}
-    >
+    <Dialog isOpen={isOpen} title="Select a date range" onClosed={close} style={{width: '652px'}}>
       <Container>
         <Box flex={{direction: 'row', gap: 8}} padding={16}>
           <DateRangePicker

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useTimeRangeFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useTimeRangeFilter.tsx
@@ -3,13 +3,14 @@ import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import isEqual from 'lodash/isEqual';
-import {Suspense, lazy, useContext, useEffect, useMemo, useState} from 'react';
+import {useContext, useEffect, useMemo, useState} from 'react';
 import styled from 'styled-components';
 
 import {FilterObject, FilterTag, FilterTagHighlightedText} from './useFilter';
 import {TimeContext} from '../../app/time/TimeContext';
 import {browserTimezone} from '../../app/time/browserTimezone';
 import {useUpdatingRef} from '../../hooks/useUpdatingRef';
+import {lazy} from '../../util/lazy';
 
 const DateRangePicker = lazy(() => import('./DateRangePickerWrapper'));
 
@@ -306,26 +307,24 @@ export function CustomTimeRangeFilterDialog({
     >
       <Container>
         <Box flex={{direction: 'row', gap: 8}} padding={16}>
-          <Suspense fallback={<div />}>
-            <DateRangePicker
-              minimumNights={0}
-              onDatesChange={({startDate, endDate}) => {
-                setStartDate(startDate ? startDate.clone().startOf('day') : null);
-                setEndDate(endDate ? endDate.clone().endOf('day') : null);
-              }}
-              onFocusChange={(focusedInput) => {
-                focusedInput && setFocusedInput(focusedInput);
-              }}
-              startDate={startDate}
-              endDate={endDate}
-              startDateId="start"
-              endDateId="end"
-              focusedInput={focusedInput}
-              withPortal={false}
-              keepOpenOnDateSelect
-              isOutsideRange={() => false}
-            />
-          </Suspense>
+          <DateRangePicker
+            minimumNights={0}
+            onDatesChange={({startDate, endDate}) => {
+              setStartDate(startDate ? startDate.clone().startOf('day') : null);
+              setEndDate(endDate ? endDate.clone().endOf('day') : null);
+            }}
+            onFocusChange={(focusedInput) => {
+              focusedInput && setFocusedInput(focusedInput);
+            }}
+            startDate={startDate}
+            endDate={endDate}
+            startDateId="start"
+            endDateId="end"
+            focusedInput={focusedInput}
+            withPortal={false}
+            keepOpenOnDateSelect
+            isOutsideRange={() => false}
+          />
         </Box>
       </Container>
       <DialogFooter topBorder>

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Markdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Markdown.tsx
@@ -1,6 +1,7 @@
 import {Colors, FontFamily} from '@dagster-io/ui-components';
-import {Suspense, lazy} from 'react';
 import styled from 'styled-components';
+
+import {lazy} from '../util/lazy';
 
 const MarkdownWithPlugins = lazy(() => import('./MarkdownWithPlugins'));
 
@@ -11,9 +12,7 @@ interface Props {
 export const Markdown = (props: Props) => {
   return (
     <Container>
-      <Suspense fallback={<div />}>
-        <MarkdownWithPlugins {...props} />
-      </Suspense>
+      <MarkdownWithPlugins {...props} />
     </Container>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/util/lazy.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/lazy.tsx
@@ -1,0 +1,38 @@
+import React, {useEffect, useMemo, useState} from 'react';
+
+import {CompletionType, useTraceDependency} from '../performance/TraceContext';
+
+type ResolvedType<T> = T extends Promise<infer U> ? U : never;
+
+export const lazy = <T extends () => Promise<{default: React.ComponentType<any>}>>(importFn: T) => {
+  type ComponentType = ResolvedType<ReturnType<T>>['default'];
+  type Props = React.ComponentProps<ComponentType>;
+
+  let promise: Promise<{default: React.ComponentType<any>}> | null = null;
+  return (props: Props & {_placeholder?: React.ReactNode}) => {
+    const [Component, setComponent] = useState<any | null>(null);
+    const [errored, setErrored] = useState(false);
+    const dependency = useTraceDependency('LazyImport');
+    useMemo(() => {
+      if (!promise) {
+        promise = importFn();
+      }
+      promise.then(
+        (res) => {
+          setComponent(() => res.default);
+        },
+        () => {
+          setErrored(true);
+        },
+      );
+    }, []);
+    useEffect(() => {
+      if (Component) {
+        dependency.completeDependency(CompletionType.SUCCESS);
+      } else if (errored) {
+        dependency.completeDependency(CompletionType.ERROR);
+      }
+    }, [dependency, errored, Component]);
+    return Component ? <Component {...props} /> : props._placeholder;
+  };
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleRow.tsx
@@ -28,6 +28,7 @@ import {InstigationStatus} from '../graphql/types';
 import {LastRunSummary} from '../instance/LastRunSummary';
 import {TICK_TAG_FRAGMENT} from '../instigation/InstigationTick';
 import {BasicInstigationStateFragment} from '../overview/types/BasicInstigationStateFragment.types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {SCHEDULE_SWITCH_FRAGMENT, ScheduleSwitch} from '../schedules/ScheduleSwitch';
@@ -79,6 +80,7 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
     },
     notifyOnNetworkStatusChange: true,
   });
+  useBlockTraceOnQueryResult(queryResult, 'SingleScheduleQuery');
 
   useDelayedRowQuery(querySchedule);
   useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);


### PR DESCRIPTION
## Summary & Motivation

We want to instrument page-load for pages. To accomplish that we need to track async dependencies correctly. One async dependency we're not currently tracking is React.lazy, this PR fixes that.

## How I Tested These Changes
![Screenshot 2024-05-07 at 1 34 19 PM](https://github.com/dagster-io/dagster/assets/2286579/396228aa-9d6b-498d-a8a4-f2190178af98)


https://app.datadoghq.com/rum/sessions?query=%40type%3Aview%20%40application.id%3A6d12cca2-0263-463b-a90e-cc6c524e14bd%20%40usr.email%3Amarco%40dagsterlabs.com&agg_m=count&agg_m_source=base&agg_t=count&cols=&event=AgAAAY9UHLgL2WlJSAAAAAAAAAAYAAAAAEFZOVVITGdMQUFCamxhTlFxQ09zV2lGZwAAACQAAAAAMDE4ZjU0MWQtMjk5Ny00ZjdiLWE3OGEtZTBlMGU4YTQ4MmE5&fromUser=false&viz=stream&from_ts=1715103092025&to_ts=1715103392025&live=true