### PR TITLE
make local code references' line number optional

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetGraphJobSidebar.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetGraphJobSidebar.types.ts
@@ -38,7 +38,7 @@ export type AssetGraphSidebarQuery = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/SidebarAssetInfo.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/SidebarAssetInfo.types.ts
@@ -30,7 +30,7 @@ export type SidebarAssetFragment = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -792,7 +792,7 @@ export type SidebarAssetFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2072,7 +2072,7 @@ export type SidebarAssetFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -3352,7 +3352,7 @@ export type SidebarAssetFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -4623,7 +4623,7 @@ export type SidebarAssetFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -5909,7 +5909,7 @@ export type SidebarAssetFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -7189,7 +7189,7 @@ export type SidebarAssetFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -8469,7 +8469,7 @@ export type SidebarAssetFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -9740,7 +9740,7 @@ export type SidebarAssetFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -11026,7 +11026,7 @@ export type SidebarAssetFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -12306,7 +12306,7 @@ export type SidebarAssetFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -13586,7 +13586,7 @@ export type SidebarAssetFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -14857,7 +14857,7 @@ export type SidebarAssetFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -16139,7 +16139,7 @@ export type SidebarAssetQuery = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -16920,7 +16920,7 @@ export type SidebarAssetQuery = {
                             | {
                                 __typename: 'LocalFileCodeReference';
                                 filePath: string;
-                                lineNumber: number;
+                                lineNumber: number | null;
                                 label: string | null;
                               }
                             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -18206,7 +18206,7 @@ export type SidebarAssetQuery = {
                             | {
                                 __typename: 'LocalFileCodeReference';
                                 filePath: string;
-                                lineNumber: number;
+                                lineNumber: number | null;
                                 label: string | null;
                               }
                             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -19492,7 +19492,7 @@ export type SidebarAssetQuery = {
                             | {
                                 __typename: 'LocalFileCodeReference';
                                 filePath: string;
-                                lineNumber: number;
+                                lineNumber: number | null;
                                 label: string | null;
                               }
                             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -20769,7 +20769,7 @@ export type SidebarAssetQuery = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -22060,7 +22060,7 @@ export type SidebarAssetQuery = {
                             | {
                                 __typename: 'LocalFileCodeReference';
                                 filePath: string;
-                                lineNumber: number;
+                                lineNumber: number | null;
                                 label: string | null;
                               }
                             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -23346,7 +23346,7 @@ export type SidebarAssetQuery = {
                             | {
                                 __typename: 'LocalFileCodeReference';
                                 filePath: string;
-                                lineNumber: number;
+                                lineNumber: number | null;
                                 label: string | null;
                               }
                             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -24632,7 +24632,7 @@ export type SidebarAssetQuery = {
                             | {
                                 __typename: 'LocalFileCodeReference';
                                 filePath: string;
-                                lineNumber: number;
+                                lineNumber: number | null;
                                 label: string | null;
                               }
                             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -25909,7 +25909,7 @@ export type SidebarAssetQuery = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -27200,7 +27200,7 @@ export type SidebarAssetQuery = {
                             | {
                                 __typename: 'LocalFileCodeReference';
                                 filePath: string;
-                                lineNumber: number;
+                                lineNumber: number | null;
                                 label: string | null;
                               }
                             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -28486,7 +28486,7 @@ export type SidebarAssetQuery = {
                             | {
                                 __typename: 'LocalFileCodeReference';
                                 filePath: string;
-                                lineNumber: number;
+                                lineNumber: number | null;
                                 label: string | null;
                               }
                             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -29772,7 +29772,7 @@ export type SidebarAssetQuery = {
                             | {
                                 __typename: 'LocalFileCodeReference';
                                 filePath: string;
-                                lineNumber: number;
+                                lineNumber: number | null;
                                 label: string | null;
                               }
                             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -31049,7 +31049,7 @@ export type SidebarAssetQuery = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
@@ -39,7 +39,7 @@ export type SpecificPartitionAssetConditionEvaluationNodeFragment = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -194,7 +194,7 @@ export type UnpartitionedAssetConditionEvaluationNodeFragment = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -436,7 +436,7 @@ export type AssetConditionEvaluationRecordFragment = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -610,7 +610,7 @@ export type AssetConditionEvaluationRecordFragment = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -864,7 +864,7 @@ export type GetEvaluationsQuery = {
                           | {
                               __typename: 'LocalFileCodeReference';
                               filePath: string;
-                              lineNumber: number;
+                              lineNumber: number | null;
                               label: string | null;
                             }
                           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1044,7 +1044,7 @@ export type GetEvaluationsQuery = {
                           | {
                               __typename: 'LocalFileCodeReference';
                               filePath: string;
-                              lineNumber: number;
+                              lineNumber: number | null;
                               label: string | null;
                             }
                           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1279,7 +1279,7 @@ export type GetEvaluationsSpecificPartitionQuery = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1453,7 +1453,7 @@ export type GetEvaluationsSpecificPartitionQuery = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetCheckDetailModal.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetCheckDetailModal.types.ts
@@ -40,7 +40,7 @@ export type AssetCheckExecutionFragment = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -219,7 +219,7 @@ export type AssetCheckDetailsQuery = {
               | {
                   __typename: 'LocalFileCodeReference';
                   filePath: string;
-                  lineNumber: number;
+                  lineNumber: number | null;
                   label: string | null;
                 }
               | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
@@ -62,7 +62,7 @@ export type AssetChecksQuery = {
                             | {
                                 __typename: 'LocalFileCodeReference';
                                 filePath: string;
-                                lineNumber: number;
+                                lineNumber: number | null;
                                 label: string | null;
                               }
                             | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/VirtualizedAssetCheckTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/VirtualizedAssetCheckTable.types.ts
@@ -45,7 +45,7 @@ export type AssetCheckTableFragment = {
               | {
                   __typename: 'LocalFileCodeReference';
                   filePath: string;
-                  lineNumber: number;
+                  lineNumber: number | null;
                   label: string | null;
                 }
               | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetMetadata.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetMetadata.types.ts
@@ -26,7 +26,7 @@ export type AssetNodeOpMetadataFragment = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -193,7 +193,7 @@ export type AssetNodeOpMetadataFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1473,7 +1473,7 @@ export type AssetNodeOpMetadataFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2753,7 +2753,7 @@ export type AssetNodeOpMetadataFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -4024,7 +4024,7 @@ export type AssetNodeOpMetadataFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -5310,7 +5310,7 @@ export type AssetNodeOpMetadataFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -6590,7 +6590,7 @@ export type AssetNodeOpMetadataFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -7870,7 +7870,7 @@ export type AssetNodeOpMetadataFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -9141,7 +9141,7 @@ export type AssetNodeOpMetadataFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -10427,7 +10427,7 @@ export type AssetNodeOpMetadataFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -11707,7 +11707,7 @@ export type AssetNodeOpMetadataFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -12987,7 +12987,7 @@ export type AssetNodeOpMetadataFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -14258,7 +14258,7 @@ export type AssetNodeOpMetadataFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetNodeDefinition.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetNodeDefinition.types.ts
@@ -620,7 +620,7 @@ export type AssetNodeDefinitionFragment = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -787,7 +787,7 @@ export type AssetNodeDefinitionFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2067,7 +2067,7 @@ export type AssetNodeDefinitionFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -3347,7 +3347,7 @@ export type AssetNodeDefinitionFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -4618,7 +4618,7 @@ export type AssetNodeDefinitionFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -5904,7 +5904,7 @@ export type AssetNodeDefinitionFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -7184,7 +7184,7 @@ export type AssetNodeDefinitionFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -8464,7 +8464,7 @@ export type AssetNodeDefinitionFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -9735,7 +9735,7 @@ export type AssetNodeDefinitionFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -11021,7 +11021,7 @@ export type AssetNodeDefinitionFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -12301,7 +12301,7 @@ export type AssetNodeDefinitionFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -13581,7 +13581,7 @@ export type AssetNodeDefinitionFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -14852,7 +14852,7 @@ export type AssetNodeDefinitionFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetPartitionDetail.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetPartitionDetail.types.ts
@@ -67,7 +67,7 @@ export type AssetPartitionDetailQuery = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -264,7 +264,7 @@ export type AssetPartitionDetailQuery = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
@@ -674,7 +674,7 @@ export type AssetViewDefinitionQuery = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -861,7 +861,7 @@ export type AssetViewDefinitionQuery = {
                               | {
                                   __typename: 'LocalFileCodeReference';
                                   filePath: string;
-                                  lineNumber: number;
+                                  lineNumber: number | null;
                                   label: string | null;
                                 }
                               | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2151,7 +2151,7 @@ export type AssetViewDefinitionQuery = {
                               | {
                                   __typename: 'LocalFileCodeReference';
                                   filePath: string;
-                                  lineNumber: number;
+                                  lineNumber: number | null;
                                   label: string | null;
                                 }
                               | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -3441,7 +3441,7 @@ export type AssetViewDefinitionQuery = {
                               | {
                                   __typename: 'LocalFileCodeReference';
                                   filePath: string;
-                                  lineNumber: number;
+                                  lineNumber: number | null;
                                   label: string | null;
                                 }
                               | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -4722,7 +4722,7 @@ export type AssetViewDefinitionQuery = {
                         | {
                             __typename: 'LocalFileCodeReference';
                             filePath: string;
-                            lineNumber: number;
+                            lineNumber: number | null;
                             label: string | null;
                           }
                         | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -6016,7 +6016,7 @@ export type AssetViewDefinitionQuery = {
                               | {
                                   __typename: 'LocalFileCodeReference';
                                   filePath: string;
-                                  lineNumber: number;
+                                  lineNumber: number | null;
                                   label: string | null;
                                 }
                               | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -7306,7 +7306,7 @@ export type AssetViewDefinitionQuery = {
                               | {
                                   __typename: 'LocalFileCodeReference';
                                   filePath: string;
-                                  lineNumber: number;
+                                  lineNumber: number | null;
                                   label: string | null;
                                 }
                               | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -8596,7 +8596,7 @@ export type AssetViewDefinitionQuery = {
                               | {
                                   __typename: 'LocalFileCodeReference';
                                   filePath: string;
-                                  lineNumber: number;
+                                  lineNumber: number | null;
                                   label: string | null;
                                 }
                               | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -9877,7 +9877,7 @@ export type AssetViewDefinitionQuery = {
                         | {
                             __typename: 'LocalFileCodeReference';
                             filePath: string;
-                            lineNumber: number;
+                            lineNumber: number | null;
                             label: string | null;
                           }
                         | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -11171,7 +11171,7 @@ export type AssetViewDefinitionQuery = {
                               | {
                                   __typename: 'LocalFileCodeReference';
                                   filePath: string;
-                                  lineNumber: number;
+                                  lineNumber: number | null;
                                   label: string | null;
                                 }
                               | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -12461,7 +12461,7 @@ export type AssetViewDefinitionQuery = {
                               | {
                                   __typename: 'LocalFileCodeReference';
                                   filePath: string;
-                                  lineNumber: number;
+                                  lineNumber: number | null;
                                   label: string | null;
                                 }
                               | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -13751,7 +13751,7 @@ export type AssetViewDefinitionQuery = {
                               | {
                                   __typename: 'LocalFileCodeReference';
                                   filePath: string;
-                                  lineNumber: number;
+                                  lineNumber: number | null;
                                   label: string | null;
                                 }
                               | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -15032,7 +15032,7 @@ export type AssetViewDefinitionQuery = {
                         | {
                             __typename: 'LocalFileCodeReference';
                             filePath: string;
-                            lineNumber: number;
+                            lineNumber: number | null;
                             label: string | null;
                           }
                         | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -16941,7 +16941,7 @@ export type AssetViewDefinitionNodeFragment = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -17108,7 +17108,7 @@ export type AssetViewDefinitionNodeFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -18388,7 +18388,7 @@ export type AssetViewDefinitionNodeFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -19668,7 +19668,7 @@ export type AssetViewDefinitionNodeFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -20939,7 +20939,7 @@ export type AssetViewDefinitionNodeFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -22225,7 +22225,7 @@ export type AssetViewDefinitionNodeFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -23505,7 +23505,7 @@ export type AssetViewDefinitionNodeFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -24785,7 +24785,7 @@ export type AssetViewDefinitionNodeFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -26056,7 +26056,7 @@ export type AssetViewDefinitionNodeFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -27342,7 +27342,7 @@ export type AssetViewDefinitionNodeFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -28622,7 +28622,7 @@ export type AssetViewDefinitionNodeFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -29902,7 +29902,7 @@ export type AssetViewDefinitionNodeFragment = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -31173,7 +31173,7 @@ export type AssetViewDefinitionNodeFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useLatestPartitionEvents.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useLatestPartitionEvents.types.ts
@@ -37,7 +37,7 @@ export type AssetOverviewMetadataEventsQuery = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -207,7 +207,7 @@ export type AssetOverviewMetadataEventsQuery = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useRecentAssetEvents.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useRecentAssetEvents.types.ts
@@ -49,7 +49,7 @@ export type AssetMaterializationFragment = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -227,7 +227,7 @@ export type AssetObservationFragment = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -414,7 +414,7 @@ export type AssetEventsQuery = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -606,7 +606,7 @@ export type AssetEventsQuery = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLink.tsx
@@ -50,7 +50,7 @@ const getCodeReferenceLink = (
     case 'LocalFileCodeReference':
       return codeLinkProtocol.protocol
         .replace('{FILE}', codeReference.filePath)
-        .replace('{LINE}', codeReference.lineNumber.toString());
+        .replace('{LINE}', (codeReference.lineNumber || 1).toString());
     case 'UrlCodeReference':
       return codeReference.url;
     default:

--- a/js_modules/dagster-ui/packages/ui-core/src/dagstertype/types/DagsterType.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/dagstertype/types/DagsterType.types.ts
@@ -44,7 +44,7 @@ export type DagsterTypeFragment_ListDagsterType = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1319,7 +1319,7 @@ export type DagsterTypeFragment_ListDagsterType = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2594,7 +2594,7 @@ export type DagsterTypeFragment_ListDagsterType = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -3860,7 +3860,7 @@ export type DagsterTypeFragment_ListDagsterType = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -5124,7 +5124,7 @@ export type DagsterTypeFragment_NullableDagsterType = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -6399,7 +6399,7 @@ export type DagsterTypeFragment_NullableDagsterType = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -7674,7 +7674,7 @@ export type DagsterTypeFragment_NullableDagsterType = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -8940,7 +8940,7 @@ export type DagsterTypeFragment_NullableDagsterType = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -10204,7 +10204,7 @@ export type DagsterTypeFragment_RegularDagsterType = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -11479,7 +11479,7 @@ export type DagsterTypeFragment_RegularDagsterType = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -12754,7 +12754,7 @@ export type DagsterTypeFragment_RegularDagsterType = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -14020,7 +14020,7 @@ export type DagsterTypeFragment_RegularDagsterType = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -15278,7 +15278,7 @@ export type InnerDagsterTypeFragment_ListDagsterType = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -16531,7 +16531,7 @@ export type InnerDagsterTypeFragment_NullableDagsterType = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -17784,7 +17784,7 @@ export type InnerDagsterTypeFragment_RegularDagsterType = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2690,7 +2690,7 @@ union SourceLocation = LocalFileCodeReference | UrlCodeReference
 
 type LocalFileCodeReference {
   filePath: String!
-  lineNumber: Int!
+  lineNumber: Int
   label: String
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2324,7 +2324,7 @@ export type LocalFileCodeReference = {
   __typename: 'LocalFileCodeReference';
   filePath: Scalars['String']['output'];
   label: Maybe<Scalars['String']['output']>;
-  lineNumber: Scalars['Int']['output'];
+  lineNumber: Maybe<Scalars['Int']['output']>;
 };
 
 export type LocationStateChangeEvent = {

--- a/js_modules/dagster-ui/packages/ui-core/src/metadata/types/MetadataEntryFragment.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/metadata/types/MetadataEntryFragment.types.ts
@@ -24,7 +24,7 @@ export type MetadataEntryFragment_CodeReferencesMetadataEntry = {
     | {
         __typename: 'LocalFileCodeReference';
         filePath: string;
-        lineNumber: number;
+        lineNumber: number | null;
         label: string | null;
       }
     | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/GraphExplorer.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/GraphExplorer.types.ts
@@ -4554,7 +4554,7 @@ export type GraphExplorerFragment_PipelineSnapshot = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/PipelineExplorerRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/PipelineExplorerRoot.types.ts
@@ -41,7 +41,7 @@ export type PipelineExplorerRootQuery = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/SidebarContainerOverview.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/SidebarContainerOverview.types.ts
@@ -4554,7 +4554,7 @@ export type SidebarRootContainerFragment_PipelineSnapshot = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsProvider.types.ts
@@ -86,7 +86,7 @@ export type PipelineRunLogsSubscription = {
                         | {
                             __typename: 'LocalFileCodeReference';
                             filePath: string;
-                            lineNumber: number;
+                            lineNumber: number | null;
                             label: string | null;
                           }
                         | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -286,7 +286,7 @@ export type PipelineRunLogsSubscription = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -483,7 +483,7 @@ export type PipelineRunLogsSubscription = {
                         | {
                             __typename: 'LocalFileCodeReference';
                             filePath: string;
-                            lineNumber: number;
+                            lineNumber: number | null;
                             label: string | null;
                           }
                         | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -667,7 +667,7 @@ export type PipelineRunLogsSubscription = {
                         | {
                             __typename: 'LocalFileCodeReference';
                             filePath: string;
-                            lineNumber: number;
+                            lineNumber: number | null;
                             label: string | null;
                           }
                         | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -848,7 +848,7 @@ export type PipelineRunLogsSubscription = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1018,7 +1018,7 @@ export type PipelineRunLogsSubscription = {
                         | {
                             __typename: 'LocalFileCodeReference';
                             filePath: string;
-                            lineNumber: number;
+                            lineNumber: number | null;
                             label: string | null;
                           }
                         | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1255,7 +1255,7 @@ export type PipelineRunLogsSubscription = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1472,7 +1472,7 @@ export type PipelineRunLogsSubscription = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1672,7 +1672,7 @@ export type PipelineRunLogsSubscription = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1850,7 +1850,7 @@ export type PipelineRunLogsSubscription = {
                         | {
                             __typename: 'LocalFileCodeReference';
                             filePath: string;
-                            lineNumber: number;
+                            lineNumber: number | null;
                             label: string | null;
                           }
                         | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2030,7 +2030,7 @@ export type PipelineRunLogsSubscription = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2209,7 +2209,7 @@ export type PipelineRunLogsSubscription = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2397,7 +2397,7 @@ export type PipelineRunLogsSubscription = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2575,7 +2575,7 @@ export type PipelineRunLogsSubscription = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2836,7 +2836,7 @@ export type PipelineRunLogsSubscription = {
                         | {
                             __typename: 'LocalFileCodeReference';
                             filePath: string;
-                            lineNumber: number;
+                            lineNumber: number | null;
                             label: string | null;
                           }
                         | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -3018,7 +3018,7 @@ export type PipelineRunLogsSubscription = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -3196,7 +3196,7 @@ export type PipelineRunLogsSubscription = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -3416,7 +3416,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -3613,7 +3613,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -3805,7 +3805,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -3986,7 +3986,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -4164,7 +4164,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -4329,7 +4329,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -4563,7 +4563,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -4775,7 +4775,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -4970,7 +4970,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -5143,7 +5143,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -5320,7 +5320,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -5494,7 +5494,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -5677,7 +5677,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -5850,7 +5850,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -6106,7 +6106,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                   | {
                       __typename: 'LocalFileCodeReference';
                       filePath: string;
-                      lineNumber: number;
+                      lineNumber: number | null;
                       label: string | null;
                     }
                   | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -6285,7 +6285,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -6458,7 +6458,7 @@ export type RunLogsSubscriptionSuccessFragment = {
                 | {
                     __typename: 'LocalFileCodeReference';
                     filePath: string;
-                    lineNumber: number;
+                    lineNumber: number | null;
                     label: string | null;
                   }
                 | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -6691,7 +6691,7 @@ export type RunLogsQuery = {
                         | {
                             __typename: 'LocalFileCodeReference';
                             filePath: string;
-                            lineNumber: number;
+                            lineNumber: number | null;
                             label: string | null;
                           }
                         | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -6891,7 +6891,7 @@ export type RunLogsQuery = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -7088,7 +7088,7 @@ export type RunLogsQuery = {
                         | {
                             __typename: 'LocalFileCodeReference';
                             filePath: string;
-                            lineNumber: number;
+                            lineNumber: number | null;
                             label: string | null;
                           }
                         | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -7272,7 +7272,7 @@ export type RunLogsQuery = {
                         | {
                             __typename: 'LocalFileCodeReference';
                             filePath: string;
-                            lineNumber: number;
+                            lineNumber: number | null;
                             label: string | null;
                           }
                         | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -7453,7 +7453,7 @@ export type RunLogsQuery = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -7623,7 +7623,7 @@ export type RunLogsQuery = {
                         | {
                             __typename: 'LocalFileCodeReference';
                             filePath: string;
-                            lineNumber: number;
+                            lineNumber: number | null;
                             label: string | null;
                           }
                         | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -7860,7 +7860,7 @@ export type RunLogsQuery = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -8077,7 +8077,7 @@ export type RunLogsQuery = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -8277,7 +8277,7 @@ export type RunLogsQuery = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -8455,7 +8455,7 @@ export type RunLogsQuery = {
                         | {
                             __typename: 'LocalFileCodeReference';
                             filePath: string;
-                            lineNumber: number;
+                            lineNumber: number | null;
                             label: string | null;
                           }
                         | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -8635,7 +8635,7 @@ export type RunLogsQuery = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -8814,7 +8814,7 @@ export type RunLogsQuery = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -9002,7 +9002,7 @@ export type RunLogsQuery = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -9180,7 +9180,7 @@ export type RunLogsQuery = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -9441,7 +9441,7 @@ export type RunLogsQuery = {
                         | {
                             __typename: 'LocalFileCodeReference';
                             filePath: string;
-                            lineNumber: number;
+                            lineNumber: number | null;
                             label: string | null;
                           }
                         | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -9623,7 +9623,7 @@ export type RunLogsQuery = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -9801,7 +9801,7 @@ export type RunLogsQuery = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsRow.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsRow.types.ts
@@ -67,7 +67,7 @@ export type LogsRowStructuredFragment_AssetCheckEvaluationEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -249,7 +249,7 @@ export type LogsRowStructuredFragment_EngineEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -426,7 +426,7 @@ export type LogsRowStructuredFragment_ExecutionStepFailureEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -592,7 +592,7 @@ export type LogsRowStructuredFragment_ExecutionStepInputEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -755,7 +755,7 @@ export type LogsRowStructuredFragment_ExecutionStepOutputEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -905,7 +905,7 @@ export type LogsRowStructuredFragment_ExecutionStepOutputEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1124,7 +1124,7 @@ export type LogsRowStructuredFragment_HandledOutputEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1321,7 +1321,7 @@ export type LogsRowStructuredFragment_LoadedInputEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1500,7 +1500,7 @@ export type LogsRowStructuredFragment_MaterializationEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1658,7 +1658,7 @@ export type LogsRowStructuredFragment_ObjectStoreOperationEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1820,7 +1820,7 @@ export type LogsRowStructuredFragment_ObservationEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1979,7 +1979,7 @@ export type LogsRowStructuredFragment_ResourceInitFailureEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2147,7 +2147,7 @@ export type LogsRowStructuredFragment_ResourceInitStartedEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2305,7 +2305,7 @@ export type LogsRowStructuredFragment_ResourceInitSuccessEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2546,7 +2546,7 @@ export type LogsRowStructuredFragment_StepExpectationResultEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2710,7 +2710,7 @@ export type LogsRowStructuredFragment_StepWorkerStartedEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2868,7 +2868,7 @@ export type LogsRowStructuredFragment_StepWorkerStartingEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsScrollingTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsScrollingTable.types.ts
@@ -67,7 +67,7 @@ export type LogsScrollingTableMessageFragment_AssetCheckEvaluationEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -249,7 +249,7 @@ export type LogsScrollingTableMessageFragment_EngineEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -426,7 +426,7 @@ export type LogsScrollingTableMessageFragment_ExecutionStepFailureEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -592,7 +592,7 @@ export type LogsScrollingTableMessageFragment_ExecutionStepInputEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -755,7 +755,7 @@ export type LogsScrollingTableMessageFragment_ExecutionStepOutputEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -905,7 +905,7 @@ export type LogsScrollingTableMessageFragment_ExecutionStepOutputEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1124,7 +1124,7 @@ export type LogsScrollingTableMessageFragment_HandledOutputEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1321,7 +1321,7 @@ export type LogsScrollingTableMessageFragment_LoadedInputEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1500,7 +1500,7 @@ export type LogsScrollingTableMessageFragment_MaterializationEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1658,7 +1658,7 @@ export type LogsScrollingTableMessageFragment_ObjectStoreOperationEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1820,7 +1820,7 @@ export type LogsScrollingTableMessageFragment_ObservationEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1979,7 +1979,7 @@ export type LogsScrollingTableMessageFragment_ResourceInitFailureEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2147,7 +2147,7 @@ export type LogsScrollingTableMessageFragment_ResourceInitStartedEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2305,7 +2305,7 @@ export type LogsScrollingTableMessageFragment_ResourceInitSuccessEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2546,7 +2546,7 @@ export type LogsScrollingTableMessageFragment_StepExpectationResultEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2710,7 +2710,7 @@ export type LogsScrollingTableMessageFragment_StepWorkerStartedEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2868,7 +2868,7 @@ export type LogsScrollingTableMessageFragment_StepWorkerStartingEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunFragments.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunFragments.types.ts
@@ -124,7 +124,7 @@ export type RunDagsterRunEventFragment_AssetCheckEvaluationEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -306,7 +306,7 @@ export type RunDagsterRunEventFragment_EngineEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -483,7 +483,7 @@ export type RunDagsterRunEventFragment_ExecutionStepFailureEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -649,7 +649,7 @@ export type RunDagsterRunEventFragment_ExecutionStepInputEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -812,7 +812,7 @@ export type RunDagsterRunEventFragment_ExecutionStepOutputEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -962,7 +962,7 @@ export type RunDagsterRunEventFragment_ExecutionStepOutputEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1181,7 +1181,7 @@ export type RunDagsterRunEventFragment_HandledOutputEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1378,7 +1378,7 @@ export type RunDagsterRunEventFragment_LoadedInputEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1558,7 +1558,7 @@ export type RunDagsterRunEventFragment_MaterializationEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1716,7 +1716,7 @@ export type RunDagsterRunEventFragment_ObjectStoreOperationEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1878,7 +1878,7 @@ export type RunDagsterRunEventFragment_ObservationEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2037,7 +2037,7 @@ export type RunDagsterRunEventFragment_ResourceInitFailureEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2205,7 +2205,7 @@ export type RunDagsterRunEventFragment_ResourceInitStartedEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2363,7 +2363,7 @@ export type RunDagsterRunEventFragment_ResourceInitSuccessEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2604,7 +2604,7 @@ export type RunDagsterRunEventFragment_StepExpectationResultEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2768,7 +2768,7 @@ export type RunDagsterRunEventFragment_StepWorkerStartedEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2926,7 +2926,7 @@ export type RunDagsterRunEventFragment_StepWorkerStartingEvent = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunMetadataProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunMetadataProvider.types.ts
@@ -199,7 +199,7 @@ export type RunMetadataProviderMessageFragment_ObjectStoreOperationEvent = {
             | {
                 __typename: 'LocalFileCodeReference';
                 filePath: string;
-                lineNumber: number;
+                lineNumber: number | null;
                 label: string | null;
               }
             | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/types/TypeExplorer.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/types/TypeExplorer.types.ts
@@ -27,7 +27,7 @@ export type TypeExplorerFragment_ListDagsterType = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -1274,7 +1274,7 @@ export type TypeExplorerFragment_NullableDagsterType = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}
@@ -2521,7 +2521,7 @@ export type TypeExplorerFragment_RegularDagsterType = {
           | {
               __typename: 'LocalFileCodeReference';
               filePath: string;
-              lineNumber: number;
+              lineNumber: number | null;
               label: string | null;
             }
           | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/types/TypeExplorerContainer.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/types/TypeExplorerContainer.types.ts
@@ -44,7 +44,7 @@ export type TypeExplorerContainerQuery = {
                       | {
                           __typename: 'LocalFileCodeReference';
                           filePath: string;
-                          lineNumber: number;
+                          lineNumber: number | null;
                           label: string | null;
                         }
                       | {__typename: 'UrlCodeReference'; url: string; label: string | null}

--- a/python_modules/dagster-graphql/dagster_graphql/schema/metadata.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/metadata.py
@@ -164,7 +164,7 @@ class GrapheneJobMetadataEntry(graphene.ObjectType):
 
 class GrapheneLocalFileCodeReference(graphene.ObjectType):
     filePath = graphene.NonNull(graphene.String)
-    lineNumber = graphene.NonNull(graphene.Int)
+    lineNumber = graphene.Int()
     label = graphene.String()
 
     class Meta:

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -35,7 +35,7 @@ class LocalFileCodeReference(DagsterModel):
     """Represents a local file source location."""
 
     file_path: str
-    line_number: int
+    line_number: Optional[int] = None
     label: Optional[str] = None
 
 
@@ -151,9 +151,10 @@ def convert_local_path_to_source_control_path(
     source_file_from_repo_root = os.path.relpath(
         local_path.file_path, repository_root_absolute_path
     )
+    line_number_suffix = f"#L{local_path.line_number}" if local_path.line_number else ""
 
     return UrlCodeReference(
-        url=f"{base_source_control_url}/{source_file_from_repo_root}#L{local_path.line_number}",
+        url=f"{base_source_control_url}/{source_file_from_repo_root}{line_number_suffix}",
         label=local_path.label,
     )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -436,10 +436,7 @@ def _attach_sql_model_code_reference(
             code_references=CodeReferencesMetadataValue(
                 code_references=[
                     *references,
-                    LocalFileCodeReference(
-                        file_path=os.fspath(abs_path),
-                        line_number=1,
-                    ),
+                    LocalFileCodeReference(file_path=os.fspath(abs_path)),
                 ],
             )
         ),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
@@ -121,8 +121,8 @@ def test_link_to_source_control_wrapper(test_jaffle_shop_manifest: Dict[str, Any
             "https://github.com/dagster-io/jaffle_shop/tree/master/"
         )
         assert model_reference.url.endswith(
-            asset_key.path[-1] + ".sql#L1"
-        ) or model_reference.url.endswith(asset_key.path[-1] + ".csv#L1")
+            asset_key.path[-1] + ".sql"
+        ) or model_reference.url.endswith(asset_key.path[-1] + ".csv")
 
         source_reference = references[1]
         assert isinstance(source_reference, UrlCodeReference)


### PR DESCRIPTION
## Summary

Makes the `line_number` field on the `LocalFileCodeReference` optional, for files where we don't have a specific line number to refer to.

## Test Plan

Existing tests