### PR TITLE
Add an lru_cache on top of TimeWindow start timestamps and end timestamps

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -549,8 +549,8 @@ def build_partition_statuses(
             ).get_partition_key_range_for_time_window(r.time_window)
             graphene_ranges.append(
                 GrapheneTimePartitionRangeStatus(
-                    startTime=r.time_window.start.timestamp(),
-                    endTime=r.time_window.end.timestamp(),
+                    startTime=r.time_window.start_timestamp(),
+                    endTime=r.time_window.end_timestamp(),
                     startKey=partition_key_range.start,
                     endKey=partition_key_range.end,
                     status=r.status,

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -803,7 +803,7 @@ class SkipOnNotAllParentsUpdatedSinceCronRule(
             # a parent as unmaterialized in the past.
             or context.legacy_context.previous_max_storage_id is None
             # new cron tick has happened since the previous tick
-            or passed_time_window.end.timestamp()
+            or passed_time_window.end_timestamp()
             > context.legacy_context.previous_evaluation_timestamp
         ):
             return context.legacy_context.instance_queryer.get_asset_subset_updated_after_time(
@@ -916,7 +916,7 @@ class SkipOnNotAllParentsUpdatedSinceCronRule(
         from .declarative_scheduling.scheduling_condition import SchedulingResult
 
         passed_time_window = self.passed_time_window(context)
-        has_new_passed_time_window = passed_time_window.end.timestamp() > (
+        has_new_passed_time_window = passed_time_window.end_timestamp() > (
             context.legacy_context.previous_evaluation_timestamp or 0
         )
         updated_subsets_by_key = self.get_parent_subsets_updated_since_cron_by_key(

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -176,7 +176,7 @@ class TimeWindowPartitionMapping(
         for window in sorted_time_windows[1:]:
             last_window = merged_time_windows[-1]
             # window starts before the end of the previous one
-            if window.start.timestamp() <= last_window.end.timestamp():
+            if window.start_timestamp() <= last_window.end_timestamp():
                 merged_time_windows[-1] = TimeWindow(
                     last_window.start, max(last_window.end, window.end, key=lambda d: d.timestamp())
                 )
@@ -300,8 +300,8 @@ class TimeWindowPartitionMapping(
             if (
                 first_window
                 and last_window
-                and time_window.start.timestamp() <= last_window.start.timestamp()
-                and time_window.end.timestamp() >= first_window.end.timestamp()
+                and time_window.start_timestamp() <= last_window.start_timestamp()
+                and time_window.end_timestamp() >= first_window.end_timestamp()
             ):
                 window_start = max(
                     time_window.start, first_window.start, key=lambda d: d.timestamp()
@@ -316,16 +316,16 @@ class TimeWindowPartitionMapping(
             else:
                 invalid_time_window = None
                 if not (first_window and last_window) or (
-                    time_window.start.timestamp() < first_window.start.timestamp()
-                    and time_window.end.timestamp() > last_window.end.timestamp()
+                    time_window.start_timestamp() < first_window.start_timestamp()
+                    and time_window.end_timestamp() > last_window.end_timestamp()
                 ):
                     invalid_time_window = time_window
-                elif time_window.start.timestamp() < first_window.start.timestamp():
+                elif time_window.start_timestamp() < first_window.start_timestamp():
                     invalid_time_window = TimeWindow(
                         time_window.start,
                         min(time_window.end, first_window.start, key=lambda d: d.timestamp()),
                     )
-                elif time_window.end.timestamp() > last_window.end.timestamp():
+                elif time_window.end_timestamp() > last_window.end_timestamp():
                     invalid_time_window = TimeWindow(
                         max(time_window.start, last_window.end, key=lambda d: d.timestamp()),
                         time_window.end,
@@ -407,8 +407,8 @@ class TimeWindowPartitionMapping(
             and (
                 from_last_partition_window is not None
                 and to_last_partition_window is not None
-                and from_last_partition_window.end.timestamp()
-                <= to_last_partition_window.end.timestamp()
+                and from_last_partition_window.end_timestamp()
+                <= to_last_partition_window.end_timestamp()
             )
         ):
             return UpstreamPartitionsResult(


### PR DESCRIPTION
Summary:
Speedscope results suggest that when we have many time windows, we spend a whole lot of time doing expensive datetime => timestamp() calculations.

The specific hotspot I've identified is here: https://github.com/dagster-io/dagster/blob/a216b8007b51dca040122419b2181b1822d346d7/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py#L1917-L1928

Test Plan: BK
Speedscope results on a large asset graph suggest that before we were spending 4.29 seconds on the aforementioned hotspot, now spending 1.53 seconds (the remaining time is primarily spent in time_window_for_partition_key despite it being lru_cached already, will investigate that separately)

## Summary & Motivation

## How I Tested These Changes
