### PR TITLE
Add brand new Dagster project example to dbt quickstart

### DIFF
--- a/docs/content/integrations/dbt/quickstart.mdx
+++ b/docs/content/integrations/dbt/quickstart.mdx
@@ -50,13 +50,13 @@ The `dagster-dbt` library installs both `dbt-core` and `dagster` as dependencies
 
 You can create a Dagster project that wraps your dbt project by using the `dagster-dbt` command line interface.
 
-To use the command, you'll need to provide 2 options - `--project-name`, the name of your Dagster project to be created, and `--dbt-project-dir`, the path to your dbt project. In our example, our Dagster project is named `my-dagster-project`and the relative path to our dbt project is `./my-dbt-project`, meaning that we are in the directory where `my-dbt-project` is located.
+To use the command, you'll need to provide 2 options - `--project-name`, the name of your Dagster project to be created, and `--dbt-project-dir`, the path to your dbt project. In our example, our Dagster project is named `my_dagster_project`and the relative path to our dbt project is `./my_dbt_project`, meaning that we are in the directory where `my_dbt_project` is located.
 
 ```shell
-dagster-dbt project scaffold --project-name my-dagster-project --dbt-project-dir ./my-dbt-project --use-experimental-dbt-project
+dagster-dbt project scaffold --project-name my_dagster_project --dbt-project-dir ./my_dbt_project --use-experimental-dbt-project
 ```
 
-This command creates a new directory called `my-dagster-project/` inside the current directory. The new `my-dagster-project/` directory will contain a set of files that define a Dagster project to load the dbt project provided in `./my-dbt-project`.
+This command creates a new directory called `my_dagster_project/` inside the current directory. The new `my_dagster_project/` directory will contain a set of files that define a Dagster project to load the dbt project provided in `./my_dbt_project`.
 
 </TabItem>
 </TabGroup>

--- a/docs/content/integrations/dbt/quickstart.mdx
+++ b/docs/content/integrations/dbt/quickstart.mdx
@@ -41,12 +41,12 @@ The `dagster-dbt` library installs both `dbt-core` and `dagster` as dependencies
 
 ---
 
-## Wrap your dbt project with Dagster
+## Load your dbt project in Dagster
 
 <TabGroup>
-<TabItem name="Option 1: Create a brand new Dagster project">
+<TabItem name="Option 1: Create a new Dagster project">
 
-### Option 1: Create a brand new Dagster project
+### Option 1: Create a new Dagster project
 
 You can create a Dagster project that wraps your dbt project by using the `dagster-dbt` command line interface.
 
@@ -56,7 +56,7 @@ To use the command, you'll need to provide 2 options - `--project-name`, the nam
 dagster-dbt project scaffold --project-name my-dagster-project --dbt-project-dir ./my-dbt-project --use-experimental-dbt-project
 ```
 
-This creates a directory called `my-dagster-project/` inside the current directory. The `my-dagster-project/` directory contains a set of files that define a Dagster project.
+This command creates a new directory called `my-dagster-project/` inside the current directory. The new `my-dagster-project/` directory will contain a set of files that define a Dagster project to load the dbt project provided in `./my-dbt-project`.
 
 </TabItem>
 </TabGroup>

--- a/docs/content/integrations/dbt/quickstart.mdx
+++ b/docs/content/integrations/dbt/quickstart.mdx
@@ -50,7 +50,12 @@ The `dagster-dbt` library installs both `dbt-core` and `dagster` as dependencies
 
 You can create a Dagster project that wraps your dbt project by using the `dagster-dbt` command line interface.
 
-To use the command, you'll need to provide 2 options - `--project-name`, the name of your Dagster project to be created, and `--dbt-project-dir`, the path to your dbt project. In our example, our Dagster project is named `my_dagster_project`and the relative path to our dbt project is `./my_dbt_project`, meaning that we are in the directory where `my_dbt_project` is located.
+To use the command, you'll need to provide two options:
+
+- `--project-name`, the name of your Dagster project to be created, and
+- `--dbt-project-dir`, the path to your dbt project.
+
+In our example, our Dagster project is named `my_dagster_project` and the relative path to our dbt project is `./my_dbt_project`, meaning that we are in the directory where `my_dbt_project` is located.
 
 ```shell
 dagster-dbt project scaffold --project-name my_dagster_project --dbt-project-dir ./my_dbt_project --use-experimental-dbt-project

--- a/docs/content/integrations/dbt/quickstart.mdx
+++ b/docs/content/integrations/dbt/quickstart.mdx
@@ -41,6 +41,28 @@ The `dagster-dbt` library installs both `dbt-core` and `dagster` as dependencies
 
 ---
 
+## Wrap your dbt project with Dagster
+
+<TabGroup>
+<TabItem name="Option 1: Create a brand new Dagster project">
+
+### Option 1: Create a brand new Dagster project
+
+You can create a Dagster project that wraps your dbt project by using the `dagster-dbt` command line interface.
+
+To use the command, you'll need to provide 2 options - `--project-name`, the name of your Dagster project to be created, and `--dbt-project-dir`, the path to your dbt project. In our example, our Dagster project is named `my-dagster-project`and the relative path to our dbt project is `./my-dbt-project`, meaning that we are in the directory where `my-dbt-project` is located.
+
+```shell
+dagster-dbt project scaffold --project-name my-dagster-project --dbt-project-dir ./my-dbt-project --use-experimental-dbt-project
+```
+
+This creates a directory called `my-dagster-project/` inside the current directory. The `my-dagster-project/` directory contains a set of files that define a Dagster project.
+
+</TabItem>
+</TabGroup>
+
+---
+
 ## Run your dbt project in Dagster's UI
 
 Now that your code is ready, you can run Dagster's UI to take a look at your dbt project.


### PR DESCRIPTION
## Summary & Motivation

This PR updates the quickstart example for dbt + Dagster - it adds the steps to create a brand new Dagster project using the scaffold to wrap a dbt project.

This work is the continuation of #21240 

## How I Tested These Changes

BK 
+
local
```
make mdx-full-format
make next-watch-build
```