### PR TITLE
[DS][x/n] Allow SchedulingConditions to target specific dependency keys

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -3,9 +3,6 @@ from typing import TYPE_CHECKING, AbstractSet, Dict, FrozenSet, NamedTuple, Opti
 
 import dagster._check as check
 from dagster._annotations import deprecated, experimental, public
-from dagster._core.definitions.declarative_scheduling.scheduling_condition import (
-    SchedulingCondition,
-)
 from dagster._serdes.serdes import (
     NamedTupleSerializer,
     UnpackContext,
@@ -17,6 +14,9 @@ if TYPE_CHECKING:
     from dagster._core.definitions.auto_materialize_rule import (
         AutoMaterializeRule,
         AutoMaterializeRuleSnapshot,
+    )
+    from dagster._core.definitions.declarative_scheduling.scheduling_condition import (
+        SchedulingCondition,
     )
 
 
@@ -65,7 +65,7 @@ class AutoMaterializePolicy(
         [
             ("rules", FrozenSet["AutoMaterializeRule"]),
             ("max_materializations_per_minute", Optional[int]),
-            ("asset_condition", Optional[SchedulingCondition]),
+            ("asset_condition", Optional["SchedulingCondition"]),
         ],
     )
 ):
@@ -128,7 +128,7 @@ class AutoMaterializePolicy(
         cls,
         rules: AbstractSet["AutoMaterializeRule"],
         max_materializations_per_minute: Optional[int] = 1,
-        asset_condition: Optional[SchedulingCondition] = None,
+        asset_condition: Optional["SchedulingCondition"] = None,
     ):
         from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 
@@ -175,12 +175,12 @@ class AutoMaterializePolicy(
         }
 
     @staticmethod
-    def from_asset_condition(asset_condition: SchedulingCondition) -> "AutoMaterializePolicy":
+    def from_asset_condition(asset_condition: "SchedulingCondition") -> "AutoMaterializePolicy":
         return AutoMaterializePolicy.from_scheduling_condition(asset_condition)
 
     @staticmethod
     def from_scheduling_condition(
-        scheduling_condition: SchedulingCondition,
+        scheduling_condition: "SchedulingCondition",
     ) -> "AutoMaterializePolicy":
         """Constructs an AutoMaterializePolicy which will materialize an asset partition whenever
         the provided scheduling_condition evaluates to True.
@@ -293,7 +293,7 @@ class AutoMaterializePolicy(
     def rule_snapshots(self) -> Sequence["AutoMaterializeRuleSnapshot"]:
         return [rule.to_snapshot() for rule in self.rules]
 
-    def to_scheduling_condition(self) -> SchedulingCondition:
+    def to_scheduling_condition(self) -> "SchedulingCondition":
         """Converts a set of materialize / skip rules into a single binary expression."""
         from .auto_materialize_rule_impls import DiscardOnMaxMaterializationsExceededRule
         from .declarative_scheduling.operators.boolean_operators import (

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -5,13 +5,13 @@ import pytz
 
 import dagster._check as check
 from dagster._annotations import public
-from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    AutoMaterializeDecisionType,
-    AutoMaterializeRuleSnapshot,
-)
 from dagster._utils.schedules import is_valid_cron_string
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.auto_materialize_rule_evaluation import (
+        AutoMaterializeDecisionType,
+        AutoMaterializeRuleSnapshot,
+    )
     from dagster._core.definitions.auto_materialize_rule_impls import (
         AutoMaterializeAssetPartitionsFilter,
         MaterializeOnCronRule,
@@ -50,7 +50,7 @@ class AutoMaterializeRule(ABC):
     """
 
     @abstractproperty
-    def decision_type(self) -> AutoMaterializeDecisionType:
+    def decision_type(self) -> "AutoMaterializeDecisionType":
         """The decision type of the rule (either `MATERIALIZE` or `SKIP`)."""
         ...
 
@@ -252,8 +252,12 @@ class AutoMaterializeRule(ABC):
 
         return SkipOnRunInProgressRule()
 
-    def to_snapshot(self) -> AutoMaterializeRuleSnapshot:
+    def to_snapshot(self) -> "AutoMaterializeRuleSnapshot":
         """Returns a serializable snapshot of this rule for historical evaluations."""
