### PR TITLE
`Definitions.merge` and don't immediately validate definitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -709,7 +709,7 @@ def repository_def_from_target_def(
 
     if isinstance(target, Definitions):
         # reassign to handle both repository and pending repo case
-        target = target.get_inner_repository_for_loading_process()
+        target = target.get_inner_repository()
 
     # special case - we can wrap a single job in a repository
     if isinstance(target, (JobDefinition, GraphDefinition)):

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps_error_informative.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps_error_informative.py
@@ -42,7 +42,7 @@ def test_typo_upstream_asset_one_similar(group_name, asset_key_prefix) -> None:
             rf"\n\t{re.escape(asset1.key.to_string())}"
         ),
     ):
-        Definitions(assets=[asset1, asset2])
+        Definitions(assets=[asset1, asset2]).validate_loadable()
 
 
 def test_typo_upstream_asset_no_similar() -> None:
@@ -59,7 +59,7 @@ def test_typo_upstream_asset_no_similar() -> None:
             r" ops and is not one of the provided sources."
         ),
     ):
-        Definitions(assets=[asset1, asset2])
+        Definitions(assets=[asset1, asset2]).validate_loadable()
 
 
 def test_typo_upstream_asset_many_similar() -> None:
@@ -85,7 +85,7 @@ def test_typo_upstream_asset_many_similar() -> None:
             rf" {re.escape(asst.key.to_string())}"
         ),
     ):
-        Definitions(assets=[asst, asset1, assets1, asset2])
+        Definitions(assets=[asst, asset1, assets1, asset2]).validate_loadable()
 
 
 def test_typo_upstream_asset_wrong_prefix() -> None:
@@ -103,7 +103,7 @@ def test_typo_upstream_asset_wrong_prefix() -> None:
             rf"\n\t{re.escape(asset1.key.to_string())}"
         ),
     ):
-        Definitions(assets=[asset1, asset2])
+        Definitions(assets=[asset1, asset2]).validate_loadable()
 
 
 def test_typo_upstream_asset_wrong_prefix_and_wrong_key() -> None:
@@ -122,7 +122,7 @@ def test_typo_upstream_asset_wrong_prefix_and_wrong_key() -> None:
             r" not one of the provided sources."
         ),
     ):
-        Definitions(assets=[asset1, asset2])
+        Definitions(assets=[asset1, asset2]).validate_loadable()
 
 
 def test_one_off_component_prefix() -> None:
@@ -141,7 +141,7 @@ def test_one_off_component_prefix() -> None:
             rf"\n\t{re.escape(asset1.key.to_string())}"
         ),
     ):
-        Definitions(assets=[asset1, asset2])
+        Definitions(assets=[asset1, asset2]).validate_loadable()
 
     # One fewer component in the prefix
     @asset(ins={"asset1": AssetIn(key=AssetKey(["my", "asset1"]))})
@@ -155,7 +155,7 @@ def test_one_off_component_prefix() -> None:
             rf"\n\t{re.escape(asset1.key.to_string())}"
         ),
     ):
-        Definitions(assets=[asset1, asset3])
+        Definitions(assets=[asset1, asset3]).validate_loadable()
 
 
 def test_accidentally_using_slashes() -> None:
@@ -174,7 +174,7 @@ def test_accidentally_using_slashes() -> None:
             rf"\n\t{re.escape(asset1.key.to_string())}"
         ),
     ):
-        Definitions(assets=[asset1, asset2])
+        Definitions(assets=[asset1, asset2]).validate_loadable()
 
 
 NUM_ASSETS_TO_TEST_PERF = 5000

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
@@ -179,4 +179,4 @@ def test_source_asset_observation_job_with_pythonic_resource(is_valid, resource_
                 assets=[foo],
                 jobs=[define_asset_job("source_asset_job", [foo])],
                 resources=resource_defs,
-            )
+            ).validate_loadable()

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_binding.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_binding.py
@@ -66,7 +66,7 @@ def test_bind_resource_to_job_at_defn_time_err() -> None:
     ):
         Definitions(
             jobs=[hello_world_job],
-        )
+        ).validate_loadable()
 
 
 def test_bind_resource_to_job_at_defn_time() -> None:
@@ -92,7 +92,7 @@ def test_bind_resource_to_job_at_defn_time() -> None:
         resources={
             "writer": WriterResource(prefix=""),
         },
-    )
+    ).validate_loadable()
 
     assert defs.get_job_def("hello_world_job").execute_in_process().success
     assert out_txt == ["hello, world!"]
@@ -104,7 +104,7 @@ def test_bind_resource_to_job_at_defn_time() -> None:
         resources={
             "writer": WriterResource(prefix="msg: "),
         },
-    )
+    ).validate_loadable()
 
     assert defs.get_job_def("hello_world_job").execute_in_process().success
     assert out_txt == ["msg: hello, world!"]
@@ -133,7 +133,7 @@ def test_bind_resource_to_job_at_defn_time_bind_resources_to_jobs() -> None:
         resources={
             "writer": WriterResource(prefix=""),
         },
