### PR TITLE
[DS][x/n] Create ChildCondition condition

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -11,7 +11,7 @@ from typing import (
 
 from dagster import _check as check
 from dagster._core.definitions.asset_subset import AssetSubset, ValidAssetSubset
-from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.multi_dimensional_partitions import (
     MultiPartitionKey,
     MultiPartitionsDefinition,
@@ -126,6 +126,11 @@ class AssetSlice:
             check.not_none(akpk.partition_key, "No None partition keys")
             for akpk in self._compatible_subset.asset_partitions
         }
+
+    def expensively_compute_asset_partitions(self) -> AbstractSet[AssetKeyPartitionKey]:
+        # this method requires computing all partition keys of the definition, which
+        # may be expensive
+        return self._compatible_subset.asset_partitions
 
     @property
     def asset_key(self) -> AssetKey:
@@ -346,6 +351,21 @@ class AssetGraphView:
     def get_asset_slice_from_valid_subset(self, subset: ValidAssetSubset) -> "AssetSlice":
         return _slice_from_subset(self, subset)
 
+    def get_asset_slice_from_asset_partitions(
+        self, asset_partitions: AbstractSet[AssetKeyPartitionKey]
+    ) -> "AssetSlice":
+        asset_keys = {akpk.asset_key for akpk in asset_partitions}
+        check.invariant(len(asset_keys) == 1, "Must have exactly one asset key")
+        asset_key = asset_keys.pop()
+        return _slice_from_subset(
+            self,
+            ValidAssetSubset.from_asset_partitions_set(
+                asset_key=asset_key,
+                partitions_def=self._get_partitions_def(asset_key),
+                asset_partitions_set=asset_partitions,
+            ),
+        )
+
     def compute_missing_subslice(
         self, asset_key: "AssetKey", from_slice: "AssetSlice"
     ) -> "AssetSlice":
@@ -469,6 +489,28 @@ class AssetGraphView:
             )
         else:
             check.failed(f"Unsupported partitions_def: {partitions_def}")
+
+    @cached_method
+    def compute_updated_since_cursor_slice(
+        self, asset_key: AssetKey, cursor: Optional[int]
+    ) -> AssetSlice:
+        subset = self._queryer.get_asset_subset_updated_after_cursor(
+            asset_key=asset_key, after_cursor=cursor
+        )
+        return self.get_asset_slice_from_valid_subset(subset)
+
+    @cached_method
+    def compute_parent_updated_since_cursor_slice(
+        self, asset_key: AssetKey, cursor: Optional[int]
+    ) -> AssetSlice:
+        result_slice = self.create_empty_slice(asset_key)
+        for parent_key in self.asset_graph.get(asset_key).parent_keys:
+            result_slice = result_slice.compute_union(
+                self.compute_updated_since_cursor_slice(
+                    asset_key=parent_key, cursor=cursor
+                ).compute_child_slice(asset_key)
+            )
+        return result_slice
 
     def create_empty_slice(self, asset_key: AssetKey) -> AssetSlice:
         return _slice_from_subset(

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -80,7 +80,7 @@ class MaterializeOnRequiredForFreshnessRule(
         true_subset, subsets_with_metadata = freshness_evaluation_results_for_asset_key(
             context.legacy_context.root_context
         )
-        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
         return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
@@ -217,7 +217,9 @@ class MaterializeOnCronRule(
             - context.legacy_context.materialized_requested_or_discarded_since_previous_tick_subset
         )
 
-        true_slice = context.asset_graph_view.get_asset_slice_from_subset(asset_subset_to_request)
+        true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(
+            asset_subset_to_request
+        )
         return SchedulingResult.create(context, true_slice=true_slice)
 
 
@@ -435,7 +437,7 @@ class MaterializeOnParentUpdatedRule(
                 ignore_subset=context.legacy_context.materialized_requested_or_discarded_since_previous_tick_subset,
             )
         )
-        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
         return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
@@ -534,7 +536,9 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
 
         return SchedulingResult.create(
             context,
-            true_slice=context.asset_graph_view.get_asset_slice_from_subset(unhandled_candidates),
+            true_slice=context.asset_graph_view.get_asset_slice_from_valid_subset(
+                unhandled_candidates
+            ),
             # we keep track of the handled subset instead of the unhandled subset because new
             # partitions may spontaneously jump into existence at any time
             extra_state=handled_subset,
@@ -588,7 +592,7 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
                 asset_partitions_by_evaluation_data, ignore_subset=subset_to_evaluate
             )
         )
-        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
         return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
@@ -645,7 +649,7 @@ class SkipOnParentMissingRule(AutoMaterializeRule, NamedTuple("_SkipOnParentMiss
                 asset_partitions_by_evaluation_data, ignore_subset=subset_to_evaluate
             )
         )
-        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
         return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
@@ -739,7 +743,7 @@ class SkipOnNotAllParentsUpdatedRule(
                 asset_partitions_by_evaluation_data, ignore_subset=subset_to_evaluate
             )
         )
-        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
         return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
