### PR TITLE
Only calculate start window timestamp once in BaseTimeWindowPartitionsSubset.__contains__

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1890,9 +1890,11 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
             TimeWindowPartitionsDefinition, self.partitions_def
         ).time_window_for_partition_key(partition_key)
 
+        time_window_start_timestamp = time_window.start.timestamp()
+
         return any(
-            time_window.start.timestamp() >= included_time_window.start.timestamp()
-            and time_window.start.timestamp() < included_time_window.end.timestamp()
+            time_window_start_timestamp >= included_time_window.start.timestamp()
+            and time_window_start_timestamp < included_time_window.end.timestamp()
             for included_time_window in self.included_time_windows
         )
 


### PR DESCRIPTION
Summary:
speedscope suggests this might actually make a difference when there are large numbers of time windows in the subset (for example, a */15 asset or hourly asset going back to 2015)

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
