### PR TITLE
avoid deprecated pydantic methods on AssetCondition and friends

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -39,7 +39,7 @@ class AssetSubsetSerializer(PydanticModelSerializer):
 
     def before_pack(self, value: "AssetSubset") -> "AssetSubset":
         if value.is_partitioned:
-            return value.copy(update={"value": value.subset_value.to_serializable_subset()})
+            return value.model_copy(update={"value": value.subset_value.to_serializable_subset()})
         return value
 
 
@@ -219,7 +219,7 @@ class ValidAssetSubset(AssetSubset):
     ) -> "ValidAssetSubset":
         """Returns the AssetSubset containing all asset partitions which are not in this AssetSubset."""
         if partitions_def is None:
-            return self.copy(update={"value": not self.bool_value})
+            return self.model_copy(update={"value": not self.bool_value})
         else:
             value = partitions_def.subset_with_partition_keys(
                 self.subset_value.get_partition_keys_not_in_subset(
@@ -228,17 +228,17 @@ class ValidAssetSubset(AssetSubset):
                     dynamic_partitions_store=dynamic_partitions_store,
                 )
             )
-            return self.copy(update={"value": value})
+            return self.model_copy(update={"value": value})
 
     def _oper(self, other: "ValidAssetSubset", oper: Callable[..., Any]) -> "ValidAssetSubset":
         value = oper(self.value, other.value)
-        return self.copy(update={"value": value})
+        return self.model_copy(update={"value": value})
 
     def __sub__(self, other: AssetSubset) -> "ValidAssetSubset":
         """Returns an AssetSubset representing self.asset_partitions - other.asset_partitions."""
         valid_other = self.get_valid(other)
         if not self.is_partitioned:
-            return self.copy(update={"value": self.bool_value and not valid_other.bool_value})
+            return self.model_copy(update={"value": self.bool_value and not valid_other.bool_value})
         return self._oper(valid_other, operator.sub)
 
     def __and__(self, other: AssetSubset) -> "ValidAssetSubset":
@@ -256,7 +256,7 @@ class ValidAssetSubset(AssetSubset):
         if self._is_compatible_with_subset(other):
             return ValidAssetSubset(asset_key=other.asset_key, value=other.value)
         else:
-            return self.copy(
+            return self.model_copy(
                 # unfortunately, this is the best way to get an empty partitions subset of an unknown
                 # type if you don't have access to the partitions definition
                 update={

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/legacy_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/legacy_context.py
@@ -202,7 +202,7 @@ class LegacyRuleEvaluationContext:
             if not parent_info:
                 continue
             parent_subset = parent_info.true_subset.as_valid(self.partitions_def)
-            subset |= parent_subset.copy(update={"asset_key": self.asset_key})
+            subset |= parent_subset.model_copy(update={"asset_key": self.asset_key})
         return subset
 
     @functools.cached_property

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
@@ -69,7 +69,7 @@ class SchedulingContext(DagsterModel):
         scheduling_condition = auto_materialize_policy.to_scheduling_condition()
 
         # construct is used here for performance
-        return SchedulingContext.construct(
+        return SchedulingContext.model_construct(
             candidate_slice=asset_graph_view.get_asset_slice(asset_key),
             condition=scheduling_condition,
             condition_unique_id=scheduling_condition.get_unique_id(None),
@@ -86,7 +86,7 @@ class SchedulingContext(DagsterModel):
         self, child_condition: SchedulingCondition, candidate_slice: AssetSlice
     ) -> "SchedulingContext":
         # construct is used here for performance
-        return SchedulingContext.construct(
+        return SchedulingContext.model_construct(
             candidate_slice=candidate_slice,
             condition=child_condition,
             condition_unique_id=child_condition.get_unique_id(

--- a/python_modules/dagster/dagster/_model/__init__.py
+++ b/python_modules/dagster/dagster/_model/__init__.py
@@ -43,3 +43,10 @@ class DagsterModel(BaseModel):
             return super().model_copy(update=update)  # type: ignore
         else:
             return super().copy(update=update)
+
+    @classmethod
+    def model_construct(cls, **kwargs: Any) -> Self:
+        if USING_PYDANTIC_2:
+            return super().model_construct(**kwargs)  # type: ignore
+        else:
+            return super().construct(**kwargs)


### PR DESCRIPTION
avoid emitting warnings by going through `DagsterModel` compat methods `model_copy` / `model_construct`


## How I Tested These Changes


see warnings from AMP perf scenario tests drop from `144263 warnings` to `5727 warnings` (just our own experimental warnings) 
