### PR TITLE
Add blog post URL in `with_openai`

### DIFF
--- a/examples/with_openai/README.md
+++ b/examples/with_openai/README.md
@@ -1,6 +1,6 @@
 # Using Dagster with OpenAI & LangChain
 
-This directory contains a pipeline leveraging Dagster, [OpenAI](https://openai.com/) and [LangChain](https://www.langchain.com/) to create a support bot. This pipeline is discussed in our [blog post](https://dagster.io/blog/building-cost-effective-ai-pipelines-openai-langchain-dagster) .
+This directory contains a pipeline leveraging Dagster, [OpenAI](https://openai.com/) and [LangChain](https://www.langchain.com/) to create a support bot. This pipeline is discussed in our [blog post](https://dagster.io/blog/building-cost-effective-ai-pipelines-openai-langchain-dagster).
 
 For more information about using OpenAI with Dagster, visit our [OpenAI integration page](https://docs.dagster.io/integrations/openai).
 

--- a/examples/with_openai/README.md
+++ b/examples/with_openai/README.md
@@ -1,6 +1,6 @@
 # Using Dagster with OpenAI & LangChain
 
-This directory contains a pipeline leveraging Dagster, [OpenAI](https://openai.com/) and [LangChain](https://www.langchain.com/) to create a support bot. This pipeline is discussed in our [blog post](ADD BLOG POST URL) .
+This directory contains a pipeline leveraging Dagster, [OpenAI](https://openai.com/) and [LangChain](https://www.langchain.com/) to create a support bot. This pipeline is discussed in our [blog post](https://dagster.io/blog/building-cost-effective-ai-pipelines-openai-langchain-dagster) .
 
 For more information about using OpenAI with Dagster, visit our [OpenAI integration page](https://docs.dagster.io/integrations/openai).
 


### PR DESCRIPTION
## Summary & Motivation

Our Dagster + OpenAI [blog post](https://dagster.io/blog/building-cost-effective-ai-pipelines-openai-langchain-dagster) is out so let's update the URL in the README of `with_openai`.

## How I Tested These Changes
N/A