+        from dagster._core.definitions.auto_materialize_rule_evaluation import (
+            AutoMaterializeRuleSnapshot,
+        )
+
         return AutoMaterializeRuleSnapshot(
             class_name=self.__class__.__name__,
             description=self.description,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/__init__.py
@@ -24,3 +24,4 @@ from .serialized_objects import (
     AssetSubsetWithMetadata as AssetSubsetWithMetadata,
     HistoricalAllPartitionsSubsetSentinel as HistoricalAllPartitionsSubsetSentinel,
 )
+from .utils import SerializableTimeDelta as SerializableTimeDelta

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/has_dep_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/has_dep_selection.py
@@ -1,0 +1,25 @@
+from typing import AbstractSet, Optional
+
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
+from dagster._model import DagsterModel
+from dagster._utils.cached_method import cached_method
+
+
+class IHasDepSelection(DagsterModel):
+    """Interface for all SchedulingConditions which contain a dep_selection."""
+
+    dep_selection: Optional[AssetSelection] = None
+
+    @cached_method
+    def get_dep_keys(
+        self, *, asset_key: AssetKey, asset_graph: BaseAssetGraph
+    ) -> AbstractSet[AssetKey]:
+        selection = AssetSelection.keys(asset_key).upstream(depth=1, include_self=False)
+        if self.dep_selection:
+            selection &= self.dep_selection
+        return selection.resolve(asset_graph)
+
+    def __hash__(self) -> int:
+        return id(self)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
@@ -52,8 +52,8 @@ class FalseAssetCondition(SchedulingCondition):
 
 
 @dataclass(frozen=True)
-class AssetConditionScenarioState(ScenarioState):
-    asset_condition: Optional[SchedulingCondition] = None
+class SchedulingConditionScenarioState(ScenarioState):
+    scheduling_condition: Optional[SchedulingCondition] = None
     previous_evaluation_state: Optional[AssetConditionEvaluationState] = None
     requested_asset_partitions: Optional[Sequence[AssetKeyPartitionKey]] = None
     ensure_empty_result: bool = True
@@ -81,16 +81,16 @@ class AssetConditionScenarioState(ScenarioState):
 
     def evaluate(
         self, asset: CoercibleToAssetKey
-    ) -> Tuple["AssetConditionScenarioState", SchedulingResult]:
+    ) -> Tuple["SchedulingConditionScenarioState", SchedulingResult]:
         asset_key = AssetKey.from_coercible(asset)
         # ensure that the top level condition never returns any asset partitions, as otherwise the
         # next evaluation will assume that those asset partitions were requested by the machinery
         asset_condition = (
             AndAssetCondition(
-                operands=[check.not_none(self.asset_condition), FalseAssetCondition()]
+                operands=[check.not_none(self.scheduling_condition), FalseAssetCondition()]
             )
             if self.ensure_empty_result
-            else check.not_none(self.asset_condition)
+            else check.not_none(self.scheduling_condition)
         )
         asset_graph = self.scenario_spec.with_asset_properties(
             asset,
@@ -150,7 +150,7 @@ class AssetConditionScenarioState(ScenarioState):
 
         return new_state, result
 
-    def without_previous_evaluation_state(self) -> "AssetConditionScenarioState":
+    def without_previous_evaluation_state(self) -> "SchedulingConditionScenarioState":
         """Removes the previous evaluation state from the state. This is useful for testing
         re-evaluating this data "from scratch" after much computation has occurred.
         """
@@ -158,5 +158,5 @@ class AssetConditionScenarioState(ScenarioState):
 
     def with_requested_asset_partitions(
         self, requested_asset_partitions: Sequence[AssetKeyPartitionKey]
-    ) -> "AssetConditionScenarioState":
+    ) -> "SchedulingConditionScenarioState":
         return dataclasses.replace(self, requested_asset_partitions=requested_asset_partitions)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_asset_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_asset_condition.py
@@ -13,11 +13,13 @@ from ..scenario_specs import (
     one_asset,
     time_partitions_start_datetime,
 )
-from .asset_condition_scenario import AssetConditionScenarioState
+from .asset_condition_scenario import SchedulingConditionScenarioState
 
 
 def test_missing_unpartitioned() -> None:
