### PR TITLE
[1/2] Split up RunTimelineQuery

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
@@ -76,7 +76,7 @@ export function useQueryRefreshAtInterval(
   );
 }
 
-export function useRefreshAtInterval<T = void>({
+export function useRefreshAtInterval<T = any>({
   refresh,
   intervalMs,
   enabled = true,

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
@@ -80,7 +80,7 @@ export const OverviewTimelineRoot = ({Header, TabButton}: Props) => {
     [hourWindow, now, offsetMsec],
   );
 
-  const {jobs, initialLoading} = useRunsForTimeline(range);
+  const {jobs, initialLoading, refreshState} = useRunsForTimeline(range);
 
   React.useEffect(() => {
     if (!initialLoading) {

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
@@ -1,7 +1,7 @@
 import {Box, Button, ButtonGroup, ErrorBoundary, TextInput} from '@dagster-io/ui-components';
 import * as React from 'react';
 
-import {FIFTEEN_SECONDS, RefreshState, useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {RefreshState} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
@@ -80,8 +80,7 @@ export const OverviewTimelineRoot = ({Header, TabButton}: Props) => {
     [hourWindow, now, offsetMsec],
   );
 
-  const {jobs, initialLoading, queryData} = useRunsForTimeline(range);
-  const refreshState = useQueryRefreshAtInterval(queryData, FIFTEEN_SECONDS);
+  const {jobs, initialLoading} = useRunsForTimeline(range);
 
   React.useEffect(() => {
     if (!initialLoading) {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsForTimeline.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsForTimeline.types.ts
@@ -4,7 +4,7 @@ import * as Types from '../../graphql/types';
 
 export type UnterminatedRunTimelineQueryVariables = Types.Exact<{
   inProgressFilter: Types.RunsFilter;
-  limit: Types.Scalars['Int']['input'];
+  limit?: Types.InputMaybe<Types.Scalars['Int']['input']>;
 }>;
 
 export type UnterminatedRunTimelineQuery = {
@@ -34,7 +34,7 @@ export type UnterminatedRunTimelineQuery = {
 
 export type TerimatedRunTimelineQueryVariables = Types.Exact<{
   terminatedFilter: Types.RunsFilter;
-  limit: Types.Scalars['Int']['input'];
+  limit?: Types.InputMaybe<Types.Scalars['Int']['input']>;
 }>;
 
 export type TerimatedRunTimelineQuery = {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsForTimeline.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsForTimeline.types.ts
@@ -2,14 +2,12 @@
 
 import * as Types from '../../graphql/types';
 
-export type RunTimelineQueryVariables = Types.Exact<{
+export type UnterminatedRunTimelineQueryVariables = Types.Exact<{
   inProgressFilter: Types.RunsFilter;
-  terminatedFilter: Types.RunsFilter;
-  tickCursor?: Types.InputMaybe<Types.Scalars['Float']['input']>;
-  ticksUntil?: Types.InputMaybe<Types.Scalars['Float']['input']>;
+  limit: Types.Scalars['Int']['input'];
 }>;
 
-export type RunTimelineQuery = {
+export type UnterminatedRunTimelineQuery = {
   __typename: 'Query';
   unterminated:
     | {__typename: 'InvalidPipelineRunsFilterError'}
@@ -32,6 +30,15 @@ export type RunTimelineQuery = {
           } | null;
         }>;
       };
+};
+
+export type TerimatedRunTimelineQueryVariables = Types.Exact<{
+  terminatedFilter: Types.RunsFilter;
+  limit: Types.Scalars['Int']['input'];
+}>;
+
+export type TerimatedRunTimelineQuery = {
+  __typename: 'Query';
   terminated:
     | {__typename: 'InvalidPipelineRunsFilterError'}
     | {__typename: 'PythonError'}
@@ -53,6 +60,15 @@ export type RunTimelineQuery = {
           } | null;
         }>;
       };
+};
+
+export type FutureTicksQueryVariables = Types.Exact<{
+  tickCursor?: Types.InputMaybe<Types.Scalars['Float']['input']>;
+  ticksUntil?: Types.InputMaybe<Types.Scalars['Float']['input']>;
+}>;
+
+export type FutureTicksQuery = {
+  __typename: 'Query';
   workspaceOrError:
     | {__typename: 'PythonError'}
     | {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -297,6 +297,7 @@ const UNTERMINATED_RUN_TIMELINE_QUERY = gql`
       }
     }
   }
+  ${RUN_TIME_FRAGMENT}
 `;
 
 const TERMINATED_RUN_TIMELINE_QUERY = gql`

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -23,8 +23,6 @@ import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePipelinePath} from '../workspace/workspacePath';
 
-const BATCH_LIMIT = 500;
-
 export const useRunsForTimeline = (
   range: [number, number],
   runsFilter: RunsFilter = {},
@@ -45,7 +43,6 @@ export const useRunsForTimeline = (
     // skip the cache entirely.
     fetchPolicy: 'no-cache',
     variables: {
-      limit: BATCH_LIMIT,
       inProgressFilter: {
         ...runsFilter,
         statuses: [RunStatus.CANCELING, RunStatus.STARTED],
@@ -64,7 +61,6 @@ export const useRunsForTimeline = (
     // skip the cache entirely.
     fetchPolicy: 'no-cache',
     variables: {
-      limit: BATCH_LIMIT,
       terminatedFilter: {
         ...runsFilter,
         statuses: Array.from(doneStatuses),
@@ -285,7 +281,7 @@ export const makeJobKey = (repoAddress: RepoAddress, jobName: string) =>
   `${jobName}-${repoAddressAsHumanString(repoAddress)}`;
 
 const UNTERMINATED_RUN_TIMELINE_QUERY = gql`
-  query UnterminatedRunTimelineQuery($inProgressFilter: RunsFilter!, $limit: Int!) {
+  query UnterminatedRunTimelineQuery($inProgressFilter: RunsFilter!, $limit: Int) {
     unterminated: runsOrError(filter: $inProgressFilter, limit: $limit) {
       ... on Runs {
         results {
@@ -304,7 +300,7 @@ const UNTERMINATED_RUN_TIMELINE_QUERY = gql`
 `;
 
 const TERMINATED_RUN_TIMELINE_QUERY = gql`
-  query TerimatedRunTimelineQuery($terminatedFilter: RunsFilter!, $limit: Int!) {
+  query TerimatedRunTimelineQuery($terminatedFilter: RunsFilter!, $limit: Int) {
     terminated: runsOrError(filter: $terminatedFilter, limit: $limit) {
       ... on Runs {
         results {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -5,7 +5,15 @@ import {doneStatuses} from './RunStatuses';
 import {TimelineJob, TimelineRun} from './RunTimeline';
 import {RUN_TIME_FRAGMENT} from './RunUtils';
 import {overlap} from './batchRunsForTimeline';
-import {RunTimelineQuery, RunTimelineQueryVariables} from './types/useRunsForTimeline.types';
+import {
+  FutureTicksQuery,
+  FutureTicksQueryVariables,
+  TerimatedRunTimelineQuery,
+  TerimatedRunTimelineQueryVariables,
+  UnterminatedRunTimelineQuery,
+  UnterminatedRunTimelineQueryVariables,
+} from './types/useRunsForTimeline.types';
+import {FIFTEEN_SECONDS, useRefreshAtInterval} from '../app/QueryRefresh';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {InstigationStatus, RunStatus, RunsFilter} from '../graphql/types';
 import {SCHEDULE_FUTURE_TICKS_FRAGMENT} from '../instance/NextTick';
@@ -15,41 +23,105 @@ import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePipelinePath} from '../workspace/workspacePath';
 
-export const useRunsForTimeline = (range: [number, number], runsFilter: RunsFilter = {}) => {
+const BATCH_LIMIT = 500;
+
+export const useRunsForTimeline = (
+  range: [number, number],
+  runsFilter: RunsFilter = {},
+  refreshInterval = FIFTEEN_SECONDS,
+) => {
   const [start, end] = range;
 
   const startSec = start / 1000.0;
   const endSec = end / 1000.0;
 
-  const queryData = useQuery<RunTimelineQuery, RunTimelineQueryVariables>(RUN_TIMELINE_QUERY, {
+  const unteriminatedRunsQueryData = useQuery<
+    UnterminatedRunTimelineQuery,
+    UnterminatedRunTimelineQueryVariables
+  >(UNTERMINATED_RUN_TIMELINE_QUERY, {
     notifyOnNetworkStatusChange: true,
     // With a very large number of runs, operating on the Apollo cache is too expensive and
     // can block the main thread. This data has to be up-to-the-second fresh anyway, so just
     // skip the cache entirely.
     fetchPolicy: 'no-cache',
     variables: {
+      limit: BATCH_LIMIT,
       inProgressFilter: {
         ...runsFilter,
         statuses: [RunStatus.CANCELING, RunStatus.STARTED],
         createdBefore: endSec,
       },
+    },
+  });
+
+  const terminatedRunsQueryData = useQuery<
+    TerimatedRunTimelineQuery,
+    TerimatedRunTimelineQueryVariables
+  >(TERMINATED_RUN_TIMELINE_QUERY, {
+    notifyOnNetworkStatusChange: true,
+    // With a very large number of runs, operating on the Apollo cache is too expensive and
+    // can block the main thread. This data has to be up-to-the-second fresh anyway, so just
+    // skip the cache entirely.
+    fetchPolicy: 'no-cache',
+    variables: {
+      limit: BATCH_LIMIT,
       terminatedFilter: {
         ...runsFilter,
         statuses: Array.from(doneStatuses),
         createdBefore: endSec,
         updatedAfter: startSec,
       },
-      tickCursor: startSec,
-      ticksUntil: endSec,
     },
   });
 
-  useBlockTraceOnQueryResult(queryData, 'RunTimelineQuery');
+  const futureTicksQueryData = useQuery<FutureTicksQuery, FutureTicksQueryVariables>(
+    FUTURE_TICKS_QUERY,
+    {
+      notifyOnNetworkStatusChange: true,
+      // With a very large number of runs, operating on the Apollo cache is too expensive and
+      // can block the main thread. This data has to be up-to-the-second fresh anyway, so just
+      // skip the cache entirely.
+      fetchPolicy: 'no-cache',
+      variables: {
+        tickCursor: startSec,
+        ticksUntil: endSec,
+      },
+    },
+  );
 
-  const {data, previousData, loading} = queryData;
+  useBlockTraceOnQueryResult(unteriminatedRunsQueryData, 'UnterminatedRunTimelineQuery');
+  useBlockTraceOnQueryResult(terminatedRunsQueryData, 'TerimatedRunTimelineQuery');
+  useBlockTraceOnQueryResult(futureTicksQueryData, 'FutureTicksQuery');
 
-  const initialLoading = loading && !data;
-  const {unterminated, terminated, workspaceOrError} = data || previousData || {};
+  const {
+    data: unterminatedRunsData,
+    previousData: previousUnterminatedRunsData,
+    loading: loadingUnterminatedRunsData,
+    refetch: refetchUnterminatedRuns,
+  } = unteriminatedRunsQueryData;
+  const {
+    data: terminatedRunsData,
+    previousData: previousTerminatedRunsData,
+    loading: loadingTerminatedRunsData,
+    refetch: refetchTerminatedRuns,
+  } = terminatedRunsQueryData;
+  const {
+    data: futureTicksData,
+    previousData: previousFutureTicksData,
+    loading: loadingFutureTicksData,
+    refetch: refetchFutureTicks,
+  } = futureTicksQueryData;
+
+  const initialLoading =
+    (loadingUnterminatedRunsData && !unterminatedRunsData) ||
+    (loadingTerminatedRunsData && !terminatedRunsQueryData) ||
+    (loadingFutureTicksData && !futureTicksData);
+
+  const {unterminated} = unterminatedRunsData ||
+    previousUnterminatedRunsData || {unterminated: undefined};
+  const {terminated} = terminatedRunsData || previousTerminatedRunsData || {terminated: undefined};
+  const {workspaceOrError} = futureTicksData ||
+    previousFutureTicksData || {workspaceOrError: undefined};
 
   const runsByJobKey = useMemo(() => {
     const map: {[jobKey: string]: TimelineRun[]} = {};
@@ -192,27 +264,29 @@ export const useRunsForTimeline = (range: [number, number], runsFilter: RunsFilt
     return jobs.sort((a, b) => earliest[a.key]! - earliest[b.key]!);
   }, [workspaceOrError, runsByJobKey, start, end]);
 
+  const refreshState = useRefreshAtInterval({
+    refresh: async () => {
+      await Promise.all([refetchFutureTicks(), refetchTerminatedRuns(), refetchUnterminatedRuns()]);
+    },
+    intervalMs: refreshInterval,
+  });
+
   return useMemo(
     () => ({
       jobs: jobsWithRuns,
       initialLoading,
-      queryData,
+      refreshState,
     }),
-    [initialLoading, jobsWithRuns, queryData],
+    [initialLoading, jobsWithRuns, refreshState],
   );
 };
 
 export const makeJobKey = (repoAddress: RepoAddress, jobName: string) =>
   `${jobName}-${repoAddressAsHumanString(repoAddress)}`;
 
-const RUN_TIMELINE_QUERY = gql`
-  query RunTimelineQuery(
-    $inProgressFilter: RunsFilter!
-    $terminatedFilter: RunsFilter!
-    $tickCursor: Float
-    $ticksUntil: Float
-  ) {
-    unterminated: runsOrError(filter: $inProgressFilter) {
+const UNTERMINATED_RUN_TIMELINE_QUERY = gql`
+  query UnterminatedRunTimelineQuery($inProgressFilter: RunsFilter!, $limit: Int!) {
+    unterminated: runsOrError(filter: $inProgressFilter, limit: $limit) {
       ... on Runs {
         results {
           id
@@ -226,7 +300,12 @@ const RUN_TIMELINE_QUERY = gql`
         }
       }
     }
-    terminated: runsOrError(filter: $terminatedFilter) {
+  }
+`;
+
+const TERMINATED_RUN_TIMELINE_QUERY = gql`
+  query TerimatedRunTimelineQuery($terminatedFilter: RunsFilter!, $limit: Int!) {
+    terminated: runsOrError(filter: $terminatedFilter, limit: $limit) {
       ... on Runs {
         results {
           id
@@ -240,6 +319,13 @@ const RUN_TIMELINE_QUERY = gql`
         }
       }
     }
+  }
+
+  ${RUN_TIME_FRAGMENT}
+`;
+
+const FUTURE_TICKS_QUERY = gql`
+  query FutureTicksQuery($tickCursor: Float, $ticksUntil: Float) {
     workspaceOrError {
       ... on Workspace {
         id
@@ -280,7 +366,5 @@ const RUN_TIMELINE_QUERY = gql`
       }
     }
   }
-
-  ${RUN_TIME_FRAGMENT}
   ${SCHEDULE_FUTURE_TICKS_FRAGMENT}
 `;


### PR DESCRIPTION
## Summary & Motivation

Split up the RunTimelineQuery into 3 distinct queries.

Next PR will chunk these queries up and apply a limit.

## How I Tested These Changes

Load the elementl Run timeline

https://app.datadoghq.com/rum/sessions?query=%40application.id%3A6d12cca2-0263-463b-a90e-cc6c524e14bd%20%40usr.email%3Amarco%40dagsterlabs.com%20%40type%3Aview&agg_m=count&agg_m_source=base&agg_q=%40issue.id&agg_q_source=base&agg_t=count&cols=&event=AgAAAY94QhVDg2Qy6QAAAAAAAAAYAAAAAEFZOTRRaFZEQUFDU2JrcW1QVkVJMWJPaAAAACQAAAAAMDE4Zjc4NDItNmU2Ny00OGU0LTk3Y2EtMTk1ZmQ5ZDYxZjAx&fromUser=true&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=6594261810473780884&tab=error&top_n=10&top_o=top&view=spans&viz=stream&x_missing=true&from_ts=1715709480599&to_ts=1715709600599&live=true