### PR TITLE
Add nonce as query string to allow analytics JS to execute JS from within an iframe

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/src/extractInitializationData.ts
+++ b/js_modules/dagster-ui/packages/app-oss/src/extractInitializationData.ts
@@ -34,7 +34,7 @@ export const extractInitializationData = (): {
     const script = document.createElement('script');
     script.defer = true;
     script.async = true;
-    script.src = 'https://dagster.io/oss-telemetry.js';
+    script.src = `https://dagster.io/oss-telemetry.js?nonce=${(window as any).__webpack_nonce__}`;
     document.head.appendChild(script);
   }
   return value;


### PR DESCRIPTION
## Summary & Motivation

The analytics script is going to dynamically insert an iframe that will execute JS and in order to obey our CSP it needs to know our nonce. The reason for the iframe is to sandbox third party scripts so that they can't see potentially sensitive information from the parent window.

