### PR TITLE
Demonstration of eager scheduling

### DIFF
--- a/docs/content/concepts/declarative-scheduling/examples.mdx
+++ b/docs/content/concepts/declarative-scheduling/examples.mdx
@@ -51,3 +51,24 @@ def asset_one() -> None: ...
 @asset(scheduling=daily_cron)
 def asset_two() -> None: ...
 ```
+
+---
+
+## Defining an asset that eagerly updates whenever its upstream updates
+
+The following examples demonstrate how to define an asset that eagerly updates whenever its upstream updates.
+
+```python file=/concepts/declarative_scheduling/eager_asset.py
+from dagster import SchedulingCondition
+from dagster._core.definitions.declarative_scheduling.ds_asset import ds_asset as asset
+
+
+@asset()
+def upstream() -> None: ...
+
+
+@asset(
+    deps=[upstream], scheduling_condition=SchedulingCondition.eager_with_rate_limit()
+)
+def downstream() -> None: ...
+```

--- a/docs/content/concepts/declarative-scheduling/examples.mdx
+++ b/docs/content/concepts/declarative-scheduling/examples.mdx
@@ -59,16 +59,16 @@ def asset_two() -> None: ...
 The following examples demonstrate how to define an asset that eagerly updates whenever its upstream updates.
 
 ```python file=/concepts/declarative_scheduling/eager_asset.py
-from dagster import SchedulingCondition
 from dagster._core.definitions.declarative_scheduling.ds_asset import ds_asset as asset
+from dagster._core.definitions.declarative_scheduling.scheduling_condition import (
+    Scheduling,
+)
 
 
 @asset()
 def upstream() -> None: ...
 
 
-@asset(
-    deps=[upstream], scheduling_condition=SchedulingCondition.eager_with_rate_limit()
-)
+@asset(deps=[upstream], scheduling=Scheduling.eager())
 def downstream() -> None: ...
 ```

--- a/examples/docs_snippets/docs_snippets/concepts/declarative_scheduling/eager_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/declarative_scheduling/eager_asset.py
@@ -1,12 +1,12 @@
-from dagster import SchedulingCondition
 from dagster._core.definitions.declarative_scheduling.ds_asset import ds_asset as asset
+from dagster._core.definitions.declarative_scheduling.scheduling_condition import (
+    Scheduling,
+)
 
 
 @asset()
 def upstream() -> None: ...
 
 
-@asset(
-    deps=[upstream], scheduling_condition=SchedulingCondition.eager()
-)
+@asset(deps=[upstream], scheduling=Scheduling.eager())
 def downstream() -> None: ...

--- a/examples/docs_snippets/docs_snippets/concepts/declarative_scheduling/eager_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/declarative_scheduling/eager_asset.py
@@ -7,6 +7,6 @@ def upstream() -> None: ...
 
 
 @asset(
-    deps=[upstream], scheduling_condition=SchedulingCondition.eager_with_rate_limit()
+    deps=[upstream], scheduling_condition=SchedulingCondition.eager()
 )
 def downstream() -> None: ...

--- a/examples/docs_snippets/docs_snippets/concepts/declarative_scheduling/eager_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/declarative_scheduling/eager_asset.py
@@ -1,0 +1,12 @@
+from dagster import SchedulingCondition
+from dagster._core.definitions.declarative_scheduling.ds_asset import ds_asset as asset
+
+
+@asset()
+def upstream() -> None: ...
+
+
+@asset(
+    deps=[upstream], scheduling_condition=SchedulingCondition.eager_with_rate_limit()
+)
+def downstream() -> None: ...


### PR DESCRIPTION
## Summary & Motivation

Use `eager`. This inspired https://github.com/dagster-io/dagster/pull/21892

## How I Tested These Changes
