### PR TITLE
provide asset suggestion for prefixed asset with same name

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/resolved_asset_deps.py
+++ b/python_modules/dagster/dagster/_core/definitions/resolved_asset_deps.py
@@ -103,12 +103,19 @@ def resolve_similar_asset_names(
             and max(len(asset_key.path), len(target_asset_key.path)) > 1
         )
 
+        # If the asset key provided has no prefix and the upstream key has
+        # the same name but a prefix of any length
+        no_prefix_but_is_match_with_prefix = (
+            len(target_asset_key) == 1 and asset_key.path[-1] == target_asset_key.path[-1]
+        )
+
         matches_slashes_turned_to_prefix_gaps = asset_key.path == target_asset_key_split
 
         if (
             is_same_prefix_similar_name
             or is_similar_prefix_same_name
             or is_off_by_one_prefix_component_same_name
+            or no_prefix_but_is_match_with_prefix
             or matches_slashes_turned_to_prefix_gaps
         ):
             similar_names.append(asset_key)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection_error_informative.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection_error_informative.py
@@ -128,3 +128,18 @@ def test_one_off_component_prefix() -> None:
     ):
         defs = Definitions(assets=[asset1], jobs=[my_job])
         defs.get_job_def("my_job")
+
+
+def test_select_without_prefix() -> None:
+    @asset(key_prefix=["my", "long", "prefix"])
+    def asset1(): ...
+
+    # Many more components in the prefix
+    my_job = define_asset_job("my_job", selection=AssetSelection.assets(["asset1"]))
+
+    with pytest.raises(
+        DagsterInvalidSubsetError,
+        match=(rf"did you mean one of the following\?\n\t{re.escape(asset1.key.to_string())}"),
+    ):
+        defs = Definitions(assets=[asset1], jobs=[my_job])
+        defs.get_job_def("my_job")


### PR DESCRIPTION
## Summary

Adds another suggestion rule which looks for assets with the same name, but any prefix, if the user-specified key has no prefix.

## Test Plan

unit test