### PR TITLE
fix iterator behavior in 3.8

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -5,6 +5,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import typing
 import uuid
 from argparse import Namespace
 from collections import abc
@@ -849,7 +850,16 @@ class DbtCliInvocation:
 T = TypeVar("T", bound=DbtDagsterEventType)
 
 
-class DbtEventIterator(abc.Iterator[T]):
+# if python 3.8, we can use the built-in typing.Iterator
+
+BaseIterator = abc.Iterator
+if sys.version_info >= (3, 9):
+    BaseIterator = abc.Iterator[T]
+else:
+    BaseIterator = typing.Iterator[T]
+
+
+class DbtEventIterator(BaseIterator):
     """A wrapper around an iterator of dbt events which contains additional methods for
     post-processing the events, such as fetching row counts for materialized tables.
     """

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -850,8 +850,7 @@ class DbtCliInvocation:
 T = TypeVar("T", bound=DbtDagsterEventType)
 
 
-# if python 3.8, we can use the built-in typing.Iterator
-
+# In 3.8, the Iterator type is not generic, but we can instead implement typing.Iterator
 BaseIterator = abc.Iterator
 if sys.version_info >= (3, 9):
     BaseIterator = abc.Iterator[T]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -17,6 +17,7 @@ from typing import (
     AbstractSet,
     Any,
     Dict,
+    Generic,
     Iterator,
     List,
     Mapping,
@@ -849,16 +850,7 @@ class DbtCliInvocation:
 # will be able to see the inner type of the iterator, rather than just `DbtEventIterator`.
 T = TypeVar("T", bound=DbtDagsterEventType)
 
-
-# In 3.8, the Iterator type is not generic, but we can instead implement typing.Iterator
-BaseIterator = abc.Iterator
-if sys.version_info >= (3, 9):
-    BaseIterator = abc.Iterator[T]
-else:
-    BaseIterator = typing.Iterator[T]
-
-
-class DbtEventIterator(BaseIterator):
+class DbtEventIterator(Generic[T], abc.Iterator):
     """A wrapper around an iterator of dbt events which contains additional methods for
     post-processing the events, such as fetching row counts for materialized tables.
     """

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -5,7 +5,6 @@ import shutil
 import signal
 import subprocess
 import sys
-import typing
 import uuid
 from argparse import Namespace
 from collections import abc
@@ -849,6 +848,7 @@ class DbtCliInvocation:
 # This is so that users who inspect the type of the return value of `DbtCliInvocation.stream()`
 # will be able to see the inner type of the iterator, rather than just `DbtEventIterator`.
 T = TypeVar("T", bound=DbtDagsterEventType)
+
 
 class DbtEventIterator(Generic[T], abc.Iterator):
     """A wrapper around an iterator of dbt events which contains additional methods for


### PR DESCRIPTION
## Summary

Moves the generic param for `DbtEventIterator` to `typing.Generic` since `collections.abc.Iterator` is not generic in 3.8

## Test Plan

Imported class successfully in 3.8 and 3.10 locally + bk

