### PR TITLE
Create NonAGVInstanceInterface to avoid accessing legacy_context directly in SchedulingContext

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/updated_since_cron_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/updated_since_cron_condition.py
@@ -38,11 +38,9 @@ class UpdatedSinceCronCondition(SchedulingCondition):
             or context.previous_evaluation_node.candidate_slice != context.candidate_slice
         ):
             # do a full recomputation
-            updated_subset = (
-                context.legacy_context.instance_queryer.get_asset_subset_updated_after_time(
-                    asset_key=context.asset_key,
-                    after_time=previous_cron_tick,
-                )
+            updated_subset = context.non_agv_instance_interface.get_asset_subset_updated_after_time(
+                asset_key=context.asset_key,
+                after_time=previous_cron_tick,
             )
             # TODO: implement this on the AssetGraphView
             true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(updated_subset)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
@@ -100,7 +100,7 @@ class SchedulingContext(NamedTuple):
             previous_evaluation_info=previous_evaluation_info,
             current_tick_evaluation_info_by_key=current_tick_evaluation_info_by_key,
             inner_legacy_context=legacy_context,
-            non_agv_instance_interface=NonAGVInstanceInterface(),
+            non_agv_instance_interface=NonAGVInstanceInterface(asset_graph_view._queryer),  # noqa
         )
 
     def for_child_condition(


### PR DESCRIPTION
## Summary & Motivation

This class exists purely for organizational purposes. I want to whitelist all the interacts that scheduling conditions do outside of the `AssetGraphView` system. The means no scheduling conditions directly access the queryer.

## How I Tested These Changes

BK
