### PR TITLE
[docs] fix malformed github link when asPath is root '/'

### DIFF
--- a/docs/next/pages/_app.tsx
+++ b/docs/next/pages/_app.tsx
@@ -66,8 +66,11 @@ const Layout = ({asPath, children, pageProps}: Props) => {
     setOpenFeedback(!isFeedbackOpen);
   };
 
+  // construct link to GitHub for doc page unless at root path of `asPath` being `/`
   const githubLink = new URL(
-    path.join('dagster-io/dagster/tree/master/docs/content', '/', asPath + '.mdx'),
+    asPath === '/'
+      ? 'dagster-io/dagster/tree/master/docs/content'
+      : path.join('dagster-io/dagster/tree/master/docs/content/', asPath + '.mdx'),
     'https://github.com',
   ).href;
 


### PR DESCRIPTION
## Summary & Motivation

- `broken-link-checker` identified malformed github links when `asPath` is root path `/`

## How I Tested These Changes

- Ran next.js locally, ran broken-link-checker