### PR TITLE
add JsonDataFieldSerializer to JsonMetadataValue

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
@@ -105,3 +105,13 @@ def test_table_schema_metadata_value():
 def test_json_metadata_value():
     assert JsonMetadataValue({"a": "b"}).data == {"a": "b"}
     assert JsonMetadataValue({"a": "b"}).value == {"a": "b"}
+
+
+def test_serdes_json_metadata():
+    old_bad_event_str = '{"__class__": "JsonMetadataEntryData", "data": {"float": {"__class__": "FloatMetadataEntryData", "value": 1.0}}}'
+    val = deserialize_value(old_bad_event_str, JsonMetadataValue)
+    assert val
+    assert isinstance(val.data["float"], dict)  # and not FloatMetadataValue
+    s = serialize_value(val)
+    val_2 = deserialize_value(s, JsonMetadataValue)
+    assert val_2 == val


### PR DESCRIPTION
fix-up side effects from the bug correction in https://github.com/dagster-io/dagster/pull/21543 to prevent non vanilla json objects from being part of JsonMetadatValue by adding special processing for the `data` field

## How I Tested These Changes

added test