-    state = AssetConditionScenarioState(one_asset, asset_condition=SchedulingCondition.missing())
+    state = SchedulingConditionScenarioState(
+        one_asset, scheduling_condition=SchedulingCondition.missing()
+    )
 
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
@@ -45,7 +47,9 @@ def test_missing_unpartitioned() -> None:
 
 def test_missing_time_partitioned() -> None:
     state = (
-        AssetConditionScenarioState(one_asset, asset_condition=SchedulingCondition.missing())
+        SchedulingConditionScenarioState(
+            one_asset, scheduling_condition=SchedulingCondition.missing()
+        )
         .with_asset_properties(partitions_def=daily_partitions_def)
         .with_current_time(time_partitions_start_datetime)
         .with_current_time_advanced(days=6, minutes=1)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
@@ -1,6 +1,8 @@
+from typing import Sequence
+
 import dagster._check as check
 import pytest
-from dagster import SchedulingCondition
+from dagster import AssetSelection, SchedulingCondition
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.declarative_scheduling.scheduling_condition import SchedulingResult
@@ -9,6 +11,7 @@ from dagster._core.definitions.declarative_scheduling.scheduling_context import 
 )
 from dagster._core.definitions.events import AssetKeyPartitionKey
 
+from ..base_scenario import run_request
 from ..scenario_specs import one_asset_depends_on_two, two_partitions_def
 from .asset_condition_scenario import SchedulingConditionScenarioState
 
@@ -123,3 +126,41 @@ def test_dep_missing_partitioned(is_any: bool) -> None:
     else:
         # now partition 2 has all parents true
         assert result.true_subset.size == 2
+
+
+@pytest.mark.parametrize("is_any", [True, False])
+@pytest.mark.parametrize(
+    "expected_initial_result_size,materialized_asset_partitions,expected_final_result_size",
+    [
+        # after A is materialized, B is still missing, but is ignored
+        (2, ["A1"], 1),
+        (2, ["A1", "A2"], 0),
+        # materializations of B have no effect
+        (2, ["A1", "B2"], 1),
+        (2, ["B1", "B2"], 2),
+    ],
+)
+def test_dep_missing_partitioned_selections(
+    is_any: bool,
+    expected_initial_result_size: int,
+    materialized_asset_partitions: Sequence[str],
+    expected_final_result_size: int,
+) -> None:
+    # NOTE: because all selections resolve to a single parent asset, ANY and ALL return the same
+    # results
+    fn = SchedulingCondition.any_deps_match if is_any else SchedulingCondition.all_deps_match
+    condition = fn(
+        SchedulingCondition.missing(),
+        dep_selection=AssetSelection.keys("A"),
+    )
+    state = SchedulingConditionScenarioState(
+        one_asset_depends_on_two, scheduling_condition=condition
+    ).with_asset_properties(partitions_def=two_partitions_def)
+
+    # all parents are missing
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == expected_initial_result_size
+
+    state = state.with_runs(*(run_request(s[0], s[1]) for s in materialized_asset_partitions))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == expected_final_result_size

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
@@ -10,7 +10,7 @@ from dagster._core.definitions.declarative_scheduling.scheduling_context import 
 from dagster._core.definitions.events import AssetKeyPartitionKey
 
 from ..scenario_specs import one_asset_depends_on_two, two_partitions_def
-from .asset_condition_scenario import AssetConditionScenarioState
+from .asset_condition_scenario import SchedulingConditionScenarioState
 
 
 def get_hardcoded_condition():
@@ -52,7 +52,9 @@ def test_dep_missing_unpartitioned(is_any: bool) -> None:
         if is_any
         else SchedulingCondition.all_deps_match(inner_condition)
     )
-    state = AssetConditionScenarioState(one_asset_depends_on_two, asset_condition=condition)
+    state = SchedulingConditionScenarioState(
+        one_asset_depends_on_two, scheduling_condition=condition
+    )
 
     # neither parent is true
     state, result = state.evaluate("C")
@@ -80,8 +82,8 @@ def test_dep_missing_partitioned(is_any: bool) -> None:
         if is_any
         else SchedulingCondition.all_deps_match(inner_condition)
     )
