### PR TITLE
RFC replace copy_py alias by a function

### DIFF
--- a/examples/deploy_docker/from_source/build.sh
+++ b/examples/deploy_docker/from_source/build.sh
@@ -31,14 +31,18 @@ if [[ -z ${DAGSTER_UI_DONT_BUILD_JS_BUNDLE+x} ]]; then
 fi
 
 echo -e "--- \033[32m:truck: Copying files...\033[0m"
-alias copy_py="rsync -av \
+
+function copy_py() {
+  rsync -av \
       --progress \
       --exclude *.egginfo \
       --exclude *.tox \
       --exclude dist \
       --exclude __pycache__ \
       --exclude *.pyc \
-      --exclude .coverage"
+      --exclude .coverage \
+      "$@"
+}
 
 copy_py $ROOT/python_modules/dagster \
         $ROOT/python_modules/dagster-pipes \


### PR DESCRIPTION
### TL;DR

The copy_py alias is not recognized in some environments, and the script is unusable as it fails to rsync the desired files.

This change replaces it with a more readily supported bash function