### PR TITLE
Fix disambiguation routes

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Route.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Route.tsx
@@ -1,9 +1,8 @@
-import {ComponentProps, ReactNode, memo, useMemo} from 'react';
+import {ComponentProps, ReactNode, memo, useLayoutEffect, useMemo} from 'react';
 import {Route as ReactRouterRoute, useRouteMatch} from 'react-router-dom';
 import {useSetRecoilState} from 'recoil';
 
 import {currentPageAtom} from './analytics';
-import {useDangerousRenderEffect} from '../hooks/useDangerousRenderEffect';
 
 export const Route = memo((props: ComponentProps<typeof ReactRouterRoute>) => {
   const {render, children, component: Component} = props;
@@ -54,9 +53,9 @@ const Wrapper = memo(({children}: {children: ReactNode}) => {
   const {path} = useRouteMatch();
 
   const setCurrentPage = useSetRecoilState(currentPageAtom);
-  useDangerousRenderEffect(() => {
+  useLayoutEffect(() => {
     setCurrentPage(({specificPath}) => ({specificPath, path}));
-  }, [path]);
+  }, [path, setCurrentPage]);
 
   return children;
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadRoot.tsx
@@ -56,6 +56,10 @@ export const JobOrAssetLaunchpad = (props: {repoAddress: RepoAddress}) => {
   } = usePermissionsForLocation(repoAddress.location);
   useBlockTraceUntilTrue('Permissions', loading);
 
+  if (loading) {
+    return null;
+  }
+
   if (!canLaunchPipelineExecution) {
     return <Redirect to={`/locations/${repoPath}/pipeline_or_job/${pipelinePath}`} />;
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSetupFromRunRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSetupFromRunRoot.tsx
@@ -34,6 +34,9 @@ export const LaunchpadSetupFromRunRoot = (props: {repoAddress: RepoAddress}) => 
   }>();
 
   useBlockTraceUntilTrue('Permissions', loading);
+  if (loading) {
+    return null;
+  }
   if (!canLaunchPipelineExecution) {
     return <Redirect to={`/locations/${repoPath}/pipeline_or_job/${pipelinePath}`} />;
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSetupRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSetupRoot.tsx
@@ -21,9 +21,13 @@ export const LaunchpadSetupRoot = (props: {repoAddress: RepoAddress}) => {
     permissions: {canLaunchPipelineExecution},
     loading,
   } = usePermissionsForLocation(repoAddress.location);
+
   useBlockTraceUntilTrue('Permissions', loading);
 
   const {repoPath, pipelinePath} = useParams<{repoPath: string; pipelinePath: string}>();
+  if (loading) {
+    return null;
+  }
 
   if (!canLaunchPipelineExecution) {
     return <Redirect to={`/locations/${repoPath}/pipeline_or_job/${pipelinePath}`} />;

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineOrJobDisambiguationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineOrJobDisambiguationRoot.tsx
@@ -1,7 +1,8 @@
+import {useContext} from 'react';
 import {Redirect, useLocation, useParams} from 'react-router-dom';
 
 import {explorerPathFromString} from './PipelinePathUtils';
-import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
+import {WorkspaceContext, isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
 
 interface Props {
@@ -13,8 +14,14 @@ export const PipelineOrJobDisambiguationRoot = (props: Props) => {
   const location = useLocation();
   const {pipelinePath} = useParams<{pipelinePath: string}>();
 
-  const {pipelineName: pipelineOrJobName} = explorerPathFromString(pipelinePath);
+  const {loading} = useContext(WorkspaceContext);
   const repo = useRepository(repoAddress);
+
+  if (loading) {
+    return null;
+  }
+
+  const {pipelineName: pipelineOrJobName} = explorerPathFromString(pipelinePath);
   const isJob = isThisThingAJob(repo, pipelineOrJobName);
   const {pathname, search} = location;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineOrJobDisambiguationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineOrJobDisambiguationRoot.tsx
@@ -2,6 +2,8 @@ import {useContext} from 'react';
 import {Redirect, useLocation, useParams} from 'react-router-dom';
 
 import {explorerPathFromString} from './PipelinePathUtils';
+import {PermissionsContext} from '../app/Permissions';
+import {useBlockTraceUntilTrue} from '../performance/TraceContext';
 import {WorkspaceContext, isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
 
@@ -15,9 +17,12 @@ export const PipelineOrJobDisambiguationRoot = (props: Props) => {
   const {pipelinePath} = useParams<{pipelinePath: string}>();
 
   const {loading} = useContext(WorkspaceContext);
+  const {loading: permissionsLoading} = useContext(PermissionsContext);
   const repo = useRepository(repoAddress);
 
-  if (loading) {
+  useBlockTraceUntilTrue('Workspace', loading);
+  useBlockTraceUntilTrue('Permissions', permissionsLoading);
+  if (loading || permissionsLoading) {
     return null;
   }
 


### PR DESCRIPTION
## Summary & Motivation

In a previous PR I removed a waterfall on the WorkspaceQuery since many of the child routes of `WorkspaceRoot`  do not actually depend on it. 

Well in removing that I made a bug that was previously pretty intermittent / infrequent happen all the time. In particular there were routes that were depending on the permissions query without actually waiting for it. Instead those routes happened to be waiting on the WorkspaceQuery which would normally come back after the permissions query hence why the routes worked before. 

The reason this bug happened intermittently before is because sometimes the WorkspaceQuery would come back before the permissions query causing this bug.

To fix this I make the routes wait for permissions to load directly.


## How I Tested These Changes

Loaded this page Via app-cloud-proxy and saw that we went to the launch pad: http://localhost:3001/elementl/prod/locations/dagster_open_platform/pipeline_or_job/dagster_quickstart_validation_job/playground/setup?config=%7B%7D%0A&tags%5B0%5D%5Bkey%5D=dagster%2Fsensor_name&tags%5B0%5D%5Bvalue%5D=dagster_quickstart_validation_sensor&tags%5B0%5D%5B__typename%5D=PipelineTag

