### PR TITLE
[spec-ify-assets-def] remove `descriptions_by_key` arg to `AssetsDefinition.with_attributes`

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -405,12 +405,19 @@ class GrapheneAssetNode(graphene.ObjectType):
             opVersion=external_asset_node.code_version,
             groupName=external_asset_node.group_name,
             owners=[
-                GrapheneUserAssetOwner(email=owner)
-                if is_valid_email(owner)
-                else GrapheneTeamAssetOwner(team=owner)
+                self._graphene_asset_owner_from_owner_str(owner)
                 for owner in (external_asset_node.owners or [])
             ],
         )
+
+    def _graphene_asset_owner_from_owner_str(
+        self, owner_str: str
+    ) -> Union[GrapheneUserAssetOwner, GrapheneTeamAssetOwner]:
+        if is_valid_email(owner_str):
+            return GrapheneUserAssetOwner(email=owner_str)
+        else:
+            check.invariant(owner_str.startswith("team:"))
+            return GrapheneTeamAssetOwner(team=owner_str[5:])
 
     @property
     def repository_location(self) -> CodeLocation:

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -8,7 +8,7 @@ from dagster._core.definitions.asset_spec import (
     AssetExecutionType,
     AssetSpec,
 )
-from dagster._core.definitions.assets import AssetsDefinition, asset_owner_to_str
+from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.base_asset_graph import (
@@ -78,9 +78,7 @@ class AssetNode(BaseAssetNode):
 
     @property
     def owners(self) -> Sequence[str]:
-        return [
-            asset_owner_to_str(owner) for owner in self.assets_def.owners_by_key.get(self.key, [])
-        ]
+        return self.assets_def.owners_by_key.get(self.key, [])
 
     @property
     def is_partitioned(self) -> bool:

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -96,7 +96,7 @@ def asset_owner_to_str(owner: AssetOwner) -> str:
     if isinstance(owner, UserAssetOwner):
         return owner.email
     elif isinstance(owner, TeamAssetOwner):
-        return owner.team
+        return f"team:{owner.team}"
     else:
         check.failed(f"Unexpected owner type {type(owner)}")
 

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1080,7 +1080,6 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         output_asset_key_replacements: Optional[Mapping[AssetKey, AssetKey]] = None,
         input_asset_key_replacements: Optional[Mapping[AssetKey, AssetKey]] = None,
         group_names_by_key: Optional[Mapping[AssetKey, str]] = None,
-        descriptions_by_key: Optional[Mapping[AssetKey, str]] = None,
         metadata_by_key: Optional[Mapping[AssetKey, ArbitraryMetadataMapping]] = None,
         tags_by_key: Optional[Mapping[AssetKey, Mapping[str, str]]] = None,
         freshness_policy: Optional[
@@ -1107,9 +1106,6 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         )
         group_names_by_key = check.opt_mapping_param(
             group_names_by_key, "group_names_by_key", key_type=AssetKey, value_type=str
-        )
-        descriptions_by_key = check.opt_mapping_param(
-            descriptions_by_key, "descriptions_by_key", key_type=AssetKey, value_type=str
         )
         metadata_by_key = check.opt_mapping_param(
             metadata_by_key, "metadata_by_key", key_type=AssetKey, value_type=dict
@@ -1189,7 +1185,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
 
         replaced_descriptions_by_key = {
             output_asset_key_replacements.get(key, key): description
-            for key, description in descriptions_by_key.items()
+            for key, description in self.descriptions_by_key.items()
         }
 
         if not metadata_by_key:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -40,7 +40,6 @@ from dagster._core.definitions import AssetIn, SourceAsset, asset, multi_asset
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.definitions.assets import TeamAssetOwner, UserAssetOwner
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.decorators.asset_decorator import graph_asset
 from dagster._core.definitions.events import AssetMaterialization
@@ -2122,7 +2121,7 @@ def test_asset_owners():
     def my_asset():
         pass
 
-    owners = [TeamAssetOwner("team1"), UserAssetOwner("claire@dagsterlabs.com")]
+    owners = ["team:team1", "claire@dagsterlabs.com"]
     assert my_asset.owners_by_key == {my_asset.key: owners}
     assert my_asset.with_attributes().owners_by_key == {my_asset.key: owners}  # copies ok
 
@@ -2176,8 +2175,8 @@ def test_multi_asset_owners():
         pass
 
     assert my_multi_asset.owners_by_key == {
-        AssetKey("out1"): [TeamAssetOwner("team1"), UserAssetOwner("user@dagsterlabs.com")],
-        AssetKey("out2"): [UserAssetOwner("user2@dagsterlabs.com")],
+        AssetKey("out1"): ["team:team1", "user@dagsterlabs.com"],
+        AssetKey("out2"): ["user2@dagsterlabs.com"],
     }
 
 
@@ -2192,16 +2191,16 @@ def test_replace_asset_keys_for_asset_with_owners():
         pass
 
     assert my_multi_asset.owners_by_key == {
-        AssetKey("out1"): [UserAssetOwner("user@dagsterlabs.com")],
-        AssetKey("out2"): [UserAssetOwner("user@dagsterlabs.com")],
+        AssetKey("out1"): ["user@dagsterlabs.com"],
+        AssetKey("out2"): ["user@dagsterlabs.com"],
     }
 
     prefixed_asset = my_multi_asset.with_attributes(
         output_asset_key_replacements={AssetKey(["out1"]): AssetKey(["prefix", "out1"])}
     )
     assert prefixed_asset.owners_by_key == {
-        AssetKey(["prefix", "out1"]): [UserAssetOwner("user@dagsterlabs.com")],
-        AssetKey("out2"): [UserAssetOwner("user@dagsterlabs.com")],
+        AssetKey(["prefix", "out1"]): ["user@dagsterlabs.com"],
+        AssetKey("out2"): ["user@dagsterlabs.com"],
     }
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -26,7 +26,6 @@ from dagster import (
     define_asset_job,
     fs_io_manager,
     graph,
-    graph_multi_asset,
     io_manager,
     job,
     materialize,
@@ -167,68 +166,6 @@ def test_retain_group():
         output_asset_key_replacements={AssetKey(["bar"]): AssetKey(["baz"])}
     )
     assert replaced.group_names_by_key[AssetKey("baz")] == "foo"
-
-
-def test_with_replaced_description() -> None:
-    @multi_asset(
-        outs={
-            "foo": AssetOut(description="foo"),
-            "bar": AssetOut(description="bar"),
-            "baz": AssetOut(description="baz"),
-        }
-    )
-    def abc(): ...
-
-    assert abc.descriptions_by_key == {
-        AssetKey("foo"): "foo",
-        AssetKey("bar"): "bar",
-        AssetKey("baz"): "baz",
-    }
-
-    # If there's no replacement description for the asset key, the original description is retained.
-    replaced = abc.with_attributes(descriptions_by_key={})
-    assert replaced.descriptions_by_key == {
-        AssetKey("foo"): "foo",
-        AssetKey("bar"): "bar",
-        AssetKey("baz"): "baz",
-    }
-
-    # Otherwise, use the replaced description.
-    replaced = abc.with_attributes(descriptions_by_key={AssetKey(["bar"]): "bar_prime"})
-    assert replaced.descriptions_by_key == {
-        AssetKey("foo"): "foo",
-        AssetKey("bar"): "bar_prime",
-        AssetKey("baz"): "baz",
-    }
-
-    @op
-    def op1(): ...
-
-    @op
-    def op2(): ...
-
-    @graph_multi_asset(
-        outs={"foo": AssetOut(description="foo"), "bar": AssetOut(description="bar")}
-    )
-    def abc_graph():
-        return {"foo": op1(), "bar": op2()}
-
-    assert abc_graph.descriptions_by_key == {
-        AssetKey("foo"): "foo",
-        AssetKey("bar"): "bar",
-    }
-
-    replaced = abc_graph.with_attributes(descriptions_by_key={})
-    assert replaced.descriptions_by_key == {
-        AssetKey("foo"): "foo",
-        AssetKey("bar"): "bar",
-    }
-
-    replaced = abc_graph.with_attributes(descriptions_by_key={AssetKey(["bar"]): "bar_prime"})
-    assert replaced.descriptions_by_key == {
-        AssetKey("foo"): "foo",
-        AssetKey("bar"): "bar_prime",
-    }
 
 
 def test_with_replaced_metadata() -> None:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -41,7 +41,6 @@ from dagster._core.definitions import (
     asset,
     multi_asset,
 )
-from dagster._core.definitions.assets import TeamAssetOwner, UserAssetOwner
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.decorators.config_mapping_decorator import config_mapping
 from dagster._core.definitions.policy import RetryPolicy
@@ -915,10 +914,7 @@ def test_graph_asset_with_args():
         maximum_lag_minutes=5
     )
     assert my_asset.tags_by_key[AssetKey("my_asset")] == {"foo": "bar"}
-    assert my_asset.owners_by_key[AssetKey("my_asset")] == [
-        TeamAssetOwner("team1"),
-        UserAssetOwner("claire@dagsterlabs.com"),
-    ]
+    assert my_asset.owners_by_key[AssetKey("my_asset")] == ["team:team1", "claire@dagsterlabs.com"]
     assert (
         my_asset.auto_materialize_policies_by_key[AssetKey("my_asset")]
         == AutoMaterializePolicy.lazy()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -21,7 +21,6 @@ from dagster import (
     asset,
     materialize,
 )
-from dagster._core.definitions.assets import UserAssetOwner
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster._core.execution.context.compute import AssetExecutionContext
 from dagster._core.types.dagster_type import DagsterType
@@ -512,11 +511,11 @@ def test_with_tag_replacements(test_jaffle_shop_manifest: Dict[str, Any]) -> Non
 
 
 def test_with_owner_replacements(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
-    expected_owners = [UserAssetOwner("custom@custom.com")]
+    expected_owners = ["custom@custom.com"]
 
     class CustomDagsterDbtTranslator(DagsterDbtTranslator):
         def get_owners(self, _: Mapping[str, Any]) -> Optional[Sequence[str]]:
-            return [owner.email for owner in expected_owners]
+            return expected_owners
 
     @dbt_assets(
         manifest=test_jaffle_shop_manifest, dagster_dbt_translator=CustomDagsterDbtTranslator()
@@ -649,9 +648,9 @@ def test_dbt_config_tags(test_meta_config_manifest: Dict[str, Any]) -> None:
 
 
 def test_dbt_meta_owners(test_meta_config_manifest: Dict[str, Any]) -> None:
-    expected_dbt_model_owners = [UserAssetOwner("kafka@amerika.com")]
-    expected_dbt_seed_owners = [UserAssetOwner("kafka@judgment.com")]
-    expected_dagster_owners = [UserAssetOwner("kafka@castle.com")]
+    expected_dbt_model_owners = ["kafka@amerika.com"]
+    expected_dbt_seed_owners = ["kafka@judgment.com"]
+    expected_dagster_owners = ["kafka@castle.com"]
 
     @dbt_assets(manifest=test_meta_config_manifest)
     def my_dbt_assets(): ...

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/test_asset_decorator.py
@@ -3,7 +3,6 @@ from typing import Any, Mapping, Optional, Sequence, Tuple
 
 import pytest
 from dagster import AssetKey
-from dagster._core.definitions.assets import UserAssetOwner
 from dagster_looker.asset_decorator import looker_assets
 from dagster_looker.dagster_looker_translator import DagsterLookerTranslator, LookMLStructureType
 
@@ -372,11 +371,11 @@ def test_with_group_replacements() -> None:
 
 
 def test_with_owner_replacements() -> None:
-    expected_owners = [UserAssetOwner("custom@custom.com")]
+    expected_owners = ["custom@custom.com"]
 
     class CustomDagsterLookerTranslator(DagsterLookerTranslator):
         def get_owners(self, _) -> Optional[Sequence[str]]:
-            return [owner.email for owner in expected_owners]
+            return expected_owners
 
     @looker_assets(
         project_dir=test_retail_demo_path,


### PR DESCRIPTION
## Summary & Motivation

This arg isn't used anywhere in the codebase, and it functions differently than the other args on `with_attributes` (overrides the prior value on conflicts, instead of erroring).

## How I Tested These Changes
