### PR TITLE
[bk] add nightly oss pipeline

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from dagster_buildkite.git import GitInfo
 from dagster_buildkite.pipelines.dagster_oss_main import build_dagster_oss_main_steps
+from dagster_buildkite.pipelines.dagster_oss_nightly_pipeline import build_dagster_oss_nightly_steps
 from dagster_buildkite.python_packages import PythonPackages
 
 from .utils import buildkite_yaml_for_steps
@@ -15,5 +16,12 @@ a pipeline.
 def dagster() -> None:
     PythonPackages.load_from_git(GitInfo(directory=Path(".")))
     steps = build_dagster_oss_main_steps()
+    buildkite_yaml = buildkite_yaml_for_steps(steps)
+    print(buildkite_yaml)  # noqa: T201
+
+
+def dagster_nightly() -> None:
+    PythonPackages.load_from_git(GitInfo(directory=Path(".")))
+    steps = build_dagster_oss_nightly_steps()
     buildkite_yaml = buildkite_yaml_for_steps(steps)
     print(buildkite_yaml)  # noqa: T201

--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_nightly_pipeline.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_nightly_pipeline.py
@@ -1,0 +1,9 @@
+from typing import List
+
+from dagster_buildkite.utils import BuildkiteStep
+
+
+def build_dagster_oss_nightly_steps() -> List[BuildkiteStep]:
+    steps: List[BuildkiteStep] = []
+
+    return steps

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -27,7 +27,7 @@ def build_example_packages_steps() -> List[BuildkiteStep]:
 
     example_packages = EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG + example_packages_with_standard_config
 
-    return _build_steps_from_package_specs(example_packages)
+    return build_steps_from_package_specs(example_packages)
 
 
 def build_library_packages_steps() -> List[BuildkiteStep]:
@@ -45,18 +45,18 @@ def build_library_packages_steps() -> List[BuildkiteStep]:
         ],
     ]
 
-    return _build_steps_from_package_specs(
+    return build_steps_from_package_specs(
         LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG + library_packages_with_standard_config
     )
 
 
 def build_dagster_ui_screenshot_steps() -> List[BuildkiteStep]:
-    return _build_steps_from_package_specs(
+    return build_steps_from_package_specs(
         [PackageSpec("docs/dagster-ui-screenshot", run_pytest=False)]
     )
 
 
-def _build_steps_from_package_specs(package_specs: List[PackageSpec]) -> List[BuildkiteStep]:
+def build_steps_from_package_specs(package_specs: List[PackageSpec]) -> List[BuildkiteStep]:
     steps: List[BuildkiteStep] = []
     all_packages = sorted(
         package_specs,

--- a/.buildkite/dagster-buildkite/setup.py
+++ b/.buildkite/dagster-buildkite/setup.py
@@ -29,6 +29,7 @@ setup(
     entry_points={
         "console_scripts": [
             "dagster-buildkite = dagster_buildkite.cli:dagster",
+            "dagster-buildkite-nightly = dagster_buildkite.cli:dagster_nightly",
         ]
     },
 )


### PR DESCRIPTION
## Summary

Templates out a basic nightly OSS test to use for Snowflake integration tests w/ `dagster-dbt`, to avoid unnecessary cost.