### PR TITLE
[op] handle pipe union based optional

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -39,11 +39,11 @@ from dagster._model.pydantic_compat_layer import (
     model_fields,
 )
 from dagster._utils.cached_method import cached_method
+from dagster._utils.typing_api import is_closed_python_optional_type
 
 from .attach_other_object_to_context import (
     IAttachDifferentObjectToOpContext as IAttachDifferentObjectToOpContext,
 )
-from .type_check_utils import is_optional
 
 try:
     from functools import cached_property  # type: ignore  # (py37 compat)
@@ -898,7 +898,7 @@ def _is_annotated_as_resource_type(annotation: Type, metadata: List[str]) -> boo
     if metadata and metadata[0] == "resource_dependency":
         return True
 
-    if is_optional(annotation):
+    if is_closed_python_optional_type(annotation):
         args = get_args(annotation)
         annotation_inner = next((arg for arg in args if arg is not None), None)
         if not annotation_inner:

--- a/python_modules/dagster/dagster/_config/pythonic_config/type_check_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/type_check_utils.py
@@ -1,14 +1,9 @@
 from typing import Any, Literal, Tuple, Type, Union
 
-from typing_extensions import Literal as ExtLiteral
-
-try:
-    # this type only exists in python 3.10+
-    from types import UnionType  # type: ignore
-except ImportError:
-    UnionType = Union
-
-from typing_extensions import get_args, get_origin
+from typing_extensions import (
+    Literal as ExtLiteral,
+    get_origin,
+)
 
 
 def safe_is_subclass(cls: Any, possible_parent_cls: Union[Type, Tuple[Type, ...]]) -> bool:
