### PR TITLE
timewindows

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -247,6 +247,7 @@ class TimeWindow(
         start: Union[datetime, TimestampWithTimezone],
         end: Union[datetime, TimestampWithTimezone],
     ):
+        # May need to optimize this case better and store it directly on the object...
         if isinstance(start, datetime):
             start = TimestampWithTimezone.create_from_datetime(start)
 
@@ -427,15 +428,15 @@ class TimeWindowPartitionsDefinition(
 
         num_partitions = 0
         for time_window in self._iterate_time_windows(self.start):
-            if self.end and time_window.end.timestamp() > self.end.timestamp():
+            if self.end and time_window.end_timestamp > self.end.timestamp():
                 break
             if (
-                time_window.end.timestamp() <= current_timestamp
+                time_window.end_timestamp <= current_timestamp
                 or partitions_past_current_time < self.end_offset
             ):
                 num_partitions += 1
 
-                if time_window.end.timestamp() > current_timestamp:
+                if time_window.end_timestamp > current_timestamp:
                     partitions_past_current_time += 1
             else:
                 break
@@ -459,12 +460,12 @@ class TimeWindowPartitionsDefinition(
         reached_end = False
 
         for idx, time_window in enumerate(self._iterate_time_windows(self.start)):
-            if time_window.end.timestamp() >= current_timestamp:
+            if time_window.end_timestamp >= current_timestamp:
                 reached_end = True
-            if self.end and time_window.end.timestamp() > self.end.timestamp():
+            if self.end and time_window.end_timestamp > self.end.timestamp():
                 reached_end = True
             if (
-                time_window.end.timestamp() <= current_timestamp
+                time_window.end_timestamp <= current_timestamp
                 or partitions_past_current_time < self.end_offset
             ):
                 if idx >= start_idx and idx < end_idx:
@@ -472,7 +473,7 @@ class TimeWindowPartitionsDefinition(
                     partition_keys.append(
                         dst_safe_strftime(time_window.start, None, self.fmt, self.cron_schedule)
                     )
-                if time_window.end.timestamp() > current_timestamp:
+                if time_window.end_timestamp > current_timestamp:
                     partitions_past_current_time += 1
             else:
                 break
@@ -494,10 +495,10 @@ class TimeWindowPartitionsDefinition(
         partitions_past_current_time = 0
         partition_keys: List[str] = []
         for time_window in self._iterate_time_windows(self.start):
-            if self.end and time_window.end.timestamp() > self.end.timestamp():
+            if self.end and time_window.end_timestamp > self.end.timestamp():
                 break
             if (
-                time_window.end.timestamp() <= current_timestamp
+                time_window.end_timestamp <= current_timestamp
                 or partitions_past_current_time < self.end_offset
             ):
                 # datetimes from _iterate_time_windows have the correct tz so use None as a optimization
@@ -505,7 +506,7 @@ class TimeWindowPartitionsDefinition(
                     dst_safe_strftime(time_window.start, None, self.fmt, self.cron_schedule)
                 )
 
-                if time_window.end.timestamp() > current_timestamp:
+                if time_window.end_timestamp > current_timestamp:
                     partitions_past_current_time += 1
             else:
                 break
@@ -592,13 +593,13 @@ class TimeWindowPartitionsDefinition(
             if start_time_window is None or end_time_window is None:
                 check.failed("No partitions in the PartitionsDefinition")
 
-            start_timestamp = start_time_window.start.timestamp()
-            end_timestamp = end_time_window.end.timestamp()
+            start_timestamp = start_time_window.start_timestamp
+            end_timestamp = end_time_window.end_timestamp
 
             partition_key_time_windows = [
                 tw
                 for tw in partition_key_time_windows
-                if tw.start.timestamp() >= start_timestamp and tw.end.timestamp() <= end_timestamp
+                if tw.start_timestamp >= start_timestamp and tw.end_timestamp <= end_timestamp
             ]
         return partition_key_time_windows
 
@@ -625,11 +626,11 @@ class TimeWindowPartitionsDefinition(
         )
         windows_iter = iter(self._iterate_time_windows(partition_key_dt))
         next(windows_iter)
-        start_time = next(windows_iter).start
-        if start_time.timestamp() >= last_partition_window.end.timestamp():
+        next_window = next(windows_iter)
+        if next_window.start_timestamp >= last_partition_window.end_timestamp:
             return None
         else:
-            return dst_safe_strftime(start_time, None, self.fmt, self.cron_schedule)
+            return dst_safe_strftime(next_window.start, None, self.fmt, self.cron_schedule)
 
     def get_next_partition_window(
         self, end_dt: datetime, current_time: Optional[datetime] = None, respect_bounds: bool = True
@@ -642,7 +643,7 @@ class TimeWindowPartitionsDefinition(
             if last_partition_window is None:
                 return None
 
-            if next_window.start.timestamp() >= last_partition_window.end.timestamp():
+            if next_window.start_timestamp >= last_partition_window.end_timestamp:
                 return None
 
         return next_window
@@ -656,7 +657,7 @@ class TimeWindowPartitionsDefinition(
             first_partition_window = self.get_first_partition_window()
             if (
                 first_partition_window is None
-                or prev_window.start.timestamp() < first_partition_window.start.timestamp()
+                or prev_window.start_timestamp < first_partition_window.start_timestamp
             ):
                 return None
 
@@ -669,7 +670,7 @@ class TimeWindowPartitionsDefinition(
         time_window = next(iter(self._iterate_time_windows(self.start)))
 
         if self.end_offset == 0:
-            return time_window if time_window.end.timestamp() <= current_timestamp else None
+            return time_window if time_window.end_timestamp <= current_timestamp else None
         elif self.end_offset > 0:
             iterator = iter(self._iterate_time_windows(current_time))
             # first returned time window is time window of current time
@@ -678,7 +679,7 @@ class TimeWindowPartitionsDefinition(
                 curr_window_plus_offset = next(iterator)
             return (
                 time_window
-                if time_window.end.timestamp() <= curr_window_plus_offset.start.timestamp()
+                if time_window.end_timestamp <= curr_window_plus_offset.start_timestamp
                 else None
             )
         else:
@@ -691,9 +692,7 @@ class TimeWindowPartitionsDefinition(
             if end_window is None:
                 check.failed("end_window should not be None")
 
-            return (
-                time_window if time_window.end.timestamp() <= end_window.start.timestamp() else None
-            )
+            return time_window if time_window.end_timestamp <= end_window.start_timestamp else None
 
     def get_first_partition_window(
         self, current_time: Optional[datetime] = None
@@ -774,9 +773,9 @@ class TimeWindowPartitionsDefinition(
     @functools.lru_cache(maxsize=5)
     def get_partition_keys_in_time_window(self, time_window: TimeWindow) -> Sequence[str]:
         result: List[str] = []
-        time_window_end_timestamp = time_window.end.timestamp()
+        time_window_end_timestamp = time_window.end_timestamp
         for partition_time_window in self._iterate_time_windows(time_window.start):
-            if partition_time_window.start.timestamp() < time_window_end_timestamp:
+            if partition_time_window.start_timestamp < time_window_end_timestamp:
                 result.append(
                     dst_safe_strftime(
                         partition_time_window.start, self.timezone, self.fmt, self.cron_schedule
@@ -787,9 +786,9 @@ class TimeWindowPartitionsDefinition(
         return result
 
     def get_partition_key_range_for_time_window(self, time_window: TimeWindow) -> PartitionKeyRange:
-        start_partition_key = self.get_partition_key_for_timestamp(time_window.start.timestamp())
+        start_partition_key = self.get_partition_key_for_timestamp(time_window.start_timestamp)
         end_partition_key = self.get_partition_key_for_timestamp(
-            cast(TimeWindow, self.get_prev_partition_window(time_window.end)).start.timestamp()
+            cast(TimeWindow, self.get_prev_partition_window(time_window.end)).start_timestamp
         )
 
         return PartitionKeyRange(start_partition_key, end_partition_key)
@@ -959,6 +958,8 @@ class TimeWindowPartitionsDefinition(
     def _iterate_time_windows(self, start: datetime) -> Iterable[TimeWindow]:
         """Returns an infinite generator of time windows that start after the given start time."""
         start_timestamp = pendulum.instance(start, tz=self.timezone).timestamp()
+
+        # TODO This can and should just output TimestampWithTimezone rather than datetimes
         iterator = cron_string_iterator(
             start_timestamp=start_timestamp,
             cron_string=self.cron_schedule,
@@ -1049,9 +1050,9 @@ class TimeWindowPartitionsDefinition(
             first_partition_window is None
             or last_partition_window is None
             # partition starts before the first valid partition
-            or partition_start_timestamp < first_partition_window.start.timestamp()
+            or partition_start_timestamp < first_partition_window.start_timestamp
             # partition starts after the last valid partition
-            or partition_start_timestamp > last_partition_window.start.timestamp()
+            or partition_start_timestamp > last_partition_window.start_timestamp
             # partition key string does not represent the start of an actual partition
             or dst_safe_strftime(partition_start_time, self.timezone, self.fmt, self.cron_schedule)
             != partition_key
@@ -1706,21 +1707,21 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
             # no partitions
             return []
 
-        last_tw_end_timestamp = last_tw.end.timestamp()
-        first_tw_start_timestamp = first_tw.start.timestamp()
+        last_tw_end_timestamp = last_tw.end_timestamp
+        first_tw_start_timestamp = first_tw.start_timestamp
 
         if len(self.included_time_windows) == 0:
             return [TimeWindow(first_tw.start, last_tw.end)]
 
         time_windows = []
-        if first_tw_start_timestamp < self.included_time_windows[0].start.timestamp():
+        if first_tw_start_timestamp < self.included_time_windows[0].start_timestamp:
             time_windows.append(TimeWindow(first_tw.start, self.included_time_windows[0].start))
 
         for i in range(len(self.included_time_windows) - 1):
-            if self.included_time_windows[i].start.timestamp() >= last_tw_end_timestamp:
+            if self.included_time_windows[i].start_timestamp >= last_tw_end_timestamp:
                 break
-            if self.included_time_windows[i].end.timestamp() < last_tw_end_timestamp:
-                if self.included_time_windows[i + 1].start.timestamp() <= last_tw_end_timestamp:
+            if self.included_time_windows[i].end_timestamp < last_tw_end_timestamp:
+                if self.included_time_windows[i + 1].start_timestamp <= last_tw_end_timestamp:
                     time_windows.append(
                         TimeWindow(
                             self.included_time_windows[i].end,
@@ -1735,7 +1736,7 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
                         )
                     )
 
-        if last_tw_end_timestamp > self.included_time_windows[-1].end.timestamp():
+        if last_tw_end_timestamp > self.included_time_windows[-1].end_timestamp:
             time_windows.append(TimeWindow(self.included_time_windows[-1].end, last_tw.end))
 
         return time_windows
@@ -1796,22 +1797,22 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
             TimeWindowPartitionsDefinition, self.partitions_def
         ).time_windows_for_partition_keys(frozenset(partition_keys), validate=validate)
         num_added_partitions = 0
-        for window in sorted(time_windows, key=lambda tw: tw.start.timestamp()):
-            window_start_timestamp = window.start.timestamp()
+        for window in sorted(time_windows, key=lambda tw: tw.start_timestamp):
+            window_start_timestamp = window.start_timestamp
             # go in reverse order because it's more common to add partitions at the end than the
             # beginning
             for i in reversed(range(len(result_windows))):
                 included_window = result_windows[i]
-                lt_end_of_range = window_start_timestamp < included_window.end.timestamp()
-                gte_start_of_range = window_start_timestamp >= included_window.start.timestamp()
+                lt_end_of_range = window_start_timestamp < included_window.end_timestamp
+                gte_start_of_range = window_start_timestamp >= included_window.start_timestamp
 
                 if lt_end_of_range and gte_start_of_range:
                     break
 
                 if not lt_end_of_range:
-                    merge_with_range = included_window.end.timestamp() == window_start_timestamp
+                    merge_with_range = included_window.end_timestamp == window_start_timestamp
                     merge_with_later_range = i + 1 < len(result_windows) and (
-                        window.end.timestamp() == result_windows[i + 1].start.timestamp()
+                        window.end_timestamp == result_windows[i + 1].start_timestamp
                     )
 
                     if merge_with_range and merge_with_later_range:
@@ -1829,7 +1830,7 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
                     num_added_partitions += 1
                     break
             else:
-                if result_windows and window_start_timestamp == result_windows[0].start.timestamp():
+                if result_windows and window_start_timestamp == result_windows[0].start_timestamp:
                     result_windows[0] = TimeWindow(window.start, included_window.end)
                 elif result_windows and window.end == result_windows[0].start:
                     result_windows[0] = TimeWindow(window.start, included_window.end)
@@ -1847,7 +1848,7 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
                 # included_time_windows is already sorted, so no need to sort here to guarantee
                 # stable serialization between identical subsets
                 "time_windows": [
-                    (window.start.timestamp(), window.end.timestamp())
+                    (window.start_timestamp, window.end_timestamp)
                     for window in self.included_time_windows
                 ],
                 "num_partitions": self.num_partitions,
@@ -1933,11 +1934,11 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
             TimeWindowPartitionsDefinition, self.partitions_def
         ).time_window_for_partition_key(partition_key)
 
-        time_window_start_timestamp = time_window.start.timestamp()
+        time_window_start_timestamp = time_window.start_timestamp
 
         return any(
-            time_window_start_timestamp >= included_time_window.start.timestamp()
-            and time_window_start_timestamp < included_time_window.end.timestamp()
+            time_window_start_timestamp >= included_time_window.start_timestamp
+            and time_window_start_timestamp < included_time_window.end_timestamp
             for included_time_window in self.included_time_windows
         )
 
@@ -2193,7 +2194,7 @@ class TimeWindowPartitionsSubset(
         Args:
             dt_cron_schedule (str): A cron schedule that dt is on one of the ticks of.
         """
-        return self.included_time_windows[-1].end.timestamp() <= dt.timestamp()
+        return self.included_time_windows[-1].end_timestamp <= dt.timestamp()
 
     @cached_property
     def num_partitions(self) -> int:
@@ -2332,8 +2333,8 @@ def _flatten(
         low_pri_tw = low_pri_time_windows[low_pri_idx]
         high_pri_tw = high_pri_time_windows[high_pri_idx]
 
-        if low_pri_tw.time_window.start.timestamp() < high_pri_tw.time_window.start.timestamp():
-            if low_pri_tw.time_window.end.timestamp() <= high_pri_tw.time_window.start.timestamp():
+        if low_pri_tw.time_window.start_timestamp < high_pri_tw.time_window.start_timestamp:
+            if low_pri_tw.time_window.end_timestamp <= high_pri_tw.time_window.start_timestamp:
                 # low_pri_tw is entirely before high pri
                 filtered_low_pri.append(low_pri_tw)
                 low_pri_idx += 1
@@ -2349,7 +2350,7 @@ def _flatten(
                     )
                 )
 
-                if low_pri_tw.time_window.end.timestamp() > high_pri_tw.time_window.end.timestamp():
+                if low_pri_tw.time_window.end_timestamp > high_pri_tw.time_window.end_timestamp:
                     # the low pri time window will continue on the other end of the high pri
                     # and get split in two. Modify low_pri[low_pri_idx] to be
                     # the second half of the low pri time window. It will be added in the next iteration.
@@ -2363,10 +2364,10 @@ def _flatten(
                     # the rest of the low pri time window is inside the high pri time window
                     low_pri_idx += 1
         else:
-            if low_pri_tw.time_window.start.timestamp() >= high_pri_tw.time_window.end.timestamp():
+            if low_pri_tw.time_window.start_timestamp >= high_pri_tw.time_window.end_timestamp:
                 # high pri is entirely before low pri. The next high pri may overlap
                 high_pri_idx += 1
-            elif low_pri_tw.time_window.end.timestamp() <= high_pri_tw.time_window.end.timestamp():
+            elif low_pri_tw.time_window.end_timestamp <= high_pri_tw.time_window.end_timestamp:
                 # low pri is entirely within high pri, skip it
                 low_pri_idx += 1
             else:


### PR DESCRIPTION
- Expose the underlying TimestampWithTimezone objects directly on TimeWindow for performance reasons
- Access timestamp fields in TimeWindowPartitions rather than repeatedly calling it on the datetime object

## Summary & Motivation

## How I Tested These Changes
