### PR TITLE
Issue #21695 terminate runs

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -18,6 +18,7 @@ from .client_queries import (
     RELOAD_REPOSITORY_LOCATION_MUTATION,
     SHUTDOWN_REPOSITORY_LOCATION_MUTATION,
     TERMINATE_RUN_JOB_MUTATION,
+    TERMINATE_RUNS_JOB_MUTATION
 )
 from .utils import (
     DagsterGraphQLClientError,
@@ -396,3 +397,35 @@ class DagsterGraphQLClient:
             raise DagsterGraphQLClientError("RunNotFoundError", f"Run Id {run_id} not found")
         else:
             raise DagsterGraphQLClientError(query_result_type, query_result["message"])
+
+    def terminate_runs(self, run_ids: List[str], termination_policy: str = "SAFE_TERMINATE"):
+        """Terminates a list of pipeline runs. This method it is useful when you would like to stop a list of pipeline runs
+        based on a external event.
+        Args:
+            run_ids (List[str]): The list run ids of the pipeline runs to terminate
+            termination_policy (str): The termination policy to use. Defaults to "SAFE_TERMINATE"
+        """
+
+        check.list_param(run_ids, "run_ids", of_type=str)
+
+        res_data: Dict[str, Dict[str, Any]] = self._execute(
+            TERMINATE_RUNS_JOB_MUTATION, {"runIds": run_ids, "terminationPolicy": termination_policy}
+        )
+
+        query_result: Dict[str, Any] = res_data["terminateRuns"]
+        run_query_result : List[Dict[str, Any]] = query_result["terminateRunResults"]
+
+        errors = []
+        for run_result in run_query_result:
+            if run_result["__typename"] == "TerminateRunSuccess":
+                continue
+            elif run_result["__typename"] == "RunNotFoundError":
+                errors.append(("RunNotFoundError", run_result["message"]))
+            else:
+                errors.append((run_result["__typename"], run_result["message"]))
+
+        if errors:
+            if len(errors) < len(run_ids):
+                raise DagsterGraphQLClientError("TerminateRunsError", f"Some runs could not be terminated: {errors}")
+            elif len(errors) == len(run_ids):
+                raise DagsterGraphQLClientError("TerminateRunsError", f"All run terminations failed: {errors}")

--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -18,7 +18,7 @@ from .client_queries import (
     RELOAD_REPOSITORY_LOCATION_MUTATION,
     SHUTDOWN_REPOSITORY_LOCATION_MUTATION,
     TERMINATE_RUN_JOB_MUTATION,
-    TERMINATE_RUNS_JOB_MUTATION
+    TERMINATE_RUNS_JOB_MUTATION,
 )
 from .utils import (
     DagsterGraphQLClientError,
@@ -401,19 +401,20 @@ class DagsterGraphQLClient:
     def terminate_runs(self, run_ids: List[str], termination_policy: str = "SAFE_TERMINATE"):
         """Terminates a list of pipeline runs. This method it is useful when you would like to stop a list of pipeline runs
         based on a external event.
+
         Args:
             run_ids (List[str]): The list run ids of the pipeline runs to terminate
             termination_policy (str): The termination policy to use. Defaults to "SAFE_TERMINATE"
         """
-
         check.list_param(run_ids, "run_ids", of_type=str)
 
         res_data: Dict[str, Dict[str, Any]] = self._execute(
-            TERMINATE_RUNS_JOB_MUTATION, {"runIds": run_ids, "terminationPolicy": termination_policy}
+            TERMINATE_RUNS_JOB_MUTATION,
+            {"runIds": run_ids, "terminationPolicy": termination_policy},
         )
 
         query_result: Dict[str, Any] = res_data["terminateRuns"]
-        run_query_result : List[Dict[str, Any]] = query_result["terminateRunResults"]
+        run_query_result: List[Dict[str, Any]] = query_result["terminateRunResults"]
 
         errors = []
         for run_result in run_query_result:
@@ -426,6 +427,10 @@ class DagsterGraphQLClient:
 
         if errors:
             if len(errors) < len(run_ids):
-                raise DagsterGraphQLClientError("TerminateRunsError", f"Some runs could not be terminated: {errors}")
+                raise DagsterGraphQLClientError(
+                    "TerminateRunsError", f"Some runs could not be terminated: {errors}"
+                )
             elif len(errors) == len(run_ids):
-                raise DagsterGraphQLClientError("TerminateRunsError", f"All run terminations failed: {errors}")
+                raise DagsterGraphQLClientError(
+                    "TerminateRunsError", f"All run terminations failed: {errors}"
+                )

--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -398,19 +398,18 @@ class DagsterGraphQLClient:
         else:
             raise DagsterGraphQLClientError(query_result_type, query_result["message"])
 
-    def terminate_runs(self, run_ids: List[str], termination_policy: str = "SAFE_TERMINATE"):
+    def terminate_runs(self, run_ids: List[str]):
         """Terminates a list of pipeline runs. This method it is useful when you would like to stop a list of pipeline runs
         based on a external event.
 
         Args:
             run_ids (List[str]): The list run ids of the pipeline runs to terminate
-            termination_policy (str): The termination policy to use. Defaults to "SAFE_TERMINATE"
         """
         check.list_param(run_ids, "run_ids", of_type=str)
 
         res_data: Dict[str, Dict[str, Any]] = self._execute(
             TERMINATE_RUNS_JOB_MUTATION,
-            {"runIds": run_ids, "terminationPolicy": termination_policy},
+            {"runIds": run_ids},
         )
 
         query_result: Dict[str, Any] = res_data["terminateRuns"]

--- a/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
@@ -149,3 +149,35 @@ mutation GraphQLClientTerminateRun($runId: String!) {
   }
 }
 """
+
+TERMINATE_RUNS_JOB_MUTATION = """
+mutation GraphQLClientTerminateRuns($runIds: [String!]!) {
+  terminateRuns(runIds: $runIds) {
+    __typename
+    ... on TerminateRunsResult {
+      terminateRunResults {
+        __typename
+        ... on TerminateRunSuccess {
+          run  {
+            runId
+          }
+        }
+        ... on TerminateRunFailure {
+          message
+        }
+        ... on RunNotFoundError {
+          runId
+          message
+        }
+        ... on UnauthorizedError {
+          message
+        }
+        ... on PythonError {
+          message
+          stack
+        }
+      }
+    }
+  }
+}
+"""

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_terminate_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_terminate_runs.py
@@ -1,0 +1,166 @@
+import pytest
+from dagster._core.utils import make_new_run_id
+from dagster_graphql import DagsterGraphQLClientError
+from .conftest import MockClient, python_client_test_suite
+
+RUN_IDS = [make_new_run_id(), make_new_run_id(), make_new_run_id()]
+
+@python_client_test_suite
+def test_successful_run_termination(mock_client: MockClient):
+    expected_result = None
+    response = {"terminateRuns": {"terminateRunResults": [
+        {"__typename": "TerminateRunSuccess", "run": {"runId": run_id}} for run_id in RUN_IDS
+    ]}}
+    mock_client.mock_gql_client.execute.return_value = response
+
+    actual_result = mock_client.python_client.terminate_runs(RUN_IDS)
+    assert actual_result == expected_result
+
+@python_client_test_suite
+def test_complete_failure_run_not_found(mock_client: MockClient):
+    error_messages = [("RunNotFoundError", f"Run Id {run_id} not found") for run_id in RUN_IDS]
+    error_message_string = f"All run terminations failed: {error_messages}"
+    response = {"terminateRuns": {"terminateRunResults": [
+        {"__typename": "RunNotFoundError", "message": f"Run Id {run_id} not found", "runId": run_id} for run_id in RUN_IDS
+    ]}}
+    mock_client.mock_gql_client.execute.return_value = response
+
+    with pytest.raises(DagsterGraphQLClientError) as exc_info:
+        mock_client.python_client.terminate_runs(RUN_IDS)
+
+    assert str(exc_info.value.args[0]) == "TerminateRunsError"
+    assert exc_info.value.args[1] == error_message_string
+
+@python_client_test_suite
+def test_partial_failure_due_to_not_found_error(mock_client: MockClient):
+    failed_ids = [RUN_IDS[0]]
+    success_ids = RUN_IDS[1:]
+
+    error_messages = [("RunNotFoundError", f"Run Id {run_id} not found") for run_id in failed_ids]
+    error_message_string = f"Some runs could not be terminated: {error_messages}"
+
+    response = {
+        "terminateRuns": {
+            "terminateRunResults": [
+                {"__typename": "TerminateRunSuccess", "runId": run_id} for run_id in success_ids
+            ] + [
+                {"__typename": "RunNotFoundError", "message": f"Run Id {run_id} not found", "runId": run_id} for run_id in failed_ids
+            ]
+        }
+    }
+    mock_client.mock_gql_client.execute.return_value = response
+
+    with pytest.raises(DagsterGraphQLClientError) as exc_info:
+        mock_client.python_client.terminate_runs(RUN_IDS)
+
+    assert str(exc_info.value.args[0]) == "TerminateRunsError"
+    assert exc_info.value.args[1] == error_message_string
+
+@python_client_test_suite
+def test_complete_failure_generic_error(mock_client: MockClient):
+    error_messages = [("TerminateRunFailure", "Unable to terminate run") for _ in RUN_IDS]
+    error_message_string = f"All run terminations failed: {error_messages}"
+    response = {"terminateRuns": {"terminateRunResults": [
+        {"__typename": "TerminateRunFailure", "message": "Unable to terminate run"} for _ in RUN_IDS
+    ]}}
+    mock_client.mock_gql_client.execute.return_value = response
+
+    with pytest.raises(DagsterGraphQLClientError) as exc_info:
+        mock_client.python_client.terminate_runs(RUN_IDS)
+
+    assert str(exc_info.value.args[0]) == "TerminateRunsError"
+    assert exc_info.value.args[1] == error_message_string
+
+@python_client_test_suite
+def test_partial_failure_generic_error(mock_client: MockClient):
+    success_ids = [RUN_IDS[0]]
+    failed_ids = RUN_IDS[1:]
+
+    error_messages = [("TerminateRunFailure", "Unable to terminate run") for _ in failed_ids]
+    error_message_string = f"Some runs could not be terminated: {error_messages}"
+
+    response = {
+        "terminateRuns": {
+            "terminateRunResults": [
+                {"__typename": "TerminateRunSuccess", "run": {"runId": run_id}} for run_id in success_ids
+            ] + [
+                {"__typename": "TerminateRunFailure", "message": "Unable to terminate run"} for run_id in failed_ids
+            ]
+        }
+    }
+    mock_client.mock_gql_client.execute.return_value = response
+
+    with pytest.raises(DagsterGraphQLClientError) as exc_info:
+        mock_client.python_client.terminate_runs(RUN_IDS)
+
+    assert str(exc_info.value.args[0]) == "TerminateRunsError"
+    assert exc_info.value.args[1] == error_message_string
+
+@python_client_test_suite
+def test_complete_failure_python_error(mock_client: MockClient):
+    error_messages = [("PythonError", "Unable to terminate run") for _ in RUN_IDS]
+    error_message_string = f"All run terminations failed: {error_messages}"
+    response = {"terminateRuns": {"terminateRunResults": [
+        {"__typename": "PythonError", "message": "Unable to terminate run"} for _ in RUN_IDS
+    ]}}
+    mock_client.mock_gql_client.execute.return_value = response
+
+    with pytest.raises(DagsterGraphQLClientError) as exc_info:
+        mock_client.python_client.terminate_runs(RUN_IDS)
+
+    assert str(exc_info.value.args[0]) == "TerminateRunsError"
+    assert exc_info.value.args[1] == error_message_string
+
+@python_client_test_suite
+def test_partial_failure_python_error(mock_client: MockClient):
+    success_ids = [RUN_IDS[0]]
+    failed_ids = RUN_IDS[1:]
+
+    error_messages = [("PythonError", "Unable to terminate run") for _ in failed_ids]
+    error_message_string = f"Some runs could not be terminated: {error_messages}"
+
+    response = {
+        "terminateRuns": {
+            "terminateRunResults": [
+                {"__typename": "TerminateRunSuccess", "run": {"runId": run_id}} for run_id in success_ids
+            ] + [
+                {"__typename": "PythonError", "message": "Unable to terminate run"} for _ in failed_ids
+            ]
+        }
+    }
+    mock_client.mock_gql_client.execute.return_value = response
+
+    with pytest.raises(DagsterGraphQLClientError) as exc_info:
+        mock_client.python_client.terminate_runs(RUN_IDS)
+
+    assert str(exc_info.value.args[0]) == "TerminateRunsError"
+    assert exc_info.value.args[1] == error_message_string
+
+@python_client_test_suite
+def test_terminate_runs_mixed_results(mock_client: MockClient):
+    success_id = RUN_IDS[0]
+    not_found_id = RUN_IDS[1]
+    python_error_id = RUN_IDS[2]
+
+    error_messages = [
+        ("RunNotFoundError", f"Run Id {not_found_id} not found"),
+        ("PythonError", "Internal server error occurred")
+    ]
+    error_message_string = f"Some runs could not be terminated: {error_messages}"
+
+    response = {
+        "terminateRuns": {
+            "terminateRunResults": [
+                {"__typename": "TerminateRunSuccess", "run": {"runId": success_id}},
+                {"__typename": "RunNotFoundError", "message": f"Run Id {not_found_id} not found", "runId": not_found_id},
+                {"__typename": "PythonError", "message": "Internal server error occurred", "stack": "Traceback info"}
+            ]
+        }
+    }
+    mock_client.mock_gql_client.execute.return_value = response
+
+    with pytest.raises(DagsterGraphQLClientError) as exc_info:
+        mock_client.python_client.terminate_runs(RUN_IDS)
+
+    assert str(exc_info.value.args[0]) == "TerminateRunsError"
+    assert exc_info.value.args[1] == error_message_string

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_terminate_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_terminate_runs.py
@@ -1,28 +1,45 @@
 import pytest
 from dagster._core.utils import make_new_run_id
 from dagster_graphql import DagsterGraphQLClientError
+
 from .conftest import MockClient, python_client_test_suite
 
 RUN_IDS = [make_new_run_id(), make_new_run_id(), make_new_run_id()]
 
+
 @python_client_test_suite
 def test_successful_run_termination(mock_client: MockClient):
     expected_result = None
-    response = {"terminateRuns": {"terminateRunResults": [
-        {"__typename": "TerminateRunSuccess", "run": {"runId": run_id}} for run_id in RUN_IDS
-    ]}}
+    response = {
+        "terminateRuns": {
+            "terminateRunResults": [
+                {"__typename": "TerminateRunSuccess", "run": {"runId": run_id}}
+                for run_id in RUN_IDS
+            ]
+        }
+    }
     mock_client.mock_gql_client.execute.return_value = response
 
     actual_result = mock_client.python_client.terminate_runs(RUN_IDS)
     assert actual_result == expected_result
 
+
 @python_client_test_suite
 def test_complete_failure_run_not_found(mock_client: MockClient):
     error_messages = [("RunNotFoundError", f"Run Id {run_id} not found") for run_id in RUN_IDS]
     error_message_string = f"All run terminations failed: {error_messages}"
-    response = {"terminateRuns": {"terminateRunResults": [
-        {"__typename": "RunNotFoundError", "message": f"Run Id {run_id} not found", "runId": run_id} for run_id in RUN_IDS
-    ]}}
+    response = {
+        "terminateRuns": {
+            "terminateRunResults": [
+                {
+                    "__typename": "RunNotFoundError",
+                    "message": f"Run Id {run_id} not found",
+                    "runId": run_id,
+                }
+                for run_id in RUN_IDS
+            ]
+        }
+    }
     mock_client.mock_gql_client.execute.return_value = response
 
     with pytest.raises(DagsterGraphQLClientError) as exc_info:
@@ -30,6 +47,7 @@ def test_complete_failure_run_not_found(mock_client: MockClient):
 
     assert str(exc_info.value.args[0]) == "TerminateRunsError"
     assert exc_info.value.args[1] == error_message_string
+
 
 @python_client_test_suite
 def test_partial_failure_due_to_not_found_error(mock_client: MockClient):
@@ -43,8 +61,14 @@ def test_partial_failure_due_to_not_found_error(mock_client: MockClient):
         "terminateRuns": {
             "terminateRunResults": [
                 {"__typename": "TerminateRunSuccess", "runId": run_id} for run_id in success_ids
-            ] + [
-                {"__typename": "RunNotFoundError", "message": f"Run Id {run_id} not found", "runId": run_id} for run_id in failed_ids
+            ]
+            + [
+                {
+                    "__typename": "RunNotFoundError",
+                    "message": f"Run Id {run_id} not found",
+                    "runId": run_id,
+                }
+                for run_id in failed_ids
             ]
         }
     }
@@ -56,13 +80,19 @@ def test_partial_failure_due_to_not_found_error(mock_client: MockClient):
     assert str(exc_info.value.args[0]) == "TerminateRunsError"
     assert exc_info.value.args[1] == error_message_string
 
+
 @python_client_test_suite
 def test_complete_failure_generic_error(mock_client: MockClient):
     error_messages = [("TerminateRunFailure", "Unable to terminate run") for _ in RUN_IDS]
     error_message_string = f"All run terminations failed: {error_messages}"
-    response = {"terminateRuns": {"terminateRunResults": [
-        {"__typename": "TerminateRunFailure", "message": "Unable to terminate run"} for _ in RUN_IDS
-    ]}}
+    response = {
+        "terminateRuns": {
+            "terminateRunResults": [
+                {"__typename": "TerminateRunFailure", "message": "Unable to terminate run"}
+                for _ in RUN_IDS
+            ]
+        }
+    }
     mock_client.mock_gql_client.execute.return_value = response
 
     with pytest.raises(DagsterGraphQLClientError) as exc_info:
@@ -70,6 +100,7 @@ def test_complete_failure_generic_error(mock_client: MockClient):
 
     assert str(exc_info.value.args[0]) == "TerminateRunsError"
     assert exc_info.value.args[1] == error_message_string
+
 
 @python_client_test_suite
 def test_partial_failure_generic_error(mock_client: MockClient):
@@ -82,9 +113,12 @@ def test_partial_failure_generic_error(mock_client: MockClient):
     response = {
         "terminateRuns": {
             "terminateRunResults": [
-                {"__typename": "TerminateRunSuccess", "run": {"runId": run_id}} for run_id in success_ids
-            ] + [
-                {"__typename": "TerminateRunFailure", "message": "Unable to terminate run"} for run_id in failed_ids
+                {"__typename": "TerminateRunSuccess", "run": {"runId": run_id}}
+                for run_id in success_ids
+            ]
+            + [
+                {"__typename": "TerminateRunFailure", "message": "Unable to terminate run"}
+                for run_id in failed_ids
             ]
         }
     }
@@ -96,13 +130,18 @@ def test_partial_failure_generic_error(mock_client: MockClient):
     assert str(exc_info.value.args[0]) == "TerminateRunsError"
     assert exc_info.value.args[1] == error_message_string
 
+
 @python_client_test_suite
 def test_complete_failure_python_error(mock_client: MockClient):
     error_messages = [("PythonError", "Unable to terminate run") for _ in RUN_IDS]
     error_message_string = f"All run terminations failed: {error_messages}"
-    response = {"terminateRuns": {"terminateRunResults": [
-        {"__typename": "PythonError", "message": "Unable to terminate run"} for _ in RUN_IDS
-    ]}}
+    response = {
+        "terminateRuns": {
+            "terminateRunResults": [
+                {"__typename": "PythonError", "message": "Unable to terminate run"} for _ in RUN_IDS
+            ]
+        }
+    }
     mock_client.mock_gql_client.execute.return_value = response
 
     with pytest.raises(DagsterGraphQLClientError) as exc_info:
@@ -110,6 +149,7 @@ def test_complete_failure_python_error(mock_client: MockClient):
 
     assert str(exc_info.value.args[0]) == "TerminateRunsError"
     assert exc_info.value.args[1] == error_message_string
+
 
 @python_client_test_suite
 def test_partial_failure_python_error(mock_client: MockClient):
@@ -122,9 +162,12 @@ def test_partial_failure_python_error(mock_client: MockClient):
     response = {
         "terminateRuns": {
             "terminateRunResults": [
-                {"__typename": "TerminateRunSuccess", "run": {"runId": run_id}} for run_id in success_ids
-            ] + [
-                {"__typename": "PythonError", "message": "Unable to terminate run"} for _ in failed_ids
+                {"__typename": "TerminateRunSuccess", "run": {"runId": run_id}}
+                for run_id in success_ids
+            ]
+            + [
+                {"__typename": "PythonError", "message": "Unable to terminate run"}
+                for _ in failed_ids
             ]
         }
     }
@@ -136,6 +179,7 @@ def test_partial_failure_python_error(mock_client: MockClient):
     assert str(exc_info.value.args[0]) == "TerminateRunsError"
     assert exc_info.value.args[1] == error_message_string
 
+
 @python_client_test_suite
 def test_terminate_runs_mixed_results(mock_client: MockClient):
     success_id = RUN_IDS[0]
@@ -144,7 +188,7 @@ def test_terminate_runs_mixed_results(mock_client: MockClient):
 
     error_messages = [
         ("RunNotFoundError", f"Run Id {not_found_id} not found"),
-        ("PythonError", "Internal server error occurred")
+        ("PythonError", "Internal server error occurred"),
     ]
     error_message_string = f"Some runs could not be terminated: {error_messages}"
 
@@ -152,8 +196,16 @@ def test_terminate_runs_mixed_results(mock_client: MockClient):
         "terminateRuns": {
             "terminateRunResults": [
                 {"__typename": "TerminateRunSuccess", "run": {"runId": success_id}},
-                {"__typename": "RunNotFoundError", "message": f"Run Id {not_found_id} not found", "runId": not_found_id},
-                {"__typename": "PythonError", "message": "Internal server error occurred", "stack": "Traceback info"}
+                {
+                    "__typename": "RunNotFoundError",
+                    "message": f"Run Id {not_found_id} not found",
+                    "runId": not_found_id,
+                },
+                {
+                    "__typename": "PythonError",
+                    "message": "Internal server error occurred",
+                    "stack": "Traceback info",
+                },
             ]
         }
     }

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_terminate_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_terminate_runs.py
@@ -184,7 +184,6 @@ def test_partial_failure_python_error(mock_client: MockClient):
 def test_terminate_runs_mixed_results(mock_client: MockClient):
     success_id = RUN_IDS[0]
     not_found_id = RUN_IDS[1]
-    python_error_id = RUN_IDS[2]
 
     error_messages = [
         ("RunNotFoundError", f"Run Id {not_found_id} not found"),

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/CLIENT_SUBMIT_PIPELINE_RUN_MUTATION/1!0+dev-2024_05_16.graphql
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/CLIENT_SUBMIT_PIPELINE_RUN_MUTATION/1!0+dev-2024_05_16.graphql
@@ -1,0 +1,43 @@
+mutation GraphQLClientSubmitRun($executionParams: ExecutionParams!) {
+  launchPipelineExecution(executionParams: $executionParams) {
+    __typename
+    ... on InvalidStepError {
+      invalidStepKey
+    }
+    ... on InvalidOutputError {
+      stepKey
+      invalidOutputName
+    }
+    ... on LaunchPipelineRunSuccess {
+      run {
+        runId
+      }
+    }
+    ... on ConflictingExecutionParamsError {
+      message
+    }
+    ... on PresetNotFoundError {
+      message
+    }
+    ... on PipelineRunConflict {
+      message
+    }
+    ... on PipelineConfigValidationInvalid {
+      errors {
+        __typename
+        message
+        path
+        reason
+      }
+    }
+    ... on PipelineNotFoundError {
+      message
+    }
+    ... on PythonError {
+      message
+    }
+    ... on UnauthorizedError {
+      message
+    }
+  }
+}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/GET_PIPELINE_RUN_STATUS_QUERY/1!0+dev-2024_05_16.graphql
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/GET_PIPELINE_RUN_STATUS_QUERY/1!0+dev-2024_05_16.graphql
@@ -1,0 +1,14 @@
+query GraphQLClientGetRunStatus($runId: ID!) {
+  pipelineRunOrError(runId: $runId) {
+    __typename
+    ... on PipelineRun {
+        status
+    }
+    ... on PipelineRunNotFoundError {
+      message
+    }
+    ... on PythonError {
+      message
+    }
+  }
+}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/RELOAD_REPOSITORY_LOCATION_MUTATION/1!0+dev-2024_05_16.graphql
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/RELOAD_REPOSITORY_LOCATION_MUTATION/1!0+dev-2024_05_16.graphql
@@ -1,0 +1,26 @@
+mutation GraphQLClientReloadCodeLocation($repositoryLocationName: String!) {
+   reloadRepositoryLocation(repositoryLocationName: $repositoryLocationName) {
+      __typename
+      ... on WorkspaceLocationEntry {
+        name
+        locationOrLoadError {
+          __typename
+          ... on RepositoryLocation {
+            isReloadSupported
+            repositories {
+                name
+            }
+          }
+          ... on PythonError {
+            message
+          }
+        }
+      }
+      ... on ReloadNotSupported {
+        message
+      }
+      ... on RepositoryLocationNotFound {
+        message
+      }
+   }
+}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/SHUTDOWN_REPOSITORY_LOCATION_MUTATION/1!0+dev-2024_05_16.graphql
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/SHUTDOWN_REPOSITORY_LOCATION_MUTATION/1!0+dev-2024_05_16.graphql
@@ -1,0 +1,11 @@
+mutation GraphQLClientShutdownCodeLocation($repositoryLocationName: String!) {
+   shutdownRepositoryLocation(repositoryLocationName: $repositoryLocationName) {
+      __typename
+      ... on PythonError {
+        message
+      }
+      ... on RepositoryLocationNotFound {
+        message
+      }
+   }
+}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/TERMINATE_RUNS_JOB_MUTATION/1!0+dev-2024_05_16.graphql
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/client_backcompat/query_snapshots/TERMINATE_RUNS_JOB_MUTATION/1!0+dev-2024_05_16.graphql
@@ -1,0 +1,29 @@
+mutation GraphQLClientTerminateRuns($runIds: [String!]!) {
+  terminateRuns(runIds: $runIds) {
+    __typename
+    ... on TerminateRunsResult {
+      terminateRunResults {
+        __typename
+        ... on TerminateRunSuccess {
+          run  {
+            runId
+          }
+        }
+        ... on TerminateRunFailure {
+          message
+        }
+        ... on RunNotFoundError {
+          runId
+          message
+        }
+        ... on UnauthorizedError {
+          message
+        }
+        ... on PythonError {
+          message
+          stack
+        }
+      }
+    }
+  }
+}

--- a/python_modules/libraries/dagster-looker/.coveragerc
+++ b/python_modules/libraries/dagster-looker/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-branch = True


### PR DESCRIPTION
## Summary
This PR adds an extra method to the DagsterGraphQL python client to enable the possibility to terminate multiple runs at the same time.

This PR is related to the following issue: https://github.com/dagster-io/dagster/issues/21695

## How I Tested These Changes

The PR contains a suit of unit tests similar to the other methods defined on the client, testing multiple edge cases for error handling.