### PR TITLE
[Runs filtering] Use like filter if run id less than 36 chars to allow passing in short id

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -621,7 +621,7 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
       return tokens.filter(({token}) => token === 'id').map((token) => token.value);
     }, [tokens]),
     freeformSearchResult: (query) => {
-      return /^([a-f0-9-]{36})$/.test(query.trim()) ? {value: query.trim(), final: true} : null;
+      return {value: query.trim(), final: true};
     },
     setState: (nextState) => {
       onChange([

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -609,14 +609,13 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
     matchType: 'all-of',
   });
 
-  const ID_EMPTY = 'Type or paste 36-character ID';
-  const ID_TOO_SHORT = 'Invalid Run ID';
+  const ID_EMPTY = 'Type or paste a Run ID';
 
   const idFilter = useSuggestionFilter({
     name: 'Run ID',
     icon: 'id',
     initialSuggestions: [],
-    getNoSuggestionsPlaceholder: (query) => (!query ? ID_EMPTY : ID_TOO_SHORT),
+    getNoSuggestionsPlaceholder: () => ID_EMPTY,
     state: useMemo(() => {
       return tokens.filter(({token}) => token === 'id').map((token) => token.value);
     }, [tokens]),

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -260,7 +260,13 @@ class SqlRunStorage(RunStorage):
         check.inst_param(filters, "filters", RunsFilter)
 
         if filters.run_ids:
-            query = query.where(RunsTable.c.run_id.in_(filters.run_ids))
+            conditions = []
+            for run_id in filters.run_ids:
+                if len(run_id) < 36:
+                    conditions.append(RunsTable.c.run_id.like(f"{run_id}%"))
+                else:
+                    conditions.append(RunsTable.c.run_id == run_id)
+            query = query.where(db.or_(*conditions))
 
         if filters.job_name:
             query = query.where(RunsTable.c.pipeline_name == filters.job_name)


### PR DESCRIPTION
## Summary & Motivation

In the UI we show Id's as their first 8 characters but in filtering we require the full 36 characters. To allow filtering by the shorter ID we update the filtering logic to use a `like` filter if the ID passed in is less than 36 characters.

## How I Tested These Changes


![Screenshot 2024-05-19 at 2 42 48 PM](https://github.com/dagster-io/dagster/assets/2286579/44e3e388-8d77-4a8e-bdef-8847495eb3c0)

Could use help identifying which tests to update
