### PR TITLE
[DataLoader] make RunRecord loadable with scaffolding

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -39,14 +39,13 @@ if TYPE_CHECKING:
     from ..schema.util import ResolveInfo
 
 
-def get_run_by_id(
+async def gen_run_by_id(
     graphene_info: "ResolveInfo", run_id: str
 ) -> Union["GrapheneRun", "GrapheneRunNotFoundError"]:
     from ..schema.errors import GrapheneRunNotFoundError
     from ..schema.pipelines.pipeline import GrapheneRun
 
-    instance = graphene_info.context.instance
-    record = instance.get_run_record_by_id(run_id)
+    record = await RunRecord.gen(graphene_info.context, run_id)
     if not record:
         return GrapheneRunNotFoundError(run_id)
     else:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -46,7 +46,6 @@ from dagster_graphql.implementation.fetch_assets import (
     get_asset_materializations,
     get_asset_observations,
 )
-from dagster_graphql.implementation.loader import BatchRunLoader
 from dagster_graphql.schema.config_types import GrapheneConfigTypeField
 from dagster_graphql.schema.inputs import GraphenePipelineSelector
 from dagster_graphql.schema.instigators import GrapheneInstigator
@@ -1099,11 +1098,8 @@ class GrapheneAssetNode(graphene.ObjectType):
             latest_materialization_by_partition.get(partition) for partition in partitions
         ]
 
-        run_ids = [event.run_id for event in ordered_materializations if event]
-        loader = BatchRunLoader(graphene_info.context.instance, run_ids) if run_ids else None
-
         return [
-            GrapheneMaterializationEvent(event=event, loader=loader) if event else None
+            GrapheneMaterializationEvent(event=event) if event else None
             for event in ordered_materializations
         ]
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -27,7 +27,6 @@ from ...implementation.fetch_pipelines import get_job_reference_or_raise
 from ...implementation.fetch_runs import get_runs, get_stats, get_step_stats
 from ...implementation.fetch_schedules import get_schedules_for_pipeline
 from ...implementation.fetch_sensors import get_sensors_for_pipeline
-from ...implementation.loader import BatchRunLoader
 from ...implementation.utils import UserFacingGraphQLError, capture_error
 from ..asset_checks import GrapheneAssetCheckHandle
 from ..asset_key import GrapheneAssetKey
@@ -235,9 +234,7 @@ class GrapheneAsset(graphene.ObjectType):
             after_timestamp=after_timestamp,
             limit=limit,
         )
