### PR TITLE
add batch fetching of data version records

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/data_version_cache.py
+++ b/python_modules/dagster/dagster/_core/execution/context/data_version_cache.py
@@ -147,7 +147,7 @@ class DataVersionCache:
                 )
 
     def _fetch_asset_records(self, asset_keys: Sequence[AssetKey]) -> Dict[AssetKey, "AssetRecord"]:
-        batch_size = int(os.getenv("ASSET_RECORD_BATCH_SIZE", "100"))
+        batch_size = int(os.getenv("GET_ASSET_RECORDS_FOR_DATA_VERSION_BATCH_SIZE", "100"))
         asset_records_by_key = {}
         to_fetch = asset_keys
         while len(to_fetch):

--- a/python_modules/dagster/dagster/_core/execution/context/data_version_cache.py
+++ b/python_modules/dagster/dagster/_core/execution/context/data_version_cache.py
@@ -1,3 +1,4 @@
+import os
 from typing import TYPE_CHECKING
 
 """This module contains the execution context objects that are internal to the system.
@@ -34,8 +35,6 @@ if TYPE_CHECKING:
 
 if TYPE_CHECKING:
     from dagster._core.execution.context.compute import StepExecutionContext
-
-ASSET_RECORD_BATCH_SIZE = 100
 
 
 @dataclass
@@ -148,14 +147,13 @@ class DataVersionCache:
                 )
 
     def _fetch_asset_records(self, asset_keys: Sequence[AssetKey]) -> Dict[AssetKey, "AssetRecord"]:
+        batch_size = int(os.getenv("ASSET_RECORD_BATCH_SIZE", "100"))
         asset_records_by_key = {}
         to_fetch = asset_keys
         while len(to_fetch):
-            for record in self._context.instance.get_asset_records(
-                to_fetch[:ASSET_RECORD_BATCH_SIZE]
-            ):
+            for record in self._context.instance.get_asset_records(to_fetch[:batch_size]):
                 asset_records_by_key[record.asset_entry.asset_key] = record
-            to_fetch = to_fetch[ASSET_RECORD_BATCH_SIZE:]
+            to_fetch = to_fetch[batch_size:]
 
         return asset_records_by_key
 

--- a/python_modules/dagster/dagster_tests/execution_tests/versioning_tests/test_data_versions.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/versioning_tests/test_data_versions.py
@@ -5,7 +5,9 @@ from unittest import mock
 
 import pytest
 from dagster import (
+    AssetIn,
     AssetMaterialization,
+    AssetOut,
     DagsterInstance,
     MaterializeResult,
     RunConfig,
@@ -16,8 +18,6 @@ from dagster import (
 )
 from dagster._config.field import Field
 from dagster._config.pythonic_config import Config
-from dagster._core.definitions.asset_in import AssetIn
-from dagster._core.definitions.asset_out import AssetOut
 from dagster._core.definitions.data_version import (
     DATA_VERSION_TAG,
     SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD,
@@ -44,6 +44,7 @@ from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
     ASSET_PARTITION_RANGE_START_TAG,
 )
+from dagster._utils import Counter, traced_counter
 from dagster._utils.test.data_versions import (
     assert_code_version,
     assert_data_version,
@@ -1175,3 +1176,33 @@ def test_output_overwrite_provenance_tag():
         assert extract_data_provenance_from_entry(record.event_log_entry).input_storage_ids == {
             AssetKey(["asset0"]): 500
         }
+
+
+def test_fan_in():
+    def create_upstream_asset(i: int):
+        @asset(name=f"upstream_asset_{i}", code_version="abc")
+        def upstream_asset():
+            return i
+
+        return upstream_asset
+
+    upstream_assets = [create_upstream_asset(i) for i in range(100)]
+
+    @asset(
+        ins={f"input_{i}": AssetIn(key=f"upstream_asset_{i}") for i in range(100)},
+        code_version="abc",
+    )
+    def downstream_asset(**kwargs):
+        return kwargs.values()
+
+    all_assets = [*upstream_assets, downstream_asset]
+    instance = DagsterInstance.ephemeral()
+    materialize_assets(all_assets, instance)
+
+    counter = Counter()
+    traced_counter.set(counter)
+    materialize_assets(all_assets, instance)[downstream_asset.key]
+    assert traced_counter.get().counts() == {
+        "DagsterInstance.get_asset_records": 1,
+        "DagsterInstance.get_run_record_by_id": 1,
+    }


### PR DESCRIPTION
## Summary & Motivation
Asset graphs with large fan-in can incur a hefty data-fetching cost when used with data versions.  This PR fetches the asset record for a batched set of asset keys.  The asset record has the last materialization record, and potentially the last observation record (in Plus), reducing the number of serial fetches we have to make to get the input data versions.

This batching of calls is only possible because we're not filtering the records (obs/mats) that we're fetching (either by partition or by storage id).

## How I Tested These Changes
Added an explicit fan-in data version test that checks the underlying data fetching calls.  It went from 200 calls to `get_event_records` => 1 call of `get_asset_records`.