### PR TITLE
store backfill logs using instigation logger

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -3228,3 +3228,6 @@ class DagsterInstance(DynamicPartitionsStore):
             if self.event_log_storage.supports_asset_checks
             else AssetCheckInstanceSupport.NEEDS_MIGRATION
         )
+
+    def backfill_log_storage_enabled(self) -> bool:
+        return False

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -2,6 +2,10 @@ import logging
 import sys
 from typing import Iterable, Mapping, Optional, Sequence, cast
 
+import pendulum
+from contextlib import contextmanager
+
+from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.execution.asset_backfill import execute_asset_backfill_iteration
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.execution.job_backfill import execute_job_backfill_iteration
@@ -45,33 +49,41 @@ def execute_backfill_jobs(
 
         # refetch, in case the backfill was updated in the meantime
         backfill = cast(PartitionBackfill, instance.get_backfill(backfill_id))
-        # create a logger that will always include the backfill_id as an `extra`
-
-        backfill_logger = cast(
-            logging.Logger,
-            logging.LoggerAdapter(logger, extra={"backfill_id": backfill.backfill_id}),
-        )
-
-        try:
-            if backfill.is_asset_backfill:
-                yield from execute_asset_backfill_iteration(
-                    backfill, backfill_logger, workspace_process_context, instance
-                )
-            else:
-                yield from execute_job_backfill_iteration(
-                    backfill,
-                    backfill_logger,
-                    workspace_process_context,
-                    debug_crash_flags,
-                    instance,
-                )
-        except Exception:
-            error_info = DaemonErrorCapture.on_exception(
-                sys.exc_info(),
-                logger=backfill_logger,
-                log_message=f"Backfill failed for {backfill.backfill_id}",
+        evaluation_time = pendulum.now("UTC")
+        log_key = ["backfill", backfill_id, evaluation_time.strftime("%Y%m%d_%H%M%S")]
+        with InstigationLogger(
+            log_key,
+            instance,
+            repository_name=None,
+            name=backfill_id,
+        ) as _logger:
+            backfill_logger = cast(logging.Logger, _logger)
+            # create a logger that will always include the backfill_id as an `extra`
+            backfill_logger = cast(
+                logging.Logger,
+                logging.LoggerAdapter(_logger, extra={"backfill_id": backfill.backfill_id}),
             )
-            instance.update_backfill(
-                backfill.with_status(BulkActionStatus.FAILED).with_error(error_info)
-            )
-            yield error_info
+
+            try:
+                if backfill.is_asset_backfill:
+                    yield from execute_asset_backfill_iteration(
+                        backfill, backfill_logger, workspace_process_context, instance
+                    )
+                else:
+                    yield from execute_job_backfill_iteration(
+                        backfill,
+                        backfill_logger,
+                        workspace_process_context,
+                        debug_crash_flags,
+                        instance,
+                    )
+            except Exception:
+                error_info = DaemonErrorCapture.on_exception(
+                    sys.exc_info(),
+                    logger=backfill_logger,
+                    log_message=f"Backfill failed for {backfill.backfill_id}",
+                )
+                instance.update_backfill(
+                    backfill.with_status(BulkActionStatus.FAILED).with_error(error_info)
+                )
+                yield error_info

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -15,7 +15,7 @@ from dagster._utils.error import SerializableErrorInfo
 
 
 @contextmanager
-def _get_instigation_logger_if_env_var_set(
+def _get_instigation_logger_if_log_storage_enabled(
     instance, backfill_id: str, default_logger: logging.Logger
 ):
     if instance.backfill_log_storage_enabled():
@@ -69,7 +69,7 @@ def execute_backfill_jobs(
 
         # refetch, in case the backfill was updated in the meantime
         backfill = cast(PartitionBackfill, instance.get_backfill(backfill_id))
-        with _get_instigation_logger_if_env_var_set(
+        with _get_instigation_logger_if_log_storage_enabled(
             instance, backfill.backfill_id, logger
         ) as _logger:
             # create a logger that will always include the backfill_id as an `extra`

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -1,10 +1,10 @@
 import logging
 import os
 import sys
+from contextlib import contextmanager
 from typing import Iterable, Mapping, Optional, Sequence, cast
 
 import pendulum
-from contextlib import contextmanager
 
 from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.execution.asset_backfill import execute_asset_backfill_iteration
@@ -15,6 +15,7 @@ from dagster._daemon.utils import DaemonErrorCapture
 from dagster._utils.error import SerializableErrorInfo
 
 
+@contextmanager
 def _get_instigation_logger_if_env_var_set(
     instance, backfill_id: str, default_logger: logging.Logger
 ):

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import sys
 from contextlib import contextmanager
 from typing import Iterable, Mapping, Optional, Sequence, cast
@@ -19,7 +18,7 @@ from dagster._utils.error import SerializableErrorInfo
 def _get_instigation_logger_if_env_var_set(
     instance, backfill_id: str, default_logger: logging.Logger
 ):
-    if os.getenv("STORE_BACKFILL_LOGS", None):
+    if instance.backfill_log_storage_enabled():
         evaluation_time = pendulum.now("UTC")
         log_key = ["backfill", backfill_id, evaluation_time.strftime("%Y%m%d_%H%M%S")]
         with InstigationLogger(


### PR DESCRIPTION
## Summary & Motivation
stores backfill logs using the InstigationLogger. gated on an instance method that we can override to control roll out. 

related internal pr https://github.com/dagster-io/internal/pull/9879

## How I Tested These Changes
