### PR TITLE
use dagster/row_count metadata in dagster-polars

### DIFF
--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/utils.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/utils.py
@@ -171,7 +171,7 @@ def get_polars_metadata(
 
         metadata["table"] = table_metadata
         metadata["stats"] = stats_metadata
-        metadata["row_count"] = MetadataValue.int(df.shape[0])
+        metadata["dagster/row_count"] = MetadataValue.int(df.shape[0])
         metadata["estimated_size_mb"] = MetadataValue.float(df.estimated_size(unit="mb"))
 
     return metadata


### PR DESCRIPTION
## Summary & Motivation

Using the new standard metadata key for row count
