### PR TITLE
[Perf monitoring] wait for delayed row query

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedWorkspaceTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedWorkspaceTable.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import {RepoAddress} from './types';
+import {CompletionType, useTraceDependency} from '../performance/TraceContext';
 import {RepoSectionHeader} from '../runs/RepoSectionHeader';
 import {Row} from '../ui/VirtualizedTable';
 
@@ -79,13 +80,15 @@ const CaptionTextContainer = styled.div`
 const JOB_QUERY_DELAY = 100;
 
 export const useDelayedRowQuery = (lazyQueryFn: () => void) => {
+  const dependency = useTraceDependency('DelayedRowQuery');
   React.useEffect(() => {
     const timer = setTimeout(() => {
       lazyQueryFn();
+      dependency.completeDependency(CompletionType.SUCCESS);
     }, JOB_QUERY_DELAY);
 
     return () => {
       clearTimeout(timer);
     };
-  }, [lazyQueryFn]);
+  }, [lazyQueryFn, dependency]);
 };


### PR DESCRIPTION
## Summary & Motivation

As titled, in practice this wasn't needed because there are other things outstanding that cause us to include these, but lets make sure this is covered just in case.

## How I Tested These Changes

<img width="1210" alt="Screenshot 2024-05-09 at 10 17 17 AM" src="https://github.com/dagster-io/dagster/assets/2286579/2e2e0f4c-e5d8-45be-aa35-50d50249a4d2">
