### PR TITLE
Fix sensor/schedule state in the left nav being outdated

### DIFF
--- a/js_modules/dagster-ui/package.json
+++ b/js_modules/dagster-ui/package.json
@@ -24,6 +24,6 @@
   },
   "packageManager": "yarn@4.1.1",
   "engines": {
-    "node": "21.x"
+    "node": ">=20.x"
   }
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/ScheduleAndSensorDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/ScheduleAndSensorDialog.tsx
@@ -66,7 +66,11 @@ export const ScheduleAndSensorDialog = ({
                   <tr key={schedule.name}>
                     {showSwitch ? (
                       <td>
-                        <ScheduleSwitch repoAddress={repoAddress} schedule={schedule} />
+                        <ScheduleSwitch
+                          repoAddress={repoAddress}
+                          schedule={schedule}
+                          hasOutdatedScheduleState
+                        />
                       </td>
                     ) : null}
                     <td>
@@ -104,7 +108,11 @@ export const ScheduleAndSensorDialog = ({
                   <tr key={sensor.name}>
                     {showSwitch ? (
                       <td>
-                        <SensorSwitch repoAddress={repoAddress} sensor={sensor} />
+                        <SensorSwitch
+                          repoAddress={repoAddress}
+                          sensor={sensor}
+                          hasOutdatedSensorState
+                        />
                       </td>
                     ) : null}
                     <td>

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/ScheduleAndSensorDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/ScheduleAndSensorDialog.tsx
@@ -69,7 +69,7 @@ export const ScheduleAndSensorDialog = ({
                         <ScheduleSwitch
                           repoAddress={repoAddress}
                           schedule={schedule}
-                          hasOutdatedScheduleState
+                          shouldFetchLatestState
                         />
                       </td>
                     ) : null}
@@ -111,7 +111,7 @@ export const ScheduleAndSensorDialog = ({
                         <SensorSwitch
                           repoAddress={repoAddress}
                           sensor={sensor}
-                          hasOutdatedSensorState
+                          shouldFetchLatestState
                         />
                       </td>
                     ) : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleSwitch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleSwitch.tsx
@@ -26,11 +26,11 @@ interface Props {
   repoAddress: RepoAddress;
   schedule: ScheduleSwitchFragment;
   size?: 'small' | 'large';
-  hasOutdatedScheduleState?: boolean;
+  shouldFetchLatestState?: boolean;
 }
 
 export const ScheduleSwitch = (props: Props) => {
-  const {repoAddress, schedule, size = 'large', hasOutdatedScheduleState} = props;
+  const {repoAddress, schedule, size = 'large', shouldFetchLatestState} = props;
   const {name, scheduleState} = schedule;
   const {id, selectorId} = scheduleState;
 
@@ -48,7 +48,7 @@ export const ScheduleSwitch = (props: Props) => {
     SCHEDULE_STATE_QUERY,
     {
       variables: {scheduleSelector},
-      skip: !hasOutdatedScheduleState,
+      skip: !shouldFetchLatestState,
     },
   );
 
@@ -77,11 +77,11 @@ export const ScheduleSwitch = (props: Props) => {
     }
   };
 
-  if (hasOutdatedScheduleState && !data && loading) {
+  if (shouldFetchLatestState && !data && loading) {
     return <Spinner purpose="body-text" />;
   }
 
-  if (hasOutdatedScheduleState && data?.scheduleOrError.__typename !== 'Schedule') {
+  if (shouldFetchLatestState && data?.scheduleOrError.__typename !== 'Schedule') {
     return (
       <Tooltip content="Error loading schedule state">
         <Icon name="error" color={Colors.accentRed()} />;
@@ -89,8 +89,8 @@ export const ScheduleSwitch = (props: Props) => {
     );
   }
 
-  const status = hasOutdatedScheduleState
-    ? // @ts-expect-error - we refined the type based on hasOutdatedScheduleState above
+  const status = shouldFetchLatestState
+    ? // @ts-expect-error - we refined the type based on shouldFetchLatestState above
       data.scheduleOrError.scheduleState.status
     : schedule.scheduleState.status;
   const running = status === InstigationStatus.RUNNING;

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleSwitch.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleSwitch.types.ts
@@ -15,3 +15,23 @@ export type ScheduleSwitchFragment = {
     status: Types.InstigationStatus;
   };
 };
+
+export type ScheduleStateQueryVariables = Types.Exact<{
+  scheduleSelector: Types.ScheduleSelector;
+}>;
+
+export type ScheduleStateQuery = {
+  __typename: 'Query';
+  scheduleOrError:
+    | {__typename: 'PythonError'}
+    | {
+        __typename: 'Schedule';
+        id: string;
+        scheduleState: {
+          __typename: 'InstigationState';
+          id: string;
+          status: Types.InstigationStatus;
+        };
+      }
+    | {__typename: 'ScheduleNotFoundError'};
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorSwitch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorSwitch.tsx
@@ -46,11 +46,11 @@ interface Props {
   repoAddress: RepoAddress;
   sensor: SensorSwitchFragment;
   size?: 'small' | 'large';
-  hasOutdatedSensorState?: boolean;
+  shouldFetchLatestState?: boolean;
 }
 
 export const SensorSwitch = (props: Props) => {
-  const {repoAddress, sensor, size = 'large', hasOutdatedSensorState} = props;
+  const {repoAddress, sensor, size = 'large', shouldFetchLatestState} = props;
   const {
     permissions: {canStartSensor, canStopSensor},
     disabledReasons,
@@ -67,7 +67,7 @@ export const SensorSwitch = (props: Props) => {
     SENSOR_STATE_QUERY,
     {
       variables: {sensorSelector},
-      skip: !hasOutdatedSensorState,
+      skip: !shouldFetchLatestState,
     },
   );
 
@@ -106,10 +106,10 @@ export const SensorSwitch = (props: Props) => {
     }
   };
 
-  if (hasOutdatedSensorState && !data && loading) {
+  if (shouldFetchLatestState && !data && loading) {
     return <Spinner purpose="body-text" />;
   }
-  if (hasOutdatedSensorState && data?.sensorOrError.__typename !== 'Sensor') {
+  if (shouldFetchLatestState && data?.sensorOrError.__typename !== 'Sensor') {
     return (
       <Tooltip content="Error loading sensor state">
         <Icon name="error" color={Colors.accentRed()} />;
@@ -117,8 +117,8 @@ export const SensorSwitch = (props: Props) => {
     );
   }
 
-  const status = hasOutdatedSensorState
-    ? // @ts-expect-error - we refined the type based on hasOutdatedSensorState above
+  const status = shouldFetchLatestState
+    ? // @ts-expect-error - we refined the type based on shouldFetchLatestState above
       data.sensorOrError.sensorState.status
     : sensor.sensorState.status;
   const running = status === InstigationStatus.RUNNING;

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorSwitch.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorSwitch.types.ts
@@ -19,3 +19,20 @@ export type SensorSwitchFragment = {
       | null;
   };
 };
+
+export type SensorStateQueryVariables = Types.Exact<{
+  sensorSelector: Types.SensorSelector;
+}>;
+
+export type SensorStateQuery = {
+  __typename: 'Query';
+  sensorOrError:
+    | {__typename: 'PythonError'}
+    | {
+        __typename: 'Sensor';
+        id: string;
+        sensorState: {__typename: 'InstigationState'; id: string; status: Types.InstigationStatus};
+      }
+    | {__typename: 'SensorNotFoundError'}
+    | {__typename: 'UnauthorizedError'};
+};


### PR DESCRIPTION
## Summary & Motivation

In a previous PR, we stopped storing the RootWorkspaceQuery in the Apollo cache. However, this change affected the left navigation, which relied on data from the workspace context. As a result, the left navigation stopped receiving updates to the schedule/sensor state after mutations, since its data source was no longer tied to the Apollo cache.

To resolve this issue, I updated the left navigation to query for the latest status separately. This new query is stored in the Apollo cache, ensuring that any changes to the state on the sensor page or the left navigation are reflected in both places.

## How I Tested These Changes


https://github.com/dagster-io/dagster/assets/2286579/39200fb1-ed51-4620-b725-66b3893d1c02


