### PR TITLE
check.opt_iterable_param(None) == []

### DIFF
--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -1189,9 +1189,9 @@ def opt_iterable_param(
     param_name: str,
     of_type: Optional[TypeOrTupleOfTypes] = None,
     additional_message: Optional[str] = None,
-) -> Optional[Iterable[T]]:
+) -> Iterable[T]:
     if obj is None:
-        return None
+        return []
 
     return iterable_param(obj, param_name, of_type, additional_message)
 

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -1482,6 +1482,7 @@ def test_iterable():
 
 
 def test_opt_iterable():
+    assert check.opt_iterable_param(None, "thisisfine") == []
     assert check.opt_iterable_param([], "thisisfine") == []
     assert check.opt_iterable_param([1], "thisisfine") == [1]
     assert check.opt_iterable_param((i for i in [1, 2]), "thisisfine")


### PR DESCRIPTION
## Summary & Motivation

When `None` is passed to `opt_sequence_param`, a sequence is returned. Same with `opt_mapping_param` and `opt_set_param`. This changes `opt_iterable_param` to be consistent.

## How I Tested These Changes
