### PR TITLE
serialize team owners with prefix

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -405,12 +405,19 @@ class GrapheneAssetNode(graphene.ObjectType):
             opVersion=external_asset_node.code_version,
             groupName=external_asset_node.group_name,
             owners=[
-                GrapheneUserAssetOwner(email=owner)
-                if is_valid_email(owner)
-                else GrapheneTeamAssetOwner(team=owner)
+                self._graphene_asset_owner_from_owner_str(owner)
                 for owner in (external_asset_node.owners or [])
             ],
         )
+
+    def _graphene_asset_owner_from_owner_str(
+        self, owner_str: str
+    ) -> Union[GrapheneUserAssetOwner, GrapheneTeamAssetOwner]:
+        if is_valid_email(owner_str):
+            return GrapheneUserAssetOwner(email=owner_str)
+        else:
+            check.invariant(owner_str.startswith("team:"))
+            return GrapheneTeamAssetOwner(team=owner_str[5:])
 
     @property
     def repository_location(self) -> CodeLocation:

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -96,7 +96,7 @@ def asset_owner_to_str(owner: AssetOwner) -> str:
     if isinstance(owner, UserAssetOwner):
         return owner.email
     elif isinstance(owner, TeamAssetOwner):
-        return owner.team
+        return f"team:{owner.team}"
     else:
         check.failed(f"Unexpected owner type {type(owner)}")
 


### PR DESCRIPTION
## Summary & Motivation

When a user provides the owner string "team:x", we serialize it on the ExternalAssetNode as just "x". This limits our flexibility to allow unprefixed owner strings to mean other things in the future.

With this change, user-provided owner strings like "team:x" are now serialized as "team:x".

This change also handles the backcompat case where an older version of Dagster sends over an ExternalAssetNode with a "team:"-less owner.

## How I Tested These Changes
