### PR TITLE
[DagsterModel] gate __init__ override on TYPE_CHECKING

### DIFF
--- a/python_modules/dagster/dagster/_model/__init__.py
+++ b/python_modules/dagster/dagster/_model/__init__.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import Any, Dict, Hashable, Optional
+from typing import TYPE_CHECKING, Any, Dict, Hashable, Optional
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr
 from typing_extensions import Self
@@ -20,8 +20,9 @@ class DagsterModel(BaseModel):
         # in pydantic 1 as it has non trivial performance impact
         _cached_method_cache__internal__: Dict[Hashable, Any] = PrivateAttr(default_factory=dict)
 
-    def __init__(self, **data: Any) -> None:
-        super().__init__(**data)
+    if TYPE_CHECKING:
+        # without this, the type checker does not understand the constructor kwargs on subclasses
+        def __init__(self, **data: Any) -> None: ...
 
     if USING_PYDANTIC_2:
         model_config = ConfigDict(  # type: ignore

--- a/python_modules/dagster/dagster_tests/model_tests/test_dagster_model.py
+++ b/python_modules/dagster/dagster_tests/model_tests/test_dagster_model.py
@@ -4,6 +4,15 @@ from dagster._utils.cached_method import CACHED_METHOD_CACHE_FIELD, cached_metho
 from pydantic import ValidationError
 
 
+def test_runtime_typecheck():
+    class MyClass(DagsterModel):
+        foo: str
+        bar: int
+
+    with pytest.raises(ValidationError):
+        MyClass(foo="fdsjk", bar="fdslk")
+
+
 def test_override_constructor_in_subclass():
     class MyClass(DagsterModel):
         foo: str

--- a/scripts/object_profile.py
+++ b/scripts/object_profile.py
@@ -4,18 +4,20 @@ import subprocess
 import timeit
 from tempfile import TemporaryDirectory
 
-import memray  # type: ignore
-from dagster import AssetKey
-
 # This script provides a way to measure the performance of instantiating an object.
 #
 # An example of when this is useful is measuring the impact of changing the backing class
 # for a model object from a NamedTuple to a dataclass or pydantic model (DagsterModel).
+import memray  # type: ignore
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_subset import AssetSubset
+
+fixed_key = AssetKey("asset_key")
 
 
 def make_one(i: int = 0):
     """Create an instance of the object you want to profile."""
-    return AssetKey(f"key_{i}")
+    return AssetSubset(asset_key=fixed_key, value=False)
 
 
 def make_n(n: int):


### PR DESCRIPTION
It appears we only need this to appease the type checker, but we pay a measurable cost for it.

Avoid that run time cost by gating it behind TYPE_CHECKING

## How I Tested These Changes
before (on https://github.com/dagster-io/dagster/pull/21702) 
```
cProfile results for creating 50000 objects:

         250003 function calls in 0.140 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.012    0.012    0.140    0.140 object_profile.py:23(make_n)
    50000    0.017    0.000    0.126    0.000 object_profile.py:18(make_one)
    50000    0.019    0.000    0.109    0.000 __init__.py:30(__init__)
    50000    0.010    0.000    0.089    0.000 main.py:166(__init__)
    50000    0.079    0.000    0.079    0.000 {method 'validate_python' of 'pydantic_core._pydantic_core.SchemaValidator' objects}
    50000    0.002    0.000    0.002    0.000 {method 'append' of 'list' objects}
        1    0.000    0.000    0.000    0.000 cProfile.py:118(__exit__)
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}


memray results for creating 50000 objects:

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃                                                                                      ┃                  ┃                 ┃                 ┃                 ┃      Allocation ┃
┃ Location                                                                             ┃   <Total Memory> ┃  Total Memory % ┃      Own Memory ┃    Own Memory % ┃           Count ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│ mem_profile at /Users/alangenfeld/dagster/./scripts/object_profile.py                │         21.424MB │         100.00% │          0.000B │           0.00% │              25 │
│ __init__ at                                                                          │         21.000MB │          98.02% │        10.000MB │          46.68% │              24 │
│ /Users/alangenfeld/dagster/python_modules/dagster/dagster/_model/__init__.py         │                  │                 │                 │                 │                 │
│ make_one at /Users/alangenfeld/dagster/./scripts/object_profile.py                   │         21.000MB │          98.02% │          0.000B │           0.00% │              24 │
│ make_n at /Users/alangenfeld/dagster/./scripts/object_profile.py                     │         11.424MB │          53.32% │       433.906KB │           1.98% │              15 │
│ __init__ at                                                                          │         11.000MB │          51.35% │        11.000MB │          51.35% │              14 │
│ /Users/alangenfeld/venvs/arm/py311/lib/python3.11/site-packages/pydantic/main.py     │                  │                 │                 │                 │                 │
└──────────────────────────────────────────────────────────────────────────────────────┴──────────────────┴─────────────────┴─────────────────┴─────────────────┴─────────────────┘


timeit results:

best of 5 trials of 500000 calls of make_one(): 975.25 ns per call
```

after
```
Object profiling for target make_one()=AssetSubset(asset_key=AssetKey(['asset_key']), value=False)

cProfile results for creating 50000 objects:

         200003 function calls in 0.119 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.012    0.012    0.119    0.119 object_profile.py:23(make_n)
    50000    0.017    0.000    0.106    0.000 object_profile.py:18(make_one)
    50000    0.011    0.000    0.089    0.000 main.py:166(__init__)
    50000    0.078    0.000    0.078    0.000 {method 'validate_python' of 'pydantic_core._pydantic_core.SchemaValidator' objects}
    50000    0.002    0.000    0.002    0.000 {method 'append' of 'list' objects}
        1    0.000    0.000    0.000    0.000 cProfile.py:118(__exit__)
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}


memray results for creating 50000 objects:

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃                                                                                      ┃                  ┃                 ┃                 ┃                 ┃      Allocation ┃
┃ Location                                                                             ┃   <Total Memory> ┃  Total Memory % ┃      Own Memory ┃    Own Memory % ┃           Count ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│ make_n at /Users/alangenfeld/dagster/./scripts/object_profile.py                     │         21.424MB │         100.00% │       433.906KB │           1.98% │              25 │
│ mem_profile at /Users/alangenfeld/dagster/./scripts/object_profile.py                │         21.424MB │         100.00% │          0.000B │           0.00% │              25 │
│ __init__ at                                                                          │         21.000MB │          98.02% │        21.000MB │          98.02% │              24 │
│ /Users/alangenfeld/venvs/arm/py311/lib/python3.11/site-packages/pydantic/main.py     │                  │                 │                 │                 │                 │
│ make_one at /Users/alangenfeld/dagster/./scripts/object_profile.py                   │         21.000MB │          98.02% │          0.000B │           0.00% │              24 │
└──────────────────────────────────────────────────────────────────────────────────────┴──────────────────┴─────────────────┴─────────────────┴─────────────────┴─────────────────┘


timeit results:

best of 5 trials of 500000 calls of make_one(): 739.18 ns per call
```
