### PR TITLE
[ui] Fix “all selected” logic on the asset graph’s code location filter

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
@@ -58,7 +58,7 @@ export function useAssetGraphExplorerFilters({
 }: Props) {
   const allAssetTags = useAssetTagsForAssets(nodes);
 
-  const {allRepos, visibleRepos} = useContext(WorkspaceContext);
+  const {allRepos} = useContext(WorkspaceContext);
 
   const {
     filters: {changedInBranch, computeKindTags, repos, owners, groups, tags, selectAllFilters},
@@ -127,7 +127,7 @@ export function useAssetGraphExplorerFilters({
       ['computeKindTags', computeKindTags, allComputeKindTags] as const,
       ['groups', groups, allAssetGroups] as const,
       ['changedInBranch', changedInBranch, Object.values(ChangeReason)] as const,
-      ['repos', visibleRepos, allRepos] as const,
+      ['repos', repos, allRepos] as const,
     ].forEach(([key, activeItems, allItems]) => {
       if (!allItems.length) {
         return;
@@ -159,7 +159,7 @@ export function useAssetGraphExplorerFilters({
     groups,
     allAssetGroups,
     changedInBranch,
-    visibleRepos,
+    repos,
     allRepos,
     didWaitAfterLoading,
   ]);


### PR DESCRIPTION
## Summary & Motivation

This was pulling from the workspace's visible repos and not from the filter repo selection. On the global asset graph the code location filter does not sync to the workspace visible / hidden state.

## How I Tested These Changes

Verify that toggling code locations on/off works on both the global asset graph and asset group graphs.

I tried to verify this behavior on the asset list / catalog pages as well, but the "all selected" feature is only in `useAssetGraphExplorerFilters` so no impact there