### PR TITLE
Resolution for: Support dbt-core 1.8+ #21774 

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -476,7 +476,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         "python_modules/libraries/dagster-dbt",
         pytest_tox_factors=[
             f"{deps_factor}-{command_factor}"
-            for deps_factor in ["dbt16", "dbt17", "pydantic1"]
+            for deps_factor in ["dbt16", "dbt17", "dbt18", "pydantic1"]
             for command_factor in ["cloud", "core", "legacy"]
         ],
         unsupported_python_versions=[

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources.py
@@ -123,6 +123,14 @@ class ConfigurableResourceWithCliFlags(ConfigurableResource):
             "additional debug information to the console."
         ),
     )
+    empty: bool = Field(
+        default=False,
+        description=(
+            "When True, dbt will invoked with the `--empty` flag, limiting the refs and sources to zero rows."
+            "dbt will still execute the model SQL against the target data warehouse but will avoid expensive reads of input data." 
+            "This validates dependencies and ensures your models will build properly."
+        ),
+    )
 
 
 class DbtCliClient(DbtClient):
@@ -149,6 +157,7 @@ class DbtCliClient(DbtClient):
         json_log_format: bool = True,
         capture_logs: bool = True,
         debug: bool = False,
+        empty: bool = False,
     ):
         self._default_flags = default_flags
         self._executable = executable
@@ -159,6 +168,7 @@ class DbtCliClient(DbtClient):
         self._json_log_format = json_log_format
         self._capture_logs = capture_logs
         self._debug = debug
+        self._empty = empty
         super().__init__(logger)
 
     @property
@@ -213,6 +223,7 @@ class DbtCliClient(DbtClient):
             json_log_format=self._json_log_format,
             capture_logs=self._capture_logs,
             debug=self._debug,
+            empty=self._empty,
         )
 
     def cli_stream_json(self, command: str, **kwargs) -> Iterator[Mapping[str, Any]]:
@@ -234,6 +245,8 @@ class DbtCliClient(DbtClient):
             json_log_format=self._json_log_format,
             capture_logs=self._capture_logs,
             debug=self._debug,
+            empty=self._empty,
+            
         ):
             if event.parsed_json_line is not None:
                 yield event.parsed_json_line
@@ -524,4 +537,5 @@ def dbt_cli_resource(context) -> DbtCliClient:
         capture_logs=context.resource_config["capture_logs"],
         json_log_format=context.resource_config["json_log_format"],
         debug=context.resource_config["debug"],
+        empty=context.resource_config["empty"],
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources.py
@@ -143,10 +143,6 @@ class ConfigurableResourceWithCliFlags(ConfigurableResource):
     )
 
 
