### PR TITLE
[dagster-dbt] add translator option to attach model files as code reference metadata

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -427,7 +427,7 @@ def _attach_sql_model_code_reference(
 
     # attempt to get root_path, which is removed from manifests in newer dbt versions
     relative_path = Path(dbt_resource_props["original_file_path"])
-    abs_path = project.project_dir.joinpath(relative_path)
+    abs_path = project.project_dir.joinpath(relative_path).resolve()
 
     return {
         **existing_metadata,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -107,9 +107,9 @@ def dbt_assets(
             are not strings will be json encoded and must meet the criteria that
             `json.loads(json.dumps(value)) == value`.
         required_resource_keys (Optional[Set[str]]): Set of required resource handles.
-        project_dir (Optional[Union[str, Path]]): The path to the dbt project directory. This directory should contain a
-            `dbt_project.yml`. Not required, but needed to attach code references from model code to Dagster
-            assets. See https://docs.getdbt.com/reference/dbt_project.yml for more information.
+        project (Optional[DbtProject]): A DbtProject instance which provides a pointer to the dbt
+            project location and manifest. Not required, but needed to attach code references from
+            model code to Dagster assets.
 
     Examples:
         Running ``dbt build`` for a dbt project:
@@ -489,10 +489,10 @@ def get_dbt_multi_asset_args(
             DAGSTER_DBT_MANIFEST_METADATA_KEY: DbtManifestWrapper(manifest=manifest),
             DAGSTER_DBT_TRANSLATOR_METADATA_KEY: dagster_dbt_translator,
         }
-        if dagster_dbt_translator.settings.attach_sql_model_code_reference:
+        if dagster_dbt_translator.settings.enable_sql_model_code_reference:
             if not project:
                 raise DagsterInvalidDefinitionError(
-                    "attach_sql_model_code_reference requires a DbtProject to be supplied"
+                    "enable_sql_model_code_reference requires a DbtProject to be supplied"
                     " to the @dbt_assets decorator."
                 )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import (
     Any,
@@ -436,7 +437,7 @@ def _attach_sql_model_code_reference(
                 code_references=[
                     *references,
                     LocalFileCodeReference(
-                        file_path=str(abs_path),
+                        file_path=os.fspath(abs_path),
                         line_number=1,
                     ),
                 ],
@@ -489,10 +490,10 @@ def get_dbt_multi_asset_args(
             DAGSTER_DBT_MANIFEST_METADATA_KEY: DbtManifestWrapper(manifest=manifest),
             DAGSTER_DBT_TRANSLATOR_METADATA_KEY: dagster_dbt_translator,
         }
-        if dagster_dbt_translator.settings.enable_sql_model_code_reference:
+        if dagster_dbt_translator.settings.enable_code_references:
             if not project:
                 raise DagsterInvalidDefinitionError(
-                    "enable_sql_model_code_reference requires a DbtProject to be supplied"
+                    "enable_code_references requires a DbtProject to be supplied"
                     " to the @dbt_assets decorator."
                 )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -39,7 +39,7 @@ class DagsterDbtTranslatorSettings:
 
     enable_asset_checks: bool = True
     enable_duplicate_source_asset_keys: bool = False
-    enable_sql_model_code_reference: bool = False
+    enable_code_references: bool = False
 
 
 class DagsterDbtTranslator:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -39,6 +39,7 @@ class DagsterDbtTranslatorSettings:
 
     enable_asset_checks: bool = True
     enable_duplicate_source_asset_keys: bool = False
+    attach_sql_model_code_reference: bool = False
 
 
 class DagsterDbtTranslator:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -39,7 +39,7 @@ class DagsterDbtTranslatorSettings:
 
     enable_asset_checks: bool = True
     enable_duplicate_source_asset_keys: bool = False
-    attach_sql_model_code_reference: bool = False
+    enable_sql_model_code_reference: bool = False
 
 
 class DagsterDbtTranslator:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
@@ -1,0 +1,34 @@
+import os
+from typing import Any, Dict
+
+from dagster._core.definitions.metadata.source_code import LocalFileCodeReference
+from dagster_dbt.asset_decorator import dbt_assets
+from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, DagsterDbtTranslatorSettings
+
+from ..dbt_projects import (
+    test_jaffle_shop_path,
+)
+
+
+def test_basic_attach_code_references(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
+    @dbt_assets(
+        manifest=test_jaffle_shop_manifest,
+        dagster_dbt_translator=DagsterDbtTranslator(
+            settings=DagsterDbtTranslatorSettings(attach_sql_model_code_reference=True)
+        ),
+        project_dir=os.fspath(test_jaffle_shop_path),
+    )
+    def my_dbt_assets(): ...
+
+    for asset_key, asset_metadata in my_dbt_assets.metadata_by_key.items():
+        assert "dagster/code_references" in asset_metadata
+
+        references = asset_metadata["dagster/code_references"].code_references
+        assert len(references) == 1
+
+        reference = references[0]
+        assert isinstance(reference, LocalFileCodeReference)
+        assert reference.file_path.endswith(
+            asset_key.path[-1] + ".sql"
+        ) or reference.file_path.endswith(asset_key.path[-1] + ".csv")
+        assert os.path.exists(reference.file_path), reference.file_path

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
@@ -26,7 +26,7 @@ def test_basic_attach_code_references(test_jaffle_shop_manifest: Dict[str, Any])
     @dbt_assets(
         manifest=test_jaffle_shop_manifest,
         dagster_dbt_translator=DagsterDbtTranslator(
-            settings=DagsterDbtTranslatorSettings(attach_sql_model_code_reference=True)
+            settings=DagsterDbtTranslatorSettings(enable_sql_model_code_reference=True)
         ),
         project=DbtProject(project_dir=os.fspath(test_jaffle_shop_path)),
     )
@@ -49,13 +49,13 @@ def test_basic_attach_code_references(test_jaffle_shop_manifest: Dict[str, Any])
 def test_basic_attach_code_references_no_project_dir(
     test_jaffle_shop_manifest: Dict[str, Any],
 ) -> None:
-    # expect exception because attach_sql_model_code_reference=True but no project_dir
+    # expect exception because enable_sql_model_code_reference=True but no project_dir
     with pytest.raises(DagsterInvalidDefinitionError):
 
         @dbt_assets(
             manifest=test_jaffle_shop_manifest,
             dagster_dbt_translator=DagsterDbtTranslator(
-                settings=DagsterDbtTranslatorSettings(attach_sql_model_code_reference=True)
+                settings=DagsterDbtTranslatorSettings(enable_sql_model_code_reference=True)
             ),
         )
         def my_dbt_assets(): ...
@@ -65,7 +65,7 @@ def test_with_source_code_references_wrapper(test_jaffle_shop_manifest: Dict[str
     @dbt_assets(
         manifest=test_jaffle_shop_manifest,
         dagster_dbt_translator=DagsterDbtTranslator(
-            settings=DagsterDbtTranslatorSettings(attach_sql_model_code_reference=True)
+            settings=DagsterDbtTranslatorSettings(enable_sql_model_code_reference=True)
         ),
         project=DbtProject(project_dir=os.fspath(test_jaffle_shop_path)),
     )
@@ -91,7 +91,7 @@ def test_link_to_source_control_wrapper(test_jaffle_shop_manifest: Dict[str, Any
     @dbt_assets(
         manifest=test_jaffle_shop_manifest,
         dagster_dbt_translator=DagsterDbtTranslator(
-            settings=DagsterDbtTranslatorSettings(attach_sql_model_code_reference=True)
+            settings=DagsterDbtTranslatorSettings(enable_sql_model_code_reference=True)
         ),
         project=DbtProject(project_dir=os.fspath(test_jaffle_shop_path)),
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
@@ -11,6 +11,7 @@ from dagster._core.definitions.metadata.source_code import (
     with_source_code_references,
 )
 from dagster._core.errors import DagsterInvalidDefinitionError
+from dagster_dbt import DbtProject
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, DagsterDbtTranslatorSettings
 
@@ -27,7 +28,7 @@ def test_basic_attach_code_references(test_jaffle_shop_manifest: Dict[str, Any])
         dagster_dbt_translator=DagsterDbtTranslator(
             settings=DagsterDbtTranslatorSettings(attach_sql_model_code_reference=True)
         ),
-        project_dir=os.fspath(test_jaffle_shop_path),
+        project=DbtProject(project_dir=os.fspath(test_jaffle_shop_path)),
     )
     def my_dbt_assets(): ...
 
@@ -66,7 +67,7 @@ def test_with_source_code_references_wrapper(test_jaffle_shop_manifest: Dict[str
         dagster_dbt_translator=DagsterDbtTranslator(
             settings=DagsterDbtTranslatorSettings(attach_sql_model_code_reference=True)
         ),
-        project_dir=os.fspath(test_jaffle_shop_path),
+        project=DbtProject(project_dir=os.fspath(test_jaffle_shop_path)),
     )
     def my_dbt_assets(): ...
 
@@ -92,7 +93,7 @@ def test_link_to_source_control_wrapper(test_jaffle_shop_manifest: Dict[str, Any
         dagster_dbt_translator=DagsterDbtTranslator(
             settings=DagsterDbtTranslatorSettings(attach_sql_model_code_reference=True)
         ),
-        project_dir=os.fspath(test_jaffle_shop_path),
+        project=DbtProject(project_dir=os.fspath(test_jaffle_shop_path)),
     )
     def my_dbt_assets(): ...
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
@@ -26,7 +26,7 @@ def test_basic_attach_code_references(test_jaffle_shop_manifest: Dict[str, Any])
     @dbt_assets(
         manifest=test_jaffle_shop_manifest,
         dagster_dbt_translator=DagsterDbtTranslator(
-            settings=DagsterDbtTranslatorSettings(enable_sql_model_code_reference=True)
+            settings=DagsterDbtTranslatorSettings(enable_code_references=True)
         ),
         project=DbtProject(project_dir=os.fspath(test_jaffle_shop_path)),
     )
@@ -49,13 +49,13 @@ def test_basic_attach_code_references(test_jaffle_shop_manifest: Dict[str, Any])
 def test_basic_attach_code_references_no_project_dir(
     test_jaffle_shop_manifest: Dict[str, Any],
 ) -> None:
-    # expect exception because enable_sql_model_code_reference=True but no project_dir
+    # expect exception because enable_code_references=True but no project_dir
     with pytest.raises(DagsterInvalidDefinitionError):
 
         @dbt_assets(
             manifest=test_jaffle_shop_manifest,
             dagster_dbt_translator=DagsterDbtTranslator(
-                settings=DagsterDbtTranslatorSettings(enable_sql_model_code_reference=True)
+                settings=DagsterDbtTranslatorSettings(enable_code_references=True)
             ),
         )
         def my_dbt_assets(): ...
@@ -65,7 +65,7 @@ def test_with_source_code_references_wrapper(test_jaffle_shop_manifest: Dict[str
     @dbt_assets(
         manifest=test_jaffle_shop_manifest,
         dagster_dbt_translator=DagsterDbtTranslator(
-            settings=DagsterDbtTranslatorSettings(enable_sql_model_code_reference=True)
+            settings=DagsterDbtTranslatorSettings(enable_code_references=True)
         ),
         project=DbtProject(project_dir=os.fspath(test_jaffle_shop_path)),
     )
@@ -91,7 +91,7 @@ def test_link_to_source_control_wrapper(test_jaffle_shop_manifest: Dict[str, Any
     @dbt_assets(
         manifest=test_jaffle_shop_manifest,
         dagster_dbt_translator=DagsterDbtTranslator(
-            settings=DagsterDbtTranslatorSettings(enable_sql_model_code_reference=True)
+            settings=DagsterDbtTranslatorSettings(enable_code_references=True)
         ),
         project=DbtProject(project_dir=os.fspath(test_jaffle_shop_path)),
     )


### PR DESCRIPTION
## Summary

Adds the option to a custom `DagsterDbtTranslator` to attach code reference metadata pointing to the dbt model files for each asset.

Unfortunately, this requires that we also get the `project_dir ` from the user, since that is only available at run time as part of the resource. Maybe there's a good way around this? The manifest used to have a `root_path` field, but this [was recently removed](https://github.com/dbt-labs/dbt-core/issues/6171).
 
```python
@dbt_assets(
    manifest=...,
    dagster_dbt_translator=DagsterDbtTranslator(
        settings=DagsterDbtTranslatorSettings(attach_sql_model_code_reference=True)
    ),
    project=DbtProject(...)
)
def my_dbt_assets():
  ...
```

## Test Plan

Unit tests.