### PR TITLE
[dagster-dbt] add chained method to fetch column metadata, lineage async

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -477,7 +477,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         pytest_tox_factors=[
             f"{deps_factor}-{command_factor}"
             for deps_factor in ["dbt16", "dbt17", "dbt18", "pydantic1"]
-            for command_factor in ["cloud", "core", "legacy"]
+            for command_factor in ["cloud", "core", "legacy", "core-derived-metadata"]
         ],
         unsupported_python_versions=[
             # duckdb

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -477,7 +477,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         pytest_tox_factors=[
             f"{deps_factor}-{command_factor}"
             for deps_factor in ["dbt16", "dbt17", "dbt18", "pydantic1"]
-            for command_factor in ["cloud", "core", "legacy", "core-derived-metadata"]
+            for command_factor in ["cloud", "core-main", "legacy", "core-derived-metadata"]
         ],
         unsupported_python_versions=[
             # duckdb

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -1091,9 +1091,6 @@ class DbtEventIterator(Generic[T], abc.Iterator):
         models in a dbt run once they are built. Note that row counts will not be fetched
         for views, since this requires running the view's SQL query which may be costly.
 
-        Args:
-            num_threads (int): The number of threads to use for fetching row counts.
-
         Returns:
             Iterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]:
                 A set of corresponding Dagster events for dbt models, with row counts attached,
@@ -1106,8 +1103,6 @@ class DbtEventIterator(Generic[T], abc.Iterator):
     def fetch_column_metadata(
         self,
         with_column_lineage: bool = True,
-        *,
-        num_threads=DEFAULT_EVENT_POSTPROCESSING_THREADPOOL_SIZE,
     ) -> (
         "DbtEventIterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]"
     ):
@@ -1117,7 +1112,6 @@ class DbtEventIterator(Generic[T], abc.Iterator):
 
         Args:
             generate_column_lineage (bool): Whether to generate column lineage metadata using sqlglot.
-            num_threads (int): The number of threads to use for fetching column metadata.
 
         Returns:
             Iterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]:
@@ -1127,7 +1121,7 @@ class DbtEventIterator(Generic[T], abc.Iterator):
         fetch_metadata = lambda invocation, event: _fetch_column_metadata(
             invocation, event, with_column_lineage
         )
