### PR TITLE
 use compute log manager to store backfill daemon logs for UI display

### DIFF
--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -157,12 +157,12 @@ def execute_backfill_jobs(
             repository_name=None,
             name=backfill_id,
         ) as _logger:
-            _logger = cast(logging.Logger, _logger)
+            backfill_logger = cast(logging.Logger, _logger)
             # create a logger that will always include the backfill_id as an `extra`
-            backfill_logger = cast(
-                logging.Logger,
-                logging.LoggerAdapter(_logger, extra={"backfill_id": backfill.backfill_id}),
-            )
+            # backfill_logger = cast(
+            #     logging.Logger,
+            #     logging.LoggerAdapter(_logger, extra={"backfill_id": backfill.backfill_id}),
+            # )
             try:
                 tick = instance.create_tick(
                     TickData(

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -159,10 +159,10 @@ def execute_backfill_jobs(
         ) as _logger:
             backfill_logger = cast(logging.Logger, _logger)
             # create a logger that will always include the backfill_id as an `extra`
-            # backfill_logger = cast(
-            #     logging.Logger,
-            #     logging.LoggerAdapter(_logger, extra={"backfill_id": backfill.backfill_id}),
-            # )
+            backfill_logger = cast(
+                logging.Logger,
+                logging.LoggerAdapter(_logger, extra={"backfill_id": backfill.backfill_id}),
+            )
             try:
                 tick = instance.create_tick(
                     TickData(

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -152,7 +152,7 @@ def execute_backfill_jobs(
             logging.Logger,
             logging.LoggerAdapter(logger, extra={"backfill_id": backfill.backfill_id}),
         )
-
+        # TODO make the logger here the InstigatorLogger so that we can store logs and fetch them for the UI
         try:
             evaluation_time = pendulum.now("UTC")
             tick = instance.create_tick(


### PR DESCRIPTION
## Summary & Motivation
proof of concept PR to look at how we can get backfill daemon logs surfaced to the UI. I left comments throughout the PR with some open design questions. If it is more convenient to do a meeting to chat through all of this, I'm happy to put that together
## How I Tested These Changes
