### PR TITLE
 Block trace on more query results

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Permissions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Permissions.tsx
@@ -6,6 +6,7 @@ import {
   PermissionsQuery,
   PermissionsQueryVariables,
 } from './types/Permissions.types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
 // used in tests, to ensure against permission renames.  Should make sure that the mapping in
 // extractPermissions is handled correctly
@@ -130,9 +131,12 @@ export const PermissionsContext = React.createContext<PermissionsContextType>({
 });
 
 export const PermissionsProvider = (props: {children: React.ReactNode}) => {
-  const {data, loading} = useQuery<PermissionsQuery, PermissionsQueryVariables>(PERMISSIONS_QUERY, {
+  const queryResult = useQuery<PermissionsQuery, PermissionsQueryVariables>(PERMISSIONS_QUERY, {
     fetchPolicy: 'cache-first', // Not expected to change after initial load.
   });
+
+  const {data, loading} = queryResult;
+  useBlockTraceOnQueryResult(queryResult, 'PermissionsQuery');
 
   const value = React.useMemo(() => {
     const unscopedPermissionsRaw = data?.unscopedPermissions || [];

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRunTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRunTag.tsx
@@ -3,6 +3,7 @@ import {Tag} from '@dagster-io/ui-components';
 import {Link} from 'react-router-dom';
 
 import {RunStatusOnlyQuery, RunStatusOnlyQueryVariables} from './types/AutomaterializeRunTag.types';
+import {useBlockTraceOnQueryResult} from '../../performance/TraceContext';
 import {RunStatusTagWithID} from '../../runs/RunStatusTag';
 
 interface Props {
@@ -10,12 +11,11 @@ interface Props {
 }
 
 export const AutomaterializeRunTag = ({runId}: Props) => {
-  const {data, loading} = useQuery<RunStatusOnlyQuery, RunStatusOnlyQueryVariables>(
-    RUN_STATUS_ONLY,
-    {
-      variables: {runId},
-    },
-  );
+  const queryResult = useQuery<RunStatusOnlyQuery, RunStatusOnlyQueryVariables>(RUN_STATUS_ONLY, {
+    variables: {runId},
+  });
+  const {data, loading} = queryResult;
+  useBlockTraceOnQueryResult(queryResult, 'RunStatusOnlyQuery');
 
   if (loading && !data) {
     return <Tag icon="spinner">Loading</Tag>;

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/RunGroupPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/RunGroupPanel.tsx
@@ -12,6 +12,7 @@ import {
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {SidebarSection} from '../pipelines/SidebarComponents';
 import {RunStatusIndicator} from '../runs/RunStatusDots';
 import {DagsterTag} from '../runs/RunTag';
@@ -38,6 +39,7 @@ export const RunGroupPanel = ({
       notifyOnNetworkStatusChange: true,
     },
   );
+  useBlockTraceOnQueryResult(queryResult, 'RunGroupPanelQuery');
 
   const {data, refetch} = queryResult;
   useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
@@ -27,6 +27,7 @@ import {BulkActionStatus} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {DaemonNotRunningAlertBody} from '../partitions/BackfillMessaging';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {useCursorPaginatedQuery} from '../runs/useCursorPaginatedQuery';
 import {useFilters} from '../ui/Filters';
 import {useStaticSetFilter} from '../ui/Filters/useStaticSetFilter';
@@ -66,6 +67,7 @@ export const InstanceBackfills = () => {
     InstanceHealthForBackfillsQuery,
     InstanceHealthForBackfillsQueryVariables
   >(INSTANCE_HEALTH_FOR_BACKFILLS_QUERY);
+  useBlockTraceOnQueryResult(queryData, 'InstanceHealthForBackfillsQuery');
 
   const [statusState, setStatusState] = useQueryPersistedState<Set<BulkActionStatus>>({
     encode: (vals) => ({status: vals.size ? Array.from(vals).join(',') : undefined}),

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
@@ -81,6 +81,7 @@ export const InstanceConcurrencyPageContent = React.memo(() => {
   >(INSTANCE_CONCURRENCY_LIMITS_QUERY, {
     notifyOnNetworkStatusChange: true,
   });
+  useBlockTraceOnQueryResult(queryResult, 'InstanceConcurrencyLimitsQuery');
 
   const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
   const {data} = queryResult;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConfig.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConfig.tsx
@@ -25,6 +25,7 @@ import {
 } from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
 const InstanceConfigStyle = createGlobalStyle`
   .CodeMirror.cm-s-instance-config.cm-s-instance-config {
@@ -49,6 +50,7 @@ export const InstanceConfigContent = memo(() => {
       notifyOnNetworkStatusChange: true,
     },
   );
+  useBlockTraceOnQueryResult(queryResult, 'InstanceConfigQuery');
 
   const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
   const {data} = queryResult;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceHealthPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceHealthPage.tsx
@@ -14,6 +14,7 @@ import {
 } from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
 export const InstanceHealthPageContent = () => {
   useTrackPageView();
@@ -25,6 +26,7 @@ export const InstanceHealthPageContent = () => {
       notifyOnNetworkStatusChange: true,
     },
   );
+  useBlockTraceOnQueryResult(queryData, 'InstanceHealthQuery');
   const refreshState = useQueryRefreshAtInterval(queryData, FIFTEEN_SECONDS);
   const {loading, data} = queryData;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/StepSummaryForRun.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/StepSummaryForRun.tsx
@@ -9,6 +9,7 @@ import {
   StepSummaryForRunQueryVariables,
 } from './types/StepSummaryForRun.types';
 import {StepEventStatus} from '../graphql/types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {failedStatuses, inProgressStatuses} from '../runs/RunStatuses';
 
 interface Props {
@@ -17,12 +18,14 @@ interface Props {
 
 export const StepSummaryForRun = (props: Props) => {
   const {runId} = props;
-  const {data} = useQuery<StepSummaryForRunQuery, StepSummaryForRunQueryVariables>(
+  const queryResult = useQuery<StepSummaryForRunQuery, StepSummaryForRunQueryVariables>(
     STEP_SUMMARY_FOR_RUN_QUERY,
     {
       variables: {runId},
     },
   );
+  const {data} = queryResult;
+  useBlockTraceOnQueryResult(queryResult, 'StepSummaryForRunQuery');
 
   const run = data?.pipelineRunOrError;
   const status = run?.__typename === 'Run' ? run.status : null;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
@@ -38,6 +38,7 @@ import {assetDetailsPathForKey} from '../../assets/assetDetailsPathForKey';
 import {AssetViewParams} from '../../assets/types';
 import {AssetKey, BulkActionStatus, RunStatus} from '../../graphql/types';
 import {useDocumentTitle} from '../../hooks/useDocumentTitle';
+import {useBlockTraceOnQueryResult} from '../../performance/TraceContext';
 import {RunFilterToken, runsPathWithFilters} from '../../runs/RunsFilterInput';
 import {testId} from '../../testing/testId';
 
@@ -55,6 +56,7 @@ export const BackfillPage = () => {
     BACKFILL_DETAILS_QUERY,
     {variables: {backfillId}},
   );
+  useBlockTraceOnQueryResult(queryResult, 'BackfillStatusesByAssetQuery');
 
   const {data} = queryResult;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/useCanSeeConfig.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/useCanSeeConfig.tsx
@@ -4,12 +4,14 @@ import {
   InstanceConfigHasInfoQuery,
   InstanceConfigHasInfoQueryVariables,
 } from './types/useCanSeeConfig.types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
 export const useCanSeeConfig = () => {
-  const {data} = useQuery<InstanceConfigHasInfoQuery, InstanceConfigHasInfoQueryVariables>(
+  const queryResult = useQuery<InstanceConfigHasInfoQuery, InstanceConfigHasInfoQueryVariables>(
     INSTANCE_CONFIG_HAS_INFO,
   );
-  return !!data?.instance.hasInfo;
+  useBlockTraceOnQueryResult(queryResult, 'InstanceConfigHasInfoQuery');
+  return !!queryResult.data?.instance.hasInfo;
 };
 
 const INSTANCE_CONFIG_HAS_INFO = gql`

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/useRunQueueConfig.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/useRunQueueConfig.tsx
@@ -4,12 +4,14 @@ import {
   InstanceRunQueueConfigQuery,
   InstanceRunQueueConfigQueryVariables,
 } from './types/useRunQueueConfig.types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
 export const useRunQueueConfig = () => {
-  const {data} = useQuery<InstanceRunQueueConfigQuery, InstanceRunQueueConfigQueryVariables>(
+  const queryResult = useQuery<InstanceRunQueueConfigQuery, InstanceRunQueueConfigQueryVariables>(
     INSTANCE_RUN_QUEUE_CONFIG,
   );
-  return data?.instance.runQueueConfig;
+  useBlockTraceOnQueryResult(queryResult, 'InstanceRunQueueConfigQuery');
+  return queryResult.data?.instance.runQueueConfig;
 };
 
 const INSTANCE_RUN_QUEUE_CONFIG = gql`

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/useSupportsCapturedLogs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/useSupportsCapturedLogs.tsx
@@ -4,13 +4,15 @@ import {
   InstanceSupportsCapturedLogsQuery,
   InstanceSupportsCapturedLogsQueryVariables,
 } from './types/useSupportsCapturedLogs.types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
 export const useSupportsCapturedLogs = () => {
-  const {data} = useQuery<
+  const queryResult = useQuery<
     InstanceSupportsCapturedLogsQuery,
     InstanceSupportsCapturedLogsQueryVariables
   >(INSTANCE_SUPPORTS_CAPTURED_LOGS);
-  return !!data?.instance.hasCapturedLogManager;
+  useBlockTraceOnQueryResult(queryResult, 'InstanceSupportsCapturedLogsQuery');
+  return !!queryResult.data?.instance.hasCapturedLogManager;
 };
 
 const INSTANCE_SUPPORTS_CAPTURED_LOGS = gql`

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/InstigationTick.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/InstigationTick.tsx
@@ -12,10 +12,11 @@ import {
 
 import {LaunchedRunListQuery, LaunchedRunListQueryVariables} from './types/InstigationTick.types';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {RUN_TABLE_RUN_FRAGMENT, RunTable} from '../runs/RunTable';
 
 export const RunList = ({runIds}: {runIds: string[]}) => {
-  const {data, loading} = useQuery<LaunchedRunListQuery, LaunchedRunListQueryVariables>(
+  const queryResult = useQuery<LaunchedRunListQuery, LaunchedRunListQueryVariables>(
     LAUNCHED_RUN_LIST_QUERY,
     {
       variables: {
@@ -25,6 +26,8 @@ export const RunList = ({runIds}: {runIds: string[]}) => {
       },
     },
   );
+  const {data, loading} = queryResult;
+  useBlockTraceOnQueryResult(queryResult, 'LaunchedRunListQuery');
 
   if (loading || !data) {
     return (

--- a/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
@@ -22,6 +22,7 @@ import {RepoFilterButton} from '../instance/RepoFilterButton';
 import {OverviewJobsTable} from '../overview/OverviewJobsTable';
 import {sortRepoBuckets} from '../overview/sortRepoBuckets';
 import {visibleRepoKeys} from '../overview/visibleRepoKeys';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {SearchInputSpinner} from '../ui/SearchInputSpinner';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
@@ -44,6 +45,7 @@ export const JobsPageContent = () => {
       notifyOnNetworkStatusChange: true,
     },
   );
+  useBlockTraceOnQueryResult(queryResultOverview, 'OverviewJobsQuery');
   const {data, loading} = queryResultOverview;
 
   const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -34,6 +34,7 @@ import {ShortcutHandler} from '../app/ShortcutHandler';
 import {PartitionDefinitionType, RepositorySelector} from '../graphql/types';
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {CreatePartitionDialog} from '../partitions/CreatePartitionDialog';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
@@ -156,7 +157,7 @@ const ConfigEditorPartitionPicker = React.memo((props: ConfigEditorPartitionPick
   const {basePath} = React.useContext(AppContext);
   const repositorySelector = repoAddressToSelector(repoAddress);
 
-  const {data, refetch, loading} = useQuery<ConfigPartitionsQuery, ConfigPartitionsQueryVariables>(
+  const queryResult = useQuery<ConfigPartitionsQuery, ConfigPartitionsQueryVariables>(
     CONFIG_PARTITIONS_QUERY,
     {
       variables: {
@@ -169,6 +170,8 @@ const ConfigEditorPartitionPicker = React.memo((props: ConfigEditorPartitionPick
       fetchPolicy: 'network-only',
     },
   );
+  const {data, refetch, loading} = queryResult;
+  useBlockTraceOnQueryResult(queryResult, 'ConfigPartitionsQuery');
 
   const sortOrderKey = `${SORT_ORDER_KEY_BASE}-${basePath}-${repoAddressAsHumanString(
     repoAddress,

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/JobMetadata.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/JobMetadata.tsx
@@ -23,6 +23,7 @@ import {
 } from './types/JobMetadata.types';
 import {tokenForAssetKey} from '../asset-graph/Utils';
 import {AutomaterializeDaemonStatusTag} from '../assets/AutomaterializeDaemonStatusTag';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {DagsterTag} from '../runs/RunTag';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
@@ -37,7 +38,7 @@ type JobMetadata = {
 };
 
 function useJobNavMetadata(repoAddress: RepoAddress, pipelineName: string) {
-  const {data} = useQuery<JobMetadataQuery, JobMetadataQueryVariables>(JOB_METADATA_QUERY, {
+  const queryResult = useQuery<JobMetadataQuery, JobMetadataQueryVariables>(JOB_METADATA_QUERY, {
     variables: {
       runsFilter: {
         pipelineName,
@@ -55,6 +56,8 @@ function useJobNavMetadata(repoAddress: RepoAddress, pipelineName: string) {
       },
     },
   });
+  const data = queryResult.data;
+  useBlockTraceOnQueryResult(queryResult, 'JobMetadataQuery');
 
   return useMemo<JobMetadata>(() => {
     return {

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/LatestRunTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/LatestRunTag.tsx
@@ -6,6 +6,7 @@ import {Link} from 'react-router-dom';
 import {LatestRunTagQuery, LatestRunTagQueryVariables} from './types/LatestRunTag.types';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {RunStatus} from '../graphql/types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {RunStatusIndicator} from '../runs/RunStatusDots';
 import {DagsterTag} from '../runs/RunTag';
 import {timingStringForStatus} from '../runs/RunTimingDetails';
@@ -40,6 +41,7 @@ export const LatestRunTag = ({
       notifyOnNetworkStatusChange: true,
     },
   );
+  useBlockTraceOnQueryResult(lastRunQuery, 'LatestRunTagQuery');
 
   useQueryRefreshAtInterval(lastRunQuery, FIFTEEN_SECONDS);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/ops/OpDetailsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ops/OpDetailsRoot.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import {OP_CARD_SOLID_DEFINITION_FRAGMENT, OpCard} from './OpCard';
 import {UsedSolidDetailsQuery, UsedSolidDetailsQueryVariables} from './types/OpDetailsRoot.types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {
   SIDEBAR_OP_DEFINITION_FRAGMENT,
   SidebarOpDefinition,
@@ -31,6 +32,7 @@ export const UsedSolidDetails = (props: UsedSolidDetailsProps) => {
       },
     },
   );
+  useBlockTraceOnQueryResult(queryResult, 'UsedSolidDetailsQuery');
 
   return (
     <Loading queryResult={queryResult}>

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewResourcesRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewResourcesRoot.tsx
@@ -16,6 +16,7 @@ import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {RepoFilterButton} from '../instance/RepoFilterButton';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {RESOURCE_ENTRY_FRAGMENT} from '../resources/WorkspaceResourcesRoot';
 import {ResourceEntryFragment} from '../resources/types/WorkspaceResourcesRoot.types';
 import {SearchInputSpinner} from '../ui/SearchInputSpinner';
@@ -44,7 +45,7 @@ export const OverviewResourcesRoot = () => {
     },
   );
   const {data, loading} = queryResultOverview;
-
+  useBlockTraceOnQueryResult(queryResultOverview, 'OverviewResourcesQuery');
   const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
   // Batch up the data and bucket by repo.

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSchedules.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSchedules.tsx
@@ -17,6 +17,7 @@ import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {useSelectionReducer} from '../hooks/useSelectionReducer';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
 import {filterPermissionedInstigationState} from '../instigation/filterPermissionedInstigationState';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {ScheduleBulkActionMenu} from '../schedules/ScheduleBulkActionMenu';
 import {SchedulerInfo} from '../schedules/SchedulerInfo';
 import {makeScheduleKey} from '../schedules/makeScheduleKey';
@@ -55,6 +56,7 @@ export const OverviewSchedules = () => {
     },
   );
   const {data, loading} = queryResultOverview;
+  useBlockTraceOnQueryResult(queryResultOverview, 'OverviewSchedulesQuery');
 
   const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/JobBackfillsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/JobBackfillsTable.tsx
@@ -10,6 +10,7 @@ import {useEffect, useState} from 'react';
 import {JobBackfillsQuery, JobBackfillsQueryVariables} from './types/JobBackfillsTable.types';
 import {RepositorySelector} from '../graphql/types';
 import {BACKFILL_TABLE_FRAGMENT, BackfillTable} from '../instance/backfill/BackfillTable';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {Loading} from '../ui/Loading';
 
 const BACKFILL_PAGE_SIZE = 10;
@@ -35,6 +36,7 @@ export const JobBackfillsTable = ({
       limit: BACKFILL_PAGE_SIZE,
     },
   });
+  useBlockTraceOnQueryResult(queryResult, 'JobBackfillsQuery');
 
   const refetch = queryResult.refetch;
   useEffect(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/OpJobPartitionsView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/OpJobPartitionsView.tsx
@@ -30,6 +30,7 @@ import {usePermissionsForLocation} from '../app/Permissions';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {RunStatus} from '../graphql/types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {DagsterTag} from '../runs/RunTag';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
@@ -44,12 +45,14 @@ export const OpJobPartitionsView = ({
   repoAddress: RepoAddress;
 }) => {
   const repositorySelector = repoAddressToSelector(repoAddress);
-  const {data, loading} = useQuery<PartitionsStatusQuery, PartitionsStatusQueryVariables>(
+  const queryResult = useQuery<PartitionsStatusQuery, PartitionsStatusQueryVariables>(
     PARTITIONS_STATUS_QUERY,
     {
       variables: {partitionSetName, repositorySelector},
     },
   );
+  const {data, loading} = queryResult;
+  useBlockTraceOnQueryResult(queryResult, 'PartitionsStatusQuery');
 
   if (!data) {
     if (loading) {

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionRunList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionRunList.tsx
@@ -6,6 +6,7 @@ import {
   PartitionRunListQueryVariables,
 } from './types/PartitionRunList.types';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {RUN_TABLE_RUN_FRAGMENT, RunTable} from '../runs/RunTable';
 import {DagsterTag} from '../runs/RunTag';
 
@@ -15,7 +16,7 @@ interface PartitionRunListProps {
 }
 
 export const PartitionRunList = (props: PartitionRunListProps) => {
-  const {data, loading} = useQuery<PartitionRunListQuery, PartitionRunListQueryVariables>(
+  const queryResult = useQuery<PartitionRunListQuery, PartitionRunListQueryVariables>(
     PARTITION_RUN_LIST_QUERY,
     {
       variables: {
@@ -26,6 +27,9 @@ export const PartitionRunList = (props: PartitionRunListProps) => {
       },
     },
   );
+
+  useBlockTraceOnQueryResult(queryResult, 'PartitionRunListQuery');
+  const {data, loading} = queryResult;
 
   if (loading || !data) {
     return <Spinner purpose="section" />;

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStepStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStepStatus.tsx
@@ -50,6 +50,7 @@ import {
 import {GanttChartMode} from '../gantt/Constants';
 import {buildLayout} from '../gantt/GanttChartLayout';
 import {RunStatus} from '../graphql/types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {linkToRunEvent} from '../runs/RunUtils';
 import {RunFilterToken} from '../runs/RunsFilterInput';
 import {MenuLink} from '../ui/MenuLink';
@@ -185,6 +186,8 @@ export const PartitionPerOpStatus = ({
   >(PARTITION_STEP_STATUS_PIPELINE_QUERY, {
     variables: {pipelineSelector},
   });
+
+  useBlockTraceOnQueryResult(pipeline, 'PartitionStepStatusPipelineQuery');
 
   const solidHandles =
     pipeline.data?.pipelineSnapshotOrError.__typename === 'PipelineSnapshot' &&

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineExplorerRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineExplorerRoot.tsx
@@ -23,6 +23,7 @@ import {AssetLocation} from '../asset-graph/useFindAssetLocation';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntryFragment';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {Loading} from '../ui/Loading';
 import {buildPipelineSelector} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
@@ -82,6 +83,7 @@ export const PipelineExplorerContainer = ({
       },
     },
   );
+  useBlockTraceOnQueryResult(pipelineResult, 'PipelineExplorerRootQuery');
 
   return (
     <Loading<PipelineExplorerRootQuery> queryResult={pipelineResult}>

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarOpExecutionGraphs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarOpExecutionGraphs.tsx
@@ -10,6 +10,7 @@ import {
 } from './types/SidebarOpExecutionGraphs.types';
 import {AssetValueGraph, AssetValueGraphData} from '../assets/AssetValueGraph';
 import {StepStatusDot} from '../gantt/GanttStatusPanel';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {linkToRunEvent} from '../runs/RunUtils';
 import {RepoAddress} from '../workspace/types';
 
@@ -45,6 +46,7 @@ export const SidebarOpExecutionGraphs = ({
       },
     },
   );
+  useBlockTraceOnQueryResult(result, 'SidebarOpGraphsQuery');
   const stepStats =
     result.data?.pipelineOrError.__typename === 'Pipeline'
       ? result.data.pipelineOrError.solidHandle?.stepStats

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/CapturedLogPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/CapturedLogPanel.tsx
@@ -15,6 +15,7 @@ import {
 } from './types/CapturedLogPanel.types';
 import {AppContext} from '../app/AppContext';
 import {WebSocketContext} from '../app/WebSocketProvider';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
 interface CapturedLogProps {
   logKey: string[];
@@ -250,6 +251,7 @@ const CapturedLogPanel = React.memo(
         variables: {logKey},
       },
     );
+    useBlockTraceOnQueryResult(queryResult, 'CapturedLogsMetadataQuery');
 
     React.useEffect(() => {
       if (!onSetDownloadUrl || !queryResult.data) {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsProvider.tsx
@@ -319,11 +319,10 @@ const LogsProviderWithQuery = (props: LogsProviderWithQueryProps) => {
           status !== RunStatus.CANCELED;
 
         dispatch({type: 'append', queued, hasMore, cursor});
+        dependency.completeDependency(CompletionType.SUCCESS);
 
         if (hasMore) {
           startPolling(POLL_INTERVAL);
-        } else {
-          dependency.completeDependency(CompletionType.SUCCESS);
         }
       },
     },

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsProvider.tsx
@@ -24,6 +24,7 @@ import {
 import {RunDagsterRunEventFragment} from './types/RunFragments.types';
 import {WebSocketContext} from '../app/WebSocketProvider';
 import {RunStatus} from '../graphql/types';
+import {CompletionType, useTraceDependency} from '../performance/TraceContext';
 
 export interface LogFilterValue extends TokenizingFieldValue {
   token?: 'step' | 'type' | 'query';
@@ -286,6 +287,8 @@ const LogsProviderWithQuery = (props: LogsProviderWithQueryProps) => {
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const {counts, cursor, nodes} = state;
 
+  const dependency = useTraceDependency('RunLogsQuery');
+
   const {stopPolling, startPolling} = useQuery<RunLogsQuery, RunLogsQueryVariables>(
     RUN_LOGS_QUERY,
     {
@@ -300,6 +303,7 @@ const LogsProviderWithQuery = (props: LogsProviderWithQueryProps) => {
           data?.pipelineRunOrError.__typename !== 'Run' ||
           data?.logsForRun.__typename !== 'EventConnection'
         ) {
+          dependency.completeDependency(CompletionType.ERROR);
           return;
         }
 
@@ -318,6 +322,8 @@ const LogsProviderWithQuery = (props: LogsProviderWithQueryProps) => {
 
         if (hasMore) {
           startPolling(POLL_INTERVAL);
+        } else {
+          dependency.completeDependency(CompletionType.SUCCESS);
         }
       },
     },

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunListTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunListTabs.tsx
@@ -10,6 +10,7 @@ import {runsPathWithFilters, useQueryPersistedRunFilters} from './RunsFilterInpu
 import {RunTabsCountQuery, RunTabsCountQueryVariables} from './types/RunListTabs.types';
 import {RunStatus, RunsFilter} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {AnchorButton} from '../ui/AnchorButton';
 
 const getDocumentTitle = (selected: ReturnType<typeof useSelectedRunsTab>) => {
@@ -39,6 +40,7 @@ export const useRunListTabs = (filter: RunsFilter = {}) => {
       },
     },
   );
+  useBlockTraceOnQueryResult(queryResult, 'RunTabsCountQuery');
 
   const {data: countData} = queryResult;
   const {queuedCount, inProgressCount} = useMemo(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunStats.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunStats.tsx
@@ -6,11 +6,14 @@ import styled from 'styled-components';
 import {RunStatsQuery, RunStatsQueryVariables} from './types/RunStats.types';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
 export const RunStats = ({runId}: {runId: string}) => {
   const stats = useQuery<RunStatsQuery, RunStatsQueryVariables>(RUN_STATS_QUERY, {
     variables: {runId},
   });
+
+  useBlockTraceOnQueryResult(stats, 'RunStatsQuery');
 
   if (stats.loading || !stats.data) {
     return (

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/ScheduledRunListRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/ScheduledRunListRoot.tsx
@@ -26,6 +26,7 @@ import {
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {SchedulerInfo} from '../schedules/SchedulerInfo';
 import {
   REPOSITORY_FOR_NEXT_TICKS_FRAGMENT,
@@ -43,6 +44,7 @@ export const ScheduledRunListRoot = () => {
       notifyOnNetworkStatusChange: true,
     },
   );
+  useBlockTraceOnQueryResult(queryResult, 'ScheduledRunsListQuery');
 
   const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -9,6 +9,7 @@ import {RunTimelineQuery, RunTimelineQueryVariables} from './types/useRunsForTim
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {InstigationStatus, RunStatus, RunsFilter} from '../graphql/types';
 import {SCHEDULE_FUTURE_TICKS_FRAGMENT} from '../instance/NextTick';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
@@ -42,6 +43,8 @@ export const useRunsForTimeline = (range: [number, number], runsFilter: RunsFilt
       ticksUntil: endSec,
     },
   });
+
+  useBlockTraceOnQueryResult(queryData, 'RunTimelineQuery');
 
   const {data, previousData, loading} = queryData;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/snapshots/SnapshotNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/snapshots/SnapshotNav.tsx
@@ -3,6 +3,7 @@ import {FontFamily, Heading, PageHeader, Tabs, Tag} from '@dagster-io/ui-compone
 import {Link} from 'react-router-dom';
 
 import {SnapshotQuery, SnapshotQueryVariables} from './types/SnapshotNav.types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {ExplorerPath, explorerPathToString} from '../pipelines/PipelinePathUtils';
 import {TabLink} from '../ui/TabLink';
 import {useActivePipelineForName} from '../workspace/WorkspaceContext';
@@ -35,9 +36,12 @@ export const SnapshotNav = (props: SnapshotNavProps) => {
   const currentPipelineState = useActivePipelineForName(pipelineName);
   const currentSnapshotID = currentPipelineState?.pipelineSnapshotId;
 
-  const {data, loading} = useQuery<SnapshotQuery, SnapshotQueryVariables>(SNAPSHOT_PARENT_QUERY, {
+  const queryResult = useQuery<SnapshotQuery, SnapshotQueryVariables>(SNAPSHOT_PARENT_QUERY, {
     variables: {snapshotId},
   });
+
+  const {data, loading} = queryResult;
+  useBlockTraceOnQueryResult(queryResult, 'SnapshotQuery');
 
   const tag = () => {
     if (loading) {

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedSensorRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedSensorRow.tsx
@@ -92,9 +92,8 @@ export const VirtualizedSensorRow = (props: SensorRowProps) => {
   useBlockTraceOnQueryResult(sensorAssetSelectionQueryResult, 'SensorAssetSelectionQuery');
 
   useDelayedRowQuery(
-    React.useCallback(() => {
-      querySensor();
-      querySensorAssetSelection();
+    React.useCallback(async () => {
+      await Promise.all([querySensor(), querySensorAssetSelection()]);
     }, [querySensor, querySensorAssetSelection]),
   );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedSensorRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedSensorRow.tsx
@@ -92,8 +92,9 @@ export const VirtualizedSensorRow = (props: SensorRowProps) => {
   useBlockTraceOnQueryResult(sensorAssetSelectionQueryResult, 'SensorAssetSelectionQuery');
 
   useDelayedRowQuery(
-    React.useCallback(async () => {
-      await Promise.all([querySensor(), querySensorAssetSelection()]);
+    React.useCallback(() => {
+      querySensor();
+      querySensorAssetSelection();
     }, [querySensor, querySensorAssetSelection]),
   );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedWorkspaceTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedWorkspaceTable.tsx
@@ -79,11 +79,11 @@ const CaptionTextContainer = styled.div`
 
 const JOB_QUERY_DELAY = 100;
 
-export const useDelayedRowQuery = (lazyQueryFn: () => void) => {
+export const useDelayedRowQuery = (lazyQueryFn: () => Promise<any>) => {
   const dependency = useTraceDependency('DelayedRowQuery');
   React.useEffect(() => {
-    const timer = setTimeout(() => {
-      lazyQueryFn();
+    const timer = setTimeout(async () => {
+      await lazyQueryFn();
       dependency.completeDependency(CompletionType.SUCCESS);
     }, JOB_QUERY_DELAY);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedWorkspaceTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedWorkspaceTable.tsx
@@ -79,11 +79,11 @@ const CaptionTextContainer = styled.div`
 
 const JOB_QUERY_DELAY = 100;
 
-export const useDelayedRowQuery = (lazyQueryFn: () => Promise<any>) => {
+export const useDelayedRowQuery = (lazyQueryFn: () => void) => {
   const dependency = useTraceDependency('DelayedRowQuery');
   React.useEffect(() => {
-    const timer = setTimeout(async () => {
-      await lazyQueryFn();
+    const timer = setTimeout(() => {
+      lazyQueryFn();
       dependency.completeDependency(CompletionType.SUCCESS);
     }, JOB_QUERY_DELAY);
 


### PR DESCRIPTION
## Summary & Motivation
Was looking at traces and saw that I missed a spot, then realized I missed a bunch more, adding those too.

## How I Tested These Changes

Took traces, eg: https://app.datadoghq.com/rum/sessions?query=%40application.id%3A6d12cca2-0263-463b-a90e-cc6c524e14bd%20%40usr.email%3Amarco%40dagsterlabs.com%20%40type%3Aview&agg_m=count&agg_m_source=base&agg_q=%40issue.id&agg_q_source=base&agg_t=count&cols=&event=AgAAAY90cI-CjM0zYQAAAAAAAAAYAAAAAEFZOTBjSS1DQUFBVktEWTBTSGZtdzJNWAAAACQAAAAAMDE4Zjc0NzAtOGY4Mi00ZmMwLWE2ZTUtMjczMjczYTRjYzA4&fromUser=false&tab=error&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1715645287234&to_ts=1715645587234&live=true 
