### PR TITLE
[dagster-yaml] yaml pydantic parsing utils

### DIFF
--- a/python_modules/dagster/dagster/_model/pydantic_compat_layer.py
+++ b/python_modules/dagster/dagster/_model/pydantic_compat_layer.py
@@ -1,14 +1,7 @@
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Optional,
-    Type,
-)
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Type
 
 import pydantic
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 USING_PYDANTIC_1 = int(pydantic.__version__.split(".")[0]) == 1
 USING_PYDANTIC_2 = int(pydantic.__version__.split(".")[0]) >= 2
@@ -141,3 +134,20 @@ except ImportError:
 
 
 compat_model_validator = model_validator
+
+
+def build_validation_error(
+    base_error: ValidationError,
+    line_errors: List,
+    hide_input: bool,
+    input_type: Literal["python", "json"],
+) -> ValidationError:
+    if USING_PYDANTIC_1:
+        return ValidationError(errors=line_errors, model=base_error.model)  # type: ignore
+    else:
+        return ValidationError.from_exception_data(  # type: ignore
+            title=base_error.title,  # type: ignore
+            line_errors=line_errors,
+            input_type=input_type,
+            hide_input=hide_input,
+        )

--- a/python_modules/dagster/dagster/_utils/pydantic_yaml.py
+++ b/python_modules/dagster/dagster/_utils/pydantic_yaml.py
@@ -1,0 +1,52 @@
+from typing import Type, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+from dagster._model.pydantic_compat_layer import build_validation_error
+
+from .source_position import KeyPath, populate_source_position_and_key_paths
+from .yaml_utils import parse_yaml_with_source_positions
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def parse_yaml_file_to_pydantic(cls: Type[T], src: str, filename: str = "<string>") -> T:
+    """Parse the YAML source and create a Pydantic model instance from it.
+
+    Attaches source position information to the `_source_position_and_key_path` attribute of the
+    Pydantic model instance and sub-objects.
+
+    Args:
+        cls (type[T]): The Pydantic model class to use for validation.
+        src (str): The YAML source string to be parsed.
+        filename (str): The filename associated with the YAML source, used for error reporting.
+            Defaults to "<string>" if not provided.
+
+    Returns:
+        T: An instance of the Pydantic model class, with the `_source_position_and_key_path`
+            attribute populated on it and all the objects inside it.
+
+    Raises:
+        ValidationError: If the YAML data does not conform to the Pydantic model schema. Errors
+            will include context information about the position in the document that the model
+            corresponds to.
+    """
+    parsed = parse_yaml_with_source_positions(src, filename)
+    try:
+        model = cls.parse_obj(parsed.value)
+    except ValidationError as e:
+        line_errors = []
+        for error in e.errors():
+            key_path: KeyPath = error["loc"]
+            key_path_str = ".".join(str(part) for part in key_path)
+            source_position = parsed.source_position_tree.lookup(key_path)
+            line_errors.append({**error, "loc": [key_path_str + " at " + str(source_position)]})
+
+        # `from None` avoids the confusing "During handling of the
+        # above exception, another exception occurred"
+        raise build_validation_error(
+            base_error=e, line_errors=line_errors, input_type="json", hide_input=False
+        ) from None
+
+    populate_source_position_and_key_paths(model, parsed.source_position_tree)
+    return model

