### PR TITLE
Add support for `dbt-core==1.8.*`

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -476,7 +476,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         "python_modules/libraries/dagster-dbt",
         pytest_tox_factors=[
             f"{deps_factor}-{command_factor}"
-            for deps_factor in ["dbt16", "dbt17", "pydantic1"]
+            for deps_factor in ["dbt16", "dbt17", "dbt18", "pydantic1"]
             for command_factor in ["cloud", "core", "legacy"]
         ],
         unsupported_python_versions=[

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -76,7 +76,7 @@ from sqlglot.optimizer import optimize
 from typing_extensions import Final, Literal, TypeVar
 
 if dbt_version >= "1.8":
-    from dbt_common.events.event_manager_client import cleanup_event_loger  # noqa
+    from dbt_common.events.event_manager_client import cleanup_event_logger  # noqa
 else:
     from dbt.events.functions import cleanup_event_logger
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -76,7 +76,7 @@ from sqlglot.optimizer import optimize
 from typing_extensions import Final, Literal, TypeVar
 
 if dbt_version >= "1.8":
-    from dbt_common.events.event_manager_client import cleanup_event_logger  # noqa
+    from dbt_common.events.event_manager_client import cleanup_event_logger  # type: ignore
 else:
     from dbt.events.functions import cleanup_event_logger
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -59,7 +59,6 @@ from dbt.adapters.factory import get_adapter, register_adapter, reset_adapters
 from dbt.config import RuntimeConfig
 from dbt.config.runtime import load_profile, load_project
 from dbt.contracts.results import NodeStatus, TestStatus
-from dbt.events.functions import cleanup_event_logger
 from dbt.flags import get_flags, set_from_args
 from dbt.node_types import NodeType
 from dbt.version import __version__ as dbt_version
@@ -75,6 +74,11 @@ from sqlglot.expressions import normalize_table_name
 from sqlglot.lineage import lineage
 from sqlglot.optimizer import optimize
 from typing_extensions import Final, Literal, TypeVar
+
+if dbt_version >= "1.8":
+    from dbt_common.events.event_manager_client import cleanup_event_loger  # noqa
+else:
+    from dbt.events.functions import cleanup_event_logger
 
 from ..asset_utils import (
     DAGSTER_DBT_EXCLUDE_METADATA_KEY,

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=[
         f"dagster{pin}",
         # Follow the version support constraints for dbt Core: https://docs.getdbt.com/docs/dbt-versions/core
-        "dbt-core>=1.6,<1.8",
+        "dbt-core>=1.6,<1.9",
         "Jinja2",
         "networkx",
         "orjson",

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -14,8 +14,8 @@ deps =
   dbt16: dbt-duckdb==1.6.*
   dbt17: dbt-core==1.7.*
   dbt17: dbt-duckdb==1.7.*
-  dbt17: dbt-core==1.8.*
-  dbt17: dbt-duckdb==1.8.*
+  dbt18: dbt-core==1.8.*
+  dbt18: dbt-duckdb==1.8.*
   pydantic1: pydantic!=1.10.7,<2.0.0
   -e .[test]
 allowlist_externals =

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -14,6 +14,8 @@ deps =
   dbt16: dbt-duckdb==1.6.*
   dbt17: dbt-core==1.7.*
   dbt17: dbt-duckdb==1.7.*
+  dbt17: dbt-core==1.8.*
+  dbt17: dbt-duckdb==1.8.*
   pydantic1: pydantic!=1.10.7,<2.0.0
   -e .[test]
 allowlist_externals =


### PR DESCRIPTION
## Summary & Motivation

dbt-core==1.8.* is support since May 9, 2024: https://docs.getdbt.com/docs/dbt-versions/core.

Not supporting it in `dagster-dbt` broke the dbt NUX because pip tries to install the latest version of the dbt adapter packages https://github.com/dagster-io/dagster/issues/21862

## How I Tested These Changes
BK
pytest
