### PR TITLE
[spec-ify-assets-def] validate_group_name -> normalize_group_name

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -71,7 +71,7 @@ from .partition_mapping import (
 )
 from .resource_definition import ResourceDefinition
 from .source_asset import SourceAsset
-from .utils import DEFAULT_GROUP_NAME, validate_group_name, validate_tags_strict
+from .utils import DEFAULT_GROUP_NAME, normalize_group_name, validate_tags_strict
 
 if TYPE_CHECKING:
     from .base_asset_graph import AssetKeyOrCheckKey
@@ -213,7 +213,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         # assets that don't have a group name get a DEFAULT_GROUP_NAME
         for key in all_asset_keys:
             group_name = group_names_by_key.get(key)
-            self._group_names_by_key[key] = validate_group_name(group_name)
+            self._group_names_by_key[key] = normalize_group_name(group_name)
 
         all_check_keys = {spec.key for spec in (check_specs_by_output_name or {}).values()}
 

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -43,7 +43,7 @@ from dagster._core.definitions.result import ObserveResult
 from dagster._core.definitions.utils import (
     DEFAULT_GROUP_NAME,
     DEFAULT_IO_MANAGER_KEY,
-    validate_group_name,
+    normalize_group_name,
 )
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
@@ -257,7 +257,7 @@ class SourceAsset(ResourceAddable):
         self.partitions_def = check.opt_inst_param(
             partitions_def, "partitions_def", PartitionsDefinition
         )
-        self.group_name = validate_group_name(group_name)
+        self.group_name = normalize_group_name(group_name)
         self.description = check.opt_str_param(description, "description")
         self.observe_fn = check.opt_callable_param(observe_fn, "observe_fn")
         self.op_tags = check.opt_mapping_param(op_tags, "op_tags")

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -207,7 +207,7 @@ def validate_tag_strict(key: str, value: str) -> None:
         )
 
 
-def validate_group_name(group_name: Optional[str]) -> str:
+def normalize_group_name(group_name: Optional[str]) -> str:
     """Ensures a string name is valid and returns a default if no name provided."""
     if group_name:
         check_valid_chars(group_name)


### PR DESCRIPTION
## Summary & Motivation

The function named `validate_group_name` doesn't just validate the group name but also returns a normalized value (filling in "default" if the input `None`). The name `normalize_group_name` more accurately reflects this.

## How I Tested These Changes