-        return self._attach_metadata(fetch_metadata, num_threads=num_threads)
+        return self._attach_metadata(fetch_metadata)
 
     def _attach_metadata(
         self,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -22,6 +22,7 @@ from typing import (
     Iterator,
     List,
     Mapping,
+    NamedTuple,
     Optional,
     Sequence,
     Set,
@@ -57,8 +58,8 @@ from dagster._core.errors import DagsterExecutionInterruptedError, DagsterInvali
 from dagster._model.pydantic_compat_layer import compat_model_validator
 from dagster._utils import pushd
 from dagster._utils.warnings import disable_dagster_warnings
-from dbt.adapters.base.impl import BaseAdapter
-from dbt.adapters.factory import get_adapter, register_adapter, reset_adapters
+from dbt.adapters.base.impl import BaseAdapter, BaseColumn
+from dbt.adapters.factory import get_adapter, register_adapter
 from dbt.config import RuntimeConfig
 from dbt.config.runtime import load_profile, load_project
 from dbt.contracts.results import NodeStatus, TestStatus
@@ -901,6 +902,204 @@ def _get_dbt_resource_props_from_event(
     return check.not_none(invocation.manifest["nodes"].get(unique_id))
 
 
+class EventHistoryMetadata(NamedTuple):
+    columns: Dict[str, Dict[str, Any]]
+    parents: Dict[str, Dict[str, Any]]
+
+
+def _build_column_lineage_metadata(
+    event_history_metadata: EventHistoryMetadata,
+    dbt_resource_props: Dict[str, Any],
+    manifest: Mapping[str, Any],
+    dagster_dbt_translator: DagsterDbtTranslator,
+    target_path: Optional[Path],
+) -> Dict[str, Any]:
+    """Process the lineage metadata for a dbt CLI event.
+
+    Args:
+        manifest (Mapping[str, Any]): The dbt manifest blob.
+        dagster_dbt_translator (DagsterDbtTranslator): The translator for dbt nodes to Dagster assets.
+        target_path (Path): The path to the dbt target folder.
+
+    Returns:
+        Dict[str, Any]: The lineage metadata.
+    """
+    if (
+        # Column lineage can only be built if initial metadata is provided.
+        not target_path
+    ):
+        return {}
+
+    event_node_info: Dict[str, Any] = dbt_resource_props
+    unique_id: str = event_node_info["unique_id"]
+
+    node_resource_type: str = event_node_info["resource_type"]
+
+    if node_resource_type not in REFABLE_NODE_TYPES:
+        return {}
+
+    # If the unique_id is a seed, then we don't need to process lineage.
+    if unique_id.startswith("seed"):
+        return {}
+
+    # 1. Retrieve the current node's SQL file and its parents' column schemas.
+    sql_dialect = manifest["metadata"]["adapter_type"]
+    sqlglot_mapping_schema = MappingSchema(dialect=sql_dialect)
+    for parent_relation_name, parent_relation_metadata in event_history_metadata.parents.items():
+        sqlglot_mapping_schema.add_table(
+            table=to_table(parent_relation_name, dialect=sql_dialect),
+            column_mapping={
+                column_name: column_data_type
+                for column_name, column_data_type in parent_relation_metadata.items()
+            },
+            dialect=sql_dialect,
+        )
+
+    node_sql_path = target_path.joinpath(
+        "compiled",
+        manifest["metadata"]["project_name"],
+        dbt_resource_props["original_file_path"],
+    )
+    optimized_node_ast = cast(
+        exp.Query,
+        optimize(
+            parse_one(sql=node_sql_path.read_text(), dialect=sql_dialect),
+            schema=sqlglot_mapping_schema,
+            dialect=sql_dialect,
+        ),
+    )
+
+    # 2. Retrieve the column names from the current node.
+    schema_column_names = {column.lower() for column in event_history_metadata.columns.keys()}
+    sqlglot_column_names = set(optimized_node_ast.named_selects)
+
+    # 3. For each column, retrieve its dependencies on upstream columns from direct parents.
+    dbt_parent_resource_props_by_relation_name: Dict[str, Dict[str, Any]] = {}
+    for parent_unique_id in dbt_resource_props["depends_on"]["nodes"]:
+        is_resource_type_source = parent_unique_id.startswith("source")
+        parent_dbt_resource_props = (
+            manifest["sources"] if is_resource_type_source else manifest["nodes"]
+        )[parent_unique_id]
+        parent_relation_name = normalize_table_name(
+            to_table(parent_dbt_resource_props["relation_name"], dialect=sql_dialect),
+            dialect=sql_dialect,
+        )
+
+        dbt_parent_resource_props_by_relation_name[parent_relation_name] = parent_dbt_resource_props
+
+    normalized_sqlglot_column_names = {
+        sqlglot_column.lower() for sqlglot_column in sqlglot_column_names
+    }
+    implicit_alias_column_names = {
+        column for column in schema_column_names if column not in normalized_sqlglot_column_names
+    }
+
+    deps_by_column: Dict[str, Sequence[TableColumnDep]] = {}
+    if implicit_alias_column_names:
+        logger.warning(
+            "The following columns are implicitly aliased and will be marked with an "
+            f" empty list column dependencies: `{implicit_alias_column_names}`."
+        )
+
+        deps_by_column = {column: [] for column in implicit_alias_column_names}
+
+    for column_name in sqlglot_column_names:
+        if column_name.lower() not in schema_column_names:
+            continue
+
+        column_deps: Set[TableColumnDep] = set()
+        for sqlglot_lineage_node in lineage(
+            column=column_name,
+            sql=optimized_node_ast,
+            schema=sqlglot_mapping_schema,
+            dialect=sql_dialect,
+        ).walk():
+            # Only the leaves of the lineage graph contain relevant information.
+            if sqlglot_lineage_node.downstream:
+                continue
+
+            # Attempt to find a table in the lineage node.
+            table = sqlglot_lineage_node.expression.find(exp.Table)
+            if not table:
+                continue
+
+            # Attempt to retrieve the table's associated asset key and column.
+            parent_column_name = exp.to_column(sqlglot_lineage_node.name).name.lower()
+            parent_relation_name = normalize_table_name(table, dialect=sql_dialect)
+            parent_resource_props = dbt_parent_resource_props_by_relation_name.get(
+                parent_relation_name
+            )
+            if not parent_resource_props:
+                continue
+
+            # Add the column dependency.
+            column_deps.add(
+                TableColumnDep(
+                    asset_key=dagster_dbt_translator.get_asset_key(parent_resource_props),
+                    column_name=parent_column_name,
+                )
+            )
+
+        deps_by_column[column_name.lower()] = list(column_deps)
+
+    # 4. Render the lineage as metadata.
+    with disable_dagster_warnings():
+        return dict(
+            TableMetadataSet(column_lineage=TableColumnLineage(deps_by_column=deps_by_column))
+        )
+
+
+def _fetch_column_metadata(
+    invocation: DbtCliInvocation,
+    event: DbtDagsterEventType,
+) -> Optional[Dict[str, Any]]:
+    adapter = check.not_none(invocation.adapter)
+
+    dbt_resource_props = _get_dbt_resource_props_from_event(invocation, event)
+
+    with adapter.connection_named(f"column_metadata_{dbt_resource_props['unique_id']}"):
+        relation = adapter.get_relation(
+            database=dbt_resource_props["database"],
+            schema=dbt_resource_props["schema"],
+            identifier=dbt_resource_props["name"],
+        )
+        cols: List[BaseColumn] = adapter.get_columns_in_relation(relation=relation)
+        column_schema_data = {col.name: col.data_type for col in cols}
+        relation_name = str(relation)
+
+        parents = {}
+        dependent_unique_ids = invocation.manifest["parent_map"].get(
+            dbt_resource_props["unique_id"], []
+        )
+        for dep_unique_id in dependent_unique_ids:
+            dep_node = invocation.manifest["nodes"].get(dep_unique_id) or invocation.manifest[
+                "sources"
+            ].get(dep_unique_id)
+
+            dep_relation_name = dep_node["relation_name"]
+            dep_relation_components = [
+                component.strip('"') for component in dep_relation_name.split(".")
+            ]
+            dep_relation = adapter.get_relation(*dep_relation_components)
+
+            dep_cols: List[BaseColumn] = adapter.get_columns_in_relation(relation=dep_relation)
+            dep_name = str(dep_relation)
+            parents[dep_name] = {col.name: col.data_type for col in dep_cols}
+
+        metadata = _build_column_lineage_metadata(
+            event_history_metadata=EventHistoryMetadata(
+                columns=column_schema_data,
+                parents=parents,
+            ),
+            dbt_resource_props=dbt_resource_props,
+            manifest=invocation.manifest,
+            dagster_dbt_translator=invocation.dagster_dbt_translator,
+            target_path=invocation.target_path,
+        )
+
+        return metadata
+
+
 def _fetch_row_count_metadata(
     invocation: DbtCliInvocation,
     event: DbtDagsterEventType,
@@ -988,6 +1187,24 @@ class DbtEventIterator(Generic[T], abc.Iterator):
                 yielded in the order they are emitted by dbt.
         """
         return self._attach_metadata(_fetch_row_count_metadata)
+
+    @public
+    @experimental
+    def fetch_column_metadata(
+        self,
+    ) -> (
+        "DbtEventIterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]"
+    ):
+        """Experimental functionality which will fetch row counts for materialized dbt
+        models in a dbt run once they are built. Note that row counts will not be fetched
+        for views, since this requires running the view's SQL query which may be costly.
+
+        Returns:
+            Iterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]:
+                A set of corresponding Dagster events for dbt models, with row counts attached,
+                yielded in the order they are emitted by dbt.
+        """
+        return self._attach_metadata(_fetch_column_metadata)
 
     def _attach_metadata(
         self,
@@ -1335,6 +1552,14 @@ class DbtCliResource(ConfigurableResource):
         project = load_project(self.project_dir, False, profile, {})
         config = RuntimeConfig.from_parts(project, profile, flags)
 
+        new_flags = Namespace()
+        for key, val in config.args.__dict__.items():
+            setattr(new_flags, key, val)
+
+        setattr(new_flags, "profile", profile.profile_name)
+        setattr(new_flags, "target", profile.target_name)
+        config.args = new_flags
+
         # If the dbt adapter is DuckDB, set the access mode to READ_ONLY, since DuckDB only allows
         # simultaneous connections for read-only access.
         try:
@@ -1362,7 +1587,7 @@ class DbtCliResource(ConfigurableResource):
 
         adapter = cast(BaseAdapter, get_adapter(config))
         # reset the adapter since the dummy flags may be different from the flags for the actual subcommand
-        reset_adapters()
+        # reset_adapters()
         return adapter
 
     def get_defer_args(self) -> Sequence[str]:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -1065,7 +1065,6 @@ def _fetch_column_metadata(
         )
         cols: List[BaseColumn] = adapter.get_columns_in_relation(relation=relation)
         column_schema_data = {col.name: col.data_type for col in cols}
-        relation_name = str(relation)
 
         parents = {}
         dependent_unique_ids = invocation.manifest["parent_map"].get(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -283,14 +283,18 @@ class DbtCliEventMessage:
             try:
                 column_data = {
                     col_name: col_data["data_type"]
-                    for col_name, col_data in self._event_history_metadata.items()
+                    for col_name, col_data in self._event_history_metadata.get(
+                        "columns", {}
+                    ).items()
                 }
                 parent_column_data = {
                     parent_key: {
                         col_name: col_data["data_type"]
                         for col_name, col_data in parent_data["columns"].items()
                     }
-                    for parent_key, parent_data in self._event_history_metadata.items()
+                    for parent_key, parent_data in self._event_history_metadata.get(
+                        "parents", {}
+                    ).items()
                 }
 
                 lineage_metadata = _build_column_lineage_metadata(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -114,7 +114,6 @@ else:
     from dbt.node_types import REFABLE_NODE_TYPES as REFABLE_NODE_TYPES
     from dbt_common.events.event_manager_client import cleanup_event_logger
 
-
 logger = get_dagster_logger()
 
 
@@ -1508,6 +1507,7 @@ class DbtCliResource(ConfigurableResource):
         if IS_DBT_CORE_VERSION_LESS_THAN_1_8_0:
             register_adapter(config)  # type: ignore
         else:
+            from dbt.adapters.protocol import MacroContextGeneratorCallable
             from dbt.context.providers import generate_runtime_macro_context
             from dbt.mp_context import get_mp_context
             from dbt.parser.manifest import ManifestLoader
@@ -1516,11 +1516,13 @@ class DbtCliResource(ConfigurableResource):
             adapter = cast(BaseAdapter, get_adapter(config))
             manifest = ManifestLoader.load_macros(
                 config,
-                adapter.connections.set_query_header,
+                adapter.connections.set_query_header,  # type: ignore
                 base_macros_only=True,
             )
             adapter.set_macro_resolver(manifest)
-            adapter.set_macro_context_generator(generate_runtime_macro_context)
+            adapter.set_macro_context_generator(
+                cast(MacroContextGeneratorCallable, generate_runtime_macro_context)
+            )
 
         adapter = cast(BaseAdapter, get_adapter(config))
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -59,7 +59,7 @@ from dagster._model.pydantic_compat_layer import compat_model_validator
 from dagster._utils import pushd
 from dagster._utils.warnings import disable_dagster_warnings
 from dbt.adapters.base.impl import BaseAdapter, BaseColumn
-from dbt.adapters.factory import get_adapter, register_adapter
+from dbt.adapters.factory import get_adapter, register_adapter, reset_adapters
 from dbt.config import RuntimeConfig
 from dbt.config.runtime import load_profile, load_project
 from dbt.contracts.results import NodeStatus, TestStatus
@@ -1497,6 +1497,9 @@ class DbtCliResource(ConfigurableResource):
             pass
 
         cleanup_event_logger()
+
+        # reset adapters list in case we have instantiated an adapter before in this process
+        reset_adapters()
         if IS_DBT_CORE_VERSION_LESS_THAN_1_8_0:
             register_adapter(config)  # type: ignore
         else:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -289,15 +289,19 @@ class DbtCliEventMessage:
                     ).items()
                 }
 
-                lineage_metadata = _build_column_lineage_metadata(
-                    event_history_metadata=EventHistoryMetadata(
-                        columns=column_data, parents=parent_column_data
-                    ),
-                    dbt_resource_props=dbt_resource_props,
-                    manifest=manifest,
-                    dagster_dbt_translator=dagster_dbt_translator,
-                    target_path=target_path,
-                )
+                if (
+                    # Column lineage can only be built if initial metadata is provided.
+                    self.has_column_lineage_metadata
+                ):
+                    lineage_metadata = _build_column_lineage_metadata(
+                        event_history_metadata=EventHistoryMetadata(
+                            columns=column_data, parents=parent_column_data
+                        ),
+                        dbt_resource_props=dbt_resource_props,
+                        manifest=manifest,
+                        dagster_dbt_translator=dagster_dbt_translator,
+                        target_path=target_path,
+                    )
             except Exception as e:
                 logger.warning(
                     "An error occurred while building column lineage metadata for the dbt resource"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -22,6 +22,8 @@ from sqlglot import Dialect
 
 from ...dbt_projects import test_jaffle_shop_path, test_metadata_path
 
+pytestmark = pytest.mark.derived_metadata
+
 
 def test_no_column_schema(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
     @dbt_assets(manifest=test_jaffle_shop_manifest)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -201,24 +201,29 @@ def test_column_lineage(
             "--exclude",
             "resource_type:test",
             "--vars",
-            json.dumps({"dagster_enable_parent_relation_metadata_collection": not defer_metadata_collection_and_lineage_processing}),
+            json.dumps(
+                {
+                    "dagster_enable_parent_relation_metadata_collection": not defer_metadata_collection_and_lineage_processing
+                }
+            ),
         ]
     ).wait()
 
     @dbt_assets(manifest=manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        execution = (
-            dbt.cli(
-                [
-                    "build",
-                    "--vars",
-                    json.dumps({"dagster_enable_parent_relation_metadata_collection": not defer_metadata_collection_and_lineage_processing}),
-                ],
-                context=context,
-            )
-            .stream()
-        )
-        if defer_metadata_collection_and_lineage_processing
+        execution = dbt.cli(
+            [
+                "build",
+                "--vars",
+                json.dumps(
+                    {
+                        "dagster_enable_parent_relation_metadata_collection": not defer_metadata_collection_and_lineage_processing
+                    }
+                ),
+            ],
+            context=context,
+        ).stream()
+        if defer_metadata_collection_and_lineage_processing:
             execution = execution.fetch_column_metadata()
         yield from execution
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -15,7 +15,6 @@ from dagster import (
     materialize,
 )
 from dagster._core.definitions.metadata import TableMetadataSet
-from dagster._utils.env import environ
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.core.resources_v2 import DbtCliResource
 from pytest_mock import MockFixture
@@ -46,48 +45,50 @@ def test_no_column_schema(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
     [True, False],
 )
 def test_column_schema(
-    test_metadata_manifest: Dict[str, Any], use_experimental_fetch_column_schema: bool
+    test_metadata_manifest: Dict[str, Any],
+    use_experimental_fetch_column_schema: bool,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    with environ(
-        {"DBT_LOG_COLUMN_METADATA": str(not use_experimental_fetch_column_schema).lower()}
-    ):
+    monkeypatch.setenv(
+        "DBT_LOG_COLUMN_METADATA", str(not use_experimental_fetch_column_schema).lower()
+    )
 
-        @dbt_assets(manifest=test_metadata_manifest)
-        def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-            cli_invocation = dbt.cli(["build"], context=context).stream()
-            if use_experimental_fetch_column_schema:
-                cli_invocation = cli_invocation.fetch_column_metadata(with_column_lineage=False)
-            yield from cli_invocation
+    @dbt_assets(manifest=test_metadata_manifest)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        cli_invocation = dbt.cli(["build"], context=context).stream()
+        if use_experimental_fetch_column_schema:
+            cli_invocation = cli_invocation.fetch_column_metadata(with_column_lineage=False)
+        yield from cli_invocation
 
-        result = materialize(
-            [my_dbt_assets],
-            resources={"dbt": DbtCliResource(project_dir=os.fspath(test_metadata_path))},
-        )
+    result = materialize(
+        [my_dbt_assets],
+        resources={"dbt": DbtCliResource(project_dir=os.fspath(test_metadata_path))},
+    )
 
-        assert result.success
+    assert result.success
 
-        table_schema_by_asset_key = {
-            event.materialization.asset_key: TableMetadataSet.extract(
-                event.materialization.metadata
-            ).column_schema
-            for event in result.get_asset_materialization_events()
-            if event.materialization.asset_key == AssetKey(["customers"])
-        }
-        expected_table_schema_by_asset_key = {
-            AssetKey(["customers"]): TableSchema(
-                columns=[
-                    TableColumn("customer_id", type="INTEGER"),
-                    TableColumn("first_name", type="character varying(256)"),
-                    TableColumn("last_name", type="character varying(256)"),
-                    TableColumn("first_order", type="DATE"),
-                    TableColumn("most_recent_order", type="DATE"),
-                    TableColumn("number_of_orders", type="BIGINT"),
-                    TableColumn("customer_lifetime_value", type="DOUBLE"),
-                ]
-            ),
-        }
+    table_schema_by_asset_key = {
+        event.materialization.asset_key: TableMetadataSet.extract(
+            event.materialization.metadata
+        ).column_schema
+        for event in result.get_asset_materialization_events()
+        if event.materialization.asset_key == AssetKey(["customers"])
+    }
+    expected_table_schema_by_asset_key = {
+        AssetKey(["customers"]): TableSchema(
+            columns=[
+                TableColumn("customer_id", type="INTEGER"),
+                TableColumn("first_name", type="character varying(256)"),
+                TableColumn("last_name", type="character varying(256)"),
+                TableColumn("first_order", type="DATE"),
+                TableColumn("most_recent_order", type="DATE"),
+                TableColumn("number_of_orders", type="BIGINT"),
+                TableColumn("customer_lifetime_value", type="DOUBLE"),
+            ]
+        ),
+    }
 
-        assert table_schema_by_asset_key == expected_table_schema_by_asset_key
+    assert table_schema_by_asset_key == expected_table_schema_by_asset_key
 
 
 @pytest.mark.parametrize(
@@ -98,32 +99,33 @@ def test_exception_column_schema(
     mocker: MockFixture,
     test_metadata_manifest: Dict[str, Any],
     use_experimental_fetch_column_schema: bool,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    with environ(
-        {"DBT_LOG_COLUMN_METADATA": str(not use_experimental_fetch_column_schema).lower()}
-    ):
-        mocker.patch(
-            "dagster_dbt.core.resources_v2.default_metadata_from_dbt_resource_props",
-            side_effect=Exception("An error occurred"),
-        )
+    monkeypatch.setenv(
+        "DBT_LOG_COLUMN_METADATA", str(not use_experimental_fetch_column_schema).lower()
+    )
+    mocker.patch(
+        "dagster_dbt.core.resources_v2.default_metadata_from_dbt_resource_props",
+        side_effect=Exception("An error occurred"),
+    )
 
-        @dbt_assets(manifest=test_metadata_manifest)
-        def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-            cli_invocation = dbt.cli(["build"], context=context).stream()
-            if use_experimental_fetch_column_schema:
-                cli_invocation = cli_invocation.fetch_column_metadata(with_column_lineage=False)
-            yield from cli_invocation
+    @dbt_assets(manifest=test_metadata_manifest)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        cli_invocation = dbt.cli(["build"], context=context).stream()
+        if use_experimental_fetch_column_schema:
+            cli_invocation = cli_invocation.fetch_column_metadata(with_column_lineage=False)
+        yield from cli_invocation
 
-        result = materialize(
-            [my_dbt_assets],
-            resources={"dbt": DbtCliResource(project_dir=os.fspath(test_metadata_path))},
-        )
+    result = materialize(
+        [my_dbt_assets],
+        resources={"dbt": DbtCliResource(project_dir=os.fspath(test_metadata_path))},
+    )
 
-        assert result.success
-        assert all(
-            not TableMetadataSet.extract(event.materialization.metadata).column_schema
-            for event in result.get_asset_materialization_events()
-        )
+    assert result.success
+    assert all(
+        not TableMetadataSet.extract(event.materialization.metadata).column_schema
+        for event in result.get_asset_materialization_events()
+    )
 
 
 def test_no_column_lineage(test_metadata_manifest: Dict[str, Any]) -> None:
@@ -158,32 +160,33 @@ def test_exception_column_lineage(
     mocker: MockFixture,
     test_metadata_manifest: Dict[str, Any],
     use_experimental_fetch_column_schema: bool,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    with environ(
-        {"DBT_LOG_COLUMN_METADATA": str(not use_experimental_fetch_column_schema).lower()}
-    ):
-        mocker.patch(
-            "dagster_dbt.core.resources_v2._build_column_lineage_metadata",
-            side_effect=Exception("An error occurred"),
-        )
+    monkeypatch.setenv(
+        "DBT_LOG_COLUMN_METADATA", str(not use_experimental_fetch_column_schema).lower()
+    )
+    mocker.patch(
+        "dagster_dbt.core.resources_v2._build_column_lineage_metadata",
+        side_effect=Exception("An error occurred"),
+    )
 
-        @dbt_assets(manifest=test_metadata_manifest)
-        def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-            cli_invocation = dbt.cli(["build"], context=context).stream()
-            if use_experimental_fetch_column_schema:
-                cli_invocation = cli_invocation.fetch_column_metadata(with_column_lineage=False)
-            yield from cli_invocation
+    @dbt_assets(manifest=test_metadata_manifest)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        cli_invocation = dbt.cli(["build"], context=context).stream()
+        if use_experimental_fetch_column_schema:
+            cli_invocation = cli_invocation.fetch_column_metadata(with_column_lineage=False)
+        yield from cli_invocation
 
-        result = materialize(
-            [my_dbt_assets],
-            resources={"dbt": DbtCliResource(project_dir=os.fspath(test_metadata_path))},
-        )
+    result = materialize(
+        [my_dbt_assets],
+        resources={"dbt": DbtCliResource(project_dir=os.fspath(test_metadata_path))},
+    )
 
-        assert result.success
-        assert all(
-            not TableMetadataSet.extract(event.materialization.metadata).column_lineage
-            for event in result.get_asset_materialization_events()
-        )
+    assert result.success
+    assert all(
+        not TableMetadataSet.extract(event.materialization.metadata).column_lineage
+        for event in result.get_asset_materialization_events()
+    )
 
 
 @pytest.mark.parametrize(
@@ -224,246 +227,233 @@ def test_column_lineage(
     test_metadata_manifest: Dict[str, Any],
     asset_key_selection: Optional[AssetKey],
     use_experimental_fetch_column_schema: bool,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    with environ(
-        {"DBT_LOG_COLUMN_METADATA": str(not use_experimental_fetch_column_schema).lower()}
-    ):
-        # Simulate the parsing of the SQL into a different dialect.
-        assert Dialect.get_or_raise(sql_dialect)
+    monkeypatch.setenv(
+        "DBT_LOG_COLUMN_METADATA", str(not use_experimental_fetch_column_schema).lower()
+    )
+    # Simulate the parsing of the SQL into a different dialect.
+    assert Dialect.get_or_raise(sql_dialect)
 
-        manifest = test_metadata_manifest.copy()
-        manifest["metadata"]["adapter_type"] = sql_dialect
+    manifest = test_metadata_manifest.copy()
+    manifest["metadata"]["adapter_type"] = sql_dialect
 
-        dbt = DbtCliResource(project_dir=os.fspath(test_metadata_path))
-        dbt.cli(
-            [
-                "--quiet",
-                "build",
-                "--exclude",
-                "resource_type:test",
-            ]
-        ).wait()
+    dbt = DbtCliResource(project_dir=os.fspath(test_metadata_path))
+    dbt.cli(
+        [
+            "--quiet",
+            "build",
+            "--exclude",
+            "resource_type:test",
+        ]
+    ).wait()
 
-        @dbt_assets(manifest=manifest)
-        def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-            cli_invocation = dbt.cli(["build"], context=context).stream()
-            if use_experimental_fetch_column_schema:
-                cli_invocation = cli_invocation.fetch_column_metadata()
-            yield from cli_invocation
+    @dbt_assets(manifest=manifest)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        cli_invocation = dbt.cli(["build"], context=context).stream()
+        if use_experimental_fetch_column_schema:
+            cli_invocation = cli_invocation.fetch_column_metadata()
+        yield from cli_invocation
 
-        result = materialize(
-            [my_dbt_assets],
-            resources={"dbt": dbt},
-            selection=asset_key_selection and AssetSelection.assets(asset_key_selection),
-        )
-        assert result.success
+    result = materialize(
+        [my_dbt_assets],
+        resources={"dbt": dbt},
+        selection=asset_key_selection and AssetSelection.assets(asset_key_selection),
+    )
+    assert result.success
 
-        column_lineage_by_asset_key = {
-            event.materialization.asset_key: TableMetadataSet.extract(
-                event.materialization.metadata
-            ).column_lineage
-            for event in result.get_asset_materialization_events()
-        }
+    column_lineage_by_asset_key = {
+        event.materialization.asset_key: TableMetadataSet.extract(
+            event.materialization.metadata
+        ).column_lineage
+        for event in result.get_asset_materialization_events()
+    }
 
-        expected_column_lineage_by_asset_key = {
-            AssetKey(["raw_customers"]): None,
-            AssetKey(["raw_payments"]): None,
-            AssetKey(["raw_orders"]): None,
-            AssetKey(["stg_payments"]): TableColumnLineage(
-                deps_by_column={
-                    "payment_id": [
-                        TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="id")
-                    ],
-                    "order_id": [
-                        TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="order_id")
-                    ],
-                    "payment_method": [
-                        TableColumnDep(
-                            asset_key=AssetKey(["raw_payments"]), column_name="payment_method"
-                        )
-                    ],
-                    "amount": [
-                        TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="amount")
-                    ],
-                }
-            ),
-            AssetKey(["stg_customers"]): TableColumnLineage(
-                deps_by_column={
-                    "customer_id": [
-                        TableColumnDep(
-                            asset_key=AssetKey(["raw_source_customers"]), column_name="id"
-                        )
-                    ],
-                    "first_name": [
-                        TableColumnDep(
-                            asset_key=AssetKey(["raw_source_customers"]), column_name="first_name"
-                        )
-                    ],
-                    "last_name": [
-                        TableColumnDep(
-                            asset_key=AssetKey(["raw_source_customers"]), column_name="last_name"
-                        )
-                    ],
-                }
-            ),
-            AssetKey(["stg_orders"]): TableColumnLineage(
-                deps_by_column={
-                    "order_id": [
-                        TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="id")
-                    ],
-                    "customer_id": [
-                        TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="user_id")
-                    ],
-                    "order_date": [
-                        TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="order_date")
-                    ],
-                    "status": [
-                        TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="status")
-                    ],
-                }
-            ),
-            AssetKey(["orders"]): TableColumnLineage(
-                deps_by_column={
-                    "order_id": [
-                        TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_id")
-                    ],
-                    "customer_id": [
-                        TableColumnDep(
-                            asset_key=AssetKey(["stg_orders"]), column_name="customer_id"
-                        )
-                    ],
-                    "order_date": [
-                        TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
-                    ],
-                    "status": [
-                        TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="status")
-                    ],
-                    "credit_card_amount": [
-                        TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
-                        TableColumnDep(
-                            asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
-                        ),
-                    ],
-                    "coupon_amount": [
-                        TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
-                        TableColumnDep(
-                            asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
-                        ),
-                    ],
-                    "bank_transfer_amount": [
-                        TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
-                        TableColumnDep(
-                            asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
-                        ),
-                    ],
-                    "gift_card_amount": [
-                        TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
-                        TableColumnDep(
-                            asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
-                        ),
-                    ],
-                    "amount": [
-                        TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
-                    ],
-                }
-            ),
-            AssetKey(["duplicate_column_dep_orders"]): TableColumnLineage(
-                deps_by_column={
-                    "amount_2x": [
-                        TableColumnDep(asset_key=AssetKey(["orders"]), column_name="amount")
-                    ],
-                }
-            ),
-            AssetKey(["incremental_orders"]): TableColumnLineage(
-                deps_by_column={
-                    "order_id": [
-                        TableColumnDep(asset_key=AssetKey(["orders"]), column_name="order_id")
-                    ],
-                }
-            ),
-            AssetKey(["customers"]): TableColumnLineage(
-                deps_by_column={
-                    "customer_id": [
-                        TableColumnDep(
-                            asset_key=AssetKey(["stg_customers"]), column_name="customer_id"
-                        )
-                    ],
-                    "first_name": [
-                        TableColumnDep(
-                            asset_key=AssetKey(["stg_customers"]), column_name="first_name"
-                        )
-                    ],
-                    "last_name": [
-                        TableColumnDep(
-                            asset_key=AssetKey(["stg_customers"]), column_name="last_name"
-                        )
-                    ],
-                    "first_order": [
-                        TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
-                    ],
-                    "most_recent_order": [
-                        TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
-                    ],
-                    "number_of_orders": [
-                        TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_id")
-                    ],
-                    "customer_lifetime_value": [
-                        TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount")
-                    ],
-                }
-            ),
-            AssetKey(["select_star_customers"]): TableColumnLineage(
-                deps_by_column={
-                    "customer_id": [
-                        TableColumnDep(asset_key=AssetKey(["customers"]), column_name="customer_id")
-                    ],
-                    "first_name": [
-                        TableColumnDep(asset_key=AssetKey(["customers"]), column_name="first_name")
-                    ],
-                    "last_name": [
-                        TableColumnDep(asset_key=AssetKey(["customers"]), column_name="last_name")
-                    ],
-                    "first_order": [
-                        TableColumnDep(asset_key=AssetKey(["customers"]), column_name="first_order")
-                    ],
-                    "most_recent_order": [
-                        TableColumnDep(
-                            asset_key=AssetKey(["customers"]), column_name="most_recent_order"
-                        )
-                    ],
-                    "number_of_orders": [
-                        TableColumnDep(
-                            asset_key=AssetKey(["customers"]), column_name="number_of_orders"
-                        )
-                    ],
-                    "customer_lifetime_value": [
-                        TableColumnDep(
-                            asset_key=AssetKey(["customers"]), column_name="customer_lifetime_value"
-                        )
-                    ],
-                }
-            ),
-            AssetKey(["count_star_customers"]): TableColumnLineage(
-                deps_by_column={
-                    "count_star": [],
-                }
-            ),
-            AssetKey(["count_star_implicit_alias_customers"]): TableColumnLineage(
-                deps_by_column={
-                    "count_star()": [],
-                }
-            ),
-        }
-        if asset_key_selection:
-            expected_column_lineage_by_asset_key = {
-                asset_key: deps_by_column
-                for asset_key, deps_by_column in expected_column_lineage_by_asset_key.items()
-                if asset_key == asset_key_selection
+    expected_column_lineage_by_asset_key = {
+        AssetKey(["raw_customers"]): None,
+        AssetKey(["raw_payments"]): None,
+        AssetKey(["raw_orders"]): None,
+        AssetKey(["stg_payments"]): TableColumnLineage(
+            deps_by_column={
+                "payment_id": [
+                    TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="id")
+                ],
+                "order_id": [
+                    TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="order_id")
+                ],
+                "payment_method": [
+                    TableColumnDep(
+                        asset_key=AssetKey(["raw_payments"]), column_name="payment_method"
+                    )
+                ],
+                "amount": [
+                    TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="amount")
+                ],
             }
+        ),
+        AssetKey(["stg_customers"]): TableColumnLineage(
+            deps_by_column={
+                "customer_id": [
+                    TableColumnDep(asset_key=AssetKey(["raw_source_customers"]), column_name="id")
+                ],
+                "first_name": [
+                    TableColumnDep(
+                        asset_key=AssetKey(["raw_source_customers"]), column_name="first_name"
+                    )
+                ],
+                "last_name": [
+                    TableColumnDep(
+                        asset_key=AssetKey(["raw_source_customers"]), column_name="last_name"
+                    )
+                ],
+            }
+        ),
+        AssetKey(["stg_orders"]): TableColumnLineage(
+            deps_by_column={
+                "order_id": [TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="id")],
+                "customer_id": [
+                    TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="user_id")
+                ],
+                "order_date": [
+                    TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="order_date")
+                ],
+                "status": [
+                    TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="status")
+                ],
+            }
+        ),
+        AssetKey(["orders"]): TableColumnLineage(
+            deps_by_column={
+                "order_id": [
+                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_id")
+                ],
+                "customer_id": [
+                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="customer_id")
+                ],
+                "order_date": [
+                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
+                ],
+                "status": [
+                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="status")
+                ],
+                "credit_card_amount": [
+                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
+                    TableColumnDep(
+                        asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
+                    ),
+                ],
+                "coupon_amount": [
+                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
+                    TableColumnDep(
+                        asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
+                    ),
+                ],
+                "bank_transfer_amount": [
+                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
+                    TableColumnDep(
+                        asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
+                    ),
+                ],
+                "gift_card_amount": [
+                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
+                    TableColumnDep(
+                        asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
+                    ),
+                ],
+                "amount": [
+                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
+                ],
+            }
+        ),
+        AssetKey(["duplicate_column_dep_orders"]): TableColumnLineage(
+            deps_by_column={
+                "amount_2x": [TableColumnDep(asset_key=AssetKey(["orders"]), column_name="amount")],
+            }
+        ),
+        AssetKey(["incremental_orders"]): TableColumnLineage(
+            deps_by_column={
+                "order_id": [
+                    TableColumnDep(asset_key=AssetKey(["orders"]), column_name="order_id")
+                ],
+            }
+        ),
+        AssetKey(["customers"]): TableColumnLineage(
+            deps_by_column={
+                "customer_id": [
+                    TableColumnDep(asset_key=AssetKey(["stg_customers"]), column_name="customer_id")
+                ],
+                "first_name": [
+                    TableColumnDep(asset_key=AssetKey(["stg_customers"]), column_name="first_name")
+                ],
+                "last_name": [
+                    TableColumnDep(asset_key=AssetKey(["stg_customers"]), column_name="last_name")
+                ],
+                "first_order": [
+                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
+                ],
+                "most_recent_order": [
+                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
+                ],
+                "number_of_orders": [
+                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_id")
+                ],
+                "customer_lifetime_value": [
+                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount")
+                ],
+            }
+        ),
+        AssetKey(["select_star_customers"]): TableColumnLineage(
+            deps_by_column={
+                "customer_id": [
+                    TableColumnDep(asset_key=AssetKey(["customers"]), column_name="customer_id")
+                ],
+                "first_name": [
+                    TableColumnDep(asset_key=AssetKey(["customers"]), column_name="first_name")
+                ],
+                "last_name": [
+                    TableColumnDep(asset_key=AssetKey(["customers"]), column_name="last_name")
+                ],
+                "first_order": [
+                    TableColumnDep(asset_key=AssetKey(["customers"]), column_name="first_order")
+                ],
+                "most_recent_order": [
+                    TableColumnDep(
+                        asset_key=AssetKey(["customers"]), column_name="most_recent_order"
+                    )
+                ],
+                "number_of_orders": [
+                    TableColumnDep(
+                        asset_key=AssetKey(["customers"]), column_name="number_of_orders"
+                    )
+                ],
+                "customer_lifetime_value": [
+                    TableColumnDep(
+                        asset_key=AssetKey(["customers"]), column_name="customer_lifetime_value"
+                    )
+                ],
+            }
+        ),
+        AssetKey(["count_star_customers"]): TableColumnLineage(
+            deps_by_column={
+                "count_star": [],
+            }
+        ),
+        AssetKey(["count_star_implicit_alias_customers"]): TableColumnLineage(
+            deps_by_column={
+                "count_star()": [],
+            }
+        ),
+    }
+    if asset_key_selection:
+        expected_column_lineage_by_asset_key = {
+            asset_key: deps_by_column
+            for asset_key, deps_by_column in expected_column_lineage_by_asset_key.items()
+            if asset_key == asset_key_selection
+        }
 
-        assert column_lineage_by_asset_key == expected_column_lineage_by_asset_key, (
-            str(column_lineage_by_asset_key) + "\n\n" + str(expected_column_lineage_by_asset_key)
-        )
+    assert column_lineage_by_asset_key == expected_column_lineage_by_asset_key, (
+        str(column_lineage_by_asset_key) + "\n\n" + str(expected_column_lineage_by_asset_key)
+    )
 
 
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -15,6 +15,7 @@ from dagster import (
     materialize,
 )
 from dagster._core.definitions.metadata import TableMetadataSet
+from dagster._utils.env import environ
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.core.resources_v2 import DbtCliResource
 from pytest_mock import MockFixture
@@ -40,64 +41,89 @@ def test_no_column_schema(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
     )
 
 
-def test_column_schema(test_metadata_manifest: Dict[str, Any]) -> None:
-    @dbt_assets(manifest=test_metadata_manifest)
-    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        yield from dbt.cli(["build"], context=context).stream()
-
-    result = materialize(
-        [my_dbt_assets],
-        resources={"dbt": DbtCliResource(project_dir=os.fspath(test_metadata_path))},
-    )
-
-    assert result.success
-
-    table_schema_by_asset_key = {
-        event.materialization.asset_key: TableMetadataSet.extract(
-            event.materialization.metadata
-        ).column_schema
-        for event in result.get_asset_materialization_events()
-        if event.materialization.asset_key == AssetKey(["customers"])
-    }
-    expected_table_schema_by_asset_key = {
-        AssetKey(["customers"]): TableSchema(
-            columns=[
-                TableColumn("customer_id", type="INTEGER"),
-                TableColumn("first_name", type="character varying(256)"),
-                TableColumn("last_name", type="character varying(256)"),
-                TableColumn("first_order", type="DATE"),
-                TableColumn("most_recent_order", type="DATE"),
-                TableColumn("number_of_orders", type="BIGINT"),
-                TableColumn("customer_lifetime_value", type="DOUBLE"),
-            ]
-        ),
-    }
-
-    assert table_schema_by_asset_key == expected_table_schema_by_asset_key
-
-
-def test_exception_column_schema(
-    mocker: MockFixture, test_metadata_manifest: Dict[str, Any]
+@pytest.mark.parametrize(
+    "use_experimental_fetch_column_schema",
+    [True, False],
+)
+def test_column_schema(
+    test_metadata_manifest: Dict[str, Any], use_experimental_fetch_column_schema: bool
 ) -> None:
-    mocker.patch(
-        "dagster_dbt.core.resources_v2.default_metadata_from_dbt_resource_props",
-        side_effect=Exception("An error occurred"),
-    )
+    with environ(
+        {"DBT_LOG_COLUMN_METADATA": str(not use_experimental_fetch_column_schema).lower()}
+    ):
 
-    @dbt_assets(manifest=test_metadata_manifest)
-    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        yield from dbt.cli(["build"], context=context).stream()
+        @dbt_assets(manifest=test_metadata_manifest)
+        def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+            cli_invocation = dbt.cli(["build"], context=context).stream()
+            if use_experimental_fetch_column_schema:
+                cli_invocation = cli_invocation.fetch_column_metadata(with_column_lineage=False)
+            yield from cli_invocation
 
-    result = materialize(
-        [my_dbt_assets],
-        resources={"dbt": DbtCliResource(project_dir=os.fspath(test_metadata_path))},
-    )
+        result = materialize(
+            [my_dbt_assets],
+            resources={"dbt": DbtCliResource(project_dir=os.fspath(test_metadata_path))},
+        )
 
-    assert result.success
-    assert all(
-        not TableMetadataSet.extract(event.materialization.metadata).column_schema
-        for event in result.get_asset_materialization_events()
-    )
+        assert result.success
+
+        table_schema_by_asset_key = {
+            event.materialization.asset_key: TableMetadataSet.extract(
+                event.materialization.metadata
+            ).column_schema
+            for event in result.get_asset_materialization_events()
+            if event.materialization.asset_key == AssetKey(["customers"])
+        }
+        expected_table_schema_by_asset_key = {
+            AssetKey(["customers"]): TableSchema(
+                columns=[
+                    TableColumn("customer_id", type="INTEGER"),
+                    TableColumn("first_name", type="character varying(256)"),
+                    TableColumn("last_name", type="character varying(256)"),
+                    TableColumn("first_order", type="DATE"),
+                    TableColumn("most_recent_order", type="DATE"),
+                    TableColumn("number_of_orders", type="BIGINT"),
+                    TableColumn("customer_lifetime_value", type="DOUBLE"),
+                ]
+            ),
+        }
+
+        assert table_schema_by_asset_key == expected_table_schema_by_asset_key
+
+
+@pytest.mark.parametrize(
+    "use_experimental_fetch_column_schema",
+    [True, False],
+)
+def test_exception_column_schema(
+    mocker: MockFixture,
+    test_metadata_manifest: Dict[str, Any],
+    use_experimental_fetch_column_schema: bool,
+) -> None:
+    with environ(
+        {"DBT_LOG_COLUMN_METADATA": str(not use_experimental_fetch_column_schema).lower()}
+    ):
+        mocker.patch(
+            "dagster_dbt.core.resources_v2.default_metadata_from_dbt_resource_props",
+            side_effect=Exception("An error occurred"),
+        )
+
+        @dbt_assets(manifest=test_metadata_manifest)
+        def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+            cli_invocation = dbt.cli(["build"], context=context).stream()
+            if use_experimental_fetch_column_schema:
+                cli_invocation = cli_invocation.fetch_column_metadata(with_column_lineage=False)
+            yield from cli_invocation
+
+        result = materialize(
+            [my_dbt_assets],
+            resources={"dbt": DbtCliResource(project_dir=os.fspath(test_metadata_path))},
+        )
+
+        assert result.success
+        assert all(
+            not TableMetadataSet.extract(event.materialization.metadata).column_schema
+            for event in result.get_asset_materialization_events()
+        )
 
 
 def test_no_column_lineage(test_metadata_manifest: Dict[str, Any]) -> None:
@@ -124,28 +150,40 @@ def test_no_column_lineage(test_metadata_manifest: Dict[str, Any]) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "use_experimental_fetch_column_schema",
+    [True, False],
+)
 def test_exception_column_lineage(
-    mocker: MockFixture, test_metadata_manifest: Dict[str, Any]
+    mocker: MockFixture,
+    test_metadata_manifest: Dict[str, Any],
+    use_experimental_fetch_column_schema: bool,
 ) -> None:
-    mocker.patch(
-        "dagster_dbt.core.resources_v2.DbtCliEventMessage._build_column_lineage_metadata",
-        side_effect=Exception("An error occurred"),
-    )
+    with environ(
+        {"DBT_LOG_COLUMN_METADATA": str(not use_experimental_fetch_column_schema).lower()}
+    ):
+        mocker.patch(
+            "dagster_dbt.core.resources_v2._build_column_lineage_metadata",
+            side_effect=Exception("An error occurred"),
+        )
 
-    @dbt_assets(manifest=test_metadata_manifest)
-    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        yield from dbt.cli(["build"], context=context).stream()
+        @dbt_assets(manifest=test_metadata_manifest)
+        def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+            cli_invocation = dbt.cli(["build"], context=context).stream()
+            if use_experimental_fetch_column_schema:
+                cli_invocation = cli_invocation.fetch_column_metadata(with_column_lineage=False)
+            yield from cli_invocation
 
-    result = materialize(
-        [my_dbt_assets],
-        resources={"dbt": DbtCliResource(project_dir=os.fspath(test_metadata_path))},
-    )
+        result = materialize(
+            [my_dbt_assets],
+            resources={"dbt": DbtCliResource(project_dir=os.fspath(test_metadata_path))},
+        )
 
-    assert result.success
-    assert all(
-        not TableMetadataSet.extract(event.materialization.metadata).column_lineage
-        for event in result.get_asset_materialization_events()
-    )
+        assert result.success
+        assert all(
+            not TableMetadataSet.extract(event.materialization.metadata).column_lineage
+            for event in result.get_asset_materialization_events()
+        )
 
 
 @pytest.mark.parametrize(
@@ -178,251 +216,254 @@ def test_exception_column_lineage(
     ],
 )
 @pytest.mark.parametrize(
-    "defer_metadata_collection_and_lineage_processing",
+    "use_experimental_fetch_column_schema",
     [True, False],
 )
 def test_column_lineage(
-    test_metadata_manifest: Dict[str, Any],
     sql_dialect: str,
+    test_metadata_manifest: Dict[str, Any],
     asset_key_selection: Optional[AssetKey],
-    defer_metadata_collection_and_lineage_processing: bool,
+    use_experimental_fetch_column_schema: bool,
 ) -> None:
-    # Simulate the parsing of the SQL into a different dialect.
-    assert Dialect.get_or_raise(sql_dialect)
+    with environ(
+        {"DBT_LOG_COLUMN_METADATA": str(not use_experimental_fetch_column_schema).lower()}
+    ):
+        # Simulate the parsing of the SQL into a different dialect.
+        assert Dialect.get_or_raise(sql_dialect)
 
-    manifest = test_metadata_manifest.copy()
-    manifest["metadata"]["adapter_type"] = sql_dialect
+        manifest = test_metadata_manifest.copy()
+        manifest["metadata"]["adapter_type"] = sql_dialect
 
-    dbt = DbtCliResource(project_dir=os.fspath(test_metadata_path))
-    dbt.cli(
-        [
-            "--quiet",
-            "build",
-            "--exclude",
-            "resource_type:test",
-            "--vars",
-            json.dumps(
-                {
-                    "dagster_enable_parent_relation_metadata_collection": not defer_metadata_collection_and_lineage_processing
-                }
-            ),
-        ]
-    ).wait()
-
-    @dbt_assets(manifest=manifest)
-    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        execution = dbt.cli(
+        dbt = DbtCliResource(project_dir=os.fspath(test_metadata_path))
+        dbt.cli(
             [
+                "--quiet",
                 "build",
-                "--vars",
-                json.dumps(
-                    {
-                        "dagster_enable_parent_relation_metadata_collection": not defer_metadata_collection_and_lineage_processing
-                    }
-                ),
-            ],
-            context=context,
-        ).stream()
-        if defer_metadata_collection_and_lineage_processing:
-            execution = execution.fetch_column_metadata()
-        yield from execution
+                "--exclude",
+                "resource_type:test",
+            ]
+        ).wait()
 
-    result = materialize(
-        [my_dbt_assets],
-        resources={"dbt": dbt},
-        selection=asset_key_selection and AssetSelection.assets(asset_key_selection),
-    )
-    assert result.success
+        @dbt_assets(manifest=manifest)
+        def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+            cli_invocation = dbt.cli(["build"], context=context).stream()
+            if use_experimental_fetch_column_schema:
+                cli_invocation = cli_invocation.fetch_column_metadata()
+            yield from cli_invocation
 
-    column_lineage_by_asset_key = {
-        event.materialization.asset_key: TableMetadataSet.extract(
-            event.materialization.metadata
-        ).column_lineage
-        for event in result.get_asset_materialization_events()
-    }
-    expected_column_lineage_by_asset_key = {
-        AssetKey(["raw_customers"]): None,
-        AssetKey(["raw_payments"]): None,
-        AssetKey(["raw_orders"]): None,
-        AssetKey(["stg_payments"]): TableColumnLineage(
-            deps_by_column={
-                "payment_id": [
-                    TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="id")
-                ],
-                "order_id": [
-                    TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="order_id")
-                ],
-                "payment_method": [
-                    TableColumnDep(
-                        asset_key=AssetKey(["raw_payments"]), column_name="payment_method"
-                    )
-                ],
-                "amount": [
-                    TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="amount")
-                ],
-            }
-        ),
-        AssetKey(["stg_customers"]): TableColumnLineage(
-            deps_by_column={
-                "customer_id": [
-                    TableColumnDep(asset_key=AssetKey(["raw_source_customers"]), column_name="id")
-                ],
-                "first_name": [
-                    TableColumnDep(
-                        asset_key=AssetKey(["raw_source_customers"]), column_name="first_name"
-                    )
-                ],
-                "last_name": [
-                    TableColumnDep(
-                        asset_key=AssetKey(["raw_source_customers"]), column_name="last_name"
-                    )
-                ],
-            }
-        ),
-        AssetKey(["stg_orders"]): TableColumnLineage(
-            deps_by_column={
-                "order_id": [TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="id")],
-                "customer_id": [
-                    TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="user_id")
-                ],
-                "order_date": [
-                    TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="order_date")
-                ],
-                "status": [
-                    TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="status")
-                ],
-            }
-        ),
-        AssetKey(["orders"]): TableColumnLineage(
-            deps_by_column={
-                "order_id": [
-                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_id")
-                ],
-                "customer_id": [
-                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="customer_id")
-                ],
-                "order_date": [
-                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
-                ],
-                "status": [
-                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="status")
-                ],
-                "credit_card_amount": [
-                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
-                    TableColumnDep(
-                        asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
-                    ),
-                ],
-                "coupon_amount": [
-                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
-                    TableColumnDep(
-                        asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
-                    ),
-                ],
-                "bank_transfer_amount": [
-                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
-                    TableColumnDep(
-                        asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
-                    ),
-                ],
-                "gift_card_amount": [
-                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
-                    TableColumnDep(
-                        asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
-                    ),
-                ],
-                "amount": [
-                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
-                ],
-            }
-        ),
-        AssetKey(["duplicate_column_dep_orders"]): TableColumnLineage(
-            deps_by_column={
-                "amount_2x": [TableColumnDep(asset_key=AssetKey(["orders"]), column_name="amount")],
-            }
-        ),
-        AssetKey(["incremental_orders"]): TableColumnLineage(
-            deps_by_column={
-                "order_id": [
-                    TableColumnDep(asset_key=AssetKey(["orders"]), column_name="order_id")
-                ],
-            }
-        ),
-        AssetKey(["customers"]): TableColumnLineage(
-            deps_by_column={
-                "customer_id": [
-                    TableColumnDep(asset_key=AssetKey(["stg_customers"]), column_name="customer_id")
-                ],
-                "first_name": [
-                    TableColumnDep(asset_key=AssetKey(["stg_customers"]), column_name="first_name")
-                ],
-                "last_name": [
-                    TableColumnDep(asset_key=AssetKey(["stg_customers"]), column_name="last_name")
-                ],
-                "first_order": [
-                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
-                ],
-                "most_recent_order": [
-                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
-                ],
-                "number_of_orders": [
-                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_id")
-                ],
-                "customer_lifetime_value": [
-                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount")
-                ],
-            }
-        ),
-        AssetKey(["select_star_customers"]): TableColumnLineage(
-            deps_by_column={
-                "customer_id": [
-                    TableColumnDep(asset_key=AssetKey(["customers"]), column_name="customer_id")
-                ],
-                "first_name": [
-                    TableColumnDep(asset_key=AssetKey(["customers"]), column_name="first_name")
-                ],
-                "last_name": [
-                    TableColumnDep(asset_key=AssetKey(["customers"]), column_name="last_name")
-                ],
-                "first_order": [
-                    TableColumnDep(asset_key=AssetKey(["customers"]), column_name="first_order")
-                ],
-                "most_recent_order": [
-                    TableColumnDep(
-                        asset_key=AssetKey(["customers"]), column_name="most_recent_order"
-                    )
-                ],
-                "number_of_orders": [
-                    TableColumnDep(
-                        asset_key=AssetKey(["customers"]), column_name="number_of_orders"
-                    )
-                ],
-                "customer_lifetime_value": [
-                    TableColumnDep(
-                        asset_key=AssetKey(["customers"]), column_name="customer_lifetime_value"
-                    )
-                ],
-            }
-        ),
-        AssetKey(["count_star_customers"]): TableColumnLineage(
-            deps_by_column={
-                "count_star": [],
-            }
-        ),
-        AssetKey(["count_star_implicit_alias_customers"]): TableColumnLineage(
-            deps_by_column={
-                "count_star()": [],
-            }
-        ),
-    }
-    if asset_key_selection:
-        expected_column_lineage_by_asset_key = {
-            asset_key: deps_by_column
-            for asset_key, deps_by_column in expected_column_lineage_by_asset_key.items()
-            if asset_key == asset_key_selection
+        result = materialize(
+            [my_dbt_assets],
+            resources={"dbt": dbt},
+            selection=asset_key_selection and AssetSelection.assets(asset_key_selection),
+        )
+        assert result.success
+
+        column_lineage_by_asset_key = {
+            event.materialization.asset_key: TableMetadataSet.extract(
+                event.materialization.metadata
+            ).column_lineage
+            for event in result.get_asset_materialization_events()
         }
 
-    assert column_lineage_by_asset_key == expected_column_lineage_by_asset_key
+        expected_column_lineage_by_asset_key = {
+            AssetKey(["raw_customers"]): None,
+            AssetKey(["raw_payments"]): None,
+            AssetKey(["raw_orders"]): None,
+            AssetKey(["stg_payments"]): TableColumnLineage(
+                deps_by_column={
+                    "payment_id": [
+                        TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="id")
+                    ],
+                    "order_id": [
+                        TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="order_id")
+                    ],
+                    "payment_method": [
+                        TableColumnDep(
+                            asset_key=AssetKey(["raw_payments"]), column_name="payment_method"
+                        )
+                    ],
+                    "amount": [
+                        TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="amount")
+                    ],
+                }
+            ),
+            AssetKey(["stg_customers"]): TableColumnLineage(
+                deps_by_column={
+                    "customer_id": [
+                        TableColumnDep(
+                            asset_key=AssetKey(["raw_source_customers"]), column_name="id"
+                        )
+                    ],
+                    "first_name": [
+                        TableColumnDep(
+                            asset_key=AssetKey(["raw_source_customers"]), column_name="first_name"
+                        )
+                    ],
+                    "last_name": [
+                        TableColumnDep(
+                            asset_key=AssetKey(["raw_source_customers"]), column_name="last_name"
+                        )
+                    ],
+                }
+            ),
+            AssetKey(["stg_orders"]): TableColumnLineage(
+                deps_by_column={
+                    "order_id": [
+                        TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="id")
+                    ],
+                    "customer_id": [
+                        TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="user_id")
+                    ],
+                    "order_date": [
+                        TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="order_date")
+                    ],
+                    "status": [
+                        TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="status")
+                    ],
+                }
+            ),
+            AssetKey(["orders"]): TableColumnLineage(
+                deps_by_column={
+                    "order_id": [
+                        TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_id")
+                    ],
+                    "customer_id": [
+                        TableColumnDep(
+                            asset_key=AssetKey(["stg_orders"]), column_name="customer_id"
+                        )
+                    ],
+                    "order_date": [
+                        TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
+                    ],
+                    "status": [
+                        TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="status")
+                    ],
+                    "credit_card_amount": [
+                        TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
+                        TableColumnDep(
+                            asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
+                        ),
+                    ],
+                    "coupon_amount": [
+                        TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
+                        TableColumnDep(
+                            asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
+                        ),
+                    ],
+                    "bank_transfer_amount": [
+                        TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
+                        TableColumnDep(
+                            asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
+                        ),
+                    ],
+                    "gift_card_amount": [
+                        TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
+                        TableColumnDep(
+                            asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
+                        ),
+                    ],
+                    "amount": [
+                        TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
+                    ],
+                }
+            ),
+            AssetKey(["duplicate_column_dep_orders"]): TableColumnLineage(
+                deps_by_column={
+                    "amount_2x": [
+                        TableColumnDep(asset_key=AssetKey(["orders"]), column_name="amount")
+                    ],
+                }
+            ),
+            AssetKey(["incremental_orders"]): TableColumnLineage(
+                deps_by_column={
+                    "order_id": [
+                        TableColumnDep(asset_key=AssetKey(["orders"]), column_name="order_id")
+                    ],
+                }
+            ),
+            AssetKey(["customers"]): TableColumnLineage(
+                deps_by_column={
+                    "customer_id": [
+                        TableColumnDep(
+                            asset_key=AssetKey(["stg_customers"]), column_name="customer_id"
+                        )
+                    ],
+                    "first_name": [
+                        TableColumnDep(
+                            asset_key=AssetKey(["stg_customers"]), column_name="first_name"
+                        )
+                    ],
+                    "last_name": [
+                        TableColumnDep(
+                            asset_key=AssetKey(["stg_customers"]), column_name="last_name"
+                        )
+                    ],
+                    "first_order": [
+                        TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
+                    ],
+                    "most_recent_order": [
+                        TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
+                    ],
+                    "number_of_orders": [
+                        TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_id")
+                    ],
+                    "customer_lifetime_value": [
+                        TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount")
+                    ],
+                }
+            ),
+            AssetKey(["select_star_customers"]): TableColumnLineage(
+                deps_by_column={
+                    "customer_id": [
+                        TableColumnDep(asset_key=AssetKey(["customers"]), column_name="customer_id")
+                    ],
+                    "first_name": [
+                        TableColumnDep(asset_key=AssetKey(["customers"]), column_name="first_name")
+                    ],
+                    "last_name": [
+                        TableColumnDep(asset_key=AssetKey(["customers"]), column_name="last_name")
+                    ],
+                    "first_order": [
+                        TableColumnDep(asset_key=AssetKey(["customers"]), column_name="first_order")
+                    ],
+                    "most_recent_order": [
+                        TableColumnDep(
+                            asset_key=AssetKey(["customers"]), column_name="most_recent_order"
+                        )
+                    ],
+                    "number_of_orders": [
+                        TableColumnDep(
+                            asset_key=AssetKey(["customers"]), column_name="number_of_orders"
+                        )
+                    ],
+                    "customer_lifetime_value": [
+                        TableColumnDep(
+                            asset_key=AssetKey(["customers"]), column_name="customer_lifetime_value"
+                        )
+                    ],
+                }
+            ),
+            AssetKey(["count_star_customers"]): TableColumnLineage(
+                deps_by_column={
+                    "count_star": [],
+                }
+            ),
+            AssetKey(["count_star_implicit_alias_customers"]): TableColumnLineage(
+                deps_by_column={
+                    "count_star()": [],
+                }
+            ),
+        }
+        if asset_key_selection:
+            expected_column_lineage_by_asset_key = {
+                asset_key: deps_by_column
+                for asset_key, deps_by_column in expected_column_lineage_by_asset_key.items()
+                if asset_key == asset_key_selection
+            }
+
+        assert column_lineage_by_asset_key == expected_column_lineage_by_asset_key, (
+            str(column_lineage_by_asset_key) + "\n\n" + str(expected_column_lineage_by_asset_key)
+        )
 
 
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -239,14 +239,7 @@ def test_column_lineage(
     manifest["metadata"]["adapter_type"] = sql_dialect
 
     dbt = DbtCliResource(project_dir=os.fspath(test_metadata_path))
-    dbt.cli(
-        [
-            "--quiet",
-            "build",
-            "--exclude",
-            "resource_type:test",
-        ]
-    ).wait()
+    dbt.cli(["--quiet", "build", "--exclude", "resource_type:test"]).wait()
 
     @dbt_assets(manifest=manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_postprocessing.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_postprocessing.py
@@ -23,6 +23,8 @@ from dagster_dbt.core.resources_v2 import (
 from ..conftest import _create_dbt_invocation
 from ..dbt_projects import test_jaffle_shop_path
 
+pytestmark = pytest.mark.derived_metadata
+
 
 @pytest.fixture(name="standalone_duckdb_dbfile_path")
 def standalone_duckdb_dbfile_path_fixture(request) -> None:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/dbt_project.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/dbt_project.yml
@@ -21,7 +21,7 @@ require-dbt-version: [">=1.0.0", "<2.0.0"]
 
 models:
   +post-hook:
-    - "{{ dagster.log_column_level_metadata(enable_parent_relation_metadata_collection=var('dagster_enable_parent_relation_metadata_collection', 'true')) }}"
+    - "{{ dagster.log_column_level_metadata(enable_parent_relation_metadata_collection=var('dagster_enable_parent_relation_metadata_collection', 'true')) if env_var('DBT_LOG_COLUMN_METADATA', 'true') == 'true' else null }}"
   test_dagster_metadata:
     materialized: table
     staging:
@@ -29,4 +29,4 @@ models:
 
 seeds:
   +post-hook:
-    - "{{ dagster.log_column_level_metadata(enable_parent_relation_metadata_collection=var('dagster_enable_parent_relation_metadata_collection', 'true')) }}"
+    - "{{ dagster.log_column_level_metadata(enable_parent_relation_metadata_collection=var('dagster_enable_parent_relation_metadata_collection', 'true')) if env_var('DBT_LOG_COLUMN_METADATA', 'true') == 'true' else null }}"

--- a/python_modules/libraries/dagster-dbt/pytest.ini
+++ b/python_modules/libraries/dagster-dbt/pytest.ini
@@ -5,7 +5,7 @@ filterwarnings=
   ignore::UserWarning
 markers =
     cloud: marks tests that use dbt Cloud APIs
-    core: marks tests that use `dagster-dbt>=0.20.0` APIs
+    core-main: marks tests that use `dagster-dbt>=0.20.0` APIs
     core-derived-metadata: subset of core tests which deal with asset metadata
     legacy: marks tests that use `dagster-dbt<0.20.0` APIs
     snowflake: marks tests that access a Snowflake warehouse, run nightly

--- a/python_modules/libraries/dagster-dbt/pytest.ini
+++ b/python_modules/libraries/dagster-dbt/pytest.ini
@@ -6,6 +6,7 @@ filterwarnings=
 markers =
     cloud: marks tests that use dbt Cloud APIs
     core: marks tests that use `dagster-dbt>=0.20.0` APIs
+    core-derived-metadata: subset of core tests which deal with asset metadata
     legacy: marks tests that use `dagster-dbt<0.20.0` APIs
     snowflake: marks tests that access a Snowflake warehouse, run nightly
     bigquery: marks tests that access a BigQuery warehouse, run nightly

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -30,7 +30,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   cloud: pytest --numprocesses 6 --durations 10 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
-  core: pytest --numprocesses 6 --durations 10 -c ../../../pyproject.toml -m "core and not snowflake and not bigquery and not derived_metadata" -vv {posargs}
+  core-main: pytest --numprocesses 6 --durations 10 -c ../../../pyproject.toml -m "core and not snowflake and not bigquery and not derived_metadata" -vv {posargs}
   core-derived-metadata: pytest --numprocesses 6 --durations 10 -c ../../../pyproject.toml -m "derived_metadata and not snowflake and not bigquery" -vv {posargs}
   legacy: pytest --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
   snowflake: pytest -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'snowflake'

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -30,7 +30,8 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   cloud: pytest --numprocesses 6 --durations 10 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
-  core: pytest --numprocesses 6 --durations 10 -c ../../../pyproject.toml -m "core and not snowflake and not bigquery" -vv {posargs}
+  core: pytest --numprocesses 6 --durations 10 -c ../../../pyproject.toml -m "core and not snowflake and not bigquery and not derived_metadata" -vv {posargs}
+  core-derived-metadata: pytest --numprocesses 6 --durations 10 -c ../../../pyproject.toml -m "derived_metadata and not snowflake and not bigquery" -vv {posargs}
   legacy: pytest --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
   snowflake: pytest -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'snowflake'
   bigquery: pytest -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'bigquery'


### PR DESCRIPTION
## Summary

Adds a new `fetch_column_metadata` method which can be chained after a dbt CLI execution to fetch column lineage metadata, which is then attached to output and materialization events.

TODO in stacked PR: cache fetching column info for models we have already fetched 

## Test Plan

Test deferred fetch alongside the existing fetching code in unit tests.