### PR TITLE
Fix return type specification of asset loader helper functions in `load_assets_from_modules`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -112,7 +112,7 @@ def load_assets_from_modules(
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
-) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
+) -> List[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
     """Constructs a list of assets and source assets from the given modules.
 
     Args:
@@ -132,7 +132,7 @@ def load_assets_from_modules(
             assets will be copies of the loaded objects, with the prefix prepended.
 
     Returns:
-        Sequence[Union[AssetsDefinition, SourceAsset]]:
+        List[Union[AssetsDefinition, SourceAsset]]:
             A list containing assets and source assets defined in the given modules.
     """
     group_name = check.opt_str_param(group_name, "group_name")
@@ -170,7 +170,7 @@ def load_assets_from_current_module(
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
-) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
+) -> List[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
     """Constructs a list of assets, source assets, and cacheable assets from the module where
     this function is called.
 
@@ -190,7 +190,7 @@ def load_assets_from_current_module(
             assets will be copies of the loaded objects, with the prefix prepended.
 
     Returns:
-        Sequence[Union[AssetsDefinition, SourceAsset, CachableAssetsDefinition]]:
+        List[Union[AssetsDefinition, SourceAsset, CachableAssetsDefinition]]:
             A list containing assets, source assets, and cacheable assets defined in the module.
     """
     caller = inspect.stack()[1]
@@ -240,7 +240,7 @@ def load_assets_from_package_module(
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
-) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
+) -> List[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
     """Constructs a list of assets and source assets that includes all asset
     definitions, source assets, and cacheable assets in all sub-modules of the given package module.
 
@@ -263,7 +263,7 @@ def load_assets_from_package_module(
             assets will be copies of the loaded objects, with the prefix prepended.
 
     Returns:
-        Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
+        List[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
             A list containing assets, source assets, and cacheable assets defined in the module.
     """
     group_name = check.opt_str_param(group_name, "group_name")
@@ -301,7 +301,7 @@ def load_assets_from_package_name(
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
-) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
+) -> List[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
     """Constructs a list of assets, source assets, and cacheable assets that includes all asset
     definitions and source assets in all sub-modules of the given package.
 
@@ -322,7 +322,7 @@ def load_assets_from_package_name(
             assets will be copies of the loaded objects, with the prefix prepended.
 
     Returns:
-        Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
+        List[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
             A list containing assets, source assets, and cacheable assets defined in the module.
     """
     package_module = import_module(package_name)
@@ -459,7 +459,7 @@ def assets_with_attributes(
     auto_materialize_policy: Optional[AutoMaterializePolicy],
     backfill_policy: Optional[BackfillPolicy],
     source_key_prefix: Optional[Sequence[str]],
-) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
+) -> List[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
     # There is a tricky edge case here where if a non-cacheable asset depends on a cacheable asset,
     # and the assets are prefixed, the non-cacheable asset's dependency will not be prefixed since
     # at prefix-time it is not known that its dependency is one of the cacheable assets.

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -133,7 +133,7 @@ def _with_code_source_single_definition(
 @experimental
 def with_source_code_references(
     assets_defs: Sequence[Union["AssetsDefinition", "SourceAsset", "CacheableAssetsDefinition"]],
-) -> Sequence[Union["AssetsDefinition", "SourceAsset", "CacheableAssetsDefinition"]]:
+) -> List[Union["AssetsDefinition", "SourceAsset", "CacheableAssetsDefinition"]]:
     """Wrapper function which attaches source code metadata to the provided asset definitions.
 
     Args:
@@ -141,6 +141,6 @@ def with_source_code_references(
             The asset definitions to which source code metadata should be attached.
 
     Returns:
-        Sequence[AssetsDefinition]: The asset definitions with source code metadata attached.
+        List[AssetsDefinition]: The asset definitions with source code metadata attached.
     """
     return [_with_code_source_single_definition(assets_def) for assets_def in assets_defs]


### PR DESCRIPTION
## Summary & Motivation
Solves: https://github.com/dagster-io/dagster/issues/21807

Basically Functions/Classes should take in generics like Sequence, but they should not return said generic if they actually return a concrete implementation. In this case, all of these functions actually return a list. So we shouldn't mistype.

## How I Tested These Changes
Ran the docs build for latest. Ran the dev test suite from where it is actually passing on master (checked out the latest green commit). My changes are minor. No failures found before or after.