### PR TITLE
remove get_event_records calls from multi asset sensor

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -21,7 +21,7 @@ from dagster._core.definitions.sensor_definition import (
     SensorType,
 )
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster._core.event_api import EventRecordsFilter
+from dagster._core.event_api import AssetRecordsFilter
 from dagster._core.events import DagsterEventType
 from dagster._core.remote_representation import CodeLocation, ExternalRepository
 from dagster._core.remote_representation.external import ExternalJob, ExternalSensor
@@ -577,15 +577,14 @@ class GrapheneAssetNode(graphene.ObjectType):
             instance=graphene_info.context.instance, asset_graph=asset_graph
         )
         data_time_resolver = CachingDataTimeResolver(instance_queryer=instance_queryer)
-        event_records = instance.get_event_records(
-            EventRecordsFilter(
-                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+        event_records = instance.fetch_materializations(
+            AssetRecordsFilter(
+                asset_key=asset_key,
                 before_timestamp=int(timestampMillis) / 1000.0 + 1,
                 after_timestamp=int(timestampMillis) / 1000.0 - 1,
-                asset_key=asset_key,
             ),
             limit=1,
-        )
+        ).records
 
         if not event_records:
             return []

--- a/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
@@ -7,8 +7,7 @@ from dagster._config.pythonic_config import (
 )
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
 from dagster._core.definitions.metadata import TextMetadataValue
-from dagster._core.event_api import EventRecordsFilter
-from dagster._core.events import DagsterEventType
+from dagster._core.event_api import AssetRecordsFilter
 from dagster._core.events.log import EventLogEntry
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.io_manager import IOManager
@@ -22,16 +21,13 @@ def get_text_metadata_value(materialization: AssetMaterialization, key: str) -> 
 def latest_materialization_log_entry(
     instance: DagsterInstance, asset_key: AssetKey, partition_key: Optional[str] = None
 ) -> Optional[EventLogEntry]:
-    event_records = [
-        *instance.get_event_records(
-            event_records_filter=EventRecordsFilter(
-                event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                asset_key=asset_key,
-                asset_partitions=[partition_key] if partition_key else None,
-            ),
-            limit=1,
-        )
-    ]
+    event_records = instance.fetch_materializations(
+        AssetRecordsFilter(
+            asset_key=asset_key,
+            asset_partitions=[partition_key] if partition_key else None,
+        ),
+        limit=1,
+    ).records
     return event_records[0].event_log_entry if event_records else None
 
 


### PR DESCRIPTION
## Summary & Motivation
We want to deprecate get_event_records calls in favor of narrower APIs.

This call-site has the most user-facing changes in converting from `get_event_records` -> `fetch_materializations`, mostly because we have to enforce a limit on a sensor method that we expose off of the context.

I'm not sure if there's a more elegant way to do this, based on the internals of the multi assent sensor, and knowing how many records we can advance per tick (I have a sneaking suspicion that we can do something more clever here).

This PR takes the crudest possible approach: batching calls for chunks in a loop, and warning when called without a limit.

## How I Tested These Changes
BK