-    state = AssetConditionScenarioState(
-        one_asset_depends_on_two, asset_condition=condition
+    state = SchedulingConditionScenarioState(
+        one_asset_depends_on_two, scheduling_condition=condition
     ).with_asset_properties(partitions_def=two_partitions_def)
 
     # no parents true

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_eager_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_eager_condition.py
@@ -5,13 +5,13 @@ from dagster import SchedulingCondition
 from dagster_tests.definitions_tests.auto_materialize_tests.base_scenario import run_request
 
 from ..scenario_specs import hourly_partitions_def, two_assets_in_sequence
-from .asset_condition_scenario import AssetConditionScenarioState
+from .asset_condition_scenario import SchedulingConditionScenarioState
 
 
 def test_eager_with_rate_limit_unpartitioned() -> None:
-    state = AssetConditionScenarioState(
+    state = SchedulingConditionScenarioState(
         two_assets_in_sequence,
-        asset_condition=SchedulingCondition.eager_with_rate_limit(),
+        scheduling_condition=SchedulingCondition.eager_with_rate_limit(),
         ensure_empty_result=False,
     )
 
@@ -50,9 +50,9 @@ def test_eager_with_rate_limit_unpartitioned() -> None:
 
 def test_eager_with_rate_limit_hourly_partitioned() -> None:
     state = (
-        AssetConditionScenarioState(
+        SchedulingConditionScenarioState(
             two_assets_in_sequence,
-            asset_condition=SchedulingCondition.eager_with_rate_limit(
+            scheduling_condition=SchedulingCondition.eager_with_rate_limit(
                 failure_retry_delta=datetime.timedelta(minutes=10)
             ),
             ensure_empty_result=False,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_failed_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_failed_condition.py
@@ -4,11 +4,13 @@ from dagster._core.definitions.events import AssetKeyPartitionKey
 
 from ..base_scenario import run_request
 from ..scenario_specs import one_asset, two_partitions_def
-from .asset_condition_scenario import AssetConditionScenarioState
+from .asset_condition_scenario import SchedulingConditionScenarioState
 
 
 def test_failed_unpartitioned() -> None:
-    state = AssetConditionScenarioState(one_asset, asset_condition=SchedulingCondition.failed())
+    state = SchedulingConditionScenarioState(
+        one_asset, scheduling_condition=SchedulingCondition.failed()
+    )
 
     # no failed partitions
     state, result = state.evaluate("A")
@@ -26,8 +28,8 @@ def test_failed_unpartitioned() -> None:
 
 
 def test_in_progress_static_partitioned() -> None:
-    state = AssetConditionScenarioState(
-        one_asset, asset_condition=SchedulingCondition.failed()
+    state = SchedulingConditionScenarioState(
+        one_asset, scheduling_condition=SchedulingCondition.failed()
     ).with_asset_properties(partitions_def=two_partitions_def)
 
     # no failed_runs

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_in_progress_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_in_progress_condition.py
@@ -3,12 +3,12 @@ from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.events import AssetKeyPartitionKey
 
 from ..scenario_specs import one_asset, two_partitions_def
-from .asset_condition_scenario import AssetConditionScenarioState
+from .asset_condition_scenario import SchedulingConditionScenarioState
 
 
 def test_in_progress_unpartitioned() -> None:
-    state = AssetConditionScenarioState(
-        one_asset, asset_condition=SchedulingCondition.in_progress()
+    state = SchedulingConditionScenarioState(
+        one_asset, scheduling_condition=SchedulingCondition.in_progress()
     )
 
     # no run in progress
@@ -27,8 +27,8 @@ def test_in_progress_unpartitioned() -> None:
 
 
 def test_in_progress_static_partitioned() -> None:
-    state = AssetConditionScenarioState(
-        one_asset, asset_condition=SchedulingCondition.in_progress()
+    state = SchedulingConditionScenarioState(
+        one_asset, scheduling_condition=SchedulingCondition.in_progress()
     ).with_asset_properties(partitions_def=two_partitions_def)
 
     # no run in progress

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_latest_time_window_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_latest_time_window_condition.py
@@ -10,12 +10,12 @@ from ..scenario_specs import (
     time_partitions_start_datetime,
     two_partitions_def,
 )
-from .asset_condition_scenario import AssetConditionScenarioState
+from .asset_condition_scenario import SchedulingConditionScenarioState
 
 
 def test_in_latest_time_window_unpartitioned() -> None:
-    state = AssetConditionScenarioState(
-        one_asset, asset_condition=SchedulingCondition.in_latest_time_window()
+    state = SchedulingConditionScenarioState(
+        one_asset, scheduling_condition=SchedulingCondition.in_latest_time_window()
     )
 
     state, result = state.evaluate("A")
@@ -23,9 +23,9 @@ def test_in_latest_time_window_unpartitioned() -> None:
 
 
 def test_in_latest_time_window_unpartitioned_lookback() -> None:
-    state = AssetConditionScenarioState(
+    state = SchedulingConditionScenarioState(
         one_asset,
-        asset_condition=SchedulingCondition.in_latest_time_window(
+        scheduling_condition=SchedulingCondition.in_latest_time_window(
             lookback_delta=datetime.timedelta(days=3)
         ),
     )
@@ -35,8 +35,8 @@ def test_in_latest_time_window_unpartitioned_lookback() -> None:
 
 
 def test_in_latest_time_window_static_partitioned() -> None:
-    state = AssetConditionScenarioState(
-        one_asset, asset_condition=SchedulingCondition.in_latest_time_window()
+    state = SchedulingConditionScenarioState(
+        one_asset, scheduling_condition=SchedulingCondition.in_latest_time_window()
     ).with_asset_properties(partitions_def=two_partitions_def)
 
     state, result = state.evaluate("A")
@@ -44,9 +44,9 @@ def test_in_latest_time_window_static_partitioned() -> None:
 
 
 def test_in_latest_time_window_static_partitioned_lookback() -> None:
-    state = AssetConditionScenarioState(
+    state = SchedulingConditionScenarioState(
         one_asset,
-        asset_condition=SchedulingCondition.in_latest_time_window(
+        scheduling_condition=SchedulingCondition.in_latest_time_window(
             lookback_delta=datetime.timedelta(days=3)
         ),
     ).with_asset_properties(partitions_def=two_partitions_def)
@@ -56,8 +56,8 @@ def test_in_latest_time_window_static_partitioned_lookback() -> None:
 
 
 def test_in_latest_time_window_time_partitioned() -> None:
-    state = AssetConditionScenarioState(
-        one_asset, asset_condition=SchedulingCondition.in_latest_time_window()
+    state = SchedulingConditionScenarioState(
+        one_asset, scheduling_condition=SchedulingCondition.in_latest_time_window()
     ).with_asset_properties(partitions_def=daily_partitions_def)
 
     # no partitions exist yet
@@ -81,9 +81,9 @@ def test_in_latest_time_window_time_partitioned() -> None:
 
 
 def test_in_latest_time_window_time_partitioned_lookback() -> None:
-    state = AssetConditionScenarioState(
+    state = SchedulingConditionScenarioState(
         one_asset,
-        asset_condition=SchedulingCondition.in_latest_time_window(
+        scheduling_condition=SchedulingCondition.in_latest_time_window(
             lookback_delta=datetime.timedelta(days=3)
         ),
     ).with_asset_properties(partitions_def=daily_partitions_def)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
@@ -18,11 +18,13 @@ from ..scenario_specs import (
     one_asset,
     time_partitions_start_datetime,
 )
-from .asset_condition_scenario import AssetConditionScenarioState
+from .asset_condition_scenario import SchedulingConditionScenarioState
 
 
 def test_missing_unpartitioned() -> None:
-    state = AssetConditionScenarioState(one_asset, asset_condition=AssetCondition.missing())
+    state = SchedulingConditionScenarioState(
+        one_asset, scheduling_condition=AssetCondition.missing()
+    )
 
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
@@ -50,7 +52,7 @@ def test_missing_unpartitioned() -> None:
 
 def test_missing_time_partitioned() -> None:
     state = (
-        AssetConditionScenarioState(one_asset, asset_condition=AssetCondition.missing())
+        SchedulingConditionScenarioState(one_asset, scheduling_condition=AssetCondition.missing())
         .with_asset_properties(partitions_def=daily_partitions_def)
         .with_current_time(time_partitions_start_datetime)
         .with_current_time_advanced(days=6, minutes=1)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_missing_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_missing_condition.py
@@ -2,11 +2,13 @@ from dagster import SchedulingCondition
 
 from ..base_scenario import run_request
 from ..scenario_specs import one_asset, two_partitions_def
-from .asset_condition_scenario import AssetConditionScenarioState
+from .asset_condition_scenario import SchedulingConditionScenarioState
 
 
 def test_missing_unpartitioned() -> None:
-    state = AssetConditionScenarioState(one_asset, asset_condition=SchedulingCondition.missing())
+    state = SchedulingConditionScenarioState(
+        one_asset, scheduling_condition=SchedulingCondition.missing()
+    )
 
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
@@ -17,8 +19,8 @@ def test_missing_unpartitioned() -> None:
 
 
 def test_missing_partitioned() -> None:
-    state = AssetConditionScenarioState(
-        one_asset, asset_condition=SchedulingCondition.missing()
+    state = SchedulingConditionScenarioState(
+        one_asset, scheduling_condition=SchedulingCondition.missing()
     ).with_asset_properties(partitions_def=two_partitions_def)
 
     state, result = state.evaluate("A")

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_on_cron_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_on_cron_condition.py
@@ -3,13 +3,13 @@ from dagster import SchedulingCondition
 from dagster_tests.definitions_tests.auto_materialize_tests.base_scenario import run_request
 
 from ..scenario_specs import hourly_partitions_def, two_assets_in_sequence
-from .asset_condition_scenario import AssetConditionScenarioState
+from .asset_condition_scenario import SchedulingConditionScenarioState
 
 
 def test_on_cron_unpartitioned() -> None:
-    state = AssetConditionScenarioState(
+    state = SchedulingConditionScenarioState(
         two_assets_in_sequence,
-        asset_condition=SchedulingCondition.on_cron(cron_schedule="0 * * * *"),
+        scheduling_condition=SchedulingCondition.on_cron(cron_schedule="0 * * * *"),
     ).with_current_time("2020-02-02T01:05:00")
 
     # parent hasn't updated yet
@@ -46,9 +46,9 @@ def test_on_cron_unpartitioned() -> None:
 
 def test_on_cron_hourly_partitioned() -> None:
     state = (
-        AssetConditionScenarioState(
+        SchedulingConditionScenarioState(
             two_assets_in_sequence,
-            asset_condition=SchedulingCondition.on_cron(cron_schedule="0 * * * *"),
+            scheduling_condition=SchedulingCondition.on_cron(cron_schedule="0 * * * *"),
         )
         .with_asset_properties(partitions_def=hourly_partitions_def)
         .with_current_time("2020-02-02T01:05:00")

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_parent_newer_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_parent_newer_condition.py
@@ -2,12 +2,12 @@ from dagster import SchedulingCondition
 
 from ..base_scenario import run_request
 from ..scenario_specs import one_asset_depends_on_two, two_partitions_def
-from .asset_condition_scenario import AssetConditionScenarioState
+from .asset_condition_scenario import SchedulingConditionScenarioState
 
 
 def test_parent_newer_unpartitioned() -> None:
-    state = AssetConditionScenarioState(
-        one_asset_depends_on_two, asset_condition=SchedulingCondition.parent_newer()
+    state = SchedulingConditionScenarioState(
+        one_asset_depends_on_two, scheduling_condition=SchedulingCondition.parent_newer()
     )
 
     state, result = state.evaluate("C")
@@ -41,8 +41,8 @@ def test_parent_newer_unpartitioned() -> None:
 
 
 def test_parent_newer_partitioned() -> None:
-    state = AssetConditionScenarioState(
-        one_asset_depends_on_two, asset_condition=SchedulingCondition.parent_newer()
+    state = SchedulingConditionScenarioState(
+        one_asset_depends_on_two, scheduling_condition=SchedulingCondition.parent_newer()
     ).with_asset_properties(partitions_def=two_partitions_def)
 
     state, result = state.evaluate("C")

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_scheduled_since_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_scheduled_since_condition.py
@@ -3,13 +3,13 @@ import datetime
 from dagster import SchedulingCondition
 
 from ..scenario_specs import one_asset, two_partitions_def
-from .asset_condition_scenario import AssetConditionScenarioState
+from .asset_condition_scenario import SchedulingConditionScenarioState
 
 
 def test_scheduled_since_unpartitioned() -> None:
-    state = AssetConditionScenarioState(
+    state = SchedulingConditionScenarioState(
         one_asset,
-        asset_condition=~SchedulingCondition.scheduled_since(
+        scheduling_condition=~SchedulingCondition.scheduled_since(
             lookback_delta=datetime.timedelta(hours=1)
         ),
         # this condition depends on having non-empty results
@@ -38,9 +38,9 @@ def test_scheduled_since_unpartitioned() -> None:
 
 
 def test_scheduled_since_partitioned() -> None:
-    state = AssetConditionScenarioState(
+    state = SchedulingConditionScenarioState(
         one_asset,
-        asset_condition=~SchedulingCondition.scheduled_since(
+        scheduling_condition=~SchedulingCondition.scheduled_since(
             lookback_delta=datetime.timedelta(hours=1)
         ),
         # this condition depends on having non-empty results

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_updated_since_cron_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_updated_since_cron_condition.py
@@ -3,12 +3,13 @@ from dagster import SchedulingCondition
 from dagster_tests.definitions_tests.auto_materialize_tests.base_scenario import run_request
 
 from ..scenario_specs import one_asset, two_partitions_def
-from .asset_condition_scenario import AssetConditionScenarioState
+from .asset_condition_scenario import SchedulingConditionScenarioState
 
 
 def test_updated_since_cron_unpartitioned() -> None:
-    state = AssetConditionScenarioState(
-        one_asset, asset_condition=SchedulingCondition.updated_since_cron(cron_schedule="0 * * * *")
+    state = SchedulingConditionScenarioState(
+        one_asset,
+        scheduling_condition=SchedulingCondition.updated_since_cron(cron_schedule="0 * * * *"),
     ).with_current_time("2020-02-02T01:05:00")
 
     state, result = state.evaluate("A")
@@ -29,9 +30,9 @@ def test_updated_since_cron_unpartitioned() -> None:
 
 def test_updated_since_cron_partitioned() -> None:
     state = (
-        AssetConditionScenarioState(
+        SchedulingConditionScenarioState(
             one_asset,
-            asset_condition=SchedulingCondition.updated_since_cron(cron_schedule="0 * * * *"),
+            scheduling_condition=SchedulingCondition.updated_since_cron(cron_schedule="0 * * * *"),
         )
         .with_asset_properties(partitions_def=two_partitions_def)
         .with_current_time("2020-02-02T01:05:00")

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_will_be_requested_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_will_be_requested_condition.py
@@ -2,12 +2,12 @@ from dagster import AssetKey, SchedulingCondition
 from dagster._core.definitions.events import AssetKeyPartitionKey
 
 from ..scenario_specs import two_assets_in_sequence, two_partitions_def
-from .asset_condition_scenario import AssetConditionScenarioState
+from .asset_condition_scenario import SchedulingConditionScenarioState
 
 
 def test_will_be_requested_unpartitioned() -> None:
     condition = SchedulingCondition.any_deps_match(SchedulingCondition.requested_this_tick())
-    state = AssetConditionScenarioState(two_assets_in_sequence, asset_condition=condition)
+    state = SchedulingConditionScenarioState(two_assets_in_sequence, scheduling_condition=condition)
 
     # no requested parents
     state, result = state.evaluate("B")
@@ -21,8 +21,8 @@ def test_will_be_requested_unpartitioned() -> None:
 
 def test_will_be_requested_static_partitioned() -> None:
     condition = SchedulingCondition.any_deps_match(SchedulingCondition.requested_this_tick())
-    state = AssetConditionScenarioState(
-        two_assets_in_sequence, asset_condition=condition
+    state = SchedulingConditionScenarioState(
+        two_assets_in_sequence, scheduling_condition=condition
     ).with_asset_properties(partitions_def=two_partitions_def)
 
     # no requested parents
@@ -45,8 +45,8 @@ def test_will_be_requested_static_partitioned() -> None:
 
 def test_will_be_requested_different_partitions() -> None:
     condition = SchedulingCondition.any_deps_match(SchedulingCondition.requested_this_tick())
-    state = AssetConditionScenarioState(
-        two_assets_in_sequence, asset_condition=condition
+    state = SchedulingConditionScenarioState(
+        two_assets_in_sequence, scheduling_condition=condition
     ).with_asset_properties("A", partitions_def=two_partitions_def)
 
     # no requested parents


### PR DESCRIPTION
## Summary & Motivation

This is a long-standing request. It's often useful to be able to detect the status of some specific set of dependency keys, rather than needing to treat all dependencies identically.

This creates a single structure for defining and resolving these sorts of collections, but does not export it as a top-level user-facing concept, as that feels a bit like jumping the gun.

This allows users to explicitly select any keys they want to select for, as well as explicitly ignore some specific keys, as either workflow is potentially useful. An explicit choice was made to not error when an "invalid" selection (i.e. one that references keys that are not dependencies) is made, as this would be pretty annoying (imo).

## How I Tested These Changes
