### PR TITLE
[DagsterModel] wrap NamedTuple fields with InstanceOf

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -20,7 +20,7 @@ from dagster._core.definitions.partition import (
 from dagster._core.definitions.time_window_partitions import (
     BaseTimeWindowPartitionsSubset,
 )
-from dagster._model import DagsterModel
+from dagster._model import DagsterModel, InstanceOf
 from dagster._serdes.serdes import (
     PydanticModelSerializer,
     whitelist_for_serdes,
@@ -51,7 +51,9 @@ class AssetSubset(DagsterModel):
     the asset is present or not.
     """
 
-    asset_key: AssetKey
+    # use InstanceOf to tell pydantic to just do an instanceof check instead of the default
+    # costly NamedTuple validation and reconstruction
+    asset_key: InstanceOf[AssetKey]
     value: Union[bool, PartitionsSubset]
 
     @property

--- a/python_modules/dagster/dagster/_model/__init__.py
+++ b/python_modules/dagster/dagster/_model/__init__.py
@@ -2,9 +2,16 @@ from functools import cached_property
 from typing import Any, Dict, Hashable, Optional
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr
-from typing_extensions import Self
+from typing_extensions import Annotated, Self, TypeAlias, TypeVar
 
 from .pydantic_compat_layer import USING_PYDANTIC_2
+
+if USING_PYDANTIC_2:
+    from pydantic import InstanceOf as InstanceOf  # type: ignore
+else:
+    # fallback to a no-op on pydantic 1 as there is no equivalent
+    AnyType = TypeVar("AnyType")
+    InstanceOf: TypeAlias = Annotated[AnyType, ...]
 
 
 class DagsterModel(BaseModel):


### PR DESCRIPTION
use `InstanceOf` to avoid the expensive default pydantic handling of `NamedTuple` which is to read them as regular tuples and new up a fresh copy of the `NamedTuple` subclass after performing its own custom validation on the `NamedTuple` properties

## How I Tested These Changes


```
from dagster._core.definitions.asset_subset import AssetSubset, AssetKey

import cProfile


keys = [AssetKey(f"key_{i}") for i in range(100000)]
with cProfile.Profile() as pr:
    for k in keys:
        AssetSubset(asset_key=k, value=True)


pr.print_stats(sort="tottime")
```
before
```
(py311) ~/internal:master$ python /tmp/cache_perf.py
         2200002 function calls in 0.589 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   100000    0.136    0.000    0.524    0.000 {method 'validate_python' of 'pydantic_core._pydantic_core.SchemaValidator' objects}
   100000    0.070    0.000    0.208    0.000 asset_key.py:42(__new__)
   100000    0.048    0.000    0.054    0.000 _validators.py:18(sequence_validator)
   100000    0.043    0.000    0.589    0.000 __init__.py:23(__init__)
   500000    0.040    0.000    0.065    0.000 {built-in method builtins.isinstance}
   100000    0.040    0.000    0.107    0.000 __init__.py:1100(sequence_param)
   100000    0.039    0.000    0.100    0.000 typing.py:1586(__subclasscheck__)
   200000    0.027    0.000    0.054    0.000 {built-in method builtins.issubclass}
   100000    0.026    0.000    0.126    0.000 typing.py:1311(__instancecheck__)
   100000    0.023    0.000    0.546    0.000 main.py:166(__init__)
   100000    0.020    0.000    0.024    0.000 __init__.py:1736(_check_iterable_items)
   100000    0.017    0.000    0.027    0.000 <frozen abc>:121(__subclasscheck__)
   100000    0.016    0.000    0.025    0.000 <string>:1(<lambda>)
   100000    0.015    0.000    0.025    0.000 <frozen abc>:117(__instancecheck__)
   100000    0.011    0.000    0.011    0.000 {built-in method _abc._abc_subclasscheck}
   100000    0.010    0.000    0.010    0.000 {built-in method __new__ of type object at 0x1038ffca8}
   100000    0.009    0.000    0.009    0.000 {built-in method _abc._abc_instancecheck}
        1    0.000    0.000    0.000    0.000 cProfile.py:118(__exit__)
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}

```


after
```
(py311) ~/internal:master$ python /tmp/cache_perf.py
         300002 function calls in 0.102 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   100000    0.049    0.000    0.049    0.000 {method 'validate_python' of 'pydantic_core._pydantic_core.SchemaValidator' objects}
   100000    0.035    0.000    0.102    0.000 __init__.py:28(__init__)
   100000    0.018    0.000    0.068    0.000 main.py:166(__init__)
        1    0.000    0.000    0.000    0.000 cProfile.py:118(__exit__)
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}

```