### PR TITLE
Speed up get_assets_latest_info when there are many asset keys in the graph

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -9,6 +9,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    Set,
     Tuple,
     Union,
     cast,
@@ -200,7 +201,7 @@ def get_asset_node_definition_collisions(
 
 
 def get_asset_nodes_by_asset_key(
-    graphene_info: "ResolveInfo", asset_keys: Optional[Sequence[AssetKey]] = None
+    graphene_info: "ResolveInfo", asset_keys: Optional[Set[AssetKey]] = None
 ) -> Mapping[AssetKey, "GrapheneAssetNode"]:
     """If multiple repositories have asset nodes for the same asset key, chooses the asset node that
     has an op.
@@ -265,8 +266,8 @@ def get_asset_nodes_by_asset_key(
     }
 
 
-def get_asset_nodes(graphene_info: "ResolveInfo"):
-    return get_asset_nodes_by_asset_key(graphene_info).values()
+def get_asset_nodes(graphene_info: "ResolveInfo", asset_keys: Optional[Set[AssetKey]] = None):
+    return get_asset_nodes_by_asset_key(graphene_info, asset_keys=asset_keys).values()
 
 
 def get_asset_node(
@@ -275,7 +276,7 @@ def get_asset_node(
     from ..schema.errors import GrapheneAssetNotFoundError
 
     check.inst_param(asset_key, "asset_key", AssetKey)
-    node = get_asset_nodes_by_asset_key(graphene_info, asset_keys=[asset_key]).get(asset_key, None)
+    node = get_asset_nodes_by_asset_key(graphene_info, asset_keys={asset_key}).get(asset_key, None)
     if not node:
         return GrapheneAssetNotFoundError(asset_key=asset_key)
     return node
@@ -290,7 +291,7 @@ def get_asset(
     check.inst_param(asset_key, "asset_key", AssetKey)
     instance = graphene_info.context.instance
 
-    asset_nodes_by_asset_key = get_asset_nodes_by_asset_key(graphene_info, asset_keys=[asset_key])
+    asset_nodes_by_asset_key = get_asset_nodes_by_asset_key(graphene_info, asset_keys={asset_key})
     asset_node = asset_nodes_by_asset_key.get(asset_key)
 
     if not asset_node and not instance.has_asset_key(asset_key):

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -177,7 +177,7 @@ def get_assets_latest_info(
     if not asset_keys:
         return []
 
-    asset_nodes = get_asset_nodes_by_asset_key(graphene_info, asset_keys)
+    asset_nodes = get_asset_nodes_by_asset_key(graphene_info, set(asset_keys))
 
     asset_records = asset_record_loader.get_asset_records(asset_keys)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -938,7 +938,9 @@ class GrapheneQuery(graphene.ObjectType):
                 else []
             )
         else:
-            results = get_asset_nodes(graphene_info)
+            results = get_asset_nodes(
+                graphene_info, resolved_asset_keys if not use_all_asset_keys else None
+            )
 
         # Filter down to requested asset keys
         results = [
@@ -1074,7 +1076,7 @@ class GrapheneQuery(graphene.ObjectType):
     ):
         asset_keys = set(AssetKey.from_graphql_input(asset_key) for asset_key in assetKeys)
 
-        results = get_asset_nodes(graphene_info)
+        results = get_asset_nodes(graphene_info, asset_keys)
 
         # Filter down to requested asset keys
         # Build mapping of asset key to the step keys required to generate the asset


### PR DESCRIPTION
Summary:
Speedscope suggests we spend meaningful amounts of time hashing in this set for all asset keys when we really only need the nodes for a small number of asset keys

Test Plan:
Existing bk on assets_latest_info, run a speedscope on a large asset graph and observe less time spend in __hash__ in this function

## Summary & Motivation

## How I Tested These Changes
