### PR TITLE
Hoist the asset daemon context out of the LegacyRuleEvaluationContext

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -224,7 +224,7 @@ class AssetDaemonContext:
 
         previous_evaluation_state = self.cursor.get_previous_evaluation_state(asset_key)
 
-        legacy_context = LegacyRuleEvaluationContext.create(
+        legacy_context = LegacyRuleEvaluationContext.create_within_asset_daemon(
             asset_key=asset_key,
             previous_evaluation_state=previous_evaluation_state,
             condition=asset_condition,

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -311,7 +311,7 @@ class AutoMaterializeAssetPartitionsFilter(
             self.latest_run_required_tags.items()
             <= {
                 AUTO_MATERIALIZE_TAG: "true",
-                **context.legacy_context.daemon_context.auto_materialize_run_tags,
+                **context.legacy_context.auto_materialize_run_tags,
             }.items()
         ):
             return will_update_asset_partitions | updated_partitions_with_required_tags
@@ -372,7 +372,7 @@ class MaterializeOnParentUpdatedRule(
                 parent_asset_partitions=parent_asset_partitions,
                 # do a precise check for updated parents, factoring in data versions, as long as
                 # we're within reasonable limits on the number of partitions to check
-                respect_materialization_data_versions=context.legacy_context.daemon_context.respect_materialization_data_versions
+                respect_materialization_data_versions=context.legacy_context.respect_materialization_data_versions
                 and len(parent_asset_partitions) + subset_to_evaluate.size < 100,
                 # ignore self-dependencies when checking for updated parents, to avoid historical
                 # rematerializations from causing a chain of materializations to be kicked off
@@ -708,7 +708,7 @@ class SkipOnNotAllParentsUpdatedRule(
                 context.legacy_context.instance_queryer.get_parent_asset_partitions_updated_after_child(
                     asset_partition=candidate,
                     parent_asset_partitions=parent_partitions,
-                    respect_materialization_data_versions=context.legacy_context.daemon_context.respect_materialization_data_versions,
+                    respect_materialization_data_versions=context.legacy_context.respect_materialization_data_versions,
                     ignored_parent_keys=set(),
                 )
                 | context.legacy_context.parent_will_update_subset.asset_partitions

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/legacy_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/legacy_context.py
@@ -1,6 +1,7 @@
 import dataclasses
 import datetime
 import functools
+import logging
 import os
 from collections import defaultdict
 from dataclasses import dataclass
@@ -78,6 +79,7 @@ class LegacyRuleEvaluationContext:
     start_timestamp: float
     respect_materialization_data_versions: bool
     auto_materialize_run_tags: Mapping[str, str]
+    logger: logging.Logger
     root_ref: Optional["LegacyRuleEvaluationContext"] = None
 
     @staticmethod
@@ -113,6 +115,7 @@ class LegacyRuleEvaluationContext:
             start_timestamp=pendulum.now("UTC").timestamp(),
             respect_materialization_data_versions=daemon_context.respect_materialization_data_versions,
             auto_materialize_run_tags=daemon_context.auto_materialize_run_tags,
+            logger=daemon_context.logger,
         )
 
     def for_child(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/legacy_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/legacy_context.py
@@ -71,16 +71,17 @@ class LegacyRuleEvaluationContext:
 
     instance_queryer: "CachingInstanceQueryer"
     data_time_resolver: "CachingDataTimeResolver"
-    daemon_context: "AssetDaemonContext"
 
     evaluation_state_by_key: Mapping[AssetKey, AssetConditionEvaluationState]
     expected_data_time_mapping: Mapping[AssetKey, Optional[datetime.datetime]]
 
     start_timestamp: float
+    respect_materialization_data_versions: bool
+    auto_materialize_run_tags: Mapping[str, str]
     root_ref: Optional["LegacyRuleEvaluationContext"] = None
 
     @staticmethod
-    def create(
+    def create_within_asset_daemon(
         asset_key: AssetKey,
         condition: "SchedulingCondition",
         previous_evaluation_state: Optional[AssetConditionEvaluationState],
@@ -107,10 +108,11 @@ class LegacyRuleEvaluationContext:
             ),
             data_time_resolver=data_time_resolver,
             instance_queryer=instance_queryer,
-            daemon_context=daemon_context,
             evaluation_state_by_key=evaluation_state_by_key,
             expected_data_time_mapping=expected_data_time_mapping,
             start_timestamp=pendulum.now("UTC").timestamp(),
+            respect_materialization_data_versions=daemon_context.respect_materialization_data_versions,
+            auto_materialize_run_tags=daemon_context.auto_materialize_run_tags,
         )
 
     def for_child(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/rule_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/rule_condition.py
@@ -28,11 +28,11 @@ class RuleCondition(AssetCondition):
         return self.rule.description
 
     def evaluate(self, context: SchedulingContext) -> SchedulingResult:
-        context.legacy_context.root_context.daemon_context.logger.debug(
+        context.legacy_context.root_context.logger.debug(
             f"Evaluating rule: {self.rule.to_snapshot()}"
         )
         evaluation_result = self.rule.evaluate_for_asset(context)
-        context.legacy_context.root_context.daemon_context.logger.debug(
+        context.legacy_context.root_context.logger.debug(
             f"Rule returned {evaluation_result.true_subset.size} partitions "
             f"({evaluation_result.end_timestamp - evaluation_result.start_timestamp:.2f} seconds)"
         )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
@@ -114,7 +114,7 @@ class AssetConditionScenarioState(ScenarioState):
                 logger=self.logger,
                 evaluation_time=self.current_time,
             )
-            legacy_context = LegacyRuleEvaluationContext.create(
+            legacy_context = LegacyRuleEvaluationContext.create_within_asset_daemon(
                 asset_key=asset_key,
                 condition=asset_condition,
                 previous_evaluation_state=self.previous_evaluation_state,


### PR DESCRIPTION
## Summary & Motivation

This goal of this is to introduce a user-facing testing API for scheduling conditions that can be executed outside of the Asset Daemon. The process here is to extract the asset condition evaluation logic out of the `AssetDaemonContext` and into its own class that does not reference `AssetDaemonContext`. The general process is to hoist the properties on the `AssetDaemonContext` that these code paths need out of that class, and then change code to reference the constituent properties instead of the context.

This PR eliminates the `AssetDaemonContext` property from `LegacyRuleEvaluationContext`

## How I Tested These Changes

BK