@@ -965,7 +969,7 @@ class SkipOnNotAllParentsUpdatedSinceCronRule(
 
         return SchedulingResult.create(
             context,
-            true_slice=context.asset_graph_view.get_asset_slice_from_subset(
+            true_slice=context.asset_graph_view.get_asset_slice_from_valid_subset(
                 context.legacy_context.candidate_subset - all_parents_updated_subset
             ),
             extra_state=list(updated_subsets_by_key.values()),
@@ -1016,7 +1020,7 @@ class SkipOnRequiredButNonexistentParentsRule(
                 asset_partitions_by_evaluation_data, ignore_subset=subset_to_evaluate
             )
         )
-        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
         return SchedulingResult.create(context, true_slice, subsets_with_metadata)
 
 
@@ -1056,7 +1060,7 @@ class SkipOnBackfillInProgressRule(
         else:
             true_subset = context.legacy_context.candidate_subset & backfilling_subset
 
-        true_slice = context.asset_graph_view.get_asset_slice_from_subset(true_subset)
+        true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
         return SchedulingResult.create(context, true_slice)
 
 
@@ -1085,7 +1089,7 @@ class DiscardOnMaxMaterializationsExceededRule(
 
         return SchedulingResult.create(
             context,
-            context.asset_graph_view.get_asset_slice_from_subset(
+            context.asset_graph_view.get_asset_slice_from_valid_subset(
                 AssetSubset.from_asset_partitions_set(
                     context.legacy_context.asset_key,
                     context.legacy_context.partitions_def,
@@ -1123,13 +1127,13 @@ class SkipOnRunInProgressRule(AutoMaterializeRule, NamedTuple("_SkipOnRunInProgr
             if dagster_run and dagster_run.status in IN_PROGRESS_RUN_STATUSES:
                 return SchedulingResult.create(
                     context,
-                    context.asset_graph_view.get_asset_slice_from_subset(
+                    context.asset_graph_view.get_asset_slice_from_valid_subset(
                         context.legacy_context.candidate_subset
                     ),
                 )
         return SchedulingResult.create(
             context,
-            context.asset_graph_view.get_asset_slice_from_subset(
+            context.asset_graph_view.get_asset_slice_from_valid_subset(
                 context.legacy_context.empty_subset()
             ),
         )

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -368,8 +368,8 @@ class MaterializeOnParentUpdatedRule(
             ).parent_partitions
 
             updated_parent_asset_partitions = context.legacy_context.instance_queryer.get_parent_asset_partitions_updated_after_child(
-                asset_partition,
-                parent_asset_partitions,
+                asset_partition=asset_partition,
+                parent_asset_partitions=parent_asset_partitions,
                 # do a precise check for updated parents, factoring in data versions, as long as
                 # we're within reasonable limits on the number of partitions to check
                 respect_materialization_data_versions=context.legacy_context.daemon_context.respect_materialization_data_versions
@@ -706,9 +706,9 @@ class SkipOnNotAllParentsUpdatedRule(
 
             updated_parent_partitions = (
                 context.legacy_context.instance_queryer.get_parent_asset_partitions_updated_after_child(
-                    candidate,
-                    parent_partitions,
-                    context.legacy_context.daemon_context.respect_materialization_data_versions,
+                    asset_partition=candidate,
+                    parent_asset_partitions=parent_partitions,
+                    respect_materialization_data_versions=context.legacy_context.daemon_context.respect_materialization_data_versions,
                     ignored_parent_keys=set(),
                 )
                 | context.legacy_context.parent_will_update_subset.asset_partitions

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
@@ -4,6 +4,7 @@ from .operands import (
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,
     InProgressSchedulingCondition as InProgressSchedulingCondition,
     MissingSchedulingCondition as MissingSchedulingCondition,
+    RequestedThisTickCondition as RequestedThisTickCondition,
 )
 from .operators import (
     AllDepsCondition as AllDepsCondition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
@@ -6,6 +6,7 @@ from .operands import (
     MissingSchedulingCondition as MissingSchedulingCondition,
     ParentNewerCondition as ParentNewerCondition,
     RequestedThisTickCondition as RequestedThisTickCondition,
+    UpdatedSinceCronCondition as UpdatedSinceCronCondition,
 )
 from .operators import (
     AllDepsCondition as AllDepsCondition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
@@ -4,6 +4,7 @@ from .operands import (
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,
     InProgressSchedulingCondition as InProgressSchedulingCondition,
     MissingSchedulingCondition as MissingSchedulingCondition,
+    ParentNewerCondition as ParentNewerCondition,
     RequestedThisTickCondition as RequestedThisTickCondition,
 )
 from .operators import (

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/rule_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/rule_condition.py
@@ -17,7 +17,7 @@ class RuleCondition(AssetCondition):
 
     rule: AutoMaterializeRule
 
-    def get_unique_id(self, parent_unique_id: Optional[str]) -> str:
+    def get_unique_id(self, *, parent_unique_id: Optional[str], index: Optional[str]) -> str:
         # preserves old (bad) behavior of not including the parent_unique_id to avoid inavlidating
         # old serialized information
         parts = [self.rule.__class__.__name__, self.description]

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/__init__.py
@@ -1,3 +1,4 @@
+from .parent_newer_condition import ParentNewerCondition as ParentNewerCondition
 from .slice_conditions import (
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,
     InProgressSchedulingCondition as InProgressSchedulingCondition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/__init__.py
@@ -2,5 +2,6 @@ from .slice_conditions import (
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,
     InProgressSchedulingCondition as InProgressSchedulingCondition,
     MissingSchedulingCondition as MissingSchedulingCondition,
+    RequestedThisTickCondition as RequestedThisTickCondition,
 )
 from .updated_since_cron_condition import UpdatedSinceCronCondition as UpdatedSinceCronCondition

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/parent_newer_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/parent_newer_condition.py
@@ -1,0 +1,106 @@
+from typing import AbstractSet
+
+from dagster._core.asset_graph_view.asset_graph_view import AssetSlice
+from dagster._core.definitions.declarative_scheduling.scheduling_condition import (
+    SchedulingCondition,
+    SchedulingResult,
+)
+from dagster._core.definitions.declarative_scheduling.scheduling_context import SchedulingContext
+from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._serdes.serdes import whitelist_for_serdes
+
+
+@whitelist_for_serdes
+class ParentNewerCondition(SchedulingCondition):
+    @property
+    def description(self) -> str:
+        return "At least one parent has been updated more recently than the candidate."
+
+    def compute_newer_parents(
+        self, context: SchedulingContext, candidate: AssetKeyPartitionKey
+    ) -> AbstractSet[AssetKeyPartitionKey]:
+        """Returns the set of parent asset partitions that are newer than the candidate."""
+        # TODO: replace this implementation with one backed by the StaleStatusResolver
+        candidate_slice = context.asset_graph_view.get_asset_slice_from_asset_partitions(
+            {candidate}
+        )
+        parent_slices = candidate_slice.compute_parent_slices()
+        all_parent_asset_partitions = {
+            ap
+            for parent_slice in parent_slices.values()
+            for ap in parent_slice.expensively_compute_asset_partitions()
+        }
+        return (
+            context.legacy_context.instance_queryer.get_parent_asset_partitions_updated_after_child(
+                asset_partition=candidate,
+                parent_asset_partitions=all_parent_asset_partitions,
+                respect_materialization_data_versions=False,
+                ignored_parent_keys=set(),
+            )
+        )
+
+    def compute_parent_newer_slice(
+        self, context: SchedulingContext, from_slice: AssetSlice
+    ) -> AssetSlice:
+        """For a given slice, computes the slice for which at least one parent is newer than the
+        given asset partition.
+        """
+        asset_partitions_with_updated_parents = {
+            ap
+            for ap in from_slice.expensively_compute_asset_partitions()
+            if len(self.compute_newer_parents(context, ap)) > 0
+        }
+        return (
+            context.asset_graph_view.get_asset_slice_from_asset_partitions(
+                asset_partitions_with_updated_parents
+            )
+            if asset_partitions_with_updated_parents
+            else context.asset_graph_view.create_empty_slice(context.asset_key)
+        )
+
+    def compute_slice_to_evaluate(self, context: SchedulingContext) -> AssetSlice:
+        """Computes the slice of the target asset that must be fully evaluated this tick."""
+        if context.previous_evaluation_max_storage_id is None:
+            # on the first tick, evaluate all candidates, as you have no previous information
+            return context.candidate_slice
+        else:
+            # on subsequent ticks, only evaluate candidates if they were not evaluated on the
+            # previous tick, or have been updated since the previous tick, or have parents that
+            # have been updated since the previous tick
+            if context.previous_candidate_slice:
+                new_candidates = context.candidate_slice.compute_difference(
+                    context.previous_candidate_slice
+                )
+            else:
+                new_candidates = context.candidate_slice
+
+            # candidates that have updated since the previous tick
+            newly_updated_slice = context.asset_graph_view.compute_updated_since_cursor_slice(
+                asset_key=context.asset_key, cursor=context.previous_evaluation_max_storage_id
+            )
+            # candidates that have parents that have updated since the previous tick
+            parent_newly_updated_slice = (
+                context.asset_graph_view.compute_parent_updated_since_cursor_slice(
+                    asset_key=context.asset_key,
+                    cursor=context.previous_evaluation_max_storage_id,
+                )
+            )
+            updated_slice = newly_updated_slice.compute_union(parent_newly_updated_slice)
+
+            return new_candidates.compute_union(
+                context.candidate_slice.compute_intersection(updated_slice)
+            )
+
+    def evaluate(self, context: SchedulingContext):
+        slice_to_evaluate = self.compute_slice_to_evaluate(context)
+        new_parent_newer_slice = self.compute_parent_newer_slice(context, slice_to_evaluate)
+
+        if context.previous_evaluation_node and context.previous_evaluation_node.true_slice:
+            # combine new results calculated this tick with results from the previous tick
+            true_slice = context.previous_evaluation_node.true_slice.compute_difference(
+                slice_to_evaluate
+            ).compute_union(new_parent_newer_slice)
+        else:
+            true_slice = new_parent_newer_slice
+
+        return SchedulingResult.create(context, true_slice=true_slice)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
@@ -49,6 +49,31 @@ class InProgressSchedulingCondition(SliceSchedulingCondition):
 
 
 @whitelist_for_serdes
+class RequestedThisTickCondition(SliceSchedulingCondition):
+    @property
+    def description(self) -> str:
+        return "Will be requested this tick"
+
+    def _executable_with_root_context_key(self, context: SchedulingContext) -> bool:
+        # TODO: once we can launch backfills via the asset daemon, this can be removed
+        root_key = context.root_context.asset_key
+        return context.legacy_context.materializable_in_same_run(
+            child_key=root_key, parent_key=context.asset_key
+        )
+
+    def compute_slice(self, context: SchedulingContext) -> AssetSlice:
+        current_info = context.current_tick_evaluation_info_by_key.get(context.asset_key)
+        if (
+            current_info
+            and current_info.requested_slice
+            and self._executable_with_root_context_key(context)
+        ):
+            return current_info.requested_slice
+        else:
+            return context.asset_graph_view.create_empty_slice(context.asset_key)
+
+
+@whitelist_for_serdes
 class InLatestTimeWindowCondition(SliceSchedulingCondition):
     # This is a serializable representation of the lookback timedelta object
     lookback_days_second_microseconds: Optional[Tuple[int, int, int]] = None

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/updated_since_cron_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/updated_since_cron_condition.py
@@ -27,9 +27,10 @@ class UpdatedSinceCronCondition(AssetCondition):
         previous_cron_tick = self._get_previous_cron_tick(context)
 
         if (
-            # never evaluated
+            # never evaluated or evaluation info is no longer valid
             context.previous_evaluation_info is None
             or context.previous_evaluation_node is None
+            or context.previous_evaluation_node.true_slice is None
             # not evaluated since latest schedule tick
             or context.previous_evaluation_info.temporal_context.effective_dt < previous_cron_tick
             # has new set of candidates
@@ -46,7 +47,7 @@ class UpdatedSinceCronCondition(AssetCondition):
             )
             # TODO: implement this on the AssetGraphView
             true_slice = context.candidate_slice.compute_intersection(
-                context.asset_graph_view.get_asset_slice_from_subset(updated_subset)
+                context.asset_graph_view.get_asset_slice_from_valid_subset(updated_subset)
             )
         else:
             true_slice = context.previous_evaluation_node.true_slice

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/__init__.py
@@ -3,6 +3,7 @@ from .boolean_operators import (
     NotAssetCondition as NotAssetCondition,
     OrAssetCondition as OrAssetCondition,
 )
+from .child_condition import ChildCondition as ChildCondition
 from .dep_operators import (
     AllDepsCondition as AllDepsCondition,
     AnyDepsCondition as AnyDepsCondition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/boolean_operators.py
@@ -25,9 +25,9 @@ class AndAssetCondition(SchedulingCondition):
     def evaluate(self, context: SchedulingContext) -> SchedulingResult:
         child_results: List[SchedulingResult] = []
         true_slice = context.candidate_slice
-        for child in self.children:
+        for i, child in enumerate(self.children):
             child_context = context.for_child_condition(
-                child_condition=child, candidate_slice=true_slice
+                child_condition=child, child_index=i, candidate_slice=true_slice
             )
             child_result = child.evaluate(child_context)
             child_results.append(child_result)
@@ -53,9 +53,9 @@ class OrAssetCondition(SchedulingCondition):
     def evaluate(self, context: SchedulingContext) -> SchedulingResult:
         child_results: List[SchedulingResult] = []
         true_slice = context.asset_graph_view.create_empty_slice(context.asset_key)
-        for child in self.children:
+        for i, child in enumerate(self.children):
             child_context = context.for_child_condition(
-                child_condition=child, candidate_slice=context.candidate_slice
+                child_condition=child, child_index=i, candidate_slice=context.candidate_slice
             )
             child_result = child.evaluate(child_context)
             child_results.append(child_result)
@@ -81,7 +81,7 @@ class NotAssetCondition(SchedulingCondition):
 
     def evaluate(self, context: SchedulingContext) -> SchedulingResult:
         child_context = context.for_child_condition(
-            child_condition=self.operand, candidate_slice=context.candidate_slice
+            child_condition=self.operand, child_index=0, candidate_slice=context.candidate_slice
         )
         child_result = self.operand.evaluate(child_context)
         true_slice = context.candidate_slice.compute_difference(child_result.true_slice)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/child_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/child_condition.py
@@ -1,0 +1,107 @@
+from collections import defaultdict
+from typing import AbstractSet, Sequence, Tuple
+
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.declarative_scheduling.operators.boolean_operators import (
+    OrAssetCondition,
+)
+
+from ..scheduling_condition import SchedulingCondition, SchedulingResult
+from ..scheduling_context import SchedulingContext
+
+
+class ChildConditionWrapperCondition(SchedulingCondition):
+    """Wrapper object which holds a reference to a condition which is shared by one or more
+    children of the target asset.
+    """
+
+    child_keys: AbstractSet[AssetKey]
+    operand: SchedulingCondition
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Condition of {', '.join([key.to_user_string() for key in sorted(self.child_keys)])}"
+        )
+
+    def evaluate(self, context: SchedulingContext) -> SchedulingResult:
+        child_context = context.for_child_condition(
+            child_condition=self.operand, child_index=0, candidate_slice=context.candidate_slice
+        )
+        child_result = self.operand.evaluate(child_context)
+        return SchedulingResult.create_from_children(
+            context=context, true_slice=child_result.true_slice, child_results=[child_result]
+        )
+
+
+class ChildCondition(SchedulingCondition):
+    """Condition which will represent the union of all child conditions."""
+
+    @property
+    def description(self) -> str:
+        return "Any SchedulingCondition applied to a child"
+
+    def _get_child_keys_with_condition(
+        self, context: SchedulingContext
+    ) -> Sequence[Tuple[AbstractSet[AssetKey], SchedulingCondition]]:
+        condition_by_tree_unique_id = {}
+        asset_keys_by_tree_unique_id = defaultdict(set)
+
+        def _find_reference_conditions(key: AssetKey) -> None:
+            # helper function which recursively finds all conditions to wrap
+            policy = context.asset_graph.get(key).auto_materialize_policy
+            condition = policy.to_scheduling_condition() if policy else None
+            if condition is None:
+                return
+            elif isinstance(condition, ChildCondition):
+                # do not wrap ChildConditions, just recurse
+                for child_key in context.asset_graph.get(key).child_keys:
+                    _find_reference_conditions(child_key)
+            else:
+                # found a non-ChildCondition to wrap
+                unique_id = condition.get_tree_unique_id()
+                condition_by_tree_unique_id[unique_id] = condition
+                asset_keys_by_tree_unique_id[unique_id].add(key)
+
+        _find_reference_conditions(context.asset_key)
+
+        return [
+            (keys, condition_by_tree_unique_id[uid])
+            for uid, keys in asset_keys_by_tree_unique_id.items()
+        ]
+
+    def evaluate(self, context: SchedulingContext) -> SchedulingResult:
+        child_conditions = self._get_child_keys_with_condition(context)
+        if len(child_conditions) == 0:
+            # no children, so empty result
+            return SchedulingResult.create(
+                context,
+                true_slice=context.asset_graph_view.create_empty_slice(context.asset_key),
+            )
+        elif len(child_conditions) == 1:
+            # only need to wrap a single child condition
+            child_keys, child_condition = child_conditions[0]
+            wrapped_condition = ChildConditionWrapperCondition(
+                child_keys=child_keys, operand=child_condition
+            )
+        else:
+            # need to wrap multiple child conditions in an OR
+            child_wrappers = sorted(
+                (
+                    ChildConditionWrapperCondition(child_keys=child_keys, operand=child_condition)
+                    for child_keys, child_condition in sorted(child_conditions)
+                ),
+                key=lambda x: sorted(x.child_keys),
+            )
+            wrapped_condition = OrAssetCondition(operands=child_wrappers)
+
+        # evaluate the wrapped condition
+        wrapped_context = context.for_child_condition(
+            child_condition=wrapped_condition,
+            child_index=0,
+            candidate_slice=context.candidate_slice,
+        )
+        wrapped_result = wrapped_condition.evaluate(wrapped_context)
+        return SchedulingResult.create_from_children(
+            context, true_slice=wrapped_result.true_slice, child_results=[wrapped_result]
+        )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/dep_operators.py
@@ -1,7 +1,6 @@
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._serdes.serdes import whitelist_for_serdes
 
-from ..legacy.asset_condition import AssetCondition
 from ..scheduling_condition import SchedulingCondition, SchedulingResult
 from ..scheduling_context import SchedulingContext
 
@@ -36,10 +35,12 @@ class DepConditionWrapperCondition(SchedulingCondition):
         )
 
 
-@whitelist_for_serdes
-class AnyDepsCondition(AssetCondition):
+class DepCondition(SchedulingCondition):
     operand: SchedulingCondition
 
+
+@whitelist_for_serdes
+class AnyDepsCondition(DepCondition):
     @property
     def description(self) -> str:
         return "Any deps"
@@ -66,9 +67,7 @@ class AnyDepsCondition(AssetCondition):
 
 
 @whitelist_for_serdes
-class AllDepsCondition(SchedulingCondition):
-    operand: SchedulingCondition
-
+class AllDepsCondition(DepCondition):
     @property
     def description(self) -> str:
         return "All deps"

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/dep_operators.py
@@ -22,7 +22,7 @@ class DepConditionWrapperCondition(SchedulingCondition):
         # only evaluate parents of the current candidates
         dep_candidate_slice = context.candidate_slice.compute_parent_slice(self.dep_key)
         dep_context = context.for_child_condition(
-            child_condition=self.operand, candidate_slice=dep_candidate_slice
+            child_condition=self.operand, child_index=0, candidate_slice=dep_candidate_slice
         )
 
         # evaluate condition against the dependency
@@ -50,11 +50,13 @@ class AnyDepsCondition(DepCondition):
         true_slice = context.asset_graph_view.create_empty_slice(context.asset_key)
 
         dep_keys = context.asset_graph_view.asset_graph.get(context.asset_key).parent_keys
-        for dep_key in dep_keys:
+        for i, dep_key in enumerate(sorted(dep_keys)):
             dep_condition = DepConditionWrapperCondition(dep_key=dep_key, operand=self.operand)
             dep_result = dep_condition.evaluate(
                 context.for_child_condition(
-                    child_condition=dep_condition, candidate_slice=context.candidate_slice
+                    child_condition=dep_condition,
+                    child_index=i,
+                    candidate_slice=context.candidate_slice,
                 )
             )
             dep_results.append(dep_result)
@@ -77,11 +79,13 @@ class AllDepsCondition(DepCondition):
         true_slice = context.candidate_slice
 
         dep_keys = context.asset_graph_view.asset_graph.get(context.asset_key).parent_keys
-        for dep_key in dep_keys:
+        for i, dep_key in enumerate(sorted(dep_keys)):
             dep_condition = DepConditionWrapperCondition(dep_key=dep_key, operand=self.operand)
             dep_result = dep_condition.evaluate(
                 context.for_child_condition(
-                    child_condition=dep_condition, candidate_slice=context.candidate_slice
+                    child_condition=dep_condition,
+                    child_index=i,
+                    candidate_slice=context.candidate_slice,
                 )
             )
             dep_results.append(dep_result)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
         InLatestTimeWindowCondition,
         InProgressSchedulingCondition,
         MissingSchedulingCondition,
+        RequestedThisTickCondition,
     )
     from .operators import (
         AllDepsCondition,
@@ -130,6 +131,13 @@ class SchedulingCondition(ABC, DagsterModel):
         from .operands import InLatestTimeWindowCondition
 
         return InLatestTimeWindowCondition.from_lookback_delta(lookback_delta)
+
+    @staticmethod
+    def requested_this_tick() -> "RequestedThisTickCondition":
+        """Returns a SchedulingCondition that is true for an asset partition if it will be requested this tick."""
+        from .operands import RequestedThisTickCondition
+
+        return RequestedThisTickCondition()
 
 
 class SchedulingResult(DagsterModel):

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
         InLatestTimeWindowCondition,
         InProgressSchedulingCondition,
         MissingSchedulingCondition,
+        ParentNewerCondition,
         RequestedThisTickCondition,
     )
     from .operators import (
@@ -138,6 +139,13 @@ class SchedulingCondition(ABC, DagsterModel):
         from .operands import RequestedThisTickCondition
 
         return RequestedThisTickCondition()
+
+    @staticmethod
+    def parent_newer() -> "ParentNewerCondition":
+        """Returns a SchedulingCondition that is true for an asset partition if at least one of its parents is newer."""
+        from .operands import ParentNewerCondition
+
+        return ParentNewerCondition()
 
 
 class SchedulingResult(DagsterModel):

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
@@ -129,9 +129,7 @@ class SchedulingCondition(ABC, DagsterModel):
         """
         from .operands import InLatestTimeWindowCondition
 
-        return InLatestTimeWindowCondition(
-            lookback_seconds=lookback_delta.total_seconds() if lookback_delta else None
-        )
+        return InLatestTimeWindowCondition.from_lookback_delta(lookback_delta)
 
 
 class SchedulingResult(DagsterModel):

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
@@ -52,9 +52,9 @@ class SchedulingCondition(ABC, DagsterModel):
             unique_id=unique_id,
         )
 
-    def get_unique_id(self, parent_unique_id: Optional[str]) -> str:
+    def get_unique_id(self, *, parent_unique_id: Optional[str], index: Optional[int]) -> str:
         """Returns a unique identifier for this condition within the broader condition tree."""
-        parts = [str(parent_unique_id), self.__class__.__name__, self.description]
+        parts = [str(parent_unique_id), str(index), self.__class__.__name__, self.description]
         return non_secure_md5_hash_str("".join(parts).encode())
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
@@ -23,8 +23,8 @@ class SchedulingEvaluationResultNode(DagsterModel):
     asset_key: AssetKey
     condition_unique_id: str
 
-    true_slice: AssetSlice
-    candidate_slice: AssetSlice
+    true_slice: Optional[AssetSlice]
+    candidate_slice: Optional[AssetSlice]
     subsets_with_metadata: Sequence[AssetSubsetWithMetadata]
 
     extra_state: Any

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
@@ -67,6 +67,7 @@ class SchedulingEvaluationInfo(DagsterModel):
 
     temporal_context: TemporalContext
     evaluation_nodes: Sequence[SchedulingEvaluationResultNode]
+    requested_slice: Optional[AssetSlice]
 
     def get_evaluation_node(self, unique_id: str) -> Optional[SchedulingEvaluationResultNode]:
         for node in self.evaluation_nodes:
@@ -87,4 +88,9 @@ class SchedulingEvaluationInfo(DagsterModel):
         nodes = SchedulingEvaluationResultNode.nodes_for_evaluation(
             asset_graph_view, state, state.previous_evaluation
         )
-        return SchedulingEvaluationInfo(temporal_context=temporal_context, evaluation_nodes=nodes)
+        requested_slice = asset_graph_view.get_asset_slice_from_subset(state.true_subset)
+        return SchedulingEvaluationInfo(
+            temporal_context=temporal_context,
+            evaluation_nodes=nodes,
+            requested_slice=requested_slice,
+        )

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -911,6 +911,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
 
     def get_parent_asset_partitions_updated_after_child(
         self,
+        *,
         asset_partition: AssetKeyPartitionKey,
         parent_asset_partitions: AbstractSet[AssetKeyPartitionKey],
         respect_materialization_data_versions: bool,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
@@ -54,6 +54,7 @@ class FalseAssetCondition(SchedulingCondition):
 @dataclass(frozen=True)
 class AssetConditionScenarioState(ScenarioState):
     asset_condition: Optional[SchedulingCondition] = None
+    ensure_empty_result: bool = True
     previous_evaluation_state: Optional[AssetConditionEvaluationState] = None
     requested_asset_partitions: Optional[Sequence[AssetKeyPartitionKey]] = None
 
@@ -84,8 +85,12 @@ class AssetConditionScenarioState(ScenarioState):
         asset_key = AssetKey.from_coercible(asset)
         # ensure that the top level condition never returns any asset partitions, as otherwise the
         # next evaluation will assume that those asset partitions were requested by the machinery
-        asset_condition = AndAssetCondition(
-            operands=[check.not_none(self.asset_condition), FalseAssetCondition()]
+        asset_condition = (
+            AndAssetCondition(
+                operands=[check.not_none(self.asset_condition), FalseAssetCondition()]
+            )
+            if self.ensure_empty_result
+            else check.not_none(self.asset_condition)
         )
         asset_graph = self.scenario_spec.with_asset_properties(
             asset,
@@ -142,7 +147,7 @@ class AssetConditionScenarioState(ScenarioState):
                 ),
             )
 
-        return new_state, full_result.child_results[0]
+        return new_state, full_result.child_results[0] if self.ensure_empty_result else full_result
 
     def without_previous_evaluation_state(self) -> "AssetConditionScenarioState":
         """Removes the previous evaluation state from the state. This is useful for testing

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_child_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_child_condition.py
@@ -1,0 +1,93 @@
+from typing import Optional
+
+import pytest
+from dagster import AutoMaterializePolicy, SchedulingCondition
+
+from ..scenario_specs import diamond
+from .asset_condition_scenario import AssetConditionScenarioState
+
+
+@pytest.mark.parametrize(
+    "b_condition, c_condition, d_condition, expected_child_descriptions",
+    [
+        (None, None, None, []),
+        (None, None, SchedulingCondition.missing(), []),
+        (None, SchedulingCondition.missing(), None, ["Condition of C"]),
+        (
+            SchedulingCondition.missing(),
+            SchedulingCondition.missing(),
+            None,
+            ["Condition of B, C"],
+        ),
+        (
+            SchedulingCondition.eager(),
+            SchedulingCondition.eager(),
+            None,
+            ["Condition of B, C"],
+        ),
+        (
+            SchedulingCondition.eager(),
+            SchedulingCondition.missing(),
+            None,
+            ["Condition of B", "Condition of C"],
+        ),
+        # recursive child condition
+        (
+            SchedulingCondition.child_condition(),
+            SchedulingCondition.child_condition(),
+            SchedulingCondition.missing(),
+            ["Condition of D"],
+        ),
+        (
+            SchedulingCondition.child_condition(),
+            SchedulingCondition.child_condition(),
+            None,
+            [],
+        ),
+        (
+            SchedulingCondition.child_condition(),
+            SchedulingCondition.missing(),
+            SchedulingCondition.missing(),
+            ["Condition of C, D"],
+        ),
+        (
+            SchedulingCondition.child_condition(),
+            SchedulingCondition.missing(),
+            SchedulingCondition.eager(),
+            ["Condition of C", "Condition of D"],
+        ),
+    ],
+)
+def test_child_condition(
+    b_condition: Optional[SchedulingCondition],
+    c_condition: Optional[SchedulingCondition],
+    d_condition: Optional[SchedulingCondition],
+    expected_child_descriptions,
+) -> None:
+    b_policy, c_policy, d_policy = (
+        AutoMaterializePolicy.from_asset_condition(c) if c else None
+        for c in [b_condition, c_condition, d_condition]
+    )
+
+    state = (
+        AssetConditionScenarioState(
+            diamond,
+            asset_condition=SchedulingCondition.child_condition(),
+            ensure_empty_result=False,
+        )
+        .with_asset_properties("B", auto_materialize_policy=b_policy)
+        .with_asset_properties("C", auto_materialize_policy=c_policy)
+        .with_asset_properties("D", auto_materialize_policy=d_policy)
+    )
+
+    state, result = state.evaluate("A")
+    child_results = result.child_results
+    if len(expected_child_descriptions) > 1:
+        # If there are multiple children, the child results are nested under an OR
+        assert len(child_results) == 1
+        or_result = next(iter(child_results))
+        assert or_result.condition.description == "Any of"
+        child_results = or_result.child_results
+    assert len(child_results) == len(expected_child_descriptions)
+    for child_result, expected_description in zip(child_results, expected_child_descriptions):
+        assert expected_description in child_result.condition.description

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
@@ -1,3 +1,4 @@
+import dagster._check as check
 import pytest
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_subset import AssetSubset
@@ -35,9 +36,11 @@ def get_hardcoded_condition():
             ).partitions_def
             return SchedulingResult.create(
                 context,
-                true_slice=context.asset_graph_view.get_asset_slice_from_subset(
-                    AssetSubset.from_asset_partitions_set(
-                        context.asset_key, partitions_def, true_candidates
+                true_slice=check.not_none(
+                    context.asset_graph_view.get_asset_slice_from_subset(
+                        AssetSubset.from_asset_partitions_set(
+                            context.asset_key, partitions_def, true_candidates
+                        )
                     )
                 ),
             )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
@@ -1,0 +1,103 @@
+import datetime
+
+from dagster import AutoMaterializePolicy, Definitions, asset
+from dagster._core.definitions.declarative_scheduling.legacy.asset_condition import (
+    AssetCondition,
+)
+from dagster._core.definitions.declarative_scheduling.serialized_objects import (
+    AssetConditionEvaluation,
+)
+from dagster._core.remote_representation.external_data import external_repository_data_from_def
+from dagster._serdes import serialize_value
+from dagster._serdes.serdes import deserialize_value
+
+from ..base_scenario import run_request
+from ..scenario_specs import (
+    daily_partitions_def,
+    day_partition_key,
+    one_asset,
+    time_partitions_start_datetime,
+)
+from .asset_condition_scenario import AssetConditionScenarioState
+
+
+def test_missing_unpartitioned() -> None:
+    state = AssetConditionScenarioState(one_asset, asset_condition=AssetCondition.missing())
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+    evaluation1 = deserialize_value(
+        serialize_value(AssetConditionEvaluation.from_result(result)), AssetConditionEvaluation
+    )
+
+    # still true
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+    evaluation2 = AssetConditionEvaluation.from_result(result)
+
+    assert evaluation2.equivalent_to_stored_evaluation(evaluation1)
+
+    # after a run of A it's now False
+    state, result = state.with_runs(run_request("A")).evaluate("A")
+    assert result.true_subset.size == 0
+
+    # if we evaluate from scratch, it's also False
+    _, result = state.without_previous_evaluation_state().evaluate("A")
+    assert result.true_subset.size == 0
+
+
+def test_missing_time_partitioned() -> None:
+    state = (
+        AssetConditionScenarioState(one_asset, asset_condition=AssetCondition.missing())
+        .with_asset_properties(partitions_def=daily_partitions_def)
+        .with_current_time(time_partitions_start_datetime)
+        .with_current_time_advanced(days=6, minutes=1)
+    )
+
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 6
+
+    # still true
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 6
+
+    # after two runs of A those partitions are now False
+    state, result = state.with_runs(
+        run_request("A", day_partition_key(time_partitions_start_datetime, 2)),
+        run_request("A", day_partition_key(time_partitions_start_datetime, 3)),
+    ).evaluate("A")
+    assert result.true_subset.size == 4
+
+    # result is stable
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 4
+
+    # if the partitions definition changes, then we have 1 fewer missing partition
+    state = state.with_asset_properties(
+        partitions_def=daily_partitions_def._replace(
+            start=time_partitions_start_datetime + datetime.timedelta(days=1)
+        )
+    )
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 3
+
+    # if we evaluate from scratch, get the same answer
+    _, result = state.without_previous_evaluation_state().evaluate("A")
+    assert result.true_subset.size == 3
+
+
+def test_serialize_definitions_with_asset_condition():
+    amp = AutoMaterializePolicy.from_asset_condition(
+        AssetCondition.parent_newer() & ~AssetCondition.updated_since_cron("0 * * * *")
+    )
+
+    @asset(auto_materialize_policy=amp)
+    def my_asset():
+        return 0
+
+    result = serialize_value(
+        external_repository_data_from_def(Definitions(assets=[my_asset]).get_repository_def())
+    )
+    assert isinstance(result, str)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_parent_newer_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_parent_newer_condition.py
@@ -1,0 +1,90 @@
+from dagster import SchedulingCondition
+
+from ..base_scenario import run_request
+from ..scenario_specs import one_asset_depends_on_two, two_partitions_def
+from .asset_condition_scenario import AssetConditionScenarioState
+
+
+def test_parent_newer_unpartitioned() -> None:
+    state = AssetConditionScenarioState(
+        one_asset_depends_on_two, asset_condition=SchedulingCondition.parent_newer()
+    )
+
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 0
+
+    state = state.with_runs(run_request("A"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+    # now C is refreshed, so no longer any newer parents
+    state = state.with_runs(run_request("C"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 0
+
+    # B and C updated -> C still newer
+    state = state.with_runs(run_request("B"))
+    state = state.with_runs(run_request("C"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 0
+
+    # C and B updated -> now B is newer
+    state = state.with_runs(run_request("C"))
+    state = state.with_runs(run_request("B"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+    # recalculate from scratch, B is still newer
+    state = state.without_previous_evaluation_state()
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+
+def test_parent_newer_partitioned() -> None:
+    state = AssetConditionScenarioState(
+        one_asset_depends_on_two, asset_condition=SchedulingCondition.parent_newer()
+    ).with_asset_properties(partitions_def=two_partitions_def)
+
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 0
+
+    state = state.with_runs(run_request("A", "1"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+    # same partition materialized again
+    state = state.with_runs(run_request("A", "1"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+    # different partition materialized, still upstream of C 1
+    state = state.with_runs(run_request("B", "1"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+    # C 2 upstream materialized
+    state = state.with_runs(run_request("B", "2"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 2
+
+    # C 1 materialized, only C 2 has a newer parent
+    state = state.with_runs(run_request("C", "1"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+    # B 1, C 1 materialized, only C 2 has a newer parent
+    state = state.with_runs(run_request("B", "1"))
+    state = state.with_runs(run_request("C", "1"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 1
+
+    # C 1, B 1 materialized, both have newer parents
+    state = state.with_runs(run_request("C", "1"))
+    state = state.with_runs(run_request("B", "1"))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 2
+
+    # recalculate from scratch, both still have newer parents
+    state = state.without_previous_evaluation_state()
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == 2

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_will_be_requested_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_will_be_requested_condition.py
@@ -1,0 +1,66 @@
+from dagster import AssetKey, SchedulingCondition
+from dagster._core.definitions.events import AssetKeyPartitionKey
+
+from ..scenario_specs import two_assets_in_sequence, two_partitions_def
+from .asset_condition_scenario import AssetConditionScenarioState
+
+
+def test_will_be_requested_unpartitioned() -> None:
+    condition = SchedulingCondition.any_deps_match(SchedulingCondition.requested_this_tick())
+    state = AssetConditionScenarioState(two_assets_in_sequence, asset_condition=condition)
+
+    # no requested parents
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # parent is requested
+    state = state.with_requested_asset_partitions([AssetKeyPartitionKey(AssetKey("A"))])
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 1
+
+
+def test_will_be_requested_static_partitioned() -> None:
+    condition = SchedulingCondition.any_deps_match(SchedulingCondition.requested_this_tick())
+    state = AssetConditionScenarioState(
+        two_assets_in_sequence, asset_condition=condition
+    ).with_asset_properties(partitions_def=two_partitions_def)
+
+    # no requested parents
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # one requested parent
+    state = state.with_requested_asset_partitions([AssetKeyPartitionKey(AssetKey("A"), "1")])
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 1
+    assert result.true_subset.asset_partitions == {AssetKeyPartitionKey(AssetKey("B"), "1")}
+
+    # two requested parents
+    state = state.with_requested_asset_partitions(
+        [AssetKeyPartitionKey(AssetKey("A"), "1"), AssetKeyPartitionKey(AssetKey("A"), "2")]
+    )
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 2
+
+
+def test_will_be_requested_different_partitions() -> None:
+    condition = SchedulingCondition.any_deps_match(SchedulingCondition.requested_this_tick())
+    state = AssetConditionScenarioState(
+        two_assets_in_sequence, asset_condition=condition
+    ).with_asset_properties("A", partitions_def=two_partitions_def)
+
+    # no requested parents
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # one requested parent, but can't execute in same run
+    state = state.with_requested_asset_partitions([AssetKeyPartitionKey(AssetKey("A"), "1")])
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # two requested parents, but can't execute in same run
+    state = state.with_requested_asset_partitions(
+        [AssetKeyPartitionKey(AssetKey("A"), "1"), AssetKeyPartitionKey(AssetKey("A"), "2")]
+    )
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0


### PR DESCRIPTION
## Summary & Motivation

Going to leave this as a draft for a bit.

This creates a condition which resolves to the union of any conditions set on a child.

The implementation as it is right now should change, but there is a bit of complication involved in the recursive case. Essentially, imagine you have the following setup (A -> B -> C):

A's condition: SchedulingCondition.child_condition()

B's condition: SchedulingCondition.child_condition() | SchedulingCondition.foo()

C's condition: SchedulingCondition.bar()

I think it's pretty natural to expect that A's condition would end up resolving to the result bar() | foo(). However, this would mean that we'd need some concept of a "resolved form" of B's condition so that we don't end up in a situation where we just do a naive copy of B's condition, resulting in `child_condition() | foo()`, which resolves to `child_condition() | foo() | foo()`, and so on.

This resolving operation would need to happen arbitrarily deep within a top-level condition, which means we'd need some method like `with_resolved_child_condtions()`. All of this seemed like a fairly large amount of machinery for a prototype PR, and the only additional ability it would enable would be the possibility of nesting these child_conditions in broader expressions.

I *do* think that is a useful ability, and so I think that design space should be explored in the future, but for now I think it's sufficient to just make it "illegal" to combine child_condition with any of the existing operands.

## How I Tested These Changes
