### PR TITLE
feat(dbt): pin dbt adapters according to `dbt-core` version upper bound

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
@@ -15,7 +15,10 @@ from typing_extensions import Annotated
 
 from ..dbt_project import DbtProject
 from ..include import STARTER_PROJECT_PATH
-from ..version import __version__ as dagster_dbt_version
+from ..version import (
+    DBT_CORE_VERSION_UPPER_BOUND,
+    __version__ as dagster_dbt_version,
+)
 
 app = typer.Typer(
     no_args_is_help=True,
@@ -157,6 +160,7 @@ def copy_scaffold(
                 dbt_parse_command=dbt_parse_command,
                 dbt_assets_name=f"{dbt_project_name}_dbt_assets",
                 dbt_adapter_packages=dbt_adapter_packages,
+                dbt_core_version_upper_bound=DBT_CORE_VERSION_UPPER_BOUND,
                 project_name=project_name,
                 use_experimental_dbt_state=use_experimental_dbt_state,
                 use_experimental_dbt_project=use_experimental_dbt_project,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/setup.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/setup.py.jinja
@@ -16,7 +16,7 @@ setup(
         "dagster-cloud",
         "dagster-dbt",
         {%- for dbt_adapter in dbt_adapter_packages %}
-        "{{ dbt_adapter }}",
+        "{{ dbt_adapter }}<{{ dbt_core_version_upper_bound }}",
         {%- endfor %}
     ],
     extras_require={

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/version.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/version.py
@@ -1,1 +1,3 @@
+DBT_CORE_VERSION_UPPER_BOUND = "1.8"
+
 __version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_scaffold.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_scaffold.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import pytest
 from dagster_dbt.cli.app import app
 from dagster_dbt.errors import DagsterDbtManifestNotFoundError
+from dagster_dbt.version import DBT_CORE_VERSION_UPPER_BOUND
 from typer.testing import CliRunner
 
 from ..dbt_projects import test_jaffle_shop_path
@@ -47,7 +48,10 @@ def _assert_scaffold_invocation(
     assert dagster_project_dir.exists()
     assert dagster_project_dir.joinpath(project_name).exists()
     assert not any(path.suffix == ".jinja" for path in dagster_project_dir.glob("**/*"))
-    assert "dbt-duckdb" in dagster_project_dir.joinpath("setup.py").read_text()
+    assert (
+        f"dbt-duckdb<{DBT_CORE_VERSION_UPPER_BOUND}"
+        in dagster_project_dir.joinpath("setup.py").read_text()
+    )
 
     if use_dbt_project_package_data_dir or use_experimental_dbt_project:
         assert dagster_project_dir.joinpath(project_name, "project.py").exists()

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -1,23 +1,23 @@
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Tuple
 
 from setuptools import find_packages, setup
 
 
-def get_version() -> str:
+def get_version() -> Tuple[str, str]:
     version: Dict[str, str] = {}
     with open(Path(__file__).parent / "dagster_dbt/version.py", encoding="utf8") as fp:
         exec(fp.read(), version)
 
-    return version["__version__"]
+    return version["__version__"], version["DBT_CORE_VERSION_UPPER_BOUND"]
 
 
-ver = get_version()
+dagster_dbt_version, DBT_CORE_VERSION_UPPER_BOUND = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "1!0+dev" else f"=={ver}"
+pin = "" if dagster_dbt_version == "1!0+dev" else f"=={dagster_dbt_version}"
 setup(
     name="dagster-dbt",
-    version=ver,
+    version=dagster_dbt_version,
     author="Dagster Labs",
     author_email="hello@dagsterlabs.com",
     license="Apache-2.0",
@@ -37,7 +37,7 @@ setup(
     install_requires=[
         f"dagster{pin}",
         # Follow the version support constraints for dbt Core: https://docs.getdbt.com/docs/dbt-versions/core
-        "dbt-core>=1.6,<1.8",
+        f"dbt-core>=1.6,<{DBT_CORE_VERSION_UPPER_BOUND}",
         "Jinja2",
         "networkx",
         "orjson",


### PR DESCRIPTION
## Summary & Motivation
Make the version upper bound of the dbt adapter explicit. Don't assume that it will follow the `dbt-core` pin from `dagster-dbt`.

## How I Tested These Changes
pytest