### PR TITLE
[spec-ify-assets-def] remove metadata_by_key arg to with_attributes

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1080,7 +1080,6 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         output_asset_key_replacements: Optional[Mapping[AssetKey, AssetKey]] = None,
         input_asset_key_replacements: Optional[Mapping[AssetKey, AssetKey]] = None,
         group_names_by_key: Optional[Mapping[AssetKey, str]] = None,
-        metadata_by_key: Optional[Mapping[AssetKey, ArbitraryMetadataMapping]] = None,
         tags_by_key: Optional[Mapping[AssetKey, Mapping[str, str]]] = None,
         freshness_policy: Optional[
             Union[FreshnessPolicy, Mapping[AssetKey, FreshnessPolicy]]
@@ -1106,9 +1105,6 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         )
         group_names_by_key = check.opt_mapping_param(
             group_names_by_key, "group_names_by_key", key_type=AssetKey, value_type=str
-        )
-        metadata_by_key = check.opt_mapping_param(
-            metadata_by_key, "metadata_by_key", key_type=AssetKey, value_type=dict
         )
 
         backfill_policy = check.opt_inst_param(backfill_policy, "backfill_policy", BackfillPolicy)
@@ -1188,12 +1184,9 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             for key, description in self.descriptions_by_key.items()
         }
 
-        if not metadata_by_key:
-            metadata_by_key = self.metadata_by_key
-
         replaced_metadata_by_key = {
             output_asset_key_replacements.get(key, key): metadata
-            for key, metadata in metadata_by_key.items()
+            for key, metadata in self.metadata_by_key.items()
         }
 
         replaced_tags_by_key = {
@@ -1517,6 +1510,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             selected_asset_check_keys=self._selected_asset_check_keys,
             owners_by_key=self._owners_by_key,
             tags_by_key=self._tags_by_key,
+            is_subset=self._is_subset,
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -138,7 +138,9 @@ def _with_code_source_single_definition(
                 ),
             }
 
-    return assets_def.with_attributes(metadata_by_key=metadata_by_key)
+    return AssetsDefinition.dagster_internal_init(
+        **{**assets_def.get_attributes_dict(), "metadata_by_key": metadata_by_key}
+    )
 
 
 def convert_local_path_to_source_control_path(
@@ -195,7 +197,9 @@ def _convert_local_path_to_source_control_path_single_definition(
             ),
         }
 
-    return assets_def.with_attributes(metadata_by_key=metadata_by_key)
+    return AssetsDefinition.dagster_internal_init(
+        **{**assets_def.get_attributes_dict(), "metadata_by_key": metadata_by_key}
+    )
 
 
 def _build_github_url(url: str, branch: str) -> str:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -168,39 +168,6 @@ def test_retain_group():
     assert replaced.group_names_by_key[AssetKey("baz")] == "foo"
 
 
-def test_with_replaced_metadata() -> None:
-    @multi_asset(
-        outs={
-            "foo": AssetOut(metadata={"foo": "foo"}),
-            "bar": AssetOut(metadata={"bar": "bar"}),
-            "baz": AssetOut(metadata={"baz": "baz"}),
-        }
-    )
-    def abc(): ...
-
-    assert abc.metadata_by_key == {
-        AssetKey("foo"): {"foo": "foo"},
-        AssetKey("bar"): {"bar": "bar"},
-        AssetKey("baz"): {"baz": "baz"},
-    }
-
-    # If there's no replacement metadata for the asset key, the original metadata is retained.
-    replaced = abc.with_attributes(metadata_by_key={})
-    assert replaced.metadata_by_key == {
-        AssetKey("foo"): {"foo": "foo"},
-        AssetKey("bar"): {"bar": "bar"},
-        AssetKey("baz"): {"baz": "baz"},
-    }
-
-    # Otherwise, use the replaced description.
-    replaced = abc.with_attributes(metadata_by_key={AssetKey(["bar"]): {"bar": "bar_prime"}})
-    assert replaced.metadata_by_key == {
-        AssetKey("foo"): {"foo": "foo"},
-        AssetKey("bar"): {"bar": "bar_prime"},
-        AssetKey("baz"): {"baz": "baz"},
-    }
-
-
 def test_retain_freshness_policy():
     fp = FreshnessPolicy(maximum_lag_minutes=24.5)
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager_asset_metadata.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager_asset_metadata.py
@@ -1,10 +1,8 @@
 from dagster import (
     AssetIn,
-    AssetKey,
     AssetOut,
     AssetsDefinition,
     GraphOut,
-    Out,
     asset,
     graph,
     graph_multi_asset,
@@ -40,33 +38,11 @@ def test_asset_with_metadata():
     materialize_expect_metadata(basic_asset_with_metadata)
 
 
-def test_with_attributes_metadata():
-    @asset
-    def basic_asset_without_metadata(): ...
-
-    materialize_expect_metadata(
-        basic_asset_without_metadata.with_attributes(
-            metadata_by_key={AssetKey("basic_asset_without_metadata"): {"fruit": "apple"}}
-        ),
-    )
-
-
 def test_multi_asset_with_metadata():
     @multi_asset(outs={"asset1": AssetOut(metadata={"fruit": "apple"})})
     def multi_asset_with_metadata(): ...
 
     materialize_expect_metadata(multi_asset_with_metadata)
-
-
-def test_multi_asset_with_attributes_metadata():
-    @multi_asset(outs={"asset1": AssetOut()})
-    def multi_asset_without_metadata(): ...
-
-    materialize_expect_metadata(
-        multi_asset_without_metadata.with_attributes(
-            metadata_by_key={AssetKey("asset1"): {"fruit": "apple"}}
-        ),
-    )
 
 
 def test_graph_asset_outer_metadata():
@@ -78,21 +54,6 @@ def test_graph_asset_outer_metadata():
         return op_without_output_metadata()
 
     materialize_expect_metadata(graph_with_outer_metadata)
-
-
-def test_graph_asset_op_metadata():
-    @op(out=Out(metadata={"fruit": "apple"}))
-    def op_without_output_metadata(): ...
-
-    @graph_multi_asset(outs={"asset1": AssetOut()})
-    def graph_without_metadata():
-        return op_without_output_metadata()
-
-    materialize_expect_metadata(
-        graph_without_metadata.with_attributes(
-            metadata_by_key={AssetKey("asset1"): {"fruit": "apple"}}
-        )
-    )
 
 
 def test_assets_definition_from_graph_metadata():


### PR DESCRIPTION
## Summary & Motivation

The argument functions differently than the other args on `with_attributes`, in that it overrides the existing value, rather than erroring on conflicts.

Rather than beef up `with_attributes` to handle different override strategies, it's clearer to just bypass it.

More context here: https://github.com/dagster-io/internal/discussions/9719#discussioncomment-9451281

## How I Tested These Changes
