### PR TITLE
Actually virtualize concurrency page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
@@ -120,7 +120,7 @@ export const InstanceConcurrencyPageContent = React.memo(() => {
 export const InstanceConcurrencyPage = () => {
   const {pageTitle} = React.useContext(InstancePageContext);
   return (
-    <Page>
+    <Page style={{padding: 0}}>
       <PageHeader
         title={<Heading>{pageTitle}</Heading>}
         tabs={<InstanceTabs tab="concurrency" />}

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrency.tsx
@@ -282,9 +282,13 @@ export const ConcurrencyLimits = ({
     onSelectKey(undefined);
   }, [onSelectKey]);
 
+  const [search, setSearch] = React.useState('');
+
   const sortedKeys = React.useMemo(() => {
-    return [...concurrencyKeys].sort((a, b) => COMMON_COLLATOR.compare(a, b));
-  }, [concurrencyKeys]);
+    return [...concurrencyKeys]
+      .filter((key) => key.includes(search))
+      .sort((a, b) => COMMON_COLLATOR.compare(a, b));
+  }, [concurrencyKeys, search]);
 
   const onAdd = () => {
     setAction({actionType: 'add'});
@@ -333,8 +337,8 @@ export const ConcurrencyLimits = ({
   }
 
   return (
-    <>
-      <ConcurrencyLimitHeader onAdd={onAdd} />
+    <Box flex={{direction: 'column'}} style={{overflow: 'auto', height: '100%'}}>
+      <ConcurrencyLimitHeader onAdd={onAdd} search={search} setSearch={setSearch} />
       {concurrencyKeys.length === 0 ? (
         <Box margin={24}>
           <NonIdealState
@@ -387,27 +391,53 @@ export const ConcurrencyLimits = ({
         concurrencyKey={selectedKey}
         onUpdate={refetch}
       />
-    </>
+    </Box>
   );
 };
 
-const ConcurrencyLimitHeader = ({onAdd}: {onAdd?: () => void}) => (
-  <Box
-    flex={{justifyContent: 'space-between', alignItems: 'center'}}
-    padding={{vertical: 16, horizontal: 24}}
-    border="top-and-bottom"
-  >
-    <Box flex={{alignItems: 'center', direction: 'row', gap: 8}}>
-      <Subheading>Global op/asset concurrency</Subheading>
-      <Tag>Experimental</Tag>
+const ConcurrencyLimitHeader = ({
+  onAdd,
+  setSearch,
+  search,
+}: {
+  onAdd?: () => void;
+} & (
+  | {
+      setSearch: (searchString: string) => void;
+      search: string;
+    }
+  | {setSearch?: never; search?: never}
+)) => {
+  return (
+    <Box flex={{direction: 'column'}}>
+      <Box
+        flex={{justifyContent: 'space-between', alignItems: 'center'}}
+        padding={{vertical: 16, horizontal: 24}}
+        border="top-and-bottom"
+      >
+        <Box flex={{alignItems: 'center', direction: 'row', gap: 8}}>
+          <Subheading>Global op/asset concurrency</Subheading>
+          <Tag>Experimental</Tag>
+        </Box>
+        {onAdd ? (
+          <Button icon={<Icon name="add_circle" />} onClick={() => onAdd()}>
+            Add concurrency limit
+          </Button>
+        ) : null}
+      </Box>
+      {setSearch ? (
+        <Box flex={{direction: 'row'}} padding={{vertical: 16, horizontal: 24}} border="bottom">
+          <TextInput
+            value={search || ''}
+            style={{width: '30vw', minWidth: 150, maxWidth: 400}}
+            placeholder="Filter concurrency keys"
+            onChange={(e: React.ChangeEvent<any>) => setSearch(e.target.value)}
+          />
+        </Box>
+      ) : null}
     </Box>
-    {onAdd ? (
-      <Button icon={<Icon name="add_circle" />} onClick={() => onAdd()}>
-        Add concurrency limit
-      </Button>
-    ) : null}
-  </Box>
-);
+  );
+};
 
 const isValidLimit = (
   concurrencyLimit?: string,


### PR DESCRIPTION
## Summary & Motivation

The wrapper of the virtualized table container didn't have a max-height so the table was rendering every single key and fetching every single key. To fix this I added a wrapper higher up the tree `<Box flex={{direction: 'column'}} style={{overflow: 'auto', height: '100%'}}>`

I also added search filtering since you can no longer search with the browser's built in search now that the table is virtualized

## How I Tested These Changes
Loaded a page from a customer with ~3,000 concurrency keys and saw the page not crash and burn.


video: https://dagsterlabs.slack.com/archives/C070G3UNNLW/p1715946929035669?thread_ts=1715895539.021559&cid=C070G3UNNLW
