### PR TITLE
Convert all Pipes clients to use TreatAsResourceParam

### DIFF
--- a/docs/sphinx/sections/api/apidocs/pipes.rst
+++ b/docs/sphinx/sections/api/apidocs/pipes.rst
@@ -32,5 +32,3 @@ Abstractions for the orchestration side of the Dagster Pipes protocol.
 .. autofunction:: open_pipes_session
 
 .. currentmodule:: dagster._core.pipes.subprocess
-
-.. autoclass:: _PipesSubprocess

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -7,7 +7,7 @@ from dagster_pipes import PipesExtras
 
 from dagster import _check as check
 from dagster._annotations import experimental, public
-from dagster._core.definitions.resource_annotation import UsableAsResourceParam
+from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.errors import DagsterExecutionInterruptedError, DagsterPipesExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
@@ -24,7 +24,7 @@ from dagster._core.pipes.utils import (
 
 
 @experimental
-class PipesSubprocessClient(PipesClient, UsableAsResourceParam):
+class PipesSubprocessClient(PipesClient, TreatAsResourceParam):
     """A pipes client that runs a subprocess with the given command and environment.
 
     By default parameters are injected via environment variables. Context is passed via

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -7,7 +7,7 @@ from dagster_pipes import PipesExtras
 
 from dagster import _check as check
 from dagster._annotations import experimental, public
-from dagster._core.definitions.resource_annotation import ResourceParam
+from dagster._core.definitions.resource_annotation import UsableAsResourceParam
 from dagster._core.errors import DagsterExecutionInterruptedError, DagsterPipesExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
@@ -24,7 +24,7 @@ from dagster._core.pipes.utils import (
 
 
 @experimental
-class _PipesSubprocess(PipesClient):
+class PipesSubprocessClient(PipesClient, UsableAsResourceParam):
     """A pipes client that runs a subprocess with the given command and environment.
 
     By default parameters are injected via environment variables. Context is passed via
@@ -134,6 +134,3 @@ class _PipesSubprocess(PipesClient):
                 raise
 
         return PipesClientCompletedInvocation(pipes_session)
-
-
-PipesSubprocessClient = ResourceParam[_PipesSubprocess]

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -554,7 +554,7 @@ def test_get_stats_from_external_repo_pipes_client(instance):
     )
     stats = get_stats_from_external_repo(external_repo)
     assert stats["dagster_resources"] == [
-        {"module_name": "dagster", "class_name": "_PipesSubprocess"}
+        {"module_name": "dagster", "class_name": "PipesSubprocessClient"}
     ]
     assert stats["has_custom_resources"] == "False"
 

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/in_process_client.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from typing import Callable, Iterator, List, Optional
 
 from dagster._annotations import public
-from dagster._core.definitions.resource_annotation import ResourceParam
+from dagster._core.definitions.resource_annotation import UsableAsResourceParam
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
     PipesClient,
@@ -90,7 +90,7 @@ class InProcessMessageReader(PipesMessageReader):
         return "In-process message reader."
 
 
-class _InProcessPipesClient(PipesClient):
+class InProcessPipesClient(PipesClient, UsableAsResourceParam):
     """An in-process pipes clients unusable in test cases. A function inside the orchestration
     process actually serves as the "external" execution. This allows us to test the inner machinery
     of pipes without actually launching subprocesses, which makes the tests much more lightweight
@@ -124,6 +124,3 @@ class _InProcessPipesClient(PipesClient):
                 fn(pipes_context)
 
         return PipesClientCompletedInvocation(session)
-
-
-InProcessPipesClient = ResourceParam[_InProcessPipesClient]

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/in_process_client.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from typing import Callable, Iterator, List, Optional
 
 from dagster._annotations import public
-from dagster._core.definitions.resource_annotation import UsableAsResourceParam
+from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
     PipesClient,
@@ -90,7 +90,7 @@ class InProcessMessageReader(PipesMessageReader):
         return "In-process message reader."
 
 
-class InProcessPipesClient(PipesClient, UsableAsResourceParam):
+class InProcessPipesClient(PipesClient, TreatAsResourceParam):
     """An in-process pipes clients unusable in test cases. A function inside the orchestration
     process actually serves as the "external" execution. This allows us to test the inner machinery
     of pipes without actually launching subprocesses, which makes the tests much more lightweight

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
@@ -9,8 +9,9 @@ from typing import TYPE_CHECKING, Any, Iterator, Mapping, Optional, Sequence
 import boto3
 import dagster._check as check
 from botocore.exceptions import ClientError
-from dagster import PipesClient, ResourceParam
+from dagster import PipesClient
 from dagster._annotations import experimental
+from dagster._core.definitions.resource_annotation import UsableAsResourceParam
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
     PipesClientCompletedInvocation,
