### PR TITLE
[bugfix] Allow null BackfillPolicy for unpartitioned assets in partitioned asset job

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -191,12 +191,11 @@ class UnresolvedAssetJobDefinition(
             ) from e
 
         # Require that all assets in the job have the same backfill policy
-        backfill_policies = {
-            job_asset_graph.get(k).backfill_policy for k in job_asset_graph.executable_asset_keys
-        }
+        executable_nodes = {job_asset_graph.get(k) for k in job_asset_graph.executable_asset_keys}
+        backfill_policies = {n.backfill_policy for n in executable_nodes if n.is_partitioned}
         if len(backfill_policies) > 1:
             raise DagsterInvalidDefinitionError(
-                f"Asset job {self.name} materializes asset with varying BackfillPolicies. All assets"
+                f"Asset job {self.name} materializes assets with varying BackfillPolicies. All assets"
                 " in a job must share the same BackfillPolicy."
             )
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -829,7 +829,13 @@ def test_backfill_policy():
     @asset(partitions_def=partitions_def, backfill_policy=BackfillPolicy.multi_run(2))
     def baz(): ...
 
+    @asset
+    def qux(): ...
+
     assert create_test_asset_job([foo, bar]).backfill_policy == BackfillPolicy.single_run()
+    # Unpartitioned assets won't affect backfill policy
+    assert create_test_asset_job([qux]).backfill_policy is None
+    assert create_test_asset_job([foo, bar, qux]).backfill_policy == BackfillPolicy.single_run()
     assert create_test_asset_job([baz]).backfill_policy == BackfillPolicy.multi_run(2)
 
     # different backfill policies


### PR DESCRIPTION
## Summary & Motivation

Prior to this PR, all assets in an asset job must have the same backfill policy. This invalidates some valid jobs that mix partitioned and unpartitioned assets. After this PR, only the partitioned assets in the job need to have the same policy.

## How I Tested These Changes

New unit tests.