### PR TITLE
Adds asset_group_name property to InputContext, OutputContext

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -344,6 +344,15 @@ class InputContext:
 
     @public
     @property
+    def asset_group_name(self) -> str:
+        """The group name for input asset."""
+        if self.asset_key is not None:
+            return self.step_context.job_def.asset_layer.get(self.asset_key).group_name
+        else:
+            check.failed("Can't get asset group name for an input with no asset key")
+
+    @public
+    @property
     def has_asset_partitions(self) -> bool:
         """Returns True if the asset being loaded as input is partitioned."""
         return self._asset_partitions_subset is not None

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -429,6 +429,23 @@ class OutputContext:
 
     @public
     @property
+    def asset_group_name(self) -> str:
+        """The group name for output asset."""
+        if self._warn_on_step_context_use:
+            warnings.warn(
+                "You are using InputContext.upstream_output.asset_group_name"
+                "This use on upstream_output is deprecated and will fail in the future"
+                "Try to obtain what you need directly from InputContext"
+                "For more details: https://github.com/dagster-io/dagster/issues/7900"
+            )
+
+        if self.asset_key is not None:
+            return self.step_context.job_def.asset_layer.get(self.asset_key).group_name
+        else:
+            check.failed("Can't get asset group name for an output with no asset key")
+
+    @public
+    @property
     def has_asset_partitions(self) -> bool:
         """Returns True if the asset being stored is partitioned."""
         if self._warn_on_step_context_use:

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
@@ -756,6 +756,27 @@ def test_asset_key():
     assert result.success
 
 
+def test_asset_group_name():
+    @asset(group_name="example_group")
+    def before():
+        pass
+
+    @asset(group_name="example_group")
+    def after(before):
+        assert before
+
+    class MyIOManager(IOManager):
+        def load_input(self, context: InputContext):
+            assert context.asset_group_name == "example_group"
+            return 1
+
+        def handle_output(self, context: OutputContext, obj):
+            assert context.asset_group_name == "example_group"
+
+    result = materialize([before, after], resources={"io_manager": MyIOManager()})
+    assert result.success
+
+
 def test_partition_key():
     @op
     def my_op():

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
@@ -756,7 +756,28 @@ def test_asset_key():
     assert result.success
 
 
-def test_asset_group_name():
+def test_asset_group_name_default():
+    @asset
+    def before():
+        pass
+
+    @asset
+    def after(before):
+        assert before
+
+    class MyIOManager(IOManager):
+        def load_input(self, context: InputContext):
+            assert context.asset_group_name == "default"
+            return 1
+
+        def handle_output(self, context: OutputContext, obj):
+            assert context.asset_group_name == "default"
+
+    result = materialize([before, after], resources={"io_manager": MyIOManager()})
+    assert result.success
+
+
+def test_asset_group_name_customized():
     @asset(group_name="example_group")
     def before():
         pass


### PR DESCRIPTION
## Summary & Motivation

- Closes https://github.com/dagster-io/dagster/issues/13945
- Adds ability to get input / output asset group name from context in I/O manager

## How I Tested These Changes

- `pytest`