--- a/python_modules/dagster/dagster/_utils/source_position.py
+++ b/python_modules/dagster/dagster/_utils/source_position.py
@@ -1,0 +1,116 @@
+from typing import Any, Mapping, NamedTuple, Optional, Sequence, Union, cast
+
+from dagster import _check as check
+
+KeyPathSegment = Union[str, int]
+KeyPath = Sequence[KeyPathSegment]
+
+
+class LineCol(NamedTuple):
+    line: int
+    col: int
+
+
+class SourcePosition(NamedTuple):
+    filename: str
+    start: LineCol
+    end: LineCol
+
+    def __str__(self):
+        return f"{self.filename}:{self.start.line}"
+
+
+class SourcePositionTree(NamedTuple):
+    """Represents a tree where every node has a SourcePosition."""
+
+    position: SourcePosition
+    children: Mapping[KeyPathSegment, "SourcePositionTree"]
+
+    def __hash__(self) -> int:
+        return hash((self.position, tuple(sorted(self.children.items()))))
+
+    def lookup(self, key_path: KeyPath) -> Optional[SourcePosition]:
+        """Returns the source position of the descendant at the given path."""
+        if len(key_path) == 0:
+            return self.position
+        head, *tail = key_path
+        if head not in self.children:
+            return None
+        return self.children[head].lookup(tail)
+
+
+class ValueAndSourcePositionTree(NamedTuple):
+    """An tree-like object (like a JSON-structured dict) and an accompanying SourcePositionTree.
+
+    Each tree node in the SourcePositionTree is expected to correspond to in value.
+    """
+
+    value: Any
+    source_position_tree: SourcePositionTree
+
+
+class SourcePositionAndKeyPath(NamedTuple):
+    """Represents a source position and key path within a file.
+
+    Attributes:
+        key_path (KeyPath): The path of keys that lead to the current object, where each element in
+            the path is either a string (for dict keys) or an integer (for list indices).
+        source_position (Optional[SourcePosition]): The source position of the object in the
+            document, if available.
+    """
+
+    key_path: KeyPath
+    source_position: Optional[SourcePosition]
+
+
+class HasSourcePositionAndKeyPath:
+    _source_position_and_key_path: Optional[SourcePositionAndKeyPath] = None
+
+
+def populate_source_position_and_key_paths(
+    obj: Any,
+    source_position_tree: Optional[SourcePositionTree],
+    key_path: KeyPath = [],
+) -> None:
+    """Populate the SourcePositionAndKeyPath for the given object and its children.
+
+    This function recursively traverses the object and its children, setting the
+    SourcePositionAndKeyPath on each object that subclasses HasSourcePositionAndKeyPath.
+
+    If the obj is a collection, its children are the elements in the collection. If obj is an
+    object, its children are its attributes.
+
+    The SourcePositionAndKeyPath is set based on the provided source position tree, which contains
+    the source position information for the object and its children.
+
+    Args:
+        obj (Any): The object to populate the source position and key path for.
+        source_position_tree (Optional[SourcePositionTree]): The tree node containing the source
+            position information for the object and its children.
+        key_path (KeyPath): The path of keys that lead to the current object.
+    """
+    if isinstance(obj, HasSourcePositionAndKeyPath):
+        check.invariant(
+            obj._source_position_and_key_path is None,  # noqa: SLF001
+            "Cannot call populate_source_position_and_key_paths() more than once on the same object",
+        )
+
+        if source_position_tree is not None:
+            obj._source_position_and_key_path = SourcePositionAndKeyPath(  # noqa: SLF001
+                key_path, source_position_tree.position
+            )
+
+    if source_position_tree is None:
+        return
+
+    for child_key_segment, child_tree in source_position_tree.children.items():
+        try:
+            child_obj = cast(Any, obj)[child_key_segment]
+        except TypeError:
+            if not isinstance(child_key_segment, str):
+                raise
+            child_obj = getattr(obj, child_key_segment)
+
+        populate_source_position_and_key_paths(
+            child_obj, child_tree, [*key_path, child_key_segment]
+        )

--- a/python_modules/dagster/dagster/_utils/yaml_utils.py
+++ b/python_modules/dagster/dagster/_utils/yaml_utils.py
@@ -1,13 +1,21 @@
 import functools
 import glob
-from typing import Any, Dict, List, Mapping, Sequence, Type
+from typing import Any, Dict, List, Mapping, Sequence, Type, cast
 
 import yaml
 
 import dagster._check as check
 
 from .merger import deep_merge_dicts
+from .source_position import (
+    KeyPathSegment,
+    LineCol,
+    SourcePosition,
+    SourcePositionTree,
+    ValueAndSourcePositionTree,
+)
 
+# Removing this implicit loader stops YAML-loading from returning datetime objects
 YAML_TIMESTAMP_TAG = "tag:yaml.org,2002:timestamp"
 YAML_STR_TAG = "tag:yaml.org,2002:str"
 
@@ -152,3 +160,93 @@ def dump_run_config_yaml(run_config: Mapping[str, Any], sort_keys: bool = True) 
         allow_unicode=True,
         sort_keys=sort_keys,
     )