-        run_ids = [event.run_id for event in events]
-        loader = BatchRunLoader(graphene_info.context.instance, run_ids) if run_ids else None
-        return [GrapheneMaterializationEvent(event=event, loader=loader) for event in events]
+        return [GrapheneMaterializationEvent(event=event) for event in events]
 
     def resolve_assetObservations(
         self,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -76,9 +76,9 @@ from ...implementation.fetch_resources import (
     get_top_level_resources_or_error,
 )
 from ...implementation.fetch_runs import (
+    gen_run_by_id,
     get_execution_plan,
     get_logs_for_run,
-    get_run_by_id,
     get_run_group,
     get_run_tag_keys,
     get_run_tags,
@@ -746,8 +746,8 @@ class GrapheneQuery(graphene.ObjectType):
             limit=limit,
         )
 
-    def resolve_pipelineRunOrError(self, graphene_info: ResolveInfo, runId: graphene.ID):
-        return get_run_by_id(graphene_info, runId)
+    async def resolve_pipelineRunOrError(self, graphene_info: ResolveInfo, runId: graphene.ID):
+        return await gen_run_by_id(graphene_info, runId)
 
     def resolve_runsOrError(
         self,
@@ -779,8 +779,8 @@ class GrapheneQuery(graphene.ObjectType):
             limit=limit,
         )
 
-    def resolve_runOrError(self, graphene_info: ResolveInfo, runId):
-        return get_run_by_id(graphene_info, runId)
+    async def resolve_runOrError(self, graphene_info: ResolveInfo, runId):
+        return await gen_run_by_id(graphene_info, runId)
 
     @capture_error
     def resolve_partitionSetsOrError(

--- a/python_modules/dagster-graphql/dagster_graphql/test/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/test/utils.py
@@ -61,11 +61,17 @@ def execute_dagster_graphql(
     variables: Optional[GqlVariables] = None,
     schema: graphene.Schema = SCHEMA,
 ) -> GqlResult:
-    result = schema.execute(
-        query,
-        context_value=context,
-        variable_values=variables,
+    result = asyncio.run(
+        schema.execute_async(
+            query,
+            context_value=context,
+            variable_values=variables,
+        )
     )
+    # It would be cleaner if we instead passed in a process context
+    # and made a request context for this invocation.
+    # For now just ensure we don't shared loaders between requests.
+    context.loaders.clear()
 
     if result.errors:
         first_error = result.errors[0]

--- a/python_modules/dagster/dagster/_core/loader.py
+++ b/python_modules/dagster/dagster/_core/loader.py
@@ -1,0 +1,103 @@
+from abc import ABC, abstractmethod
+from functools import partial
+from typing import TYPE_CHECKING, Dict, Generic, Iterable, Optional, Type, TypeVar
+
+from typing_extensions import Self
+
+import dagster._check as check
+from dagster._utils.aiodataloader import DataLoader
+
+TResult = TypeVar("TResult")
+TKey = TypeVar("TKey")
+
+
+if TYPE_CHECKING:
+    from .instance import DagsterInstance
+
+"""
+Loadable - asyncio driven batching
+
+    When resolving a GraphQL operation, it is common to end up with a pattern where a
+    set of objects are resolved, and then a field on those objects requires fetching
+    a related object by id. To avoid serially fetching those objects by id, something
+    must be done. In this past, this batching was solved by manual bespoke classes.
+
+    Loadable is an abstraction that replaces this explicit batching with an implicit scheme
+    leveraging the asyncio event loop.
+
+    Within a LoadingContext, requests for the same Loadable object are routed through a shared
+    DataLoader instance. This instance accumulates requests that happen in the same event loop
+    pass and batches them together. Any subsequent requests for the same ID in the same
+    LoadingContext will be served from an in memory cache. This means that mutations need to
+    clear the LoadingContext cache.
+
+    The Loadable interface is two methods, `gen` for fetching a single object by its id
+    and `gen_many` for loading N by their ids. The "gen" (for generator)[1] name is chosen
+    to stand out and make it clear that the method needs to be awaited, which at this time
+    is anomalous in a codebase where async is rarely used.
+
+Additional resources:
+* https://xuorig.medium.com/the-graphql-dataloader-pattern-visualized-3064a00f319f
+[1] Brought to you by the 201X Facebook codebase
+"""
+
+
+class LoadingContext(ABC):
+    """A scoped object in which Loadable objects will be fetched in batches and cached.
+
+    Expected to be implemented by request scoped context objects that have access to the DagsterInstance.
+    """
+
+    @property
+    @abstractmethod
+    def instance(self) -> "DagsterInstance":
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def loaders(self) -> Dict[Type, DataLoader]:
+        raise NotImplementedError()
+
+    def get_loader_for(self, ttype: Type["InstanceLoadableBy"]) -> DataLoader:
+        if ttype not in self.loaders:
+            if not issubclass(ttype, InstanceLoadableBy):
+                check.failed(f"{ttype} is not Loadable")
+
+            self.loaders[ttype] = DataLoader(
+                batch_load_fn=partial(
+                    ttype._batch_load,  # noqa
+                    instance=self.instance,
+                ),
+            )
+
+        return self.loaders[ttype]
+
+
+# Expected there may be other "Loadable" base classes based on what is needed to load.
+
+
+class InstanceLoadableBy(ABC, Generic[TKey]):
+    """Make An object Loadable by ID of type TKey using a DagsterInstance."""
+
+    @classmethod
+    @abstractmethod
+    async def _batch_load(
+        cls,
+        keys: Iterable[TKey],
+        instance: "DagsterInstance",
+    ) -> Iterable[Optional[Self]]:
+        raise NotImplementedError()
+
+    @classmethod
+    async def gen(cls, context: LoadingContext, id: TKey) -> Self:
+        """Fetch an object by its id."""
+        loader = context.get_loader_for(cls)
+        return await loader.load(id)
+
+    @classmethod
+    async def gen_many(
+        cls, context: LoadingContext, ids: Iterable[TKey]
+    ) -> Iterable[Optional[Self]]:
+        """Fetch N objects by their id."""
+        loader = context.get_loader_for(cls)
+        return await loader.load_many(ids)


### PR DESCRIPTION
Replace `BatchRunLoader` with `DataLoader` based abstractions

Adds:
* `InstanceLoadableBy[TKey]` - the parent class for objects loadable via the instance
* `LoadingContext` - the parent class for request contexts for scoping where loaders get cached

stacked on https://github.com/dagster-io/dagster/pull/21618

## How I Tested These Changes

existing tests 

notably 
`python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py::test_asset_batching`
which was added to verify `BatchRunLoader` was batching succesfully