### PR TITLE
Extending Markdoc link node to use NextJS next/link component.

### DIFF
--- a/docs/next/markdoc/nodes/index.ts
+++ b/docs/next/markdoc/nodes/index.ts
@@ -1,2 +1,3 @@
 /* Use this file to export your markdoc nodes */
 export * from './heading.markdoc';
+export * from './link.markdoc';

--- a/docs/next/markdoc/nodes/link.markdoc.ts
+++ b/docs/next/markdoc/nodes/link.markdoc.ts
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export const link = {
+  render: Link,
+  attributes: {
+    href: {
+      type: String,
+    },
+  },
+};


### PR DESCRIPTION
## Summary & Motivation
Updated the Markdoc link node to 

Markdoc has a concept called "nodes" which are the mapping between default Markdown elements and HTML output. We can extend these nodes to take advantage of React's and Next's capabilities while letting the authors continue to write using familiar Markdown syntax.

This update extends the markdoc syntax to use the next/link 

## How I Tested These Changes

- Add links to pages. 
- Clicked links. 
- Confirm links route to correct location.
- Confirm using React Developer Tools that Link component mounts correctly.
<img width="1066" alt="image" src="https://github.com/dagster-io/dagster/assets/39569270/c8f828e2-c68c-47cd-bd69-9557383787ee">

