### PR TITLE
refactor(looker): rename `lookml_element` to `lookml_structure`

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker/dagster_looker_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/dagster_looker_translator.py
@@ -8,18 +8,18 @@ from dagster._annotations import experimental, public
 @experimental
 class DagsterLookerTranslator:
     """Holds a set of methods that derive Dagster asset definition metadata given a representation
-    of a LookML element (dashboards, explores, views).
+    of a LookML structure (dashboards, explores, views).
 
     This class is exposed so that methods can be overriden to customize how Dagster asset metadata
     is derived.
     """
 
     @public
-    def get_asset_key(self, lookml_element: Tuple[Path, Mapping[str, Any]]) -> AssetKey:
-        """A method that takes in a dictionary representing a LookML element
-        (dashboards, explores, views) and returns the Dagster asset key that represents the element.
+    def get_asset_key(self, lookml_structure: Tuple[Path, Mapping[str, Any]]) -> AssetKey:
+        """A method that takes in a dictionary representing a LookML structure
+        (dashboards, explores, views) and returns the Dagster asset key that represents the structure.
 
-        The LookML element is parsed using ``lkml``. You can learn more about this here:
+        The LookML structure is parsed using ``lkml``. You can learn more about this here:
         https://lkml.readthedocs.io/en/latest/simple.html.
 
         You can learn more about LookML dashboards and the properties available in this
@@ -28,34 +28,34 @@ class DagsterLookerTranslator:
         You can learn more about LookML explores and views and the properties available in this
         dictionary here: https://cloud.google.com/looker/docs/reference/lookml-quick-reference.
 
-        This method can be overriden to provide a custom asset key for a LookML element.
+        This method can be overriden to provide a custom asset key for a LookML structure.
 
         Args:
