### PR TITLE
feat(dbt): divest from `fqn` in a subsetted execution

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -1645,9 +1645,6 @@ def _get_subset_selection_for_context(
     if exclude:
         default_dbt_selection += ["--exclude", exclude]
 
-    dbt_resource_props_by_output_name = get_dbt_resource_props_by_output_name(manifest)
-    dbt_resource_props_by_test_name = get_dbt_resource_props_by_test_name(manifest)
-
     assets_def = context.assets_def
     is_asset_subset = assets_def.keys_by_output_name != assets_def.node_keys_by_output_name
     is_checks_subset = (
@@ -1668,15 +1665,15 @@ def _get_subset_selection_for_context(
         # aren't modeled as asset checks currently).
         return default_dbt_selection, None
 
-    selected_dbt_non_test_resources = []
-    for output_name in context.selected_output_names:
-        dbt_resource_props = dbt_resource_props_by_output_name[output_name]
-
-        # Explicitly select a dbt resource by its fully qualified name (FQN).
-        # https://docs.getdbt.com/reference/node-selection/methods#the-file-or-fqn-method
-        fqn_selector = ".".join(dbt_resource_props["fqn"])
-
-        selected_dbt_non_test_resources.append(fqn_selector)
+    # Explicitly select a dbt resource by its path. Selecting a resource by path is more terse
+    # than selecting it by its fully qualified name.
+    # https://docs.getdbt.com/reference/node-selection/methods#the-path-method
+    dbt_resource_props_by_output_name = get_dbt_resource_props_by_output_name(manifest)
+    selected_dbt_non_test_resources = get_dbt_resource_names_for_output_names(
+        output_names=context.selected_output_names,
+        dbt_resource_props_by_output_name=dbt_resource_props_by_output_name,
+        dagster_dbt_translator=dagster_dbt_translator,
+    )
 
     # if all asset checks for the subsetted assets are selected, then we can just select the
     # assets and use indirect selection for the tests. We verify that
@@ -1707,8 +1704,10 @@ def _get_subset_selection_for_context(
         # Since we're setting DBT_INDIRECT_SELECTION=empty, we won't run any singular tests.
         selected_dbt_resources = [
             *selected_dbt_non_test_resources,
-            *_get_dbt_test_names_for_asset_checks(
-                context.selected_asset_check_keys, dbt_resource_props_by_test_name
+            *get_dbt_test_names_for_asset_checks(
+                check_keys=context.selected_asset_check_keys,
+                dbt_resource_props_by_test_name=get_dbt_resource_props_by_test_name(manifest),
+                dagster_dbt_translator=dagster_dbt_translator,
             ),
         ]
         indirect_selection_override = DBT_EMPTY_INDIRECT_SELECTION
@@ -1723,8 +1722,10 @@ def _get_subset_selection_for_context(
         # explicitly select the tests that won't be run via indirect selection
         selected_dbt_resources = [
             *selected_dbt_non_test_resources,
-            *_get_dbt_test_names_for_asset_checks(
-                checks_on_non_selected_assets, dbt_resource_props_by_test_name
+            *get_dbt_test_names_for_asset_checks(
+                check_keys=checks_on_non_selected_assets,
+                dbt_resource_props_by_test_name=get_dbt_resource_props_by_test_name(manifest),
+                dagster_dbt_translator=dagster_dbt_translator,
             ),
         ]
         indirect_selection_override = None
@@ -1766,15 +1767,40 @@ def get_dbt_resource_props_by_test_name(
     }
 
 
-def _get_dbt_test_names_for_asset_checks(
-    check_keys: Iterable[AssetCheckKey], dbt_resource_props_by_test_name
-) -> List[str]:
-    selected_dbt_tests = []
-    for key in check_keys:
-        test_resource_props = dbt_resource_props_by_test_name[key.name]
+def get_dbt_resource_names_for_output_names(
+    output_names: Iterable[str],
+    dbt_resource_props_by_output_name: Mapping[str, Any],
+    dagster_dbt_translator: DagsterDbtTranslator,
+) -> Sequence[str]:
+    # Explicitly select a dbt resource by its file name.
+    # https://docs.getdbt.com/reference/node-selection/methods#the-file-method
+    if dagster_dbt_translator.settings.enable_dbt_selection_by_name:
+        return [
+            Path(dbt_resource_props_by_output_name[output_name]["original_file_path"]).stem
+            for output_name in output_names
+        ]
 
-        # Explicitly select a dbt resource by its fully qualified name (FQN).
-        # https://docs.getdbt.com/reference/node-selection/methods#the-file-or-fqn-method
-        fqn_selector = ".".join(test_resource_props["fqn"])
-        selected_dbt_tests.append(fqn_selector)
-    return selected_dbt_tests
+    # Explictly select a dbt resource by its fully qualified name (FQN).
+    # https://docs.getdbt.com/reference/node-selection/methods#the-file-or-fqn-method
+    return [
+        ".".join(dbt_resource_props_by_output_name[output_name]["fqn"])
+        for output_name in output_names
+    ]
+
+
+def get_dbt_test_names_for_asset_checks(
+    check_keys: Iterable[AssetCheckKey],
+    dbt_resource_props_by_test_name: Mapping[str, Any],
+    dagster_dbt_translator: DagsterDbtTranslator,
+) -> Sequence[str]:
+    # Explicitly select a dbt test by its test name.
+    # https://docs.getdbt.com/reference/node-selection/test-selection-examples#more-complex-selection.
+    if dagster_dbt_translator.settings.enable_dbt_selection_by_name:
+        return [asset_check_key.name for asset_check_key in check_keys]
+
+    # Explictly select a dbt test by its fully qualified name (FQN).
+    # https://docs.getdbt.com/reference/node-selection/methods#the-file-or-fqn-method
+    return [
+        ".".join(dbt_resource_props_by_test_name[asset_check_key.name]["fqn"])
+        for asset_check_key in check_keys
+    ]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -35,11 +35,16 @@ class DagsterDbtTranslatorSettings:
             Defaults to True.
         enable_duplicate_source_asset_keys (bool): Whether to allow dbt sources with duplicate
             Dagster asset keys. Defaults to False.
+        enable_code_references (bool): Whether to enable Dagster code references for dbt resources.
+            Defaults to False.
+        enable_dbt_selection_by_name (bool): Whether to enable selecting dbt resources by name,
+            rather than fully qualified name. Defaults to False.
     """
 
     enable_asset_checks: bool = True
     enable_duplicate_source_asset_keys: bool = False
     enable_code_references: bool = False
+    enable_dbt_selection_by_name: bool = False
 
 
 class DagsterDbtTranslator:


### PR DESCRIPTION
## Summary & Motivation
More thoughts on the line of https://github.com/dagster-io/dagster/pull/21851: we don't actually need
to rely on selecting by `fqn`, which can be very long.

Instead, we can use other markers of uniqueness, if we assume that a project is standalone. This is a reasonable assumption, considering that [multi-project setups are only supported by dbt Cloud](https://docs.getdbt.com/docs/collaborate/govern/project-dependencies). 

---

From https://docs.getdbt.com/reference/node-selection/methods:

> Selector methods return all resources that share a common property, using the syntax `method:value`. While it is recommended to explicitly denote the method, you can omit it (the default value will be one of `path`, `file` or `fqn`).

And https://docs.getdbt.com/faqs/models/unique-model-names:

> Within one project: yes! To build dependencies between models, you need to use the ref function, and pass in the model name as an argument. dbt uses that model name to uniquely resolve the ref to a specific model. As a result, these model names need to be unique, even if they are in distinct folders.

So, for models and snapshots, we can rely on running tests by their file name.

---

And from: https://docs.getdbt.com/reference/node-selection/test-selection-examples#more-complex-selection

> Through the combination of direct and indirect selection, there are many ways to accomplish the same outcome. Let's say we have a data test named assert_total_payment_amount_is_positive that depends on a model named payments. All of the following would manage to select and execute that test specifically:
>
> dbt test --select "assert_total_payment_amount_is_positive" # directly select the test by name

We can select tests using their test name.

---

After applying these optimizations when constructing the subset selection, the selection string is reduced in size by about 30-40%.

## How I Tested These Changes
pytest