### PR TITLE
Add `link_to_source_control_if_cloud` utility to conditionally alter code reference metadata

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -303,6 +303,26 @@ def link_to_source_control_if_cloud(
     source_control_branch: Optional[str] = None,
     repository_root_absolute_path: Optional[Union[Path, str]] = None,
 ) -> Sequence[Union["AssetsDefinition", "SourceAsset", "CacheableAssetsDefinition"]]:
+    """Wrapper function which converts local file path code references to source control URLs
+    if running in a Dagster Plus cloud environment. This is determined by the presence of
+    the `DAGSTER_CLOUD_DEPLOYMENT_NAME` environment variable. When running in any other context,
+    the local file references are left as is.
+
+    Args:
+        assets_defs (Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]):
+            The asset definitions to which source control metadata should be attached.
+            Only assets with local file code references (such as those created by
+            `with_source_code_references`) will be converted.
+        source_control_url (Optional[str]): Override base URL for the source control system. By default,
+            inferred from the `DAGSTER_CLOUD_GIT_URL` environment variable provided by cloud.
+            For example, "https://github.com/dagster-io/dagster".
+        source_control_branch (str): Override branch in the source control system, such as "master".
+            Defaults to the `DAGSTER_CLOUD_GIT_SHA` or `DAGSTER_CLOUD_GIT_BRANCH` environment variable.
+        repository_root_absolute_path (Union[Path, str]): Override path to the root of the
+            repository on disk. This is used to calculate the relative path to the source file
+            from the repository root and append it to the source control URL. By default, inferred
+            from walking up the directory tree from the code location entrypoint.
+    """
     is_dagster_cloud = os.getenv("DAGSTER_CLOUD_DEPLOYMENT_NAME") is not None
 
     if not is_dagster_cloud:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
@@ -1,6 +1,7 @@
 import os
 from typing import cast
 
+import pytest
 from dagster import AssetsDefinition, load_assets_from_modules
 from dagster._core.definitions.metadata import (
     LocalFileCodeReference,
@@ -8,7 +9,13 @@ from dagster._core.definitions.metadata import (
     link_to_source_control,
     with_source_code_references,
 )
+from dagster._core.definitions.metadata.source_code import link_to_source_control_if_cloud
+from dagster._core.types.loadable_target_origin import (
+    LoadableTargetOrigin,
+    enter_loadable_target_origin_load_context,
+)
 from dagster._utils import file_relative_path
+from dagster._utils.env import environ
 
 # path of the `dagster` package on the filesystem
 DAGSTER_PACKAGE_PATH = os.path.normpath(file_relative_path(__file__, "../../"))
@@ -137,3 +144,171 @@ def test_asset_code_origins_source_control() -> None:
                     + (expected_file_path[len(DAGSTER_PACKAGE_PATH) :])
                     + f"#L{expected_line_number}"
                 )
