### PR TITLE
[ui] introduce pill for `storage_kind` tag across UI

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -68,7 +68,7 @@ export const AssetNode = React.memo(({definition, selected}: Props) => {
             <AssetNodeChecksRow definition={definition} liveData={liveData} />
           )}
         </AssetNodeBox>
-        <Box style={{right: -2}} flex={{direction: 'row-reverse', gap: 8}}>
+        <Box flex={{direction: 'row-reverse', gap: 8}}>
           {storageKindTag && (
             <AssetStorageKindTag
               storageKind={storageKindTag.value}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -18,7 +18,11 @@ import {ChangedReasonsTag, MinimalNodeChangedDot} from '../assets/ChangedReasons
 import {MinimalNodeStaleDot, StaleReasonsTag, isAssetStale} from '../assets/Stale';
 import {AssetChecksStatusSummary} from '../assets/asset-checks/AssetChecksStatusSummary';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
-import {AssetComputeKindTag} from '../graph/KindTags';
+import {
+  AssetComputeKindTag,
+  AssetStorageKindTag,
+  isCanonicalStorageKindTag,
+} from '../graph/KindTags';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';
 
 interface Props {
@@ -30,6 +34,7 @@ export const AssetNode = React.memo(({definition, selected}: Props) => {
   const isSource = definition.isSource;
 
   const {liveData} = useAssetLiveData(definition.assetKey);
+  const storageKindTag = definition.tags?.find(isCanonicalStorageKindTag);
   return (
     <AssetInsetForHoverEffect>
       <Box
@@ -63,7 +68,18 @@ export const AssetNode = React.memo(({definition, selected}: Props) => {
             <AssetNodeChecksRow definition={definition} liveData={liveData} />
           )}
         </AssetNodeBox>
-        <AssetComputeKindTag definition={definition} style={{right: -2, paddingTop: 7}} />
+        <Box style={{right: -2}} flex={{direction: 'row-reverse', gap: 8}}>
+          {storageKindTag && (
+            <AssetStorageKindTag
+              storageKind={storageKindTag.value}
+              style={{position: 'relative', paddingTop: 7, margin: 0}}
+            />
+          )}
+          <AssetComputeKindTag
+            definition={definition}
+            style={{position: 'relative', paddingTop: 7, margin: 0}}
+          />
+        </Box>
       </AssetNodeContainer>
     </AssetInsetForHoverEffect>
   );
@@ -249,6 +265,10 @@ export const ASSET_NODE_FRAGMENT = gql`
     isSource
     assetKey {
       ...AssetNodeKey
+    }
+    tags {
+      key
+      value
     }
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -18,7 +18,7 @@ import {ChangedReasonsTag, MinimalNodeChangedDot} from '../assets/ChangedReasons
 import {MinimalNodeStaleDot, StaleReasonsTag, isAssetStale} from '../assets/Stale';
 import {AssetChecksStatusSummary} from '../assets/asset-checks/AssetChecksStatusSummary';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
-import {AssetComputeKindTag} from '../graph/OpTags';
+import {AssetComputeKindTag} from '../graph/KindTags';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';
 
 interface Props {
@@ -387,7 +387,7 @@ const MinimalAssetNodeBox = styled.div<{
       &::after {
         inset: 0;
         position: absolute;
-        animation: pulse 0.75s infinite alternate; 
+        animation: pulse 0.75s infinite alternate;
         border-radius: 16px;
         border: 4px solid ${p.$border};
         content: '';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetNode.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetNode.types.ts
@@ -17,6 +17,7 @@ export type AssetNodeFragment = {
   isObservable: boolean;
   isSource: boolean;
   assetKey: {__typename: 'AssetKey'; path: Array<string>};
+  tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
 };
 
 export type AssetNodeKeyFragment = {__typename: 'AssetKey'; path: Array<string>};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -51,7 +51,7 @@ import {
 import {StatusDot} from '../asset-graph/sidebar/StatusDot';
 import {AssetNodeForGraphQueryFragment} from '../asset-graph/types/useAssetGraphData.types';
 import {DagsterTypeSummary} from '../dagstertype/DagsterType';
-import {AssetComputeKindTag} from '../graph/OpTags';
+import {AssetComputeKindTag, AssetStorageKindTag} from '../graph/KindTags';
 import {IntMetadataEntry} from '../graphql/types';
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
 import {isCanonicalRowCountMetadataEntry} from '../metadata/MetadataEntry';
@@ -216,6 +216,9 @@ export const AssetNodeOverview = ({
     </>
   );
 
+  const storageKindTag = assetNode.tags?.find((tag) => tag.key === 'storage_kind');
+  const filteredTags = assetNode.tags?.filter((tag) => tag.key !== 'storage_kind');
+
   const renderDefinitionSection = () => (
     <Box flex={{direction: 'column', gap: 12}}>
       <AttributeAndValue label="Group">
@@ -255,15 +258,31 @@ export const AssetNodeOverview = ({
             ),
           )}
       </AttributeAndValue>
-      <AttributeAndValue label="Compute kind">
-        {assetNode.computeKind && (
-          <AssetComputeKindTag style={{position: 'relative'}} definition={assetNode} reduceColor />
-        )}
-      </AttributeAndValue>
+      <Box style={{display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))'}}>
+        <AttributeAndValue label="Compute kind">
+          {assetNode.computeKind && (
+            <AssetComputeKindTag
+              style={{position: 'relative'}}
+              definition={assetNode}
+              reduceColor
+            />
+          )}
+        </AttributeAndValue>
+        <AttributeAndValue label="Storage kind">
+          {storageKindTag && (
+            <AssetStorageKindTag
+              style={{position: 'relative'}}
+              storageKind={storageKindTag.value}
+              reduceColor
+            />
+          )}
+        </AttributeAndValue>
+      </Box>
+
       <AttributeAndValue label="Tags">
-        {assetNode.tags &&
-          assetNode.tags.length > 0 &&
-          assetNode.tags.map((tag, idx) => <Tag key={idx}>{buildTagString(tag)}</Tag>)}
+        {filteredTags &&
+          filteredTags.length > 0 &&
+          filteredTags.map((tag, idx) => <Tag key={idx}>{buildTagString(tag)}</Tag>)}
       </AttributeAndValue>
     </Box>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -51,7 +51,11 @@ import {
 import {StatusDot} from '../asset-graph/sidebar/StatusDot';
 import {AssetNodeForGraphQueryFragment} from '../asset-graph/types/useAssetGraphData.types';
 import {DagsterTypeSummary} from '../dagstertype/DagsterType';
-import {AssetComputeKindTag, AssetStorageKindTag} from '../graph/KindTags';
+import {
+  AssetComputeKindTag,
+  AssetStorageKindTag,
+  isCanonicalStorageKindTag,
+} from '../graph/KindTags';
 import {IntMetadataEntry} from '../graphql/types';
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
 import {isCanonicalRowCountMetadataEntry} from '../metadata/MetadataEntry';
@@ -216,8 +220,8 @@ export const AssetNodeOverview = ({
     </>
   );
 
-  const storageKindTag = assetNode.tags?.find((tag) => tag.key === 'storage_kind');
-  const filteredTags = assetNode.tags?.filter((tag) => tag.key !== 'storage_kind');
+  const storageKindTag = assetNode.tags?.find(isCanonicalStorageKindTag);
+  const filteredTags = assetNode.tags?.filter((tag) => tag.key !== 'dagster/storage_kind');
 
   const renderDefinitionSection = () => (
     <Box flex={{direction: 'column', gap: 12}}>
@@ -258,27 +262,20 @@ export const AssetNodeOverview = ({
             ),
           )}
       </AttributeAndValue>
-      <Box style={{display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))'}}>
-        <AttributeAndValue label="Compute kind">
-          {assetNode.computeKind && (
-            <AssetComputeKindTag
-              style={{position: 'relative'}}
-              definition={assetNode}
-              reduceColor
-            />
-          )}
-        </AttributeAndValue>
-        <AttributeAndValue label="Storage kind">
-          {storageKindTag && (
-            <AssetStorageKindTag
-              style={{position: 'relative'}}
-              storageKind={storageKindTag.value}
-              reduceColor
-            />
-          )}
-        </AttributeAndValue>
-      </Box>
-
+      <AttributeAndValue label="Compute kind">
+        {assetNode.computeKind && (
+          <AssetComputeKindTag style={{position: 'relative'}} definition={assetNode} reduceColor />
+        )}
+      </AttributeAndValue>
+      <AttributeAndValue label="Storage kind">
+        {storageKindTag && (
+          <AssetStorageKindTag
+            style={{position: 'relative'}}
+            storageKind={storageKindTag.value}
+            reduceColor
+          />
+        )}
+      </AttributeAndValue>
       <AttributeAndValue label="Tags">
         {filteredTags &&
           filteredTags.length > 0 &&

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -53,7 +53,6 @@ import {
 import {useAssetGraphData} from '../asset-graph/useAssetGraphData';
 import {StaleReasonsTag} from '../assets/Stale';
 import {CodeLink} from '../code-links/CodeLink';
-import {AssetComputeKindTag} from '../graph/KindTags';
 import {CodeReferencesMetadataEntry} from '../graphql/types';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {isCanonicalCodeSourceEntry} from '../metadata/TableSchema';
@@ -609,7 +608,6 @@ const AssetViewPageHeaderTags = ({
             changedReasons={definition.changedReasons}
             assetKey={definition.assetKey}
           />
-          <AssetComputeKindTag style={{position: 'relative'}} definition={definition} reduceColor />
         </>
       ) : null}
     </>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -53,7 +53,7 @@ import {
 import {useAssetGraphData} from '../asset-graph/useAssetGraphData';
 import {StaleReasonsTag} from '../assets/Stale';
 import {CodeLink} from '../code-links/CodeLink';
-import {AssetComputeKindTag} from '../graph/OpTags';
+import {AssetComputeKindTag} from '../graph/KindTags';
 import {CodeReferencesMetadataEntry} from '../graphql/types';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {isCanonicalCodeSourceEntry} from '../metadata/TableSchema';

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
@@ -1,3 +1,4 @@
+import {CaptionMono, Tooltip} from '@dagster-io/ui-components';
 import * as React from 'react';
 
 import {OpTags} from './OpTags';
@@ -19,17 +20,28 @@ export const AssetComputeKindTag = ({
     return null;
   }
   return (
-    <OpTags
-      {...rest}
-      tags={[
-        {
-          label: definition.computeKind,
-          onClick: () => {
-            window.requestAnimationFrame(() => document.dispatchEvent(new Event('show-kind-info')));
+    <Tooltip
+      content={
+        <>
+          Compute kind <CaptionMono>{definition.computeKind}</CaptionMono>
+        </>
+      }
+      placement="bottom"
+    >
+      <OpTags
+        {...rest}
+        tags={[
+          {
+            label: definition.computeKind,
+            onClick: () => {
+              window.requestAnimationFrame(() =>
+                document.dispatchEvent(new Event('show-kind-info')),
+              );
+            },
           },
-        },
-      ]}
-    />
+        ]}
+      />
+    </Tooltip>
   );
 };
 
@@ -44,16 +56,27 @@ export const AssetStorageKindTag = ({
   reversed?: boolean;
 }) => {
   return (
-    <OpTags
-      {...rest}
-      tags={[
-        {
-          label: storageKind,
-          onClick: () => {
-            window.requestAnimationFrame(() => document.dispatchEvent(new Event('show-kind-info')));
+    <Tooltip
+      content={
+        <>
+          Storage kind <CaptionMono>{storageKind}</CaptionMono>
+        </>
+      }
+      placement="bottom"
+    >
+      <OpTags
+        {...rest}
+        tags={[
+          {
+            label: storageKind,
+            onClick: () => {
+              window.requestAnimationFrame(() =>
+                document.dispatchEvent(new Event('show-kind-info')),
+              );
+            },
           },
-        },
-      ]}
-    />
+        ]}
+      />
+    </Tooltip>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 
 import {OpTags} from './OpTags';
+import {DefinitionTag} from '../graphql/types';
+
+export const isCanonicalStorageKindTag = (tag: DefinitionTag) => tag.key === 'dagster/storage_kind';
 
 export const AssetComputeKindTag = ({
   definition,

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
@@ -69,11 +69,7 @@ export const AssetStorageKindTag = ({
         tags={[
           {
             label: storageKind,
-            onClick: () => {
-              window.requestAnimationFrame(() =>
-                document.dispatchEvent(new Event('show-kind-info')),
-              );
-            },
+            onClick: () => {},
           },
         ]}
       />

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+
+import {OpTags} from './OpTags';
+
+export const AssetComputeKindTag = ({
+  definition,
+  ...rest
+}: {
+  definition: {computeKind: string | null};
+  style: React.CSSProperties;
+  reduceColor?: boolean;
+  reduceText?: boolean;
+  reversed?: boolean;
+}) => {
+  if (!definition.computeKind) {
+    return null;
+  }
+  return (
+    <OpTags
+      {...rest}
+      tags={[
+        {
+          label: definition.computeKind,
+          onClick: () => {
+            window.requestAnimationFrame(() => document.dispatchEvent(new Event('show-kind-info')));
+          },
+        },
+      ]}
+    />
+  );
+};
+
+export const AssetStorageKindTag = ({
+  storageKind,
+  ...rest
+}: {
+  storageKind: string;
+  style: React.CSSProperties;
+  reduceColor?: boolean;
+  reduceText?: boolean;
+  reversed?: boolean;
+}) => {
+  return (
+    <OpTags
+      {...rest}
+      tags={[
+        {
+          label: storageKind,
+          onClick: () => {
+            window.requestAnimationFrame(() => document.dispatchEvent(new Event('show-kind-info')));
+          },
+        },
+      ]}
+    />
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/OpTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/OpTags.tsx
@@ -557,34 +557,6 @@ function coerceToStandardLabel(label: string) {
   return label.replace(/[ _-]/g, '').toLowerCase();
 }
 
-export const AssetComputeKindTag = ({
-  definition,
-  ...rest
-}: {
-  definition: {computeKind: string | null};
-  style: React.CSSProperties;
-  reduceColor?: boolean;
-  reduceText?: boolean;
-  reversed?: boolean;
-}) => {
-  if (!definition.computeKind) {
-    return null;
-  }
-  return (
-    <OpTags
-      {...rest}
-      tags={[
-        {
-          label: definition.computeKind,
-          onClick: () => {
-            window.requestAnimationFrame(() => document.dispatchEvent(new Event('show-kind-info')));
-          },
-        },
-      ]}
-    />
-  );
-};
-
 export const extractIconSrc = (knownTag: KnownTag | undefined) => {
   // Storybook imports SVGs are string but nextjs imports them as object.
   // This is a temporary work around until we can get storybook to import them the same way as nextjs

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -21,7 +21,11 @@ import {StaleReasonsLabel} from '../assets/Stale';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {AssetTableDefinitionFragment} from '../assets/types/AssetTableFragment.types';
 import {AssetViewType} from '../assets/useAssetView';
-import {AssetComputeKindTag} from '../graph/KindTags';
+import {
+  AssetComputeKindTag,
+  AssetStorageKindTag,
+  isCanonicalStorageKindTag,
+} from '../graph/KindTags';
 import {AssetKeyInput} from '../graphql/types';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
@@ -76,6 +80,8 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
     }
   };
 
+  const storageKindTag = definition?.tags.find(isCanonicalStorageKindTag);
+
   return (
     <Row $height={height} $start={start} data-testid={testId(`row-${tokenForAssetKey({path})}`)}>
       <RowGrid border="bottom" $showRepoColumn={showRepoColumn}>
@@ -100,6 +106,14 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
                 reduceColor
                 reduceText
                 definition={definition}
+                style={{position: 'relative'}}
+              />
+            )}
+            {storageKindTag && (
+              <AssetStorageKindTag
+                reduceColor
+                reduceText
+                storageKind={storageKindTag.value}
                 style={{position: 'relative'}}
               />
             )}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -21,7 +21,7 @@ import {StaleReasonsLabel} from '../assets/Stale';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {AssetTableDefinitionFragment} from '../assets/types/AssetTableFragment.types';
 import {AssetViewType} from '../assets/useAssetView';
-import {AssetComputeKindTag} from '../graph/OpTags';
+import {AssetComputeKindTag} from '../graph/KindTags';
 import {AssetKeyInput} from '../graphql/types';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';


### PR DESCRIPTION
## Summary

Implements a very basic visual tag for `storage_kind` on assets. Right now, this special rendering only displays on the catalog page, asset list, and asset graph. A stacked PR handles adding the filtering.

Uses the same iconset as compute kind.

<img width="304" alt="Screenshot 2024-05-22 at 2 09 55 PM" src="https://github.com/dagster-io/dagster/assets/10215173/7988910f-642d-4f00-9753-3b0a156079a3">


<img width="391" alt="Screenshot 2024-05-22 at 1 33 08 PM" src="https://github.com/dagster-io/dagster/assets/10215173/0845ce88-e198-4dfb-a347-9cd7a949ea08">


<img width="1449" alt="Screenshot 2024-05-22 at 1 33 04 PM" src="https://github.com/dagster-io/dagster/assets/10215173/1e255c51-a5f1-4365-9b96-16121247a648">

<img width="258" alt="Screenshot 2024-05-22 at 2 09 43 PM" src="https://github.com/dagster-io/dagster/assets/10215173/8918e281-2bc0-48fb-ae03-748ef7a92fce">


## Test Plan

Tested locally.