-
-    #exclude-resource-type
-
-
 class DbtCliClient(DbtClient):
     """A resource that allows you to execute dbt cli commands.
 
@@ -264,7 +260,6 @@ class DbtCliClient(DbtClient):
             debug=self._debug,
             resource_type=self._resource_type,
             exclude_resource_type=self._exclude_resource_type,
-            
         ):
             if event.parsed_json_line is not None:
                 yield event.parsed_json_line
@@ -528,7 +523,7 @@ class DbtCliClientResource(ConfigurableResourceWithCliFlags, IAttachDifferentObj
             capture_logs=self.capture_logs,
             debug=self.debug,
             resource_type=self.resource_type,
-            exclude_resource_type=self.exclude_resource_type
+            exclude_resource_type=self.exclude_resource_type,
         )
 
     def get_object_to_set_on_execution_context(self) -> Any:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/utils.py
@@ -75,7 +75,8 @@ def _create_command_list(
     command: str,
     flags_dict: Mapping[str, Any],
     debug: bool,
-    empty: bool,
+    resource_type: Optional[str]=None,
+    exclude_resource_type: Optional[str]=None,
 ) -> Sequence[str]:
     prefix = [executable]
     if warn_error:
@@ -84,8 +85,10 @@ def _create_command_list(
         prefix += ["--no-use-colors", "--log-format", "json"]
     if debug:
         prefix += ["--debug"]
-    if empty:
-        prefix += ["--empty"]
+    if resource_type:
+        prefix += ["--resource-type", resource_type]
+    if exclude_resource_type:
+        prefix += ["--exclude-resource-type", exclude_resource_type]
 
     full_command = [*command.split(" "), *build_command_args_from_flags(flags_dict)]
 
@@ -166,7 +169,9 @@ def execute_cli_stream(
     json_log_format: bool = True,
     capture_logs: bool = True,
     debug: bool = False,
-    empty: bool = False,
+    resource_type: Optional[str] = None,
+    exclude_resource_type: Optional[str] = None,
+
 ) -> Iterator[DbtCliEvent]:
     """Executes a command on the dbt CLI in a subprocess."""
     command_list = _create_command_list(
@@ -176,7 +181,8 @@ def execute_cli_stream(
         command=command,
         flags_dict=flags_dict,
         debug=debug,
-        empty=empty,
+        resource_type=resource_type,
+        exclude_resource_type=exclude_resource_type
     )
     log.info(f"Executing command: {' '.join(command_list)}")
 
@@ -208,7 +214,8 @@ def execute_cli(
     json_log_format: bool = True,
     capture_logs: bool = True,
     debug: bool = False,
-    empty: bool = False,
+    resource_type: Optional[str]=None,
+    exclude_resource_type: Optional[str]=None,
 ) -> DbtCliOutput:
     """Executes a command on the dbt CLI in a subprocess."""
     check.str_param(executable, "executable")
@@ -224,7 +231,8 @@ def execute_cli(
         command=command,
         flags_dict=flags_dict,
         debug=debug,
-        empty=empty,
+        resource_type=resource_type,
+        exclude_resource_type=exclude_resource_type
     )
     log.info(f"Executing command: {' '.join(command_list)}")
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/utils.py
@@ -75,8 +75,8 @@ def _create_command_list(
     command: str,
     flags_dict: Mapping[str, Any],
     debug: bool,
-    resource_type: Optional[str]=None,
-    exclude_resource_type: Optional[str]=None,
+    resource_type: Optional[str] = None,
+    exclude_resource_type: Optional[str] = None,
 ) -> Sequence[str]:
     prefix = [executable]
     if warn_error:
@@ -171,7 +171,6 @@ def execute_cli_stream(
     debug: bool = False,
     resource_type: Optional[str] = None,
     exclude_resource_type: Optional[str] = None,
-
 ) -> Iterator[DbtCliEvent]:
     """Executes a command on the dbt CLI in a subprocess."""
     command_list = _create_command_list(
@@ -182,7 +181,7 @@ def execute_cli_stream(
         flags_dict=flags_dict,
         debug=debug,
         resource_type=resource_type,
-        exclude_resource_type=exclude_resource_type
+        exclude_resource_type=exclude_resource_type,
     )
     log.info(f"Executing command: {' '.join(command_list)}")
 
@@ -214,8 +213,8 @@ def execute_cli(
     json_log_format: bool = True,
     capture_logs: bool = True,
     debug: bool = False,
-    resource_type: Optional[str]=None,
-    exclude_resource_type: Optional[str]=None,
+    resource_type: Optional[str] = None,
+    exclude_resource_type: Optional[str] = None,
 ) -> DbtCliOutput:
     """Executes a command on the dbt CLI in a subprocess."""
     check.str_param(executable, "executable")
@@ -232,7 +231,7 @@ def execute_cli(
         flags_dict=flags_dict,
         debug=debug,
         resource_type=resource_type,
-        exclude_resource_type=exclude_resource_type
+        exclude_resource_type=exclude_resource_type,
     )
     log.info(f"Executing command: {' '.join(command_list)}")
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/utils.py
@@ -75,6 +75,7 @@ def _create_command_list(
     command: str,
     flags_dict: Mapping[str, Any],
     debug: bool,
+    empty: bool,
 ) -> Sequence[str]:
     prefix = [executable]
     if warn_error:
@@ -83,6 +84,8 @@ def _create_command_list(
         prefix += ["--no-use-colors", "--log-format", "json"]
     if debug:
         prefix += ["--debug"]
+    if empty:
+        prefix += ["--empty"]
 
     full_command = [*command.split(" "), *build_command_args_from_flags(flags_dict)]
 
@@ -163,6 +166,7 @@ def execute_cli_stream(
     json_log_format: bool = True,
     capture_logs: bool = True,
     debug: bool = False,
+    empty: bool = False,
 ) -> Iterator[DbtCliEvent]:
     """Executes a command on the dbt CLI in a subprocess."""
     command_list = _create_command_list(
@@ -172,6 +176,7 @@ def execute_cli_stream(
         command=command,
         flags_dict=flags_dict,
         debug=debug,
+        empty=empty,
     )
     log.info(f"Executing command: {' '.join(command_list)}")
 
@@ -203,6 +208,7 @@ def execute_cli(
     json_log_format: bool = True,
     capture_logs: bool = True,
     debug: bool = False,
+    empty: bool = False,
 ) -> DbtCliOutput:
     """Executes a command on the dbt CLI in a subprocess."""
     check.str_param(executable, "executable")
@@ -218,6 +224,7 @@ def execute_cli(
         command=command,
         flags_dict=flags_dict,
         debug=debug,
+        empty=empty,
     )
     log.info(f"Executing command: {' '.join(command_list)}")
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/setup.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/setup.py.jinja
@@ -15,6 +15,7 @@ setup(
         "dagster",
         "dagster-cloud",
         "dagster-dbt",
+        "dbt-core",
         {%- for dbt_adapter in dbt_adapter_packages %}
         "{{ dbt_adapter }}",
         {%- endfor %}

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -312,6 +312,35 @@ def test_dbt_cli_debug_execution(
     result = materialize([my_dbt_assets], resources={"dbt": dbt})
     assert result.success
 
+@pytest.mark.skipif(
+    version.parse(dbt_version) < version.parse("1.8.0"),
+    reason="The `resource-type` flag is only available in `dbt-core>=1.8.0`",
+)
+def test_dbt_resource_type_execution(
+    test_jaffle_shop_manifest: Dict[str, Any],
+    dbt: DbtCliResource,       
+) -> None:
+    @dbt_assets(manifest=test_jaffle_shop_manifest)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        yield from dbt.cli(["--resource-type data_test", "build"], context=context).stream()
+
+    result = materialize([my_dbt_assets], resources={"dbt": dbt})
+    assert result.success
+
+@pytest.mark.skipif(
+    version.parse(dbt_version) < version.parse("1.8.0"),
+    reason="The `exclude-resource-type` flag is only available in `dbt-core>=1.8.0`",
+)
+def test_dbt_exclude_resource_type_execution(
+    test_jaffle_shop_manifest: Dict[str, Any],
+    dbt: DbtCliResource,       
+) -> None:
+    @dbt_assets(manifest=test_jaffle_shop_manifest)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        yield from dbt.cli(["--exclude-resource-type data_test", "build"], context=context).stream()
+
+    result = materialize([my_dbt_assets], resources={"dbt": dbt})
+    assert result.success
 
 @pytest.mark.skipif(
     version.parse(dbt_version) < version.parse("1.7.9"),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -312,13 +312,14 @@ def test_dbt_cli_debug_execution(
     result = materialize([my_dbt_assets], resources={"dbt": dbt})
     assert result.success
 
+
 @pytest.mark.skipif(
     version.parse(dbt_version) < version.parse("1.8.0"),
     reason="The `resource-type` flag is only available in `dbt-core>=1.8.0`",
 )
 def test_dbt_resource_type_execution(
     test_jaffle_shop_manifest: Dict[str, Any],
-    dbt: DbtCliResource,       
+    dbt: DbtCliResource,
 ) -> None:
     @dbt_assets(manifest=test_jaffle_shop_manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
@@ -327,13 +328,14 @@ def test_dbt_resource_type_execution(
     result = materialize([my_dbt_assets], resources={"dbt": dbt})
     assert result.success
 
+
 @pytest.mark.skipif(
     version.parse(dbt_version) < version.parse("1.8.0"),
     reason="The `exclude-resource-type` flag is only available in `dbt-core>=1.8.0`",
 )
 def test_dbt_exclude_resource_type_execution(
     test_jaffle_shop_manifest: Dict[str, Any],
-    dbt: DbtCliResource,       
+    dbt: DbtCliResource,
 ) -> None:
     @dbt_assets(manifest=test_jaffle_shop_manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
@@ -341,6 +343,7 @@ def test_dbt_exclude_resource_type_execution(
 
     result = materialize([my_dbt_assets], resources={"dbt": dbt})
     assert result.success
+
 
 @pytest.mark.skipif(
     version.parse(dbt_version) < version.parse("1.7.9"),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/models/schema.yml
@@ -7,7 +7,7 @@ models:
     columns:
       - name: customer_id
         description: This is a unique identifier for a customer
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -34,14 +34,14 @@ models:
 
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
         description: This is a unique identifier for an order
 
       - name: customer_id
         description: Foreign key to the customers table
-        tests:
+        data_tests:
           - not_null
           - relationships:
               to: ref('customers')
@@ -52,32 +52,32 @@ models:
 
       - name: status
         description: '{{ doc("orders_status") }}'
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
 
       - name: amount
         description: Total amount (AUD) of the order
-        tests:
+        data_tests:
           - not_null
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
-        tests:
+        data_tests:
           - not_null
 
       - name: coupon_amount
         description: Amount of the order (AUD) paid for by coupon
-        tests:
+        data_tests:
           - not_null
 
       - name: bank_transfer_amount
         description: Amount of the order (AUD) paid for by bank transfer
-        tests:
+        data_tests:
           - not_null
 
       - name: gift_card_amount
         description: Amount of the order (AUD) paid for by gift card
-        tests:
+        data_tests:
           - not_null

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/models/staging/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/models/staging/schema.yml
@@ -4,18 +4,18 @@ models:
   - name: stg_customers
     columns:
       - name: customer_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
   - name: stg_orders
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: status
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
@@ -23,10 +23,10 @@ models:
   - name: stg_payments
     columns:
       - name: payment_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: payment_method
-        tests:
+        data_tests:
           - accepted_values:
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_checks/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_checks/models/schema.yml
@@ -9,7 +9,7 @@ models:
     columns:
       - name: customer_id
         description: This is a unique identifier for a customer
-        tests:
+        data_tests:
           - unique:
               severity: "warn"
               tags: ["data_quality"]
@@ -39,14 +39,14 @@ models:
 
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
         description: This is a unique identifier for an order
 
       - name: customer_id
         description: Foreign key to the customers table
-        tests:
+        data_tests:
           - not_null
           - relationships:
               to: ref('customers')
@@ -64,7 +64,7 @@ models:
 
       - name: status
         description: '{{ doc("orders_status") }}'
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
@@ -74,33 +74,33 @@ models:
 
       - name: amount
         description: Total amount (AUD) of the order
-        tests:
+        data_tests:
           - not_null
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
-        tests:
+        data_tests:
           - not_null
 
       - name: coupon_amount
         description: Amount of the order (AUD) paid for by coupon
-        tests:
+        data_tests:
           - not_null
 
       - name: bank_transfer_amount
         description: Amount of the order (AUD) paid for by bank transfer
-        tests:
+        data_tests:
           - not_null
 
       - name: gift_card_amount
         description: Amount of the order (AUD) paid for by gift card
-        tests:
+        data_tests:
           - not_null
 
   - name: fail_tests_model
     columns:
       - name: id
-        tests:
+        data_tests:
           - unique:
               config:
                 # will always warn
@@ -108,7 +108,7 @@ models:
                 error_if: "=-1"
 
       - name: first_name
-        tests:
+        data_tests:
           - accepted_values:
               values: ["foo", "bar", "baz"]
               config:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_checks/models/staging/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_checks/models/staging/schema.yml
@@ -4,18 +4,18 @@ models:
   - name: stg_customers
     columns:
       - name: customer_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
   - name: stg_orders
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: status
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
@@ -23,10 +23,10 @@ models:
   - name: stg_payments
     columns:
       - name: payment_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: payment_method
-        tests:
+        data_tests:
           - accepted_values:
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_key_exceptions/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_key_exceptions/models/schema.yml
@@ -7,7 +7,7 @@ models:
     columns:
       - name: customer_id
         description: This is a unique identifier for a customer
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -34,14 +34,14 @@ models:
 
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
         description: This is a unique identifier for an order
 
       - name: customer_id
         description: Foreign key to the customers table
-        tests:
+        data_tests:
           - not_null
           - relationships:
               to: ref('customers')
@@ -52,32 +52,32 @@ models:
 
       - name: status
         description: '{{ doc("orders_status") }}'
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
 
       - name: amount
         description: Total amount (AUD) of the order
-        tests:
+        data_tests:
           - not_null
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
-        tests:
+        data_tests:
           - not_null
 
       - name: coupon_amount
         description: Amount of the order (AUD) paid for by coupon
-        tests:
+        data_tests:
           - not_null
 
       - name: bank_transfer_amount
         description: Amount of the order (AUD) paid for by bank transfer
-        tests:
+        data_tests:
           - not_null
 
       - name: gift_card_amount
         description: Amount of the order (AUD) paid for by gift card
-        tests:
+        data_tests:
           - not_null

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_key_exceptions/models/staging/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_asset_key_exceptions/models/staging/schema.yml
@@ -4,18 +4,18 @@ models:
   - name: stg_customers
     columns:
       - name: customer_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
   - name: stg_orders
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: status
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
@@ -23,10 +23,10 @@ models:
   - name: stg_payments
     columns:
       - name: payment_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: payment_method
-        tests:
+        data_tests:
           - accepted_values:
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_alias/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_alias/models/schema.yml
@@ -10,7 +10,7 @@ models:
     columns:
       - name: customer_id
         description: This is a unique identifier for a customer
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -40,14 +40,14 @@ models:
 
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
         description: This is a unique identifier for an order
 
       - name: customer_id
         description: Foreign key to the customers table
-        tests:
+        data_tests:
           - not_null
           - relationships:
               to: ref('customers')
@@ -58,32 +58,32 @@ models:
 
       - name: status
         description: '{{ doc("orders_status") }}'
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
 
       - name: amount
         description: Total amount (AUD) of the order
-        tests:
+        data_tests:
           - not_null
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
-        tests:
+        data_tests:
           - not_null
 
       - name: coupon_amount
         description: Amount of the order (AUD) paid for by coupon
-        tests:
+        data_tests:
           - not_null
 
       - name: bank_transfer_amount
         description: Amount of the order (AUD) paid for by bank transfer
-        tests:
+        data_tests:
           - not_null
 
       - name: gift_card_amount
         description: Amount of the order (AUD) paid for by gift card
-        tests:
+        data_tests:
           - not_null

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_alias/models/staging/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_alias/models/staging/schema.yml
@@ -4,18 +4,18 @@ models:
   - name: staging.customers
     columns:
       - name: customer_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
   - name: staging.orders
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: status
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
@@ -23,10 +23,10 @@ models:
   - name: staging.payments
     columns:
       - name: payment_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: payment_method
-        tests:
+        data_tests:
           - accepted_values:
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_model_versions/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_model_versions/models/schema.yml
@@ -7,7 +7,7 @@ models:
     columns:
       - name: customer_id
         description: This is a unique identifier for a customer
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -34,14 +34,14 @@ models:
 
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
         description: This is a unique identifier for an order
 
       - name: customer_id
         description: Foreign key to the customers table
-        tests:
+        data_tests:
           - not_null
           - relationships:
               to: ref('customers')
@@ -52,32 +52,32 @@ models:
 
       - name: status
         description: '{{ doc("orders_status") }}'
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
 
       - name: amount
         description: Total amount (AUD) of the order
-        tests:
+        data_tests:
           - not_null
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
-        tests:
+        data_tests:
           - not_null
 
       - name: coupon_amount
         description: Amount of the order (AUD) paid for by coupon
-        tests:
+        data_tests:
           - not_null
 
       - name: bank_transfer_amount
         description: Amount of the order (AUD) paid for by bank transfer
-        tests:
+        data_tests:
           - not_null
 
       - name: gift_card_amount
         description: Amount of the order (AUD) paid for by gift card
-        tests:
+        data_tests:
           - not_null

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_model_versions/models/staging/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_model_versions/models/staging/schema.yml
@@ -7,18 +7,18 @@ models:
       - v: 2
     columns:
       - name: customer_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
   - name: stg_orders
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: status
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
@@ -26,10 +26,10 @@ models:
   - name: stg_payments
     columns:
       - name: payment_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: payment_method
-        tests:
+        data_tests:
           - accepted_values:
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_python_interleaving/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_python_interleaving/models/schema.yml
@@ -7,7 +7,7 @@ models:
     columns:
       - name: customer_id
         description: This is a unique identifier for a customer
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -34,7 +34,7 @@ models:
 
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
         description: This is a unique identifier for an order
@@ -44,32 +44,32 @@ models:
 
       - name: status
         description: '{{ doc("orders_status") }}'
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
 
       - name: amount
         description: Total amount (AUD) of the order
-        tests:
+        data_tests:
           - not_null
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
-        tests:
+        data_tests:
           - not_null
 
       - name: coupon_amount
         description: Amount of the order (AUD) paid for by coupon
-        tests:
+        data_tests:
           - not_null
 
       - name: bank_transfer_amount
         description: Amount of the order (AUD) paid for by bank transfer
-        tests:
+        data_tests:
           - not_null
 
       - name: gift_card_amount
         description: Amount of the order (AUD) paid for by gift card
-        tests:
+        data_tests:
           - not_null

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_python_interleaving/models/staging/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_python_interleaving/models/staging/schema.yml
@@ -4,18 +4,18 @@ models:
   - name: stg_customers
     columns:
       - name: customer_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
   - name: stg_orders
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: status
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
@@ -23,10 +23,10 @@ models:
   - name: stg_payments
     columns:
       - name: payment_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: payment_method
-        tests:
+        data_tests:
           - accepted_values:
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/models/schema.yml
@@ -7,7 +7,7 @@ models:
     columns:
       - name: customer_id
         description: This is a unique identifier for a customer
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -34,14 +34,14 @@ models:
 
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
         description: This is a unique identifier for an order
 
       - name: customer_id
         description: Foreign key to the customers table
-        tests:
+        data_tests:
           - not_null
           - relationships:
               to: ref('customers')
@@ -52,32 +52,32 @@ models:
 
       - name: status
         description: '{{ doc("orders_status") }}'
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
 
       - name: amount
         description: Total amount (AUD) of the order
-        tests:
+        data_tests:
           - not_null
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
-        tests:
+        data_tests:
           - not_null
 
       - name: coupon_amount
         description: Amount of the order (AUD) paid for by coupon
-        tests:
+        data_tests:
           - not_null
 
       - name: bank_transfer_amount
         description: Amount of the order (AUD) paid for by bank transfer
-        tests:
+        data_tests:
           - not_null
 
       - name: gift_card_amount
         description: Amount of the order (AUD) paid for by gift card
-        tests:
+        data_tests:
           - not_null

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/models/staging/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/models/staging/schema.yml
@@ -4,18 +4,18 @@ models:
   - name: stg_customers
     columns:
       - name: customer_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
   - name: stg_orders
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: status
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
@@ -23,10 +23,10 @@ models:
   - name: stg_payments
     columns:
       - name: payment_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: payment_method
-        tests:
+        data_tests:
           - accepted_values:
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_source_freshness/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_source_freshness/models/schema.yml
@@ -7,7 +7,7 @@ models:
     columns:
       - name: customer_id
         description: This is a unique identifier for a customer
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -34,14 +34,14 @@ models:
 
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
         description: This is a unique identifier for an order
 
       - name: customer_id
         description: Foreign key to the customers table
-        tests:
+        data_tests:
           - not_null
           - relationships:
               to: ref('customers')
@@ -52,32 +52,32 @@ models:
 
       - name: status
         description: '{{ doc("orders_status") }}'
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
 
       - name: amount
         description: Total amount (AUD) of the order
-        tests:
+        data_tests:
           - not_null
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
-        tests:
+        data_tests:
           - not_null
 
       - name: coupon_amount
         description: Amount of the order (AUD) paid for by coupon
-        tests:
+        data_tests:
           - not_null
 
       - name: bank_transfer_amount
         description: Amount of the order (AUD) paid for by bank transfer
-        tests:
+        data_tests:
           - not_null
 
       - name: gift_card_amount
         description: Amount of the order (AUD) paid for by gift card
-        tests:
+        data_tests:
           - not_null

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_source_freshness/models/staging/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_source_freshness/models/staging/schema.yml
@@ -4,18 +4,18 @@ models:
   - name: stg_customers
     columns:
       - name: customer_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
   - name: stg_orders
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: status
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
@@ -23,10 +23,10 @@ models:
   - name: stg_payments
     columns:
       - name: payment_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: payment_method
-        tests:
+        data_tests:
           - accepted_values:
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_duplicate_source_asset_key/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_duplicate_source_asset_key/models/schema.yml
@@ -7,7 +7,7 @@ models:
     columns:
       - name: customer_id
         description: This is a unique identifier for a customer
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -34,14 +34,14 @@ models:
 
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
         description: This is a unique identifier for an order
 
       - name: customer_id
         description: Foreign key to the customers table
-        tests:
+        data_tests:
           - not_null
           - relationships:
               to: ref('customers')
@@ -52,32 +52,32 @@ models:
 
       - name: status
         description: '{{ doc("orders_status") }}'
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
 
       - name: amount
         description: Total amount (AUD) of the order
-        tests:
+        data_tests:
           - not_null
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
-        tests:
+        data_tests:
           - not_null
 
       - name: coupon_amount
         description: Amount of the order (AUD) paid for by coupon
-        tests:
+        data_tests:
           - not_null
 
       - name: bank_transfer_amount
         description: Amount of the order (AUD) paid for by bank transfer
-        tests:
+        data_tests:
           - not_null
 
       - name: gift_card_amount
         description: Amount of the order (AUD) paid for by gift card
-        tests:
+        data_tests:
           - not_null

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_duplicate_source_asset_key/models/staging/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_duplicate_source_asset_key/models/staging/schema.yml
@@ -4,18 +4,18 @@ models:
   - name: stg_customers
     columns:
       - name: customer_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
   - name: stg_orders
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: status
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
@@ -23,10 +23,10 @@ models:
   - name: stg_payments
     columns:
       - name: payment_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: payment_method
-        tests:
+        data_tests:
           - accepted_values:
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_exceptions/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_exceptions/models/schema.yml
@@ -7,7 +7,7 @@ models:
     columns:
       - name: customer_id
         description: This is a unique identifier for a customer
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -34,14 +34,14 @@ models:
 
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
         description: This is a unique identifier for an order
 
       - name: customer_id
         description: Foreign key to the customers table
-        tests:
+        data_tests:
           - not_null
           - relationships:
               to: ref('customers')
@@ -52,32 +52,32 @@ models:
 
       - name: status
         description: '{{ doc("orders_status") }}'
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
 
       - name: amount
         description: Total amount (AUD) of the order
-        tests:
+        data_tests:
           - not_null
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
-        tests:
+        data_tests:
           - not_null
 
       - name: coupon_amount
         description: Amount of the order (AUD) paid for by coupon
-        tests:
+        data_tests:
           - not_null
 
       - name: bank_transfer_amount
         description: Amount of the order (AUD) paid for by bank transfer
-        tests:
+        data_tests:
           - not_null
 
       - name: gift_card_amount
         description: Amount of the order (AUD) paid for by gift card
-        tests:
+        data_tests:
           - not_null

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_exceptions/models/staging/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_exceptions/models/staging/schema.yml
@@ -4,18 +4,18 @@ models:
   - name: stg_customers
     columns:
       - name: customer_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
   - name: stg_orders
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: status
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
@@ -23,10 +23,10 @@ models:
   - name: stg_payments
     columns:
       - name: payment_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: payment_method
-        tests:
+        data_tests:
           - accepted_values:
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_meta_config/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_meta_config/models/schema.yml
@@ -26,7 +26,7 @@ models:
     columns:
       - name: customer_id
         description: This is a unique identifier for a customer
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -53,14 +53,14 @@ models:
 
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
         description: This is a unique identifier for an order
 
       - name: customer_id
         description: Foreign key to the customers table
-        tests:
+        data_tests:
           - not_null
           - relationships:
               to: ref('customers')
@@ -71,32 +71,32 @@ models:
 
       - name: status
         description: '{{ doc("orders_status") }}'
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
 
       - name: amount
         description: Total amount (AUD) of the order
-        tests:
+        data_tests:
           - not_null
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
-        tests:
+        data_tests:
           - not_null
 
       - name: coupon_amount
         description: Amount of the order (AUD) paid for by coupon
-        tests:
+        data_tests:
           - not_null
 
       - name: bank_transfer_amount
         description: Amount of the order (AUD) paid for by bank transfer
-        tests:
+        data_tests:
           - not_null
 
       - name: gift_card_amount
         description: Amount of the order (AUD) paid for by gift card
-        tests:
+        data_tests:
           - not_null

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_meta_config/models/staging/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_meta_config/models/staging/schema.yml
@@ -15,7 +15,7 @@ models:
           group: customized_dagster_group
     columns:
       - name: customer_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -27,11 +27,11 @@ models:
           asset_key: ["customized", "staging", "orders"]
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: status
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
@@ -46,10 +46,10 @@ models:
           owners: ["kafka@castle.com"]
     columns:
       - name: payment_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: payment_method
-        tests:
+        data_tests:
           - accepted_values:
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/schema.yml
@@ -7,7 +7,7 @@ models:
     columns:
       - name: customer_id
         description: This is a unique identifier for a customer
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -34,14 +34,14 @@ models:
 
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
         description: This is a unique identifier for an order
 
       - name: customer_id
         description: Foreign key to the customers table
-        tests:
+        data_tests:
           - not_null
           - relationships:
               to: ref('customers')
@@ -52,32 +52,32 @@ models:
 
       - name: status
         description: '{{ doc("orders_status") }}'
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
 
       - name: amount
         description: Total amount (AUD) of the order
-        tests:
+        data_tests:
           - not_null
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
-        tests:
+        data_tests:
           - not_null
 
       - name: coupon_amount
         description: Amount of the order (AUD) paid for by coupon
-        tests:
+        data_tests:
           - not_null
 
       - name: bank_transfer_amount
         description: Amount of the order (AUD) paid for by bank transfer
-        tests:
+        data_tests:
           - not_null
 
       - name: gift_card_amount
         description: Amount of the order (AUD) paid for by gift card
-        tests:
+        data_tests:
           - not_null

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/staging/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/staging/schema.yml
@@ -4,18 +4,18 @@ models:
   - name: stg_customers
     columns:
       - name: customer_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
   - name: stg_orders
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: status
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 ["placed", "shipped", "completed", "return_pending", "returned"]
@@ -23,10 +23,10 @@ models:
   - name: stg_payments
     columns:
       - name: payment_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: payment_method
-        tests:
+        data_tests:
           - accepted_values:
               values: ["credit_card", "coupon", "bank_transfer", "gift_card"]

--- a/python_modules/libraries/dagster-dbt/dbt_packages/dagster/dbt_project.yml
+++ b/python_modules/libraries/dagster-dbt/dbt_packages/dagster/dbt_project.yml
@@ -2,7 +2,7 @@ name: "dagster"
 version: "0.0.1"
 config-version: 2
 
-require-dbt-version: [">=1.5.0", "<2.0.0"]
+require-dbt-version: [">=1.6.0", "<2.0.0"]
 
 macro-paths: ["macros"]
 

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=[
         f"dagster{pin}",
         # Follow the version support constraints for dbt Core: https://docs.getdbt.com/docs/dbt-versions/core
-        "dbt-core>=1.6,<1.8",
+        "dbt-core>=1.6,<1.9",
         "Jinja2",
         "networkx",
         "orjson",

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -14,6 +14,8 @@ deps =
   dbt16: dbt-duckdb==1.6.*
   dbt17: dbt-core==1.7.*
   dbt17: dbt-duckdb==1.7.*
+  dbt18: dbt-core==1.8.*
+  dbt18: dbt-duckdb==1.8.*
   pydantic1: pydantic!=1.10.7,<2.0.0
   -e .[test]
 allowlist_externals =


### PR DESCRIPTION
## Summary & Motivation

Resolves https://github.com/dagster-io/dagster/issues/21774

With the update of dbt 1.8, dagster-dbt will be able to support dbt-core>=1.8.0 and dbt—[adapter]>=1.8.0.

I am also looking to add new functionality introduced in dbt 1.8. Highlight in the [press release](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v1.8)

### The PR will address the following 1.8 additions.

1. Add the new CLI flags `resource-type` and `exclude-resource-type`
2. Change tests and example dbt projects to reflect the replacing `data_tests` syntax

### This PR will not address the following

1. Introducing asset checks for the new **unit tests**

## How I Tested These Changes
With the `test_dbt_resource_type_execution` and `test_dbt_exclude_resource_type_execution` pytests
