### PR TITLE
[docs] set feedback modal position as fixed

### DIFF
--- a/docs/next/components/FeedbackModal.tsx
+++ b/docs/next/components/FeedbackModal.tsx
@@ -40,7 +40,7 @@ const FeedbackModal = ({isOpen, closeFeedback}: {isOpen: boolean; closeFeedback:
   return (
     <Transition show={isOpen}>
       <section
-        className="absolute inset-y-0 pl-16 max-w-full right-0 flex z-50"
+        className="fixed right-0 inset-y-0 pl-16 max-w-full flex z-50"
         aria-labelledby="slide-over-heading"
       >
         <Transition.Child


### PR DESCRIPTION
## Summary & Motivation

- Feedback modal was lost when scrolled on the page, this persists the modal by setting the position to `fixed`

## How I Tested These Changes

- Running locally