+
+
+def parse_yaml_with_source_positions(
+    src: str,
+    filename: str = "<string>",
+    implicits_to_remove: Sequence[str] = [YAML_TIMESTAMP_TAG],
+) -> ValueAndSourcePositionTree:
+    """Parse YAML source with source position information.
+    This function takes a YAML source string and an optional filename, and returns a
+    `ValueAndSourcePositionTree` object. The `ValueAndSourcePositionTree` contains the
+    parsed YAML value and a `SourcePositionTree` that holds the source position information for
+    the YAML structure.
+
+    The function uses a custom YAML loader (`SourcePositionLoader`) that tracks the source position
+    information for each YAML node. It also allows for the removal of specific implicit resolvers,
+    such as the default timestamp resolver.
+
+    Args:
+        src (str): The YAML source string to be parsed.
+        filename (str): The filename associated with the YAML source, used for error reporting.
+            Defaults to "<string>" if not provided.
+        implicits_to_remove (list[str]): A list of YAML implicit resolvers to remove. Defaults to
+            removing the timestamp resolver.
+
+    Returns:
+        ValueAndSourcePositionTree: An object containing the parsed YAML value and the corresponding
+            source position information.
+    """
+
+    class SourcePositionLoader(yaml.SafeLoader, _CanRemoveImplicitResolver):
+        def construct_object(self, node: Any, deep: Any = False) -> ValueAndSourcePositionTree:
+            """Returns a ValueAndSourcePositionTree object where:
+            - Its value is what the regular yaml.SafeLoader returns
+            - Its source_position_tree is a tree where each node corresponds to a node in the YAML
+              tree.
+            """
+            source_position = SourcePosition(
+                filename=filename,
+                start=LineCol(line=node.start_mark.line + 1, col=node.start_mark.column + 1),
+                end=LineCol(line=node.end_mark.line + 1, col=node.end_mark.column + 1),
+            )
+
+            value = super().construct_object(node, True)
+            # If value is a collection, then all of its elements will be ValueAndSourcePositionTree
+            # instances. We need to do two things:
+            # - Strip out the enclosing ValueAndSourcePositionTrees, so we're just returning a
+            #   collection of the raw values
+            # - Assemble the source position subtrees into a super-tree
+
+            if isinstance(value, dict):
+                dict_with_raw_values: dict[Any, Any] = {}
+                child_trees: dict[KeyPathSegment, SourcePositionTree] = {}
+                for k, v in cast(
+                    Mapping[ValueAndSourcePositionTree, ValueAndSourcePositionTree], value
+                ).items():
+                    dict_with_raw_values[k.value] = v.value
+                    child_trees[k.value] = v.source_position_tree
+                return ValueAndSourcePositionTree(
+                    dict_with_raw_values,
+                    SourcePositionTree(position=source_position, children=child_trees),
+                )
+            if isinstance(value, list):
+                list_with_raw_values: list[Any] = []
+                child_trees: dict[KeyPathSegment, SourcePositionTree] = {}
+                for i, v in enumerate(cast(Sequence[ValueAndSourcePositionTree], value)):
+                    list_with_raw_values.append(v.value)
+                    child_trees[i] = v.source_position_tree
+                return ValueAndSourcePositionTree(
+                    list_with_raw_values,
+                    SourcePositionTree(position=source_position, children=child_trees),
+                )
+
+            return ValueAndSourcePositionTree(
+                value,
+                SourcePositionTree(position=source_position, children={}),
+            )
+
+    for implicit_to_remove in implicits_to_remove:
+        SourcePositionLoader.remove_implicit_resolver(implicit_to_remove)
+
+    try:
+        value_and_tree_node = yaml.load(src, Loader=SourcePositionLoader)
+    except yaml.MarkedYAMLError as e:
+        if e.context_mark is not None:
+            e.context_mark.name = filename
+        if e.problem_mark is not None:
+            e.problem_mark.name = filename
+        raise e
+
+    return value_and_tree_node

--- a/python_modules/dagster/dagster_tests/utils_tests/test_pydantic_yaml.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_pydantic_yaml.py
@@ -1,0 +1,37 @@
+import traceback
+
+import pytest
+from dagster._utils.pydantic_yaml import parse_yaml_file_to_pydantic
+from dagster._utils.source_position import HasSourcePositionAndKeyPath
+from pydantic import BaseModel, ValidationError
+
+
+def test_parse_yaml_file_to_pydantic_error() -> None:
+    class BrokenModel2(BaseModel):
+        bar: str
+
+    class BrokenModel(BaseModel):
+        foo: list[BrokenModel2]
+
+    with pytest.raises(ValidationError) as excinfo:
+        parse_yaml_file_to_pydantic(BrokenModel, "foo:\n  - bar: 1")
+
+    e = excinfo.value
+    e_str = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+
+    assert "foo.0.bar at <string>:2" in e_str
+    # No funny business with showing the same exception twice, which can happen with
+    # "During handling of the above exception, another exception occurred"
+    assert e_str.count("ValidationError:") == 1
+
+
+def test_parse_yaml_file_to_pydantic() -> None:
+    class MyModel2(BaseModel, HasSourcePositionAndKeyPath):
+        name: str
+
+    class MyModel(BaseModel):
+        child: MyModel2
+
+    rv = parse_yaml_file_to_pydantic(MyModel, "child:\n  name: foo")
+    assert rv.child.name == "foo"
+    assert str(rv.child._source_position_and_key_path.source_position) == "<string>:2"  # noqa: SLF001 # type: ignore

