### PR TITLE
fetch backfills logs in GQL

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2786,6 +2786,7 @@ type PartitionBackfill {
   tags: [PipelineTag!]!
   title: String
   description: String
+  logEvents(cursor: String): InstigationEventConnection!
 }
 
 enum BulkActionStatus {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -3084,6 +3084,10 @@ export type PartitionBackfill = {
   user: Maybe<Scalars['String']['output']>;
 };
 
+export type PartitionBackfillLogEventsArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type PartitionBackfillPartitionsTargetedForAssetKeyArgs = {
   assetKey?: InputMaybe<AssetKeyInput>;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -3065,6 +3065,7 @@ export type PartitionBackfill = {
   id: Scalars['String']['output'];
   isAssetBackfill: Scalars['Boolean']['output'];
   isValidSerialization: Scalars['Boolean']['output'];
+  logEvents: InstigationEventConnection;
   numCancelable: Scalars['Int']['output'];
   numPartitions: Maybe<Scalars['Int']['output']>;
   partitionNames: Maybe<Array<Scalars['String']['output']>>;
@@ -10644,6 +10645,12 @@ export const buildPartitionBackfill = (
       overrides && overrides.hasOwnProperty('isValidSerialization')
         ? overrides.isValidSerialization!
         : false,
+    logEvents:
+      overrides && overrides.hasOwnProperty('logEvents')
+        ? overrides.logEvents!
+        : relationshipsToOmit.has('InstigationEventConnection')
+        ? ({} as InstigationEventConnection)
+        : buildInstigationEventConnection({}, relationshipsToOmit),
     numCancelable:
       overrides && overrides.hasOwnProperty('numCancelable') ? overrides.numCancelable! : 53,
     numPartitions:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -548,7 +548,9 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         if not isinstance(instance.compute_log_manager, CapturedLogManager):
             return GrapheneInstigationEventConnection(events=[], cursor="", hasMore=False)
 
-        # TODO - need to gate to plus only
+        if not instance.backfill_log_storage_enabled():
+            # myabe need to return something else to indicate that a setting needs to be changed
+            return GrapheneInstigationEventConnection(events=[], cursor="", hasMore=False)
 
         log_keys = sorted(
             instance.compute_log_manager.get_log_keys_for_log_key_prefix(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -532,7 +532,6 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         return self._backfill_job.description
 =======
     def resolve_logEvents(self, graphene_info: ResolveInfo, cursor: Optional[str] = None):
-        # very unsure how the cursor gets passed through, especially if called from get_backfills which also has a cursor
         from ..schema.instigation import (
             GrapheneInstigationEvent,
             GrapheneInstigationEventConnection,
@@ -540,7 +539,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         from ..schema.logs.log_level import GrapheneLogLevel
 
         backfill_id = self._backfill_job.backfill_id
-        # TODO find a better way to keep this in sync. maybe store as part of the asset backfill data?
+        # TODO find a better way to keep the log key prefix in sync. maybe store as part of the asset backfill data?
         backfill_log_key_prefix = ["backfill", backfill_id]
 
         instance = graphene_info.context.instance
@@ -549,7 +548,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             return GrapheneInstigationEventConnection(events=[], cursor="", hasMore=False)
 
         if not instance.backfill_log_storage_enabled():
-            # myabe need to return something else to indicate that a setting needs to be changed
+            # maybe need to return something else to indicate that a setting needs to be changed
             return GrapheneInstigationEventConnection(events=[], cursor="", hasMore=False)
 
         log_keys = sorted(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -1,8 +1,9 @@
+import json
 from typing import TYPE_CHECKING, Optional, Sequence
 
 import dagster._check as check
 import graphene
-from dagster import AssetKey
+from dagster import AssetKey, _seven
 from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPolicyType
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
@@ -15,7 +16,9 @@ from dagster._core.execution.asset_backfill import (
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.external import ExternalPartitionSet
+from dagster._core.storage.captured_log_manager import CapturedLogManager
 from dagster._core.storage.dagster_run import DagsterRun, RunPartitionData, RunRecord, RunsFilter
+from dagster._core.storage.local_compute_log_manager import LocalComputeLogManager
 from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
     ASSET_PARTITION_RANGE_START_TAG,
@@ -279,6 +282,10 @@ class GraphenePartitionBackfill(graphene.ObjectType):
     tags = non_null_list("dagster_graphql.schema.tags.GraphenePipelineTag")
     title = graphene.Field(graphene.String)
     description = graphene.Field(graphene.String)
+    logEvents = graphene.Field(
+        graphene.NonNull("dagster_graphql.schema.instigation.GrapheneInstigationEventConnection"),
+        cursor=graphene.String()
+    )
 
     def __init__(self, backfill_job: PartitionBackfill):
         self._backfill_job = check.inst_param(backfill_job, "backfill_job", PartitionBackfill)
@@ -517,11 +524,73 @@ class GraphenePartitionBackfill(graphene.ObjectType):
     def resolve_user(self, _graphene_info: ResolveInfo) -> Optional[str]:
         return self._backfill_job.user
 
+<<<<<<< HEAD
     def resolve_title(self, _graphene_info: ResolveInfo) -> Optional[str]:
         return self._backfill_job.title
 
     def resolve_description(self, _graphene_info: ResolveInfo) -> Optional[str]:
         return self._backfill_job.description
+=======
+    def resolve_logEvents(self, graphene_info: ResolveInfo, cursor: Optional[str] = None):
+        # very unsure how the cursor gets passed through, especially if called from get_backfills which also has a cursor
+        from ..schema.instigation import (
+            GrapheneInstigationEvent,
+            GrapheneInstigationEventConnection,
+        )
+        from ..schema.logs.log_level import GrapheneLogLevel
+
+        backfill_id = self._backfill_job.backfill_id
+        # TODO find a better way to keep this in sync. maybe store as part of the asset backfill data?
+        backfill_log_key_prefix = ["backfill", backfill_id]
+
+        instance = graphene_info.context.instance
+
+        if not isinstance(instance.compute_log_manager, CapturedLogManager):
+            return GrapheneInstigationEventConnection(events=[], cursor="", hasMore=False)
+
+        # TODO - need to gate to plus only
+
+        log_keys = sorted(
+            instance.compute_log_manager.get_log_keys_for_log_key_prefix(backfill_log_key_prefix, io_type=ComputeIOType.STDERR)
+        )
+        log_key_to_fetch = cursor.split("/") if cursor else log_keys[0]
+        log_data = instance.compute_log_manager.get_log_data(log_key_to_fetch)
+        raw_logs = log_data.stderr.decode("utf-8") if log_data.stderr else ""
+
+        records = []
+        for line in raw_logs.split("\n"):
+            if not line:
+                continue
+            try:
+                records.append(_seven.json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+        events = []
+        for record_dict in records:
+            exc_info = record_dict.get("exc_info")
+            message = record_dict.get("msg")
+            if exc_info:
+                message = f"{message}\n\n{exc_info}"
+            event = GrapheneInstigationEvent(
+                message=message,
+                level=GrapheneLogLevel.from_level(record_dict["levelno"]),
+                timestamp=int(record_dict["created"] * 1000),
+            )
+
+            events.append(event)
+        current_log_key_idx = log_keys.index(log_key_to_fetch)
+        has_more = current_log_key_idx < len(log_keys) - 1
+        if has_more:
+            next_log_key = log_keys[current_log_key_idx + 1] if current_log_key_idx < len(log_keys) - 1 else None
+        else:
+            next_log_key = None # TODO what should this be?
+        return GrapheneInstigationEventConnection(
+            events=events,
+            cursor="/".join(next_log_key),
+            hasMore=has_more,
+        )
+>>>>>>> a9867e6d16 (able to fetch logs together in gql)
 
 
 class GrapheneBackfillNotFoundError(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -571,23 +571,10 @@ class GraphenePartitionBackfill(graphene.ObjectType):
 
             events.append(event)
 
-        if (
-            new_cursor
-            and not new_cursor.has_more
-            and self.status
-            in [
-                GrapheneBulkActionStatus.COMPLETED,
-                GrapheneBulkActionStatus.FAILED,
-                GrapheneBulkActionStatus.CANCELED,
-            ]
-        ):
-            has_more = False
-        else:
-            has_more = True
         return GrapheneInstigationEventConnection(
             events=events,
             cursor=new_cursor.to_string() if new_cursor else None,
-            hasMore=has_more,
+            hasMore=new_cursor.has_more_now if new_cursor else False,
         )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -16,6 +16,8 @@ from dagster._core.definitions.repository_definition.repository_definition impor
 from dagster._core.execution.asset_backfill import AssetBackfillData
 from dagster._core.instance import DagsterInstance
 from dagster._core.test_utils import ensure_dagster_tests_import, instance_for_test
+from dagster._daemon import get_default_daemon_logger
+from dagster._daemon.backfill import execute_backfill_iteration
 from dagster_graphql.client.query import LAUNCH_PARTITION_BACKFILL_MUTATION
 from dagster_graphql.test.utils import (
     GqlResult,
@@ -25,6 +27,10 @@ from dagster_graphql.test.utils import (
 )
 
 ensure_dagster_tests_import()
+from dagster_tests.daemon_tests.test_backfill import (
+    wait_for_all_runs_to_finish,
+    wait_for_all_runs_to_start,
+)
 from dagster_tests.definitions_tests.auto_materialize_tests.scenarios.asset_graphs import (
     root_assets_different_partitions_same_downstream,
 )
@@ -88,6 +94,23 @@ ASSET_BACKFILL_DATA_QUERY = """
             }
         }
         isAssetBackfill
+      }
+    }
+  }
+"""
+
+ASSET_BACKFILL_LOGS_QUERY = """
+  query BackfillStatusesByAsset($backfillId: String!) {
+    partitionBackfillOrError(backfillId: $backfillId) {
+      ... on PartitionBackfill {
+        logEvents {
+            events {
+                message
+                timestamp
+                level
+            }
+            cursor
+        }
       }
     }
   }
@@ -939,3 +962,42 @@ def _get_error_message(launch_backfill_result: GqlResult) -> Optional[str]:
         if "message" in launch_backfill_result.data["launchPartitionBackfill"]
         else None
     )
+
+
+def test_backfill_logs():
+    repo = get_repo()
+    all_asset_keys = repo.asset_graph.materializable_asset_keys
+
+    with instance_for_test() as instance:
+        # need to override this method on the instance since it defaults ot False in OSS. When we enable this
+        # feature in OSS we can remove this override
+        def override_backfill_storage_setting(self):
+            return True
+
+        instance.backfill_log_storage_enabled = override_backfill_storage_setting.__get__(
+            instance, DagsterInstance
+        )
+        with define_out_of_process_context(__file__, "get_repo", instance) as context:
+            # launchPartitionBackfill
+            launch_backfill_result = execute_dagster_graphql(
+                context,
+                LAUNCH_PARTITION_BACKFILL_MUTATION,
+                variables={
+                    "backfillParams": {
+                        "partitionNames": ["a", "b"],
+                        "assetSelection": [key.to_graphql_input() for key in all_asset_keys],
+                    }
+                },
+            )
+            backfill_id, asset_backfill_data = _get_backfill_data(
+                launch_backfill_result, instance, repo
+            )
+            assert asset_backfill_data.target_subset.asset_keys == all_asset_keys
+
+            list(execute_backfill_iteration(context, get_default_daemon_logger("BackfillDaemon")))
+            assert instance.get_runs_count() == 3
+            wait_for_all_runs_to_start(instance, timeout=15)
+            assert instance.get_runs_count() == 3
+            wait_for_all_runs_to_finish(instance, timeout=15)
+
+            # copy code from test_backfill that runs the backfill daemon, then runt he GQL query to get the logs

--- a/python_modules/dagster/dagster/_core/captured_log_api.py
+++ b/python_modules/dagster/dagster/_core/captured_log_api.py
@@ -3,12 +3,14 @@ from typing import NamedTuple, Sequence
 
 from dagster._seven import json
 
+# This should be emitted as a log message to indicate that no more logs will be emitted for that process
+# this lets the log reader know that it can stop polling for more logs
 LOG_STREAM_COMPLETED_SIGIL = "LOGS COMPLETED"
 
 
-class JSONLogLineCursor(NamedTuple):
-    """Representation of an JSON compute log cursor, keeping track of the log query state.
-    The compute logs are stored in multiple files in the same direcotry. The cursor keeps
+class LogLineCursor(NamedTuple):
+    """Representation of a log line cursor, to keep track of the place in the logs.
+    The captured logs are stored in multiple files in the same direcotry. The cursor keeps
     track of the file name and the number of lines read so far.
 
     line=-1 means that the entire file has been read and the next file should be read. This covers the
@@ -29,6 +31,6 @@ class JSONLogLineCursor(NamedTuple):
         return base64.b64encode(bytes(raw, encoding="utf-8")).decode("utf-8")
 
     @staticmethod
-    def parse(cursor_str: str) -> "JSONLogLineCursor":
+    def parse(cursor_str: str) -> "LogLineCursor":
         raw = json.loads(base64.b64decode(cursor_str).decode("utf-8"))
-        return JSONLogLineCursor(raw["log_key"], raw["line"], raw["has_more"])
+        return LogLineCursor(raw["log_key"], raw["line"], raw["has_more"])

--- a/python_modules/dagster/dagster/_core/captured_log_api.py
+++ b/python_modules/dagster/dagster/_core/captured_log_api.py
@@ -3,10 +3,6 @@ from typing import NamedTuple, Sequence
 
 from dagster._seven import json
 
-# This should be emitted as a log message to indicate that no more logs will be emitted for that process
-# this lets the log reader know that it can stop polling for more logs
-LOG_STREAM_COMPLETED_SIGIL = "LOGS COMPLETED"
-
 
 class LogLineCursor(NamedTuple):
     """Representation of a log line cursor, to keep track of the place in the logs.

--- a/python_modules/dagster/dagster/_core/captured_log_api.py
+++ b/python_modules/dagster/dagster/_core/captured_log_api.py
@@ -13,20 +13,26 @@ class LogLineCursor(NamedTuple):
     case when and entire file has been read, but the next file does not exist in storage yet.
     line=0 means no lines from the file have been read.
     line=n means lines 0 through n-1 have been read from the file.
+
+    has_more_now indicates if there are more log lines that can be read immediately. If the process writing
+    logs is still running, but has not writen a log file, has_more_now will be False once all currently readable
+    log files have been read. It does not mean that no new logs will be written in the future.
     """
 
     log_key: Sequence[str]
     line: int  # maybe rename line_offset?
-    has_more: bool
+    has_more_now: bool
 
     def __str__(self) -> str:
         return self.to_string()
 
     def to_string(self) -> str:
-        raw = json.dumps({"log_key": self.log_key, "line": self.line, "has_more": self.has_more})
+        raw = json.dumps(
+            {"log_key": self.log_key, "line": self.line, "has_more_now": self.has_more_now}
+        )
         return base64.b64encode(bytes(raw, encoding="utf-8")).decode("utf-8")
 
     @staticmethod
     def parse(cursor_str: str) -> "LogLineCursor":
         raw = json.loads(base64.b64decode(cursor_str).decode("utf-8"))
-        return LogLineCursor(raw["log_key"], raw["line"], raw["has_more"])
+        return LogLineCursor(raw["log_key"], raw["line"], raw["has_more_now"])

--- a/python_modules/dagster/dagster/_core/compute_log_api.py
+++ b/python_modules/dagster/dagster/_core/compute_log_api.py
@@ -1,0 +1,34 @@
+import base64
+from typing import NamedTuple, Sequence
+
+from dagster._seven import json
+
+LOG_STREAM_COMPLETED_SIGIL = "LOGS COMPLETED"
+
+
+class JSONLogLineCursor(NamedTuple):
+    """Representation of an JSON compute log cursor, keeping track of the log query state.
+    The compute logs are stored in multiple files in the same direcotry. The cursor keeps
+    track of the file name and the number of lines read so far.
+
+    line=-1 means that the entire file has been read and the next file should be read. This covers the
+    case when and entire file has been read, but the next file does not exist in storage yet.
+    line=0 means no lines from the file have been read.
+    line=n means lines 0 through n-1 have been read from the file.
+    """
+
+    log_key: Sequence[str]
+    line: int  # maybe rename line_offset?
+    has_more: bool
+
+    def __str__(self) -> str:
+        return self.to_string()
+
+    def to_string(self) -> str:
+        raw = json.dumps({"log_key": self.log_key, "line": self.line, "has_more": self.has_more})
+        return base64.b64encode(bytes(raw, encoding="utf-8")).decode("utf-8")
+
+    @staticmethod
+    def parse(cursor_str: str) -> "JSONLogLineCursor":
+        raw = json.loads(base64.b64decode(cursor_str).decode("utf-8"))
+        return JSONLogLineCursor(raw["log_key"], raw["line"], raw["has_more"])

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -162,6 +162,10 @@ class PartitionBackfill(
         return self.partition_set_origin.partition_set_name
 
     @property
+    def log_storage_prefix(self) -> Sequence[str]:
+        return ["backfill", self.backfill_id]
+
+    @property
     def user(self) -> Optional[str]:
         if self.tags:
             return self.tags.get(USER_TAG)

--- a/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
@@ -262,11 +262,11 @@ class CapturedLogManager(ABC):
         """Legacy adapter to translate run_id/key to captured log manager-based log_key."""
         return [run_id, "compute_logs", step_key]
 
-    @abstractmethod
     def get_log_keys_for_log_key_prefix(self, log_key_prefix: Sequence[str]) -> Sequence[str]:
         """Returns the logs keys for a given log key prefix.This is determined by looking at the
         directory defined by the log key prefix and creating a log_key for each file in the directory.
         """
+        raise NotImplementedError("Must implement get_log_keys_for_log_key_prefix")
 
     def _read_json_lines(self, start_line, num_lines, log_lines):
         records = []

--- a/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
@@ -3,11 +3,9 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import (
     IO,
-    Any,
     Callable,
     Generator,
     Iterator,
-    Mapping,
     NamedTuple,
     Optional,
     Sequence,
@@ -296,7 +294,7 @@ class CapturedLogManager(ABC):
 
     def read_log_lines_for_log_key_prefix(
         self, log_key_prefix: Sequence[str], cursor: Optional[str], num_lines: int = 100
-    ) -> Tuple[Sequence[Mapping[str, Any]], Optional[LogLineCursor]]:
+    ) -> Tuple[Sequence[str], Optional[LogLineCursor]]:
         """For a given directory defined by log_key_prefix that contains files, read the logs from the files
         as if they are a single continuous file. Reads num_lines lines at a time. Returns the lines read and the next cursor.
         """

--- a/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
@@ -299,7 +299,9 @@ class CapturedLogManager(ABC):
         as if they are a single continuous file. Reads num_lines lines at a time. Returns the lines read and the next cursor.
         """
         # find all of the log_keys to read from and sort them in the order to be read
-        log_keys = sorted(list(self.get_log_keys_for_log_key_prefix(log_key_prefix)))
+        log_keys = sorted(
+            self.get_log_keys_for_log_key_prefix(log_key_prefix), key=lambda x: "/".join(x)
+        )
         if len(log_keys) == 0:
             return [], None
 

--- a/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
@@ -1,16 +1,7 @@
 import os
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import (
-    IO,
-    Callable,
-    Generator,
-    Iterator,
-    NamedTuple,
-    Optional,
-    Sequence,
-    Tuple,
-)
+from typing import IO, Callable, Generator, Iterator, NamedTuple, Optional, Sequence, Tuple
 
 from typing_extensions import Final, Self
 

--- a/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
@@ -299,7 +299,7 @@ class CapturedLogManager(ABC):
         as if they are a single continuous file. Reads num_lines lines at a time. Returns the lines read and the next cursor.
         """
         # find all of the log_keys to read from and sort them in the order to be read
-        log_keys = sorted(self.get_log_keys_for_log_key_prefix(log_key_prefix))
+        log_keys = sorted(list(self.get_log_keys_for_log_key_prefix(log_key_prefix)))
         if len(log_keys) == 0:
             return [], None
 

--- a/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
@@ -243,6 +243,22 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
     def unsubscribe(self, subscription):
         self.on_unsubscribe(subscription)
 
+    def get_log_keys_for_log_key_prefix(self, log_key_prefix: Sequence[str]) -> Sequence[str]:
+        """Returns the logs keys for a given log key prefix.This is determined by looking at the
+        directory defined by the log key prefix and creating a log_key for each file in the directory.
+        """
+        base_dir_path = Path(self._base_dir).resolve()
+        directory = base_dir_path.joinpath(*log_key_prefix)
+        objects = directory.iterdir()
+        results = []
+        list_key_prefix = list(log_key_prefix)
+
+        for obj in objects:
+            if obj.is_file() and obj.suffix == "." + IO_TYPE_EXTENSION[ComputeIOType.STDERR]:
+                results.append(list_key_prefix + [obj.stem])
+
+        return results
+
     ###############################################
     #
     # Methods for the ComputeLogManager interface

--- a/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
@@ -111,6 +111,16 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
     def is_capture_complete(self, log_key: Sequence[str]) -> bool:
         return os.path.exists(self.complete_artifact_path(log_key))
 
+    def get_log_files_in_directory(self, log_key_dir: Sequence[str]) -> Sequence[str]:
+        base_dir_path = Path(self._base_dir).resolve()
+        log_dir = base_dir_path.joinpath(*log_key_dir).resolve()
+
+        return [
+            filename.rsplit(".", 1)[0]  # TODO - need to remove the file extension. feels hacky
+            for filename in os.listdir(log_dir)
+            if os.path.isfile(os.path.join(log_dir, filename))
+        ]
+
     def get_log_data(
         self, log_key: Sequence[str], cursor: Optional[str] = None, max_bytes: Optional[int] = None
     ) -> CapturedLogData:

--- a/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
@@ -111,16 +111,6 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
     def is_capture_complete(self, log_key: Sequence[str]) -> bool:
         return os.path.exists(self.complete_artifact_path(log_key))
 
-    def get_log_files_in_directory(self, log_key_dir: Sequence[str]) -> Sequence[str]:
-        base_dir_path = Path(self._base_dir).resolve()
-        log_dir = base_dir_path.joinpath(*log_key_dir).resolve()
-
-        return [
-            filename.rsplit(".", 1)[0]  # TODO - need to remove the file extension. feels hacky
-            for filename in os.listdir(log_dir)
-            if os.path.isfile(os.path.join(log_dir, filename))
-        ]
-
     def get_log_data(
         self, log_key: Sequence[str], cursor: Optional[str] = None, max_bytes: Optional[int] = None
     ) -> CapturedLogData:

--- a/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
@@ -244,7 +244,7 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
         self.on_unsubscribe(subscription)
 
     def get_log_keys_for_log_key_prefix(self, log_key_prefix: Sequence[str]) -> Sequence[str]:
-        """Returns the logs keys for a given log key prefix.This is determined by looking at the
+        """Returns the logs keys for a given log key prefix. This is determined by looking at the
         directory defined by the log key prefix and creating a log_key for each file in the directory.
         """
         base_dir_path = Path(self._base_dir).resolve()
@@ -254,6 +254,9 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
         list_key_prefix = list(log_key_prefix)
 
         for obj in objects:
+            # Note: This method was implemented to support backfill logs, which are always stored as .err files.
+            # If other file extensions need to be supported, this method will need to be updated to look at the
+            # correct part of log_data based on an io_type parameter
             if obj.is_file() and obj.suffix == "." + IO_TYPE_EXTENSION[ComputeIOType.STDERR]:
                 results.append(list_key_prefix + [obj.stem])
 

--- a/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
@@ -243,7 +243,9 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
     def unsubscribe(self, subscription):
         self.on_unsubscribe(subscription)
 
-    def get_log_keys_for_log_key_prefix(self, log_key_prefix: Sequence[str]) -> Sequence[str]:
+    def get_log_keys_for_log_key_prefix(
+        self, log_key_prefix: Sequence[str]
+    ) -> Sequence[Sequence[str]]:
         """Returns the logs keys for a given log key prefix. This is determined by looking at the
         directory defined by the log key prefix and creating a log_key for each file in the directory.
         """

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -5,7 +5,7 @@ from typing import Iterable, Mapping, Optional, Sequence, cast
 
 import pendulum
 
-from dagster._core.compute_log_api import LOG_STREAM_COMPLETED_SIGIL
+from dagster._core.captured_log_api import LOG_STREAM_COMPLETED_SIGIL
 from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.execution.asset_backfill import execute_asset_backfill_iteration
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -5,7 +5,6 @@ from typing import Iterable, Mapping, Optional, Sequence, cast
 
 import pendulum
 
-from dagster._core.captured_log_api import LOG_STREAM_COMPLETED_SIGIL
 from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.execution.asset_backfill import execute_asset_backfill_iteration
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
@@ -17,16 +16,16 @@ from dagster._utils.error import SerializableErrorInfo
 
 @contextmanager
 def _get_instigation_logger_if_log_storage_enabled(
-    instance, backfill_id: str, default_logger: logging.Logger
+    instance, backfill: PartitionBackfill, default_logger: logging.Logger
 ):
     if instance.backfill_log_storage_enabled():
         evaluation_time = pendulum.now("UTC")
-        log_key = ["backfill", backfill_id, evaluation_time.strftime("%Y%m%d_%H%M%S")]
+        log_key = [*backfill.log_storage_prefix, evaluation_time.strftime("%Y%m%d_%H%M%S")]
         with InstigationLogger(
             log_key,
             instance,
             repository_name=None,
-            name=backfill_id,
+            name=backfill.backfill_id,
         ) as _logger:
             backfill_logger = cast(logging.Logger, _logger)
             yield backfill_logger
@@ -70,9 +69,7 @@ def execute_backfill_jobs(
 
         # refetch, in case the backfill was updated in the meantime
         backfill = cast(PartitionBackfill, instance.get_backfill(backfill_id))
-        with _get_instigation_logger_if_log_storage_enabled(
-            instance, backfill.backfill_id, logger
-        ) as _logger:
+        with _get_instigation_logger_if_log_storage_enabled(instance, backfill, logger) as _logger:
             # create a logger that will always include the backfill_id as an `extra`
             backfill_logger = cast(
                 logging.Logger,
@@ -102,12 +99,3 @@ def execute_backfill_jobs(
                     backfill.with_status(BulkActionStatus.FAILED).with_error(error_info)
                 )
                 yield error_info
-
-            # refetch the backfill to add the end of log stream sigil if the backfill is in any finished state
-            backfill = cast(PartitionBackfill, instance.get_backfill(backfill.backfill_id))
-            if backfill.status in [
-                BulkActionStatus.COMPLETED,
-                BulkActionStatus.FAILED,
-                BulkActionStatus.CANCELED,
-            ]:
-                backfill_logger.info(LOG_STREAM_COMPLETED_SIGIL)

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -36,8 +36,6 @@ from dagster import (
     repository,
 )
 from dagster._core.definitions import StaticPartitionsDefinition
-from dagster._core.captured_log_api import LOG_STREAM_COMPLETED_SIGIL
-
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.events import AssetKeyPartitionKey

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -2327,6 +2327,7 @@ def test_asset_backfill_logs(
     logs, cursor = cm.read_log_lines_for_log_key_prefix(
         ["backfill", backfill.backfill_id], cursor=None
     )
+    assert cursor is not None
     assert logs
     for log_line in logs:
         if not log_line:
@@ -2349,6 +2350,7 @@ def test_asset_backfill_logs(
         cursor=cursor.to_string(),
     )
 
+    assert cursor is not None
     assert not cursor.has_more_now
     for log_line in logs:
         if not log_line:

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -1,3 +1,4 @@
+import json
 import os
 import random
 import string
@@ -34,6 +35,7 @@ from dagster import (
     repository,
 )
 from dagster._core.definitions import StaticPartitionsDefinition
+from dagster._core.captured_log_api import LOG_STREAM_COMPLETED_SIGIL
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.events import AssetKeyPartitionKey
@@ -2272,3 +2274,68 @@ def test_old_dynamic_partitions_job_backfill(
     list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
 
     assert instance.get_runs_count() == 4
+
+
+def test_asset_backfill_logs(
+    instance: DagsterInstance,
+    workspace_context: WorkspaceProcessContext,
+    external_repo: ExternalRepository,
+):
+    # need to override this method on the instance since it defaults ot False in OSS. When we enable this
+    # feature in OSS we can remove this override
+    def override_backfill_storage_setting(self):
+        return True
+
+    instance.backfill_log_storage_enabled = override_backfill_storage_setting.__get__(
+        instance, DagsterInstance
+    )
+
+    partition_keys = static_partitions.get_partition_keys()
+    asset_selection = [AssetKey("foo"), AssetKey("a1"), AssetKey("bar")]
+    instance.add_backfill(
+        PartitionBackfill.from_asset_partitions(
+            asset_graph=workspace_context.create_request_context().asset_graph,
+            backfill_id="backfill_with_asset_selection",
+            tags={"custom_tag_key": "custom_tag_value"},
+            backfill_timestamp=pendulum.now().timestamp(),
+            asset_selection=asset_selection,
+            partition_names=partition_keys,
+            dynamic_partitions_store=instance,
+            all_partitions=False,
+            title=None,
+            description=None,
+        )
+    )
+    assert instance.get_runs_count() == 0
+    backfill = instance.get_backfill("backfill_with_asset_selection")
+    assert backfill
+    assert backfill.status == BulkActionStatus.REQUESTED
+
+    list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
+    assert instance.get_runs_count() == 3
+    wait_for_all_runs_to_start(instance, timeout=30)
+    assert instance.get_runs_count() == 3
+    wait_for_all_runs_to_finish(instance, timeout=30)
+
+    logs, cursor = instance.compute_log_manager.read_json_log_lines_for_log_key_prefix(
+        ["backfill", backfill.backfill_id], cursor=None, num_lines=15
+    )
+    assert logs
+    for log_line in logs:
+        assert log_line.get("msg")
+
+    list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
+    backfill = instance.get_backfill("backfill_with_asset_selection")
+    assert backfill
+    assert backfill.status == BulkActionStatus.COMPLETED
+
+    # set num_lines hihg so we know we get all of the remaining logs
+    logs, cursor = instance.compute_log_manager.read_json_log_lines_for_log_key_prefix(
+        ["backfill", backfill.backfill_id], cursor=cursor.to_string(), num_lines=100
+    )
+
+    assert not cursor.has_more
+    for log_line in logs:
+        assert log_line.get("msg")
+
+    assert LOG_STREAM_COMPLETED_SIGIL not in json.dumps(logs[-1])

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -53,6 +53,7 @@ from dagster._core.remote_representation import (
     InProcessCodeLocationOrigin,
     RemoteRepositoryOrigin,
 )
+from dagster._core.storage.captured_log_manager import CapturedLogManager
 from dagster._core.storage.dagster_run import IN_PROGRESS_RUN_STATUSES, DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
@@ -2318,6 +2319,8 @@ def test_asset_backfill_logs(
     wait_for_all_runs_to_finish(instance, timeout=15)
 
     os.environ["DAGSTER_CAPTURED_LOG_CHUNK_SIZE"] = "20"
+
+    assert isinstance(instance.compute_log_manager, CapturedLogManager)
 
     logs, cursor = instance.compute_log_manager.read_log_lines_for_log_key_prefix(
         ["backfill", backfill.backfill_id], cursor=None

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -37,6 +37,7 @@ from dagster import (
 )
 from dagster._core.definitions import StaticPartitionsDefinition
 from dagster._core.captured_log_api import LOG_STREAM_COMPLETED_SIGIL
+
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.events import AssetKeyPartitionKey
@@ -2348,5 +2349,3 @@ def test_asset_backfill_logs(
     assert not cursor.has_more
     for log_line in logs:
         assert log_line.get("msg")
-
-    assert LOG_STREAM_COMPLETED_SIGIL not in json.dumps(logs[-1])

--- a/python_modules/dagster/dagster_tests/storage_tests/test_captured_log_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_captured_log_manager.py
@@ -7,7 +7,7 @@ from typing import Any, Generator, Mapping, Sequence
 import pendulum
 import pytest
 from dagster import job, op
-from dagster._core.compute_log_api import LOG_STREAM_COMPLETED_SIGIL
+from dagster._core.captured_log_api import LOG_STREAM_COMPLETED_SIGIL
 from dagster._core.events import DagsterEventType
 from dagster._core.storage.captured_log_manager import CapturedLogContext
 from dagster._core.storage.compute_log_manager import ComputeIOType

--- a/python_modules/dagster/dagster_tests/storage_tests/test_captured_log_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_captured_log_manager.py
@@ -115,7 +115,7 @@ def test_get_log_keys_for_log_key_prefix():
         ]
 
 
-def test_get_json_log_lines_for_log_key_prefix():
+def test_read_log_lines_for_log_key_prefix():
     """Tests that we can read a sequence of files in a bucket as if they are a single file."""
     with tempfile.TemporaryDirectory() as tmpdir_path:
         cm = LocalComputeLogManager(tmpdir_path)
@@ -130,7 +130,8 @@ def test_get_json_log_lines_for_log_key_prefix():
                 for j in range(10):
                     json_msg = {"file": file_id, "message_idx": j}
                     all_logs.append(json_msg)
-                    f.write("\n")
+                    if j > 0:
+                        f.write("\n")
                     json.dump(json_msg, f)
 
                 if last_log_file:
@@ -142,7 +143,7 @@ def test_get_json_log_lines_for_log_key_prefix():
 
         all_logs_iter = iter(all_logs)
         # read the entirety of the first file
-        log_lines, cursor = cm.read_json_log_lines_for_log_key_prefix(
+        log_lines, cursor = cm.read_log_lines_for_log_key_prefix(
             log_key_prefix, cursor=None, num_lines=10
         )
         assert len(log_lines) == 10
@@ -153,7 +154,7 @@ def test_get_json_log_lines_for_log_key_prefix():
             assert ll == next(all_logs_iter)
 
         # read half of the next log file
-        log_lines, cursor = cm.read_json_log_lines_for_log_key_prefix(
+        log_lines, cursor = cm.read_log_lines_for_log_key_prefix(
             log_key_prefix, cursor=cursor.to_string(), num_lines=5
         )
         assert len(log_lines) == 5
@@ -165,7 +166,7 @@ def test_get_json_log_lines_for_log_key_prefix():
             assert ll == next(all_logs_iter)
 
         # read the next ten lines, five will be in the second file, five will be in the third
-        log_lines, cursor = cm.read_json_log_lines_for_log_key_prefix(
+        log_lines, cursor = cm.read_log_lines_for_log_key_prefix(
             log_key_prefix, cursor=cursor.to_string(), num_lines=10
         )
         assert len(log_lines) == 10
@@ -177,7 +178,7 @@ def test_get_json_log_lines_for_log_key_prefix():
             assert ll == next(all_logs_iter)
 
         # read the remaining 15 lines, but request 20
-        log_lines, cursor = cm.read_json_log_lines_for_log_key_prefix(
+        log_lines, cursor = cm.read_log_lines_for_log_key_prefix(
             log_key_prefix, cursor=cursor.to_string(), num_lines=20
         )
         assert len(log_lines) == 15
@@ -192,7 +193,7 @@ def test_get_json_log_lines_for_log_key_prefix():
 
         write_log_file(4, last_log_file=True)
 
-        log_lines, cursor = cm.read_json_log_lines_for_log_key_prefix(
+        log_lines, cursor = cm.read_log_lines_for_log_key_prefix(
             log_key_prefix, cursor=cursor.to_string(), num_lines=15
         )
         assert len(log_lines) == 10


### PR DESCRIPTION
## Summary & Motivation
Fetches backfill logs using the captured log manager. 

Adds functionality to the captured log manager to read a sequence of files in a directory as if they are a single file by sorting the file names and then reading through the files N lines at a time. The majority of the logic is in the base CapturedLogManager class, but each implementor class will need to implement a method to get the log keys for a given directory. I implemented this method for the LocalComputeLogManager to enable testing, and follow up PRs can implement it for the remaining ComputeLogManagers. internal pr https://github.com/dagster-io/internal/pull/9879 that implements the method for the cloud compute log manager

Fetching logs via GQL is gated on an instance method we can override to control roll out

## How I Tested These Changes
new unit tests for the pagination scheme, added a unit test where we run a backfill and then fetch the logs