### PR TITLE
Enable dlt asset metadata via translator

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/asset_decorator.py
@@ -99,6 +99,7 @@ def dlt_assets(
                     META_KEY_SOURCE: dlt_source,
                     META_KEY_PIPELINE: dlt_pipeline,
                     META_KEY_TRANSLATOR: dlt_dagster_translator,
+                    **(dlt_dagster_translator.get_metadata(dlt_source_resource) or {}),
                 },
             )
             for dlt_source_resource in dlt_source.selected_resources.values()

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/asset_decorator.py
@@ -99,7 +99,7 @@ def dlt_assets(
                     META_KEY_SOURCE: dlt_source,
                     META_KEY_PIPELINE: dlt_pipeline,
                     META_KEY_TRANSLATOR: dlt_dagster_translator,
-                    **(dlt_dagster_translator.get_metadata(dlt_source_resource) or {}),
+                    **dlt_dagster_translator.get_metadata(dlt_source_resource),
                 },
             )
             for dlt_source_resource in dlt_source.selected_resources.values()

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/translator.py
@@ -11,8 +11,6 @@ from dlt.extract.resource import DltResource
 
 @dataclass
 class DagsterDltTranslator:
-    metadata_by_resource_name: Optional[Mapping[str, Any]] = None
-
     @public
     def get_asset_key(self, resource: DltResource) -> AssetKey:
         """Defines asset key for a given dlt resource key and dataset name.
@@ -64,6 +62,4 @@ class DagsterDltTranslator:
         Returns:
             Mapping[str, Any]: The custom metadata entries for this resource.
         """
-        if not self.metadata_by_resource_name:
-            return {}
-        return self.metadata_by_resource_name.get(resource.name, {})
+        return {}

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/translator.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Iterable, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 from dagster import (
     AssetKey,
@@ -11,6 +11,8 @@ from dlt.extract.resource import DltResource
 
 @dataclass
 class DagsterDltTranslator:
+    metadata_by_resource_name: Optional[Mapping[str, Any]] = None
+
     @public
     def get_asset_key(self, resource: DltResource) -> AssetKey:
         """Defines asset key for a given dlt resource key and dataset name.
@@ -51,3 +53,17 @@ class DagsterDltTranslator:
 
         """
         return None
+
+    @public
+    def get_metadata(self, resource: DltResource) -> Mapping[str, Any]:
+        """Defines resource specific metadata.
+
+        Args:
+            resource (DltResource): dlt resource / transformer
+
+        Returns:
+            Mapping[str, Any]: The custom metadata entries for this resource.
+        """
+        if not self.metadata_by_resource_name:
+            return {}
+        return self.metadata_by_resource_name.get(resource.name, {})

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_dlt.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_dlt.py
@@ -205,3 +205,44 @@ def test_resource_failure_aware_materialization(dlt_pipeline: Pipeline) -> None:
     assert not res.success
     asset_materizations = res.get_asset_materialization_events()
     assert len(asset_materizations) == 0
+
+
+def test_asset_metadata(dlt_pipeline: Pipeline) -> None:
+    custom_dlt_dagster_translator = DagsterDltTranslator(
+        metadata_by_resource_name={
+            "repos": {"mode": "upsert", "primary_key": "id"},
+            "repo_issues": {"mode": "upsert", "primary_key": ["repo_id", "issue_id"]},
+        }
+    )
+
+    @dlt_assets(
+        dlt_source=pipeline(),
+        dlt_pipeline=dlt_pipeline,
+        dlt_dagster_translator=custom_dlt_dagster_translator,
+    )
+    def example_pipeline_assets(
+        context: AssetExecutionContext, dlt_pipeline_resource: DagsterDltResource
+    ):
+        yield from dlt_pipeline_resource.run(context=context)
+
+    first_asset_metadata = next(iter(example_pipeline_assets.metadata_by_key.values()))
+    dagster_dlt_source = first_asset_metadata.get("dagster_dlt/source")
+    dagster_dlt_pipeline = first_asset_metadata.get("dagster_dlt/pipeline")
+    dagster_dlt_translator = first_asset_metadata.get("dagster_dlt/translator")
+
+    assert example_pipeline_assets.metadata_by_key == {
+        AssetKey("dlt_pipeline_repos"): {
+            "dagster_dlt/source": dagster_dlt_source,
+            "dagster_dlt/pipeline": dagster_dlt_pipeline,
+            "dagster_dlt/translator": dagster_dlt_translator,
+            "mode": "upsert",
+            "primary_key": "id",
+        },
+        AssetKey("dlt_pipeline_repo_issues"): {
+            "dagster_dlt/source": dagster_dlt_source,
+            "dagster_dlt/pipeline": dagster_dlt_pipeline,
+            "dagster_dlt/translator": dagster_dlt_translator,
+            "mode": "upsert",
+            "primary_key": ["repo_id", "issue_id"],
+        },
+    }


### PR DESCRIPTION
## Summary & Motivation

Asset metadata is an essential component of assets definition in real projects. This PR adds a parameter in the DagsterDltTranslator to define resource specific metadata.

This is an idea to circumvent the fact that dlt does nor uses a configuration file such as Sling's replication.yaml, where would be natural to define metadata to be read by the translator.

## How I Tested These Changes

make pyright
make ruff
python -m pytest python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests