### PR TITLE
AssetCheckSummaryRecord

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -979,6 +979,16 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         return self._selected_asset_check_keys
 
     @property
+    def check_key(self) -> AssetCheckKey:
+        check.invariant(
+            len(self.check_keys) == 1,
+            "Tried to retrieve asset check key from an assets definition with more or less than 1 asset check key: "
+            + ", ".join([ak.to_user_string() for ak in self.check_keys]),
+        )
+
+        return next(iter(self.check_keys))
+
+    @property
     def execution_type(self) -> AssetExecutionType:
         value = self._get_external_asset_metadata_value(SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE)
         if value is None:

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -134,6 +134,12 @@ class AssetRecord(NamedTuple):
     asset_entry: AssetEntry
 
 
+class AssetCheckSummaryRecord(NamedTuple):
+    asset_check_key: AssetCheckKey
+    last_check_execution_record: Optional[AssetCheckExecutionRecord]
+    last_run_id: Optional[str]
+
+
 class PlannedMaterializationInfo(NamedTuple):
     """Internal representation of an planned materialization event, containing storage_id / run_id.
 
@@ -311,6 +317,12 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     def get_asset_records(
         self, asset_keys: Optional[Sequence[AssetKey]] = None
     ) -> Sequence[AssetRecord]:
+        pass
+
+    @abstractmethod
+    def get_asset_check_summary_records(
+        self, asset_check_keys: Sequence[AssetCheckKey]
+    ) -> Mapping[AssetCheckKey, AssetCheckSummaryRecord]:
         pass
 
     @property

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -90,6 +90,7 @@ from dagster._utils.warnings import deprecation_warning
 
 from ..dagster_run import DagsterRunStatsSnapshot
 from .base import (
+    AssetCheckSummaryRecord,
     AssetEntry,
     AssetRecord,
     AssetRecordsFilter,
@@ -1319,6 +1320,19 @@ class SqlEventLogStorage(EventLogStorage):
                 )
 
         return asset_records
+
+    def get_asset_check_summary_records(
+        self, asset_check_keys: Sequence[AssetCheckKey]
+    ) -> Mapping[AssetCheckKey, AssetCheckSummaryRecord]:
+        states = {}
+        for asset_check_key in asset_check_keys:
+            execution_record = self.get_asset_check_execution_history(asset_check_key, limit=1)
+            states[asset_check_key] = AssetCheckSummaryRecord(
+                asset_check_key=asset_check_key,
+                last_check_execution_record=execution_record[0] if execution_record else None,
+                last_run_id=execution_record[0].run_id if execution_record else None,
+            )
+        return states
 
     def has_asset_key(self, asset_key: AssetKey) -> bool:
         check.inst_param(asset_key, "asset_key", AssetKey)

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -13,6 +13,7 @@ from dagster import (
     _check as check,
 )
 from dagster._config.config_schema import UserConfigSchema
+from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.declarative_scheduling.serialized_objects import (
     AssetConditionEvaluationWithRunIds,
 )
@@ -21,6 +22,7 @@ from dagster._core.event_api import EventHandlerFn
 from dagster._core.storage.asset_check_execution_record import (
     AssetCheckExecutionRecord,
 )
+from dagster._core.storage.event_log.base import AssetCheckSummaryRecord
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 from dagster._utils import PrintFn
 from dagster._utils.concurrency import ConcurrencyClaimStatus, ConcurrencyKeyInfo
@@ -504,6 +506,11 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         self, asset_keys: Optional[Sequence["AssetKey"]] = None
     ) -> Iterable[AssetRecord]:
         return self._storage.event_log_storage.get_asset_records(asset_keys)
+
+    def get_asset_check_summary_records(
+        self, asset_check_keys: Sequence["AssetCheckKey"]
+    ) -> Mapping["AssetCheckKey", AssetCheckSummaryRecord]:
+        return self._storage.event_log_storage.get_asset_check_summary_records(asset_check_keys)
 
     def has_asset_key(self, asset_key: "AssetKey") -> bool:
         return self._storage.event_log_storage.has_asset_key(asset_key)

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_checks.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_checks.py
@@ -1,0 +1,46 @@
+import pytest
+from dagster import DagsterInstance, asset
+from dagster._core.definitions.asset_check_result import AssetCheckResult
+from dagster._core.definitions.decorators.asset_check_decorator import asset_check
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.test_utils import instance_for_test
+
+
+@pytest.fixture
+def instance():
+    with instance_for_test() as instance:
+        yield instance
+
+
+@asset
+def the_asset():
+    return 1
+
+
+@asset_check(asset=the_asset)
+def the_asset_check():
+    return AssetCheckResult(passed=True)
+
+
+defs = Definitions(assets=[the_asset], asset_checks=[the_asset_check])
+
+
+def test_get_asset_check_summary_records(instance: DagsterInstance):
+    records = instance.event_log_storage.get_asset_check_summary_records(
+        asset_check_keys=list(the_asset_check.check_keys)
+    )
+    assert len(records) == 1
+    check_key = the_asset_check.check_key
+    summary_record = records[check_key]
+    assert summary_record.asset_check_key == next(iter(the_asset_check.check_keys))
+    assert summary_record.last_check_execution_record is None
+    assert summary_record.last_run_id is None
+    implicit_job = defs.get_all_job_defs()[0]
+    result = implicit_job.execute_in_process(instance=instance)
+    assert result.success
+    records = instance.event_log_storage.get_asset_check_summary_records(
+        asset_check_keys=list(the_asset_check.check_keys)
+    )
+    assert len(records) == 1
+    assert records[check_key].last_check_execution_record.event.asset_check_evaluation.passed  # type: ignore
+    assert records[check_key].last_run_id == result.run_id


### PR DESCRIPTION
Adds an "AssetCheckState" API; which functions similarly to an AssetRecord. The core conceit is to be able to query just based on asset check key a set of information about the "state" of the asset check (most recent run, for now), without having any references to the event log.

For now, it's actually powered by the event log, however.

How I tested this
- Added a new semi-end-to-end test to our event log storage tests. This required me setting up an instance hooked up to an event log storage; which I think is nice to have anyway.
- There's one failing test here that's confusing me; test_get_event_records_sqlite. I changed it to use the instance passed in by fixture, which should in theory not change the results? But it seems like it has. Probably missing something here.

There will be a follow up cloud pr.