### PR TITLE
Eliminate legacy_context reference in RuleCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/rule_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/rule_condition.py
@@ -28,11 +28,9 @@ class RuleCondition(AssetCondition):
         return self.rule.description
 
     def evaluate(self, context: SchedulingContext) -> SchedulingResult:
-        context.legacy_context.root_context.logger.debug(
-            f"Evaluating rule: {self.rule.to_snapshot()}"
-        )
+        context.logger.debug(f"Evaluating rule: {self.rule.to_snapshot()}")
         evaluation_result = self.rule.evaluate_for_asset(context)
-        context.legacy_context.root_context.logger.debug(
+        context.logger.debug(
             f"Rule returned {evaluation_result.true_subset.size} partitions "
             f"({evaluation_result.end_timestamp - evaluation_result.start_timestamp:.2f} seconds)"
         )


### PR DESCRIPTION
## Summary & Motivation

This is series of changes to make us more disciplined about accessing the `legacy_context`. Here just getting the top-level logger.

## How I Tested These Changes

BK