### PR TITLE
[spec-ify-assets-def] remove TeamAssetOwner and UserAssetOwner

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -8,7 +8,7 @@ from dagster._core.definitions.asset_spec import (
     AssetExecutionType,
     AssetSpec,
 )
-from dagster._core.definitions.assets import AssetsDefinition, asset_owner_to_str
+from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.base_asset_graph import (
@@ -78,9 +78,7 @@ class AssetNode(BaseAssetNode):
 
     @property
     def owners(self) -> Sequence[str]:
-        return [
-            asset_owner_to_str(owner) for owner in self.assets_def.owners_by_key.get(self.key, [])
-        ]
+        return self.assets_def.owners_by_key.get(self.key, [])
 
     @property
     def is_partitioned(self) -> bool:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -40,7 +40,6 @@ from dagster._core.definitions import AssetIn, SourceAsset, asset, multi_asset
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.definitions.assets import TeamAssetOwner, UserAssetOwner
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.decorators.asset_decorator import graph_asset
 from dagster._core.definitions.events import AssetMaterialization
@@ -2122,7 +2121,7 @@ def test_asset_owners():
     def my_asset():
         pass
 
-    owners = [TeamAssetOwner("team1"), UserAssetOwner("claire@dagsterlabs.com")]
+    owners = ["team:team1", "claire@dagsterlabs.com"]
     assert my_asset.owners_by_key == {my_asset.key: owners}
     assert my_asset.with_attributes().owners_by_key == {my_asset.key: owners}  # copies ok
 
@@ -2176,8 +2175,8 @@ def test_multi_asset_owners():
         pass
 
     assert my_multi_asset.owners_by_key == {
-        AssetKey("out1"): [TeamAssetOwner("team1"), UserAssetOwner("user@dagsterlabs.com")],
-        AssetKey("out2"): [UserAssetOwner("user2@dagsterlabs.com")],
+        AssetKey("out1"): ["team:team1", "user@dagsterlabs.com"],
+        AssetKey("out2"): ["user2@dagsterlabs.com"],
     }
 
 
@@ -2192,16 +2191,16 @@ def test_replace_asset_keys_for_asset_with_owners():
         pass
 
     assert my_multi_asset.owners_by_key == {
-        AssetKey("out1"): [UserAssetOwner("user@dagsterlabs.com")],
-        AssetKey("out2"): [UserAssetOwner("user@dagsterlabs.com")],
+        AssetKey("out1"): ["user@dagsterlabs.com"],
+        AssetKey("out2"): ["user@dagsterlabs.com"],
     }
 
     prefixed_asset = my_multi_asset.with_attributes(
         output_asset_key_replacements={AssetKey(["out1"]): AssetKey(["prefix", "out1"])}
     )
     assert prefixed_asset.owners_by_key == {
-        AssetKey(["prefix", "out1"]): [UserAssetOwner("user@dagsterlabs.com")],
-        AssetKey("out2"): [UserAssetOwner("user@dagsterlabs.com")],
+        AssetKey(["prefix", "out1"]): ["user@dagsterlabs.com"],
+        AssetKey("out2"): ["user@dagsterlabs.com"],
     }
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -41,7 +41,6 @@ from dagster._core.definitions import (
     asset,
     multi_asset,
 )
-from dagster._core.definitions.assets import TeamAssetOwner, UserAssetOwner
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.decorators.config_mapping_decorator import config_mapping
 from dagster._core.definitions.policy import RetryPolicy
@@ -915,10 +914,7 @@ def test_graph_asset_with_args():
         maximum_lag_minutes=5
     )
     assert my_asset.tags_by_key[AssetKey("my_asset")] == {"foo": "bar"}
