### PR TITLE
allow serdes objects in JsonMetadataValue

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
@@ -1,5 +1,6 @@
 from dagster import (
     AssetKey,
+    FloatMetadataValue,
     GraphDefinition,
     IntMetadataValue,
     JsonMetadataValue,
@@ -105,3 +106,8 @@ def test_table_schema_metadata_value():
 def test_json_metadata_value():
     assert JsonMetadataValue({"a": "b"}).data == {"a": "b"}
     assert JsonMetadataValue({"a": "b"}).value == {"a": "b"}
+
+
+def test_serdes_json_metadata():
+    val = JsonMetadataValue({"float": FloatMetadataValue(1.0)})
+    assert deserialize_value(serialize_value(val)) == val


### PR DESCRIPTION
fix for unintended consequence of https://github.com/dagster-io/dagster/pull/21543  that previously `MetadataValue` classes would pass this serialization check due to being tuples but no longer do when becoming DagsterModel

to handle this, we now allow any serdes model to be present in `JsonMetadataValue`

## How I Tested These Changes

existing tests
added test
