### PR TITLE
[graphql] add permissions field to WorkspaceLocationEntryStatus

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3305,6 +3305,7 @@ type WorkspaceLocationStatusEntry {
   name: String!
   loadStatus: RepositoryLocationLoadStatus!
   updateTimestamp: Float!
+  permissions: [Permission!]!
 }
 
 union GraphOrError = Graph | GraphNotFoundError | PythonError

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -5505,6 +5505,7 @@ export type WorkspaceLocationStatusEntry = {
   id: Scalars['ID']['output'];
   loadStatus: RepositoryLocationLoadStatus;
   name: Scalars['String']['output'];
+  permissions: Array<Permission>;
   updateTimestamp: Scalars['Float']['output'];
 };
 
@@ -14917,6 +14918,7 @@ export const buildWorkspaceLocationStatusEntry = (
         ? overrides.loadStatus!
         : RepositoryLocationLoadStatus.LOADED,
     name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : 'corporis',
+    permissions: overrides && overrides.hasOwnProperty('permissions') ? overrides.permissions! : [],
     updateTimestamp:
       overrides && overrides.hasOwnProperty('updateTimestamp') ? overrides.updateTimestamp! : 7.09,
   };

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -146,11 +146,17 @@ class GrapheneWorkspaceLocationStatusEntry(graphene.ObjectType):
     loadStatus = graphene.NonNull(GrapheneRepositoryLocationLoadStatus)
     updateTimestamp = graphene.NonNull(graphene.Float)
 
+    permissions = graphene.Field(non_null_list(GraphenePermission))
+
     class Meta:
         name = "WorkspaceLocationStatusEntry"
 
     def __init__(self, id, name, load_status, update_timestamp):
         super().__init__(id=id, name=name, loadStatus=load_status, updateTimestamp=update_timestamp)
+
+    def resolve_permissions(self, graphene_info):
+        permissions = graphene_info.context.permissions_for_location(location_name=self.name)
+        return [GraphenePermission(permission, value) for permission, value in permissions.items()]
 
 
 class GrapheneWorkspaceLocationStatusEntries(graphene.ObjectType):


### PR DESCRIPTION
Fetching these off the workspace directly blocks them on loading the whole workspace, and in some environments that is costly.
Make it available off of the other code location scoped object for faster access.

## How I Tested These Changes

updated test
