### PR TITLE
[dagster-dbt] Add general attach_metadata method to chain async metadata fetches to dbt execution

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -1031,7 +1031,7 @@ class DbtEventIterator(Generic[T], abc.Iterator):
         ):
             with ThreadPoolExecutor(
                 max_workers=self._dbt_cli_invocation.postprocessing_threadpool_num_threads,
-                thread_name_prefix="fetch_row_counts",
+                thread_name_prefix=fn.__name__,
             ) as executor:
                 yield from imap(
                     executor=executor,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -1031,7 +1031,7 @@ class DbtEventIterator(Generic[T], abc.Iterator):
         ):
             with ThreadPoolExecutor(
                 max_workers=self._dbt_cli_invocation.postprocessing_threadpool_num_threads,
-                thread_name_prefix=fn.__name__,
+                thread_name_prefix=f"dbt_attach_metadata_{fn.__name__}",
             ) as executor:
                 yield from imap(
                     executor=executor,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import (
     AbstractSet,
     Any,
+    Callable,
     Dict,
     Generic,
     Iterable,
@@ -893,6 +894,64 @@ class DbtCliInvocation:
 T = TypeVar("T", bound=DbtDagsterEventType)
 
 
+def _get_dbt_resource_props_from_event(
+    invocation: DbtCliInvocation, event: DbtDagsterEventType
+) -> Dict[str, Any]:
+    unique_id = cast(TextMetadataValue, event.metadata["unique_id"]).text
+    return check.not_none(invocation.manifest["nodes"].get(unique_id))
+
+
+def _fetch_row_count_metadata(
+    invocation: DbtCliInvocation,
+    event: DbtDagsterEventType,
+) -> Optional[Dict[str, Any]]:
+    """Threaded task which fetches row counts for materialized dbt models in a dbt run
+    once they are built, and attaches the row count as metadata to the event.
+    """
+    if not isinstance(event, (AssetMaterialization, Output)):
+        return None
+
+    adapter = check.not_none(invocation.adapter)
+
+    dbt_resource_props = _get_dbt_resource_props_from_event(invocation, event)
+    is_view = dbt_resource_props["config"]["materialized"] == "view"
+
+    # Avoid counting rows for views, since they may include complex SQL queries
+    # that are costly to execute. We can revisit this in the future if there is
+    # a demand for it.
+    if is_view:
+        return None
+
+    unique_id = dbt_resource_props["unique_id"]
+    logger.debug("Fetching row count for %s", unique_id)
+    table_str = f"{dbt_resource_props['database']}.{dbt_resource_props['schema']}.{dbt_resource_props['name']}"
+
+    try:
+        with adapter.connection_named(f"row_count_{unique_id}"):
+            query_result = adapter.execute(
+                f"""
+                    SELECT
+                    count(*) as row_count
+                    FROM
+                    {table_str}
+                """,
+                fetch=True,
+            )
+        query_result_table = query_result[1]
+        # some adapters do not output the column names, so we need
+        # to index by position
+        row_count = query_result_table[0][0]
+        return {**TableMetadataSet(row_count=row_count)}
+
+    except Exception as e:
+        logger.exception(
+            f"An error occurred while fetching row count for {unique_id}. Row count metadata"
+            " will not be included in the event.\n\n"
+            f"Exception: {e}"
+        )
+        return None
+
+
 class DbtEventIterator(Generic[T], abc.Iterator):
     """A wrapper around an iterator of dbt events which contains additional methods for
     post-processing the events, such as fetching row counts for materialized tables.
@@ -912,63 +971,6 @@ class DbtEventIterator(Generic[T], abc.Iterator):
     def __iter__(self) -> "DbtEventIterator[T]":
         return self
 
-    def _get_dbt_resource_props_from_event(self, event: DbtDagsterEventType) -> Dict[str, Any]:
-        unique_id = cast(TextMetadataValue, event.metadata["unique_id"]).text
-        return check.not_none(self._dbt_cli_invocation.manifest["nodes"].get(unique_id))
-
-    def _fetch_and_attach_row_count_metadata(
-        self,
-        event: DbtDagsterEventType,
-    ) -> DbtDagsterEventType:
-        """Threaded task which fetches row counts for materialized dbt models in a dbt run
-        once they are built, and attaches the row count as metadata to the event.
-        """
-        if not isinstance(event, (AssetMaterialization, Output)):
-            return event
-
-        adapter = check.not_none(self._dbt_cli_invocation.adapter)
-        dbt_resource_props = self._get_dbt_resource_props_from_event(event)
-        is_view = dbt_resource_props["config"]["materialized"] == "view"
-
-        # Avoid counting rows for views, since they may include complex SQL queries
-        # that are costly to execute. We can revisit this in the future if there is
-        # a demand for it.
-        if is_view:
-            return event
-
-        unique_id = dbt_resource_props["unique_id"]
-        logger.debug("Fetching row count for %s", unique_id)
-        table_str = f"{dbt_resource_props['database']}.{dbt_resource_props['schema']}.{dbt_resource_props['name']}"
-
-        try:
-            with adapter.connection_named(f"row_count_{unique_id}"):
-                query_result = adapter.execute(
-                    f"""
-                        SELECT
-                        count(*) as row_count
-                        FROM
-                        {table_str}
-                    """,
-                    fetch=True,
-                )
-
-            query_result_table = query_result[1]
-            # some adapters do not output the column names, so we need
-            # to index by position
-            row_count = query_result_table[0][0]
-            new_metadata = {
-                **TableMetadataSet(row_count=row_count),
-            }
-            return event.with_metadata({**event.metadata, **new_metadata})
-
-        except Exception as e:
-            logger.exception(
-                f"An error occurred while fetching row count for {unique_id}. Row count metadata"
-                " will not be included in the event.\n\n"
-                f"Exception: {e}"
-            )
-            return event
-
     @public
     @experimental
     def fetch_row_counts(
@@ -985,6 +987,21 @@ class DbtEventIterator(Generic[T], abc.Iterator):
                 A set of corresponding Dagster events for dbt models, with row counts attached,
                 yielded in the order they are emitted by dbt.
         """
+        return self.attach_metadata(_fetch_row_count_metadata)
+
+    def attach_metadata(
+        self,
+        fn: Callable[[DbtCliInvocation, DbtDagsterEventType], Optional[Dict[str, Any]]],
+        *,
+        num_threads=DEFAULT_EVENT_POSTPROCESSING_THREADPOOL_SIZE,
+    ) -> "DbtEventIterator[DbtDagsterEventType]":
+        def _map_fn(event: DbtDagsterEventType) -> DbtDagsterEventType:
+            result = fn(self._dbt_cli_invocation, event)
+            if result is None:
+                return event
+
+            return event.with_metadata({**event.metadata, **result})
+
         # If the adapter is DuckDB, we need to wait for the dbt CLI process to complete
         # so that the DuckDB lock is released. This is because DuckDB does not allow for
         # opening multiple connections to the same database when a write connection, such
@@ -1008,7 +1025,7 @@ class DbtEventIterator(Generic[T], abc.Iterator):
                 yield from imap(
                     executor=executor,
                     iterable=event_stream,
-                    func=self._fetch_and_attach_row_count_metadata,
+                    func=_map_fn,
                 )
 
         return DbtEventIterator(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -992,8 +992,6 @@ class DbtEventIterator(Generic[T], abc.Iterator):
     def _attach_metadata(
         self,
         fn: Callable[[DbtCliInvocation, DbtDagsterEventType], Optional[Dict[str, Any]]],
-        *,
-        num_threads=DEFAULT_EVENT_POSTPROCESSING_THREADPOOL_SIZE,
     ) -> "DbtEventIterator[DbtDagsterEventType]":
         """Runs a threaded task to attach metadata to each event in the iterator.
 
@@ -1001,7 +999,6 @@ class DbtEventIterator(Generic[T], abc.Iterator):
             fn (Callable[[DbtCliInvocation, DbtDagsterEventType], Optional[Dict[str, Any]]]):
                 A function which takes a DbtCliInvocation and a DbtDagsterEventType and returns
                 a dictionary of metadata to attach to the event.
-            num_threads (int): The number of threads to use for processing the events.
 
         Returns:
              Iterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]:
@@ -1029,7 +1026,7 @@ class DbtEventIterator(Generic[T], abc.Iterator):
         except ImportError:
             pass
 
-        def _threadpool_fetch_and_attach_row_count_metadata() -> (
+        def _threadpool_wrap_map_fn() -> (
             Iterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]
         ):
             with ThreadPoolExecutor(
@@ -1043,7 +1040,7 @@ class DbtEventIterator(Generic[T], abc.Iterator):
                 )
 
         return DbtEventIterator(
-            _threadpool_fetch_and_attach_row_count_metadata(),
+            _threadpool_wrap_map_fn(),
             dbt_cli_invocation=self._dbt_cli_invocation,
         )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_postprocessing.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_postprocessing.py
@@ -167,7 +167,9 @@ def test_row_count_err(
         assert "An error occurred while fetching row count for " in caplog.text
 
 
-def test_summary(test_jaffle_shop_manifest_standalone_duckdb_dbfile: Dict[str, Any]) -> None:
+def test_attach_metadata(
+    test_jaffle_shop_manifest_standalone_duckdb_dbfile: Dict[str, Any],
+) -> None:
     def _summarize(
         invocation: DbtCliInvocation,
         event: DbtDagsterEventType,
@@ -196,7 +198,7 @@ def test_summary(test_jaffle_shop_manifest_standalone_duckdb_dbfile: Dict[str, A
 
     @dbt_assets(manifest=test_jaffle_shop_manifest_standalone_duckdb_dbfile)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        yield from dbt.cli(["build"], context=context).stream().attach_metadata(_summarize)
+        yield from dbt.cli(["build"], context=context).stream()._attach_metadata(_summarize)  # noqa: SLF001
 
     result = materialize(
         [my_dbt_assets],

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_row_count_postprocessing.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_row_count_postprocessing.py
@@ -1,4 +1,5 @@
 import os
+from decimal import Decimal
 from typing import Any, Dict, cast
 
 import mock
@@ -185,7 +186,10 @@ def test_summary(test_jaffle_shop_manifest_standalone_duckdb_dbfile: Dict[str, A
             )
 
         table_metadata = MetadataValue.table(
-            records=[TableRecord({k: v for k, v in row.items()}) for row in query_result[1].rows]
+            records=[
+                TableRecord({k: float(v) if isinstance(v, Decimal) else v for k, v in row.items()})
+                for row in query_result[1].rows
+            ]
         )
 
         return {"summary": table_metadata}

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_row_count_postprocessing.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_row_count_postprocessing.py
@@ -8,10 +8,15 @@ from dagster import (
     _check as check,
     materialize,
 )
+from dagster._core.definitions.events import AssetMaterialization, Output
+from dagster._core.definitions.metadata.metadata_value import MetadataValue, TableMetadataValue
+from dagster._core.definitions.metadata.table import TableRecord
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.core.resources_v2 import (
     DbtCliInvocation,
     DbtCliResource,
+    DbtDagsterEventType,
+    _get_dbt_resource_props_from_event,
 )
 
 from ..conftest import _create_dbt_invocation
@@ -159,3 +164,57 @@ def test_row_count_err(
 
         # assert we have warning message in logs
         assert "An error occurred while fetching row count for " in caplog.text
+
+
+def test_summary(test_jaffle_shop_manifest_standalone_duckdb_dbfile: Dict[str, Any]) -> None:
+    def _summarize(
+        invocation: DbtCliInvocation,
+        event: DbtDagsterEventType,
+    ):
+        if not isinstance(event, (AssetMaterialization, Output)):
+            return None
+
+        dbt_resource_props = _get_dbt_resource_props_from_event(invocation, event)
+        table_str = f"{dbt_resource_props['database']}.{dbt_resource_props['schema']}.{dbt_resource_props['name']}"
+
+        assert invocation.adapter
+        with invocation.adapter.connection_named(f"row_count_{dbt_resource_props['unique_id']}"):
+            query_result = invocation.adapter.execute(
+                f"SUMMARIZE {table_str}",
+                fetch=True,
+            )
+
+        table_metadata = MetadataValue.table(
+            records=[TableRecord({k: v for k, v in row.items()}) for row in query_result[1].rows]
+        )
+
+        return {"summary": table_metadata}
+
+    @dbt_assets(manifest=test_jaffle_shop_manifest_standalone_duckdb_dbfile)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        yield from dbt.cli(["build"], context=context).stream().attach_metadata(_summarize)
+
+    result = materialize(
+        [my_dbt_assets],
+        resources={"dbt": DbtCliResource(project_dir=os.fspath(test_jaffle_shop_path))},
+    )
+
+    assert result.success
+
+    # Validate that we have summaries for all models
+    metadata_by_asset_key = {
+        check.not_none(event.asset_key): event.materialization.metadata
+        for event in result.get_asset_materialization_events()
+    }
+    assert all("summary" in metadata for _, metadata in metadata_by_asset_key.items()), str(
+        metadata_by_asset_key
+    )
+
+    summaries_by_asset_key = {
+        asset_key: cast(TableMetadataValue, metadata["summary"])
+        for asset_key, metadata in metadata_by_asset_key.items()
+    }
+    assert all(
+        len(summary.records) > 0 and "column_name" in summary.records[0].data
+        for summary in summaries_by_asset_key.values()
+    ), str(summaries_by_asset_key)


### PR DESCRIPTION
## Summary

Continues the restructuring of chaining async dbt work from #12943 to specify a `attach_metadata` method which can be used to specify a function which will run in a thread after each dbt event completes and will attach any additional user-specified metadata to that event before it is emitted.

Right now, it's classified as private so we can adjust the signature if need be before making it public - I'd like to unblock future work stacking on this shared impl, but I think we'll want to pass a single, proper context class rather than the loose `invocation`, `event` params.

Used internally for the `fetch_row_count` implementation.

## Test Plan

Example unit test with `SUMMARIZE` SQL metadata.