--- a/python_modules/dagster/dagster_tests/utils_tests/test_source_position.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_source_position.py
@@ -1,0 +1,113 @@
+from dagster._utils.source_position import (
+    HasSourcePositionAndKeyPath,
+    KeyPath,
+    SourcePositionTree,
+    populate_source_position_and_key_paths,
+)
+from dagster._utils.yaml_utils import parse_yaml_with_source_positions
+
+
+def test_parse_yaml_with_source_positions() -> None:
+    source = """
+foo:
+  bar: 1
+  q: [r, s, t]
+  baz:
+    - a
+    - b:
+      a: b
+  # a comment
+  c: "d"
+"""
+
+    value_and_tree = parse_yaml_with_source_positions(source, filename="foo.yaml")
+
+    assert value_and_tree.value == {
+        "foo": {
+            "bar": 1,
+            "q": ["r", "s", "t"],
+            "baz": ["a", {"b": None, "a": "b"}],
+            "c": "d",
+        }
+    }
+    flattened: dict[str, str] = {}
+
+    def visit(path: KeyPath, tree: SourcePositionTree):
+        flattened[".".join(str(segment) for segment in path)] = str(tree.position)
+        for segment, next_tree in tree.children.items():
+            visit([*path, segment], next_tree)
+
+    visit([], value_and_tree.source_position_tree)
+    assert flattened == {
+        "": "foo.yaml:2",
+        "foo": "foo.yaml:3",
+        "foo.bar": "foo.yaml:3",
+        "foo.q": "foo.yaml:4",
+        "foo.q.0": "foo.yaml:4",
+        "foo.q.1": "foo.yaml:4",
+        "foo.q.2": "foo.yaml:4",
+        "foo.baz": "foo.yaml:6",
+        "foo.baz.0": "foo.yaml:6",
+        "foo.baz.1": "foo.yaml:7",
+        "foo.baz.1.b": "foo.yaml:7",
+        "foo.baz.1.a": "foo.yaml:8",
+        "foo.c": "foo.yaml:10",
+    }
+
+
+def test_populate_source_position_and_key_paths() -> None:
+    class CustomStr(str, HasSourcePositionAndKeyPath):
+        pass
+
+    class Leaf(HasSourcePositionAndKeyPath):
+        def __init__(self):
+            self.str1 = "str1"
+            self.str2 = CustomStr("str2")
+
+    class Child(HasSourcePositionAndKeyPath):
+        def __init__(self):
+            self.dicts = {1: {2: Leaf()}, 3: {4: Leaf()}, 5: {6: Leaf()}}
+
+    class Root:
+        def __init__(self):
+            self.child = Child()
+
+    parsed = parse_yaml_with_source_positions(
+        """
+child:
+  dicts:
+    1:
+      2:
+        str1: str1
+        str2: str2
+    3:
+      4:
+        str1: str1
+        str2: str2
+    5:
+      6:
+        str1: str1
+        str2: str2
+"""
+    )
+    value = Root()
+
+    populate_source_position_and_key_paths(value, parsed.source_position_tree)
+    assert value.child.dicts[3][4]._source_position_and_key_path is not None  # noqa: SLF001
+    assert (
+        str(value.child.dicts[3][4]._source_position_and_key_path.source_position) == "<string>:10"  # noqa: SLF001
+    )
+    assert value.child.dicts[3][4]._source_position_and_key_path.key_path == [  # noqa: SLF001
+        "child",
+        "dicts",
+        3,
+        4,
+    ]
+
+    assert value.child.dicts[3][4].str2._source_position_and_key_path is not None  # noqa: SLF001
+    assert (
+        str(value.child.dicts[3][4].str2._source_position_and_key_path.source_position)  # noqa: SLF001
+        == "<string>:11"
+    )
+
+    assert not hasattr(value.child.dicts[3][4].str1, "object_mapping_context")


### PR DESCRIPTION
## Summary & Motivation

Tools for parsing YAML files into pydantic models, preserving information about source positions, including those source positions in validation errors.

Adapted from @petehunt's versions of these in the internal repo.

## How I Tested These Changes
