### PR TITLE
pin fsspec in test

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -136,6 +136,7 @@ setup(
             "syrupy>=4.0.0",
             "tox==3.25.0",
             "morefs[asynclocal]",
+            "fsspec<2024.5.0",  # morefs incompatibly
             "rapidfuzz",
         ],
         "mypy": ["mypy==1.8.0"],


### PR DESCRIPTION
incompatibility manifests as: 

```
  File "/Users/alangenfeld/dagster/python_modules/dagster/dagster/_core/storage/upath_io_manager.py", line 386, in load_partitions_async
    awaited_objects = asyncio.get_event_loop().run_until_complete(collect())
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alangenfeld/.pyenv/versions/3.11.7/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/alangenfeld/dagster/python_modules/dagster/dagster/_core/storage/upath_io_manager.py", line 373, in collect
    raise result
  File "/Users/alangenfeld/dagster/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py", line 480, in load_from_path
    fs = self.get_async_filesystem(path)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alangenfeld/dagster/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py", line 499, in get_async_filesystem
    import morefs.asyn_local
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "/Users/alangenfeld/venvs/arm/py311/lib/python3.11/site-packages/ddtrace/internal/module.py", line 208, in _exec_module
    self.loader.exec_module(module)
  File "/Users/alangenfeld/venvs/arm/py311/lib/python3.11/site-packages/morefs/asyn_local.py", line 30, in <module>
    class AsyncLocalFileSystem(AsyncFileSystem, LocalFileSystem):
  File "/Users/alangenfeld/venvs/arm/py311/lib/python3.11/site-packages/morefs/asyn_local.py", line 66, in AsyncLocalFileSystem
    _mv_file = wrap(LocalFileSystem.mv_file)
                    ^^^^^^^^^^^^^^^^^^^^^^^
		    ```

https://buildkite.com/dagster/dagster-dagster/builds/83178#018f7d50-31c0-42a1-aecb-6f8a2d80910e

## How I Tested These Changes

bk