### PR TITLE
feat(dbt): omit `fqn:` when constructing a subssetted execution

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -1634,7 +1634,7 @@ def _get_subset_selection_for_context(
 
         # Explicitly select a dbt resource by its fully qualified name (FQN).
         # https://docs.getdbt.com/reference/node-selection/methods#the-file-or-fqn-method
-        fqn_selector = f"fqn:{'.'.join(dbt_resource_props['fqn'])}"
+        fqn_selector = ".".join(dbt_resource_props["fqn"])
 
         selected_dbt_non_test_resources.append(fqn_selector)
 
@@ -1644,7 +1644,7 @@ def _get_subset_selection_for_context(
 
         # Explicitly select a dbt resource by its fully qualified name (FQN).
         # https://docs.getdbt.com/reference/node-selection/methods#the-file-or-fqn-method
-        fqn_selector = f"fqn:{'.'.join(test_resource_props['fqn'])}"
+        fqn_selector = ".".join(test_resource_props["fqn"])
 
         selected_dbt_tests.append(fqn_selector)
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -328,7 +328,7 @@ def test_materialize_asset_and_checks(
         test_asset_checks_manifest,
         dbt_commands,
         selection=AssetSelection.assets(AssetKey(["customers"])),
-        expected_dbt_selection={"fqn:test_dagster_asset_checks.customers"},
+        expected_dbt_selection={"test_dagster_asset_checks.customers"},
     )
     assert result.success
     assert len(result.get_asset_materialization_events()) == 1
@@ -377,7 +377,7 @@ def test_materialize_asset_and_checks_with_python_check(
         test_asset_checks_manifest,
         dbt_commands,
         selection=AssetSelection.assets(AssetKey(["customers"])),
-        expected_dbt_selection={"fqn:test_dagster_asset_checks.customers"},
+        expected_dbt_selection={"test_dagster_asset_checks.customers"},
         additional_assets=[my_python_check],
     )
     assert result.success
@@ -394,7 +394,7 @@ def test_materialize_asset_checks_disabled(
         test_asset_checks_manifest,
         dbt_commands,
         selection=AssetSelection.assets(AssetKey(["customers"])),
-        expected_dbt_selection={"fqn:test_dagster_asset_checks.customers"},
+        expected_dbt_selection={"test_dagster_asset_checks.customers"},
         dagster_dbt_translator=dagster_dbt_translator_without_checks,
     )
     assert result.success
@@ -412,7 +412,7 @@ def test_materialize_asset_no_checks(
         test_asset_checks_manifest,
         dbt_commands,
         selection=AssetSelection.assets(AssetKey(["customers"])).without_checks(),
-        expected_dbt_selection={"fqn:test_dagster_asset_checks.customers"},
+        expected_dbt_selection={"test_dagster_asset_checks.customers"},
     )
     assert result.success
     assert len(result.get_asset_materialization_events()) == 1
@@ -432,10 +432,10 @@ def test_materialize_checks_no_asset(
             - AssetSelection.assets(AssetKey(["customers"])).without_checks()
         ),
         expected_dbt_selection={
-            "fqn:test_dagster_asset_checks.not_null_customers_customer_id",
-            "fqn:test_dagster_asset_checks.singular_test_with_meta_and_multiple_dependencies",
-            "fqn:test_dagster_asset_checks.singular_test_with_single_dependency",
-            "fqn:test_dagster_asset_checks.unique_customers_customer_id",
+            "test_dagster_asset_checks.not_null_customers_customer_id",
+            "test_dagster_asset_checks.singular_test_with_meta_and_multiple_dependencies",
+            "test_dagster_asset_checks.singular_test_with_single_dependency",
+            "test_dagster_asset_checks.unique_customers_customer_id",
         },
     )
     assert result.success

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -370,8 +370,8 @@ def test_dbt_cli_asset_selection(
 ) -> None:
     dbt_select = " ".join(
         [
-            "fqn:jaffle_shop.raw_customers",
-            "fqn:jaffle_shop.staging.stg_customers",
+            "jaffle_shop.raw_customers",
+            "jaffle_shop.staging.stg_customers",
         ]
     )
 
@@ -391,8 +391,8 @@ def test_dbt_cli_subsetted_execution(
     test_jaffle_shop_manifest: Dict[str, Any], dbt: DbtCliResource
 ) -> None:
     dbt_select = [
-        "fqn:jaffle_shop.raw_customers",
-        "fqn:jaffle_shop.staging.stg_customers",
+        "jaffle_shop.raw_customers",
+        "jaffle_shop.staging.stg_customers",
     ]
 
     @dbt_assets(manifest=test_jaffle_shop_manifest)


### PR DESCRIPTION
## Summary & Motivation
Save 4 characters per each selected dbt asset and check.

Before, we were being explicit that `fqn:` was being used. Instead, we can just let dbt figure that out. From https://docs.getdbt.com/reference/node-selection/methods, `fqn:` is one of the default selectors anyways.

This isn't going to make a huge dent in the most diabolical of cases, but might as well cash in on some character savings.

## How I Tested These Changes
pytest