### PR TITLE
Declarative Scheduling cron example and scaffolding

### DIFF
--- a/docs/content/concepts/declarative-scheduling/examples.mdx
+++ b/docs/content/concepts/declarative-scheduling/examples.mdx
@@ -1,0 +1,39 @@
+---
+title: "Declarative scheduling examples | Dagster Docs"
+description: "Examples focused on Declarative Scehduling."
+---
+
+# Schedule examples
+
+This reference contains a variety of examples using Declarative Scheduling.
+
+- A summary
+- Additional notes
+- Links to relevant documentation
+- A list of the APIs used in the example
+
+---
+
+## Defining basic cron schedules
+
+The following examples demonstrate how to define some cron schedules.
+
+```python file=/concepts/declarative_scheduling/single_asset_cron.py
+from dagster import Definitions, asset
+from dagster._core.definitions.declarative_scheduling.declarative_scheduling_job import (
+    DeclarativeSchedulingJob,
+)
+
+
+@asset()
+def my_asset() -> None: ...
+
+
+defs = Definitions(
+    jobs=[
+        DeclarativeSchedulingJob.cron(
+            name="daily_job", targets=[my_asset], cron_schedule="0 0 * * *"
+        )
+    ]
+)
+```

--- a/examples/docs_snippets/docs_snippets/concepts/declarative_scheduling/single_asset_cron.py
+++ b/examples/docs_snippets/docs_snippets/concepts/declarative_scheduling/single_asset_cron.py
@@ -1,0 +1,17 @@
+from dagster import Definitions, asset
+from dagster._core.definitions.declarative_scheduling.declarative_scheduling_job import (
+    DeclarativeSchedulingJob,
+)
+
+
+@asset()
+def my_asset() -> None: ...
+
+
+defs = Definitions(
+    jobs=[
+        DeclarativeSchedulingJob.cron(
+            name="daily_job", targets=[my_asset], cron_schedule="0 0 * * *"
+        )
+    ]
+)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/ds_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/ds_asset.py
@@ -1,0 +1,40 @@
+from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence
+
+from dagster._core.definitions.asset_check_spec import AssetCheckSpec
+from dagster._core.definitions.asset_key import CoercibleToAssetKey
+from dagster._core.definitions.declarative_scheduling.scheduling_condition import (
+    SchedulingCondition,
+)
+from dagster._core.definitions.decorators.asset_decorator import asset
+from dagster._core.definitions.metadata import ArbitraryMetadataMapping
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.asset_dep import CoercibleToAssetDep
+
+
+# shim for building docs
+def ds_asset(
+    *,
+    deps: Optional[Iterable["CoercibleToAssetDep"]] = None,
+    description: Optional[str] = None,
+    metadata: Optional[ArbitraryMetadataMapping] = None,
+    group_name: Optional[str] = None,
+    code_version: Optional[str] = None,
+    key: Optional[CoercibleToAssetKey] = None,
+    scheduling: Optional[SchedulingCondition] = None,
+    check_specs: Optional[Sequence[AssetCheckSpec]] = None,
+    owners: Optional[Sequence[str]] = None,
+    tags: Optional[Mapping[str, str]] = None,
+):
+    return asset(
+        key=key,
+        deps=deps,
+        description=description,
+        metadata=metadata,
+        group_name=group_name,
+        code_version=code_version,
+        auto_materialize_policy=scheduling.as_auto_materialize_policy() if scheduling else None,
+        check_specs=check_specs,
+        owners=owners,
+        tags=tags,
+    )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
@@ -40,6 +40,20 @@ if TYPE_CHECKING:
     from .scheduling_context import SchedulingContext
 
 
+# static factory
+class Scheduling:
+    @staticmethod
+    def eager_with_rate_limit(
+        *,
+        failure_retry_delta: datetime.timedelta = datetime.timedelta(hours=1),
+    ) -> "SchedulingCondition":
+        return SchedulingCondition.eager_with_rate_limit(failure_retry_delta=failure_retry_delta)
+
+    @staticmethod
+    def on_cron(cron_schedule: str, cron_timezone: str = "UTC") -> "SchedulingCondition":
+        return SchedulingCondition.on_cron(cron_schedule=cron_schedule, cron_timezone=cron_timezone)
+
+
 @experimental
 class SchedulingCondition(ABC, DagsterModel):
     @property

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/utils.py
@@ -1,7 +1,13 @@
 import datetime
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 from dagster._serdes.serdes import whitelist_for_serdes
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+    from dagster._core.definitions.declarative_scheduling.scheduling_condition import (
+        SchedulingCondition,
+    )
 
 
 @whitelist_for_serdes
@@ -25,3 +31,7 @@ class SerializableTimeDelta(NamedTuple):
         return datetime.timedelta(
             days=self.days, seconds=self.seconds, microseconds=self.microseconds
         )
+
+
+def as_amp(scheduling_condition: "SchedulingCondition") -> "AutoMaterializePolicy":
+    return scheduling_condition.as_auto_materialize_policy()


### PR DESCRIPTION
## Summary & Motivation

This begins the process of building up a battery of examples that will end up in docs (these are hidden from the docs site for now).

To simulate the end state APIs I set up a shim layer that has a `scheduling` argument. That way the test code looks like:

```python
from dagster._core.definitions.declarative_scheduling.ds_asset import ds_asset as asset
from dagster._core.definitions.declarative_scheduling.scheduling_condition import (
    Scheduling,
)
@asset(scheduling=Scheduling.on_cron("0 0 * * *"))
def my_asset() -> None: ...
```

As you can see I also propose adding a top-level class `Scheduling` for common more coarse-grained policies and shortening the argument to `scheduling` which I think is less verbose and provides some option value if we need to add types that this can accept.

## How I Tested These Changes
