### PR TITLE
Update telemetry docs

### DIFF
--- a/docs/content/about/telemetry.mdx
+++ b/docs/content/about/telemetry.mdx
@@ -6,27 +6,15 @@ title: "Dagster telemetry | Dagster Docs"
 
 As an open source project, we collect usage statistics to better understand how users engage with Dagster and to inform development priorities. Telemetry data will motivate projects such as adding functionality in frequently-used parts of the product and will help us understand adoption of new features.
 
-The following is an example telemetry blob:
+We collect telemetry from both the frontend and backend. We do not collect any data processed by Dagster pipelines, and we do not collect any identifiable information about your Dagster definitions, including the names of your assets, ops, or jobs.
 
-```json
-{
-  "location_name_hash": "94ca34d0fb35a5612a30090cac5caef430f7ce377368177da02fd8e0535752f6",
-  "num_assets_in_repo": "1",
-  "num_dynamic_partitioned_assets_in_repo": "0",
-  "num_pipelines_in_repo": "1",
-  "num_schedules_in_repo": "0",
-  "num_sensors_in_repo": "0",
-  "pipeline_name_hash": "",
-  "repo_hash": "f17e9128abe12b4ff329425c469a7c5abc06bace32a2237848bc3a71cf9ef808",
-  "source": "dagster-webserver"
-}
-```
+Front end telemetry is collected from a JavaScript bundle hosted unminified at `https://dagster.io/oss-telemetry.js`. This bundle may change over time.
 
-We will not see or store any data that is processed within ops and jobs. We will not see or store op definitions (including generated context) or job definitions (including resources).
+Backend telemetry collection is logged at `$DAGSTER_HOME/logs/` if `$DAGSTER_HOME` is set or `~/.dagster/logs/` if not set.
 
-To see the logs we send, open `$DAGSTER_HOME/logs/` if `$DAGSTER_HOME` is set or `~/.dagster/logs/` if not set.
+Use of telemetry data is governed by the [Dagster Privacy Policy](https://dagster.io/privacy).
 
-If you'd like to opt-out, you can add the following to `$DAGSTER_HOME/dagster.yaml` (creating that file if necessary):
+If you’d like to opt-out, you can add the following to `$DAGSTER_HOME/dagster.yaml` (creating that file if necessary):
 
 ```yaml
 telemetry:


### PR DESCRIPTION
## Summary & Motivation

We're adding frontend javascript based telemetry and we want to be transparent so we're updating the docs to point to that javascript. We're still not collecting any identifiable information about Dagster definitions.