### PR TITLE
update TableRecord type annotation to accept None values

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/table.py
@@ -15,13 +15,15 @@ from dagster._serdes.serdes import (
 @experimental
 @whitelist_for_serdes
 class TableRecord(
-    NamedTuple("TableRecord", [("data", PublicAttr[Mapping[str, Union[str, int, float, bool]]])])
+    NamedTuple(
+        "TableRecord", [("data", PublicAttr[Mapping[str, Optional[Union[str, int, float, bool]]]])]
+    )
 ):
     """Represents one record in a table. Field keys are arbitrary strings-- field values must be
     strings, integers, floats, or bools.
     """
 
-    def __new__(cls, data: Mapping[str, Union[str, int, float, bool]]):
+    def __new__(cls, data: Mapping[str, Optional[Union[str, int, float, bool]]]):
         check.dict_param(
             data,
             "data",


### PR DESCRIPTION
## Summary & Motivation

This reflects the runtime type-checking we're doing inside the constructor.

This was causing problems, because we were loading values from the DB that had `None` values and then an outer class that was a Pydantic model was using the type annotations to validate them, and erroring.

```
records.0.0.extension.bool
  Input should be a valid boolean [type=bool_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.6/v/bool_type
```

## How I Tested These Changes
