### PR TITLE
Replace deprecated utcfromtimestamp method

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/telemetry.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/telemetry.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from dagster._core.telemetry import log_action
@@ -18,7 +18,9 @@ def log_ui_telemetry_event(
     instance = graphene_info.context.instance
     metadata = json.loads(metadata)
     assert isinstance(metadata, dict)
-    client_datetime = datetime.utcfromtimestamp(int(client_time) / 1000)
+    client_datetime = datetime.fromtimestamp(int(client_time) / 1000, timezone.utc).replace(
+        tzinfo=None
+    )
     log_action(
         instance=instance,
         action=action,

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -453,9 +453,10 @@ class CachingDataTimeResolver:
         ):
             return current_data_time
 
-        run_failure_time = datetime.datetime.utcfromtimestamp(
-            latest_run_record.end_time or datetime_as_float(latest_run_record.create_timestamp)
-        ).replace(tzinfo=datetime.timezone.utc)
+        run_failure_time = datetime.datetime.fromtimestamp(
+            latest_run_record.end_time or datetime_as_float(latest_run_record.create_timestamp),
+            datetime.timezone.utc,
+        )
         return self._get_in_progress_data_time_in_run(
             run_id=run_id, asset_key=asset_key, current_time=run_failure_time
         )
@@ -528,8 +529,8 @@ class CachingDataTimeResolver:
         if data_time is None:
             return None
         else:
-            return datetime.datetime.utcfromtimestamp(cast(float, data_time.value)).replace(
-                tzinfo=datetime.timezone.utc
+            return datetime.datetime.fromtimestamp(
+                cast(float, data_time.value), datetime.timezone.utc
             )
 
     def get_minutes_overdue(

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -394,7 +394,9 @@ class SqlEventLogStorage(EventLogStorage):
                             value=new_tags[tag],
                             # Postgres requires a datetime that is in UTC but has no timezone info
                             # set in order to be stored correctly
-                            event_timestamp=datetime.utcfromtimestamp(event_timestamp),
+                            event_timestamp=datetime.fromtimestamp(
+                                event_timestamp, timezone.utc
+                            ).replace(tzinfo=None),
                         )
                         for tag in added_tags
                     ],
@@ -881,7 +883,9 @@ class SqlEventLogStorage(EventLogStorage):
         if asset_details and asset_details.last_wipe_timestamp:
             query = query.where(
                 SqlEventLogStorageTable.c.timestamp
-                > datetime.utcfromtimestamp(asset_details.last_wipe_timestamp)
+                > datetime.fromtimestamp(asset_details.last_wipe_timestamp, timezone.utc).replace(
+                    tzinfo=None
+                )
             )
 
         if apply_cursor_filters:
@@ -907,13 +911,17 @@ class SqlEventLogStorage(EventLogStorage):
         if event_records_filter.before_timestamp:
             query = query.where(
                 SqlEventLogStorageTable.c.timestamp
-                < datetime.utcfromtimestamp(event_records_filter.before_timestamp)
+                < datetime.fromtimestamp(
+                    event_records_filter.before_timestamp, timezone.utc
+                ).replace(tzinfo=None)
             )
 
         if event_records_filter.after_timestamp:
             query = query.where(
                 SqlEventLogStorageTable.c.timestamp
-                > datetime.utcfromtimestamp(event_records_filter.after_timestamp)
+                > datetime.fromtimestamp(
+                    event_records_filter.after_timestamp, timezone.utc
+                ).replace(tzinfo=None)
             )
 
         if event_records_filter.storage_ids:
@@ -1618,7 +1626,9 @@ class SqlEventLogStorage(EventLogStorage):
                         db.and_(
                             asset_key_in_row,
                             SqlEventLogStorageTable.c.timestamp
-                            > datetime.utcfromtimestamp(asset_details.last_wipe_timestamp),
+                            > datetime.fromtimestamp(
+                                asset_details.last_wipe_timestamp, timezone.utc
+                            ).replace(tzinfo=None),
                         ),
                         db.not_(asset_key_in_row),
                     )
@@ -1668,7 +1678,9 @@ class SqlEventLogStorage(EventLogStorage):
             if asset_details and asset_details.last_wipe_timestamp:
                 tags_query = tags_query.where(
                     AssetEventTagsTable.c.event_timestamp
-                    > datetime.utcfromtimestamp(asset_details.last_wipe_timestamp)
+                    > datetime.fromtimestamp(
+                        asset_details.last_wipe_timestamp, timezone.utc
+                    ).replace(tzinfo=None)
                 )
         else:
             table = self._apply_tags_table_joins(AssetEventTagsTable, filter_tags, asset_key)
@@ -1683,7 +1695,9 @@ class SqlEventLogStorage(EventLogStorage):
             if asset_details and asset_details.last_wipe_timestamp:
                 tags_query = tags_query.where(
                     AssetEventTagsTable.c.event_timestamp
-                    > datetime.utcfromtimestamp(asset_details.last_wipe_timestamp)
+                    > datetime.fromtimestamp(
+                        asset_details.last_wipe_timestamp, timezone.utc
+                    ).replace(tzinfo=None)
                 )
 
         if filter_event_id is not None:

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -70,7 +70,7 @@ T = TypeVar("T")
 U = TypeVar("U")
 V = TypeVar("V")
 
-EPOCH = datetime.datetime.utcfromtimestamp(0)
+EPOCH = datetime.datetime.fromtimestamp(0, timezone.utc).replace(tzinfo=None)
 
 PICKLE_PROTOCOL = 4
 


### PR DESCRIPTION
## Summary & Motivation

Fixes issue mentioned by @psarka

Refactors method to explicitly specify timezone when converting from unix timestamp to ISO8601.
Subsequently retains or discards the timezone depending on existing functionality.

## How I Tested These Changes

There is probably a good learning opportunity for me here. I used a snippet to validate the output was unchanged.
Please educate me about how you want to do this properly.
