### PR TITLE
Switch our requests pin to only exclude 2.32.0

### DIFF
--- a/integration_tests/test_suites/backcompat-test-suite/webserver_service/pins.txt
+++ b/integration_tests/test_suites/backcompat-test-suite/webserver_service/pins.txt
@@ -18,4 +18,4 @@ sqlalchemy<2.0.0
 pendulum<3
 
 # https://github.com/dagster-io/dagster/pull/21977
-requests!=2.32.0
+requests!=2.32.0,!=2.32.1

--- a/integration_tests/test_suites/backcompat-test-suite/webserver_service/pins.txt
+++ b/integration_tests/test_suites/backcompat-test-suite/webserver_service/pins.txt
@@ -17,5 +17,5 @@ sqlalchemy<2.0.0
 # Added pendulum pin in later versions
 pendulum<3
 
-# 2.32.0 breaks our docker tests https://buildkite.com/dagster/dagster-dagster/builds/83562
-requests<2.32.0
+# https://github.com/dagster-io/dagster/pull/21977
+requests!=2.32.0

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -138,7 +138,7 @@ setup(
             "morefs[asynclocal]",
             "fsspec<2024.5.0",  # morefs incompatibly
             "rapidfuzz",
-            "requests!=2.32.0",  # https://github.com/dagster-io/dagster/pull/21977
+            "requests!=2.32.0,2.32.1",  # https://github.com/dagster-io/dagster/pull/21977
         ],
         "mypy": ["mypy==1.8.0"],
         "pyright": [

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -138,7 +138,7 @@ setup(
             "morefs[asynclocal]",
             "fsspec<2024.5.0",  # morefs incompatibly
             "rapidfuzz",
-            "requests<2.32.0",  # 2.32.0 breaks our docker tests https://buildkite.com/dagster/dagster-dagster/builds/83562
+            "requests!=2.32.0",  # https://github.com/dagster-io/dagster/pull/21977
         ],
         "mypy": ["mypy==1.8.0"],
         "pyright": [

--- a/python_modules/libraries/dagster-celery-docker/setup.py
+++ b/python_modules/libraries/dagster-celery-docker/setup.py
@@ -36,7 +36,7 @@ setup(
         f"dagster-celery{pin}",
         f"dagster-graphql{pin}",
         "docker",
-        "requests<2.32.0",  # 2.32.0 breaks our docker tests https://buildkite.com/dagster/dagster-dagster/builds/83562
+        "requests!=2.32.0",  # https://github.com/dagster-io/dagster/pull/21977
     ],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-celery-docker/setup.py
+++ b/python_modules/libraries/dagster-celery-docker/setup.py
@@ -36,7 +36,7 @@ setup(
         f"dagster-celery{pin}",
         f"dagster-graphql{pin}",
         "docker",
-        "requests!=2.32.0",  # https://github.com/dagster-io/dagster/pull/21977
+        "requests!=2.32.0,!2.32.1",  # https://github.com/dagster-io/dagster/pull/21977
     ],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-docker/setup.py
+++ b/python_modules/libraries/dagster-docker/setup.py
@@ -38,7 +38,7 @@ setup(
         f"dagster{pin}",
         "docker",
         "docker-image-py",
-        "requests<2.32.0",  # 2.32.0 breaks our docker tests https://buildkite.com/dagster/dagster-dagster/builds/83562
+        "requests!=2.32.0",  # https://github.com/dagster-io/dagster/pull/21977
     ],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-docker/setup.py
+++ b/python_modules/libraries/dagster-docker/setup.py
@@ -38,7 +38,7 @@ setup(
         f"dagster{pin}",
         "docker",
         "docker-image-py",
-        "requests!=2.32.0",  # https://github.com/dagster-io/dagster/pull/21977
+        "requests!=2.32.0,!=2.32.1",  # https://github.com/dagster-io/dagster/pull/21977
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
Both docker-py and requests have fixes in flight. We can narrow our pin to only exclude the breaking version.

https://github.com/docker/docker-py/pull/3257
https://github.com/psf/requests/issues/6707#issuecomment-2122490651