### PR TITLE
[dagster-dbt] attach `dagster/storage_kind` tag to dbt assets

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -21,6 +21,7 @@ from dagster import (
     asset,
     materialize,
 )
+from dagster._core.definitions.tags import StorageKindTagSet
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster._core.execution.context.compute import AssetExecutionContext
 from dagster._core.types.dagster_type import DagsterType
@@ -642,9 +643,13 @@ def test_dbt_config_tags(test_meta_config_manifest: Dict[str, Any]) -> None:
     @dbt_assets(manifest=test_meta_config_manifest)
     def my_dbt_assets(): ...
 
-    assert my_dbt_assets.tags_by_key[AssetKey("customers")] == {"foo": "", "bar-baz": ""}
+    assert my_dbt_assets.tags_by_key[AssetKey("customers")] == {
+        "foo": "",
+        "bar-baz": "",
+        **StorageKindTagSet(storage_kind="duckdb"),
+    }
     for asset_key in my_dbt_assets.keys - {AssetKey("customers")}:
-        assert my_dbt_assets.tags_by_key[asset_key] == {}
+        assert my_dbt_assets.tags_by_key[asset_key] == {**StorageKindTagSet(storage_kind="duckdb")}
 
 
 def test_dbt_meta_owners(test_meta_config_manifest: Dict[str, Any]) -> None:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -512,11 +512,9 @@ def test_with_tag_replacements(test_jaffle_shop_manifest: Dict[str, Any]) -> Non
 
 
 def test_with_storage_kind_tag_override(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
-    expected_tags = {**StorageKindTagSet(storage_kind="my_custom_storage_kind")}
-
     class CustomDagsterDbtTranslator(DagsterDbtTranslator):
         def get_tags(self, _: Mapping[str, Any]) -> Mapping[str, str]:
-            return expected_tags
+            return {**StorageKindTagSet(storage_kind="my_custom_storage_kind")}
 
     @dbt_assets(
         manifest=test_jaffle_shop_manifest, dagster_dbt_translator=CustomDagsterDbtTranslator()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -516,6 +516,12 @@ def test_with_storage_kind_tag_override(test_jaffle_shop_manifest: Dict[str, Any
         def get_tags(self, _: Mapping[str, Any]) -> Mapping[str, str]:
             return {**StorageKindTagSet(storage_kind="my_custom_storage_kind")}
 
+    @dbt_assets(manifest=test_jaffle_shop_manifest)
+    def my_dbt_assets_no_override(): ...
+
+    for metadata in my_dbt_assets_no_override.tags_by_key.values():
+        assert metadata["dagster/storage_kind"] == "duckdb"
+
     @dbt_assets(
         manifest=test_jaffle_shop_manifest, dagster_dbt_translator=CustomDagsterDbtTranslator()
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -511,6 +511,22 @@ def test_with_tag_replacements(test_jaffle_shop_manifest: Dict[str, Any]) -> Non
         assert metadata["customized"] == "tag"
 
 
+def test_with_storage_kind_tag_override(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
+    expected_tags = {**StorageKindTagSet(storage_kind="my_custom_storage_kind")}
+
+    class CustomDagsterDbtTranslator(DagsterDbtTranslator):
+        def get_tags(self, _: Mapping[str, Any]) -> Mapping[str, str]:
+            return expected_tags
+
+    @dbt_assets(
+        manifest=test_jaffle_shop_manifest, dagster_dbt_translator=CustomDagsterDbtTranslator()
+    )
+    def my_dbt_assets(): ...
+
+    for metadata in my_dbt_assets.tags_by_key.values():
+        assert metadata["dagster/storage_kind"] == "my_custom_storage_kind"
+
+
 def test_with_owner_replacements(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
     expected_owners = ["custom@custom.com"]
 


### PR DESCRIPTION
## Summary

Grabs the dbt adapter_type from the manifest and uses it to set the `storage_kind` tag on dbt-output assets, by default.

Users can still override this behavior in the translator if they so desire.

## Test Plan

Unit tests.