### PR TITLE
Speed up get_num_partitions for common cases

### DIFF
--- a/python_modules/dagster/dagster/_utils/cronstring.py
+++ b/python_modules/dagster/dagster/_utils/cronstring.py
@@ -1,0 +1,42 @@
+def is_basic_daily(cron_schedule: str) -> bool:
+    return cron_schedule == "0 0 * * *"
+
+
+def is_basic_hourly(cron_schedule: str) -> bool:
+    return cron_schedule == "0 * * * *"
+
+
+def get_fixed_minute_interval(cron_schedule: str):
+    """Given a cronstring, returns whether or not it is safe to
+    assume there is a fixed number of minutes between every tick. For
+    many cronstrings this is not the case due to Daylight Savings Time,
+    but for basic hourly cron schedules and cron schedules like */15 it
+    is safe to assume that there are a fixed number of minutes between each
+    tick.
+    """
+    if is_basic_hourly(cron_schedule):
+        return 60
+
+    cron_parts = cron_schedule.split()
+    is_wildcard = [part == "*" for part in cron_parts]
+
+    # To match this criteria, every other field besides the first must end in *
+    # since it must be an every-n-minutes cronstring like */15
+    if not is_wildcard[1:]:
+        return None
+
+    if not cron_parts[0].startswith("*/"):
+        return None
+
+    try:
+        # interval makes up the characters after the "*/"
+        interval = int(cron_parts[0][2:])
+    except ValueError:
+        return None
+
+    # cronstrings like */7 do not have a fixed interval because they jump
+    # from :54 to :07, but divisors of 60 do
+    if interval > 0 and interval < 60 and 60 % interval == 0:
+        return interval
+
+    return None

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1228,6 +1228,18 @@ def test_time_window_partition_len():
         == partitions_def.get_partition_keys(current_time=current_time)[50:53]
     )
 
+    partitions_def = TimeWindowPartitionsDefinition(
+        cron_schedule="*/15 * * * *",
+        start="2020-11-01-00:30",
+        timezone="US/Pacific",
+        fmt="%Y-%m-%d-%H:%M",
+    )
+    current_time = datetime.strptime("2021-06-20", "%Y-%m-%d")
+
+    assert partitions_def.get_num_partitions(current_time) == len(
+        partitions_def.get_partition_keys(current_time)
+    )
+
 
 def test_get_first_partition_window():
     assert DailyPartitionsDefinition(


### PR DESCRIPTION
Summary:
For daily, hourly, and minute-ly partition sets, do basic math rather than enumerating every single partition key and counting them.

Test Plan: A representative large asset graph with many large partition sets goes from taking 65 seconds to computing counts on all assets to taking 0.4 seconds to compute counts on all assets

## Summary & Motivation

## How I Tested These Changes