-    assert my_asset.owners_by_key[AssetKey("my_asset")] == [
-        TeamAssetOwner("team1"),
-        UserAssetOwner("claire@dagsterlabs.com"),
-    ]
+    assert my_asset.owners_by_key[AssetKey("my_asset")] == ["team:team1", "claire@dagsterlabs.com"]
     assert (
         my_asset.auto_materialize_policies_by_key[AssetKey("my_asset")]
         == AutoMaterializePolicy.lazy()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -21,7 +21,6 @@ from dagster import (
     asset,
     materialize,
 )
-from dagster._core.definitions.assets import UserAssetOwner
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster._core.execution.context.compute import AssetExecutionContext
 from dagster._core.types.dagster_type import DagsterType
@@ -512,11 +511,11 @@ def test_with_tag_replacements(test_jaffle_shop_manifest: Dict[str, Any]) -> Non
 
 
 def test_with_owner_replacements(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
-    expected_owners = [UserAssetOwner("custom@custom.com")]
+    expected_owners = ["custom@custom.com"]
 
     class CustomDagsterDbtTranslator(DagsterDbtTranslator):
         def get_owners(self, _: Mapping[str, Any]) -> Optional[Sequence[str]]:
-            return [owner.email for owner in expected_owners]
+            return expected_owners
 
     @dbt_assets(
         manifest=test_jaffle_shop_manifest, dagster_dbt_translator=CustomDagsterDbtTranslator()
@@ -649,9 +648,9 @@ def test_dbt_config_tags(test_meta_config_manifest: Dict[str, Any]) -> None:
 
 
 def test_dbt_meta_owners(test_meta_config_manifest: Dict[str, Any]) -> None:
-    expected_dbt_model_owners = [UserAssetOwner("kafka@amerika.com")]
-    expected_dbt_seed_owners = [UserAssetOwner("kafka@judgment.com")]
-    expected_dagster_owners = [UserAssetOwner("kafka@castle.com")]
+    expected_dbt_model_owners = ["kafka@amerika.com"]
+    expected_dbt_seed_owners = ["kafka@judgment.com"]
+    expected_dagster_owners = ["kafka@castle.com"]
 
     @dbt_assets(manifest=test_meta_config_manifest)
     def my_dbt_assets(): ...

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/test_asset_decorator.py
@@ -3,7 +3,6 @@ from typing import Any, Mapping, Optional, Sequence, Tuple
 
 import pytest
 from dagster import AssetKey
-from dagster._core.definitions.assets import UserAssetOwner
 from dagster_looker.asset_decorator import looker_assets
 from dagster_looker.dagster_looker_translator import DagsterLookerTranslator, LookMLStructureType
 
@@ -372,11 +371,11 @@ def test_with_group_replacements() -> None:
 
 
 def test_with_owner_replacements() -> None:
-    expected_owners = [UserAssetOwner("custom@custom.com")]
+    expected_owners = ["custom@custom.com"]
 
     class CustomDagsterLookerTranslator(DagsterLookerTranslator):
         def get_owners(self, _) -> Optional[Sequence[str]]:
-            return [owner.email for owner in expected_owners]
+            return expected_owners
 
     @looker_assets(
         project_dir=test_retail_demo_path,


### PR DESCRIPTION
## Summary & Motivation

Background:
- When someone provides an owner string to an `AssetsDefinition`, we internally convert it into either a `TeamAssetOwner` or a `UserAssetOwner`.
- These are not publicly exposed classes.
- Before sending owners over the wire, we convert them back into strings.
- I'm trying to replace the swarm of dictionaries in `AssetsDefinition` with a single `dict[AssetKey, AssetSpec]`.
- `AssetSpec` represents owners as strings, not `TeamAssetOwner` or `UserAssetOwner`.

This PR proposes removing these classes for the time being, which allows us to move forward with `AssetsDefinition` replacement without complicating `AssetSpec`s.

In retrospect, I think adding these classes was a little bit premature. Until we are ready to expose them publicly and finalize those APIs, I think it introduces internal complexity without much benefit.

## How I Tested These Changes
