### PR TITLE
[DS] Force rule condition into whitelist_for_serdes

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -1,12 +1,8 @@
 from enum import Enum
-from typing import AbstractSet, Dict, FrozenSet, NamedTuple, Optional, Sequence
+from typing import TYPE_CHECKING, AbstractSet, Dict, FrozenSet, NamedTuple, Optional, Sequence
 
 import dagster._check as check
 from dagster._annotations import deprecated, experimental, public
-from dagster._core.definitions.auto_materialize_rule import (
-    AutoMaterializeRule,
-    AutoMaterializeRuleSnapshot,
-)
 from dagster._core.definitions.declarative_scheduling.scheduling_condition import (
     SchedulingCondition,
 )
@@ -17,11 +13,19 @@ from dagster._serdes.serdes import (
     whitelist_for_serdes,
 )
 
+if TYPE_CHECKING:
+    from dagster._core.definitions.auto_materialize_rule import (
+        AutoMaterializeRule,
+        AutoMaterializeRuleSnapshot,
+    )
+
 
 class AutoMaterializePolicySerializer(NamedTupleSerializer):
     def before_unpack(
         self, context: UnpackContext, unpacked_dict: Dict[str, UnpackedValue]
     ) -> Dict[str, UnpackedValue]:
+        from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
+
         backcompat_map = {
             "on_missing": AutoMaterializeRule.materialize_on_missing(),
             "on_new_parent_data": AutoMaterializeRule.materialize_on_parent_updated(),
@@ -59,7 +63,7 @@ class AutoMaterializePolicy(
     NamedTuple(
         "_AutoMaterializePolicy",
         [
-            ("rules", FrozenSet[AutoMaterializeRule]),
+            ("rules", FrozenSet["AutoMaterializeRule"]),
             ("max_materializations_per_minute", Optional[int]),
             ("asset_condition", Optional[SchedulingCondition]),
         ],

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
@@ -1,3 +1,4 @@
+from .legacy import RuleCondition as RuleCondition
 from .legacy.asset_condition import AssetCondition as AssetCondition
 from .operands import (
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,
@@ -12,3 +13,9 @@ from .operators import (
     OrAssetCondition as OrAssetCondition,
 )
 from .scheduling_condition import SchedulingCondition as SchedulingCondition
+from .serialized_objects import (
+    AssetConditionEvaluationState as AssetConditionEvaluationState,
+    AssetConditionSnapshot as AssetConditionSnapshot,
+    AssetSubsetWithMetadata as AssetSubsetWithMetadata,
+    HistoricalAllPartitionsSubsetSentinel as HistoricalAllPartitionsSubsetSentinel,
+)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/__init__.py
@@ -1,0 +1,1 @@
+from .rule_condition import RuleCondition as RuleCondition

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_asset_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_asset_condition.py
@@ -1,7 +1,4 @@
-from dagster import AutoMaterializePolicy, Definitions, asset
-from dagster._core.definitions.declarative_scheduling.legacy.asset_condition import (
-    AssetCondition,
-)
+from dagster import AssetCondition, AutoMaterializePolicy, Definitions, asset
 from dagster._core.definitions.declarative_scheduling.serialized_objects import (
     AssetConditionEvaluation,
 )
@@ -73,16 +70,26 @@ def test_missing_time_partitioned() -> None:
     assert result.true_subset.size == 4
 
 
-def test_serialize_definitions_with_asset_condition():
+def test_serialize_definitions_with_asset_condition() -> None:
     amp = AutoMaterializePolicy.from_asset_condition(
         AssetCondition.parent_newer() & ~AssetCondition.updated_since_cron("0 * * * *")
     )
 
     @asset(auto_materialize_policy=amp)
-    def my_asset():
+    def my_asset() -> int:
         return 0
 
-    result = serialize_value(
+    serialized = serialize_value(amp)
+    assert isinstance(serialized, str)
+
+    serialized = serialize_value(
         external_repository_data_from_def(Definitions(assets=[my_asset]).get_repository_def())
     )
-    assert isinstance(result, str)
+    assert isinstance(serialized, str)
+
+
+def test_deserialize_definitions_with_asset_condition() -> None:
+    serialized = """{"__class__": "AutoMaterializePolicy", "asset_condition": {"__class__": "AndAssetCondition", "operands": [{"__class__": "RuleCondition", "rule": {"__class__": "MaterializeOnParentUpdatedRule", "updated_parent_filter": null}}, {"__class__": "NotAssetCondition", "operand": {"__class__": "NotAssetCondition", "operand": {"__class__": "RuleCondition", "rule": {"__class__": "MaterializeOnCronRule", "all_partitions": false, "cron_schedule": "0 * * * *", "timezone": "UTC"}}}}]}, "max_materializations_per_minute": null, "rules": {"__frozenset__": []}, "time_window_partition_scope_minutes": 1e-06}"""
+
+    deserialized = deserialize_value(serialized, AutoMaterializePolicy)
+    assert isinstance(deserialized, AutoMaterializePolicy)


### PR DESCRIPTION
## Summary & Motivation

We need to force this file to be imported on module load, otherwise this will not be crawled as part of the whitelist.

I don't think the serialized_objects things are actually necessary to import here (as they're imported via other paths), but added them just to be safe

## How I Tested These Changes
