### PR TITLE
Disallow legacy access in SchedulingCondiitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/rule_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/rule_condition.py
@@ -29,6 +29,7 @@ class RuleCondition(AssetCondition):
 
     def evaluate(self, context: SchedulingContext) -> SchedulingResult:
         context.logger.debug(f"Evaluating rule: {self.rule.to_snapshot()}")
+        # Allow for access to legacy context in legacy rule evaluation
         evaluation_result = self.rule.evaluate_for_asset(context._replace(allow_legacy_access=True))
         context.logger.debug(
             f"Rule returned {evaluation_result.true_subset.size} partitions "

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/rule_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/rule_condition.py
@@ -29,7 +29,7 @@ class RuleCondition(AssetCondition):
 
     def evaluate(self, context: SchedulingContext) -> SchedulingResult:
         context.logger.debug(f"Evaluating rule: {self.rule.to_snapshot()}")
-        evaluation_result = self.rule.evaluate_for_asset(context)
+        evaluation_result = self.rule.evaluate_for_asset(context._replace(allow_legacy_access=True))
         context.logger.debug(
             f"Rule returned {evaluation_result.true_subset.size} partitions "
             f"({evaluation_result.end_timestamp - evaluation_result.start_timestamp:.2f} seconds)"

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
@@ -188,7 +188,9 @@ class SchedulingContext(NamedTuple):
         return (
             self.inner_legacy_context
             if self.allow_legacy_access
-            else check.failed("Legacy access only allow in auto_materialize_rules_impls.py")
+            else check.failed(
+                "Legacy access only allowed in AutoMaterializeRule subclasses in auto_materialize_rules_impls.py"
+            )
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
@@ -90,6 +90,7 @@ class SchedulingContext(NamedTuple):
 
     # hack to avoid circular references during pydantic validation
     inner_legacy_context: Any
+    allow_legacy_access: bool
 
     @staticmethod
     def create(
@@ -120,6 +121,7 @@ class SchedulingContext(NamedTuple):
             non_agv_instance_interface=NonAGVInstanceInterface(
                 asset_graph_view.get_inner_queryer_for_back_compat()
             ),
+            allow_legacy_access=False,
         )
 
     def for_child_condition(
@@ -137,7 +139,7 @@ class SchedulingContext(NamedTuple):
             logger=self.logger,
             previous_evaluation_info=self.previous_evaluation_info,
             current_tick_evaluation_info_by_key=self.current_tick_evaluation_info_by_key,
-            inner_legacy_context=self.legacy_context.for_child(
+            inner_legacy_context=self.inner_legacy_context.for_child(
                 child_condition,
                 child_condition.get_unique_id(
                     parent_unique_id=self.condition_unique_id, index=child_index
@@ -145,6 +147,7 @@ class SchedulingContext(NamedTuple):
                 candidate_slice.convert_to_valid_asset_subset(),
             ),
             non_agv_instance_interface=self.non_agv_instance_interface,
+            allow_legacy_access=self.allow_legacy_access,
         )
 
     @property
@@ -182,7 +185,11 @@ class SchedulingContext(NamedTuple):
 
     @property
     def legacy_context(self) -> LegacyRuleEvaluationContext:
-        return self.inner_legacy_context
+        return (
+            self.inner_legacy_context
+            if self.allow_legacy_access
+            else check.failed("Legacy access only allow in auto_materialize_rules_impls.py")
+        )
 
     @property
     def previous_requested_slice(self) -> Optional[AssetSlice]:
@@ -216,4 +223,4 @@ class SchedulingContext(NamedTuple):
     @property
     def new_max_storage_id(self) -> Optional[int]:
         # TODO: pull this from the AssetGraphView instead
-        return self.legacy_context.new_max_storage_id
+        return self.inner_legacy_context.new_max_storage_id


### PR DESCRIPTION
## Summary & Motivation

Added a tripwire to accessing the legacy context object that is enabled by default. When calling into `evaluate_for_asset` on legacy auto-materialize rules we enable access

## How I Tested These Changes

BK