@@ -163,7 +164,7 @@ class PipesLambdaEventContextInjector(PipesEnvContextInjector):
 
 
 @experimental
-class _PipesLambdaClient(PipesClient):
+class PipesLambdaClient(PipesClient, UsableAsResourceParam):
     """A pipes client for invoking AWS lambda.
 
     By default context is injected via the lambda input event and messages are parsed out of the
@@ -240,6 +241,3 @@ class _PipesLambdaClient(PipesClient):
 
         # should probably have a way to return the lambda result payload
         return PipesClientCompletedInvocation(session)
-
-
-PipesLambdaClient = ResourceParam[_PipesLambdaClient]

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
@@ -11,7 +11,7 @@ import dagster._check as check
 from botocore.exceptions import ClientError
 from dagster import PipesClient
 from dagster._annotations import experimental
-from dagster._core.definitions.resource_annotation import UsableAsResourceParam
+from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
     PipesClientCompletedInvocation,
@@ -164,7 +164,7 @@ class PipesLambdaEventContextInjector(PipesEnvContextInjector):
 
 
 @experimental
-class PipesLambdaClient(PipesClient, UsableAsResourceParam):
+class PipesLambdaClient(PipesClient, TreatAsResourceParam):
     """A pipes client for invoking AWS lambda.
 
     By default context is injected via the lambda input event and messages are parsed out of the

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -10,7 +10,7 @@ from typing import Iterator, Literal, Mapping, Optional, Sequence, TextIO
 
 import dagster._check as check
 from dagster._annotations import experimental
-from dagster._core.definitions.resource_annotation import ResourceParam
+from dagster._core.definitions.resource_annotation import UsableAsResourceParam
 from dagster._core.errors import DagsterExecutionInterruptedError, DagsterPipesExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
@@ -36,7 +36,7 @@ from pydantic import Field
 
 
 @experimental
-class _PipesDatabricksClient(PipesClient):
+class PipesDatabricksClient(PipesClient, UsableAsResourceParam):
     """Pipes client for databricks.
 
     Args:
@@ -206,8 +206,6 @@ class _PipesDatabricksClient(PipesClient):
 
             time.sleep(self.poll_interval_seconds)
 
-
-PipesDatabricksClient = ResourceParam[_PipesDatabricksClient]
 
 _CONTEXT_FILENAME = "context.json"
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -10,7 +10,7 @@ from typing import Iterator, Literal, Mapping, Optional, Sequence, TextIO
 
 import dagster._check as check
 from dagster._annotations import experimental
-from dagster._core.definitions.resource_annotation import UsableAsResourceParam
+from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.errors import DagsterExecutionInterruptedError, DagsterPipesExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
@@ -36,7 +36,7 @@ from pydantic import Field
 
 
 @experimental
-class PipesDatabricksClient(PipesClient, UsableAsResourceParam):
+class PipesDatabricksClient(PipesClient, TreatAsResourceParam):
     """Pipes client for databricks.
 
     Args:

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -4,10 +4,10 @@ from typing import Any, Iterator, Mapping, Optional, Sequence, Union
 import docker
 from dagster import (
     OpExecutionContext,
-    ResourceParam,
     _check as check,
 )
 from dagster._annotations import experimental
+from dagster._core.definitions.resource_annotation import UsableAsResourceParam
 from dagster._core.pipes.client import (
     PipesClient,
     PipesClientCompletedInvocation,
@@ -62,7 +62,7 @@ class PipesDockerLogsMessageReader(PipesMessageReader):
 
 
 @experimental
-class _PipesDockerClient(PipesClient):
+class PipesDockerClient(PipesClient, UsableAsResourceParam):
     """A pipes client that runs external processes in docker containers.
 
     By default context is injected via environment variables and messages are parsed out of the
@@ -213,6 +213,3 @@ class _PipesDockerClient(PipesClient):
             },
             **kwargs,
         )
-
-
-PipesDockerClient = ResourceParam[_PipesDockerClient]

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -7,7 +7,7 @@ from dagster import (
     _check as check,
 )
 from dagster._annotations import experimental
-from dagster._core.definitions.resource_annotation import UsableAsResourceParam
+from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.pipes.client import (
     PipesClient,
     PipesClientCompletedInvocation,
@@ -62,7 +62,7 @@ class PipesDockerLogsMessageReader(PipesMessageReader):
 
 
 @experimental
-class PipesDockerClient(PipesClient, UsableAsResourceParam):
+class PipesDockerClient(PipesClient, TreatAsResourceParam):
     """A pipes client that runs external processes in docker containers.
 
     By default context is injected via environment variables and messages are parsed out of the


### PR DESCRIPTION
## Summary & Motivation

Now that we have TreatAsResourceParam, convert all Pipes clients to use it.

## How I Tested These Changes


BK
