### PR TITLE
Use an empty iframe for analytics to ensure analytics JS can't see the parent document's location.

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/src/extractInitializationData.ts
+++ b/js_modules/dagster-ui/packages/app-oss/src/extractInitializationData.ts
@@ -31,11 +31,14 @@ export const extractInitializationData = (): {
     }
   }
   if (value.telemetryEnabled) {
-    const script = document.createElement('script');
-    script.defer = true;
-    script.async = true;
-    script.src = 'https://dagster.io/oss-telemetry.js';
-    document.head.appendChild(script);
+    const iframe = document.createElement('iframe');
+    iframe.src = 'https://dagster.io/dagit_iframes/oss-telemetry';
+    iframe.height = '0';
+    iframe.width = '0';
+    iframe.tabIndex = -1;
+    iframe.title = 'Analytics';
+    iframe.style.display = 'none';
+    document.body.appendChild(iframe);
   }
   return value;
 };


### PR DESCRIPTION
## Summary & Motivation

We want all of our OSS analytics to come from the same URL to make it easier to see.

## How I Tested These Changes

Build the app,
Run dagster dev, observe things running normally
<img width="941" alt="Screenshot 2024-05-15 at 1 39 42 PM" src="https://github.com/dagster-io/dagster/assets/2286579/70a46926-52d2-47b2-8cf8-b68a8304fcb0">
<img width="1139" alt="Screenshot 2024-05-15 at 1 39 35 PM" src="https://github.com/dagster-io/dagster/assets/2286579/cb61009e-5a5b-4313-be37-978eb6c957fb">