-    )
+    ).validate_loadable()
 
     assert defs.get_job_def("hello_world_job").execute_in_process().success
     assert out_txt == ["hello, world!"]
@@ -146,7 +146,7 @@ def test_bind_resource_to_job_at_defn_time_bind_resources_to_jobs() -> None:
         resources={
             "writer": WriterResource(prefix="msg: "),
         },
-    )
+    ).validate_loadable()
 
     assert defs.get_job_def("hello_world_job").execute_in_process().success
     assert out_txt == ["msg: hello, world!"]
@@ -181,7 +181,7 @@ def test_bind_resource_to_job_with_job_config() -> None:
         resources={
             "writer": WriterResource(prefix="msg: "),
         },
-    )
+    ).validate_loadable()
 
     assert defs.get_job_def("hello_world_job").execute_in_process().success
     assert out_txt == ["msg: hello, world!"]
@@ -197,7 +197,7 @@ def test_bind_resource_to_job_with_job_config() -> None:
     ):
         Definitions(
             jobs=[hello_world_job],
-        )
+        ).validate_loadable()
 
 
 def test_bind_resource_to_job_at_defn_time_override() -> None:
@@ -231,7 +231,7 @@ def test_bind_resource_to_job_at_defn_time_override() -> None:
         resources={
             "writer": WriterResource(prefix="definitions says: "),
         },
-    )
+    ).validate_loadable()
 
     assert defs.get_job_def("hello_world_job_with_override").execute_in_process().success
     assert out_txt == ["job says: hello, world!"]
@@ -274,7 +274,7 @@ def test_bind_resource_to_instigator(include_job_in_definitions) -> None:
         resources={
             "writer": WriterResource(prefix="msg: "),
         },
-    )
+    ).validate_loadable()
 
     assert (
         cast(JobDefinition, defs.get_sensor_def("hello_world_sensor").job)
@@ -327,7 +327,7 @@ def test_bind_resource_to_instigator_by_name() -> None:
         resources={
             "writer": WriterResource(prefix="msg: "),
         },
-    )
+    ).validate_loadable()
 
     assert (
         defs.get_job_def(cast(str, defs.get_sensor_def("hello_world_sensor").job_name))
@@ -372,7 +372,7 @@ def test_bind_io_manager_default() -> None:
         resources={
             "io_manager": MyIOManager(),
         },
-    )
+    ).validate_loadable()
 
     assert defs.get_job_def("hello_world_job").execute_in_process().success
     assert outputs == ["foo"]
@@ -410,7 +410,7 @@ def test_bind_io_manager_override() -> None:
         resources={
             "io_manager": MyOtherIOManager(),
         },
-    )
+    ).validate_loadable()
 
     assert defs.get_job_def("hello_world_job").execute_in_process().success
     assert outputs == ["foo"]
@@ -445,7 +445,7 @@ def test_bind_top_level_resource_sensor_multi_job() -> None:
         resources={
             "foo": FooResource(my_str="foo"),
         },
-    )
+    ).validate_loadable()
 
 
 def test_override_default_value_in_asset_config() -> None:

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -66,7 +66,7 @@ def test_repository_snap_all_props():
 
 
 def resolve_pending_repo_if_required(definitions: Definitions) -> RepositoryDefinition:
-    repo_or_caching_repo = definitions.get_inner_repository_for_loading_process()
+    repo_or_caching_repo = definitions.get_inner_repository()
     return (
         repo_or_caching_repo.compute_repository_definition()
         if isinstance(repo_or_caching_repo, PendingRepositoryDefinition)


### PR DESCRIPTION
## Summary & Motivation

### What

This PR proposes turning `Definitions` into a "dumb" data class that primarily holds collections of definitions. And it adds a static `merge` method for merging multiple `Definitions` objects into a single `Definitions` object.

A big change here is that we no longer validate that a `Definitions` object is loadable as a code location at construction time. Instead, a `validate_loadable` method is offered. This enables:
- Putting resource definitions in one `Definitions` object and asset definitions in another `Definitions` object and later merging them together.
- Putting unresolved asset jobs in one `Definitions` object and asset definitions in another `Definitions` object and later merging them together.

A beneficial side effect of this is that less work will happen at module import time. This gives users more flexibility to determine where they want to incur the cost of this validation. It also likely helps move towards a future world where run/step workers only need to load/validate the subset of definitions that they need.

An alternative could be introducing something like an `UnresolvedDefinitions` class. Though I'm having trouble coming up with a name that makes this feel ergonomic.

### Why

There are diverse situations where it's useful to be able to pass around collections of definitions. Doing this in Dagster right now is quite awkward.

Relevant situations:
- Writing a factory that returns a few assets, a few checks, and a job that executes them together.
- A submodule defines a few assets, a job, and a schedule. A different submodule does the same. They should all be in the same code location.
- https://github.com/dagster-io/dagster/pull/21387#issuecomment-2081029765
- https://github.com/dagster-io/internal/discussions/8216

## How I Tested These Changes
