### PR TITLE
[DS][37/n] Reorganize AssetGraphView methods

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
@@ -45,7 +45,7 @@ class InProgressSchedulingCondition(SliceSchedulingCondition):
         return "Part of an in-progress run"
 
     def compute_slice(self, context: SchedulingContext) -> AssetSlice:
-        return context.asset_graph_view.compute_in_progress_asset_slice(context.asset_key)
+        return context.asset_graph_view.compute_in_progress_asset_slice(asset_key=context.asset_key)
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/updated_since_cron_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/updated_since_cron_condition.py
@@ -51,7 +51,7 @@ class UpdatedSinceCronCondition(SchedulingCondition):
             # since the previous evaluation
             true_slice = context.previous_evaluation_node.true_slice.compute_union(
                 context.asset_graph_view.compute_updated_since_cursor_slice(
-                    context.asset_key, context.previous_evaluation_max_storage_id
+                    asset_key=context.asset_key, cursor=context.previous_evaluation_max_storage_id
                 )
             )
 


### PR DESCRIPTION
## Summary & Motivation

As title -- just sorts the methods a bit to make thigns with similar purposes be next to each other. Also adds cached_method decorators to a few methods and adds a * to their type signatures (cached method does not support positional arguments)

## How I Tested These Changes
