### PR TITLE
add object profiling script

### DIFF
--- a/scripts/object_profile.py
+++ b/scripts/object_profile.py
@@ -1,0 +1,76 @@
+# ruff: noqa: T201
+import cProfile
+import subprocess
+import timeit
+from tempfile import TemporaryDirectory
+
+import memray  # type: ignore
+from dagster import AssetKey
+
+# This script provides a way to measure the performance of instantiating an object.
+#
+# An example of when this is useful is measuring the impact of changing the backing class
+# for a model object from a NamedTuple to a dataclass or pydantic model (DagsterModel).
+
+
+def make_one(i: int = 0):
+    """Create an instance of the object you want to profile."""
+    return AssetKey(f"key_{i}")
+
+
+def make_n(n: int):
+    things = []
+    for i in range(n):
+        things.append(make_one(i))
+    return things
+
+
+def cpu_profile(n: int):
+    print(f"cProfile results for creating {n} objects:\n")
+    with cProfile.Profile() as pr:
+        make_n(n)
+    pr.print_stats(sort="cumtime")
+
+
+def mem_profile(n: int):
+    print(f"memray results for creating {n} objects:\n")
+    with TemporaryDirectory() as d:
+        f_name = d + "/memray.log"
+        with memray.Tracker(f_name):
+            _ = make_n(n)
+
+        subprocess.run(["memray", "summary", f_name], check=False)
+    print("\n")
+
+
+def timing() -> int:
+    repeat = 5
+
+    print("timeit results:\n")
+    t = timeit.Timer(globals=globals(), stmt="make_one()")
+    number, _ = t.autorange()
+    raw_timings = t.repeat(repeat=repeat, number=number)
+
+    print(
+        f"best of {repeat} trials of {number} calls of make_one(): {fmt_time(min(raw_timings) / number)} per call\n"
+    )
+    return number
+
+
+def fmt_time(seconds):
+    if seconds < 1e-6:
+        return f"{seconds * 1e9:.2f} ns"
+    elif seconds < 1e-3:
+        return f"{seconds * 1e6:.2f} μs"
+    elif seconds < 1:
+        return f"{seconds * 1e3:.2f} ms"
+    else:
+        return f"{seconds:.2f} s"
+
+
+if __name__ == "__main__":
+    n = 50_000
+    print(f"\nObject profiling for target {make_one()=}\n")
+    cpu_profile(n)
+    mem_profile(n)
+    timing()


### PR DESCRIPTION
Doing a bunch of profiling recently, this script captures what I think is a good set of measurements to check.

## How I Tested These Changes

output:
```

Object profiling for target make_one()=AssetKey(['key_0'])

cProfile results for creating 50000 objects:

         300003 function calls in 0.106 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.013    0.013    0.106    0.106 object_profile.py:20(make_n)
    50000    0.015    0.000    0.092    0.000 object_profile.py:15(make_one)
    50000    0.021    0.000    0.077    0.000 asset_key.py:42(__new__)
    50000    0.006    0.000    0.055    0.000 <string>:1(<lambda>)
    50000    0.049    0.000    0.049    0.000 {built-in method __new__ of type object at 0x103977ca8}
    50000    0.002    0.000    0.002    0.000 {built-in method builtins.isinstance}
    50000    0.002    0.000    0.002    0.000 {method 'append' of 'list' objects}
        1    0.000    0.000    0.000    0.000 cProfile.py:118(__exit__)
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}


memray results for creating 50000 objects:

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃                                                                                      ┃                  ┃                 ┃                 ┃                 ┃      Allocation ┃
┃ Location                                                                             ┃   <Total Memory> ┃  Total Memory % ┃      Own Memory ┃    Own Memory % ┃           Count ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│ mem_profile at /Users/alangenfeld/dagster/scripts/object_profile.py                  │          8.424MB │         100.00% │          0.000B │           0.00% │               9 │
│ make_one at /Users/alangenfeld/dagster/scripts/object_profile.py                     │          7.000MB │          83.10% │         7.000MB │          83.10% │               7 │
│ __new__ at                                                                           │          1.000MB │          11.87% │         1.000MB │          11.87% │               1 │
│ /Users/alangenfeld/dagster/python_modules/dagster/dagster/_core/definitions/asset_k… │                  │                 │                 │                 │                 │
│ make_n at /Users/alangenfeld/dagster/scripts/object_profile.py                       │        433.906KB │           5.03% │       433.906KB │           5.03% │               1 │
└──────────────────────────────────────────────────────────────────────────────────────┴──────────────────┴─────────────────┴─────────────────┴─────────────────┴─────────────────┘


timeit results:

best of 5 trials of 1000000 calls of make_one(): 324.54 ns per call

```
