### PR TITLE
in toy, rename AssetSpec

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/user_computed_data_versions/__init__.py
+++ b/python_modules/dagster-test/dagster_test/toys/user_computed_data_versions/__init__.py
@@ -39,14 +39,14 @@ from dagster import (
 )
 from typing_extensions import TypedDict
 
-from .external_system import AssetSpec, ExternalSystem, ProvenanceSpec, SourceAssetSpec
+from .external_system import AssetInfo, ExternalSystem, ProvenanceSpec, SourceAssetInfo
 
 warnings.filterwarnings("ignore", category=ExperimentalWarning)
 
 
-def external_asset(asset_spec: AssetSpec):
+def external_asset(asset_spec: AssetInfo):
     """Factory to build an `AssetsDefinition` object to represent an asset externally defined by an
-    `AssetSpec`.
+    `AssetInfo`.
 
     The op attached to the `AssetsDefinition` forwards materialization requests to the external
     system, sending an asset key and provenance info for the last recorded materialization of the
@@ -56,7 +56,7 @@ def external_asset(asset_spec: AssetSpec):
     `Nothing` because Dagster is not handling passing data in between ops in this scenario.
 
     Args:
-        asset_spec (AssetSpec):
+        asset_spec (AssetInfo):
             A dictionary containing the metadata that defines the asset.
 
     Returns (AssetsDefinition):
@@ -99,14 +99,14 @@ def external_asset(asset_spec: AssetSpec):
     )
 
 
-def external_source_asset(source_asset_spec: SourceAssetSpec) -> SourceAsset:
-    """Factory to build a `SourceAsset` object to represent a source asset externally defined by a `SourceAssetSpec`.
+def external_source_asset(source_asset_spec: SourceAssetInfo) -> SourceAsset:
+    """Factory to build a `SourceAsset` object to represent a source asset externally defined by a `SourceAssetInfo`.
 
     The op attached to the `SourceAsset` forwards observation requests to the external system. The
     external system responds with the current data version of the asset.
 
     Args:
-        source_asset_spec (SourceAssetSpec):
+        source_asset_spec (SourceAssetInfo):
             A dictionary containing the metadata that defines the source asset.
 
     Returns (SourceAsset):
@@ -138,8 +138,8 @@ def provenance_to_dict(provenance: DataProvenance) -> ProvenanceSpec:
 
 
 class Schema(TypedDict):
-    assets: Sequence[AssetSpec]
-    source_assets: Sequence[SourceAssetSpec]
+    assets: Sequence[AssetInfo]
+    source_assets: Sequence[SourceAssetInfo]
 
 
 SCHEMA: Schema = {

--- a/python_modules/dagster-test/dagster_test/toys/user_computed_data_versions/external_system.py
+++ b/python_modules/dagster-test/dagster_test/toys/user_computed_data_versions/external_system.py
@@ -17,13 +17,13 @@ _SOURCE_ASSETS: Mapping[str, Any] = {
 }
 
 
-class AssetSpec(TypedDict):
+class AssetInfo(TypedDict):
     key: str
     code_version: str
     dependencies: AbstractSet[str]
 
 
-class SourceAssetSpec(TypedDict):
+class SourceAssetInfo(TypedDict):
     key: str
 
 
@@ -46,7 +46,7 @@ class ExternalSystem:
         self._db = _Database(storage_path)
 
     def materialize(
-        self, asset_spec: AssetSpec, provenance_spec: Optional[ProvenanceSpec]
+        self, asset_spec: AssetInfo, provenance_spec: Optional[ProvenanceSpec]
     ) -> MaterializeResult:
         """Recompute an asset if its provenance is missing or stale.
 
@@ -55,7 +55,7 @@ class ExternalSystem:
         dependencies to determine whether something has changed and the asset should be recomputed.
 
         Args:
-            asset_spec (AssetSpec):
+            asset_spec (AssetInfo):
                 A dictionary containing an asset key, code version, and data dependencies.
             provenance_spec (ProvenanceSpec):
                 A dictionary containing provenance info for the last materialization of the
@@ -83,11 +83,11 @@ class ExternalSystem:
             is_memoized = True
         return {"data_version": record.data_version, "is_memoized": is_memoized}
 
-    def observe(self, asset_spec: Union[AssetSpec, SourceAssetSpec]) -> ObserveResult:
+    def observe(self, asset_spec: Union[AssetInfo, SourceAssetInfo]) -> ObserveResult:
         """Observe an asset or source asset, returning its current data version.
 
         Args:
-            asset_spec (Union[AssetSpec, SourceAssetSpec]):
+            asset_spec (Union[AssetInfo, SourceAssetInfo]):
                 A dictionary containing an asset key.
 
         Returns (ObserveResult):
@@ -95,7 +95,7 @@ class ExternalSystem:
         """
         return {"data_version": self._db.get(asset_spec["key"]).data_version}
 
-    def _is_provenance_stale(self, asset_spec: AssetSpec, provenance_spec: ProvenanceSpec) -> bool:
+    def _is_provenance_stale(self, asset_spec: AssetInfo, provenance_spec: ProvenanceSpec) -> bool:
         # did code change?
         if provenance_spec["code_version"] != asset_spec["code_version"]:
             return True


### PR DESCRIPTION
## Summary & Motivation

Whenever I go to the definition of "AssetSpec" in my editor, this comes up. Renaming it to avoid the collision with the dagster class.

## How I Tested These Changes
