### PR TITLE
[ui] Fix overflowing non-ideal state on the asset overview page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -571,6 +571,7 @@ export const AssetNodeOverviewNonSDA = ({
         <LargeCollapsibleSection header="Definition" icon="info">
           <Box flex={{direction: 'column', gap: 12}}>
             <NonIdealState
+              shrinkable
               description="This asset doesn't have a software definition in any of your code locations."
               icon="materialization"
               title=""


### PR DESCRIPTION
Fixes FE-349

## Summary & Motivation

<img width="1274" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/e54deaf4-c58b-4a75-992d-9d28efd4e82d">
