### PR TITLE
[Run timeline] Dedupe runs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -337,7 +337,14 @@ export const useRunsForTimeline = (
               pipelineName: pipeline.name,
               isJob: pipeline.isJob,
             }),
-            runs: [...jobRuns, ...jobTicks],
+            runs: [
+              ...jobRuns.filter((job, idx, arr) => {
+                // Jobs can show up in multiple buckets due to the way were are filtering. Lets dedupe them for now
+                // while we think of a better way to query while also caching.
+                return arr.findIndex((bJob) => bJob.id === job.id) === idx;
+              }),
+              ...jobTicks,
+            ],
           } as TimelineJob);
         }
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -339,7 +339,7 @@ export const useRunsForTimeline = (
             }),
             runs: [
               ...jobRuns.filter((run, idx, arr) => {
-                // Jobs can show up in multiple buckets due to the way were are filtering. Lets dedupe them for now
+                // Runs can show up in multiple buckets due to the way were are filtering. Lets dedupe them for now
                 // while we think of a better way to query while also caching.
                 return arr.findIndex((bRun) => bRun.id === run.id) === idx;
               }),

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -338,10 +338,10 @@ export const useRunsForTimeline = (
               isJob: pipeline.isJob,
             }),
             runs: [
-              ...jobRuns.filter((job, idx, arr) => {
+              ...jobRuns.filter((run, idx, arr) => {
                 // Jobs can show up in multiple buckets due to the way were are filtering. Lets dedupe them for now
                 // while we think of a better way to query while also caching.
-                return arr.findIndex((bJob) => bJob.id === job.id) === idx;
+                return arr.findIndex((bRun) => bRun.id === run.id) === idx;
               }),
               ...jobTicks,
             ],


### PR DESCRIPTION
## Summary & Motivation

Due to the way we're filtering with `createdBefore` / `updatedAfter`, runs can appear in multiple buckets. Dedupe them to work around the issue while we think of a better approach.

<img width="897" alt="Screenshot 2024-05-17 at 5 07 21 PM" src="https://github.com/dagster-io/dagster/assets/2286579/557df7a9-2d5b-4a79-abb8-60b342700ee9">



## How I Tested These Changes

Saw that a job spanning multiple buckets only shows up once.

<img width="1393" alt="Screenshot 2024-05-17 at 5 07 35 PM" src="https://github.com/dagster-io/dagster/assets/2286579/bbd82be3-fa62-4fc5-8792-a3fa84853656">
