### PR TITLE
[chore] Middle truncate asset check names

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -9,6 +9,7 @@ import {
   CursorPaginationProps,
   ExternalAnchorButton,
   Icon,
+  MiddleTruncate,
   NonIdealState,
   Spinner,
   Subtitle1,
@@ -229,7 +230,9 @@ export const AssetChecks = ({
                             >
                               {getCheckIcon(check)}
                             </Box>
-                            <Body2>{check.name}</Body2>
+                            <Body2 style={{overflow: 'hidden'}}>
+                              <MiddleTruncate text={check.name} />
+                            </Body2>
                           </Box>
                           <Box padding={{horizontal: 24}}>
                             <Caption


### PR DESCRIPTION
## Summary & Motivation

before:
<img width="328" alt="Screenshot 2024-05-13 at 5 30 04 PM" src="https://github.com/dagster-io/dagster/assets/2286579/98fcf256-058b-4e3c-9589-a7ed33c925c5">


after:
<img width="454" alt="Screenshot 2024-05-13 at 5 28 55 PM" src="https://github.com/dagster-io/dagster/assets/2286579/8954133b-dcb2-4367-ad8d-54aea9b8a196">
