### PR TITLE
only fetch observations in get_latest_data_version_record if required

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -3139,42 +3139,46 @@ class DagsterInstance(DynamicPartitionsStore):
         before_cursor: Optional[int] = None,
         after_cursor: Optional[int] = None,
     ) -> Optional["EventLogRecord"]:
-        from dagster._core.events import DagsterEventType
-        from dagster._core.storage.event_log.base import EventRecordsFilter
+        from dagster._core.storage.event_log.base import AssetRecordsFilter
 
         # When we cant don't know whether the requested key corresponds to a source or regular
         # asset, we need to retrieve both the latest observation and materialization for all assets.
         # If there is a materialization, it's a regular asset and we can ignore the observation.
-
-        observation: Optional[EventLogRecord] = None
-        if is_source or is_source is None:
-            observations = self.get_event_records(
-                EventRecordsFilter(
-                    event_type=DagsterEventType.ASSET_OBSERVATION,
-                    asset_key=key,
-                    asset_partitions=[partition_key] if partition_key else None,
-                    before_cursor=before_cursor,
-                    after_cursor=after_cursor,
-                ),
-                limit=1,
-            )
-            observation = next(iter(observations), None)
-
-        materialization: Optional[EventLogRecord] = None
         if not is_source:
-            materializations = self.get_event_records(
-                EventRecordsFilter(
-                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                    asset_key=key,
-                    asset_partitions=[partition_key] if partition_key else None,
-                    before_cursor=before_cursor,
-                    after_cursor=after_cursor,
+            last_materialization = next(
+                iter(
+                    self.fetch_materializations(
+                        AssetRecordsFilter(
+                            asset_key=key,
+                            asset_partitions=[partition_key] if partition_key else None,
+                            before_storage_id=before_cursor,
+                            after_storage_id=after_cursor,
+                        ),
+                        limit=1,
+                    ).records
                 ),
-                limit=1,
+                None,
             )
-            materialization = next(iter(materializations), None)
+            if last_materialization:
+                return last_materialization
 
-        return materialization or observation
+        if is_source or is_source is None:
+            return next(
+                iter(
+                    self.fetch_observations(
+                        AssetRecordsFilter(
+                            asset_key=key,
+                            asset_partitions=[partition_key] if partition_key else None,
+                            before_storage_id=before_cursor,
+                            after_storage_id=after_cursor,
+                        ),
+                        limit=1,
+                    ).records
+                ),
+                None,
+            )
+
+        return None
 
     @public
     def get_latest_materialization_code_versions(


### PR DESCRIPTION
## Summary & Motivation
The current implementation of `get_latest_data_version_record` would always fetch the latest observation AND the latest materialization.  It would then return one or the other, preferring the materialization in the ambiguous case.

This PR short-circuits the ambiguous case such that we only fetch the observation when the materialization is not present.  This effectively halves (from 2 calls => 1 call) the round-trips to storage in the most common case (materializable assets).

Additionally, this PR replaces calls to the generic `get_event_records` API with the narrower `fetch_X` APIs.

This PR is orthogonal to https://github.com/dagster-io/dagster/pull/21798, which replaces calls to `get_latest_data_version_record` with calls to the batchable `get_asset_records` in the simple case where storage_id filters and partition filters are not applied.

Should note: this does not change the logic of which record is returned.  The API name is a little misleading because we will return the latest materialization record even if the observation record is more recent for materializable assets with both types of records.

## How I Tested These Changes
BK
