### PR TITLE
feat(looker): implement `get_deps` for `DagsterLookerTranslator`

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker/__init__.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/__init__.py
@@ -1,7 +1,10 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
 from .asset_decorator import looker_assets as looker_assets
-from .dagster_looker_translator import DagsterLookerTranslator as DagsterLookerTranslator
+from .dagster_looker_translator import (
+    DagsterLookerTranslator as DagsterLookerTranslator,
+    LookMLStructureType as LookMLStructureType,
+)
 from .version import __version__ as __version__
 
 DagsterLibraryRegistry.register("dagster-looker", __version__)

--- a/python_modules/libraries/dagster-looker/dagster_looker/asset_utils.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/asset_utils.py
@@ -1,18 +1,11 @@
-import itertools
-import logging
-import re
 from pathlib import Path
-from typing import AbstractSet, Any, Iterator, List, Mapping, Optional, Sequence, Tuple, cast
+from typing import List, Sequence
 
 import lkml
 import yaml
-from dagster import AssetKey, AssetSpec
-from sqlglot import exp, parse_one, to_table
-from sqlglot.optimizer import Scope, build_scope, optimize
+from dagster import AssetSpec
 
 from .dagster_looker_translator import DagsterLookerTranslator
-
-logger = logging.getLogger("dagster_looker")
 
 
 def build_looker_dashboard_specs(
@@ -24,21 +17,12 @@ def build_looker_dashboard_specs(
     # https://cloud.google.com/looker/docs/reference/param-lookml-dashboard
     for lookml_dashboard_path in project_dir.rglob("*.dashboard.lookml"):
         for lookml_dashboard_props in yaml.safe_load(lookml_dashboard_path.read_bytes()):
-            lookml_dashboard = (lookml_dashboard_path, lookml_dashboard_props)
+            lookml_dashboard = (lookml_dashboard_path, "dashboard", lookml_dashboard_props)
 
             looker_dashboard_specs.append(
                 AssetSpec(
                     key=dagster_looker_translator.get_asset_key(lookml_dashboard),
-                    deps={
-                        AssetKey(["explore", lookml_dashboard_element_props["explore"]])
-                        for lookml_dashboard_element_props in itertools.chain(
-                            # https://cloud.google.com/looker/docs/reference/param-lookml-dashboard#elements_2
-                            lookml_dashboard_props.get("elements", []),
-                            # https://cloud.google.com/looker/docs/reference/param-lookml-dashboard#filters
-                            lookml_dashboard_props.get("filters", []),
-                        )
-                        if lookml_dashboard_element_props.get("explore")
-                    },
+                    deps=dagster_looker_translator.get_deps(lookml_dashboard),
                     description=dagster_looker_translator.get_description(lookml_dashboard),
                     metadata=dagster_looker_translator.get_metadata(lookml_dashboard),
                     group_name=dagster_looker_translator.get_group_name(lookml_dashboard),
@@ -59,23 +43,12 @@ def build_looker_explore_specs(
     # https://cloud.google.com/looker/docs/reference/param-explore
     for lookml_model_path in project_dir.rglob("*.model.lkml"):
         for lookml_explore_props in lkml.load(lookml_model_path.read_text()).get("explores", []):
-            lookml_explore = (lookml_model_path, lookml_explore_props)
-
-            # https://cloud.google.com/looker/docs/reference/param-explore-from
-            explore_base_view = [
-                {"name": lookml_explore_props.get("from") or lookml_explore_props["name"]}
-            ]
-
-            # https://cloud.google.com/looker/docs/reference/param-explore-join
-            explore_join_views: Sequence[Mapping[str, Any]] = lookml_explore_props.get("joins", [])
+            lookml_explore = (lookml_model_path, "explore", lookml_explore_props)
 
             looker_explore_specs.append(
                 AssetSpec(
                     key=dagster_looker_translator.get_asset_key(lookml_explore),
-                    deps={
-                        AssetKey(["view", view["name"]])
-                        for view in itertools.chain(explore_base_view, explore_join_views)
-                    },
+                    deps=dagster_looker_translator.get_deps(lookml_explore),
                     description=dagster_looker_translator.get_description(lookml_explore),
                     metadata=dagster_looker_translator.get_metadata(lookml_explore),
                     group_name=dagster_looker_translator.get_group_name(lookml_explore),
@@ -87,62 +60,6 @@ def build_looker_explore_specs(
     return looker_explore_specs
 
 
-def build_asset_key_from_sqlglot_table(table: exp.Table) -> AssetKey:
-    return AssetKey([part.name.replace("*", "_star") for part in table.parts])
-
-
-def parse_upstream_asset_keys_from_lookml_view(
-    lookml_view: Tuple[Path, Mapping[str, Any]],
-) -> AbstractSet[AssetKey]:
-    lookml_view_path, lookml_view_props = lookml_view
-    sql_dialect = "bigquery"
-
-    # https://cloud.google.com/looker/docs/derived-tables
-    derived_table_sql: Optional[str] = lookml_view_props.get("derived_table", {}).get("sql")
-    if not derived_table_sql:
-        # https://cloud.google.com/looker/docs/reference/param-view-sql-table-name
-        sql_table_name = lookml_view_props.get("sql_table_name") or lookml_view_props["name"]
-        sqlglot_table = to_table(sql_table_name.replace("`", ""), dialect=sql_dialect)
-
-        return {build_asset_key_from_sqlglot_table(sqlglot_table)}
-
-    # We need to handle the Looker substitution operator ($) properly since the lkml
-    # compatible SQL may not be parsable yet by sqlglot.
-    #
-    # https://cloud.google.com/looker/docs/sql-and-referring-to-lookml#substitution_operator_
-    upstream_view_pattern = re.compile(r"\${(.*?)\.SQL_TABLE_NAME\}")
-    if upstream_looker_views_from_substitution := upstream_view_pattern.findall(derived_table_sql):
-        return {
-            AssetKey(["view", upstream_looker_view_name])
-            for upstream_looker_view_name in upstream_looker_views_from_substitution
-        }
-
-    upstream_sqlglot_tables: Sequence[exp.Table] = []
-    try:
-        optimized_derived_table_ast = optimize(
-            parse_one(sql=derived_table_sql, dialect=sql_dialect),
-            dialect=sql_dialect,
-            validate_qualify_columns=False,
-        )
-        root_scope = build_scope(optimized_derived_table_ast)
-
-        upstream_sqlglot_tables = [
-            source
-            for scope in cast(Iterator[Scope], root_scope.traverse() if root_scope else [])
-            for (_, source) in scope.selected_sources.values()
-            if isinstance(source, exp.Table)
-        ]
-    except Exception as e:
-        logger.warn(
-            f"Failed to optimize derived table SQL for view `{lookml_view_props['name']}`"
-            f" in file `{lookml_view_path.name}`."
-            " The upstream dependencies for the view will be omitted.\n\n"
-            f"Exception: {e}"
-        )
-
-    return {build_asset_key_from_sqlglot_table(table) for table in upstream_sqlglot_tables}
-
-
 def build_looker_view_specs(
     project_dir: Path,
     dagster_looker_translator: DagsterLookerTranslator,
@@ -152,12 +69,12 @@ def build_looker_view_specs(
     # https://cloud.google.com/looker/docs/reference/param-view
     for lookml_view_path in project_dir.rglob("*.view.lkml"):
         for lookml_view_props in lkml.load(lookml_view_path.read_text()).get("views", []):
-            lookml_view = (lookml_view_path, lookml_view_props)
+            lookml_view = (lookml_view_path, "view", lookml_view_props)
 
             looker_view_specs.append(
                 AssetSpec(
                     key=dagster_looker_translator.get_asset_key(lookml_view),
-                    deps=parse_upstream_asset_keys_from_lookml_view(lookml_view),
+                    deps=dagster_looker_translator.get_deps(lookml_view),
                     description=dagster_looker_translator.get_description(lookml_view),
                     metadata=dagster_looker_translator.get_metadata(lookml_view),
                     group_name=dagster_looker_translator.get_group_name(lookml_view),

--- a/python_modules/libraries/dagster-looker/dagster_looker/dagster_looker_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/dagster_looker_translator.py
@@ -1,8 +1,149 @@
+import itertools
+import logging
+import re
 from pathlib import Path
-from typing import Any, Mapping, Optional, Sequence, Tuple
+from typing import Any, Iterator, Literal, Mapping, Optional, Sequence, Tuple, cast
 
 from dagster import AssetKey
 from dagster._annotations import experimental, public
+from sqlglot import exp, parse_one, to_table
+from sqlglot.optimizer import Scope, build_scope, optimize
+
+LookMLStructureType = Literal["dashboard", "explore", "table", "view"]
+
+logger = logging.getLogger("dagster_looker")
+
+
+def build_deps_for_looker_dashboard(
+    dagster_looker_translator: "DagsterLookerTranslator",
+    lookml_structure: Tuple[Path, LookMLStructureType, Mapping[str, Any]],
+) -> Sequence[AssetKey]:
+    lookml_view_path, _, lookml_dashboard_props = lookml_structure
+
+    return list(
+        {
+            dagster_looker_translator.get_asset_key(
+                lookml_structure=(
+                    lookml_view_path,
+                    "explore",
+                    lookml_element_from_dashboard_props,
+                )
+            )
+            for lookml_element_from_dashboard_props in itertools.chain(
+                # https://cloud.google.com/looker/docs/reference/param-lookml-dashboard#elements_2
+                lookml_dashboard_props.get("elements", []),
+                # https://cloud.google.com/looker/docs/reference/param-lookml-dashboard#filters
+                lookml_dashboard_props.get("filters", []),
+            )
+            if lookml_element_from_dashboard_props.get("explore")
+        }
+    )
+
+
+def build_deps_for_looker_explore(
+    dagster_looker_translator: "DagsterLookerTranslator",
+    lookml_structure: Tuple[Path, LookMLStructureType, Mapping[str, Any]],
+) -> Sequence[AssetKey]:
+    lookml_explore_path, _, lookml_explore_props = lookml_structure
+
+    # https://cloud.google.com/looker/docs/reference/param-explore-from
+    explore_base_view = [{"name": lookml_explore_props.get("from") or lookml_explore_props["name"]}]
+
+    # https://cloud.google.com/looker/docs/reference/param-explore-join
+    explore_join_views: Sequence[Mapping[str, Any]] = lookml_explore_props.get("joins", [])
+
+    return list(
+        {
+            dagster_looker_translator.get_asset_key(
+                lookml_structure=(
+                    lookml_explore_path,
+                    "view",
+                    lookml_view_from_explore_props,
+                )
+            )
+            for lookml_view_from_explore_props in itertools.chain(
+                explore_base_view, explore_join_views
+            )
+        }
+    )
+
+
+def build_deps_for_looker_view(
+    dagster_looker_translator: "DagsterLookerTranslator",
+    lookml_structure: Tuple[Path, LookMLStructureType, Mapping[str, Any]],
+) -> Sequence[AssetKey]:
+    lookml_view_path, _, lookml_view_props = lookml_structure
+    sql_dialect = "bigquery"
+
+    # https://cloud.google.com/looker/docs/derived-tables
+    derived_table_sql: Optional[str] = lookml_view_props.get("derived_table", {}).get("sql")
+    if not derived_table_sql:
+        # https://cloud.google.com/looker/docs/reference/param-view-sql-table-name
+        sql_table_name = lookml_view_props.get("sql_table_name") or lookml_view_props["name"]
+        sqlglot_table = to_table(sql_table_name.replace("`", ""), dialect=sql_dialect)
+
+        return [
+            dagster_looker_translator.get_asset_key(
+                lookml_structure=(
+                    lookml_view_path,
+                    "table",
+                    {"table": sqlglot_table, "from_structure": lookml_view_props},
+                )
+            )
+        ]
+
+    # We need to handle the Looker substitution operator ($) properly since the lkml
+    # compatible SQL may not be parsable yet by sqlglot.
+    #
+    # https://cloud.google.com/looker/docs/sql-and-referring-to-lookml#substitution_operator_
+    upstream_view_pattern = re.compile(r"\${(.*?)\.SQL_TABLE_NAME\}")
+    if upstream_looker_views_from_substitution := upstream_view_pattern.findall(derived_table_sql):
+        return [
+            dagster_looker_translator.get_asset_key(
+                lookml_structure=(
+                    lookml_view_path,
+                    "view",
+                    {"name": upstream_looker_view_name},
+                )
+            )
+            for upstream_looker_view_name in set(upstream_looker_views_from_substitution)
+        ]
+
+    upstream_sqlglot_tables: Sequence[exp.Table] = []
+    try:
+        optimized_derived_table_ast = optimize(
+            parse_one(sql=derived_table_sql, dialect=sql_dialect),
+            dialect=sql_dialect,
+            validate_qualify_columns=False,
+        )
+        root_scope = build_scope(optimized_derived_table_ast)
+
+        upstream_sqlglot_tables = [
+            source
+            for scope in cast(Iterator[Scope], root_scope.traverse() if root_scope else [])
+            for (_, source) in scope.selected_sources.values()
+            if isinstance(source, exp.Table)
+        ]
+    except Exception as e:
+        logger.warn(
+            f"Failed to optimize derived table SQL for view `{lookml_view_props['name']}`"
+            f" in file `{lookml_view_path.name}`."
+            " The upstream dependencies for the view will be omitted.\n\n"
+            f"Exception: {e}"
+        )
+
+    return list(
+        {
+            dagster_looker_translator.get_asset_key(
+                lookml_structure=(
+                    lookml_view_path,
+                    "table",
+                    {"table": sqlglot_table, "from_structure": lookml_view_props},
+                )
+            )
+            for sqlglot_table in upstream_sqlglot_tables
+        }
+    )
 
 
 @experimental
@@ -15,9 +156,11 @@ class DagsterLookerTranslator:
     """
 
     @public
-    def get_asset_key(self, lookml_structure: Tuple[Path, Mapping[str, Any]]) -> AssetKey:
-        """A method that takes in a dictionary representing a LookML structure
-        (dashboards, explores, views) and returns the Dagster asset key that represents the structure.
+    def get_asset_key(
+        self, lookml_structure: Tuple[Path, LookMLStructureType, Mapping[str, Any]]
+    ) -> AssetKey:
+        """A method that takes in a LookML structure (dashboards, explores, views) and
+        returns the Dagster asset key that represents the structure.
 
         The LookML structure is parsed using ``lkml``. You can learn more about this here:
         https://lkml.readthedocs.io/en/latest/simple.html.
@@ -31,29 +174,96 @@ class DagsterLookerTranslator:
         This method can be overriden to provide a custom asset key for a LookML structure.
 
         Args:
-            lookml_structure (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
-                defining a LookML structure, and a dictionary representing a LookML structure.
+            lookml_structure (Tuple[Path, str, Mapping[str, Any]]): A tuple with the path to file
+                defining a LookML structure, the LookML structure type, and a dictionary
+                representing a LookML structure.
 
         Returns:
             AssetKey: The Dagster asset key that represents the LookML structure.
         """
-        lookml_structure_path, lookml_structure_props = lookml_structure
+        lookml_structure_path, lookml_structure_type, lookml_structure_props = lookml_structure
 
-        if lookml_structure_path.suffixes == [".dashboard", ".lookml"]:
+        if lookml_structure_type == "dashboard":
             return AssetKey(["dashboard", lookml_structure_props["dashboard"]])
 
-        if lookml_structure_path.suffixes == [".view", ".lkml"]:
+        if lookml_structure_type == "view":
             return AssetKey(["view", lookml_structure_props["name"]])
 
-        if lookml_structure_path.suffixes == [".model", ".lkml"]:
-            return AssetKey(["explore", lookml_structure_props["name"]])
+        if lookml_structure_type == "table":
+            sqlglot_table = lookml_structure_props["table"]
 
-        raise ValueError(f"Unsupported LookML structure: {lookml_structure_path}")
+            return AssetKey([part.name.replace("*", "_star") for part in sqlglot_table.parts])
+
+        if lookml_structure_type == "explore":
+            explore_name = lookml_structure_props.get("explore") or lookml_structure_props.get(
+                "name"
+            )
+
+            if not explore_name:
+                raise ValueError(
+                    f"Could not find `name` or `explore` property in LookML structure type `{lookml_structure_type}`"
+                    f" at path `{lookml_structure_path}` with properties {lookml_structure_props}"
+                )
+
+            return AssetKey(["explore", explore_name])
+
+        raise ValueError(
+            f"Unsupported LookML structure type `{lookml_structure_type}` at path `{lookml_structure_path}`"
+        )
 
     @public
-    def get_description(self, lookml_structure: Tuple[Path, Mapping[str, Any]]) -> Optional[str]:
-        """A method that takes in a dictionary representing a LookML structure
-        (dashboards, explores, views) and returns the Dagster asset key that represents the structure.
+    def get_deps(
+        self, lookml_structure: Tuple[Path, LookMLStructureType, Mapping[str, Any]]
+    ) -> Sequence[AssetKey]:
+        """A method that takes in a LookML structure (dashboards, explores, views) and
+        returns the Dagster dependencies of that the structure.
+
+        The LookML structure is parsed using ``lkml``. You can learn more about this here:
+        https://lkml.readthedocs.io/en/latest/simple.html.
+
+        You can learn more about LookML dashboards and the properties available in this
+        dictionary here: https://cloud.google.com/looker/docs/reference/param-lookml-dashboard.
+
+        You can learn more about LookML explores and views and the properties available in this
+        dictionary here: https://cloud.google.com/looker/docs/reference/lookml-quick-reference.
+
+        This method can be overriden to provide custom dependencies for a LookML structure.
+
+        Args:
+            lookml_structure (Tuple[Path, str, Mapping[str, Any]]): A tuple with the path to file
+                defining a LookML structure, the LookML structure type, and a dictionary
+                representing a LookML structure.
+
+        Returns:
+            AssetKey: The Dagster dependencies for the LookML structure.
+        """
+        lookml_structure_path, lookml_structure_type, _ = lookml_structure
+
+        if lookml_structure_type == "dashboard":
+            return build_deps_for_looker_dashboard(
+                dagster_looker_translator=self, lookml_structure=lookml_structure
+            )
+
+        if lookml_structure_type == "explore":
+            return build_deps_for_looker_explore(
+                dagster_looker_translator=self, lookml_structure=lookml_structure
+            )
+
+        if lookml_structure_type == "view":
+            return build_deps_for_looker_view(
+                dagster_looker_translator=self, lookml_structure=lookml_structure
+            )
+
+        raise ValueError(
+            f"Unsupported LookML structure type `{lookml_structure_type}` at path `{lookml_structure_path}`"
+        )
+
+    @public
+    def get_description(
+        self, lookml_structure: Tuple[Path, LookMLStructureType, Mapping[str, Any]]
+    ) -> Optional[str]:
+        """A method that takes in a LookML structure (dashboards, explores, views) and
+        returns the Dagster description of the structure.
 
         The LookML structure is parsed using ``lkml``. You can learn more about this here:
         https://lkml.readthedocs.io/en/latest/simple.html.
@@ -67,22 +277,23 @@ class DagsterLookerTranslator:
         This method can be overriden to provide a custom description for a LookML structure.
 
         Args:
-            lookml_structure (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
-                defining a LookML structure, and a dictionary representing a LookML structure.
+            lookml_structure (Tuple[Path, str, Mapping[str, Any]]): A tuple with the path to file
+                defining a LookML structure, the LookML structure type, and a dictionary
+                representing a LookML structure.
 
         Returns:
             Optional[str]: The Dagster description for the LookML structure.
         """
-        _, lookml_structure_props = lookml_structure
+        _, _, lookml_structure_props = lookml_structure
 
         return lookml_structure_props.get("description")
 
     @public
     def get_metadata(
-        self, lookml_structure: Tuple[Path, Mapping[str, Any]]
+        self, lookml_structure: Tuple[Path, LookMLStructureType, Mapping[str, Any]]
     ) -> Optional[Mapping[str, Any]]:
-        """A method that takes in a dictionary representing a LookML structure
-        (dashboards, explores, views) and returns the Dagster asset key that represents the structure.
+        """A method that takes in a LookML structure (dashboards, explores, views) and
+        returns the Dagster metadata of the structure.
 
         The LookML structure is parsed using ``lkml``. You can learn more about this here:
         https://lkml.readthedocs.io/en/latest/simple.html.
@@ -96,8 +307,9 @@ class DagsterLookerTranslator:
         This method can be overriden to provide custom metadata for a LookML structure.
 
         Args:
-            lookml_structure (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
-                defining a LookML structure, and a dictionary representing a LookML structure.
+            lookml_structure (Tuple[Path, str, Mapping[str, Any]]): A tuple with the path to file
+                defining a LookML structure, the LookML structure type, and a dictionary
+                representing a LookML structure.
 
         Returns:
             Optional[Mapping[str, Any]]: A dictionary representing the Dagster metadata for the
@@ -106,9 +318,11 @@ class DagsterLookerTranslator:
         return None
 
     @public
-    def get_group_name(self, lookml_structure: Tuple[Path, Mapping[str, Any]]) -> Optional[str]:
-        """A method that takes in a dictionary representing a LookML structure
-        (dashboards, explores, views) and returns the Dagster asset key that represents the structure.
+    def get_group_name(
+        self, lookml_structure: Tuple[Path, LookMLStructureType, Mapping[str, Any]]
+    ) -> Optional[str]:
+        """A method that takes in a LookML structure (dashboards, explores, views) and
+        returns the Dagster group name of the structure.
 
         The LookML structure is parsed using ``lkml``. You can learn more about this here:
         https://lkml.readthedocs.io/en/latest/simple.html.
@@ -122,8 +336,9 @@ class DagsterLookerTranslator:
         This method can be overriden to provide a custom group name for a LookML structure.
 
         Args:
-            lookml_structure (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
-                defining a LookML structure, and a dictionary representing a LookML structure.
+            lookml_structure (Tuple[Path, str, Mapping[str, Any]]): A tuple with the path to file
+                defining a LookML structure, the LookML structure type, and a dictionary
+                representing a LookML structure.
 
         Returns:
             Optional[str]: A Dagster group name for the LookML structure.
@@ -132,10 +347,10 @@ class DagsterLookerTranslator:
 
     @public
     def get_owners(
-        self, lookml_structure: Tuple[Path, Mapping[str, Any]]
+        self, lookml_structure: Tuple[Path, LookMLStructureType, Mapping[str, Any]]
     ) -> Optional[Sequence[str]]:
-        """A method that takes in a dictionary representing a LookML structure
-        (dashboards, explores, views) and returns the Dagster asset key that represents the structure.
+        """A method that takes in a LookML structure (dashboards, explores, views) and
+        returns the Dagster owners of the structure.
 
         The LookML structure is parsed using ``lkml``. You can learn more about this here:
         https://lkml.readthedocs.io/en/latest/simple.html.
@@ -149,8 +364,9 @@ class DagsterLookerTranslator:
         This method can be overriden to provide custom owners for a LookML structure.
 
         Args:
-            lookml_structure (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
-                defining a LookML structure, and a dictionary representing a LookML structure.
+            lookml_structure (Tuple[Path, str, Mapping[str, Any]]): A tuple with the path to file
+                defining a LookML structure, the LookML structure type, and a dictionary
+                representing a LookML structure.
 
         Returns:
             Optional[Sequence[str]]: A sequence of Dagster owners for the LookML structure.
@@ -159,10 +375,10 @@ class DagsterLookerTranslator:
 
     @public
     def get_tags(
-        self, lookml_structure: Tuple[Path, Mapping[str, Any]]
+        self, lookml_structure: Tuple[Path, LookMLStructureType, Mapping[str, Any]]
     ) -> Optional[Mapping[str, str]]:
-        """A method that takes in a dictionary representing a LookML structure
-        (dashboards, explores, views) and returns the Dagster asset key that represents the structure.
+        """A method that takes in a LookML structure (dashboards, explores, views) and
+        returns the Dagster tags of the structure.
 
         The LookML structure is parsed using ``lkml``. You can learn more about this here:
         https://lkml.readthedocs.io/en/latest/simple.html.
@@ -176,8 +392,9 @@ class DagsterLookerTranslator:
         This method can be overriden to provide custom tags for a LookML structure.
 
         Args:
-            lookml_structure (Tuple[Path, Mapping[str, Any]]): A tuple with the path to file
-                defining a LookML structure, and a dictionary representing a LookML structure.
+            lookml_structure (Tuple[Path, str, Mapping[str, Any]]): A tuple with the path to file
+                defining a LookML structure, the LookML structure type, and a dictionary
+                representing a LookML structure.
 
         Returns:
             Optional[Mapping[str, str]]: A dictionary representing the Dagster tags for the

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/test_asset_decorator.py
@@ -5,7 +5,7 @@ import pytest
 from dagster import AssetKey
 from dagster._core.definitions.assets import UserAssetOwner
 from dagster_looker.asset_decorator import looker_assets
-from dagster_looker.dagster_looker_translator import DagsterLookerTranslator
+from dagster_looker.dagster_looker_translator import DagsterLookerTranslator, LookMLStructureType
 
 from .looker_projects import test_exception_derived_table_path, test_retail_demo_path
 
@@ -286,7 +286,9 @@ def test_asset_deps_exception_derived_table(caplog: pytest.LogCaptureFixture) ->
 
 def test_with_asset_key_replacements() -> None:
     class CustomDagsterLookerTranslator(DagsterLookerTranslator):
-        def get_asset_key(self, lookml_structure: Tuple[Path, Mapping[str, Any]]) -> AssetKey:
+        def get_asset_key(
+            self, lookml_structure: Tuple[Path, LookMLStructureType, Mapping[str, Any]]
+        ) -> AssetKey:
             return super().get_asset_key(lookml_structure).with_prefix("prefix")
 
     @looker_assets(
@@ -295,20 +297,34 @@ def test_with_asset_key_replacements() -> None:
     )
     def my_looker_assets(): ...
 
+    assert my_looker_assets.asset_deps.keys()
     assert all(key.has_prefix(["prefix"]) for key in my_looker_assets.asset_deps.keys())
+    assert all(deps for deps in my_looker_assets.asset_deps.values())
     assert all(
-        dep.has_prefix(["prefix"])
-        for deps in my_looker_assets.asset_deps.values()
-        for dep in deps
-        if len(dep.path) > 1 and dep.path[1] in ["dashboard", "explore", "view"]
+        dep.has_prefix(["prefix"]) for deps in my_looker_assets.asset_deps.values() for dep in deps
     )
+
+
+def test_with_deps_replacements() -> None:
+    class CustomDagsterLookerTranslator(DagsterLookerTranslator):
+        def get_deps(self, _) -> Sequence[AssetKey]:
+            return []
+
+    @looker_assets(
+        project_dir=test_retail_demo_path,
+        dagster_looker_translator=CustomDagsterLookerTranslator(),
+    )
+    def my_looker_assets(): ...
+
+    assert my_looker_assets.asset_deps.keys()
+    assert all(not deps for deps in my_looker_assets.asset_deps.values())
 
 
 def test_with_description_replacements() -> None:
     expected_description = "customized description"
 
     class CustomDagsterLookerTranslator(DagsterLookerTranslator):
-        def get_description(self, _: Tuple[Path, Mapping[str, Any]]) -> Optional[str]:
+        def get_description(self, _) -> Optional[str]:
             return expected_description
 
     @looker_assets(
@@ -325,7 +341,7 @@ def test_with_metadata_replacements() -> None:
     expected_metadata = {"customized": "metadata"}
 
     class CustomDagsterLookerTranslator(DagsterLookerTranslator):
-        def get_metadata(self, _: Tuple[Path, Mapping[str, Any]]) -> Optional[Mapping[str, Any]]:
+        def get_metadata(self, _) -> Optional[Mapping[str, Any]]:
             return expected_metadata
 
     @looker_assets(
@@ -342,7 +358,7 @@ def test_with_group_replacements() -> None:
     expected_group = "customized_group"
 
     class CustomDagsterLookerTranslator(DagsterLookerTranslator):
-        def get_group_name(self, _: Tuple[Path, Mapping[str, Any]]) -> Optional[str]:
+        def get_group_name(self, _) -> Optional[str]:
             return expected_group
 
     @looker_assets(
@@ -359,7 +375,7 @@ def test_with_owner_replacements() -> None:
     expected_owners = [UserAssetOwner("custom@custom.com")]
 
     class CustomDagsterLookerTranslator(DagsterLookerTranslator):
-        def get_owners(self, _: Tuple[Path, Mapping[str, Any]]) -> Optional[Sequence[str]]:
+        def get_owners(self, _) -> Optional[Sequence[str]]:
             return [owner.email for owner in expected_owners]
 
     @looker_assets(
@@ -376,7 +392,7 @@ def test_with_tag_replacements() -> None:
     expected_tags = {"customized": "tag"}
 
     class CustomDagsterLookerTranslator(DagsterLookerTranslator):
-        def get_tags(self, _: Tuple[Path, Mapping[str, Any]]) -> Optional[Mapping[str, str]]:
+        def get_tags(self, _) -> Optional[Mapping[str, str]]:
             return expected_tags
 
     @looker_assets(


### PR DESCRIPTION
## Summary & Motivation
Before, `DagsterLookerTranslator.get_asset_key(...)` only operated to generate the `key` of the `AssetSpec` in question. Now, it also operates on the `deps` of the `AssetSpec`.

Also, implement `DagsterLookerTranslator.get_deps(...)`.

## How I Tested These Changes
pytest:

- See all keys of a `@looker_assets` instance change when overriding `get_asset_key`
- See `deps` change when overriding `get_deps`.