### PR TITLE
RFC: Add a serializable argument class in preparation for invocation across a process boundary

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -21,9 +21,14 @@ import pendulum
 
 import dagster._check as check
 from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView, TemporalContext
+
+# from dagster._core.definitions.asset_condition_evaluator import AssetConditionEvaluatorArguments
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.data_version import CachingStaleStatusResolver
+from dagster._core.definitions.declarative_scheduling.scheduling_condition_evaluator import (
+    SchedulingConditionEvaluatorArguments,
+)
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.time_window_partitions import (
@@ -199,13 +204,15 @@ class AssetDaemonContext:
 
         evaluator = SchedulingConditionEvaluator(
             asset_graph=self.asset_graph,
-            asset_keys=self.auto_materialize_asset_keys,
             asset_graph_view=self.asset_graph_view,
             logger=self._logger,
-            cursor=self.cursor,
             data_time_resolver=self.data_time_resolver,
-            respect_materialization_data_versions=self.respect_materialization_data_versions,
-            auto_materialize_run_tags=self.auto_materialize_run_tags,
+            evaluator_arguments=SchedulingConditionEvaluatorArguments(
+                cursor=self.cursor,
+                asset_keys=self.auto_materialize_asset_keys,
+                respect_materialization_data_versions=self.respect_materialization_data_versions,
+                auto_materialize_run_tags=self.auto_materialize_run_tags,
+            ),
         )
         return evaluator.evaluate()
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition_evaluator.py
@@ -26,6 +26,7 @@ from dagster._core.definitions.declarative_scheduling.scheduling_evaluation_info
     SchedulingEvaluationInfo,
 )
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._serdes.serdes import whitelist_for_serdes
 
 from ..asset_daemon_cursor import AssetDaemonCursor
 from ..base_asset_graph import BaseAssetGraph
@@ -45,39 +46,51 @@ if TYPE_CHECKING:
 from dataclasses import dataclass
 
 
+@whitelist_for_serdes
+@dataclass(frozen=True)
+# These are the arguments the evaluator that would be arguments if
+# the evaluator was across a serialization boundary (e.g. RPC)
+class SchedulingConditionEvaluatorArguments:
+    asset_keys: AbstractSet[AssetKey]
+    cursor: AssetDaemonCursor
+    # https://linear.app/dagster-labs/issue/FOU-210/figure-out-future-of-respect-materialization-data-versions
+    respect_materialization_data_versions: bool
+    # Mapping from run tags to values that should be automatically added run emitted by
+    # the declarative scheduling system. This ends up getting sources from places such
+    # as https://docs.dagster.io/deployment/dagster-instance#auto-materialize
+    # Should this be a supported feature in DS?
+    auto_materialize_run_tags: Mapping[str, str]
+
+
 @dataclass
 class SchedulingConditionEvaluator:
     def __init__(
         self,
         *,
         asset_graph: BaseAssetGraph,
-        asset_keys: AbstractSet[AssetKey],
         asset_graph_view: AssetGraphView,
         logger: logging.Logger,
-        cursor: AssetDaemonCursor,
         data_time_resolver: CachingDataTimeResolver,
-        respect_materialization_data_versions: bool,
-        # Mapping from run tags to values that should be automatically added run emitted by
-        # the declarative scheduling system. This ends up getting sources from places such
-        # as https://docs.dagster.io/deployment/dagster-instance#auto-materialize
-        # Should this be a supported feature in DS?
-        auto_materialize_run_tags: Mapping[str, str],
+        evaluator_arguments: SchedulingConditionEvaluatorArguments,
     ):
         self.asset_graph = asset_graph
-        self.asset_keys = asset_keys
         self.asset_graph_view = asset_graph_view
         self.logger = logger
-        self.cursor = cursor
         self.data_time_resolver = data_time_resolver
-        self.respect_materialization_data_versions = respect_materialization_data_versions
-        self.auto_materialize_run_tags = auto_materialize_run_tags
+
+        self.asset_keys = evaluator_arguments.asset_keys
+        self.cursor = evaluator_arguments.cursor
+        self.respect_materialization_data_versions = (
+            evaluator_arguments.respect_materialization_data_versions
+        )
+        self.auto_materialize_run_tags = evaluator_arguments.auto_materialize_run_tags
 
         self.evaluation_state_by_key = {}
         self.current_evaluation_info_by_key = {}
         self.expected_data_time_mapping = defaultdict()
         self.to_request = set()
         self.num_checked_assets = 0
-        self.num_asset_keys = len(asset_keys)
+        self.num_asset_keys = len(self.asset_keys)
 
     asset_graph: BaseAssetGraph
     asset_keys: AbstractSet[AssetKey]

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_user_space_ds_api.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_user_space_ds_api.py
@@ -7,6 +7,7 @@ from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.declarative_scheduling.scheduling_condition_evaluator import (
     SchedulingConditionEvaluator,
+    SchedulingConditionEvaluatorArguments,
 )
 from dagster._core.definitions.declarative_scheduling.serialized_objects import (
     AssetConditionEvaluationState,
@@ -29,13 +30,15 @@ def execute_ds_tick(defs: Definitions) -> SchedulingTickResult:
 
     evaluator = SchedulingConditionEvaluator(
         asset_graph=asset_graph,
-        asset_keys=asset_graph.all_asset_keys,
         asset_graph_view=asset_graph_view,
         logger=logging.getLogger(__name__),
         data_time_resolver=data_time_resolver,
-        cursor=AssetDaemonCursor.empty(),
-        respect_materialization_data_versions=True,
-        auto_materialize_run_tags={},
+        evaluator_arguments=SchedulingConditionEvaluatorArguments(
+            asset_keys=asset_graph.all_asset_keys,
+            cursor=AssetDaemonCursor.empty(),
+            respect_materialization_data_versions=True,
+            auto_materialize_run_tags={},
+        ),
     )
     result = evaluator.evaluate()
 


### PR DESCRIPTION
## Summary & Motivation

Preparing for user-space execution of AMP rules.  This separates arguments into ones that might be serialized by the daemon and passed to user space. The other arguments (e.g. `AssetGraphView`) can be reconstructed in the user process

## How I Tested These Changes

BK
