### PR TITLE
Introduce storage kind tag, helpers to @asset, @multi_asset

### DIFF
--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2246,6 +2246,20 @@ def test_multi_assets_asset_spec_with_storage_kind_override() -> None:
     @multi_asset(
         specs=[
             AssetSpec("asset1"),
+            AssetSpec("asset2", storage_kind="bigquery"),
+        ],
+        storage_kind="snowflake",
+    )
+    def assets2(): ...
+
+    assert assets2.tags_by_key[AssetKey("asset1")] == {"dagster/storage_kind": "snowflake"}
+    assert assets2.tags_by_key[AssetKey("asset2")] == {"dagster/storage_kind": "bigquery"}
+
+
+def test_multi_assets_asset_spec_with_storage_kind_tag_override() -> None:
+    @multi_asset(
+        specs=[
+            AssetSpec("asset1"),
             AssetSpec("asset2", tags={**StorageKindTagSet(storage_kind="bigquery")}),
         ],
         storage_kind="snowflake",


### PR DESCRIPTION
## Summary

Introduces a `storage_kind` param to `@asset`, `@multi_assets` decorator and to `AssetSpec` which sets the `dagster/storage_kind` tag from #22029 on the corresponding assets, similar to the `kind` tag we set on ops from `compute_kind`.

This is much more committal than #22029, so ok holding off for now.

```python
@asset(compute_kind="python", storage_kind="snowflake")
def my_snowflake_asset():
  ...
```

```python
@multi_assets(
  specs=
  compute_kind="python",
  storage_kind="bigquery"
)
def my_multi_assets():
  ...
```

```python
@multi_asset(
    specs=[
        AssetSpec("asset1", storage_kind="snowflake"),
        AssetSpec("asset2", storage_kind="bigquery"),
    ],
)
def my_multi_assets():
  ...
```

This can be displayed in the UI specially as well as automatically populated by our various integrations.

## Test Plan

Unit tests.

