### PR TITLE
Add backend support for partition wiping

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -138,6 +138,15 @@ def asset_node_iter(
             yield location, repository, external_asset_node
 
 
+def get_external_asset_node(
+    graphene_info: "ResolveInfo", asset_key: AssetKey
+) -> Optional[ExternalAssetNode]:
+    for _, _, external_asset_node in asset_node_iter(graphene_info):
+        if external_asset_node.asset_key == asset_key:
+            return external_asset_node
+    return None
+
+
 def get_additional_required_keys(
     graphene_info: "ResolveInfo", asset_keys: AbstractSet[AssetKey]
 ) -> List["AssetKey"]:

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -39,6 +39,7 @@ from dagster._core.definitions.asset_check_evaluation import (
 )
 from dagster._core.definitions.data_version import extract_data_provenance_from_entry
 from dagster._core.definitions.events import AssetKey, AssetObservation
+from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.errors import (
     DagsterHomeNotSetError,
     DagsterInvalidInvocationError,
@@ -1356,7 +1357,6 @@ class DagsterInstance(DynamicPartitionsStore):
         job_partitions_def: Optional["PartitionsDefinition"],
     ) -> None:
         from dagster._core.definitions.partition import DynamicPartitionsDefinition
-        from dagster._core.definitions.partition_key_range import PartitionKeyRange
         from dagster._core.events import AssetMaterializationPlannedData, DagsterEvent
 
         partition_tag = dagster_run.tags.get(PARTITION_NAME_TAG)
@@ -2235,6 +2235,19 @@ class DagsterInstance(DynamicPartitionsStore):
         check.list_param(asset_keys, "asset_keys", of_type=AssetKey)
         for asset_key in asset_keys:
             self._event_storage.wipe_asset(asset_key)
+
+    def wipe_asset_partitions(
+        self,
+        asset_key: AssetKey,
+        partition_keys: Sequence[str],
+    ) -> None:
+        """Wipes asset event history from the event log for the given asset key and partition keys.
+
+        Args:
+            asset_key (Sequence[AssetKey]): Asset key to wipe.
+            partition_keys (Sequence[str]): Partition keys to wipe.
+        """
+        self._event_storage.wipe_asset_partitions(asset_key, partition_keys)
 
     @traced
     def get_materialized_partitions(

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -421,6 +421,10 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """Remove asset index history from event log for given asset_key."""
 
     @abstractmethod
+    def wipe_asset_partitions(self, asset_key: AssetKey, partition_keys: Sequence[str]) -> None:
+        """Remove asset index history from event log for given asset partitions."""
+
+    @abstractmethod
     def get_materialized_partitions(
         self,
         asset_key: AssetKey,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1784,6 +1784,12 @@ class SqlEventLogStorage(EventLogStorage):
                 )
             )
 
+    def wipe_asset_partitions(self, asset_key: AssetKey, partition_keys: Sequence[str]) -> None:
+        """Remove asset index history from event log for given asset partitions."""
+        raise NotImplementedError(
+            "Partitioned asset wipe is not supported yet for this event log storage."
+        )
+
     def get_materialized_partitions(
         self,
         asset_key: AssetKey,

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -521,6 +521,12 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     def wipe_asset(self, asset_key: "AssetKey") -> None:
         return self._storage.event_log_storage.wipe_asset(asset_key)
 
+    def wipe_asset_partitions(self, asset_key: AssetKey, partition_keys: Sequence[str]) -> None:
+        """Remove asset index history from event log for given asset partitions."""
+        raise NotImplementedError(
+            "Partitioned asset wipe is not supported yet for this event log storage."
+        )
+
     def get_materialized_partitions(
         self,
         asset_key: AssetKey,


### PR DESCRIPTION
Internal companion PR: https://github.com/dagster-io/internal/pull/9993

## Summary & Motivation

The status quo is no API at all for performing partition-scoped asset wiping. This PR (together with its companion) adds support for partition wiping with cloud storage, but not OSS. The reason for this limitation is that we have no way to performantly store partition-specific wipe timestamps without the cloud-only `AssetPartitionsTable`. In the future we may be able to get around this by storing partition ranges directly in the DB, but there are unresolved questions around how to handle `StaticPartitionsDefinition` in this scenario.

How this PR works:

- GraphQL
    - The existing `wipeAssets` mutation has been modified (downstack in #22249) to accept the existing `GraphenePartitionsByAssetSelector` instead of `GrapheneAssetKey`. `GraphenePartitionsByAssetSelector` already accepts an optional partition range.
    - The `wipeAssets` resolver examines each item in the provided selector and calls the (existing and unchanged) `DagsterInstance.wipe_assets` if there is no attached partition range.
    - `wipeAssets` calls the (new) `DagsterInstance.wipe_asset_partitions` if there is partition info. The provided partition range is resolved into a list of keys inside the GQL resolver-- `DagsterInstance.wipe_asset_partitions` does not operate directly on ranges.
- Instance/storage
    - `DagsterInstance.wipe_asset_partitions` (currently private) simply forwards the call to `EventLogStorage.wipe_asset_partitions`.
    - All non-cloud `EventLogStorage` immediately throw if `wipe_asset_partitions` is called. Only `PostgresCloudEventLogStorage` implements `wipe_asset_partitions`. This is OK because the UI for wiping asset partitions should not appear accept for cloud UI.
    - `PostgresCloudEventLogStorage.wipe_asset_partitions` deletes all rows from `AssetMaterializationsTable`, `AssetObservationsTable`, and `AssetPartitionsTable` matching an asset partition. This approach is mimicking what `wipe_assets` does without the partition key qualifier. We also set the `cached_status_data` on the `AssetKeyTable` record to `None`. We do not touch any other fields on the `AssetKeyTable`-- this means that the `last_materialization_time` for the asset as a whole will remain X even if X is from a run that had all its partitions wiped since. I was a little unsure what to do here but it would add complexity to look up the last non-deleted partition and adjust `last_materialization_time` back.


## How I Tested These Changes

- Internal:
    - New unit test for `PostgresCloudEventLogStorage.wipe_asset_partitions`
- OSS:
    - There is a test added downstack in #22249 that checks for the right error message when wiping partitions-- in that PR the error is thrown in the GQL resolver, here the error has been pushed down to the `EventLogStorage`. That the test is passing indicates that we are still returning the right error message.