### PR TITLE
Add long but public access to we can get instance queryer instance off of AssetGraphView

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -326,6 +326,13 @@ class AssetGraphView:
     def _queryer(self) -> "CachingInstanceQueryer":
         return self._stale_resolver.instance_queryer
 
+    # In our transitional period there are lots of code path that take
+    # a AssetGraphView and then call methods on the queryer. This is
+    # formal accesor to we can do this legally, instead of using noqa accesses
+    # of a private proeprty
+    def get_inner_queryer_for_back_compat(self) -> "CachingInstanceQueryer":
+        return self._queryer
+
     def _get_partitions_def(self, asset_key: "AssetKey") -> Optional["PartitionsDefinition"]:
         return self.asset_graph.get(asset_key).partitions_def
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_condition_evaluator.py
@@ -92,7 +92,7 @@ class AssetConditionEvaluator:
 
     @property
     def instance_queryer(self) -> "CachingInstanceQueryer":
-        return self.asset_graph_view._queryer  # noqa: SLF001
+        return self.asset_graph_view.get_inner_queryer_for_back_compat()
 
     def evaluate(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
@@ -100,7 +100,9 @@ class SchedulingContext(NamedTuple):
             previous_evaluation_info=previous_evaluation_info,
             current_tick_evaluation_info_by_key=current_tick_evaluation_info_by_key,
             inner_legacy_context=legacy_context,
-            non_agv_instance_interface=NonAGVInstanceInterface(asset_graph_view._queryer),  # noqa
+            non_agv_instance_interface=NonAGVInstanceInterface(
+                asset_graph_view.get_inner_queryer_for_back_compat()
+            ),
         )
 
     def for_child_condition(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_user_space_ds_api.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_user_space_ds_api.py
@@ -21,7 +21,9 @@ class SchedulingTickResult(NamedTuple):
 def execute_ds_tick(defs: Definitions) -> SchedulingTickResult:
     asset_graph = defs.get_asset_graph()
     asset_graph_view = AssetGraphView.for_test(defs)
-    data_time_resolver = CachingDataTimeResolver(asset_graph_view._queryer)  # noqa
+    data_time_resolver = CachingDataTimeResolver(
+        asset_graph_view.get_inner_queryer_for_back_compat()
+    )
 
     evaluator = AssetConditionEvaluator(
         asset_graph=asset_graph,


### PR DESCRIPTION
## Summary & Motivation

Add supported, public, but awkwardly named method to access the inner queryer from an `AssetGraphView`. This is better than status quo of using `noqa` IMO.

## How I Tested These Changes

BK