### PR TITLE
[ui] add filters for storage kind

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
@@ -38,6 +38,7 @@ const defaultState: AssetFilterState = {
     repos: [],
     selectAllFilters: [],
     tags: [],
+    storageKindTags: [],
   },
   setAssetTags: () => {},
   setChangedInBranch: () => {},
@@ -48,6 +49,7 @@ const defaultState: AssetFilterState = {
   setRepos: () => {},
   setSelectAllFilters: () => {},
   filterFn: () => true,
+  setStorageKindTags: () => {},
 };
 
 export function useAssetGraphExplorerFilters({

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useStorageKindFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useStorageKindFilter.tsx
@@ -1,0 +1,49 @@
+import {Box, Icon} from '@dagster-io/ui-components';
+import {useMemo} from 'react';
+
+import {buildDefinitionTag} from './useAssetTagFilter';
+import {useStaticSetFilter} from './useStaticSetFilter';
+import {DefinitionTag} from '../../graphql/types';
+import {TruncatedTextWithFullTextOnHover} from '../../nav/getLeftNavItemsForOption';
+
+const emptyArray: any[] = [];
+
+export const useStorageKindFilter = ({
+  allAssetStorageKindTags,
+  storageKindTags,
+  setStorageKindTags,
+}: {
+  allAssetStorageKindTags: DefinitionTag[];
+  storageKindTags?: null | DefinitionTag[];
+  setStorageKindTags?: null | ((s: DefinitionTag[]) => void);
+}) => {
+  const memoizedState = useMemo(() => storageKindTags?.map(buildDefinitionTag), [storageKindTags]);
+  return useStaticSetFilter<DefinitionTag>({
+    name: 'Storage kind',
+    icon: 'tag',
+    allValues: useMemo(
+      () =>
+        allAssetStorageKindTags.map((value) => ({
+          value,
+          match: [value.key + ':' + value.value],
+        })),
+      [allAssetStorageKindTags],
+    ),
+    menuWidth: '300px',
+    renderLabel: ({value: tag}) => {
+      return (
+        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+          <Icon name="tag" />
+          <TruncatedTextWithFullTextOnHover tooltipText={tag.value} text={tag.value} />
+        </Box>
+      );
+    },
+    getStringValue: ({value}) => value,
+    state: memoizedState ?? emptyArray,
+    onStateChanged: (values) => {
+      setStorageKindTags?.(Array.from(values));
+    },
+    matchType: 'all-of',
+    canSelectAll: false,
+  });
+};


### PR DESCRIPTION
## Summary

Add frontend filters for storage kind to the asset list and asset graph pages.

<img width="562" alt="Screenshot 2024-05-22 at 2 14 30 PM" src="https://github.com/dagster-io/dagster/assets/10215173/4a201721-3517-4021-9243-67482722c6d9">

## Test Plan

Tested locally