### PR TITLE
[4/5] Run Timeline IndexedDB Caching

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/src/App.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/App.tsx
@@ -17,7 +17,7 @@ import {CommunityNux} from './NUX/CommunityNux';
 import {extractInitializationData} from './extractInitializationData';
 import {telemetryLink} from './telemetryLink';
 
-const {pathPrefix, telemetryEnabled, liveDataPollRate} = extractInitializationData();
+const {pathPrefix, telemetryEnabled, liveDataPollRate, instanceId} = extractInitializationData();
 
 const apolloLinks = [logLink, errorLink, timeStartLink];
 
@@ -44,7 +44,7 @@ export default function AppPage() {
     <RecoilRoot>
       <InjectedComponents>
         <LiveDataPollRateContext.Provider value={liveDataPollRate ?? 2000}>
-          <AppProvider appCache={appCache} config={config}>
+          <AppProvider appCache={appCache} config={config} localCacheIdPrefix={instanceId}>
             <AppTopNav allowGlobalReload>
               <HelpMenu showContactSales={false} />
               <UserSettingsButton />

--- a/js_modules/dagster-ui/packages/app-oss/src/extractInitializationData.ts
+++ b/js_modules/dagster-ui/packages/app-oss/src/extractInitializationData.ts
@@ -1,10 +1,12 @@
-const ELEMENT_ID = 'initialization-data';
-const PREFIX_PLACEHOLDER = '__PATH_PREFIX__';
-const TELEMETRY_PLACEHOLDER = '__TELEMETRY_ENABLED__';
-const LIVE_DATA_POLL_RATE = '__LIVE_DATA_POLL_RATE__';
+export const ELEMENT_ID = 'initialization-data';
+export const PREFIX_PLACEHOLDER = '__PATH_PREFIX__';
+export const TELEMETRY_PLACEHOLDER = '__TELEMETRY_ENABLED__';
+export const LIVE_DATA_POLL_RATE_PLACEHOLDER = '__LIVE_DATA_POLL_RATE__';
+export const INSTANCE_ID_PLACEHOLDER = '__INSTANCE_ID__';
 
-let value: {pathPrefix: string; telemetryEnabled: boolean; liveDataPollRate?: number} | undefined =
-  undefined;
+let value:
+  | {pathPrefix: string; telemetryEnabled: boolean; liveDataPollRate?: number; instanceId: string}
+  | undefined = undefined;
 
 // Determine the path prefix value, which is set server-side.
 // This value will be used for prefixing paths for the GraphQL
@@ -13,9 +15,10 @@ export const extractInitializationData = (): {
   pathPrefix: string;
   telemetryEnabled: boolean;
   liveDataPollRate?: number;
+  instanceId: string;
 } => {
   if (!value) {
-    value = {pathPrefix: '', telemetryEnabled: false};
+    value = {pathPrefix: '', telemetryEnabled: false, instanceId: ''};
     const element = document.getElementById(ELEMENT_ID);
     if (element) {
       const parsed = JSON.parse(element.innerHTML);
@@ -25,8 +28,11 @@ export const extractInitializationData = (): {
       if (parsed.telemetryEnabled !== TELEMETRY_PLACEHOLDER) {
         value.telemetryEnabled = parsed.telemetryEnabled;
       }
-      if (parsed.liveDataPollRate !== LIVE_DATA_POLL_RATE) {
+      if (parsed.liveDataPollRate !== LIVE_DATA_POLL_RATE_PLACEHOLDER) {
         value.liveDataPollRate = parsed.liveDataPollRate;
+      }
+      if (parsed.instanceId !== INSTANCE_ID_PLACEHOLDER) {
+        value.instanceId = parsed.instanceId;
       }
     }
   }

--- a/js_modules/dagster-ui/packages/app-oss/src/pages/_document.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/pages/_document.tsx
@@ -3,6 +3,14 @@ import path from 'path';
 
 import {Head, Html, Main, NextScript} from 'next/document';
 
+import {
+  ELEMENT_ID,
+  INSTANCE_ID_PLACEHOLDER,
+  LIVE_DATA_POLL_RATE_PLACEHOLDER,
+  PREFIX_PLACEHOLDER,
+  TELEMETRY_PLACEHOLDER,
+} from '../extractInitializationData';
+
 function getSecurityPolicy() {
   return fs.readFileSync(path.join(__dirname, '../../../csp-header-dev.txt'), {encoding: 'utf8'});
 }
@@ -10,6 +18,12 @@ function getSecurityPolicy() {
 // eslint-disable-next-line import/no-default-export
 export default function Document() {
   const isDev = process.env.NODE_ENV === 'development';
+  const values = {
+    pathPrefix: PREFIX_PLACEHOLDER,
+    telemetryEnabled: TELEMETRY_PLACEHOLDER,
+    liveDataPollRate: LIVE_DATA_POLL_RATE_PLACEHOLDER,
+    instanceId: isDev ? 'dev' : INSTANCE_ID_PLACEHOLDER,
+  };
   return (
     <Html lang="en">
       <Head nonce="NONCE-PLACEHOLDER">
@@ -28,17 +42,11 @@ export default function Document() {
         {isDev ? <meta httpEquiv="Content-Security-Policy" content={getSecurityPolicy()} /> : null}
         <script
           type="application/json"
-          id="initialization-data"
+          id={ELEMENT_ID}
           nonce="NONCE-PLACEHOLDER"
-          dangerouslySetInnerHTML={{
-            __html: `
-    {
-      "pathPrefix": "__PATH_PREFIX__",
-      "telemetryEnabled": "__TELEMETRY_ENABLED__",
-      "liveDataPollRate": "__LIVE_DATA_POLL_RATE__"
-    }
-  `,
-          }}
+          // Very silly but the python tests expects to find "pathPrefix": "/dagster-path"" on a single line soo
+          // format the json...
+          dangerouslySetInnerHTML={{__html: JSON.stringify(values, null, 2)}}
         />
         <link
           rel="manifest"

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppContext.tsx
@@ -8,6 +8,7 @@ export type AppContextValue = {
   rootServerURI: string;
   telemetryEnabled: boolean;
   statusPolling?: Set<DeploymentStatusType>;
+  localCacheIdPrefix?: string;
 };
 
 export const AppContext = createContext<AppContextValue>({

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -52,10 +52,13 @@ export interface AppProviderProps {
     telemetryEnabled?: boolean;
     statusPolling: Set<DeploymentStatusType>;
   };
+
+  // Used for localStorage/IndexedDB caching to be isolated between instances/deployments
+  localCacheIdPrefix?: string;
 }
 
 export const AppProvider = (props: AppProviderProps) => {
-  const {appCache, config} = props;
+  const {appCache, config, localCacheIdPrefix} = props;
   const {
     apolloLinks,
     basePath = '',
@@ -116,8 +119,9 @@ export const AppProvider = (props: AppProviderProps) => {
       basePath,
       rootServerURI,
       telemetryEnabled,
+      localCacheIdPrefix,
     }),
-    [basePath, rootServerURI, telemetryEnabled],
+    [basePath, rootServerURI, telemetryEnabled, localCacheIdPrefix],
   );
 
   const analytics = React.useMemo(() => dummyAnalytics(), []);

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
@@ -1,5 +1,6 @@
 import {Box, Button, ButtonGroup, ErrorBoundary, TextInput} from '@dagster-io/ui-components';
 import * as React from 'react';
+import {useDeferredValue} from 'react';
 
 import {RefreshState} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
@@ -79,7 +80,10 @@ export const OverviewTimelineRoot = ({Header, TabButton}: Props) => {
     [hourWindow, now, offsetMsec],
   );
 
-  const {jobs, initialLoading, refreshState} = useRunsForTimeline(range);
+  const runsForTimelineRet = useRunsForTimeline(range);
+
+  // Use deferred value to allow paginating quickly with the UI feeling more responsive.
+  const {jobs, initialLoading, refreshState} = useDeferredValue(runsForTimelineRet);
 
   React.useEffect(() => {
     if (!initialLoading) {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/__tests__/HourlyDataCache.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/__tests__/HourlyDataCache.test.tsx
@@ -1,10 +1,21 @@
 import {HourlyDataCache, ONE_HOUR_S, getHourlyBuckets} from '../HourlyDataCache';
 
+const mockedCache = {
+  has: jest.fn(),
+  get: jest.fn(),
+  set: jest.fn(),
+};
+jest.mock('idb-lru-cache', () => {
+  return {
+    cache: jest.fn(() => mockedCache),
+  };
+});
+
 describe('HourlyDataCache', () => {
   let cache: HourlyDataCache<number>;
 
   beforeEach(() => {
-    cache = new HourlyDataCache<number>();
+    cache = new HourlyDataCache<number>('test');
   });
 
   describe('addData', () => {
@@ -175,5 +186,69 @@ describe('HourlyDataCache Subscriptions', () => {
     cache.addData(ONE_HOUR_S, 2 * ONE_HOUR_S, [4, 5, 6]);
 
     expect(callback).not.toHaveBeenCalled();
+  });
+});
+
+describe('HourlyDataCache with IndexedDB', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should load cache from IndexedDB on initialization', async () => {
+    mockedCache.has.mockResolvedValue(true);
+
+    const sec = Date.now() / 1000;
+    const nowHour = Math.floor(sec / ONE_HOUR_S);
+    mockedCache.get.mockResolvedValue({
+      value: new Map([[nowHour, [{start: nowHour, end: nowHour + ONE_HOUR_S, data: [1, 2, 3]}]]]),
+    });
+
+    const cache = new HourlyDataCache<number>('test');
+
+    await cache.loadCacheFromIndexedDB();
+
+    expect(cache.getHourData(sec)).toEqual([1, 2, 3]);
+    expect(mockedCache.has).toHaveBeenCalledWith('hourlyData');
+    expect(mockedCache.get).toHaveBeenCalledWith('hourlyData');
+  });
+
+  it('should save cache to IndexedDB when data is added', async () => {
+    const cache = new HourlyDataCache<number>('test');
+
+    cache.addData(0, ONE_HOUR_S, [1, 2, 3]);
+
+    const mockCallArgs = mockedCache.set.mock.calls[0];
+    const map = mockCallArgs[1];
+    expect(map).toEqual(
+      new Map<number, {data: number[]; end: number; start: number}[]>([
+        [0, [{data: [1, 2, 3], end: 3600, start: 0}]],
+      ]),
+    );
+  });
+
+  it('should clear old entries from the cache and save to IndexedDB', async () => {
+    const eightDaysAgo = Date.now() / 1000 - 8 * 24 * 60 * 60;
+    const sixDaysAgo = Date.now() / 1000 - 6 * 24 * 60 * 60;
+
+    mockedCache.has.mockResolvedValue(true);
+    mockedCache.get.mockResolvedValue({
+      value: new Map([
+        [
+          Math.floor(eightDaysAgo / ONE_HOUR_S),
+          [{start: eightDaysAgo, end: eightDaysAgo + ONE_HOUR_S, data: [1, 2, 3]}],
+        ],
+        [
+          Math.floor(sixDaysAgo / ONE_HOUR_S),
+          [{start: sixDaysAgo, end: eightDaysAgo + ONE_HOUR_S, data: [1, 2, 3]}],
+        ],
+      ]),
+    });
+
+    const cache = new HourlyDataCache<number>('test');
+
+    await cache.loadCacheFromIndexedDB();
+
+    expect(cache.getHourData(sixDaysAgo)).toEqual([1, 2, 3]);
+    expect(cache.getHourData(eightDaysAgo)).toEqual([]);
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -48,8 +48,6 @@ export const useRunsForTimeline = (
 
   const buckets = useMemo(() => getHourlyBuckets(startSec, endSec), [startSec, endSec]);
 
-  const singleBucket = useMemo(() => [range], [range]);
-
   const client = useApolloClient();
 
   const {localCacheIdPrefix} = useContext(AppContext);


### PR DESCRIPTION
## Summary & Motivation

Store the Run Timeline data in indexedb so that new page loads can reuse data from previous page loads.

Q: How is data cleared?
A: Whenever we load the page and create the cache instance we check if the cache has entries over a week old and delete them.

Q: How is data keyed in OSS?
A: We use the run_storage_id which is unique to the instance. That way if a user blows away their instance and start fresh they will get a completely separate cache.

Q: How is data keyed in Cloud?
A:  https://github.com/dagster-io/internal/pull/9828

## How I Tested These Changes

Extensive use of the RunTimeline in cache + jest.