-            lookml_element (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
-                defining a LookML element, and a dictionary representing a LookML element.
+            lookml_structure (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
+                defining a LookML structure, and a dictionary representing a LookML structure.
 
         Returns:
-            AssetKey: The Dagster asset key that represents the LookML element.
+            AssetKey: The Dagster asset key that represents the LookML structure.
         """
-        lookml_element_path, lookml_element_props = lookml_element
+        lookml_structure_path, lookml_structure_props = lookml_structure
 
-        if lookml_element_path.suffixes == [".dashboard", ".lookml"]:
-            return AssetKey(["dashboard", lookml_element_props["dashboard"]])
+        if lookml_structure_path.suffixes == [".dashboard", ".lookml"]:
+            return AssetKey(["dashboard", lookml_structure_props["dashboard"]])
 
-        if lookml_element_path.suffixes == [".view", ".lkml"]:
-            return AssetKey(["view", lookml_element_props["name"]])
+        if lookml_structure_path.suffixes == [".view", ".lkml"]:
+            return AssetKey(["view", lookml_structure_props["name"]])
 
-        if lookml_element_path.suffixes == [".model", ".lkml"]:
-            return AssetKey(["explore", lookml_element_props["name"]])
+        if lookml_structure_path.suffixes == [".model", ".lkml"]:
+            return AssetKey(["explore", lookml_structure_props["name"]])
 
-        raise ValueError(f"Unsupported LookML element: {lookml_element_path}")
+        raise ValueError(f"Unsupported LookML structure: {lookml_structure_path}")
 
     @public
-    def get_description(self, lookml_element: Tuple[Path, Mapping[str, Any]]) -> Optional[str]:
-        """A method that takes in a dictionary representing a LookML element
-        (dashboards, explores, views) and returns the Dagster asset key that represents the element.
+    def get_description(self, lookml_structure: Tuple[Path, Mapping[str, Any]]) -> Optional[str]:
+        """A method that takes in a dictionary representing a LookML structure
+        (dashboards, explores, views) and returns the Dagster asset key that represents the structure.
 
-        The LookML element is parsed using ``lkml``. You can learn more about this here:
+        The LookML structure is parsed using ``lkml``. You can learn more about this here:
         https://lkml.readthedocs.io/en/latest/simple.html.
 
         You can learn more about LookML dashboards and the properties available in this
@@ -64,27 +64,27 @@ class DagsterLookerTranslator:
         You can learn more about LookML explores and views and the properties available in this
         dictionary here: https://cloud.google.com/looker/docs/reference/lookml-quick-reference.
 
-        This method can be overriden to provide a custom description for a LookML element.
+        This method can be overriden to provide a custom description for a LookML structure.
 
         Args:
-            lookml_element (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
-                defining a LookML element, and a dictionary representing a LookML element.
+            lookml_structure (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
+                defining a LookML structure, and a dictionary representing a LookML structure.
 
         Returns:
-            Optional[str]: The Dagster description for the LookML element.
+            Optional[str]: The Dagster description for the LookML structure.
         """
-        _, lookml_element_props = lookml_element
+        _, lookml_structure_props = lookml_structure
 
-        return lookml_element_props.get("description")
+        return lookml_structure_props.get("description")
 
     @public
     def get_metadata(
-        self, lookml_element: Tuple[Path, Mapping[str, Any]]
+        self, lookml_structure: Tuple[Path, Mapping[str, Any]]
     ) -> Optional[Mapping[str, Any]]:
-        """A method that takes in a dictionary representing a LookML element
-        (dashboards, explores, views) and returns the Dagster asset key that represents the element.
+        """A method that takes in a dictionary representing a LookML structure
+        (dashboards, explores, views) and returns the Dagster asset key that represents the structure.
 
-        The LookML element is parsed using ``lkml``. You can learn more about this here:
+        The LookML structure is parsed using ``lkml``. You can learn more about this here:
         https://lkml.readthedocs.io/en/latest/simple.html.
 
         You can learn more about LookML dashboards and the properties available in this
@@ -93,24 +93,24 @@ class DagsterLookerTranslator:
         You can learn more about LookML explores and views and the properties available in this
         dictionary here: https://cloud.google.com/looker/docs/reference/lookml-quick-reference.
 
-        This method can be overriden to provide custom metadata for a LookML element.
+        This method can be overriden to provide custom metadata for a LookML structure.
 
         Args:
-            lookml_element (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
-                defining a LookML element, and a dictionary representing a LookML element.
+            lookml_structure (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
+                defining a LookML structure, and a dictionary representing a LookML structure.
 
         Returns:
             Optional[Mapping[str, Any]]: A dictionary representing the Dagster metadata for the
-                LookML element.
+                LookML structure.
         """
         return None
 
     @public
-    def get_group_name(self, lookml_element: Tuple[Path, Mapping[str, Any]]) -> Optional[str]:
-        """A method that takes in a dictionary representing a LookML element
-        (dashboards, explores, views) and returns the Dagster asset key that represents the element.
+    def get_group_name(self, lookml_structure: Tuple[Path, Mapping[str, Any]]) -> Optional[str]:
+        """A method that takes in a dictionary representing a LookML structure
+        (dashboards, explores, views) and returns the Dagster asset key that represents the structure.
 
-        The LookML element is parsed using ``lkml``. You can learn more about this here:
+        The LookML structure is parsed using ``lkml``. You can learn more about this here:
         https://lkml.readthedocs.io/en/latest/simple.html.
 
         You can learn more about LookML dashboards and the properties available in this
@@ -119,23 +119,25 @@ class DagsterLookerTranslator:
         You can learn more about LookML explores and views and the properties available in this
         dictionary here: https://cloud.google.com/looker/docs/reference/lookml-quick-reference.
 
-        This method can be overriden to provide a custom group name for a LookML element.
+        This method can be overriden to provide a custom group name for a LookML structure.
 
         Args:
-            lookml_element (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
-                defining a LookML element, and a dictionary representing a LookML element.
+            lookml_structure (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
+                defining a LookML structure, and a dictionary representing a LookML structure.
 
         Returns:
-            Optional[str]: A Dagster group name for the LookML element.
+            Optional[str]: A Dagster group name for the LookML structure.
         """
         return None
 
     @public
-    def get_owners(self, lookml_element: Tuple[Path, Mapping[str, Any]]) -> Optional[Sequence[str]]:
-        """A method that takes in a dictionary representing a LookML element
-        (dashboards, explores, views) and returns the Dagster asset key that represents the element.
+    def get_owners(
+        self, lookml_structure: Tuple[Path, Mapping[str, Any]]
+    ) -> Optional[Sequence[str]]:
+        """A method that takes in a dictionary representing a LookML structure
+        (dashboards, explores, views) and returns the Dagster asset key that represents the structure.
 
-        The LookML element is parsed using ``lkml``. You can learn more about this here:
+        The LookML structure is parsed using ``lkml``. You can learn more about this here:
         https://lkml.readthedocs.io/en/latest/simple.html.
 
         You can learn more about LookML dashboards and the properties available in this
@@ -144,25 +146,25 @@ class DagsterLookerTranslator:
         You can learn more about LookML explores and views and the properties available in this
         dictionary here: https://cloud.google.com/looker/docs/reference/lookml-quick-reference.
 
-        This method can be overriden to provide custom owners for a LookML element.
+        This method can be overriden to provide custom owners for a LookML structure.
 
         Args:
-            lookml_element (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
-                defining a LookML element, and a dictionary representing a LookML element.
+            lookml_structure (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
+                defining a LookML structure, and a dictionary representing a LookML structure.
 
         Returns:
-            Optional[Sequence[str]]: A sequence of Dagster owners for the LookML element.
+            Optional[Sequence[str]]: A sequence of Dagster owners for the LookML structure.
         """
         return None
 
     @public
     def get_tags(
-        self, lookml_element: Tuple[Path, Mapping[str, Any]]
+        self, lookml_structure: Tuple[Path, Mapping[str, Any]]
     ) -> Optional[Mapping[str, str]]:
-        """A method that takes in a dictionary representing a LookML element
-        (dashboards, explores, views) and returns the Dagster asset key that represents the element.
+        """A method that takes in a dictionary representing a LookML structure
+        (dashboards, explores, views) and returns the Dagster asset key that represents the structure.
 
-        The LookML element is parsed using ``lkml``. You can learn more about this here:
+        The LookML structure is parsed using ``lkml``. You can learn more about this here:
         https://lkml.readthedocs.io/en/latest/simple.html.
 
         You can learn more about LookML dashboards and the properties available in this
@@ -171,14 +173,14 @@ class DagsterLookerTranslator:
         You can learn more about LookML explores and views and the properties available in this
         dictionary here: https://cloud.google.com/looker/docs/reference/lookml-quick-reference.
 
-        This method can be overriden to provide custom tags for a LookML element.
+        This method can be overriden to provide custom tags for a LookML structure.
 
         Args:
-            lookml_element (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
-                defining a LookML element, and a dictionary representing a LookML element.
+            lookml_structure (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
+                defining a LookML structure, and a dictionary representing a LookML structure.
 
         Returns:
             Optional[Mapping[str, str]]: A dictionary representing the Dagster tags for the
-                LookML element.
+                LookML structure.
         """
         return None

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/test_asset_decorator.py
@@ -283,8 +283,8 @@ def test_asset_deps_exception_derived_table(caplog: pytest.LogCaptureFixture) ->
 
 def test_with_asset_key_replacements() -> None:
     class CustomDagsterLookerTranslator(DagsterLookerTranslator):
-        def get_asset_key(self, lookml_element: Tuple[Path, Mapping[str, Any]]) -> AssetKey:
-            return super().get_asset_key(lookml_element).with_prefix("prefix")
+        def get_asset_key(self, lookml_structure: Tuple[Path, Mapping[str, Any]]) -> AssetKey:
+            return super().get_asset_key(lookml_structure).with_prefix("prefix")
 
     @looker_assets(
         project_dir=test_retail_demo_path,


### PR DESCRIPTION
## Summary & Motivation
LookML element already exists: https://cloud.google.com/looker/docs/reference/param-lookml-dashboard-element

Instead, label it as a "LookML structure": https://cloud.google.com/looker/docs/lookml-terms-and-concepts#major_lookml_structures. A "LookML structure" can be a model, view, explore, etc. It's defined by a path to the file defining the structure, the structure type, and the parsed contents of the structure.

## How I Tested These Changes
N/A, it's a rename.