### PR TITLE
Includes .direnv/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ celerybeat-schedule
 .envrc
 
 # virtualenv
+.direnv/
 .venv
 venv/
 ENV/


### PR DESCRIPTION
## Summary & Motivation

- [direnv](https://github.com/direnv/direnv) is a utility to automatically enable virtual environments when in a specific directory. It creates a `.direnv/` directory for the Python virtual environment. I would like for this to be excluded from version control like `.venv/` and `venv/`

## How I Tested These Changes

- Confirmed `.direnv/` was not included in version control