+
+
+def test_link_to_source_control_if_cloud_no_cloud_context() -> None:
+    from dagster_tests.asset_defs_tests import asset_package
+
+    from .asset_package import module_with_assets
+
+    collection = load_assets_from_modules([asset_package, module_with_assets])
+    collection_with_source_metadata = with_source_code_references(collection)
+    # should be a no-op since we don't have the necessary environment variables set
+    collection_with_potential_source_control_metadata = link_to_source_control_if_cloud(
+        collection_with_source_metadata
+    )
+
+    for asset in collection_with_potential_source_control_metadata:
+        if isinstance(asset, AssetsDefinition):
+            op_name = asset.op.name
+            assert op_name in EXPECTED_ORIGINS, f"Missing expected origin for op {op_name}"
+
+            expected_file_path, expected_line_number = EXPECTED_ORIGINS[op_name].split(":")
+
+            for key in asset.keys:
+                assert "dagster/code_references" in asset.metadata_by_key[key]
+
+                # `chuck_berry` is the only asset with source code metadata manually
+                # attached to it, which coexists with the automatically attached metadata
+                if op_name == "chuck_berry":
+                    assert (
+                        len(asset.metadata_by_key[key]["dagster/code_references"].code_references)
+                        == 2
+                    )
+                else:
+                    assert (
+                        len(asset.metadata_by_key[key]["dagster/code_references"].code_references)
+                        == 1
+                    )
+
+                assert isinstance(
+                    asset.metadata_by_key[key]["dagster/code_references"].code_references[-1],
+                    LocalFileCodeReference,
+                )
+                meta = cast(
+                    LocalFileCodeReference,
+                    asset.metadata_by_key[key]["dagster/code_references"].code_references[-1],
+                )
+
+                assert meta.file_path == expected_file_path
+                assert meta.line_number == int(expected_line_number)
+
+
+def test_link_to_source_control_if_cloud_cloud_context() -> None:
+    from dagster_tests.asset_defs_tests import asset_package
+
+    from .asset_package import module_with_assets
+
+    collection = load_assets_from_modules([asset_package, module_with_assets])
+    collection_with_source_metadata = with_source_code_references(collection)
+
+    # Setup the cloud context so that our code references are linked to source control
+    with environ(
+        {
+            "DAGSTER_CLOUD_DEPLOYMENT_NAME": "prod",
+            "DAGSTER_CLOUD_GIT_URL": "https://github.com/dagster-io/dagster",
+            "DAGSTER_CLOUD_GIT_BRANCH": "master",
+        }
+    ), enter_loadable_target_origin_load_context(
+        loadable_target_origin=LoadableTargetOrigin(python_file=__file__)
+    ):
+        # should link to source control since we have the necessary environment variables set
+        collection_with_source_control_metadata = link_to_source_control_if_cloud(
+            collection_with_source_metadata,
+        )
+
+        for asset in collection_with_source_control_metadata:
+            if isinstance(asset, AssetsDefinition):
+                op_name = asset.op.name
+                assert op_name in EXPECTED_ORIGINS, f"Missing expected origin for op {op_name}"
+
+                expected_file_path, expected_line_number = EXPECTED_ORIGINS[op_name].split(":")
+
+                for key in asset.keys:
+                    assert "dagster/code_references" in asset.metadata_by_key[key]
+
+                    assert isinstance(
+                        asset.metadata_by_key[key]["dagster/code_references"].code_references[-1],
+                        UrlCodeReference,
+                    )
+                    meta = cast(
+                        UrlCodeReference,
+                        asset.metadata_by_key[key]["dagster/code_references"].code_references[-1],
+                    )
+
+                    assert meta.url == (
+                        "https://github.com/dagster-io/dagster/tree/master/python_modules/dagster"
+                        + (expected_file_path[len(DAGSTER_PACKAGE_PATH) :])
+                        + f"#L{expected_line_number}"
+                    )
+
+
+def test_link_to_source_control_if_cloud_partial_cloud_context() -> None:
+    from dagster_tests.asset_defs_tests import asset_package
+
+    from .asset_package import module_with_assets
+
+    collection = load_assets_from_modules([asset_package, module_with_assets])
+    collection_with_source_metadata = with_source_code_references(collection)
+
+    # Setup the cloud context but do not provide the other necessary environment variables
+    with environ(
+        {
+            "DAGSTER_CLOUD_DEPLOYMENT_NAME": "prod",
+        }
+    ), enter_loadable_target_origin_load_context(
+        loadable_target_origin=LoadableTargetOrigin(python_file=__file__)
+    ):
+        # We lack the branch/url environment variables so this should raise an error
+        with pytest.raises(ValueError):
+            link_to_source_control_if_cloud(
+                collection_with_source_metadata,
+            )
+
+
+def test_link_to_source_control_if_cloud_override_cloud_context() -> None:
+    from dagster_tests.asset_defs_tests import asset_package
+
+    from .asset_package import module_with_assets
+
+    collection = load_assets_from_modules([asset_package, module_with_assets])
+    collection_with_source_metadata = with_source_code_references(collection)
+
+    # Setup the cloud context so that our code references are linked to source control
+    with environ(
+        {"DAGSTER_CLOUD_DEPLOYMENT_NAME": "prod"}
+    ), enter_loadable_target_origin_load_context(
+        loadable_target_origin=LoadableTargetOrigin(python_file=__file__)
+    ):
+        # should link to source control despite missing the necessary environment variables
+        # because we provide the necessary source control information as arguments
+        collection_with_source_control_metadata = link_to_source_control_if_cloud(
+            collection_with_source_metadata,
+            source_control_url="https://github.com/dagster-io/other-repo",
+            source_control_branch="main",
+        )
+
+        for asset in collection_with_source_control_metadata:
+            if isinstance(asset, AssetsDefinition):
+                op_name = asset.op.name
+                assert op_name in EXPECTED_ORIGINS, f"Missing expected origin for op {op_name}"
+
+                expected_file_path, expected_line_number = EXPECTED_ORIGINS[op_name].split(":")
+
+                for key in asset.keys:
+                    assert "dagster/code_references" in asset.metadata_by_key[key]
+
+                    assert isinstance(
+                        asset.metadata_by_key[key]["dagster/code_references"].code_references[-1],
+                        UrlCodeReference,
+                    )
+                    meta = cast(
+                        UrlCodeReference,
+                        asset.metadata_by_key[key]["dagster/code_references"].code_references[-1],
+                    )
+
+                    assert meta.url == (
+                        "https://github.com/dagster-io/other-repo/tree/main/python_modules/dagster"
+                        + (expected_file_path[len(DAGSTER_PACKAGE_PATH) :])
+                        + f"#L{expected_line_number}"
+                    )


### PR DESCRIPTION
## Summary

Adds a new `link_to_source_control_if_cloud` utility which conditionally converts local code reference metadata to URL metadata pointing at source control, automatically populated from Cloud env vars (in https://github.com/dagster-io/internal/pull/9761).


```python
defs = Definitions(
    assets=link_to_source_control_if_cloud(with_source_code_references([my_asset, my_other_asset]))
)
```

Under the hood, toggles this behavior based on presence of the `DAGSTER_CLOUD_DEPLOYMENT_NAME` env var. Infers the git root by walking the folder tree (otherwise must be explicitly provided) & the git url/hash from other Cloud-populated env vars. If any of the inferences/env vars are not present in the Cloud case, loudly errors.

## Test Plan

Unit tests.