@@ -23,33 +18,6 @@ def safe_is_subclass(cls: Any, possible_parent_cls: Union[Type, Tuple[Type, ...]
         # even though the isinstance check will succeed (as will inspect.isclass), for example
         # list[dict[str, str]] will raise a TypeError
         return False
-
-
-def is_optional(annotation: Type) -> bool:
-    """Returns true if the annotation signifies an Optional type.
-
-    In particular, this can be:
-    - Optional[T]
-    - Union[T, None]
-    - Union[None, T]
-    - T | None (in Python 3.10+)
-    - None | T (in Python 3.10+).
-
-    """
-    # Optional[T] is equivalent to Union[T, None], see
-    # https://docs.python.org/3/library/typing.html#typing.Optional
-    # A user could also specify a Union themselves
-    if get_origin(annotation) == Union:
-        return len(get_args(annotation)) == 2 and type(None) in get_args(annotation)
-
-    # The Python 3.10 pipe syntax evaluates to a UnionType
-    # rather than a Union, so we need to check for that as well
-    # UnionType values are equivalent to Unions, e.g. str | None == Union[str, None]
-    # but the types themselves are not, e.g. type(str | None) != type(Union[str, None])
-    if get_origin(annotation) == UnionType:
-        return len(get_args(annotation)) == 2 and type(None) in get_args(annotation)
-
-    return False
 
 
 def is_literal(annotation: Type) -> bool:

--- a/python_modules/dagster/dagster/_utils/typed_dict.py
+++ b/python_modules/dagster/dagster/_utils/typed_dict.py
@@ -2,13 +2,13 @@ from typing import Type, TypeVar, cast
 
 from typing_extensions import NotRequired, get_origin, is_typeddict
 
+from .typing_api import is_closed_python_optional_type
+
 _TypedDictClass = TypeVar("_TypedDictClass")
 
 
 def init_optional_typeddict(cls: Type[_TypedDictClass]) -> _TypedDictClass:
     """Initialize a TypedDict with optional values."""
-    from dagster._config.pythonic_config.type_check_utils import is_optional
-
     if not is_typeddict(cls):
         raise Exception("Must pass a TypedDict class to init_optional_typeddict")
     result = {}
@@ -16,7 +16,7 @@ def init_optional_typeddict(cls: Type[_TypedDictClass]) -> _TypedDictClass:
         # If the value is a typed dict, recursively initialize it
         if is_typeddict(value):
             result[key] = init_optional_typeddict(value)
-        elif is_optional(value):
+        elif is_closed_python_optional_type(value):
             result[key] = None
         elif get_origin(value) is dict:
             result[key] = {}

--- a/python_modules/dagster/dagster/_utils/typing_api.py
+++ b/python_modules/dagster/dagster/_utils/typing_api.py
@@ -8,12 +8,39 @@ from typing_extensions import get_args, get_origin
 
 import dagster._check as check
 
+try:
+    # this type only exists in python 3.10+
+    from types import UnionType  # type: ignore
+except ImportError:
+    UnionType = typing.Union
 
-def is_closed_python_optional_type(ttype):
-    # Optional[X] is Union[X, NoneType] which is what we match against here
-    origin = get_origin(ttype)
-    args = get_args(ttype)
-    return origin is typing.Union and len(args) == 2 and args[1] is type(None)
+
+def is_closed_python_optional_type(annotation) -> bool:
+    """Returns true if the annotation signifies an Optional type
+    that is closed over a non-None T.
+
+    In particular, this can be:
+    - Optional[T]
+    - Union[T, None]
+    - Union[None, T]
+    - T | None (in Python 3.10+)
+    - None | T (in Python 3.10+).
+
+    """
+    # Optional[T] is equivalent to Union[T, None], see
+    # https://docs.python.org/3/library/typing.html#typing.Optional
+    # A user could also specify a Union themselves
+    if get_origin(annotation) == typing.Union:
+        return len(get_args(annotation)) == 2 and type(None) in get_args(annotation)
+
+    # The Python 3.10 pipe syntax evaluates to a UnionType
+    # rather than a Union, so we need to check for that as well
+    # UnionType values are equivalent to Unions, e.g. str | None == Union[str, None]
+    # but the types themselves are not, e.g. type(str | None) != type(Union[str, None])
+    if get_origin(annotation) == UnionType:
+        return len(get_args(annotation)) == 2 and type(None) in get_args(annotation)
+
+    return False
 
 
 def is_python_dict_type(ttype):

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_utils.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_utils.py
@@ -1,35 +1,35 @@
 import sys
 
 import pytest
-from dagster._config.pythonic_config.type_check_utils import is_optional
+from dagster._utils.typing_api import is_closed_python_optional_type
 
 
-def test_is_optional() -> None:
+def test_is_closed_python_optional_type() -> None:
     from typing import Optional, Union
 
-    assert is_optional(Optional[str])
-    assert is_optional(Optional[int])
+    assert is_closed_python_optional_type(Optional[str])
+    assert is_closed_python_optional_type(Optional[int])
 
-    assert not is_optional(str)
-    assert not is_optional(int)
+    assert not is_closed_python_optional_type(str)
+    assert not is_closed_python_optional_type(int)
 
-    assert is_optional(Union[str, None])
-    assert is_optional(Union[int, None])
+    assert is_closed_python_optional_type(Union[str, None])
+    assert is_closed_python_optional_type(Union[int, None])
 
-    assert is_optional(Union[None, str])
-    assert is_optional(Union[None, int])
+    assert is_closed_python_optional_type(Union[None, str])
+    assert is_closed_python_optional_type(Union[None, int])
 
-    assert not is_optional(Union[str, int])
-    assert not is_optional(Union[str, int, None])
+    assert not is_closed_python_optional_type(Union[str, int])
+    assert not is_closed_python_optional_type(Union[str, int, None])
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10")
-def test_is_optional_310_types() -> None:
-    assert is_optional(str | None)  # type: ignore
-    assert is_optional(int | None)  # type: ignore
+def test_is_closed_python_optional_type_310_types() -> None:
+    assert is_closed_python_optional_type(str | None)  # type: ignore
+    assert is_closed_python_optional_type(int | None)  # type: ignore
 
-    assert is_optional(None | str)  # type: ignore
-    assert is_optional(None | int)  # type: ignore
+    assert is_closed_python_optional_type(None | str)  # type: ignore
+    assert is_closed_python_optional_type(None | int)  # type: ignore
 
-    assert not is_optional(str | int)  # type: ignore
-    assert not is_optional(str | int | None)  # type: ignore
+    assert not is_closed_python_optional_type(str | int)  # type: ignore
+    assert not is_closed_python_optional_type(str | int | None)  # type: ignore

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_op_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_op_definition.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 from dagster import DagsterInvariantViolationError, In, Nothing, OpDefinition, Out, Output, job, op
 
@@ -81,3 +83,15 @@ def test_multi_out_implicit_none():
         match="has multiple outputs, but only one output was returned",
     ):
         untyped_job.execute_in_process()
+
+
+pytest.mark.skipif(sys.version_info < (3, 10), reason="| operator Python 3.10 or higher")
+
+
+def test_pipe_union_optional():
+    # union is not yet supported, but you can express optional as union of T and None
+    @op
+    def pipe_union(thing: str | None) -> str | None:  # type: ignore
+        return thing
+
+    assert pipe_union


### PR DESCRIPTION
consolidate the `is_optional` check that was added for configurable resources in to the older `is_closed_python_optional_type` to support `|` based `Optional` types in `@op` and friends 

## How I Tested These Changes

added test